### PR TITLE
Post default consents when none are set via ajax consent journey

### DIFF
--- a/identity/app/utils/ConsentOrder.scala
+++ b/identity/app/utils/ConsentOrder.scala
@@ -22,8 +22,12 @@ object ConsentOrder {
     * @param consentHint optional hint which would move that particular consent to the front
     * @return copy of user with reordered consents
     */
-  def userWithOrderedConsents(userDO: User, consentHint: Option[String]): User =
-    userDO.copy(consents = hintedConsents(orderedConsents(userDO.consents), consentHint))
+  def userWithOrderedConsents(userDO: User, consentHint: Option[String]): User = {
+    val consentsToReorder =
+      if (userDO.consents.isEmpty) Consent.defaultConsents else userDO.consents
+
+    userDO.copy(consents = hintedConsents(orderedConsents(consentsToReorder), consentHint))
+  }
 
   /** If consentHint is provided it moves that consent to the head of consents list */
   private def hintedConsents(consents: List[Consent], consentHint: Option[String]): List[Consent] = {


### PR DESCRIPTION
## What does this change?

* If users do not select any consent during the consent journey then nothing is posted to IDAPI. This PR ensures default consents are posted in this case.

* If users do not have any consents, then ensure consents are still ordered.

## What is the value of this and can you measure success?

Bug fix.
