### PR TITLE
Football stats line spacing fixed

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1,6 +1,7 @@
 $quote-tail: 25px;
 $quote-mark: 35px;
 
+
 .content {
     padding-bottom: 0;
 }
@@ -1148,4 +1149,36 @@ $quote-mark: 35px;
     height: 100%;
     display: block;
     object-fit: cover;
+}
+// *************** Football ***************
+
+.content--type-article {
+    .team__info {
+        @include fs-headlineGarnett(3);
+
+        @include mq(mobileLandscape) {
+            @include fs-headlineGarnett(4);
+        }
+    }
+    .match-summary--responsive {
+        .team__info {
+            @include fs-headlineGarnett(7);
+        }
+    }
+    .goal-attempts__off-target,
+    .goal-attempts__on-target {
+        @include fs-headerGarnett(2);
+        line-height: $gs-baseline * 1.5;
+    }
+
+    .chart--football-possession {
+        .chart__label-value {
+            @include fs-headerGarnett(5);
+        }
+    }
+    .bar-fight__bar {
+        @include fs-headerGarnett(2);
+        line-height: $gs-baseline * 1.5;
+        padding: $gs-baseline/6 ($gs-gutter/4)+3  $gs-baseline/2;
+    }
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1,7 +1,6 @@
 $quote-tail: 25px;
 $quote-mark: 35px;
 
-
 .content {
     padding-bottom: 0;
 }

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -10,6 +10,13 @@ $font-scale: (
         4: (font-size: 22, line-height: 28),
         5: (font-size: 24, line-height: 28),
     ),
+    headerGarnett: (
+        1: (font-size: 14, line-height: 18),
+        2: (font-size: 16, line-height: 20),
+        3: (font-size: 18, line-height: 20),
+        4: (font-size: 20, line-height: 24),
+        5: (font-size: 22, line-height: 24),
+    ),
     headline: (
         1: (font-size: 14, line-height: 18),
         2: (font-size: 16, line-height: 20),
@@ -28,6 +35,7 @@ $font-scale: (
         4: (font-size: 28, line-height: 32),
         5: (font-size: 30, line-height: 34),
         6: (font-size: 34, line-height: 38),
+        7: (font-size: 38, line-height: 46),
     ),
     bodyHeading: (
         1: (font-size: 14, line-height: 22),
@@ -77,6 +85,19 @@ $font-scale: (
 
     @if $size-only == false {
         @include f-header;
+    }
+}
+
+@mixin f-headerGarnett {
+    font-family: $f-serif-headline;
+    font-weight: 900;
+}
+
+@mixin fs-headerGarnett($level, $size-only: false) {
+    @include font-size(get-font-size(header, $level), get-line-height(header, $level));
+
+    @if $size-only == false {
+        @include f-headerGarnett;
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6727874/34389164-07d3d338-eb30-11e7-862b-8d4b59d0e1de.png)

Fixed some odd spacing on team info and match stats. Introduced header styles for Garnett.