### PR TITLE
Clarify distinction between user from cookie vs. user from IDAPI actions

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -1,15 +1,12 @@
 package actions
 
-import java.net.URLEncoder
-
 import actions.AuthenticatedActions.AuthRequest
 import conf.switches.Switches.{IdentityAllowAccessToGdprJourneyPageSwitch, IdentityPointToConsentJourneyPage}
 import idapiclient.IdApiClient
-import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
+import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import services._
 import utils.Logging
-
 import scala.concurrent.{ExecutionContext, Future}
 
 object AuthenticatedActions {
@@ -22,13 +19,12 @@ class AuthenticatedActions(
     identityUrlBuilder: IdentityUrlBuilder,
     controllerComponents: ControllerComponents,
     newsletterService: NewsletterService,
-    idRequestParser: IdRequestParser
-) extends Logging with Results {
+    idRequestParser: IdRequestParser) extends Logging with Results {
 
   private lazy val anyContentParser: BodyParser[AnyContent] = controllerComponents.parsers.anyContent
   private implicit lazy val ec: ExecutionContext = controllerComponents.executionContext
 
-  def redirectWithReturn(request: RequestHeader, path: String): Result = {
+  private def redirectWithReturn(request: RequestHeader, path: String): Result = {
     val returnUrl = identityUrlBuilder.buildUrl(request.uri)
 
     val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, List(
@@ -68,105 +64,117 @@ class AuthenticatedActions(
     }
   }
 
-  def checkRecentAuthenticationAndRedirect[A](request: Request[A]): Future[Either[Result, AuthRequest[A]]] = Future.successful {
-    authService.authenticatedUserFor(request) match {
+  private def checkRecentAuthenticationAndRedirect[A](request: Request[A]): Future[Either[Result, AuthRequest[A]]] = Future.successful {
+    authService.fullyAuthenticatedUser(request) match {
       case Some(user) if user.hasRecentlyAuthenticated => Right(new AuthenticatedRequest(user, request))
       case _ => Left(sendUserToReauthenticate(request))
     }
   }
 
-  def authRefiner: ActionRefiner[Request, AuthRequest] = new ActionRefiner[Request, AuthRequest] {
-    override val executionContext = ec
+  private def fullAuthRefiner: ActionRefiner[Request, AuthRequest] =
+    new ActionRefiner[Request, AuthRequest] {
+      override val executionContext = ec
 
-    def refine[A](request: Request[A]) =
-      authService.authenticatedUserFor(request) match {
-        case Some(authenticatedUser) => Future.successful(Right(new AuthenticatedRequest(authenticatedUser, request)))
-        case None => checkIdApiForUserAndRedirect(request)
-      }
-  }
+      def refine[A](request: Request[A]) =
+        authService.fullyAuthenticatedUser(request) match {
+          case Some(authenticatedUser) => Future.successful(Right(new AuthenticatedRequest(authenticatedUser, request)))
+          case None => checkIdApiForUserAndRedirect(request)
+        }
+    }
 
-  def permissionRefiner: ActionRefiner[Request, AuthRequest] = new ActionRefiner[Request, AuthRequest] {
-    override val executionContext = ec
+  private def permissionRefiner: ActionRefiner[Request, AuthRequest] =
+    new ActionRefiner[Request, AuthRequest] {
+      override val executionContext = ec
 
-    def refine[A](request: Request[A]) =
-      authService.authenticateUserForPermissions(request) match {
-        case Some(permUser) => Future.successful(Right(new AuthenticatedRequest(permUser, request)))
-        case _ => checkRecentAuthenticationAndRedirect(request)
-      }
-  }
+      def refine[A](request: Request[A]) =
+        authService.consentAuthenticatedUser(request) match {
+          case Some(permUser) => Future.successful(Right(new AuthenticatedRequest(permUser, request)))
+          case _ => checkRecentAuthenticationAndRedirect(request)
+        }
+    }
 
-  def agreeAction(unAuthorizedCallback: (RequestHeader) => Result): AuthenticatedBuilder[AuthenticatedUser] =
-    new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, unAuthorizedCallback)
+  private def retrieveUserFromIdapiRefiner: ActionRefiner[AuthRequest, AuthRequest] =
+    new ActionRefiner[AuthRequest, AuthRequest] {
+      override val executionContext = ec
 
-  def apiVerifiedUserRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
-    override val executionContext = ec
+      def refine[A](request: AuthRequest[A]) =
+        identityApiClient.me(request.user.auth).map {
+          _.fold(
+            errors => {
+              logger.warn(s"Failed to look up logged-in user: $errors")
+              Left(sendUserToSignin(request))
+            },
+            userDO => {
+              logger.trace("user is logged in")
+              Right(new AuthRequest(request.user.copy(user = userDO), request))
+            }
+          )
+        }
+    }
 
-    def refine[A](request: AuthRequest[A]) =
-      identityApiClient.me(request.user.auth).map {
-        _.fold(
-          errors => {
-            logger.warn(s"Failed to look up logged-in user: $errors")
-            Left(sendUserToSignin(request))
-          },
-          userDO => {
-            logger.trace("user is logged in")
-            Right(new AuthRequest(request.user.copy(user = userDO), request))
-          }
-        )
-      }
-  }
+  private def apiUserShouldRepermissionRefiner: ActionRefiner[AuthRequest, AuthRequest] =
+    new ActionRefiner[AuthRequest, AuthRequest] {
+      override val executionContext = ec
 
-  def apiUserShouldRepermissionRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
-    override val executionContext = ec
+      def refine[A](request: AuthRequest[A]) =
+        if (IdentityPointToConsentJourneyPage.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
+          decideConsentJourney(request)
+        else
+          Future.successful(Right(request))
 
-    def refine[A](request: AuthRequest[A]) =
-      if (IdentityPointToConsentJourneyPage.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
-        decideConsentJourney(request)
-      else
-        Future.successful(Right(request))
+      private def decideConsentJourney[A](request: AuthRequest[A]) =
+        (userEmailValidated(request), userHasRepermissioned(request)) match {
+          case (false, _) =>
+            Future.successful(Left(sendUserToValidateEmail(request)))
 
-    private def decideConsentJourney[A](request: AuthRequest[A]) =
-      userEmailValidated(request) -> userHasRepermissioned(request) match {
-        case (false, _) => Future.successful(Left(sendUserToValidateEmail(request)))
-        case (true, false) => Future.successful(Left(sendUserToAllConsentsJourney(request)))
-        case (true, true) =>
-          newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
-            if (newsletterService.getV1EmailSubscriptions(emailFilledForm).isEmpty)
-              Right(request)
-            else
-              Left(sendUserToNewslettersConsentsJourney(request))
-          }
-      }
+          case (true, false) =>
+            Future.successful(Left(sendUserToAllConsentsJourney(request)))
 
-    private def userHasRepermissioned(request: AuthRequest[_]): Boolean =
-      request.user.statusFields.hasRepermissioned.contains(true)
+          case (true, true) =>
+            newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map {
+              emailFilledForm =>
+                if (newsletterService.getV1EmailSubscriptions(emailFilledForm).isEmpty)
+                  Right(request)
+                else
+                  Left(sendUserToNewslettersConsentsJourney(request))
+              }
+        }
 
-    private def userEmailValidated(request: AuthRequest[_]): Boolean =
-      request.user.statusFields.isUserEmailValidated
-}
+      private def userHasRepermissioned(request: AuthRequest[_]): Boolean =
+        request.user.statusFields.hasRepermissioned.contains(true)
 
-  def recentlyAuthenticatedRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
-    override val executionContext = ec
+      private def userEmailValidated(request: AuthRequest[_]): Boolean =
+        request.user.statusFields.isUserEmailValidated
+    }
 
-    def refine[A](request: AuthRequest[A]) = checkRecentAuthenticationAndRedirect(request)
-  }
+  private def recentlyAuthenticatedRefiner: ActionRefiner[AuthRequest, AuthRequest] =
+    new ActionRefiner[AuthRequest, AuthRequest] {
+      override val executionContext = ec
+
+      def refine[A](request: AuthRequest[A]) = checkRecentAuthenticationAndRedirect(request)
+    }
+
   // Play will not let you set up an ActionBuilder with a Refiner hence this empty actionBuilder to set up Auth
-  def noOpActionBuilder: DefaultActionBuilder = DefaultActionBuilder(anyContentParser)
+  private def noOpActionBuilder: DefaultActionBuilder = DefaultActionBuilder(anyContentParser)
 
-  def authAction: ActionBuilder[AuthRequest, AnyContent] =
-    noOpActionBuilder andThen authRefiner
+  /** SC_GU_U cookie present */
+  def fullAuthAction: ActionBuilder[AuthRequest, AnyContent] =
+    noOpActionBuilder andThen fullAuthRefiner
 
-  def authActionWithUser: ActionBuilder[AuthRequest, AnyContent] =
-    authAction andThen apiVerifiedUserRefiner
+  /** SC_GU_U cookie present and user retrieved from IDAPI */
+  def fullAuthWithIdapiUserAction: ActionBuilder[AuthRequest, AnyContent] =
+    fullAuthAction andThen retrieveUserFromIdapiRefiner
 
-  def recentlyAuthenticated: ActionBuilder[AuthRequest, AnyContent] =
-    authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
+  /** Recently obtained SC_GU_U cookie and user retrieved from IDAPI */
+  def recentFullAuthWithIdapiUserAction: ActionBuilder[AuthRequest, AnyContent] =
+    fullAuthAction andThen recentlyAuthenticatedRefiner andThen retrieveUserFromIdapiRefiner
 
-  def authWithConsentRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
-    authWithRPCookie andThen apiUserShouldRepermissionRefiner
+  /** Auth with at least SC_GU_RP, that is, auth with SC_GU_U or else SC_GU_RP, and user retrieved from IDAPI */
+  def consentAuthWithIdapiUserAction: ActionBuilder[AuthRequest, AnyContent] =
+    noOpActionBuilder andThen permissionRefiner andThen retrieveUserFromIdapiRefiner
 
-  /** Auth with at least SC_GU_RP, that is, auth with SC_GU_U or else SC_GU_RP */
-  def authWithRPCookie: ActionBuilder[AuthRequest, AnyContent] =
-    noOpActionBuilder andThen permissionRefiner andThen apiVerifiedUserRefiner
+  /** Auth wiht at least SC_GU_RP and decide if user should be redirected to consent journey */
+  def consentJourneyRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
+    consentAuthWithIdapiUserAction andThen apiUserShouldRepermissionRefiner
 
 }

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -189,7 +189,7 @@ class AuthenticatedActions(
   def consentAuthWithIdapiUserAction: ActionBuilder[AuthRequest, AnyContent] =
     noOpActionBuilder andThen consentAuthRefiner andThen retrieveUserFromIdapiRefiner
 
-  /** Auth wiht at least SC_GU_RP and decide if user should be redirected to consent journey */
+  /** Auth with at least SC_GU_RP and decide if user should be redirected to consent journey */
   def consentJourneyRedirectAction: ActionBuilder[AuthRequest, AnyContent] =
     consentAuthWithIdapiUserAction andThen apiUserShouldRepermissionFilter
 

--- a/identity/app/controllers/AccountDeletionController.scala
+++ b/identity/app/controllers/AccountDeletionController.scala
@@ -51,14 +51,14 @@ class AccountDeletionController(
   ))
 
   def renderAccountDeletionForm: Action[AnyContent] = csrfAddToken {
-    authActionWithUser.async { implicit request =>
+    fullAuthWithIdapiUserAction.async { implicit request =>
       val form = accountDeletionForm.bindFromFlash.getOrElse(accountDeletionForm)
       Future(NoCache(Ok(views.html.profile.deletion.accountDeletion(page, idRequestParser(request), idUrlBuilder, form, Nil, request.user))))
     }
   }
 
   def processAccountDeletionForm: Action[AnyContent] = csrfCheck {
-    authActionWithUser.async { implicit request =>
+    fullAuthWithIdapiUserAction.async { implicit request =>
       val boundForm = accountDeletionForm.bindFromRequest
 
       boundForm.fold(

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -30,7 +30,7 @@ class ChangePasswordController(
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging with Mappings with implicits.Forms {
 
-  import authenticatedActions.authAction
+  import authenticatedActions.fullAuthAction
 
   val page = IdentityPage("/password/change", "Change Password")
 
@@ -57,7 +57,7 @@ class ChangePasswordController(
   )
 
   def displayForm(): Action[AnyContent] = csrfAddToken {
-    authAction.async {
+    fullAuthAction.async {
       implicit request =>
 
         val form = passwordForm.bindFromFlash.getOrElse(passwordForm)
@@ -73,12 +73,12 @@ class ChangePasswordController(
 
   def renderPasswordConfirmation: Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
-    val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+    val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     NoCache(Ok(views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)))
   }
 
   def submitForm(): Action[AnyContent] = csrfCheck {
-    authAction.async {
+    fullAuthAction.async {
       implicit request =>
         val idRequest = idRequestParser(request)
         val boundForm = passwordFormWithConstraints.bindFromRequest()
@@ -102,7 +102,7 @@ class ChangePasswordController(
               SeeOther(routes.ChangePasswordController.displayForm().url).flashing(clearPasswords(form).toFlash)
             )
           } else {
-            val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+            val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
             NoCache(SeeOther(routes.ChangePasswordController.renderPasswordConfirmation().url))
           }
         }

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -23,7 +23,7 @@ class EmailVerificationController(api: IdApiClient,
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging {
 
   import ValidationState._
-  import authenticatedActions.authActionWithUser
+  import authenticatedActions.fullAuthWithIdapiUserAction
 
   val page = IdentityPage("/verify-email", "Verify Email")
 
@@ -43,7 +43,7 @@ class EmailVerificationController(api: IdApiClient,
 
             case Right(ok) => validated
           }
-          val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+          val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
           val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
           val verifiedReturnUrl = verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl)
           val encodedReturnUrl = URLEncoder.encode(verifiedReturnUrl, "utf-8")
@@ -56,7 +56,7 @@ class EmailVerificationController(api: IdApiClient,
       }
   }
 
-  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean): Action[AnyContent] = authActionWithUser.async {
+  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
     implicit request =>
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("You must verify your email to continue.") else None

--- a/identity/app/controllers/ExactTargetController.scala
+++ b/identity/app/controllers/ExactTargetController.scala
@@ -19,9 +19,9 @@ class ExactTargetController(
   val controllerComponents: ControllerComponents
 ) extends BaseController with ImplicitControllerExecutionContext with SafeLogging {
 
-  import authenticatedActions.authAction
+  import authenticatedActions.fullAuthAction
 
-  def subscribe(subscriptionDefId: String, returnUrl: String): Action[AnyContent] = authAction.apply {
+  def subscribe(subscriptionDefId: String, returnUrl: String): Action[AnyContent] = fullAuthAction.apply {
     implicit request =>
 
       idRequestParser(request).returnUrl match {

--- a/identity/app/controllers/FormstackController.scala
+++ b/identity/app/controllers/FormstackController.scala
@@ -21,11 +21,11 @@ class FormstackController(
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging {
 
-  import authenticatedActions.authAction
+  import authenticatedActions.fullAuthAction
 
   val page = IdentityPage("/form", "Form")
 
-  def formstackForm(formReference: String, composer: Boolean): Action[AnyContent] = authAction.async { implicit request =>
+  def formstackForm(formReference: String, composer: Boolean): Action[AnyContent] = fullAuthAction.async { implicit request =>
     if (Switches.IdentityFormstackSwitch.isSwitchedOn) {
       FormstackForm.extractFromSlug(formReference).map { formstackForm =>
         formStackApi.checkForm(formstackForm).map {

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -26,10 +26,10 @@ class ReauthenticationController(
     val controllerComponents: ControllerComponents,
     val httpConfiguration: HttpConfiguration)
     (implicit context: ApplicationContext)
-  extends BaseController 
-  with ImplicitControllerExecutionContext 
-  with SafeLogging 
-  with Mappings 
+  extends BaseController
+  with ImplicitControllerExecutionContext
+  with SafeLogging
+  with Mappings
   with Forms {
 
   val page = IdentityPage("/reauthenticate", "Re-authenticate")
@@ -47,7 +47,7 @@ class ReauthenticationController(
     )
   )
 
-  def renderForm(returnUrl: Option[String]): Action[AnyContent] = authenticatedActions.authActionWithUser { implicit request =>
+  def renderForm(returnUrl: Option[String]): Action[AnyContent] = authenticatedActions.fullAuthWithIdapiUserAction { implicit request =>
     val filledForm = form.bindFromFlash.getOrElse(form.fill(""))
 
     logger.trace("Rendering reauth form")
@@ -61,7 +61,7 @@ class ReauthenticationController(
     ))
   }
 
-  def processForm: Action[AnyContent] = authenticatedActions.authActionWithUser.async { implicit request =>
+  def processForm: Action[AnyContent] = authenticatedActions.fullAuthWithIdapiUserAction.async { implicit request =>
     val idRequest = idRequestParser(request)
     val boundForm = formWithConstraints.bindFromRequest
     val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -109,7 +109,7 @@ class ResetPasswordController(
             }
 
           case Right(ok) =>
-            val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+            val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
             NoCache(SeeOther(routes.ResetPasswordController.renderPasswordResetConfirmation.url))
         }
     }
@@ -119,7 +119,7 @@ class ResetPasswordController(
 
   def renderPasswordResetConfirmation: Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
-    val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+    val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     Ok(views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn))
   }
 

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -4,45 +4,60 @@ import idapiclient.{Auth, ScGuRp, ScGuU}
 import com.gu.identity.model.User
 import conf.FrontendIdentityCookieDecoder
 import play.api.mvc.{Cookie, RequestHeader, Results}
-
 import scala.language.implicitConversions
 import org.joda.time.Minutes
-import utils.Logging
 
 object AuthenticatedUser {
   implicit def authUserToUser(authUser: AuthenticatedUser): User = authUser.user
 }
 
-case class AuthenticatedUser(user: User, auth: Auth, hasRecentlyAuthenticated: Boolean = false)
+case class AuthenticatedUser(
+  user: User,
+  auth: Auth,
+  hasRecentlyAuthenticated: Boolean = false)
 
-class AuthenticationService(cookieDecoder: FrontendIdentityCookieDecoder,
-                            idRequestParser: IdRequestParser,
-                            identityUrlBuilder: IdentityUrlBuilder) extends Logging with Results {
+class AuthenticationService(
+    cookieDecoder: FrontendIdentityCookieDecoder,
+    idRequestParser: IdRequestParser,
+    identityUrlBuilder: IdentityUrlBuilder) extends Results {
 
-  def authenticatedUserFor[A](request: RequestHeader): Option[AuthenticatedUser] = for {
-    scGuU <- request.cookies.get("SC_GU_U")
-    guU <- request.cookies.get("GU_U")
-    scGuLaOpt = request.cookies.get("SC_GU_LA")
-    minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
-    guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
-    fullUser = guUCookieData.getUser if fullUser.getId == minimalSecureUser.getId
-  } yield {
-    AuthenticatedUser(fullUser, ScGuU(scGuU.value, guUCookieData), hasRecentlyAuthenticated(fullUser, scGuLaOpt))
+  /** User has SC_GU_U and GU_U cookies */
+  def fullyAuthenticatedUser[A](request: RequestHeader): Option[AuthenticatedUser] =
+    for {
+      scGuU         <- request.cookies.get("SC_GU_U")
+      guU           <- request.cookies.get("GU_U")
+      userFromScGuU <- cookieDecoder.getUserDataForScGuU(scGuU.value)
+      dataFromGuU   <- cookieDecoder.getUserDataForGuU(guU.value)
+      if dataFromGuU.getUser.getId == userFromScGuU.getId
+    } yield {
+      AuthenticatedUser(
+        user = dataFromGuU.getUser,
+        auth = ScGuU(scGuU.value, dataFromGuU),
+        hasRecentlyAuthenticated = hasRecentlyAuthenticated(dataFromGuU.getUser, request.cookies.get("SC_GU_LA")))
+    }
+
+  /** User has SC_GU_RP or SC_GU_U */
+  def consentAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = {
+    fullyAuthenticatedUser(request)
+      .orElse(consentCookieAuthenticatedUser(request))
   }
 
-  def hasRecentlyAuthenticated(user: User, cookie: Option[Cookie]): Boolean = {
-    cookie.exists(scGuLa => cookieDecoder.userHasRecentScGuLaCookie(user, scGuLa.value, Minutes.minutes(20).toStandardDuration))
+  def userIsFullyAuthenticated(request: RequestHeader): Boolean =
+    fullyAuthenticatedUser(request).isDefined
+
+  private def hasRecentlyAuthenticated(user: User, cookie: Option[Cookie]): Boolean = {
+    cookie.exists(scGuLa =>
+      cookieDecoder.userHasRecentScGuLaCookie(
+        user,
+        scGuLa.value,
+        Minutes.minutes(20).toStandardDuration))
   }
 
-  def authenticateUserForPermissions(request: RequestHeader): Option[AuthenticatedUser] = {
-    lazy val guRpAuth =
-      for {
-        scGuRp <- request.cookies.get("SC_GU_RP")
-        fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
-      } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
-    authenticatedUserFor(request).orElse(guRpAuth)
+  private def consentCookieAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = {
+    for {
+      scGuRp          <- request.cookies.get("SC_GU_RP")
+      userFromScGuRp  <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
+    } yield AuthenticatedUser(userFromScGuRp, ScGuRp(scGuRp.value))
   }
-
-  def requestPresentsAuthenticationCredentials(request: RequestHeader): Boolean = authenticatedUserFor(request).isDefined
 
 }

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -63,7 +63,7 @@ import scala.concurrent.Future
       new ProfileMapping
     )
 
-    when(authService.authenticatedUserFor(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
+    when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
     when(api.me(testAuth)) thenReturn Future.successful(Right(user))
 
     when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -32,7 +32,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
   when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
   when(idRequest.trackingData) thenReturn trackingData
-  when(authenticationService.requestPresentsAuthenticationCredentials(MockitoMatchers.any[Request[_]])) thenReturn true
+  when(authenticationService.userIsFullyAuthenticated(MockitoMatchers.any[Request[_]])) thenReturn true
   when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(Some("http://www.theguardian.com/football"))
 
   val controller = new EmailVerificationController(

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -44,7 +44,7 @@ class FormstackControllerTest extends path.FreeSpec
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
   val authenticatedActions = new AuthenticatedActions(authService, mock[IdApiClient], mock[IdentityUrlBuilder], controllerComponents, newsletterService, requestParser)
 
-  when(authService.authenticatedUserFor(MockitoMatchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, ScGuU("abc", GuUCookieData(user, 0, None))))
+  when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, ScGuU("abc", GuUCookieData(user, 0, None))))
 
   when(requestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
   when(idRequest.trackingData) thenReturn trackingData


### PR DESCRIPTION
## What does this change?

Refactor `AuthenticatedActions` to hopefully clarify the distinction between various actions.

Note the difference between 

* user from cookie
* user form idapi
* full auth via `SC_GU_U`
* partial auth via `SC_GU_RP` which gives access to (at least) consents related fields

Related PR: https://github.com/guardian/frontend/pull/18638

## What is the value of this and can you measure success?

Refactoring.

