### PR TITLE
Garnett Type Width Expanding

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -543,20 +543,14 @@ $quote-mark: 35px;
         color: $neutral-1;
         padding-top: 2px;
         margin-bottom: $gs-baseline*2;
-        max-width: gs-span(3) - $gs-gutter;
-        @include mq(mobileMedium) {
-            max-width: gs-span(4)- $gs-gutter;
-        }
-        @include mq(mobileLandscape) {
-            max-width: gs-span(4);
-        }
+        max-width: 80%;
         @include mq(phablet) {
-            max-width: gs-span(5);
+            max-width: gs-span(6);
             margin-left: 20px;
             margin-bottom: $gs-baseline*2;
         }
         @include mq(tablet) {
-            max-width: gs-span(6);
+            max-width: gs-span(7);
             margin-left: 0;
         }
         @include mq(leftCol) {
@@ -1199,10 +1193,10 @@ $quote-mark: 35px;
 .content--type-feature,
 .content--type-review {
     .content__standfirst {
-        @include fs-headlineGarnett(1);
+        @include fs-headlineGarnett(0);
         font-weight: 200;
         @include mq(tablet) {
-            @include fs-headlineGarnett(2);
+            @include fs-headlineGarnett(1);
         }
     }
 }

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -13,9 +13,9 @@ $font-scale: (
     headerGarnett: (
         1: (font-size: 14, line-height: 18),
         2: (font-size: 16, line-height: 20),
-        3: (font-size: 18, line-height: 20),
+        3: (font-size: 18, line-height: 22),
         4: (font-size: 20, line-height: 24),
-        5: (font-size: 22, line-height: 24),
+        5: (font-size: 22, line-height: 26),
     ),
     headline: (
         1: (font-size: 14, line-height: 18),
@@ -29,6 +29,7 @@ $font-scale: (
         9: (font-size: 44, line-height: 48),
     ),
     headlineGarnett: (
+        0: (font-size: 18, line-height: 22),
         1: (font-size: 20, line-height: 24),
         2: (font-size: 22, line-height: 26),
         3: (font-size: 26, line-height: 30),


### PR DESCRIPTION
Some type sizing changes.
Standfirst width expanding for Garnett

![expand](https://user-images.githubusercontent.com/6727874/34534161-0938cae6-f0b5-11e7-931f-aa53f5d52a1c.gif)
