### PR TITLE
[Identity] Consent channel explainer text

### DIFF
--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -116,7 +116,7 @@
                 @channelConsentForm
             } else {
                 <p class="identity-title-explainer">
-                    Update your <a href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="identity : email : add-channel-info">account details</a> with your phone number or home address to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
+                    Update your <a href="@idUrlBuilder.buildUrl(routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="identity : email : add-channel-info">account details</a> with your phone number or home address to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
                 </p>
             }
         </div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -116,7 +116,7 @@
                 @channelConsentForm
             } else {
                 <p class="identity-title-explainer">
-                    Complete your <a href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="identity : email : add-channel-info">Account details</a> with your phone number or your home address to your to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
+                    Update your <a href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="identity : email : add-channel-info">account details</a> with your phone number or home address to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
                 </p>
             }
         </div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -104,15 +104,21 @@
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
 
 @* CHANNELS *@
-@if(IdentityShowCommunicationChannelConsents.isSwitchedOn && communicationChannelsForUser(user).nonEmpty) {
+@if(IdentityShowCommunicationChannelConsents.isSwitchedOn) {
     <hr class="manage-account-divider" />
 
     <fieldset class="fieldset fieldset--manage-account-noborder">
         <div class="fieldset__heading">
-            <h2 class="form__heading">How can we get in touch with you?</h2>
+            <h2 class="form__heading">How else can we get in touch with you?</h2>
         </div>
         <div class="fieldset__fields">
-            @channelConsentForm
+            @if(communicationChannelsForUser(user).nonEmpty) {
+                @channelConsentForm
+            } else {
+                <p class="identity-title-explainer">
+                    Complete your <a href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="identity : email : add-channel-info">Account details</a> with your phone number or your home address to your to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
+                </p>
+            }
         </div>
     </fieldset>
 }

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -27,9 +27,6 @@ Wrapper
 
 .identity-forms-wrapper__title {
     margin-bottom: $gs-baseline * 2;
-    .identity-title-explainer:first-child {
-        margin-top: 0;
-    }
 }
 
 @supports (display: flex) {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -131,7 +131,7 @@ $identity-header-height: 48px;
 
 .identity-title-explainer {
     @include fs-bodyCopy(1);
-    margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
 }
 
 .identity-title--public-profile {


### PR DESCRIPTION
## What does this change?
Changes the consent channel block (not live yet) so in the event the user has 0 possible consent channels available to them (no postcode or phone in profile), a quite helpful message appears prompting them to fill those out to be able to tick said channels

## Lingering questions
- [x] Is this desired behaviour?
- [x] Is the copy ok?

## Screenshots
![screen shot 2018-01-04 at 12 01 38](https://user-images.githubusercontent.com/11539094/34562607-0c2b557e-f147-11e7-85ee-4f6040724ba1.png)