### PR TITLE
admin app audit switches

### DIFF
--- a/admin/app/controllers/AdminAudit.scala
+++ b/admin/app/controllers/AdminAudit.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import conf.switches.Switch
+import play.api.Logger
+import play.api.mvc.{Request, Result, Results}
+
+import scala.concurrent.Future
+
+object AdminAudit extends Results {
+  private def unavailableMessage[A]()(implicit request: Request[A]) = {
+    Logger.warn(s"Request to removed feature ${request.path}")
+    ServiceUnavailable(s"If you want to use this feature, contact the Dotcom Platform Team regarding ${request.path}")
+  }
+
+  def endpointAudit[A](switch: Switch)(result: => Result)(implicit request: Request[A]): Result = {
+    if (switch.isSwitchedOn) unavailableMessage() else result
+  }
+
+  def endpointAuditF[A](switch: Switch)(result: => Future[Result])(implicit request: Request[A]): Future[Result] = {
+    if (switch.isSwitchedOn) Future.successful(unavailableMessage()) else result
+  }
+}

--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -2,6 +2,8 @@ package controllers.admin
 
 import conf.Configuration
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import implicits.Strings
 import play.api.mvc._
 import play.api.libs.ws.WSClient
@@ -9,55 +11,63 @@ import model.NoCache
 
 class Api(wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with Logging with ImplicitControllerExecutionContext with Strings {
 
-  def proxy(path: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val queryString = request.queryString.map { p =>
-       "%s=%s".format(p._1, p._2.head.urlEncoded)
-    }.mkString("&")
+  def proxy(path: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiProxy) {
+      val queryString = request.queryString.map { p =>
+        "%s=%s".format(p._1, p._2.head.urlEncoded)
+      }.mkString("&")
 
-    val url = s"${Configuration.contentApi.contentApiHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+      val url = s"${Configuration.contentApi.contentApiHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
-    log.info("Proxying tag API query to: %s" format url)
+      log.info("Proxying tag API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def tag(q: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val url = "%s/tags?format=json&page-size=50%s&callback=%s&q=%s".format(
-      Configuration.contentApi.contentApiHost,
-      Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
-      callback.javascriptEscaped.urlEncoded,
-      q.javascriptEscaped.urlEncoded
-    )
+  def tag(q: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiTag) {
+      val url = "%s/tags?format=json&page-size=50%s&callback=%s&q=%s".format(
+        Configuration.contentApi.contentApiHost,
+        Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
+        callback.javascriptEscaped.urlEncoded,
+        q.javascriptEscaped.urlEncoded
+      )
 
-    log.info("Proxying tag API query to: %s" format url)
+      log.info("Proxying tag API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def item(path: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val url = "%s/%s?format=json&page-size=1%s&callback=%s".format(
-      Configuration.contentApi.contentApiHost,
-      path.javascriptEscaped.urlEncoded,
-      Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
-      callback.javascriptEscaped.urlEncoded
-    )
+  def item(path: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiItem) {
+      val url = "%s/%s?format=json&page-size=1%s&callback=%s".format(
+        Configuration.contentApi.contentApiHost,
+        path.javascriptEscaped.urlEncoded,
+        Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
+        callback.javascriptEscaped.urlEncoded
+      )
 
-    log.info("Proxying item API query to: %s" format url)
+      log.info("Proxying item API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def json(url: String): Action[AnyContent] = Action.async { request =>
-    log.info("Proxying json request to: %s" format url)
+  def json(url: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveJsonProxy) {
+      log.info("Proxying json request to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/json"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/json"))
+      }
     }
   }
 }

--- a/admin/app/controllers/OphanApiController.scala
+++ b/admin/app/controllers/OphanApiController.scala
@@ -1,22 +1,30 @@
 package controllers.admin
 
 import common.ImplicitControllerExecutionContext
+import conf.switches.Switches
+import controllers.AdminAudit
 import play.api.mvc._
 import services.OphanApi
 import model.NoCache
 
 class OphanApiController(ophanApi: OphanApi, val controllerComponents: ControllerComponents) extends BaseController with ImplicitControllerExecutionContext {
 
-  def pageViews(path: String): Action[AnyContent] = Action.async { request =>
-    ophanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
+  def pageViews(path: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
-  def platformPageViews: Action[AnyContent] = Action.async { request =>
-    ophanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
+  def platformPageViews: Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
-  def adsRenderTime: Action[AnyContent] = Action.async { request =>
-    ophanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
+  def adsRenderTime: Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
 }

--- a/admin/app/controllers/R2PressController.scala
+++ b/admin/app/controllers/R2PressController.scala
@@ -3,6 +3,8 @@ package controllers.admin
 import java.io.File
 
 import common.{AkkaAsync, ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import model.{ApplicationContext, R2PressMessage}
 import play.api.mvc._
 import services.{R2PagePressNotifier, R2PressedPageTakedownNotifier}
@@ -14,7 +16,9 @@ class R2PressController(
   extends BaseController with Logging with ImplicitControllerExecutionContext {
 
   def pressForm(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty): Action[AnyContent] = Action { implicit request =>
-    Ok(views.html.pressR2(urlMsgs, fileMsgs))
+    AdminAudit.endpointAudit(Switches.AdminRemovePressR2) {
+      Ok(views.html.pressR2(urlMsgs, fileMsgs))
+    }
   }
 
   def batchUpload(): Action[AnyContent] = Action { implicit request =>

--- a/admin/app/controllers/SportTroubleshooterController.scala
+++ b/admin/app/controllers/SportTroubleshooterController.scala
@@ -2,15 +2,21 @@ package controllers.admin
 
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import common.Logging
+import conf.switches.Switches
+import controllers.AdminAudit
 import model.{ApplicationContext, NoCache}
 
 class SportTroubleshooterController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends BaseController with Logging {
 
   def renderFootballTroubleshooter(): Action[AnyContent] = Action { implicit request =>
-    NoCache(Ok(views.html.footballTroubleshooter()))
+    AdminAudit.endpointAudit(Switches.AdminRemoveTroubleshootFootball) {
+      NoCache(Ok(views.html.footballTroubleshooter()))
+    }
   }
 
   def renderCricketTroubleshooter(): Action[AnyContent] = Action { implicit request =>
-    NoCache(Ok(views.html.cricketTroubleshooter()))
+    AdminAudit.endpointAudit(Switches.AdminRemoveTroubleshootCricket) {
+      NoCache(Ok(views.html.cricketTroubleshooter()))
+    }
   }
 }

--- a/admin/app/controllers/SportTroubleshooterController.scala
+++ b/admin/app/controllers/SportTroubleshooterController.scala
@@ -2,21 +2,15 @@ package controllers.admin
 
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import common.Logging
-import conf.switches.Switches
-import controllers.AdminAudit
 import model.{ApplicationContext, NoCache}
 
 class SportTroubleshooterController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends BaseController with Logging {
 
   def renderFootballTroubleshooter(): Action[AnyContent] = Action { implicit request =>
-    AdminAudit.endpointAudit(Switches.AdminRemoveTroubleshootFootball) {
-      NoCache(Ok(views.html.footballTroubleshooter()))
-    }
+    NoCache(Ok(views.html.footballTroubleshooter()))
   }
 
   def renderCricketTroubleshooter(): Action[AnyContent] = Action { implicit request =>
-    AdminAudit.endpointAudit(Switches.AdminRemoveTroubleshootCricket) {
-      NoCache(Ok(views.html.cricketTroubleshooter()))
-    }
+    NoCache(Ok(views.html.cricketTroubleshooter()))
   }
 }

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,6 +1,8 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import model.ApplicationContext
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
@@ -8,26 +10,28 @@ import tools._
 class AnalyticsConfidenceController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
   extends BaseController with Logging with ImplicitControllerExecutionContext {
   def renderConfidence(): Action[AnyContent] = Action.async { implicit request =>
-    for {
-      ophan <- CloudWatch.ophanConfidence()
-      google <- CloudWatch.googleConfidence()
-    } yield {
-      val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
-      val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
+    AdminAudit.endpointAuditF(Switches.AdminRemoveAnalyticsConfidence) {
+      for {
+        ophan <- CloudWatch.ophanConfidence()
+        google <- CloudWatch.googleConfidence()
+      } yield {
+        val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
+        val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
 
-      val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-        override lazy val dataset = ophan.dataset.map{ point =>
-          point.copy(values =  point.values :+ ophanAverage)
+        val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+          override lazy val dataset = ophan.dataset.map { point =>
+            point.copy(values = point.values :+ ophanAverage)
+          }
         }
-      }
 
-      val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-        override lazy val dataset = google.dataset.map{ point =>
-          point.copy(values =  point.values :+ googleAverage)
+        val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+          override lazy val dataset = google.dataset.map { point =>
+            point.copy(values = point.values :+ googleAverage)
+          }
         }
-      }
 
-      Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
+        Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
+      }
     }
   }
 }

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,8 +1,6 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
-import conf.switches.Switches
-import controllers.AdminAudit
 import model.ApplicationContext
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
@@ -10,28 +8,26 @@ import tools._
 class AnalyticsConfidenceController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
   extends BaseController with Logging with ImplicitControllerExecutionContext {
   def renderConfidence(): Action[AnyContent] = Action.async { implicit request =>
-    AdminAudit.endpointAuditF(Switches.AdminRemoveAnalyticsConfidence) {
-      for {
-        ophan <- CloudWatch.ophanConfidence()
-        google <- CloudWatch.googleConfidence()
-      } yield {
-        val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
-        val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
+    for {
+      ophan <- CloudWatch.ophanConfidence()
+      google <- CloudWatch.googleConfidence()
+    } yield {
+      val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
+      val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
 
-        val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-          override lazy val dataset = ophan.dataset.map { point =>
-            point.copy(values = point.values :+ ophanAverage)
-          }
+      val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+        override lazy val dataset = ophan.dataset.map { point =>
+          point.copy(values = point.values :+ ophanAverage)
         }
-
-        val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-          override lazy val dataset = google.dataset.map { point =>
-            point.copy(values = point.values :+ googleAverage)
-          }
-        }
-
-        Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
       }
+
+      val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+        override lazy val dataset = google.dataset.map { point =>
+          point.copy(values = point.values :+ googleAverage)
+        }
+      }
+
+      Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
     }
   }
 }

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -1,13 +1,13 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
 import model.{ApplicationContext, NoCache}
 import conf.{Configuration, Static}
-
-import scala.concurrent.Future
+import controllers.AdminAudit
 
 class MetricsController(
   wsClient: WSClient,
@@ -44,9 +44,11 @@ class MetricsController(
   }
 
   def renderGooglebot404s(): Action[AnyContent] = Action.async { implicit request =>
-    for {
-      googleBot404s <- HttpErrors.googlebot404s()
-    } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
+    AdminAudit.endpointAuditF(Switches.AdminRemoveMetricsGooglebot) {
+      for {
+        googleBot404s <- HttpErrors.googlebot404s()
+      } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
+    }
   }
 
   def renderAfg(): Action[AnyContent] = Action.async { implicit request =>

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -44,11 +44,9 @@ class MetricsController(
   }
 
   def renderGooglebot404s(): Action[AnyContent] = Action.async { implicit request =>
-    AdminAudit.endpointAuditF(Switches.AdminRemoveMetricsGooglebot) {
-      for {
-        googleBot404s <- HttpErrors.googlebot404s()
-      } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
-    }
+    for {
+      googleBot404s <- HttpErrors.googlebot404s()
+    } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
   }
 
   def renderAfg(): Action[AnyContent] = Action.async { implicit request =>

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -13,6 +13,8 @@ import conf.Configuration
 import scala.concurrent.Future
 import pa._
 import concurrent.FutureOpt
+import conf.switches.Switches
+import controllers.AdminAudit
 import org.joda.time.LocalDate
 import football.model.SnapFields
 import pa.Season
@@ -29,8 +31,10 @@ class FrontsController(
   val SNAP_CSS = "football"
 
   def index: Action[AnyContent] = Action.async { implicit request =>
-    fetchCompetitionsAndTeams.map {
-      case (competitions, teams) => Cached(3600)(RevalidatableResult.Ok(views.html.football.fronts.index(competitions, teams)))
+    AdminAudit.endpointAuditF(Switches.AdminRemoveAdminFootballFronts) {
+      fetchCompetitionsAndTeams.map {
+        case (competitions, teams) => Cached(3600)(RevalidatableResult.Ok(views.html.football.fronts.index(competitions, teams)))
+      }
     }
   }
 

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -6,6 +6,8 @@ import football.services.PaFootballClient
 import pa.{PlayerAppearances, PlayerProfile, StatsSummary}
 import implicits.Requests
 import common.{ImplicitControllerExecutionContext, JsonComponent, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import org.joda.time.LocalDate
 import football.model.PA
 
@@ -19,8 +21,10 @@ import play.api.libs.ws.WSClient
 class PlayerController(val wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit val context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with PaFootballClient with Requests with Logging {
 
   def playerIndex: Action[AnyContent] = Action.async { implicit request =>
-    fetchCompetitionsAndTeams.map {
-      case (competitions, teams) => Cached(600)(RevalidatableResult.Ok(views.html.football.player.playerIndex(competitions, teams)))
+    AdminAudit.endpointAuditF(Switches.AdminRemoveAdminFootballPlayer) {
+      fetchCompetitionsAndTeams.map {
+        case (competitions, teams) => Cached(600)(RevalidatableResult.Ok(views.html.football.player.playerIndex(competitions, teams)))
+      }
     }
   }
 

--- a/admin/app/football/controllers/SiteController.scala
+++ b/admin/app/football/controllers/SiteController.scala
@@ -1,6 +1,8 @@
 package controllers.admin
 
 import common.ImplicitControllerExecutionContext
+import conf.switches.Switches
+import controllers.AdminAudit
 import model.{ApplicationContext, Cached}
 import model.Cached.RevalidatableResult
 import play.api.mvc._
@@ -8,7 +10,9 @@ import play.api.mvc._
 class SiteController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext {
 
   def index: Action[AnyContent] = Action { implicit request =>
-    Cached(60)(RevalidatableResult.Ok(views.html.football.index()))
+    AdminAudit.endpointAudit(Switches.AdminRemoveAdminFootball) {
+      Cached(60)(RevalidatableResult.Ok(views.html.football.index()))
+    }
   }
 
 }

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -1,6 +1,8 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import football.model.PA
 import football.services.PaFootballClient
 import model.Cached.RevalidatableResult
@@ -15,11 +17,13 @@ import scala.concurrent.Future
 class TablesController(val wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit val context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with PaFootballClient with Logging {
 
   def tablesIndex: Action[AnyContent] = Action.async { implicit request =>
-    for {
-      allCompetitions <- client.competitions
-    } yield {
-      val filteredCompetitions = PA.filterCompetitions(allCompetitions)
-      Cached(60)(RevalidatableResult.Ok(views.html.football.leagueTables.tablesIndex(filteredCompetitions, PA.teams.all)))
+    AdminAudit.endpointAuditF(Switches.AdminRemoveAdminFootballTables) {
+      for {
+        allCompetitions <- client.competitions
+      } yield {
+        val filteredCompetitions = PA.filterCompetitions(allCompetitions)
+        Cached(60)(RevalidatableResult.Ok(views.html.football.leagueTables.tablesIndex(filteredCompetitions, PA.teams.all)))
+      }
     }
   }
 

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -1,6 +1,6 @@
 package football
 
-
+import _root_.conf.switches.Switches
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
 import play.api.test._
 import play.api.test.Helpers._
@@ -16,6 +16,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestWsClient}
 
 
   "test index page loads" in {
+    Switches.AdminRemoveAdminFootball.switchOff()
     val Some(result) = route(app, FakeRequest(GET, "/admin/football"))
     status(result) should equal(OK)
   }

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -1,6 +1,5 @@
 package football
 
-import _root_.conf.switches.Switches
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
 import play.api.test._
 import play.api.test.Helpers._
@@ -16,7 +15,6 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestWsClient}
 
 
   "test index page loads" in {
-    Switches.AdminRemoveAdminFootball.switchOff()
     val Some(result) = route(app, FakeRequest(GET, "/admin/football"))
     status(result) should equal(OK)
   }

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -1,6 +1,5 @@
 package football
 
-import _root_.conf.switches.Switches
 import _root_.controllers.admin.TablesController
 import football.model.PA
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
@@ -23,7 +22,6 @@ import scala.language.postfixOps
     with WithTestApplicationContext {
 
   "test tables index page loads with leagues" in {
-    Switches.AdminRemoveAdminFootballTables.switchOff()
     val Some(result) = route(app, FakeRequest(GET, "/admin/football/tables"))
     status(result) should equal(OK)
     val content = contentAsString(result)

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -1,6 +1,6 @@
 package football
 
-
+import _root_.conf.switches.Switches
 import _root_.controllers.admin.TablesController
 import football.model.PA
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
@@ -23,6 +23,7 @@ import scala.language.postfixOps
     with WithTestApplicationContext {
 
   "test tables index page loads with leagues" in {
+    Switches.AdminRemoveAdminFootballTables.switchOff()
     val Some(result) = route(app, FakeRequest(GET, "/admin/football/tables"))
     status(result) should equal(OK)
     val content = contentAsString(result)

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -502,7 +502,7 @@ trait FeatureSwitches {
     "admin-audit-remove-press-r2",
     "When ON, the /press/r2 page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -512,7 +512,7 @@ trait FeatureSwitches {
     "admin-audit-remove-admin-football",
     "When ON, the /admin/football page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -522,7 +522,7 @@ trait FeatureSwitches {
     "admin-audit-remove-admin-football-tables",
     "When ON, the /admin/football/tables page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -532,7 +532,7 @@ trait FeatureSwitches {
     "admin-audit-remove-admin-player",
     "When ON, the /admin/football/player page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -542,7 +542,7 @@ trait FeatureSwitches {
     "admin-audit-remove-admin-football-fronts",
     "When ON, the /admin/football/fronts page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -552,7 +552,7 @@ trait FeatureSwitches {
     "admin-audit-remove-troubleshoot-football",
     "When ON, the /troubleshoot/football page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
@@ -562,7 +562,7 @@ trait FeatureSwitches {
     "admin-audit-remove-troubleshoot-cricket",
     "When ON, the /troubleshoot/cricket page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -566,4 +566,77 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
+
+
+
+
+  val AdminRemoveApiProxy = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-proxy",
+    "When ON, the /api/proxy page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveApiTag = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-tag",
+    "When ON, the /api/tag page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveApiItem = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-item",
+    "When ON, the /api/item page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveJsonProxy = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-json-proxy",
+    "When ON, the /josn/proxy page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveOphan = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-ophan",
+    "When ON, the /ophan page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAnalyticsConfidence = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-analytics-confidence",
+    "When ON, the /analytics/confidence page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveMetricsGooglebot = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-metrics-googlebot",
+    "When ON, the /metrics/googlebot page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -567,9 +567,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-
-
-
   val AdminRemoveApiProxy = Switch(
     SwitchGroup.Feature,
     "admin-audit-remove-api-proxy",

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -494,4 +494,76 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 1, 11),
     exposeClientSide = true
   )
+
+  // Admin Audit Switches:
+
+  val AdminRemovePressR2 = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-press-r2",
+    "When ON, the /press/r2 page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAdminFootball = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-admin-football",
+    "When ON, the /admin/football page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAdminFootballTables = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-admin-football-tables",
+    "When ON, the /admin/football/tables page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAdminFootballPlayer = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-admin-player",
+    "When ON, the /admin/football/player page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAdminFootballFronts = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-admin-football-fronts",
+    "When ON, the /admin/football/fronts page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveTroubleshootFootball = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-troubleshoot-football",
+    "When ON, the /troubleshoot/football page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveTroubleshootCricket = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-troubleshoot-cricket",
+    "When ON, the /troubleshoot/cricket page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -547,26 +547,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val AdminRemoveTroubleshootFootball = Switch(
-    SwitchGroup.Feature,
-    "admin-audit-remove-troubleshoot-football",
-    "When ON, the /troubleshoot/football page returns 503",
-    owners = Seq(Owner.withGithub("quarpt")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 1),
-    exposeClientSide = false
-  )
-
-  val AdminRemoveTroubleshootCricket = Switch(
-    SwitchGroup.Feature,
-    "admin-audit-remove-troubleshoot-cricket",
-    "When ON, the /troubleshoot/cricket page returns 503",
-    owners = Seq(Owner.withGithub("quarpt")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 1),
-    exposeClientSide = false
-  )
-
   val AdminRemoveApiProxy = Switch(
     SwitchGroup.Feature,
     "admin-audit-remove-api-proxy",
@@ -617,20 +597,20 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val AdminRemoveAnalyticsConfidence = Switch(
+  val AdminRemoveRadiator = Switch(
     SwitchGroup.Feature,
-    "admin-audit-remove-analytics-confidence",
-    "When ON, the /analytics/confidence page returns 503",
+    "admin-audit-remove-radiator",
+    "When ON, the /radiator page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
 
-  val AdminRemoveMetricsGooglebot = Switch(
+  val AdminRemoveRadiatorCommit = Switch(
     SwitchGroup.Feature,
-    "admin-audit-remove-metrics-googlebot",
-    "When ON, the /metrics/googlebot page returns 503",
+    "admin-audit-remove-radiator-commit",
+    "When ON, the /radiator/commit/*hash page returns 503",
     owners = Seq(Owner.withGithub("quarpt")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 3, 1),


### PR DESCRIPTION
## What does this change?
Puts these endpoints behind feature switches:
```
/admin/football/*

/api/proxy/*path
/api/tag
/api/item/*path

/json/proxy/*absUrl

/radiator
/radiator/commit/*hash
/ophan/pageviews/*path
/ophan/pageviews
/ophan/ads/render-time
```
## What is the value of this and can you measure success?

If no one complains we can remove the endpoints and simplify the admin app

## Tested in CODE?

Locally
