### PR TITLE
Add the height: auto back to the responsive image class for Garnett.

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
@@ -22,6 +22,12 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
 */
 
 @mixin fc-item--full-media-100 {
+
+    .responsive-img {
+        top: -25%;
+        height: auto;
+    }
+
     .fc-item__header {
         @include fs-headline(4, true);
         @include fs-headline-quote(4);
@@ -39,7 +45,7 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
             display: block;
             padding-bottom: 40%;
         }
-        
+
         @include fc-sublinks--below;
     }
 }


### PR DESCRIPTION
## What does this change?
fixes https://trello.com/c/WCirtMfk/162-image-crop-on-culture-front-is-causing-the-image-to-stretch by restoring this css rule https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-100.scss#L32

paging @GHaberis because I'm sure this rule was removed for a good reason.

## What is the value of this and can you measure success?
🐛
## Does this affect other platforms - Amp, Apps, etc?
no
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
no

## Screenshots
no :(
## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
