### PR TITLE
Enable immersive articles

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -91,7 +91,7 @@ trait FapiFrontPress extends Logging {
     adjustSearchQuery: AdjustSearchQuery = identity,
     adjustSnapItemQuery: AdjustItemQuery = identity): Response[List[PressedContent]]
 
-  val showFields = "body,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalPageCode,main"
+  val showFields = "body,displayHint,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalPageCode,main"
   val searchApiQuery: AdjustSearchQuery = (searchQuery: SearchQuery) =>
     searchQuery
       .showSection(true)


### PR DESCRIPTION
## What does this change?

Show displayHint field on fapi search query for pressing fronts. This field is required for viewing deriving immersive articles

## What is the value of this and can you measure success?

Show display hint field on fapi search query for pressing fronts. 

## Tested in CODE?

No
