### PR TITLE
Tidy up V2 consent layout on /email-prefs

### DIFF
--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -35,23 +35,31 @@
 
         <div class="js-errorHolder manage-account__errors"></div>
 
-        <h2 class="manage-account-header">Would you like to receive information from the Guardian and their partners?</h2>
-        <p class="identity-title-subtitle">The Guardian and their partners would like to occasionally send you information about their products, services and events</p>
-        <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
-            <div class="manage-account__switches">
-                <ul>
-                @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
-                    <li>
-                        @if(index == 0) {
-                            @fragments.consentSwitch(consentField, consentHint)(messages)
-                        } else {
-                            @fragments.consentSwitch(consentField)(messages)
-                        }
-                    </li>
-                }
-                </ul>
+        <fieldset class="fieldset fieldset--manage-account-noborder">
+
+            <div class="fieldset__heading">
+                <h2 class="form__heading">What would you like to hear about?</h2>
+                <p class="form__note">The Guardian and their partners would like to occasionally send you information about their products, services and events</p>
             </div>
-        </div>
+
+            <div class="fieldset__fields">
+
+                <div class="manage-account__switches manage-account__switches--single-column">
+                    <ul>
+                    @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
+                        <li>
+                            @if(index == 0) {
+                                @fragments.consentSwitch(consentField, consentHint)(messages)
+                            } else {
+                                @fragments.consentSwitch(consentField)(messages)
+                            }
+                        </li>
+                    }
+                    </ul>
+                </div>
+            </div>
+
+        </fieldset>
 
         <fieldset class="fieldset fieldset--manage-account-rightsubmit js-manage-account__ajaxForm-submit">
             <div class="fieldset__heading"></div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -107,7 +107,14 @@
 @* CHANNELS *@
 @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
     <hr class="manage-account-divider" />
-    <h2 class="form__heading">How can we get in touch with you?</h2>
-    @channelConsentForm
+
+    <fieldset class="fieldset fieldset--manage-account-noborder">
+        <div class="fieldset__heading">
+            <h2 class="form__heading">How can we get in touch with you?</h2>
+        </div>
+        <div class="fieldset__fields">
+            @channelConsentForm
+        </div>
+    </fieldset>
 }
 @registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -101,13 +101,13 @@
 
 @* NEWSLETTERS *@
 <hr class="manage-account-divider" />
-<h2 class="manage-account-header">Select which newsletters you would like to receive</h2>
+<h2 class="form__heading">Select which newsletters you would like to receive</h2>
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
 
 @* CHANNELS *@
 @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
     <hr class="manage-account-divider" />
-    <h2 class="manage-account-header">How can we get in touch with you?</h2>
+    <h2 class="form__heading">How can we get in touch with you?</h2>
     @channelConsentForm
 }
 @registrationFooter(idRequest, idUrlBuilder)

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -18,7 +18,6 @@ $checkbox-size: $gs-gutter / 1.25;
 
     ul {
         display: grid;
-        padding-top: $local-gutter;
         grid-row-gap: $row-gutter;
         grid-column-gap: $row-gutter;
         grid-template-columns: repeat(1, 1fr);

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -33,6 +33,11 @@ $checkbox-size: $gs-gutter / 1.25;
         grid-template-columns: repeat(1, 1fr);
     }
 
+    &.manage-account__switches--single-column ul {
+        grid-template-columns: repeat(1, 1fr);
+        grid-auto-rows: min-content;
+    }
+
     li {
         display: flex;
         margin-bottom: $local-gutter;


### PR DESCRIPTION
## What does this change?
The V2 consent layout on `/email-prefs` was still using a 2 column layout and looked kind of too heavy handed vs the lighter V1 one, so I changed it. All the scope of this PR is hidden under flags so it shouldn't be noticeable on prod (except for the email preferences title. I made it match the rest of titles in the page, as it sort of sticks out in V1 now)

## What is the value of this and can you measure success?
The page will look more familiar after the V2 rollout.

Not only this makes me happier but also @stephanfowler wanted the consent list in a single column for the journey page . so that's 2 birds in one stone! Now all the consent lists show up in 1 column.

## Do you have lots of screenshots?
So many! (the scope of this pr is the page itself, the header shifts a bit between screenshots due other build differences)

![screen shot 2017-12-22 at 16 15 42](https://user-images.githubusercontent.com/11539094/34304918-c26cb21a-e733-11e7-9152-9a5dc262325f.png)
![screen shot 2017-12-22 at 16 15 49](https://user-images.githubusercontent.com/11539094/34304919-c2b0650a-e733-11e7-9cba-14d6293ac480.png)
![screen shot 2017-12-22 at 16 16 20](https://user-images.githubusercontent.com/11539094/34304920-c2c46500-e733-11e7-9d79-1f52dd2e400f.png)

## Is something else bothering you?
Yes! The newsletter preferences should ideally adopt this layout too, which makes the whole page have a much nicer vertical flow AND makes the accordion look less like section dividers and more like an actual dropdown. 

I left this alone for a separate PR because this change warrants discussion/testing

### Doesn't the V2 page have a nice vertical flow _now_ before this pr?
Almost but nope, the newsletter options break into two columns Plus honestly? the whole thing is just too wide and the rest of pages use the proposed layout
