### PR TITLE
Downgrade weather error logging (attempt 2)

### DIFF
--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -1,6 +1,7 @@
 package weather
 
 import java.net.{URI, URLEncoder}
+import java.util.concurrent.TimeoutException
 
 import akka.actor.{ActorSystem, Scheduler}
 import common.{Logging, ResourcesHelper}
@@ -13,7 +14,8 @@ import weather.models.accuweather.{ForecastResponse, LocationResponse, WeatherRe
 import model.ApplicationContext
 
 import scala.concurrent.duration._
-import play.api.Mode
+import play.api.{MarkerContext, Mode}
+import net.logstash.logback.marker.Markers.append
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -54,11 +56,18 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
   }
 
   private def getJsonWithRetry(url: String): Future[JsValue] = {
-    WeatherApi.retryWeatherRequest(() => getJsonRequest(url), requestRetryDelay, actorSystem.scheduler, requestRetryMax).recover {
-      case NonFatal(error) =>
-        log.error(s"Error fetching $url - $error")
-        throw error
+    val weatherLogsMarkerContext: MarkerContext = MarkerContext(append("weatherRequestPath", url))
+    val weatherApiResponse: Future[JsValue] = WeatherApi.retryWeatherRequest(() => getJsonRequest(url), requestRetryDelay, actorSystem.scheduler, requestRetryMax)
+    weatherApiResponse.foreach {
+      case NonFatal(error: TimeoutException) =>
+        log.warn(
+          s"Request to weather api ($url) timed out (this is expected, especially at 0 and 30 mins past the hour due to" +
+          s" a problem with accuweather).", error)(weatherLogsMarkerContext)
+      case NonFatal(error: Throwable) =>
+        log.error("Weather API request failed", error)(weatherLogsMarkerContext)
+      case _ => Unit
     }
+    weatherApiResponse
   }
 
   private def getJsonRequest(url: String): Future[JsValue] = {


### PR DESCRIPTION
## What does this change?
This is https://github.com/guardian/frontend/pull/18538 with the [match error](https://kibana.gu-web.net/app/kibana#/doc/logstash-*/logstash-2017.12.22/logs?id=AWB98-ELyMgfs1D16pzz&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))) fixed, which previously caused an error to be thrown every time the request to the weather api was successful.

## Tested in CODE?
Yep
