### PR TITLE
admin app audit switches 2

### DIFF
--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -2,6 +2,8 @@ package controllers.admin
 
 import conf.Configuration
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import implicits.Strings
 import play.api.mvc._
 import play.api.libs.ws.WSClient
@@ -9,55 +11,63 @@ import model.NoCache
 
 class Api(wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with Logging with ImplicitControllerExecutionContext with Strings {
 
-  def proxy(path: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val queryString = request.queryString.map { p =>
-       "%s=%s".format(p._1, p._2.head.urlEncoded)
-    }.mkString("&")
+  def proxy(path: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiProxy) {
+      val queryString = request.queryString.map { p =>
+        "%s=%s".format(p._1, p._2.head.urlEncoded)
+      }.mkString("&")
 
-    val url = s"${Configuration.contentApi.contentApiHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+      val url = s"${Configuration.contentApi.contentApiHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
-    log.info("Proxying tag API query to: %s" format url)
+      log.info("Proxying tag API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def tag(q: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val url = "%s/tags?format=json&page-size=50%s&callback=%s&q=%s".format(
-      Configuration.contentApi.contentApiHost,
-      Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
-      callback.javascriptEscaped.urlEncoded,
-      q.javascriptEscaped.urlEncoded
-    )
+  def tag(q: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiTag) {
+      val url = "%s/tags?format=json&page-size=50%s&callback=%s&q=%s".format(
+        Configuration.contentApi.contentApiHost,
+        Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
+        callback.javascriptEscaped.urlEncoded,
+        q.javascriptEscaped.urlEncoded
+      )
 
-    log.info("Proxying tag API query to: %s" format url)
+      log.info("Proxying tag API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def item(path: String, callback: String): Action[AnyContent] = Action.async { request =>
-    val url = "%s/%s?format=json&page-size=1%s&callback=%s".format(
-      Configuration.contentApi.contentApiHost,
-      path.javascriptEscaped.urlEncoded,
-      Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
-      callback.javascriptEscaped.urlEncoded
-    )
+  def item(path: String, callback: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveApiItem) {
+      val url = "%s/%s?format=json&page-size=1%s&callback=%s".format(
+        Configuration.contentApi.contentApiHost,
+        path.javascriptEscaped.urlEncoded,
+        Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
+        callback.javascriptEscaped.urlEncoded
+      )
 
-    log.info("Proxying item API query to: %s" format url)
+      log.info("Proxying item API query to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/javascript"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/javascript"))
+      }
     }
   }
 
-  def json(url: String): Action[AnyContent] = Action.async { request =>
-    log.info("Proxying json request to: %s" format url)
+  def json(url: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveJsonProxy) {
+      log.info("Proxying json request to: %s" format url)
 
-    wsClient.url(url).get().map { response =>
-      NoCache(Ok(response.body).as("application/json"))
+      wsClient.url(url).get().map { response =>
+        NoCache(Ok(response.body).as("application/json"))
+      }
     }
   }
 }

--- a/admin/app/controllers/OphanApiController.scala
+++ b/admin/app/controllers/OphanApiController.scala
@@ -1,22 +1,30 @@
 package controllers.admin
 
 import common.ImplicitControllerExecutionContext
+import conf.switches.Switches
+import controllers.AdminAudit
 import play.api.mvc._
 import services.OphanApi
 import model.NoCache
 
 class OphanApiController(ophanApi: OphanApi, val controllerComponents: ControllerComponents) extends BaseController with ImplicitControllerExecutionContext {
 
-  def pageViews(path: String): Action[AnyContent] = Action.async { request =>
-    ophanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
+  def pageViews(path: String): Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
-  def platformPageViews: Action[AnyContent] = Action.async { request =>
-    ophanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
+  def platformPageViews: Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
-  def adsRenderTime: Action[AnyContent] = Action.async { request =>
-    ophanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
+  def adsRenderTime: Action[AnyContent] = Action.async { implicit request =>
+    AdminAudit.endpointAuditF(Switches.AdminRemoveOphan) {
+      ophanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
+    }
   }
 
 }

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,6 +1,8 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
+import controllers.AdminAudit
 import model.ApplicationContext
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
@@ -8,26 +10,28 @@ import tools._
 class AnalyticsConfidenceController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
   extends BaseController with Logging with ImplicitControllerExecutionContext {
   def renderConfidence(): Action[AnyContent] = Action.async { implicit request =>
-    for {
-      ophan <- CloudWatch.ophanConfidence()
-      google <- CloudWatch.googleConfidence()
-    } yield {
-      val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
-      val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
+    AdminAudit.endpointAuditF(Switches.AdminRemoveAnalyticsConfidence) {
+      for {
+        ophan <- CloudWatch.ophanConfidence()
+        google <- CloudWatch.googleConfidence()
+      } yield {
+        val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
+        val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
 
-      val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-        override lazy val dataset = ophan.dataset.map{ point =>
-          point.copy(values =  point.values :+ ophanAverage)
+        val ophanGraph = new AwsLineChart("Ophan confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+          override lazy val dataset = ophan.dataset.map { point =>
+            point.copy(values = point.values :+ ophanAverage)
+          }
         }
-      }
 
-      val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
-        override lazy val dataset = google.dataset.map{ point =>
-          point.copy(values =  point.values :+ googleAverage)
+        val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+          override lazy val dataset = google.dataset.map { point =>
+            point.copy(values = point.values :+ googleAverage)
+          }
         }
-      }
 
-      Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
+        Ok(views.html.lineCharts(Seq(ophanGraph, googleGraph)))
+      }
     }
   }
 }

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -1,13 +1,13 @@
 package controllers.admin
 
 import common.{ImplicitControllerExecutionContext, Logging}
+import conf.switches.Switches
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
 import model.{ApplicationContext, NoCache}
 import conf.{Configuration, Static}
-
-import scala.concurrent.Future
+import controllers.AdminAudit
 
 class MetricsController(
   wsClient: WSClient,
@@ -44,9 +44,11 @@ class MetricsController(
   }
 
   def renderGooglebot404s(): Action[AnyContent] = Action.async { implicit request =>
-    for {
-      googleBot404s <- HttpErrors.googlebot404s()
-    } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
+    AdminAudit.endpointAuditF(Switches.AdminRemoveMetricsGooglebot) {
+      for {
+        googleBot404s <- HttpErrors.googlebot404s()
+      } yield NoCache(Ok(views.html.lineCharts(googleBot404s, Some("GoogleBot 404s"))))
+    }
   }
 
   def renderAfg(): Action[AnyContent] = Action.async { implicit request =>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -638,9 +638,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-
-
-
   val AdminRemoveApiProxy = Switch(
     SwitchGroup.Feature,
     "admin-audit-remove-api-proxy",

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -637,4 +637,77 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
+
+
+
+
+  val AdminRemoveApiProxy = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-proxy",
+    "When ON, the /api/proxy page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveApiTag = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-tag",
+    "When ON, the /api/tag page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveApiItem = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-api-item",
+    "When ON, the /api/item page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveJsonProxy = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-json-proxy",
+    "When ON, the /josn/proxy page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveOphan = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-ophan",
+    "When ON, the /ophan page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveAnalyticsConfidence = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-analytics-confidence",
+    "When ON, the /analytics/confidence page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
+
+  val AdminRemoveMetricsGooglebot = Switch(
+    SwitchGroup.Feature,
+    "admin-audit-remove-metrics-googlebot",
+    "When ON, the /metrics/googlebot page returns 503",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+  )
 }


### PR DESCRIPTION
## What does this change?

Put admin miscellaneous behind switches before we turn them off

## What is the value of this and can you measure success?

Eventually remove unused endpoints before we remove them from the codebase.

## Tested in CODE?

Locally
