### PR TITLE
[identity] [minor] use neutral-5 for border colors

### DIFF
--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -7,7 +7,7 @@
         left: 0;
         right: 0;
         margin-top: $gs-gutter * 2;
-        border-top: 1px solid transparentize($identity-main, .5);
+        border-top: 1px solid $neutral-5;
         justify-content: space-between;
         z-index: $zindex-sticky;
         @include mq($until: tablet) {

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -11,7 +11,7 @@ Messages
         }
     }
     .identity-forms-message__body {
-        border-top: 1px solid $neutral-7;
+        border-top: 1px solid $neutral-5;
         margin-top: $gs-baseline * 2;
         padding-top: $gs-baseline / 2;
     }
@@ -21,7 +21,7 @@ Messages
 Wrapper
 */
 .identity-forms-wrapper {
-    border-top: 1px solid $neutral-8;
+    border-top: 1px solid $neutral-5;
     padding-top: $gs-baseline;
 }
 


### PR DESCRIPTION
## What does this change?
Makes the borders on the new email error page, consent journey slightly darker, this matches the rest of borders on the site
  