### PR TITLE
Garnett: Remove line height override for byline (facia)

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -204,8 +204,6 @@ $fc-item-gutter: $gs-gutter / 4;
 .fc-item__byline {
     margin-bottom: 0;
     font-style: italic;
-    //close up the line height to make it look the same as the headline
-    line-height: 15px;
     letter-spacing: .2px;
 }
 


### PR DESCRIPTION
## What does this change?

The byline line-height on Garnett facia cards had been overridden and set to 15px, this caused the first and second line of a byline to overlap in Garnett. This PR removes this line height override for bylines, which fixes the overlap issue.

## What is the value of this and can you measure success?

N/A

## Does this affect other platforms - Amp, Apps, etc?

N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

No
