### PR TITLE
Fix ad container sizes to the size of the advert being rendered

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -7,7 +7,7 @@ import reportError from 'lib/report-error';
 import { fire } from 'common/modules/analytics/beacon';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { Advert } from 'commercial/modules/dfp/Advert';
-import renderAdvert from 'commercial/modules/dfp/render-advert';
+import { renderAdvert } from 'commercial/modules/dfp/render-advert';
 import { emptyAdvert } from 'commercial/modules/dfp/empty-advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -12,7 +12,7 @@ import renderAdvertLabel from 'commercial/modules/dfp/render-advert-label';
 import { geoMostPopular } from 'common/modules/onward/geo-most-popular';
 import { Toggles } from 'common/modules/ui/toggles';
 import { recordUserAdFeedback } from 'commercial/modules/user-ad-feedback';
-import type SlotRenderEndedEvent from 'commercial/types';
+import type { SlotRenderEndedEvent } from 'commercial/types';
 /**
  * ADVERT RENDERING
  * ----------------
@@ -207,7 +207,7 @@ export const renderAdvert = (
                       })
                     : Promise.resolve();
 
-            const applyFeedbackOnClickListeners = slotRender => {
+            const applyFeedbackOnClickListeners = () => {
                 const readyClass = 'js-onclick-ready';
                 return isRendered
                     ? fastdom.write(() => {
@@ -216,11 +216,12 @@ export const renderAdvert = (
                           ).forEach(el => {
                               const slotId = el.getAttribute('data-slot');
                               const problem = el.getAttribute('data-problem');
+
                               el.addEventListener('click', () => {
                                   recordUserAdFeedback(
                                       window.location.pathname,
                                       slotId,
-                                      slotRender,
+                                      slotRenderEndedEvent,
                                       problem
                                   );
                               });
@@ -233,7 +234,7 @@ export const renderAdvert = (
             return callSizeCallback()
                 .then(() => renderAdvertLabel(advert.node))
                 .then(addFeedbackDropdownToggle)
-                .then(() => applyFeedbackOnClickListeners(slotRenderEndedEvent))
+                .then(applyFeedbackOnClickListeners)
                 .then(addRenderedClass)
                 .then(() => isRendered);
         })

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -150,7 +150,7 @@ const addContentClass = adSlotNode => {
  * @param slotRenderEndedEvent - GPT slotRenderEndedEvent
  * @returns {Promise} - resolves once all necessary rendering is queued up
  */
-const renderAdvert = (
+export const renderAdvert = (
     advert: Advert,
     slotRenderEndedEvent: SlotRenderEndedEvent
 ): Promise<boolean> => {
@@ -239,5 +239,3 @@ const renderAdvert = (
         })
         .catch(raven.captureException);
 };
-
-export default renderAdvert;

--- a/static/src/javascripts/projects/commercial/modules/user-ad-feedback.js
+++ b/static/src/javascripts/projects/commercial/modules/user-ad-feedback.js
@@ -3,6 +3,7 @@ import fastdom from 'fastdom';
 import fetch from 'lib/fetch';
 import config from 'lib/config';
 import { getUserAgent, getBreakpoint } from 'lib/detect';
+import type { SlotRenderEndedEvent } from 'commercial/types';
 
 const onComplete = adSlotId => {
     // we're complete - update the UI
@@ -17,10 +18,7 @@ const onComplete = adSlotId => {
 const recordUserAdFeedback = function(
     pagePath: string,
     adSlotId: string,
-    slotRenderEvent: {
-        sourceAgnosticCreativeId: string,
-        sourceAgnosticLineItemId: string,
-    },
+    slotRenderEndedEvent: SlotRenderEndedEvent,
     feedbackType: string
 ): Promise<void> {
     const feedbackUrl =
@@ -33,8 +31,8 @@ const recordUserAdFeedback = function(
         stage,
         page: pagePath,
         adSlotId,
-        creativeId: slotRenderEvent.sourceAgnosticCreativeId.toString(),
-        lineId: slotRenderEvent.sourceAgnosticLineItemId.toString(),
+        creativeId: slotRenderEndedEvent.creativeId,
+        lineId: slotRenderEndedEvent.lineItemId,
         feedback: feedbackType,
         browser:
             typeof ua === 'object'

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -210,9 +210,6 @@
 }
 
 .ad-slot--liveblog-inline,
-.ad-slot--gallery-inline {
-    background-color: transparent;
-}
 
 .ad-slot--container-inline,
 .ad-slot--container-inline.ad-slot--fluid {
@@ -225,6 +222,7 @@
 }
 .ad-slot--gallery-inline {
     background-color: $media-background;
+    margin-left: 0;
 
     @include mq(mobileLandscape) {
         width: 300px;

--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -37,10 +37,6 @@ $mobile-max-container-width: gs-span(8);
         padding-top: 0;
         padding-bottom: 0;
     }
-
-    &.ad-slot--gallery-inline {
-        margin-left: 0;
-    }
 }
 
 .frame {


### PR DESCRIPTION
## What does this change?
Currently, when an ad is rendered into a container, the size of the container `div` isn't fixed to a size. This means that the `Advertisement` label that sits in the container is full width rather than extending only to the width of the ad, as per the design*.

This has the added benefit of ensuring that the rendering of any ads that don't enforce their own width will be contained to the correct size.

I've also simplified some types and styling.

*Before*
![image](https://user-images.githubusercontent.com/1821099/34491980-975d1efe-efdd-11e7-91ab-6378f00a3f67.png)

*After*
![image](https://user-images.githubusercontent.com/1821099/34491926-6824cbe6-efdd-11e7-844d-c4ddbc71ecc9.png)