### PR TITLE
Move transition:none to explicitly need no-player.

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -125,10 +125,13 @@
 }
 
 .youtube-media-atom__play-button.vjs-control-text {
-    transition: none;
     overflow: hidden !important;
     display: inline-block;
     z-index: 2;
+}
+
+.no-player .youtube-media-atom__play-button.vjs-control-text {
+    transition: none;
 }
 
 .youtube-media-atom__bottom-bar {


### PR DESCRIPTION
## What does this change?

Somehow, the transition:none for nonplayable youtube atoms was affecting the mouseout for playable ones. This just increases specificity of the selector.

## What is the value of this and can you measure success?
Fixes animation.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
