### PR TITLE
Garnett: Meta in the right place for articles

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -64,7 +64,11 @@
 
 
                             @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
-                                @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)
+                                @if(article.metadata.designType.nameOrDefault == "comment") {
+                                    @fragments.articleHeaderCommentGarnett(article, model, isPaidContent, amp = amp)
+                                } else {
+                                    @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)
+                                }
                             }
 
                             @fragments.witnessCallToAction(article.content)

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -58,11 +58,13 @@
                             <div class="js-score"></div>
                             <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
 
+                            @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
+                                @fragments.headTonalGarnett(article, model, isPaidContent, amp = amp)
+                            }
 
-                            @fragments.headTonalGarnett(article, model, isPaidContent, amp = amp)
 
                             @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
-                                @fragments.mainMedia(article, amp)
+                                @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)
                             }
 
                             @fragments.witnessCallToAction(article.content)

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -1,0 +1,88 @@
+@(article: model.Article, page: model.Page, showBadge: Boolean = false, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@import views.html.fragments.langAttributes
+@import model.Badges.badgeFor
+@import views.support.Commercial.isPaidContent
+@import views.support.ContributorLinks
+@import views.support.TrailCssClasses.toneClass
+
+<header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
+    @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) { content__head--byline-pic}
+    @badgeFor(article).map { badge => content__head--is-badged
+        @badge.classModifier.map(modifier => s"content__head--$modifier")
+    }">
+
+    @fragments.meta.metaInline(article, amp)
+
+    <div class="content__header tonal__header">
+        <div class="u-cf">
+
+            <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+                @Html(article.trail.headline)
+            </h1>
+
+            @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) {
+                @fragments.meta.bylineImage(article.tags)
+            }
+
+            @if(article.content.hasTonalHeaderByline) {
+                @article.trail.byline.map { text =>
+                    <span class="content__headline content__headline--byline">@ContributorLinks(text, article.tags.contributors)</span>
+                }
+            }
+
+            @if(article.content.hasTonalHeaderIllustration) {
+                <span class="content__head__illustration hide-on-mobile">@fragments.inlineSvg("illustration-letters", "icon")</span>
+            }
+
+            @article.content.starRating.map { rating =>
+                <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
+                    <meta articleprop="worstRating" content="1" />
+                    <span articleprop="ratingValue">@rating</span> /
+                    <span articleprop="bestRating">5</span> stars
+                </span>
+            @fragments.items.elements.starRating(rating)
+            }
+
+            @article.content.imdb.map { imdbId =>
+                <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Movie">
+                    <link articleprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
+                    @defining(article.content.primaryKeyWordTag.map(_.name).getOrElse(".")) { tag =>
+                        @* we're not the authority on the film name, but just to keep google validator happy
+                        *@<meta articleprop="name" content="@tag"/>
+                    }
+                </div>
+            }
+
+            @article.content.isbn.map { isbn =>
+                <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Book">
+                    <meta articleprop="isbn" content="@isbn">
+                    <div articleprop="author" articlescope articletype="http://schema.org/Person">
+                        <meta articleprop="sameAs" content="http://schema.org/Person@* we can't know *@">
+                        <meta articleprop="name" content=".@* we can't know *@">
+                    </div>
+                    <meta articleprop="name" content=".@* we can't know *@">
+                </div>
+            }
+
+            @if(showBadge && !isPaidContent(page)) {
+                @fragments.commercial.badge(article, page)
+            }
+
+        </div>
+    </div>
+
+    <div class="tonal__standfirst u-cf">
+        @if(article.fields.standfirst.isDefined) {
+            @if(showBadge && isPaidContent(page)) {
+                <div class="content__meta-container js-content-meta js-football-meta u-cf">
+                @fragments.commercial.badge(article, page)
+                </div>
+            }
+            @fragments.standfirst(article)
+        }
+    </div>
+
+    @fragments.contentMeta(article, page, amp = amp)
+    @fragments.mainMedia(article, amp)
+</header>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -1,0 +1,90 @@
+@(article: model.Article, page: model.Page, showBadge: Boolean = false, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@import views.html.fragments.langAttributes
+@import model.Badges.badgeFor
+@import views.support.Commercial.isPaidContent
+@import views.support.ContributorLinks
+@import views.support.TrailCssClasses.toneClass
+
+<header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
+    @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) { content__head--byline-pic}
+    @badgeFor(article).map { badge => content__head--is-badged
+        @badge.classModifier.map(modifier => s"content__head--$modifier")
+    }">
+
+    @fragments.meta.metaInline(article, amp)
+
+    <div class="content__headline-standfirst-wrapper">
+        <div class="content__header tonal__header">
+            <div class="u-cf">
+
+                <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+                    @Html(article.trail.headline)
+                </h1>
+
+                @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) {
+                    @fragments.meta.bylineImage(article.tags)
+                }
+
+                @if(article.content.hasTonalHeaderByline) {
+                    @article.trail.byline.map { text =>
+                        <span class="content__headline content__headline--byline">@ContributorLinks(text, article.tags.contributors)</span>
+                    }
+                }
+
+                @if(article.content.hasTonalHeaderIllustration) {
+                    <span class="content__head__illustration hide-on-mobile">@fragments.inlineSvg("illustration-letters", "icon")</span>
+                }
+
+                @article.content.starRating.map { rating =>
+                    <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
+                        <meta articleprop="worstRating" content="1" />
+                        <span articleprop="ratingValue">@rating</span> /
+                        <span articleprop="bestRating">5</span> stars
+                    </span>
+                    @fragments.items.elements.starRating(rating)
+                }
+
+                @article.content.imdb.map { imdbId =>
+                    <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Movie">
+                        <link articleprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
+                        @defining(article.content.primaryKeyWordTag.map(_.name).getOrElse(".")) { tag =>
+                            @* we're not the authority on the film name, but just to keep google validator happy
+                            *@<meta articleprop="name" content="@tag"/>
+                        }
+                    </div>
+                }
+
+                @article.content.isbn.map { isbn =>
+                    <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Book">
+                        <meta articleprop="isbn" content="@isbn">
+                        <div articleprop="author" articlescope articletype="http://schema.org/Person">
+                            <meta articleprop="sameAs" content="http://schema.org/Person@* we can't know *@">
+                            <meta articleprop="name" content=".@* we can't know *@">
+                        </div>
+                        <meta articleprop="name" content=".@* we can't know *@">
+                    </div>
+                }
+
+                @if(showBadge && !isPaidContent(page)) {
+                    @fragments.commercial.badge(article, page)
+                }
+
+            </div>
+        </div>
+
+        <div class="tonal__standfirst u-cf">
+            @if(article.fields.standfirst.isDefined) {
+                @if(showBadge && isPaidContent(page)) {
+                    <div class="content__meta-container js-content-meta js-football-meta u-cf">
+                        @fragments.commercial.badge(article, page)
+                    </div>
+                }
+                @fragments.standfirst(article)
+            }
+        </div>
+    </div>
+
+    @fragments.mainMedia(article, amp)
+    @fragments.contentMeta(article, page, amp = amp)
+</header>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -84,7 +84,6 @@
             }
         </div>
     </div>
