### PR TITLE
Show an error when javascript is disabled in /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -8,7 +8,7 @@
 @import views.support.fragment.Switch._
 @import views.support.fragment.ConsentChannel._
 @import conf.switches.Switches.IdentityShowCommunicationChannelConsents
-@import common.{LinkTo}
+@import common.LinkTo
 
 
 @(
@@ -188,7 +188,7 @@
                             Setting your preferences requires a browser with Javascript enabled.
                         </p>
                         <p>
-                            Please consider upgrading to one of our <a href="@LinkTo {/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo {/info/tech-feedback}">contact us</a>.
+                            Please consider upgrading to one of our <a href="@LinkTo(/help/recommended-browsers)">recommended browsers</a>. If you need more help please <a href="@LinkTo(/info/tech-feedback)">contact us</a>.
                         </p>
                     </div>
                 </noscript>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -8,6 +8,7 @@
 @import views.support.fragment.Switch._
 @import views.support.fragment.ConsentChannel._
 @import conf.switches.Switches.IdentityShowCommunicationChannelConsents
+@import common.{LinkTo}
 
 
 @(
@@ -181,7 +182,16 @@
 
                 <div class="js-errorHolder manage-account__errors"></div>
 
-                <div class="identity-wizard identity-wizard--consent" data-journey="@journey" data-component="identity-consent-journey-@journey">
+                <noscript>
+                    <div class="form__error">
+                        <strong>
+                            Sorry!
+                        </strong>
+                        At this time updating your preferences in the Guardian requires Javascript to be enabled in your browser. If this is a problem, please contact <a href="@LinkTo {/info/tech-feedback}">user help</a> who will be able to assist you.
+                    </div>
+                </noscript>
+
+                <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
                     @journey match {
                         case "newsletters" => {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -188,7 +188,7 @@
                             Setting your preferences requires a browser with Javascript enabled.
                         </p>
                         <p>
-                            Please consider upgrading to one of our <a href="@LinkTo(/help/recommended-browsers)">recommended browsers</a>. If you need more help please <a href="@LinkTo(/info/tech-feedback)">contact us</a>.
+                            Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
                         </p>
                     </div>
                 </noscript>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -184,10 +184,13 @@
 
                 <noscript>
                     <div class="form__error">
-                        <strong>
-                            Sorry!
-                        </strong>
-                        At this time updating your preferences in the Guardian requires Javascript to be enabled in your browser. If this is a problem, please contact <a href="@LinkTo {/info/tech-feedback}">user help</a> who will be able to assist you.
+                        <p>
+                            <strong>Sorry!</strong>
+                            Setting your preferences in the Guardian requires a browser with Javascript enabled.
+                        </p>
+                        <p>
+                            Please consider upgrading to one of our <a href="@LinkTo {/help/recommended-browsers}">recommended browsers</a>. If you need more help, please <a href="@LinkTo {/info/tech-feedback}">contact us</a>.
+                        </p>
                     </div>
                 </noscript>
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -185,11 +185,10 @@
                 <noscript>
                     <div class="form__error">
                         <p>
-                            <strong>Sorry!</strong>
-                            Setting your preferences in the Guardian requires a browser with Javascript enabled.
+                            Setting your preferences requires a browser with Javascript enabled.
                         </p>
                         <p>
-                            Please consider upgrading to one of our <a href="@LinkTo {/help/recommended-browsers}">recommended browsers</a>. If you need more help, please <a href="@LinkTo {/info/tech-feedback}">contact us</a>.
+                            Please consider upgrading to one of our <a href="@LinkTo {/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo {/info/tech-feedback}">contact us</a>.
                         </p>
                     </div>
                 </noscript>

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -138,6 +138,9 @@ const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
     });
 };
 
+const showWizard = (wizardEl: HTMLElement): Promise<void> =>
+    fastdom.write(() => wizardEl.classList.remove('u-h'));
+
 const bindNextButton = (buttonEl: HTMLElement): void => {
     const wizardEl: ?Element = buttonEl.closest('.identity-wizard--consent');
     if (wizardEl && wizardEl instanceof HTMLElement) {
@@ -190,6 +193,7 @@ const enhanceConsentWizard = (): void => {
     const loaders = [
         ['.identity-consent-wizard-counter', createEmailConsentCounter],
         ['.identity-wizard--consent', bindEmailConsentCounterToWizard],
+        ['.identity-wizard--consent', showWizard],
         ['.js-identity-consent-wizard__next', bindNextButton],
         ['.js-identity-consent-wizard__next', bindScrollForNextButton],
     ];


### PR DESCRIPTION
## What does this change?
Hides the (unusable without JS at the moment) consent collection form and directs users to update their browser and/or email user help mostly to give them a way forward should they not know what javascript is / how to enable it / etc

## What is the value of this and can you measure success?
It used to just not work without javascript, now it shows possible recovery paths.

## Screenshots
![screen shot 2017-12-28 at 13 57 10](https://user-images.githubusercontent.com/11539094/34412750-06ce722a-ebd7-11e7-8202-c1c17fb1e93d.png)
