### PR TITLE
Identity: Fix reauth on /consents

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -153,7 +153,7 @@ class AuthenticatedActions(
     authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
 
   def authWithConsentRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
-    recentlyAuthenticated andThen apiUserShouldRepermissionRefiner
+    noOpActionBuilder andThen permissionRefiner andThen apiUserShouldRepermissionRefiner
 
   def authWithRPCookie: ActionBuilder[AuthRequest, AnyContent] =
     noOpActionBuilder andThen permissionRefiner andThen apiVerifiedUserRefiner

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -35,10 +35,12 @@ class AuthenticationService(cookieDecoder: FrontendIdentityCookieDecoder,
   }
 
   def authenticateUserForPermissions(request: RequestHeader): Option[AuthenticatedUser] = {
-    for {
-      scGuRp <- request.cookies.get("SC_GU_RP")
-      fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
-    } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
+    lazy val guRpAuth =
+      for {
+        scGuRp <- request.cookies.get("SC_GU_RP")
+        fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
+      } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
+    authenticatedUserFor(request).orElse(guRpAuth)
   }
 
   def requestPresentsAuthenticationCredentials(request: RequestHeader): Boolean = authenticatedUserFor(request).isDefined


### PR DESCRIPTION
## What does this change?

- Changes RePermissionRefiner to allow RP and GU_U cookies to be used 

## What is the value of this and can you measure success?

- Consent Email Magic links work correctly when the ID Redirect to consents switch is active

## Does this affect other platforms - Amp, Apps, etc?

No 

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

NA

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
