### PR TITLE
Two column layout in consent journey

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -188,61 +188,59 @@
     </fieldset>
 }
 
-<div class="monocol-wrapper">
-    <div class="u-cf identity-wrapper identity-wrapper--with-wizard">
+<div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-wizard">
 
-        <div class="js-errorHolder manage-account__errors"></div>
+    <div class="js-errorHolder manage-account__errors"></div>
 
-        <noscript>
-            <div class="form__error">
-                <p>
-                    Setting your preferences requires a browser with Javascript enabled.
-                </p>
-                <p>
-                    Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
-                </p>
-            </div>
-        </noscript>
-
-        <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
-
-            @journey match {
-                case "newsletters" => {
-                    @emailRepermissionStep()
-                }
-                case "all" => {
-                    @consentStep(journey = "all")
-                    @emailRepermissionStep()
-                    @channelStep()
-                }
-                case _ => {
-                    @consentStep(journey = "consent")
-                    @emailRepermissionOrSignupStep()
-                    @channelStep()
-                }
-            }
-
-            @endcardStep()
-
-            <div class="identity-wizard__controls">
-                <button
-                    data-link-name="consents : navigation : prev"
-                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
-                >
-                    <span class="u-h">Previous</span>
-                    @fragments.inlineSvg("arrow-left-stem", "icon")
-                </button>
-                <div class="identity-consent-wizard__revealable identity-consent-wizard-counter">
-                </div>
-                <button
-                    data-link-name="consents : navigation : next"
-                    class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
-                >
-                    <span>Next</span>
-                    @fragments.inlineSvg("arrow-right", "icon")
-                </button>
-            </div>
+    <noscript>
+        <div class="form__error">
+            <p>
+                Setting your preferences requires a browser with Javascript enabled.
+            </p>
+            <p>
+                Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
+            </p>
         </div>
+    </noscript>
 
+    <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
+
+        @journey match {
+            case "newsletters" => {
+                @emailRepermissionStep()
+            }
+            case "all" => {
+                @consentStep(journey = "all")
+                @emailRepermissionStep()
+                @channelStep()
+            }
+            case _ => {
+                @consentStep(journey = "consent")
+                @emailRepermissionOrSignupStep()
+                @channelStep()
+            }
+        }
+
+        @endcardStep()
+
+        <div class="identity-wizard__controls">
+            <button
+                data-link-name="consents : navigation : prev"
+                class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
+            >
+                <span class="u-h">Previous</span>
+                @fragments.inlineSvg("arrow-left-stem", "icon")
+            </button>
+            <div class="identity-consent-wizard__revealable identity-consent-wizard-counter">
+            </div>
+            <button
+                data-link-name="consents : navigation : next"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
+            >
+                <span>Next</span>
+                @fragments.inlineSvg("arrow-right", "icon")
+            </button>
+        </div>
     </div>
+
 </div>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -37,20 +37,24 @@
     @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
         <fieldset class="identity-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
 
-            <legend class="identity-title" id="consentWizardChannelsTitle">
-                How can we get in touch with you?
-            </legend>
-            <p class="identity-title-subtitle">
-                Besides email, are there any other ways you would like us to get in touch with you?
-            </p>
+            <div class="identity-forms-wrapper">
+                <div class="identity-forms-wrapper__title">
+                    <legend class="identity-title" id="consentWizardChannelsTitle">
+                        How can we get in touch with you?
+                    </legend>
+                    <p class="identity-title-subtitle">
+                        Besides email, are there any other ways you would like us to get in touch with you?
+                    </p>
+                </div>
 
-            <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
-                <div class="manage-account__switches">
-                    <ul>
-                        @communicationChannelsForUser(user).map((channel) =>
-                            Html(s"<li>${checkboxName(channel)}</li>")
-                        )
-                    </ul>
+                <div class="identity-forms-wrapper__fields">
+                    <div class="manage-account__switches">
+                        <ul>
+                            @communicationChannelsForUser(user).map((channel) =>
+                                Html(s"<li>${checkboxName(channel)}</li>")
+                            )
+                        </ul>
+                    </div>
                 </div>
             </div>
 
