### PR TITLE
Consent journey a11y fixes, round 2

### DIFF
--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -4,7 +4,6 @@
 <div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active} @if(isAnimated){dropdown--animated}">
     <button class="dropdown__button u-button-reset js-dropdown-button"
             type="button"
-            tabindex="0"
             data-link-name="Show dropdown: @if(isClientSideTemplate) {<%=name%>} else {@name}"
             aria-controls="@hash"
             aria-expanded="@{isActive.toString}">

--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -4,6 +4,7 @@
 <div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active} @if(isAnimated){dropdown--animated}">
     <button class="dropdown__button u-button-reset js-dropdown-button"
             type="button"
+            tabindex="0"
             data-link-name="Show dropdown: @if(isClientSideTemplate) {<%=name%>} else {@name}"
             aria-controls="@hash"
             aria-expanded="@{isActive.toString}">
@@ -11,10 +12,10 @@
         @fragments.inlineSvg("dropdown-mask", "icon", List("control", "modern-visible"))
     </button>
 
-    <label class="dropdown__toggle-label u-h"
+    <label class="dropdown__toggle-label"
            aria-controls="@hash"
            for="@{hash}__label">Show</label>
-    <input class="dropdown__toggle u-h"
+    <input class="dropdown__toggle"
             aria-controls="@hash"
             type="checkbox"
             id="@{hash}__label" />

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -30,7 +30,7 @@ object MembershipEditProfilePage extends IdentityPage("/membership/edit", "Membe
 object recurringContributionPage extends IdentityPage("/contribution/recurring/edit", "Contributions")
 object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
 
-sealed abstract class ConsentJourneyPage(id: String, val journey: String) extends IdentityPage(id, "Consent")
+sealed abstract class ConsentJourneyPage(id: String, val journey: String) extends IdentityPage(id, "Consent", isFlow = true)
 object ConsentJourneyPageAll extends ConsentJourneyPage("/consents/all", "all")
 object ConsentJourneyPageNewsletters extends ConsentJourneyPage("/consents/newsletters", "newsletters")
 object ConsentJourneyPageDefault extends ConsentJourneyPage("/consents", "default")

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -6,7 +6,8 @@ case class IdentityPage(
   id: String,
   webTitle: String,
   returnUrl: Option[String] = None,
-  registrationType: Option[String] = None) extends StandalonePage {
+  registrationType: Option[String] = None,
+  isFlow: Boolean = false ) extends StandalonePage {
 
   private val javascriptConfig = Seq(
     returnUrl.map("returnUrl" -> JsString(_)),

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -42,7 +42,7 @@ object IdentityHtmlPage {
           content
         ),
         inlineJSNonBlocking(),
-        views.html.layout.identityFooter(),
+        views.html.layout.identityFooter() when !page.isFlow,
         analytics.base()
       ),
       devTakeShot()

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -34,7 +34,7 @@
 
 @channelStep() = {
     @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
-        <div class="manage-account-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
+        <fieldset class="manage-account-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
 
             <h2 class="identity-title" id="consentWizardChannelsTitle">
                 How can we get in touch with you?
@@ -53,12 +53,12 @@
                 </div>
             </div>
 
-        </div>
+        </fieldset>
     }
 }
 
 @consentStep(journey:String) = {
-    <div class="manage-account-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
+    <fieldset class="manage-account-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
 
         <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
@@ -91,12 +91,12 @@
             </div>
         </form>
 
-    </div>
+    </fieldset>
 }
 
 @emailRepermissionStep() = {
     @if(emailRepermissionStepShouldDisplay) {
-        <div class="manage-account-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
+        <fieldset class="manage-account-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
 
             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
                 @views.html.helper.CSRF.formField
@@ -122,12 +122,12 @@
                     </ul>
                 </div>
             </form>
-        </div>
+        </fieldset>
     }
 }
 
 @emailSignupStep() = {
-    <div class="manage-account-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
+    <fieldset class="manage-account-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
 
         <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
@@ -142,7 +142,7 @@
                 @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
             </div>
         </form>
-    </div>
+    </fieldset>
 }
 
 @emailRepermissionOrSignupStep() = {
@@ -154,7 +154,7 @@
 }
 
 @endcardStep() = {
-    <div class="manage-account-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
+    <fieldset class="manage-account-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
         <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
             <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
             @views.html.helper.CSRF.formField
@@ -168,7 +168,7 @@
                 >Continue</button>
             </aside>
         </form>
-    </div>
+    </fieldset>
 }
 
 <div class="identity-wrapper-for-bg identity-wrapper-for-bg--overflows">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -155,11 +155,11 @@
 
 @endcardStep() = {
     <fieldset class="identity-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
-        <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
+        <form class="identity-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
             <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
             @views.html.helper.CSRF.formField
-            <h2 class="manage-account-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</h2>
-            <aside class="manage-account-consent-thanks__content">
+            <h2 class="identity-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</h2>
+            <aside class="identity-consent-thanks__content">
                 <p>Your support helps us deliver the quality independent journalism the world needs</p>
                 <button
                     type="submit"

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -155,19 +155,21 @@
 
 @endcardStep() = {
     <fieldset class="identity-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
-        <form class="identity-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
-            <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
-            @views.html.helper.CSRF.formField
-            <h2 class="identity-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</h2>
-            <aside class="identity-consent-thanks__content">
-                <p>Your support helps us deliver the quality independent journalism the world needs</p>
-                <button
-                    type="submit"
-                    class="manage-account__button"
-                    data-link-name="consents : submit"
-                >Continue</button>
-            </aside>
-        </form>
+        <div class="identity-consent-thanks__wrap">
+            <form class="identity-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
+                <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
+                @views.html.helper.CSRF.formField
+                <h2 class="identity-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</h2>
+                <aside class="identity-consent-thanks__content">
+                    <p>Your support helps us deliver the quality independent journalism the world needs</p>
+                    <button
+                        type="submit"
+                        class="manage-account__button"
+                        data-link-name="consents : submit"
+                    >Continue</button>
+                </aside>
+            </form>
+        </div>
     </fieldset>
 }
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -184,7 +184,6 @@
                     @journey match {
                         case "newsletters" => {
                             @emailRepermissionStep()
-                            @channelStep()
                         }
                         case "all" => {
                             @consentStep(journey = "all")

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -28,6 +28,10 @@
     }
 }
 
+@emailRepermissionStepShouldDisplay = @{
+    onlySubscribedToV1Newsletters.nonEmpty
+}
+
 @channelStep() = {
     @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
         <div class="manage-account-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
@@ -90,25 +94,19 @@
     </div>
 }
 
-@emailStep(isNarrow: Boolean = false) = {
-    @if(onlySubscribedToV1Newsletters.nonEmpty) {
+@emailRepermissionStep() = {
+    @if(emailRepermissionStepShouldDisplay) {
         <div class="manage-account-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
 
             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
                 @views.html.helper.CSRF.formField
                 @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-                @if(isNarrow) {
-                    <h2 class="identity-title" id="consentWizardEmailTitle">Sorry for the interruption</h2>
-                    <p class="identity-title-subtitle">
-                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                    </p>
-                } else {
-                    <h2 class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</h2>
-                    <p class="identity-title-subtitle">
-                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                    </p>
-                }
+                <h2 class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</h2>
+                <p class="identity-title-subtitle">
+                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
+                </p>
+
                 <div class="manage-account__switches">
                     <ul>
                     @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
@@ -147,6 +145,14 @@
     </div>
 }
 
+@emailRepermissionOrSignupStep() = {
+    @if(emailRepermissionStepShouldDisplay) {
+        @emailRepermissionStep()
+    } else {
+        @emailSignupStep()
+    }
+}
+
 @endcardStep() = {
     <div class="manage-account-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
         <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
@@ -177,17 +183,17 @@
 
                     @journey match {
                         case "newsletters" => {
-                            @emailStep(isNarrow = true)
+                            @emailRepermissionStep()
                             @channelStep()
                         }
                         case "all" => {
                             @consentStep(journey = "all")
-                            @emailStep()
+                            @emailRepermissionStep()
                             @channelStep()
                         }
                         case _ => {
-                            @consentStep("consent")
-                            @emailStep()
+                            @consentStep(journey = "consent")
+                            @emailRepermissionOrSignupStep()
                             @channelStep()
                         }
                     }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -202,16 +202,16 @@
                     <div class="identity-wizard__controls">
                         <button
                             data-link-name="consents : navigation : prev"
-                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
+                            class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
                         >
                             <span class="u-h">Previous</span>
                             @fragments.inlineSvg("arrow-left-stem", "icon")
                         </button>
-                        <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
+                        <div class="identity-consent-wizard__revealable identity-consent-wizard-counter">
                         </div>
                         <button
                             data-link-name="consents : navigation : next"
-                            class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next manage-account__button--icon--rotate-down"
+                            class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
                         >
                             <span>Next</span>
                             @fragments.inlineSvg("arrow-right", "icon")

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -36,9 +36,9 @@
     @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
         <fieldset class="identity-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
 
-            <h2 class="identity-title" id="consentWizardChannelsTitle">
+            <legend class="identity-title" id="consentWizardChannelsTitle">
                 How can we get in touch with you?
-            </h2>
+            </legend>
             <p class="identity-title-subtitle">
                 Besides email, are there any other ways you would like us to get in touch with you?
             </p>
@@ -64,14 +64,14 @@
             @views.html.helper.CSRF.formField
 
             @if(journey == "all") {
-                <h2 class="identity-title" id="consentWizardConsentTitle">
+                <legend class="identity-title" id="consentWizardConsentTitle">
                     We need you to consent again to receiving communications from The Guardian
-                </h2>
+                </legend>
                 <p class="identity-title-subtitle">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
             } else {
-                <h2 class="identity-title" id="consentWizardConsentTitle">
+                <legend class="identity-title" id="consentWizardConsentTitle">
                     What would you like to hear about?
-                </h2>
+                </legend>
                 <p class="identity-title-subtitle">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
             }
             <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
@@ -102,7 +102,7 @@
                 @views.html.helper.CSRF.formField
                 @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-                <h2 class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</h2>
+                <legend class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</legend>
                 <p class="identity-title-subtitle">
                     You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
                 </p>
@@ -133,7 +133,7 @@
             @views.html.helper.CSRF.formField
             @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-            <h2 class="identity-title" id="consentWizardEmailSignupTitle">Your newsletters</h2>
+            <legend class="identity-title" id="consentWizardEmailSignupTitle">Your newsletters</legend>
             <p class="identity-title-subtitle">
                 Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below. Just so you know, your newsletter might include messages about how you can support the Guardian, as well as our events, jobs, masterclasses and holidays.
             </p>
@@ -159,7 +159,7 @@
             <form class="identity-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
                 <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
                 @views.html.helper.CSRF.formField
-                <h2 class="identity-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</h2>
+                <legend class="identity-consent-thanks__title" id="consentWizardEmailSignupTitle">Thank you</legend>
                 <aside class="identity-consent-thanks__content">
                     <p>Your support helps us deliver the quality independent journalism the world needs</p>
                     <button

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -34,7 +34,7 @@
 
 @channelStep() = {
     @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
-        <fieldset class="manage-account-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
+        <fieldset class="identity-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
 
             <h2 class="identity-title" id="consentWizardChannelsTitle">
                 How can we get in touch with you?
@@ -58,7 +58,7 @@
 }
 
 @consentStep(journey:String) = {
-    <fieldset class="manage-account-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
+    <fieldset class="identity-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
 
         <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
@@ -96,7 +96,7 @@
 
 @emailRepermissionStep() = {
     @if(emailRepermissionStepShouldDisplay) {
-        <fieldset class="manage-account-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
+        <fieldset class="identity-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
 
             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
                 @views.html.helper.CSRF.formField
@@ -127,7 +127,7 @@
 }
 
 @emailSignupStep() = {
-    <fieldset class="manage-account-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
+    <fieldset class="identity-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
 
         <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
@@ -154,7 +154,7 @@
 }
 
 @endcardStep() = {
-    <fieldset class="manage-account-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
+    <fieldset class="identity-wizard__step" data-wizard-step-name="endcard" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
         <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
             <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
             @views.html.helper.CSRF.formField
@@ -179,7 +179,7 @@
 
                 <div class="js-errorHolder manage-account__errors"></div>
 
-                <div class="manage-account-wizard manage-account-wizard--consent" data-journey="@journey" data-component="identity-consent-journey-@journey">
+                <div class="identity-wizard identity-wizard--consent" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
                     @journey match {
                         case "newsletters" => {
@@ -199,10 +199,10 @@
 
                     @endcardStep()
 
-                    <div class="manage-account-wizard__controls">
+                    <div class="identity-wizard__controls">
                         <button
                             data-link-name="consents : navigation : prev"
-                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev"
+                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
                         >
                             <span class="u-h">Previous</span>
                             @fragments.inlineSvg("arrow-left-stem", "icon")

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -122,6 +122,7 @@ const shouldNextButtonScroll = (): Promise<boolean> =>
     );
 
 const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
+
     const check = () =>
         shouldNextButtonScroll().then(shouldIt =>
             fastdom.write(() => {
@@ -133,8 +134,9 @@ const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
         );
 
     mediator.on('window:throttledScroll', debounce(check, 100));
-
-    check();
+    window.addEventListener(wizardPageChangedEv, ev => {
+        check();
+    });
 };
 
 const bindNextButton = (buttonEl: HTMLElement): void => {

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -55,7 +55,7 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
             fastdom
                 .read(() => [
                     wizardEl.getElementsByClassName(
-                        'manage-account-wizard__step'
+                        'identity-wizard__step'
                     ).length,
                     [
                         ...document.getElementsByClassName(
@@ -140,7 +140,7 @@ const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
 
 const bindNextButton = (buttonEl: HTMLElement): void => {
     const wizardEl: ?Element = buttonEl.closest(
-        '.manage-account-wizard--consent'
+        '.identity-wizard--consent'
     );
     if (wizardEl && wizardEl instanceof HTMLElement) {
         buttonEl.addEventListener('click', (ev: Event) => {
@@ -193,7 +193,7 @@ const createEmailConsentCounter = (counterEl: HTMLElement): void => {
 const enhanceConsentWizard = (): void => {
     const loaders = [
         ['.manage-account-consent-wizard-counter', createEmailConsentCounter],
-        ['.manage-account-wizard--consent', bindEmailConsentCounterToWizard],
+        ['.identity-wizard--consent', bindEmailConsentCounterToWizard],
         ['.js-manage-account-consent-wizard__next', bindNextButton],
         ['.js-manage-account-consent-wizard__next', bindScrollForNextButton],
     ];

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -122,7 +122,6 @@ const shouldNextButtonScroll = (): Promise<boolean> =>
     );
 
 const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
-
     const check = () =>
         shouldNextButtonScroll().then(shouldIt =>
             fastdom.write(() => {
@@ -134,7 +133,7 @@ const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
         );
 
     mediator.on('window:throttledScroll', debounce(check, 100));
-    window.addEventListener(wizardPageChangedEv, ev => {
+    window.addEventListener(wizardPageChangedEv, () => {
         check();
     });
 };

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -59,12 +59,12 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                     ).length,
                     [
                         ...document.getElementsByClassName(
-                            'manage-account-consent-wizard-counter'
+                            'identity-consent-wizard-counter'
                         ),
                     ][0],
                     [
                         ...document.getElementsByClassName(
-                            'manage-account-consent-wizard-button-back'
+                            'identity-consent-wizard-button-back'
                         ),
                     ][0],
                 ])
@@ -95,7 +95,7 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                                     );
                                 }
                                 buttonBackEl.classList.toggle(
-                                    'manage-account-consent-wizard__revealable--visible',
+                                    'identity-consent-wizard__revealable--visible',
                                     displayButtonBack
                                 );
                             }
@@ -106,7 +106,7 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                                 (!displayCounter).toString()
                             );
                             counterEl.classList.toggle(
-                                'manage-account-consent-wizard__revealable--visible',
+                                'identity-consent-wizard__revealable--visible',
                                 displayCounter
                             );
                         })
@@ -170,9 +170,9 @@ const createEmailConsentCounter = (counterEl: HTMLElement): void => {
     const checkboxesEl = getEmailCheckboxes();
 
     indicatorEl.classList.add(
-        'manage-account-consent-wizard-counter__indicator'
+        'identity-consent-wizard-counter__indicator'
     );
-    textEl.classList.add('manage-account-consent-wizard-counter__text');
+    textEl.classList.add('identity-consent-wizard-counter__text');
 
     updateCounterIndicator(indicatorEl, checkboxesEl);
 
@@ -192,10 +192,10 @@ const createEmailConsentCounter = (counterEl: HTMLElement): void => {
 
 const enhanceConsentWizard = (): void => {
     const loaders = [
-        ['.manage-account-consent-wizard-counter', createEmailConsentCounter],
+        ['.identity-consent-wizard-counter', createEmailConsentCounter],
         ['.identity-wizard--consent', bindEmailConsentCounterToWizard],
-        ['.js-manage-account-consent-wizard__next', bindNextButton],
-        ['.js-manage-account-consent-wizard__next', bindScrollForNextButton],
+        ['.js-identity-consent-wizard__next', bindNextButton],
+        ['.js-identity-consent-wizard__next', bindScrollForNextButton],
     ];
     loadEnhancers(loaders);
 };

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -54,9 +54,8 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
         if (ev.target === wizardEl) {
             fastdom
                 .read(() => [
-                    wizardEl.getElementsByClassName(
-                        'identity-wizard__step'
-                    ).length,
+                    wizardEl.getElementsByClassName('identity-wizard__step')
+                        .length,
                     [
                         ...document.getElementsByClassName(
                             'identity-consent-wizard-counter'
@@ -139,9 +138,7 @@ const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
 };
 
 const bindNextButton = (buttonEl: HTMLElement): void => {
-    const wizardEl: ?Element = buttonEl.closest(
-        '.identity-wizard--consent'
-    );
+    const wizardEl: ?Element = buttonEl.closest('.identity-wizard--consent');
     if (wizardEl && wizardEl instanceof HTMLElement) {
         buttonEl.addEventListener('click', (ev: Event) => {
             ev.preventDefault();
@@ -169,9 +166,7 @@ const createEmailConsentCounter = (counterEl: HTMLElement): void => {
     const textEl = document.createElement('div');
     const checkboxesEl = getEmailCheckboxes();
 
-    indicatorEl.classList.add(
-        'identity-consent-wizard-counter__indicator'
-    );
+    indicatorEl.classList.add('identity-consent-wizard-counter__indicator');
     textEl.classList.add('identity-consent-wizard-counter__text');
 
     updateCounterIndicator(indicatorEl, checkboxesEl);

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -3,18 +3,18 @@
 import fastdom from 'lib/fastdom-promise';
 import { scrollTo } from 'lib/scroller';
 
-const completedClassname = 'manage-account-wizard--completed';
-const pagerClassname = 'manage-account-wizard__controls-pager';
-const nextButtonElClassname = 'js-manage-account-wizard__next';
-const prevButtonElClassname = 'js-manage-account-wizard__prev';
-const containerClassname = 'manage-account-wizard';
+const completedClassname = 'identity-wizard--completed';
+const pagerClassname = 'identity-wizard__controls-pager';
+const nextButtonElClassname = 'js-identity-wizard__next';
+const prevButtonElClassname = 'js-identity-wizard__prev';
+const containerClassname = 'identity-wizard';
 
-const stepClassname = 'manage-account-wizard__step';
-const stepHiddenClassname = 'manage-account-wizard__step--hidden';
-const stepOutClassname = 'manage-account-wizard__step--out';
-const stepInClassname = 'manage-account-wizard__step--in';
-const stepOutReverseClassname = 'manage-account-wizard__step--out-reverse';
-const stepInReverseClassname = 'manage-account-wizard__step--in-reverse';
+const stepClassname = 'identity-wizard__step';
+const stepHiddenClassname = 'identity-wizard__step--hidden';
+const stepOutClassname = 'identity-wizard__step--out';
+const stepInClassname = 'identity-wizard__step--in';
+const stepOutReverseClassname = 'identity-wizard__step--out-reverse';
+const stepInReverseClassname = 'identity-wizard__step--in-reverse';
 const stepTransitionClassnames = [
     stepInClassname,
     stepInReverseClassname,

--- a/static/src/javascripts/projects/common/modules/identity/wizard.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.spec.js
@@ -78,8 +78,7 @@ test('only the first element should be visible', () => {
             `.identity-wizard__step:nth-child(${index + 1})`
         );
         expect(
-            stepEl &&
-                stepEl.classList.contains('identity-wizard__step--hidden')
+            stepEl && stepEl.classList.contains('identity-wizard__step--hidden')
         ).toEqual(index !== 0);
     });
 });
@@ -93,9 +92,7 @@ test('only the second element should be visible after moving', () => {
             );
             expect(
                 stepEl &&
-                    stepEl.classList.contains(
-                        'identity-wizard__step--hidden'
-                    )
+                    stepEl.classList.contains('identity-wizard__step--hidden')
             ).toEqual(index !== 2);
         });
     });

--- a/static/src/javascripts/projects/common/modules/identity/wizard.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.spec.js
@@ -10,13 +10,13 @@ beforeEach(() => {
     if (document.body) {
         document.body.innerHTML = `
             <div class="${containerClassname}">
-                <div class="manage-account-wizard__step">1</div>
-                <div class="manage-account-wizard__step">2</div> 
-                <div class="manage-account-wizard__step">3</div> 
-                <div class="manage-account-wizard__step">4</div> 
-                <div class="manage-account-wizard__controls-pager">
-                    <div class="js-manage-account-wizard__next"></div>
-                    <div class="js-manage-account-wizard__prev"></div>
+                <div class="identity-wizard__step">1</div>
+                <div class="identity-wizard__step">2</div> 
+                <div class="identity-wizard__step">3</div> 
+                <div class="identity-wizard__step">4</div> 
+                <div class="identity-wizard__controls-pager">
+                    <div class="js-identity-wizard__next"></div>
+                    <div class="js-identity-wizard__prev"></div>
                 </div>
             </div>
         `;
@@ -24,8 +24,8 @@ beforeEach(() => {
     return enhance(document.getElementsByClassName(containerClassname)[0]);
 });
 
-test('containerClassname must be manage-account-wizard', () => {
-    expect(containerClassname).toEqual('manage-account-wizard');
+test('containerClassname must be identity-wizard', () => {
+    expect(containerClassname).toEqual('identity-wizard');
 });
 
 test('data-position is set', () => {
@@ -50,7 +50,7 @@ test('data-position is updated when value is off-range', () => {
 test('move-next works', () => {
     const wizardEl = document.getElementsByClassName(containerClassname)[0];
     const moveEl = document.getElementsByClassName(
-        'js-manage-account-wizard__next'
+        'js-identity-wizard__next'
     )[0];
     moveEl.dispatchEvent(new Event('click'));
     setTimeout(() => {
@@ -61,7 +61,7 @@ test('move-next works', () => {
 test('move-prev works', () => {
     const wizardEl = document.getElementsByClassName(containerClassname)[0];
     const moveEl = document.getElementsByClassName(
-        'js-manage-account-wizard__prev'
+        'js-identity-wizard__prev'
     )[0];
 
     return setPosition(wizardEl, 2).then(() => {
@@ -75,11 +75,11 @@ test('move-prev works', () => {
 test('only the first element should be visible', () => {
     steps.forEach((step, index) => {
         const stepEl = document.querySelector(
-            `.manage-account-wizard__step:nth-child(${index + 1})`
+            `.identity-wizard__step:nth-child(${index + 1})`
         );
         expect(
             stepEl &&
-                stepEl.classList.contains('manage-account-wizard__step--hidden')
+                stepEl.classList.contains('identity-wizard__step--hidden')
         ).toEqual(index !== 0);
     });
 });
@@ -89,12 +89,12 @@ test('only the second element should be visible after moving', () => {
     return setPosition(wizardEl, 2).then(() => {
         steps.forEach((step, index) => {
             const stepEl = document.querySelector(
-                `.manage-account-wizard__step:nth-child(${index + 1})`
+                `.identity-wizard__step:nth-child(${index + 1})`
             );
             expect(
                 stepEl &&
                     stepEl.classList.contains(
-                        'manage-account-wizard__step--hidden'
+                        'identity-wizard__step--hidden'
                     )
             ).toEqual(index !== 2);
         });
@@ -105,7 +105,7 @@ test('wizard gets completed on final step', () => {
     const wizardEl = document.getElementsByClassName(containerClassname)[0];
     return setPosition(wizardEl, steps.length - 1).then(() => {
         expect(
-            wizardEl.classList.contains('manage-account-wizard--completed')
+            wizardEl.classList.contains('identity-wizard--completed')
         ).toEqual(true);
     });
 });

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -10,7 +10,6 @@ const updateAria = (container: Element): void => {
     const v: boolean = container.classList.contains('dropdown--active');
     const content = [...container.getElementsByClassName(contentCN)];
     const button = container.getElementsByClassName(buttonCN);
-
     content.forEach((c: Element) => {
         c.setAttribute('aria-hidden', (!v).toString());
     });
@@ -31,9 +30,13 @@ const init = (): void => {
                     const isActive: boolean = container.classList.contains(
                         'dropdown--active'
                     );
-                    const isAnimated: boolean = container.classList.contains(
-                        'dropdown--animated'
-                    );
+                    const isAnimated: boolean =
+                        container.classList.contains(
+                            'dropdown--animated'
+                        )
+                        && document.documentElement
+                        && !document.documentElement.classList.contains('disable-flashing-elements')
+                    ;
                     const contentEstimatedHeight =
                         content.offsetHeight !== undefined &&
                         content.offsetHeight < window.innerHeight
@@ -85,7 +88,6 @@ const init = (): void => {
                                             'transitionend',
                                             () => {
                                                 fastdom.write(() => {
-                                                    updateAria(container);
                                                     content.style.height =
                                                         'auto';
                                                     container.style.pointerEvents =
@@ -95,7 +97,8 @@ const init = (): void => {
                                                             'dropdown--active'
                                                         );
                                                     }
-                                                });
+                                                    updateAria(container);
+                                                })
                                             }
                                         );
                                     });

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -26,17 +26,19 @@ const init = (): void => {
         if (container) {
             fastdom
                 .read(() => {
+                    const documentElement: ?HTMLElement =
+                        document.documentElement;
                     const content = container.querySelector(`.${contentCN}`);
                     const isActive: boolean = container.classList.contains(
                         'dropdown--active'
                     );
                     const isAnimated: boolean =
-                        container.classList.contains(
-                            'dropdown--animated'
-                        )
-                        && document.documentElement
-                        && !document.documentElement.classList.contains('disable-flashing-elements')
-                    ;
+                        container.classList.contains('dropdown--animated') &&
+                        (documentElement !== null &&
+                            documentElement !== undefined &&
+                            documentElement.classList.contains(
+                                'disable-flashing-elements'
+                            ) === false);
                     const contentEstimatedHeight =
                         content.offsetHeight !== undefined &&
                         content.offsetHeight < window.innerHeight
@@ -98,7 +100,7 @@ const init = (): void => {
                                                         );
                                                     }
                                                     updateAria(container);
-                                                })
+                                                });
                                             }
                                         );
                                     });

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -27,6 +27,10 @@
         color: $neutral-1;
         text-align: left;
 
+        &:focus {
+            color: $guardian-brand;
+        }
+
         .control {
             border-color: $neutral-5;
             float: right;

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -57,13 +57,18 @@
     }
 }
 
+.js-on .dropdown__toggle-label,
+.js-on .dropdown__toggle {
+    display: none;
+}
+
 .dropdown__content {
     transition: height .2s linear;
 }
 
 .dropdown__toggle:checked + .dropdown__content,
 .dropdown--active .dropdown__content,
-.dropdown--animated.dropdown--active .dropdown__content {
+html:not(.disable-flashing-elements) .dropdown--animated.dropdown--active .dropdown__content {
     position: static;
     visibility: visible;
     pointer-events: all;
@@ -77,13 +82,14 @@
     overflow: hidden;
 }
 
-.dropdown--animated .dropdown__content {
+html:not(.disable-flashing-elements) .dropdown--animated .dropdown__content {
     display: block;
     overflow: hidden;
     position: fixed;
     top: -9999em;
     left: -9999em;
     visibility: hidden;
+    height: auto;
     pointer-events: none;
     transition: height .2s linear;
     /*

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -1,9 +1,9 @@
-.manage-account-wizard--consent {
-    .manage-account-wizard__step {
+.identity-wizard--consent {
+    .identity-wizard__step {
         min-height: 72vh;
         padding: $gs-gutter 0;
     }
-    .manage-account-wizard__controls {
+    .identity-wizard__controls {
         padding: $gs-gutter;
         margin-top: $gs-gutter;
         background: #ffffff;

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -16,7 +16,7 @@
         margin-right: $gs-gutter * -1;
         justify-content: space-between;
     }
-    .manage-account-consent-wizard-counter {
+    .identity-consent-wizard-counter {
         flex: 1 1 auto;
         margin: 0 $gs-gutter / 3;
     }
@@ -27,23 +27,23 @@
     }
 }
 
-.manage-account-consent-wizard__revealable {
+.identity-consent-wizard__revealable {
     will-change: transform, opacity;
     transform: translateX($gs-gutter/4);
     opacity: 0;
     transition: .2s linear;
 }
-.manage-account-consent-wizard__revealable--visible {
+.identity-consent-wizard__revealable--visible {
     transform: translateX(0);
     opacity: 1;
 }
 
-.manage-account-consent-wizard-counter {
+.identity-consent-wizard-counter {
     @include fs-textSans(2);
     color: $identity-main;
 }
 
-.manage-account-consent-wizard-counter__indicator {
+.identity-consent-wizard-counter__indicator {
     display: inline;
     font-weight: 800;
     @supports(display: flex) {
@@ -60,7 +60,7 @@
     }
 }
 
-.manage-account-consent-wizard-counter__text {
+.identity-consent-wizard-counter__text {
     display: inline;
     vertical-align: middle;
     margin-left: $gs-gutter/4;

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -20,7 +20,7 @@
         flex: 1 1 auto;
         margin: 0 $gs-gutter / 3;
     }
-    &[data-journey=repermission], &[data-journey=repermission-narrow] {
+    &[data-journey=all], &[data-journey=newsletters] {
         .manage-account__switch-footer-email-preview {
             display: none;
         }

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -67,6 +67,14 @@
 }
 
 
+.identity-consent-thanks__wrap {
+    @supports(display: flex) and (min-height: 1vh) {
+        min-height: 60vh;
+        display: flex;
+        align-items: center;
+    }
+}
+
 
 .identity-consent-thanks {
     @include mq(desktop) {

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -68,7 +68,7 @@
 
 
 
-.manage-account-consent-thanks {
+.identity-consent-thanks {
     @include mq(desktop) {
         display: grid;
         grid-column-gap: $gs-gutter * 4;
@@ -79,7 +79,7 @@
     }
 }
 
-.manage-account-consent-thanks__title {
+.identity-consent-thanks__title {
     @include fs-headline(8);
     color: $identity-main;
     font-weight: 800;
@@ -94,7 +94,7 @@
     }
 }
 
-.manage-account-consent-thanks__content {
+.identity-consent-thanks__content {
 
     @include mq(desktop) {
         grid-column: 3;

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -16,6 +16,7 @@
     right: 0;
     will-change: transform;
     outline: none;
+    border: none;
 }
 .js-off .manage-account-wizard__step {
     border: 1px solid $neutral-8;

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -16,7 +16,7 @@
     right: 0;
     will-change: transform;
     outline: none;
-    border: none;
+    border: 0;
 }
 .js-off .identity-wizard__step {
     border: 1px solid $neutral-8;

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -1,16 +1,16 @@
-.manage-account-wizard {
+.identity-wizard {
     @include clearfix();
     position: relative;
     transition: min-height .2s;
     will-change: min-height;
 }
-.manage-account-wizard--completed {
-    .manage-account-wizard__controls {
+.identity-wizard--completed {
+    .identity-wizard__controls {
         display: none;
     }
 }
 
-.manage-account-wizard__step {
+.identity-wizard__step {
     top: 0;
     left: 0;
     right: 0;
@@ -18,49 +18,49 @@
     outline: none;
     border: none;
 }
-.js-off .manage-account-wizard__step {
+.js-off .identity-wizard__step {
     border: 1px solid $neutral-8;
     margin-bottom: $gs-gutter*4;
     padding-bottom: $gs-gutter*4;
 }
-.manage-account-wizard__step--hidden {
+.identity-wizard__step--hidden {
     display: none;
 }
-.manage-account-wizard__step--out {
+.identity-wizard__step--out {
     display: block;
     position: absolute;
-    animation: manage-account-wizard__fadeLeft .2s both;
-    .disable-flashing-elements .manage-account-wizard__step--out {
+    animation: identity-wizard__fadeLeft .2s both;
+    .disable-flashing-elements .identity-wizard__step--out {
         animation: none;
         display: none;
     }
 }
-.manage-account-wizard__step--in {
-    animation: manage-account-wizard__fadeRight .2s reverse both;
-    .disable-flashing-elements .manage-account-wizard__step--in {
+.identity-wizard__step--in {
+    animation: identity-wizard__fadeRight .2s reverse both;
+    .disable-flashing-elements .identity-wizard__step--in {
         animation: none;
         display: block;
     }
 }
-.manage-account-wizard__step--out-reverse {
+.identity-wizard__step--out-reverse {
     display: block;
     position: absolute;
-    animation: manage-account-wizard__fadeRight .2s both;
-    .disable-flashing-elements .manage-account-wizard__step--out-reverse {
+    animation: identity-wizard__fadeRight .2s both;
+    .disable-flashing-elements .identity-wizard__step--out-reverse {
         animation: none;
         display: none;
     }
 }
-.manage-account-wizard__step--in-reverse {
-    animation: manage-account-wizard__fadeLeft .2s reverse both;
-    .disable-flashing-elements .manage-account-wizard__step--in-reverse {
+.identity-wizard__step--in-reverse {
+    animation: identity-wizard__fadeLeft .2s reverse both;
+    .disable-flashing-elements .identity-wizard__step--in-reverse {
         animation: none;
         display: block;
     }
 }
 
 
-.manage-account-wizard__controls {
+.identity-wizard__controls {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -69,7 +69,7 @@
     }
 }
 
-.manage-account-wizard__controls-pager {
+.identity-wizard__controls-pager {
     @include fs-textSans(1);
     @include mq($until: tablet) {
         display: none;
@@ -81,7 +81,7 @@
 for a .2s transition
 */
 
-@keyframes manage-account-wizard__fadeLeft {
+@keyframes identity-wizard__fadeLeft {
     from {
         transform: translateX(0);
         opacity: 1;
@@ -92,7 +92,7 @@ for a .2s transition
     }
 }
 
-@keyframes manage-account-wizard__fadeRight {
+@keyframes identity-wizard__fadeRight {
     from {
         transform: translateX(0);
         opacity: 1;


### PR DESCRIPTION
## What does this change?
Minor tweaks (all over the place sadly) to improve the consent journey's accesibility, namely:

- 🎋  Fix dropdowns not working without js, give them a focus state
- 🎋  Better autofocus after clicking `next` by making wizard pages themselves focused instead of their first element
- 🎋  Wizard pages become `fieldset` elements and their titles `legend` 
- 🎋  The continue button better reflects state