### PR TITLE
Send UK banner traffic to just contribute version of support landing page

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -74,10 +74,15 @@ const supporterEngagementCtaCopyJustOne = (location: string): string =>
         ? 'Support the Guardian from as little as $1.'
         : 'Support the Guardian from as little as £1.';
 
+const getSupporterLinkUrl = (location: string): string =>
+    location === 'GB'
+        ? 'https://support.theguardian.com/?bundle=contribute'
+        : 'https://support.theguardian.com';
+
 const supporterParams = (location: string): EngagementBannerParams =>
     Object.assign({}, baseParams, {
         buttonCaption: 'Support the Guardian',
-        linkUrl: 'https://support.theguardian.com',
+        linkUrl: getSupporterLinkUrl(location),
         products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
         messageText: engagementBannerCopy(),
         ctaText: supporterEngagementCtaCopyJustOne(location),


### PR DESCRIPTION
## What does this change?
[This test](https://github.com/guardian/frontend/pull/18563) showed that sending the UK banner traffic to the one off and recurring contributions only page increased AV by 110% (!), as well as pushing up the absolute amount and relative percentage from recurring payments. 

Therefore, we will send the UK audience to this page. 

This means that the UK will be going to this page: 
![screenshot at jan 03 09-55-40](https://user-images.githubusercontent.com/2844554/34515902-56d205d6-f06c-11e7-94c2-81288ba6f1c8.png)