@@ -61,22 +65,23 @@
 @consentStep(journey:String) = {
     <fieldset class="identity-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
 
-        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+        <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
-
-            @if(journey == "all") {
-                <legend class="identity-title" id="consentWizardConsentTitle">
-                    We need you to consent again to receiving communications from The Guardian
-                </legend>
-                <p class="identity-title-subtitle">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
-            } else {
-                <legend class="identity-title" id="consentWizardConsentTitle">
-                    What would you like to hear about?
-                </legend>
-                <p class="identity-title-subtitle">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
-            }
-            <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
-                <div class="manage-account__switches manage-account__switches--wide">
+            <div class="identity-forms-wrapper__title">
+                @if(journey == "all") {
+                    <legend class="identity-title" id="consentWizardConsentTitle">
+                        We need you to consent again to receiving communications from The Guardian
+                    </legend>
+                    <p class="identity-title-subtitle">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
+                } else {
+                    <legend class="identity-title" id="consentWizardConsentTitle">
+                        What would you like to hear about?
+                    </legend>
+                    <p class="identity-title-subtitle">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
+                }
+            </div>
+            <div class="identity-forms-wrapper__fields">
+                <div class="manage-account__switches manage-account__switches--single-column">
                     <ul>
                     @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
                         <li>
@@ -99,28 +104,32 @@
     @if(emailRepermissionStepShouldDisplay) {
         <fieldset class="identity-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
 
-            <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-                @views.html.helper.CSRF.formField
-                @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+            <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
 
-                <legend class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</legend>
-                <p class="identity-title-subtitle">
-                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                </p>
+                <div class="identity-forms-wrapper__title">
+                    @views.html.helper.CSRF.formField
+                    @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-                <div class="manage-account__switches">
-                    <ul>
-                    @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
-                    <li>
-                        @fragments.newsletterSwitch(
-                            emailPrefsForm,
-                            emailSubscriptions,
-                            newsletter = newsletter,
-                            unchecked = true
-                        )(nonInputFields, messages, request)
-                    </li>
-                    }
-                    </ul>
+                    <legend class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</legend>
+                    <p class="identity-title-subtitle">
+                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
+                    </p>
+                </div>
+                <div class="identity-forms-wrapper__fields">
+                    <div class="manage-account__switches manage-account__switches--single-column">
+                        <ul>
+                        @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
+                        <li>
+                            @fragments.newsletterSwitch(
+                                emailPrefsForm,
+                                emailSubscriptions,
+                                newsletter = newsletter,
+                                unchecked = true
+                            )(nonInputFields, messages, request)
+                        </li>
+                        }
+                        </ul>
+                    </div>
                 </div>
             </form>
         </fieldset>
@@ -130,17 +139,22 @@
 @emailSignupStep() = {
     <fieldset class="identity-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
 
-        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+        <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
             @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-            <legend class="identity-title" id="consentWizardEmailSignupTitle">Your newsletters</legend>
-            <p class="identity-title-subtitle">
-                Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below. Just so you know, your newsletter might include messages about how you can support the Guardian, as well as our events, jobs, masterclasses and holidays.
-            </p>
+            <div class="identity-forms-wrapper__title">
 
-            <div class="manage-account__switches">
-                @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
+                <legend class="identity-title" id="consentWizardEmailSignupTitle">Your newsletters</legend>
+                <p class="identity-title-subtitle">
+                    Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
+                </p>
+            </div>
+
+            <div class="identity-forms-wrapper__fields">
+                <div class="manage-account__switches">
+                    @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
+                </div>
             </div>
         </form>
     </fieldset>
@@ -174,66 +188,61 @@
     </fieldset>
 }
 
-<div class="identity-wrapper-for-bg identity-wrapper-for-bg--overflows">
-    <div class="gs-container">
-        <div class="monocol-wrapper">
+<div class="monocol-wrapper">
+    <div class="u-cf identity-wrapper identity-wrapper--with-wizard">
 
-            <div class="u-cf identity-section identity-wrapper identity-wrapper--with-wizard">
+        <div class="js-errorHolder manage-account__errors"></div>
 
-                <div class="js-errorHolder manage-account__errors"></div>
+        <noscript>
+            <div class="form__error">
+                <p>
+                    Setting your preferences requires a browser with Javascript enabled.
+                </p>
+                <p>
+                    Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
+                </p>
+            </div>
+        </noscript>
 
-                <noscript>
-                    <div class="form__error">
-                        <p>
-                            Setting your preferences requires a browser with Javascript enabled.
-                        </p>
-                        <p>
-                            Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
-                        </p>
-                    </div>
-                </noscript>
+        <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
-                <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
+            @journey match {
+                case "newsletters" => {
+                    @emailRepermissionStep()
+                }
+                case "all" => {
+                    @consentStep(journey = "all")
+                    @emailRepermissionStep()
+                    @channelStep()
+                }
+                case _ => {
+                    @consentStep(journey = "consent")
+                    @emailRepermissionOrSignupStep()
+                    @channelStep()
+                }
+            }
 
-                    @journey match {
-                        case "newsletters" => {
-                            @emailRepermissionStep()
-                        }
-                        case "all" => {
-                            @consentStep(journey = "all")
-                            @emailRepermissionStep()
-                            @channelStep()
-                        }
-                        case _ => {
-                            @consentStep(journey = "consent")
-                            @emailRepermissionOrSignupStep()
-                            @channelStep()
-                        }
-                    }
+            @endcardStep()
 
