### PR TITLE
Fix consent auth with SC_GU_RP cookie

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -155,7 +155,7 @@ class AuthenticatedActions(
   def authWithConsentRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
     recentlyAuthenticated andThen apiUserShouldRepermissionRefiner
 
-  def permissionAuthentication: ActionBuilder[AuthRequest, AnyContent] =
+  def authWithRPCookie: ActionBuilder[AuthRequest, AnyContent] =
     noOpActionBuilder andThen permissionRefiner andThen apiVerifiedUserRefiner
 
 }

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -69,15 +69,14 @@ class EditProfileController(
   def displayEmailPrefsForm(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] =
     displayForm(EmailPrefsProfilePage, consentsUpdated, consentHint)
 
-  def displayConsentJourneyForm(page: ConsentJourneyPage, consentHint: Option[String]): Action[AnyContent] = {
+  def displayConsentJourneyForm(page: ConsentJourneyPage, consentHint: Option[String]): Action[AnyContent] =
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
       recentlyAuthenticated { implicit request =>
         NotFound(views.html.errors._404())
       }
-    }
-    else {
+    } else {
       csrfAddToken {
-        permissionAuthentication.async { implicit request =>
+        authWithRPCookie.async { implicit request =>
           consentJourneyView(
             page = page,
             journey = page.journey,
@@ -88,7 +87,6 @@ class EditProfileController(
         }
       }
     }
-  }
 
   def displayPrivacyFormRedirect(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] = csrfAddToken {
     recentlyAuthenticated { implicit request =>
@@ -120,7 +118,7 @@ class EditProfileController(
 
   def saveConsentPreferencesAjax: Action[AnyContent] =
     csrfCheck {
-      authActionWithUser.async { implicit request =>
+      authWithRPCookie.async { implicit request =>
         val userDO = request.user
         val marketingConsentForm: Form[PrivacyFormData] = Form(profileFormsMapping.privacyMapping.formMapping)
 
@@ -151,7 +149,7 @@ class EditProfileController(
 
   def submitRepermissionedFlag: Action[AnyContent] =
     csrfCheck {
-      authActionWithUser.async { implicit request =>
+      authWithRPCookie.async { implicit request =>
         val returnUrlForm = Form(single("returnUrl" -> nonEmptyText))
         returnUrlForm.bindFromRequest.fold(
           formWithErrors => Future.successful(BadRequest(Json.toJson(formWithErrors.errors.toList))),

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -8,7 +8,6 @@ import play.api.data.JodaForms.jodaDate
 import play.api.data.Mapping
 import play.api.i18n.MessagesProvider
 import utils.SafeLogging
-
 import scala.util.Try
 
 class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
@@ -94,7 +93,7 @@ case class PrivacyFormData(
     val newConsents = updateConsents(oldUserDO.consents, consents)
 
     UserUpdateDTO(
-      statusFields = Some(new StatusFields(
+      statusFields = Some(StatusFields(
         receive3rdPartyMarketing = newReceive3rdPartyMarketing,
         receiveGnmMarketing = newReceiveGnmMarketing,
         allowThirdPartyProfiling = newAllowThirdPartyProfiling

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -1,14 +1,15 @@
 package form
 
-import com.gu.identity.model.{Consent,User,ConsentWording}
 import com.gu.identity.model.Consent._
+import com.gu.identity.model.{Consent, StatusFields, User}
 import idapiclient.UserUpdateDTO
 import play.api.data.Forms._
 import play.api.data.JodaForms.jodaDate
 import play.api.data.Mapping
 import play.api.i18n.MessagesProvider
 import utils.SafeLogging
-import scala.util.{Try, Success, Failure}
+
+import scala.util.Try
 
 class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
@@ -93,7 +94,7 @@ case class PrivacyFormData(
     val newConsents = updateConsents(oldUserDO.consents, consents)
 
     UserUpdateDTO(
-      statusFields = Some(oldUserDO.statusFields.copy(
+      statusFields = Some(new StatusFields(
         receive3rdPartyMarketing = newReceive3rdPartyMarketing,
         receiveGnmMarketing = newReceiveGnmMarketing,
         allowThirdPartyProfiling = newAllowThirdPartyProfiling

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -34,10 +34,12 @@ class AuthenticationService(cookieDecoder: FrontendIdentityCookieDecoder,
     cookie.exists(scGuLa => cookieDecoder.userHasRecentScGuLaCookie(user, scGuLa.value, Minutes.minutes(20).toStandardDuration))
   }
 
-  def authenticateUserForPermissions(request: RequestHeader): Option[AuthenticatedUser] = for {
-    scGuRp <- request.cookies.get("SC_GU_RP")
-    fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
-  } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
+  def authenticateUserForPermissions(request: RequestHeader): Option[AuthenticatedUser] = {
+    for {
+      scGuRp <- request.cookies.get("SC_GU_RP")
+      fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
+    } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
+  }
 
   def requestPresentsAuthenticationCredentials(request: RequestHeader): Boolean = authenticatedUserFor(request).isDefined
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.99"
+  val identityLibVersion = "3.100"
   val awsVersion = "1.11.240"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.43"


### PR DESCRIPTION
## What does this change?

Enable `/consents` journey to post consents with just `SC_G_RP` cookie.

Related PR: https://github.com/guardian/identity/pull/758

## What is the value of this and can you measure success?

GDPR work.

@rahilb 
