### PR TITLE
Tidy up newsletter layout in /email-prefs

### DIFF
--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -12,7 +12,7 @@
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
     @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
-        <div class="manage-account__switches">
+        <div class="manage-account__switches manage-account__switches--single-column">
             <ul>
                 @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
                     <li>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -23,13 +23,22 @@
         <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
     }
 
-    @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
+    <fieldset class="fieldset fieldset--manage-account-noborder">
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Your newsletters</h2>
+            <p class="form__note">Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.</p>
+        </div>
+        <div class="fieldset__fields">
+            @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
+        </div>
+    </fieldset>
+
 
     <div class="email-subscription__fieldset">
 
         <fieldset class="fieldset">
             <div class="fieldset__heading">
-                <h2 class="form__heading">Newsletter options</h2>
+                <h2 class="form__heading">Options</h2>
             </div>
 
             <div class="fieldset__fields email-subscription__options">

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -101,7 +101,6 @@
 
 @* NEWSLETTERS *@
 <hr class="manage-account-divider" />
-<h2 class="form__heading">Select which newsletters you would like to receive</h2>
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
 
 @* CHANNELS *@

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -343,9 +343,6 @@ $identity-header-height: 48px;
 
 /* Email subscriptions
    ========================================================================== */
-.email-subscriptions {
-    margin-top: $gs-baseline*2;
-}
 .email-subscription {
     border-top: 1px solid $neutral-5;
     margin-bottom: $gs-baseline*2;


### PR DESCRIPTION
## What does this change?
The long awaited more controversial follow up to #18599 that brings the newsletter settings in `/email-prefs` to 1 column too, making the whole page have a consistent layout. 

This change makes visually clearer what the newsletters block _is_ in the hierarchy compared to the current one which sort of expands all over the page. And the extra space on the left also allows for some nicer copy matching the one already in `/consents`

## Is there a downside?
Going from 2 columns to 1 column means the newsletter list in tablet/pc is significantly longer. (It has always been 1 column on phones though) There's some marginal gains from the longer width of the cards & the fact that they now have elastic heights but it's still about ~75% longer

## Screenshots
<div align=center>

🕐 Current 🕐
![screen shot 2017-12-28 at 14 37 03](https://user-images.githubusercontent.com/11539094/34413632-9bc95606-ebdc-11e7-99ab-42f2444f96e7.png)

🍬 Proposed 🍬
![screen shot 2017-12-28 at 14 36 40](https://user-images.githubusercontent.com/11539094/34413633-9be6c1c8-ebdc-11e7-8d92-a178b856f8f1.png)

Thoughts?