-                    @endcardStep()
-
-                    <div class="identity-wizard__controls">
-                        <button
-                            data-link-name="consents : navigation : prev"
-                            class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
-                        >
-                            <span class="u-h">Previous</span>
-                            @fragments.inlineSvg("arrow-left-stem", "icon")
-                        </button>
-                        <div class="identity-consent-wizard__revealable identity-consent-wizard-counter">
-                        </div>
-                        <button
-                            data-link-name="consents : navigation : next"
-                            class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
-                        >
-                            <span>Next</span>
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </button>
-                    </div>
+            <div class="identity-wizard__controls">
+                <button
+                    data-link-name="consents : navigation : prev"
+                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
+                >
+                    <span class="u-h">Previous</span>
+                    @fragments.inlineSvg("arrow-left-stem", "icon")
+                </button>
+                <div class="identity-consent-wizard__revealable identity-consent-wizard-counter">
                 </div>
-
+                <button
+                    data-link-name="consents : navigation : next"
+                    class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
+                >
+                    <span>Next</span>
+                    @fragments.inlineSvg("arrow-right", "icon")
+                </button>
             </div>
         </div>
+
     </div>
 </div>

--- a/static/src/stylesheets/head.identity.scss
+++ b/static/src/stylesheets/head.identity.scss
@@ -17,6 +17,8 @@
 @import 'module/identity/_identity';
 
 @import 'module/identity/_header';
+@import 'module/identity/_forms';
+
 @import 'module/identity/_manage-account-tab';
 @import 'module/identity/_formstack';
 @import 'module/identity/_dropdown';

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -1,20 +1,19 @@
 .identity-wizard--consent {
-    .identity-wizard__step {
-        min-height: 72vh;
-        padding: $gs-gutter 0;
-    }
     .identity-wizard__controls {
         padding: $gs-gutter;
-        margin-top: $gs-gutter;
         background: #ffffff;
-        border-top: 1px solid transparentize($identity-main, .5);
         position: sticky;
         bottom: 0;
         left: 0;
         right: 0;
         margin-left: $gs-gutter * -1;
         margin-right: $gs-gutter * -1;
+        margin-top: $gs-gutter * 2;
+        border-top: 1px solid transparentize($identity-main, .5);
         justify-content: space-between;
+        @include mq(desktop) {
+            margin-top: $gs-gutter * 4;
+        }
     }
     .identity-consent-wizard-counter {
         flex: 1 1 auto;

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -1,18 +1,18 @@
 .identity-wizard--consent {
     .identity-wizard__controls {
-        padding: $gs-gutter;
+        padding: $gs-gutter 0;
         background: #ffffff;
         position: sticky;
         bottom: 0;
         left: 0;
         right: 0;
-        margin-left: $gs-gutter * -1;
-        margin-right: $gs-gutter * -1;
         margin-top: $gs-gutter * 2;
         border-top: 1px solid transparentize($identity-main, .5);
         justify-content: space-between;
-        @include mq(desktop) {
-            margin-top: $gs-gutter * 4;
+        @include mq($until: tablet) {
+            padding: $gs-gutter * .5;
+            margin-left: $gs-gutter * -.5;
+            margin-right: $gs-gutter * -.5;
         }
     }
     .identity-consent-wizard-counter {

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -1,0 +1,23 @@
+.identity-forms-wrapper__title {
+    margin-bottom: $gs-baseline * 2;
+}
+
+
+@supports (display: flex) {
+    @include mq(desktop) {
+        .identity-forms-wrapper {
+            display: flex;
+        }
+        .identity-forms-wrapper__title {
+            width: gs-span(3.5);
+            flex: 0 0 1;
+            margin-bottom: 0;
+        }
+        .identity-forms-wrapper__fields {
+            flex: 1 1 0;
+        }
+        .identity-forms-wrapper__title + .identity-forms-wrapper__fields {
+            margin-left: gs-span(1);
+        }
+    }
+}

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -18,6 +18,7 @@
     outline: none;
     border: 0;
     margin: 0;
+    padding: 0;
 }
 .js-off .identity-wizard__step {
     border: 1px solid $neutral-8;

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -17,6 +17,7 @@
     will-change: transform;
     outline: none;
     border: 0;
+    margin: 0;
 }
 .js-off .identity-wizard__step {
     border: 1px solid $neutral-8;


### PR DESCRIPTION
## What does this change?
Followup of sorts to #18610 that applies the same layout to all pages of the consent journey on desktop too. It now involves less scrolling plus looks neater if you ask me.

Something bad is that the checkboxes now look a bit dull but knowing they'll sit on the page uniformly like that i can spruce them up a bit in a later pr

## What is the value of this and can you measure success?

## Screenshots?
<div align=center>

🐟 𝖇𝖊𝖋𝖔𝖗𝖊 🐟
![screen shot 2017-12-29 at 15 33 06](https://user-images.githubusercontent.com/11539094/34440604-0e962a70-ecae-11e7-8ec6-1ebaafc509d4.png)

✨ 𝖆𝖋𝖙𝖊𝖗 ✨
![screen shot 2017-12-29 at 15 32 47](https://user-images.githubusercontent.com/11539094/34440605-12ac62dc-ecae-11e7-9a33-e6f912a6d0c3.png)
