### PR TITLE
Bugfix for showmore on when configured off

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -368,7 +368,7 @@ object Front extends implicits.Collections {
   }
 
   private def applyShowMoreExperiment(faciaContainer: FaciaContainer)(implicit request: RequestHeader): FaciaContainer = {
-    val showMoreEnabled = !ActiveExperiments.isParticipating(HideShowMoreButtonExperiment)
+    val showMoreEnabled = if (faciaContainer.hasShowMoreEnabled) !ActiveExperiments.isParticipating(HideShowMoreButtonExperiment) else false
     faciaContainer.copy(hasShowMoreEnabled = showMoreEnabled)
   }
 

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -368,7 +368,7 @@ object Front extends implicits.Collections {
   }
 
   private def applyShowMoreExperiment(faciaContainer: FaciaContainer)(implicit request: RequestHeader): FaciaContainer = {
-    val showMoreEnabled = if (faciaContainer.hasShowMoreEnabled) !ActiveExperiments.isParticipating(HideShowMoreButtonExperiment) else false
+    val showMoreEnabled = faciaContainer.hasShowMoreEnabled && !ActiveExperiments.isParticipating(HideShowMoreButtonExperiment)
     faciaContainer.copy(hasShowMoreEnabled = showMoreEnabled)
   }
 


### PR DESCRIPTION
## What does this change?

Only override showMoreEnabled for experiment when show-more is configured on

## What is the value of this and can you measure success?

Fixes a bug where showmore is on when it has been configured off

## Tested in CODE?

No