### PR TITLE
Remove supportFrontendLiveInUk and supportFrontendLiveInUS switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -525,28 +525,7 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  // Owner: Simple & Coherent
-  val UkSupportFrontendActive = Switch(
-    SwitchGroup.Feature,
-    "uk-supporter-traffic-to-new-support-frontend",
-    "When ON, all UK membership/contribute/support links send traffic to support.theguardian.com (aside from the banner)",
-    owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = On,
-    sellByDate = new LocalDate(2018, 10, 17),
-    exposeClientSide = true
-  )
-
-  val UsSupportFrontendActive = Switch(
-    SwitchGroup.Feature,
-    "us-supporter-traffic-to-new-support-frontend",
-    "When ON, all US membership/contribute/support links send traffic to support.theguardian.com (aside from the banner)",
-    owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 10, 17),
-    exposeClientSide = true
-  )
-
-    // Owner: Journalism
+  // Owner: Journalism
   val ReaderAnswersDeliveryMechanism = Switch(
     SwitchGroup.Feature,
     "reader-answers-preferred-delivery-mechanism",

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,7 +1,6 @@
 package navigation
 
 import experiments._
-import conf.switches.Switches.{UkSupportFrontendActive, UsSupportFrontendActive}
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
@@ -108,9 +107,8 @@ object UrlHelpers {
 
   def countryUrlLogic(editionId: String, position: Position, defaultDestination: ReaderRevenueSite)(implicit request: RequestHeader): String =
     editionId match {
-      case "us" if UsSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(SupportUsContribute, position)
-      case "us" if !UsSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(Contribute, position)
-      case "uk" if UkSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(Support, position)
+      case "us" => getReaderRevenueUrl(SupportUsContribute, position)
+      case "uk" => getReaderRevenueUrl(Support, position)
       case _ => getReaderRevenueUrl(defaultDestination, position)
     }
 
@@ -130,7 +128,7 @@ object UrlHelpers {
 
   def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
-    if (editionId == "uk" && UkSupportFrontendActive.isSwitchedOn) {
+    if (editionId == "uk") {
       getReaderRevenueUrl(Support, position)
     } else {
       getReaderRevenueUrl(Subscribe, position)

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -1,9 +1,8 @@
 // @flow
 import {
-    supportFrontendLiveInUk,
-    supportFrontendLiveInUs,
-} from 'common/modules/commercial/support-utilities';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+    getSync as geolocationGetSync,
+    getLocalCurrencySymbol,
+} from 'lib/geolocation';
 
 // control
 const controlHeading = 'Since you’re here &hellip;';
@@ -24,27 +23,27 @@ const controlP1Regulars =
     '&hellip; today we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight"> unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 
 const ctaLinkSentence = (
-    membershipUrl: string,
+    supportUrl: string,
     contributionUrl: string,
     currencySymbol: string
 ): string => {
-    if (supportFrontendLiveInUs) {
+    if (geolocationGetSync() === 'US') {
         return `<span class="contributions__highlight"> For as little as ${
             currencySymbol
         }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
-            membershipUrl
+            supportUrl
         }" target="_blank" class="u-underline">Make a contribution</a>`;
-    } else if (supportFrontendLiveInUk) {
+    } else if (geolocationGetSync() === 'GB') {
         return `<span class="contributions__highlight">For as little as ${
             currencySymbol
         }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
-            membershipUrl
+            supportUrl
         }" target="_blank" class="u-underline">Make a contribution or get a subscription</a>`;
     }
     return `<span class="contributions__highlight"> For as little as ${
         currencySymbol
     }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
-        membershipUrl
+        supportUrl
     }" target="_blank" class="u-underline">Become a monthly supporter</a> or <a href="${
         contributionUrl
     }" target="_blank" class="u-underline">make a one-off contribution</a>`;
@@ -75,13 +74,13 @@ export const endOfYearCountdown = (
     p2: controlP2(),
 });
 
-export const liveblog = (
-    membershipUrl: string,
+export const liveblogCopy = (
+    supportUrl: string,
     contributionsUrl: string
 ): AcquisitionsEpicTemplateCopy => ({
     p1: `Since you’re here ${controlP1}`,
     p2: `${controlP2FirstSentence} ${ctaLinkSentence(
-        membershipUrl,
+        supportUrl,
         contributionsUrl,
         getLocalCurrencySymbol()
     )}. - Guardian HQ`,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -26,23 +26,17 @@ import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'commercial/modules/user-features';
 import {
     useSupportDomain,
-    selectBaseUrl,
+    supportBaseURL,
 } from 'common/modules/commercial/support-utilities';
 
 type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
 export type CtaUrls = {
-    membershipUrl?: string,
     contributeUrl?: string,
     supportUrl?: string,
 };
 
-const membershipBaseURL = selectBaseUrl(
-    'https://membership.theguardian.com/supporter'
-);
-const contributionsBaseURL = selectBaseUrl(
-    'https://contribute.theguardian.com'
-);
+const contributionsBaseURL = 'https://contribute.theguardian.com';
 
 // How many times the user can see the Epic,
 // e.g. 6 times within 7 days with minimum of 1 day in between views.
@@ -65,7 +59,6 @@ const controlTemplate: EpicTemplate = ({ options = {} }, copy) =>
         componentName: options.componentName,
         testimonialBlock: options.testimonialBlock,
         buttonTemplate: options.buttonTemplate({
-            membershipUrl: options.membershipURL,
             contributeUrl: options.contributeURL,
             supportUrl: options.supportURL,
         }),
@@ -203,19 +196,8 @@ const makeABTestVariant = (
                 variant: id,
             },
         }),
-        membershipURL = addTrackingCodesToUrl({
-            base: membershipBaseURL,
-            componentType: parentTest.componentType,
-            componentId: campaignCode,
-            campaignCode,
-            abTest: {
-                name: parentTest.id,
-                variant: id,
-            },
-        }),
-        supportCustomURL = null,
         supportURL = addTrackingCodesToUrl({
-            base: supportCustomURL || selectBaseUrl(),
+            base: supportBaseURL,
             componentType: parentTest.componentType,
             componentId: campaignCode,
             campaignCode,
@@ -291,7 +273,6 @@ const makeABTestVariant = (
             products,
             campaignCode,
             contributeURL,
-            membershipURL,
             supportURL,
             template,
             buttonTemplate,
@@ -387,35 +368,8 @@ const makeABTestVariant = (
                 render.apply(this);
             }
         },
-
         impression,
         success,
-
-        contributionsURLBuilder(codeModifier) {
-            return addTrackingCodesToUrl({
-                base: contributionsBaseURL,
-                componentType: parentTest.componentType,
-                componentId: codeModifier(campaignCode),
-                campaignCode: codeModifier(campaignCode),
-                abTest: {
-                    name: parentTest.id,
-                    variant: id,
-                },
-            });
-        },
-
-        membershipURLBuilder(codeModifier) {
-            return addTrackingCodesToUrl({
-                base: membershipBaseURL,
-                componentType: parentTest.componentType,
-                componentId: codeModifier(campaignCode),
-                campaignCode: codeModifier(campaignCode),
-                abTest: {
-                    name: parentTest.id,
-                    variant: id,
-                },
-            });
-        },
     };
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -4,8 +4,10 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 const useSupportDomain = (): boolean =>
     geolocationGetSync() === 'GB' || geolocationGetSync() === 'US';
 
+const supportPath = geolocationGetSync() === 'US' ? '/us/contribute' : '/uk';
+
 const supportBaseURL = useSupportDomain()
-    ? 'https://support.theguardian.com'
+    ? `https://support.theguardian.com${supportPath}`
     : 'https://membership.theguardian.com/supporter';
 
 export { useSupportDomain, supportBaseURL };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,25 +1,11 @@
 // @flow
-
-import config from 'lib/config';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
-const liveInUk =
-    config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
-    geolocationGetSync() === 'GB';
-const liveInUs =
-    config.get('switches.usSupporterTrafficToNewSupportFrontend') &&
-    geolocationGetSync() === 'US';
-const supportBaseURL = liveInUs
-    ? 'https://support.theguardian.com/us/contribute'
-    : 'https://support.theguardian.com/uk';
-const supportButtonCaption = 'Support the Guardian';
+const useSupportDomain = (): boolean =>
+    geolocationGetSync() === 'GB' || geolocationGetSync() === 'US';
 
-const useSupportDomain = (): boolean => liveInUk || liveInUs;
-const selectBaseUrl = (defaultUrl: string = supportBaseURL): string =>
-    useSupportDomain() ? supportBaseURL : defaultUrl;
-const selectEngagementBannerButtonCaption = (defaultCaption: string) =>
-    useSupportDomain() ? supportButtonCaption : defaultCaption;
+const supportBaseURL = useSupportDomain()
+    ? 'https://support.theguardian.com'
+    : 'https://membership.theguardian.com/supporter';
 
-export const supportFrontendLiveInUk = liveInUk;
-export const supportFrontendLiveInUs = liveInUs;
-export { useSupportDomain, selectBaseUrl, selectEngagementBannerButtonCaption };
+export { useSupportDomain, supportBaseURL };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-referrer-contribute-and-digipack.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-referrer-contribute-and-digipack.js
@@ -3,12 +3,12 @@ import type { CtaUrls } from 'common/modules/commercial/contributions-utilities'
 import config from 'lib/config';
 
 export const epicButtonsReferrerContributeAndDigipackTemplate = ({
-    membershipUrl = '',
+    supportUrl = '',
 }: CtaUrls) => {
     const button = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
-             href="${membershipUrl}&bundle=contribute-and-digipack"
+             href="${supportUrl}&bundle=contribute-and-digipack"
              target="_blank">
              Support the Guardian
             </a>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-referrer-just-contribute.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-referrer-just-contribute.js
@@ -3,12 +3,12 @@ import type { CtaUrls } from 'common/modules/commercial/contributions-utilities'
 import config from 'lib/config';
 
 export const epicButtonsReferrerJustContributeTemplate = ({
-    membershipUrl = '',
+    supportUrl = '',
 }: CtaUrls) => {
     const button = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
-             href="${membershipUrl}&bundle=contribute"
+             href="${supportUrl}&bundle=contribute"
              target="_blank">
              Support the Guardian
             </a>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-split-cta.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-split-cta.js
@@ -3,12 +3,12 @@ import type { CtaUrls } from 'common/modules/commercial/contributions-utilities'
 import config from 'lib/config';
 
 export const epicButtonsSplitCtaTemplate = ({
-    membershipUrl = '',
+    supportUrl = '',
 }: CtaUrls): string => {
     const contribButton = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-             href="${membershipUrl}&bundle=contribute"
+             href="${supportUrl}&bundle=contribute"
              target="_blank">
              Make a contribution
             </a>
@@ -16,7 +16,7 @@ export const epicButtonsSplitCtaTemplate = ({
     const subscribeButton = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-              href="${membershipUrl}&bundle=subscribe"
+              href="${supportUrl}&bundle=subscribe"
               target="_blank">
               Get a subscription
             </a>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -38,8 +38,11 @@ export const epicButtonsTemplate = (
 
     return `
         <div class="contributions__amount-field">
-            ${!useSupportDomain ? supportButtonBecome : supportButtonSupport}
-            ${!useSupportDomain ? contribButton : ''}
+            ${
+                useSupportDomain
+                    ? supportButtonSupport
+                    : supportButtonBecome + contribButton
+            }
             ${paymentLogos}
         </div>`;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -3,7 +3,7 @@ import type { CtaUrls } from 'common/modules/commercial/contributions-utilities'
 import config from 'lib/config';
 
 export const epicButtonsTemplate = (
-    { membershipUrl = '', contributeUrl = '' }: CtaUrls,
+    { supportUrl = '', contributeUrl = '' }: CtaUrls,
     useSupportDomain: boolean = false
 ) => {
     const contribButton = `
@@ -17,7 +17,7 @@ export const epicButtonsTemplate = (
     const supportButtonBecome = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-              href="${membershipUrl}"
+              href="${supportUrl}"
               target="_blank">
               Become a supporter
             </a>
@@ -25,7 +25,7 @@ export const epicButtonsTemplate = (
     const supportButtonSupport = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
-              href="${membershipUrl}"
+              href="${supportUrl}"
               target="_blank">
               Support the Guardian
             </a>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
@@ -53,7 +53,6 @@ export const acquisitionsEpicElectionInteractiveEnd = makeABTest({
                         copy: control,
                         componentName: variant.options.componentName,
                         buttonTemplate: defaultButtonTemplate({
-                            membershipUrl: variant.options.membershipURL,
                             contributeUrl: variant.options.contributeURL,
                             supportUrl: variant.options.supportURL,
                         }),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -7,7 +7,7 @@ import mediator from 'lib/mediator';
 import { elementInView } from 'lib/element-inview';
 import fastdom from 'lib/fastdom-promise';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { liveblog as liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
+import { liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
 
 const pageId: string = config.get('page.pageId', '');
 
@@ -165,7 +165,7 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
                 template(variant) {
                     return epicLiveBlogTemplate({
                         copy: liveblogCopy(
-                            variant.options.membershipURL,
+                            variant.options.supportURL,
                             variant.options.contributeURL
                         ),
                         componentName: variant.options.componentName,


### PR DESCRIPTION
## What does this change?
These switches are no longer necessary as we now know the `support.theguardian.com` to be reliable enough to not need a kill switch. 

This PR removes these switches from the codebase.

As part of this work, I am removing the `membershipBaseURL` from contributions utilities, and replacing it with `supportBaseURL`.  This variable carries the following values depending on the geolocation of the reader:

UK: https://support.theguardian.com/uk
US: https://support.theguardian.com/us/contribute
ROW: https://membership.theguardian.com/supporter

`contributeURL` never needs to be anything other than `https://contribute.theguardian.com`, so this PR also implements this behaviour