### PR TITLE
Die Hard with a Garnett Vengeance

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1263,3 +1263,12 @@ $quote-mark: 35px;
 .social__tray-close .social-tray__icon {
     box-sizing: content-box;
 }
+
+.content__head--byline-pic .content__header {
+    box-sizing: border-box;
+    min-height: 150px;
+
+    @include mq(phablet) {
+        min-height: 180px;
+    }
+}


### PR DESCRIPTION
Head shots are cropped when the headline is too short.