### PR TITLE
Garnett: correct colour timestamp in liveblog garnett cards (facia)

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -23,7 +23,7 @@
             color: #ffffff;
         }
 
-        .fc-trail__count--commentcount {
+        .fc-item__meta {
             color: $color2;
 
             .inline-icon {


### PR DESCRIPTION
## What does this change?

Applies correct font/icon colour on timestamps in liveblog garnett cards

## What is the value of this and can you measure success?

N/A

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No