### PR TITLE
Fix authWithConsentRedirectAction to retrieve user from IDAPI

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -153,8 +153,9 @@ class AuthenticatedActions(
     authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
 
   def authWithConsentRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
-    noOpActionBuilder andThen permissionRefiner andThen apiUserShouldRepermissionRefiner
+    authWithRPCookie andThen apiUserShouldRepermissionRefiner
 
+  /** Auth with at least SC_GU_RP, that is, auth with SC_GU_U or else SC_GU_RP */
   def authWithRPCookie: ActionBuilder[AuthRequest, AnyContent] =
     noOpActionBuilder andThen permissionRefiner andThen apiVerifiedUserRefiner
 


### PR DESCRIPTION
## What does this change?

Adds `apiVerifiedUserRefiner` to `authWithConsentRedirectAction` to make sure user is retrieved from IDAPI, otherwise only user data from the `SC_GU_U` or `SC_GU_RP` cookie is visible.

Note, `SC_GU_U` is able to retrieve everything, while `SC_GU_RP` can retrieve `consents` and `statusFields.hasRepermissiones`.

We keep hitting this issue where we mixup actions that retrieve user data just from the cookies vs actions that retrieve user data from IDAPI. I will open a separate PR to try to make this distinction clearer. 

Related PR: https://github.com/guardian/frontend/pull/18626

## What is the value of this and can you measure success?

GDPR work.