-
-    @fragments.mainMedia(article, amp)
     @fragments.contentMeta(article, page, amp = amp)
+    @fragments.mainMedia(article, amp)
 </header>

--- a/common/app/views/fragments/headTonalGarnett.scala.html
+++ b/common/app/views/fragments/headTonalGarnett.scala.html
@@ -97,7 +97,8 @@
                 @fragments.standfirst(item)
             }
         }
-
-        @fragments.contentMeta(item, page, amp = amp)
+        @if(item.tags.isFeature && item.elements.hasShowcaseMainElement) {
+            @fragments.contentMeta(item, page, amp = amp)
+        }
     </div>
 </header>

--- a/static/src/stylesheets/module/content-garnett/_article.scss
+++ b/static/src/stylesheets/module/content-garnett/_article.scss
@@ -1,15 +1,5 @@
 .media-primary {
-    margin: 0 $gs-gutter * -.5;
     position: relative;
-
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter / -1;
-        margin-right: $gs-gutter / -1;
-    }
-    @include mq(phablet) {
-        margin-left: 0;
-        margin-right: 0;
-    }
 }
 
 .content__main-column--article {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1353,6 +1353,10 @@
     .content__headline-standfirst-wrapper {
         @include mq($until: tablet) {
             order: 1;
+
+            .content--type-comment & {
+                order: 0;
+            }
         }
 
         @include mq($from: leftCol) {
@@ -1370,6 +1374,10 @@
         @include mq($until: tablet) {
             order: 1;
             margin-top: 0;
+
+            .content--type-comment & {
+                order: 0;
+            }
         }
 
         @include mq($from: leftCol) {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1316,7 +1316,6 @@
     }
 }
 
-
 // This section below makes the meta align with the image on leftCol, and has the main media first on mobile.
 .content__head--article {
     @include mq($until: tablet) {
@@ -1329,7 +1328,11 @@
             margin-left: -($left-column + $gs-gutter);
             display: grid;
             grid-template-columns: ($left-column + $gs-gutter) auto;
-            grid-template-areas: 'labels headline' 'meta main-media';
+            grid-template-areas: 'labels headline-standfirst' 'meta main-media';
+
+            .content--type-comment & {
+                grid-template-areas: 'labels headline' 'meta standfirst' '. main-media';
+            }
         }
     }
 
@@ -1360,13 +1363,25 @@
         }
 
         @include mq($from: leftCol) {
-            grid-area: headline;
+            grid-area: headline-standfirst;
         }
     }
 
     .media-primary {
         @include mq($from: leftCol) {
             grid-area: main-media;
+        }
+    }
+
+    .content__header {
+        @include mq($from: leftCol) {
+            grid-area: headline;
+        }
+    }
+
+    .tonal__standfirst {
+        @include mq($from: leftCol) {
+            grid-area: standfirst;
         }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1315,3 +1315,74 @@
         display: none;
     }
 }
