### PR TITLE
Add headers to consent journey

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -39,10 +39,10 @@
 
             <div class="identity-forms-wrapper">
                 <div class="identity-forms-wrapper__title">
-                    <legend class="identity-title" id="consentWizardChannelsTitle">
+                    <legend class="identity-title identity-title--small" id="consentWizardChannelsTitle">
                         How can we get in touch with you?
                     </legend>
-                    <p class="identity-title-subtitle">
+                    <p class="identity-title-explainer">
                         Besides email, are there any other ways you would like us to get in touch with you?
                     </p>
                 </div>
@@ -69,15 +69,15 @@
             @views.html.helper.CSRF.formField
             <div class="identity-forms-wrapper__title">
                 @if(journey == "all") {
-                    <legend class="identity-title" id="consentWizardConsentTitle">
+                    <legend class="identity-title identity-title--small" id="consentWizardConsentTitle">
                         We need you to consent again to receiving communications from The Guardian
                     </legend>
-                    <p class="identity-title-subtitle">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
+                    <p class="identity-title-explainer">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
                 } else {
-                    <legend class="identity-title" id="consentWizardConsentTitle">
+                    <legend class="identity-title identity-title--small" id="consentWizardConsentTitle">
                         What would you like to hear about?
                     </legend>
-                    <p class="identity-title-subtitle">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
+                    <p class="identity-title-explainer">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
                 }
             </div>
             <div class="identity-forms-wrapper__fields">
@@ -110,8 +110,8 @@
                     @views.html.helper.CSRF.formField
                     @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-                    <legend class="identity-title" id="consentWizardEmailTitle">Your existing newsletters</legend>
-                    <p class="identity-title-subtitle">
+                    <legend class="identity-title identity-title--small" id="consentWizardEmailTitle">Your existing newsletters</legend>
+                    <p class="identity-title-explainer">
                         You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
                     </p>
                 </div>
@@ -145,8 +145,8 @@
 
             <div class="identity-forms-wrapper__title">
 
-                <legend class="identity-title" id="consentWizardEmailSignupTitle">Your newsletters</legend>
-                <p class="identity-title-subtitle">
+                <legend class="identity-title identity-title--small" id="consentWizardEmailSignupTitle">Your newsletters</legend>
+                <p class="identity-title-explainer">
                     Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
                 </p>
             </div>
@@ -168,9 +168,18 @@
     }
 }
 
+@title(journey: String) = @{
+    journey match {
+        case "default" => "Complete your registration"
+        case _ => "Edit your profile"
+    }
+}
+
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-wizard">
 
     <div class="js-errorHolder manage-account__errors"></div>
+
+    <h1 class="identity-title identity-title--page-title">@title(journey)</h1>
 
     <noscript>
         <div class="form__error">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -167,6 +167,38 @@
     }
 }
 
+@getStepsForJourney(journey: String) = @{
+    @journey match {
+        case "newsletters" => {
+            List(
+                if(emailRepermissionStep.show) {
+                    emailRepermissionStep
+                } else {
+                    ConsentStep(
+                        name = "error",
+                        title = "Sorry",
+                        content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
+                    )
+                }
+            )
+        }
+        case "all" => {
+            List(
+                communicationConsentStep,
+                emailRepermissionStep,
+                channelStep
+            )
+        }
+        case _ => {
+            List(
+                communicationConsentStep,
+                emailRepermissionOrSignupStep,
+                channelStep
+            )
+        }
+    }
+}
+
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-wizard">
 
     <div class="js-errorHolder manage-account__errors"></div>
@@ -184,35 +216,7 @@
 
     <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
