### PR TITLE
Banner test to link to contribute-only support.theguardian.com

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -162,7 +162,7 @@ trait ABTestSwitches {
     "Test linking to a contributions-only version of support.theguardian.com",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 1, 20),
+    sellByDate = new LocalDate(2018, 1, 22),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -155,4 +155,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 1, 10),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-just-contribute",
+    "Test linking to a contributions-only version of support.theguardian.com",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 20),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-contribute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-contribute.js
@@ -1,0 +1,35 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+
+export const AcquisitionsBannerJustContribute: AcquisitionsABTest = {
+    id: 'AcquisitionsBannerJustContribute',
+    campaignId: 'banner_just_contribute',
+    start: '2017-12-20',
+    expiry: '2018-01-30',
+    author: 'Joseph Smith',
+    description:
+        'Test linking to a contributions-only version of support.theguardian.com',
+    successMeasure: 'AV 2.0 per impression',
+    idealOutcome: 'Makes more money',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    audienceCriteria: 'All',
+    locations: ['GB'],
+    audience: 1,
+    audienceOffset: 0,
+    canRun: () => true,
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'just_contribute',
+            options: {
+                engagementBannerParams: {
+                    linkUrl:
+                        'https://support.theguardian.com/uk?bundle=contribute',
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,4 +1,6 @@
 // @flow
+import { AcquisitionsBannerJustContribute } from 'common/modules/experiments/tests/acquisitions-banner-just-contribute';
+
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsBannerJustContribute];


### PR DESCRIPTION
Following on from #18421, where the winning variant was the one that pointed to the contribute-only version of https://support.theguardian.com, we're doing a similar test on the banner but with just that winning variant.

The banner looks the same in both control and variant

# control
Links to normal support site:
![picture 94](https://user-images.githubusercontent.com/5122968/34222164-80ef43ac-e5b2-11e7-815b-bba23e48badb.png)


# just_contribute
Links to https://support.theguardian.com/uk?bundle=contribute:
![picture 93](https://user-images.githubusercontent.com/5122968/34222097-4d53d4ae-e5b2-11e7-9187-d9ac321cacbe.png)