+
+
+// This section below makes the meta align with the image on leftCol, and has the main media first on mobile.
+.content__head--article {
+    @include mq($until: tablet) {
+        display: flex;
+        flex-direction: column;
+    }
+
+    @include mq($from: leftCol) {
+        @supports (display: grid) {
+            margin-left: -($left-column + $gs-gutter);
+            display: grid;
+            grid-template-columns: ($left-column + $gs-gutter) auto;
+            grid-template-areas: 'labels headline' 'meta main-media';
+        }
+    }
+
+    @include mq($from: wide) {
+        @supports (display: grid) {
+            margin-left: -($left-column-wide + $gs-gutter);
+            grid-template-columns: ($left-column-wide + $gs-gutter) auto;
+        }
+    }
+
+    .content__labels {
+        @include mq($from: leftCol) {
+            @supports (display: grid) {
+                grid-area: labels;
+                position: relative;
+                margin: 0;
+            }
+        }
+    }
+
+    .content__headline-standfirst-wrapper {
+        @include mq($until: tablet) {
+            order: 1;
+        }
+
+        @include mq($from: leftCol) {
+            grid-area: headline;
+        }
+    }
+
+    .media-primary {
+        @include mq($from: leftCol) {
+            grid-area: main-media;
+        }
+    }
+
+    .content__meta-container {
+        @include mq($until: tablet) {
+            order: 1;
+            margin-top: 0;
+        }
+
+        @include mq($from: leftCol) {
+            // adds enough space so that this doesn't clash with the content labels if css gris is not supported
+            top: gs-height(3);
+
+            @supports (display: grid) {
+                grid-area: meta;
+                position: relative !important;
+                top: 0;
+                margin: 0;
+                align-self: start;
+            }
+        }
+    }
+}

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -111,6 +111,7 @@ $quote-mark: 35px;
     .content__meta-container,
     .content__standfirst {
         @include mq(phablet, tablet) {
+            width: 100%;
             max-width: 38.75rem;
             margin: auto;
             position: relative;
@@ -148,16 +149,16 @@ $quote-mark: 35px;
         display: flex;
         flex-flow: row wrap;
         justify-content: space-between;
-        margin-top: -$gs-baseline;
         margin-bottom: 0;
+
         @include mq(leftCol) {
             position: absolute;
+            margin-top: -$gs-baseline;
         }
     }
 
     .badge,
     .content__meta-container {
-        order: 0;
         flex: 1 100%;
         @include mq(leftCol) {
             width: gs-span(2);


### PR DESCRIPTION
## What does this change?
If css grid is supported, on desktop this aligns content meta with the image on articles. 
The fallback is almost the same, but there is no way to correctly align the content meta, so instead it just sits below the content labels.

If css flex is supported, on mobile the order is:
Image
Headline
Standfirst
Content Meta

If its not supported the order is:
Headline
Standfirst
Image
Meta

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
