### PR TITLE
Editorials as CIF

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -65,7 +65,7 @@
 
                             @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
                                 @if(article.metadata.designType.nameOrDefault == "comment" ||
-                                    article.metadata.designType.nameOfDefault == "guardianview") {
+                                    article.metadata.designType.nameOrDefault == "guardianview") {
                                     @fragments.articleHeaderCommentGarnett(article, model, isPaidContent, amp = amp)
                                 } else {
                                     @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -64,7 +64,8 @@
 
 
                             @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
-                                @if(article.metadata.designType.nameOrDefault == "comment") {
+                                @if(article.metadata.designType.nameOrDefault == "comment" ||
+                                    article.metadata.designType.nameOfDefault == "guardianview") {
                                     @fragments.articleHeaderCommentGarnett(article, model, isPaidContent, amp = amp)
                                 } else {
                                     @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1330,7 +1330,7 @@
             grid-template-columns: ($left-column + $gs-gutter) auto;
             grid-template-areas: 'labels headline-standfirst' 'meta main-media';
 
-            .content--type-guardianview,
+            .content--type-guardianview &,
             .content--type-comment & {
                 grid-template-areas: 'labels headline' 'meta standfirst' '. main-media';
             }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1330,6 +1330,7 @@
             grid-template-columns: ($left-column + $gs-gutter) auto;
             grid-template-areas: 'labels headline-standfirst' 'meta main-media';
 
+            .content--type-guardianview,
             .content--type-comment & {
                 grid-template-areas: 'labels headline' 'meta standfirst' '. main-media';
             }
@@ -1357,6 +1358,7 @@
         @include mq($until: tablet) {
             order: 1;
 
+            .content--type-guardianview &,
             .content--type-comment & {
                 order: 0;
             }
@@ -1390,6 +1392,7 @@
             order: 1;
             margin-top: 0;
 
+            .content--type-guardianview &,
             .content--type-comment & {
                 order: 0;
             }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -186,22 +186,26 @@
 }
 
 .content--pillar-opinion,
-.content--type-comment {
+.content--type-comment,
+.content--type-guardianview {
     @include colorPalatte($opinion-garnett-main-1, $opinion-garnett-main-1, $opinion-garnett-media-main-1);
 }
 
 .content--pillar-arts,
-.content--pillar-arts.content--type-comment {
+.content--pillar-arts.content--type-comment,
+.content--pillar-arts.content--type-guardianview {
     @include colorPalatte($arts-garnett-main-1, $arts-garnett-feature, $arts-garnett-media-main-1);
 }
 
 .content--pillar-lifestyle,
-.content--pillar-lifestyle.content--type-comment {
+.content--pillar-lifestyle.content--type-comment,
+.content--pillar-lifestyle.content--type-guardianview {
     @include colorPalatte($lifestyle-garnett-main-1, $lifestyle-garnett-feature, $lifestyle-garnett-media-main-1);
 }
 
 .content--pillar-sport,
-.content--pillar-sport.content--type-comment {
+.content--pillar-sport.content--type-comment,
+.content--pillar-sport.content--type-guardianview {
     @include colorPalatte($sport-garnett-main-1, $sport-garnett-feature, $sport-garnett-media-main-1);
 }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -8,6 +8,7 @@ $quote-mark: 35px;
 .content--liveblog,
 .content--media,
 .content--type-analysis,
+.content--type-guardianview,
 .content--type-article,
 .content--type-comment,
 .content--type-feature,
@@ -816,6 +817,7 @@ $quote-mark: 35px;
 }
 // *************** Opinion Styles ***************
 
+.content--type-guardianview,
 .content--type-comment {
     .content__head {
         overflow: hidden;
@@ -1187,6 +1189,7 @@ $quote-mark: 35px;
 }
 // *************** Opinion quote weight overrides ***************
 
+.content--type-guardianview,
 .content--type-comment {
     .element-pullquote.element--supporting .pullquote-cite,
     .element-pullquote.element--supporting .pullquote-paragraph {
@@ -1195,6 +1198,7 @@ $quote-mark: 35px;
 }
 // *************** Opinion and Feature standfirst overrides ***************
 
+.content--type-guardianview,
 .content--type-comment,
 .content--type-feature,
 .content--type-review {


### PR DESCRIPTION
Editorial articles (identified by the GuardianView design type) will pull in the comment type colours and layout.