-        @journey match {
-            case "newsletters" => {
-                @renderSteps(List(
-                    if(emailRepermissionStep.show) {
-                        emailRepermissionStep
-                    } else {
-                        ConsentStep(
-                            name = "error",
-                            title = "Sorry",
-                            content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
-                        )
-                    }
-                ))
-            }
-            case "all" => {
-                @renderSteps(List(
-                    communicationConsentStep,
-                    emailRepermissionStep,
-                    channelStep
-                ))
-            }
-            case _ => {
-                @renderSteps(List(
-                    communicationConsentStep,
-                    emailRepermissionOrSignupStep,
-                    channelStep
-                ))
-            }
-        }
+        @renderSteps(getStepsForJourney(journey))
 
         <form class="identity-wizard__controls" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
             <button

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -168,7 +168,7 @@
 }
 
 @getStepsForJourney(journey: String) = @{
-    @journey match {
+    journey match {
         case "newsletters" => {
             List(
                 if(emailRepermissionStep.show) {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -100,7 +100,7 @@
     ConsentStep(
         name = "consent",
         title = if(journey == "all") {
-            "We need you to consent again to receiving communications from The Guardian"
+            "We need you to consent again to receiving communications from the Guardian"
         } else {
             "What would you like to hear about?"
         },

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -38,22 +38,15 @@
             role="dialog"
             aria-labelledby="consentWizard@{step.name.capitalize}Title"
         >
+            <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
             <div class="identity-forms-wrapper">
-                <div class="identity-forms-wrapper__title">
-                    <legend
-                        class="identity-title identity-title--small"
-                        id="consentWizard@{step.name.capitalize}Title"
-                    >
-                        @step.title
-                    </legend>
-                    @if(step.help) {
-                        <p class="identity-title-explainer">
-                            @step.help.map(paragraph =>
-                                Html(s"<p>$paragraph</p>")
-                            )
-                        </p>
-                    }
-                </div>
+                @if(step.help) {
+                    <div class="identity-forms-wrapper__title">
+                        @step.help.map(paragraph =>
+                            Html(s"<p class='identity-title-explainer'>$paragraph</p>")
+                        )
+                    </div>
+                }
                 <div class="identity-forms-wrapper__fields">
                     @step.content
                 </div>
@@ -103,7 +96,7 @@
         </div>
     </form>
 }
-@consentStep(journey:String) = @{
+@communicationConsentStep = @{
     ConsentStep(
         name = "consent",
         title = if(journey == "all") {
@@ -174,18 +167,9 @@
     }
 }
 
-@title(journey: String) = @{
-    journey match {
-        case "default" => "Complete your registration"
-        case _ => "Edit your profile"
-    }
-}
-
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-wizard">
 
     <div class="js-errorHolder manage-account__errors"></div>
-
-    <h1 class="identity-title identity-title--page-title">@title(journey)</h1>
 
     <noscript>
         <div class="form__error">
@@ -216,14 +200,14 @@
             }
             case "all" => {
                 @renderSteps(List(
-                    consentStep(journey = "all"),
+                    communicationConsentStep,
                     emailRepermissionStep,
                     channelStep
-                ));
+                ))
             }
             case _ => {
                 @renderSteps(List(
-                    consentStep(journey = "consent"),
+                    communicationConsentStep,
                     emailRepermissionOrSignupStep,
                     channelStep
                 ))

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,7 +30,7 @@
     }
 }
 
-@renderStep(step: ConsentStep) = {
+@renderStep(step: ConsentStep, index: Option[Int] = None) = {
     @if(step.show) {
         <fieldset
             class="identity-wizard__step"
@@ -45,6 +45,11 @@
                         @step.help.map(paragraph =>
                             Html(s"<p class='identity-title-explainer'>$paragraph</p>")
                         )
+                        @if(index.contains(0)) {
+                            <p class='identity-title-explainer'>
+                                By continuing you are confirming that you are aged over 13.
+                            </p>
+                        }
                     </div>
                 }
                 <div class="identity-forms-wrapper__fields">
@@ -56,7 +61,7 @@
     }
 }
 @renderSteps(steps:List[ConsentStep]) = @{
-    steps.map(renderStep)
+    steps.zipWithIndex.map{ case (element, index) => renderStep(element, Some(index)) }
 }
 
 @channelStepContent = {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -6,6 +6,7 @@
 @import form.IdFormHelpers.nonInputFields
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.fragment.Switch._
+@import views.support.fragment.ConsentStep
 @import views.support.fragment.ConsentChannel._
 @import conf.switches.Switches.IdentityShowCommunicationChannelConsents
 @import common.LinkTo
@@ -29,142 +30,147 @@
     }
 }
 
-@emailRepermissionStepShouldDisplay = @{
-    onlySubscribedToV1Newsletters.nonEmpty
-}
-
-@channelStep() = {
-    @if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
-        <fieldset class="identity-wizard__step" data-wizard-step-name="channels" role="dialog" aria-labelledby="consentWizardChannelsTitle">
-
+@renderStep(step: ConsentStep) = {
+    @if(step.show) {
+        <fieldset
+            class="identity-wizard__step"
+            data-wizard-step-name="@step.name"
+            role="dialog"
+            aria-labelledby="consentWizard@{step.name.capitalize}Title"
+        >
             <div class="identity-forms-wrapper">
                 <div class="identity-forms-wrapper__title">
-                    <legend class="identity-title identity-title--small" id="consentWizardChannelsTitle">
-                        How can we get in touch with you?
+                    <legend
+                        class="identity-title identity-title--small"
+                        id="consentWizard@{step.name.capitalize}Title"
+                    >
+                        @step.title
                     </legend>
-                    <p class="identity-title-explainer">
-                        Besides email, are there any other ways you would like us to get in touch with you?
-                    </p>
-                </div>
-
-                <div class="identity-forms-wrapper__fields">
-                    <div class="manage-account__switches">
-                        <ul>
-                            @communicationChannelsForUser(user).map((channel) =>
-                                Html(s"<li>${checkboxName(channel)}</li>")
+                    @if(step.help) {
+                        <p class="identity-title-explainer">
+                            @step.help.map(paragraph =>
+                                Html(s"<p>$paragraph</p>")
                             )
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
-        </fieldset>
-    }
-}
-
-@consentStep(journey:String) = {
-    <fieldset class="identity-wizard__step" data-wizard-step-name="consent" role="dialog" aria-labelledby="consentWizardConsentTitle">
-
-        <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-            @views.html.helper.CSRF.formField
-            <div class="identity-forms-wrapper__title">
-                @if(journey == "all") {
-                    <legend class="identity-title identity-title--small" id="consentWizardConsentTitle">
-                        We need you to consent again to receiving communications from The Guardian
-                    </legend>
-                    <p class="identity-title-explainer">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
-                } else {
-                    <legend class="identity-title identity-title--small" id="consentWizardConsentTitle">
-                        What would you like to hear about?
-                    </legend>
-                    <p class="identity-title-explainer">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
-                }
-            </div>
-            <div class="identity-forms-wrapper__fields">
-                <div class="manage-account__switches manage-account__switches--single-column">
-                    <ul>
-                    @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
-                        <li>
-                            @if(index == 0) {
-                                @fragments.consentSwitch(consentField, consentHint)(messages)
-                            } else {
-                                @fragments.consentSwitch(consentField)(messages)
-                            }
-                        </li>
+                        </p>
                     }
-                    </ul>
-                </div>
-            </div>
-        </form>
-
-    </fieldset>
-}
-
-@emailRepermissionStep() = {
-    @if(emailRepermissionStepShouldDisplay) {
-        <fieldset class="identity-wizard__step" data-wizard-step-name="email" role="dialog" aria-labelledby="consentWizardEmailTitle">
-
-            <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-
-                <div class="identity-forms-wrapper__title">
-                    @views.html.helper.CSRF.formField
-                    @fragments.form.hidden(emailPrefsForm("htmlPreference"))
-
-                    <legend class="identity-title identity-title--small" id="consentWizardEmailTitle">Your existing newsletters</legend>
-                    <p class="identity-title-explainer">
-                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                    </p>
                 </div>
                 <div class="identity-forms-wrapper__fields">
-                    <div class="manage-account__switches manage-account__switches--single-column">
-                        <ul>
-                        @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
-                        <li>
-                            @fragments.newsletterSwitch(
-                                emailPrefsForm,
-                                emailSubscriptions,
-                                newsletter = newsletter,
-                                unchecked = true
-                            )(nonInputFields, messages, request)
-                        </li>
-                        }
-                        </ul>
-                    </div>
+                    @step.content
                 </div>
-            </form>
+            </div>
+
         </fieldset>
     }
 }
-
-@emailSignupStep() = {
-    <fieldset class="identity-wizard__step" data-wizard-step-name="email-signup" role="dialog" aria-labelledby="consentWizardEmailSignupTitle">
-
-        <form class="identity-forms-wrapper" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-            @views.html.helper.CSRF.formField
-            @fragments.form.hidden(emailPrefsForm("htmlPreference"))
-
-            <div class="identity-forms-wrapper__title">
-
-                <legend class="identity-title identity-title--small" id="consentWizardEmailSignupTitle">Your newsletters</legend>
-                <p class="identity-title-explainer">
-                    Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
-                </p>
-            </div>
-
-            <div class="identity-forms-wrapper__fields">
-                <div class="manage-account__switches">
-                    @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
-                </div>
-            </div>
-        </form>
-    </fieldset>
+@renderSteps(steps:List[ConsentStep]) = @{
+    steps.map(renderStep)
 }
 
-@emailRepermissionOrSignupStep() = {
-    @if(emailRepermissionStepShouldDisplay) {
-        @emailRepermissionStep()
+@channelStepContent = {
+    <div class="manage-account__switches">
+        <ul>
+        @communicationChannelsForUser(user).map((channel) =>
+            Html(s"<li>${checkboxName(channel)}</li>")
+        )
+        </ul>
+    </div>
+}
+@channelStep = @{
+    ConsentStep(
+        name = "channels",
+        title = "How can we get in touch with you?",
+        help = List("Besides email, are there any other ways you would like us to get in touch with you?"),
+        content = channelStepContent,
+        show = IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty
+    )
+}
+
+@consentStepContent = {
+    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+        @views.html.helper.CSRF.formField
+        <div class="manage-account__switches manage-account__switches--single-column">
+            <ul>
+            @helper.repeatWithIndex(forms.privacyForm("consents"), min = 1) { (consentField, index) =>
+                <li>
+                    @if(index == 0) {
+                        @fragments.consentSwitch(consentField, consentHint)(messages)
+                    } else {
+                        @fragments.consentSwitch(consentField)(messages)
+                    }
+                </li>
+            }
+            </ul>
+        </div>
+    </form>
+}
+@consentStep(journey:String) = @{
+    ConsentStep(
+        name = "consent",
+        title = if(journey == "all") {
+            "We need you to consent again to receiving communications from The Guardian"
+        } else {
+            "What would you like to hear about?"
+        },
+        help = List("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        content = consentStepContent
+    )
+}
+
+@emailRepermissionStepContent = {
+    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+        @views.html.helper.CSRF.formField
+        @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+        <div class="manage-account__switches manage-account__switches--single-column">
+            <ul>
+            @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
+            <li>
+                @fragments.newsletterSwitch(
+                    emailPrefsForm,
+                    emailSubscriptions,
+                    newsletter = newsletter,
+                    unchecked = true
+                )(nonInputFields, messages, request)
+            </li>
+            }
+            </ul>
+        </div>
+    </form>
+}
+@emailRepermissionStep() = @{
+    ConsentStep(
+        name = "email",
+        title = "Your existing newsletters",
+        help = List("You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them."),
+        content = emailRepermissionStepContent,
+        show = onlySubscribedToV1Newsletters.nonEmpty
+    )
+}
+
+@emailSignupStepContent = {
+    <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+        @views.html.helper.CSRF.formField
+        @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+
+        <div class="manage-account__switches">
+        @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
+        </div>
+    </form>
+}
+@emailSignupStep() = @{
+    ConsentStep(
+        name = "email-signup",
+        title = "Your newsletters",
+        help = List("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below."),
+        content = emailSignupStepContent,
+        show = true
+    )
+}
+
+@emailRepermissionOrSignupStep = @{
+    if(emailRepermissionStep.show) {
+        emailRepermissionStep()
     } else {
-        @emailSignupStep()
+        emailSignupStep()
     }
 }
 
@@ -196,25 +202,31 @@
 
         @journey match {
             case "newsletters" => {
-                @if(emailRepermissionStepShouldDisplay) {
-                    @emailRepermissionStep()
-                } else {
-                    <div class="identity-wizard__step form__error">
-                        <p>
-                            Something went wrong updating your newsletters.
-                        </p>
-                    </div>
-                }
+                @renderSteps(List(
+                    if(emailRepermissionStep.show) {
+                        emailRepermissionStep
+                    } else {
+                        ConsentStep(
+                            name = "error",
+                            title = "Sorry",
+                            content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
+                        )
+                    }
+                ))
             }
             case "all" => {
-                @consentStep(journey = "all")
-                @emailRepermissionStep()
-                @channelStep()
+                @renderSteps(List(
+                    consentStep(journey = "all"),
+                    emailRepermissionStep,
+                    channelStep
+                ));
             }
             case _ => {
-                @consentStep(journey = "consent")
-                @emailRepermissionOrSignupStep()
-                @channelStep()
+                @renderSteps(List(
+                    consentStep(journey = "consent"),
+                    emailRepermissionOrSignupStep,
+                    channelStep
+                ))
             }
         }
 

--- a/identity/app/views/support/fragment/ConsentStep.scala
+++ b/identity/app/views/support/fragment/ConsentStep.scala
@@ -1,0 +1,11 @@
+package views.support.fragment
+
+import play.twirl.api.Html
+
+case class ConsentStep (
+  name: String,
+  title: String,
+  help: List[String] = List(),
+  content: Html = Html(""),
+  show: Boolean = true,
+)

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -1,7 +1,11 @@
+.identity-forms-wrapper {
+    border-top: 1px solid $neutral-8;
+    padding-top: $gs-baseline;
+}
+
 .identity-forms-wrapper__title {
     margin-bottom: $gs-baseline * 2;
 }
-
 
 @supports (display: flex) {
     @include mq(desktop) {

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -5,6 +5,9 @@
 
 .identity-forms-wrapper__title {
     margin-bottom: $gs-baseline * 2;
+    .identity-title-explainer:first-child {
+        margin-top: 0;
+    }
 }
 
 @supports (display: flex) {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -58,7 +58,7 @@ $identity-header-height: 48px;
     margin-right: auto;
     max-width: gs-span(6);
     padding-bottom: $gs-baseline*4;
-    padding-top: $gs-baseline*4;
+    padding-top: $gs-baseline * 2;
 
     &.identity-wrapper--with-wizard {
         padding-bottom: 0;
@@ -117,8 +117,20 @@ $identity-header-height: 48px;
     }
 }
 
-.identity-title-subtitle {
-    @include fs-bodyCopy(2);
+.identity-title--small {
+    @include fs-headline(3);
+    @include mq(desktop) {
+        @include fs-headline(3, true);
+        font-weight: 500;
+    }
+}
+
+.identity-title--page-title {
+    margin-bottom: $gs-baseline * 2;
+}
+
+.identity-title-explainer {
+    @include fs-bodyCopy(1);
     margin-top: $gs-baseline;
 }
 


### PR DESCRIPTION
## What does this change?
Adds page headers to consent journey pages, and brings down the titles in line with other heading sizes across profile pages

## What is the value of this and can you measure success?
Better hierarchy of content. The large side headers on the existing version look too statement-y with a very narrow line length, which sometimes works, sometimes doesn't. It also gives the page a clear title which is an a11y win (that said current titles are kinda bad)

## Screenshots
![screen shot 2018-01-02 at 17 21 56](https://user-images.githubusercontent.com/11539094/34492974-b0007074-efe1-11e7-9a69-4014b2943417.png)
![screen shot 2018-01-02 at 17 21 55](https://user-images.githubusercontent.com/11539094/34492971-addc95a2-efe1-11e7-92bb-a2462272fd5c.png)