### PR TITLE
[Identity] Improve error design

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -10,6 +10,7 @@ import utils.SafeLogging
 import model.{ApplicationContext, IdentityPage}
 import actions.AuthenticatedActions
 import conf.switches.Switches.IdentityPointToConsentJourneyPage
+import pages.IdentityHtmlPage
 
 
 class EmailVerificationController(api: IdApiClient,
@@ -61,7 +62,9 @@ class EmailVerificationController(api: IdApiClient,
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("You must verify your email to continue.") else None
       api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData).map { _ =>
-        Ok(views.html.verificationEmailResent(request.user, page, idRequest, idUrlBuilder, customMessage))
+        Ok(
+          IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage))(page, request, context)
+        )
       }
   }
 }

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -1,6 +1,5 @@
 @(
     user: com.gu.identity.model.User,
-    page: model.Page,
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     customMessage: Option[String] = None
@@ -8,15 +7,12 @@
 
 @import views.html.fragments.registrationFooter
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
-    <div class="identity-wrapper monocolumn-wrapper">
-        @for(m <- customMessage) {
-            <h1 class="identity-title">@m</h1>
-        }
-        <h1 class="identity-title">A new validation email has been sent to your account.</h1>
-        <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
-        <p>Validation links are valid for 30 minutes before expiring.</p>
-        @registrationFooter(idRequest, idUrlBuilder)
-    </div>
-}
+<div class="identity-wrapper monocolumn-wrapper">
+    @for(m <- customMessage) {
+        <h1 class="identity-title">@m</h1>
+    }
+    <h1 class="identity-title">A new validation email has been sent to your account.</h1>
+    <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
+    <p>Validation links are valid for 30 minutes before expiring.</p>
+    @registrationFooter(idRequest, idUrlBuilder)
+</div>

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -8,11 +8,15 @@
 @import views.html.fragments.registrationFooter
 
 <div class="identity-wrapper monocolumn-wrapper">
-    @for(m <- customMessage) {
-        <h1 class="identity-title">@m</h1>
-    }
-    <h1 class="identity-title">A new validation email has been sent to your account.</h1>
-    <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
-    <p>Validation links are valid for 30 minutes before expiring.</p>
+    <div class="identity-forms-message">
+        <h1 class="identity-title">A new validation email has been sent to your account.</h1>
+        <div class="identity-forms-message__body">
+            @for(m <- customMessage) {
+                <p><strong>@m</strong></p>
+            }
+        <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
+        <p>Validation links are valid for 30 minutes before expiring.</p>
+        </div>
+    </div>
     @registrationFooter(idRequest, idUrlBuilder)
 </div>

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -1,3 +1,25 @@
+/*
+Messages
+*/
+.identity-forms-message {
+    max-width: gs-span(6);
+    margin: 0 auto;
+    @include mq(tablet) {
+        margin: ($gs-baseline * 4) auto;
+        @supports(height: 1vh) {
+            margin: 15vh auto;
+        }
+    }
+    .identity-forms-message__body {
+        border-top: 1px solid $neutral-7;
+        margin-top: $gs-baseline * 2;
+        padding-top: $gs-baseline / 2;
+    }
+}
+
+/*
+Wrapper
+*/
 .identity-forms-wrapper {
     border-top: 1px solid $neutral-8;
     padding-top: $gs-baseline;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -5,9 +5,9 @@ Messages
     max-width: gs-span(6);
     margin: 0 auto;
     @include mq(tablet) {
-        margin: ($gs-baseline * 4) auto;
+        margin: ($gs-baseline * 4) auto ($gs-baseline * 2);
         @supports(height: 1vh) {
-            margin: 15vh auto;
+            margin: 12.5vh auto 17.5vh;
         }
     }
     .identity-forms-message__body {


### PR DESCRIPTION
## What does this change?
Makes the email verification error message more 𝓯𝓪𝓷𝓬𝔂 by means of making it float alone in a sea of white space. Adrift and lost, in an artistic statement about the loss of trust and the sense of hopelessness that having to go to the email inbox conveys.

## What is the value of this and can you measure success?
I mean, it just looks prettier. The front code is pretty reusable too and it can be ported over to all other error templates

## Before / After
![screen shot 2018-01-03 at 13 21 06](https://user-images.githubusercontent.com/11539094/34522175-5a3966a2-f089-11e7-942e-ba6a96f22eb8.png)
![screen shot 2018-01-03 at 13 25 29](https://user-images.githubusercontent.com/11539094/34522235-96e71b8a-f089-11e7-901c-1d1a129b7a87.png)
