### PR TITLE
Garnett: fix js-video-player

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -39,11 +39,7 @@ $fc-item-gutter: $gs-gutter / 4;
         }
     }
 
-    .fc-item__media-wrapper {
-        flex-basis: $media-width;
-    }
-
-    .fc-item__video-fallback {
+    .fc-item__media-wrapper, .fc-item__video-fallback {
         flex-basis: $media-width;
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -43,6 +43,10 @@ $fc-item-gutter: $gs-gutter / 4;
         flex-basis: $media-width;
     }
 
+    .fc-item__video-fallback {
+        flex-basis: $media-width;
+    }
+
     .fc-item__content {
         flex-basis: (100% - $media-width);
         // DAMN YOU IE10/11 FLEXWRAP BOX SIZING BUG


### PR DESCRIPTION
## What does this change?
Makes the video images show up in garnett
## What is the value of this and can you measure success?
It won't look broken.
## Does this affect other platforms - Amp, Apps, etc?
No.
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
