### PR TITLE
Nice underlines everywhere

### DIFF
--- a/static/src/stylesheets/amp/_helpers.scss
+++ b/static/src/stylesheets/amp/_helpers.scss
@@ -59,16 +59,17 @@
 
 .u-underline,
 %u-underline {
-    text-decoration: none;
-    border-bottom: 1px solid $neutral-4;
-    transition: border-color .15s ease-out;
+    text-decoration: underline;
+    text-decoration-color: $neutral-4;
+    text-decoration-skip: ink;
 
     &:hover,
     &:focus {
-        border-color: mix($news-default, $neutral-4, 50%);
+        text-decoration-color: mix($news-default, $neutral-4, 50%);
     }
     &:active {
-        border-color: $news-accent;
+        text-decoration-color: $news-accent;
+        text-decoration: underline;
     }
 }
 

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -215,16 +215,17 @@
 
 .u-underline,
 %u-underline {
-    text-decoration: none !important;
-    border-bottom: 1px solid $neutral-4;
-    transition: border-color .15s ease-out;
+    text-decoration: underline;
+    text-decoration-color: $neutral-4;
+    text-decoration-skip: ink;
 
     &:hover,
     &:focus {
-        border-color: mix($news-default, $neutral-4, 50%);
+        text-decoration-color: mix($news-default, $neutral-4, 50%);
     }
     &:active {
-        border-color: $news-accent;
+        text-decoration-color: $news-accent;
+        text-decoration: underline;
     }
 }
 

--- a/static/src/stylesheets/base/_links.scss
+++ b/static/src/stylesheets/base/_links.scss
@@ -7,6 +7,7 @@ a,
     &:hover,
     &:focus {
         text-decoration: underline;
+        text-decoration-skip: ink;
     }
     &:active {
         color: $news-accent;

--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -88,6 +88,7 @@
         .headline-list__body,
         .fc-item__headline {
             text-decoration: underline;
+            text-decoration-skip: ink;
         }
 
         .headline-list__count {


### PR DESCRIPTION
## What does this change?
Underlines across the website will no longer overlap descenders. Using a nifty new(ish) css rule. If it's not supported we get the same underline we had before, so nothing is lost. 

Changes:
- On supported browsers underlines will skip descenders
- Body underlines will no longer have a transition animation on hover
- On IE and unsupported browsers, body articles will have standard underlines for links

The result is easier on the eye and much more accessible to those with cognitive disablities. ([Here's why.](https://medium.com/@iamhiwelo/improving-text-readability-for-dyslexic-users-with-skip-ink-underlines-bf52a2f3426b))

[Browser compatibility](https://caniuse.com/#search=text-decoration-skip)

# Before
<img width="763" alt="screen shot 2018-01-03 at 14 49 22" src="https://user-images.githubusercontent.com/14570016/34525066-a294acf2-f095-11e7-9dce-9d9355e49e7b.png">

# After
<img width="768" alt="screen shot 2018-01-03 at 14 50 32" src="https://user-images.githubusercontent.com/14570016/34525070-a463ccfc-f095-11e7-9fb4-7b41449846af.png">

# Before
<img width="909" alt="screen shot 2018-01-04 at 10 42 49" src="https://user-images.githubusercontent.com/14570016/34560016-1cad40e8-f13c-11e7-8b2f-95da61b0530d.png">

# After
<img width="828" alt="screen shot 2018-01-04 at 10 42 32" src="https://user-images.githubusercontent.com/14570016/34560025-21550658-f13c-11e7-80e0-a45705f6a19b.png">

NB: Garnett crew - there will be some hover rules you need to change to match this, but I don't think they should be in this PR. CC @Joshua-David @superfrank 
  