### PR TITLE
Require a validated email to do the RP Journey

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -56,11 +56,12 @@ class EmailVerificationController(api: IdApiClient,
       }
   }
 
-  def resendEmailValidationEmail(): Action[AnyContent] = authActionWithUser.async {
+  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean): Action[AnyContent] = authActionWithUser.async {
     implicit request =>
       val idRequest = idRequestParser(request)
+      val customMessage = if (isRepermissioningRedirect) Some("You must verify your email to continue.") else None
       api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData).map { _ =>
-        Ok(views.html.verificationEmailResent(request.user, page, idRequest, idUrlBuilder))
+        Ok(views.html.verificationEmailResent(request.user, page, idRequest, idUrlBuilder, customMessage))
       }
   }
 }

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -1,10 +1,19 @@
-@(user: com.gu.identity.model.User, page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(
+    user: com.gu.identity.model.User,
+    page: model.Page,
+    idRequest: services.IdentityRequest,
+    idUrlBuilder: services.IdentityUrlBuilder,
+    customMessage: Option[String] = None
+)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.registrationFooter
 
 @mainLegacy(page, projectName = Option("identity")){
 }{
     <div class="identity-wrapper monocolumn-wrapper">
+        @for(m <- customMessage) {
+            <h1 class="identity-title">@m</h1>
+        }
         <h1 class="identity-title">A new validation email has been sent to your account.</h1>
         <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
         <p>Validation links are valid for 30 minutes before expiring.</p>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -22,7 +22,7 @@ GET         /user/id/:id/:activityType              controllers.PublicProfileCon
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
-GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail()
+GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false)
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)


### PR DESCRIPTION
## What does this change?

Introduces a prerequisite of a validated email to access the re-permissioning journey. 

## What is the value of this and can you measure success?

GDPR Compliance

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

![screencapture-profile-thegulocal-verify-email-1514908939909](https://user-images.githubusercontent.com/3636251/34516488-de5fe854-f06e-11e7-8b88-715eba4229fe.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
