### PR TITLE
[garnett] Changes for feature showcase.

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -46,28 +46,21 @@
                 @fragments.guBand()
             }
 
-            @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                @fragments.mainMedia(article, amp)
-            }
+
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
-                            @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                                @fragments.headTonalGarnett(article, model, isPaidContent, amp = amp)
-                            }
 
-
-                            @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
                                 @if(article.metadata.designType.nameOrDefault == "comment" ||
                                     article.metadata.designType.nameOrDefault == "guardianview") {
                                     @fragments.articleHeaderCommentGarnett(article, model, isPaidContent, amp = amp)
                                 } else {
                                     @fragments.articleHeaderGarnett(article, model, isPaidContent, amp = amp)
                                 }
-                            }
+
 
                             @fragments.witnessCallToAction(article.content)
                             @BodyCleaner(article, article.fields.body, amp = amp)

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -16,10 +16,25 @@
         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
     </div>
 
+@if((article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
+    <div class="content__headline-showcase-wrapper">
+        <div class="content__header tonal__header">
+
+            <div class="u-cf">
+
+                <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+                @Html(article.trail.headline)
+                </h1>
+            </div>
+        </div>
+    </div>
+}
+
     @fragments.meta.metaInline(article, amp)
 
     <div class="content__headline-standfirst-wrapper">
         <div class="content__header tonal__header">
+
             <div class="u-cf">
 
                 <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
@@ -39,14 +54,17 @@
                 @if(article.content.hasTonalHeaderIllustration) {
                     <span class="content__head__illustration hide-on-mobile">@fragments.inlineSvg("illustration-letters", "icon")</span>
                 }
+                @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
 
-                @article.content.starRating.map { rating =>
-                    <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
-                        <meta articleprop="worstRating" content="1" />
-                        <span articleprop="ratingValue">@rating</span> /
-                        <span articleprop="bestRating">5</span> stars
-                    </span>
+                    @article.content.starRating.map { rating =>
+                        <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
+                            <meta articleprop="worstRating" content="1" />
+                            <span articleprop="ratingValue">@rating</span> /
+                            <span articleprop="bestRating">5</span> stars
+                        </span>
+
                     @fragments.items.elements.starRating(rating)
+                    }
                 }
 
                 @article.content.imdb.map { imdbId =>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -107,5 +107,18 @@
         </div>
     </div>
     @fragments.contentMeta(article, page, amp = amp)
+    @if((article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
+    <div class="media-primary media-content  media-primary--showcase  ">
+        @article.content.starRating.map { rating =>
+            <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
+                <meta articleprop="worstRating" content="1" />
+                <span articleprop="ratingValue">@rating</span> /
+                <span articleprop="bestRating">5</span> stars
+            </span>
+
+        @fragments.items.elements.starRating(rating)
+        }
+    }
     @fragments.mainMedia(article, amp)
+    @if((article.tags.isFeature && article.elements.hasShowcaseMainElement)) {</div>}
 </header>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -107,7 +107,7 @@
         </div>
     </div>
     @fragments.contentMeta(article, page, amp = amp)
-    @if((article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
+    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement && article.content.starRating.isDefined) {
     <div class="media-primary media-content  media-primary--showcase  ">
         @article.content.starRating.map { rating =>
             <span class="u-h" articleprop="reviewRating" articlescope articletype="http://schema.org/Rating">
@@ -120,5 +120,7 @@
         }
     }
     @fragments.mainMedia(article, amp)
-    @if((article.tags.isFeature && article.elements.hasShowcaseMainElement)) {</div>}
+    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement && article.content.starRating.isDefined) {
+    </div>
+    }
 </header>

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -28,7 +28,7 @@
 @if(!isImmersiveMainMedia) {
     @picture.largestImage.map{ largestImage =>
         <div
-        class="u-responsive-ratio@if(isFeatureAndShowcase) { u-responsive-ratio--letterbox}"
+        class="u-responsive-ratio@if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett) && isFeatureAndShowcase) { u-responsive-ratio--letterbox}"
             @if(isFeatureAndShowcase) {} else {style="padding-bottom: @{"%.2f".format(100 * largestImage.height.toDouble / largestImage.width)}%"}
         >
     }

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -12,7 +12,7 @@
 /* ==========================================================================
    Global modules
    ========================================================================== */
-@import 'module/_layout-hints';
+@import 'module/_layout-hints.garnett';
 @import 'module/content-garnett/_article';
 @import 'module/content-garnett/_content';
 @import 'module/content-garnett/_pillars';

--- a/static/src/stylesheets/module/_layout-hints.garnett.scss
+++ b/static/src/stylesheets/module/_layout-hints.garnett.scss
@@ -26,15 +26,6 @@
     font-weight: 200;
     font-style: normal;
     color: $neutral-2;
-
-    @if ($svg-support) {
-        &:before {
-            @extend %i-quote-blue;
-            @extend %svg-i-quote-blue;
-            content: '';
-            display: block;
-        }
-    }
 }
 
 figure.element.element--supporting {

--- a/static/src/stylesheets/module/_layout-hints.garnett.scss
+++ b/static/src/stylesheets/module/_layout-hints.garnett.scss
@@ -179,10 +179,6 @@ figure {
         height: auto;
     }
 
-    .caption--main {
-        padding-left: 0;
-    }
-
     .u-responsive-ratio--letterbox {
         transition: padding-bottom 1s;
     }

--- a/static/src/stylesheets/module/_layout-hints.garnett.scss
+++ b/static/src/stylesheets/module/_layout-hints.garnett.scss
@@ -1,0 +1,191 @@
+@mixin deport-left {
+    @include mq(leftCol) {
+        margin-left: -1 * ($left-column + $gs-gutter);
+    }
+
+    @include mq(wide) {
+        margin-left: -1 * ($left-column-wide + $gs-gutter);
+    }
+}
+
+@mixin reduce-left {
+    @include mq(leftCol) {
+        width: $left-column;
+    }
+
+    @include mq(wide) {
+        width: $left-column-wide;
+    }
+}
+
+@mixin pull-quote {
+    @include fs-headline(4);
+    float: left;
+    margin-top: 0;
+    margin-right: 24px;
+    font-weight: 200;
+    font-style: normal;
+    color: $neutral-2;
+
+    @if ($svg-support) {
+        &:before {
+            @extend %i-quote-blue;
+            @extend %svg-i-quote-blue;
+            content: '';
+            display: block;
+        }
+    }
+}
+
+figure.element.element--supporting {
+    @include mq(tablet) {
+        position: relative;
+        float: left;
+        width: gs-span(4);
+        margin-top: $gs-baseline/2;
+        margin-bottom: $gs-baseline;
+        margin-right: $gs-gutter;
+
+        &.img--landscape {
+            margin-right: $gs-gutter;
+        }
+    }
+
+    @include mq(leftCol) {
+        @include deport-left;
+    }
+
+    @include mq(wide) {
+        width: gs-span(5);
+    }
+}
+
+figure.element.element--thumbnail {
+    float: left;
+    clear: left;
+    margin-bottom: 0;
+    width: gs-span(2) - $gs-gutter;
+    margin-right: $gs-gutter;
+    margin-top: $gs-baseline/2;
+
+    @include mq(tablet) {
+        width: gs-span(2);
+
+        &.img--landscape {
+            margin-right: $gs-gutter; // repeat to override negative margin on img--landscape
+        }
+    }
+
+    @include mq(leftCol) {
+        @include deport-left;
+        position: relative;
+    }
+
+    @include mq(wide) {
+        margin-left: -1 * (gs-span(2) + $gs-gutter);
+    }
+}
+
+figure.element.element--showcase {
+    @include mq(leftCol) {
+        @include deport-left;
+        position: relative;
+        margin-bottom: ($gs-baseline/3)*4;
+        clear: both;
+    }
+}
+
+figure.element.element--supporting,
+figure.element-video,
+figure.element-atom {
+    figcaption {
+        padding-top: ($gs-baseline/3)*2;
+        padding-bottom: ($gs-baseline/3)*2;
+    }
+    @include mq(leftCol) {
+        figcaption {
+            padding-left: 0;
+            top: 100%;
+        }
+    }
+}
+
+figure.element.element--showcase {
+    @include mq(leftCol) {
+        figcaption {
+            padding-left: 0;
+            top: 100%;
+        }
+    }
+}
+
+figure.element-video {
+    @include mq(leftCol) {
+        &.element--thumbnail {
+            padding-bottom: 0;
+            border-bottom: 0;
+        }
+    }
+}
+
+
+figure.element.element--supporting.element-tweet {
+    margin-top: -$gs-baseline/2;
+}
+
+figure {
+    &.img--supporting {
+        @include mq(leftCol) {
+            float: left;
+            width: gs-span(5);
+            margin-top: $gs-baseline/2;
+            margin-right: $gs-gutter;
+        }
+
+        @include mq(wide) {
+            width: gs-span(6);
+        }
+    }
+}
+
+.media-primary--full-width {
+    width: 100%;
+    margin-bottom: $gs-baseline*2;
+}
+
+.media-primary.media-primary--showcase {
+    @include deport-left;
+}
+
+// Articles can have the feature tone applied, but it's not always primary tone
+.has-feature-showcase-element .media-primary.media-primary--showcase {
+    margin-left: 0;
+    margin-right: 0;
+    z-index: 2; // Put the showcase element on top of the left and right layout borders
+    position: relative;
+
+    @include mq(leftCol) {
+        margin: 0 auto;
+        width: gs-span(12);
+        max-width: unset;
+    }
+
+    @include mq(wide) {
+        width: gs-span(13);
+    }
+
+
+    .responsive-img {
+        height: auto;
+    }
+
+    .caption--main {
+        padding-left: 0;
+    }
+
+    .u-responsive-ratio--letterbox {
+        transition: padding-bottom 1s;
+    }
+
+
+}

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1205,6 +1205,15 @@ $quote-mark: 35px;
         }
 
     }
+    figure > .gs-container {
+        margin: 0;
+        padding: 0;
+        .content__main-column {
+            max-width: unset;
+            margin: 0;
+            padding: 0;
+        }
+    }
     .content__secondary-column {
         @include mq($from: wide) {
             padding-top: (aspect-ratio-height(5, 3, gs-span(13)) + gs-height(5));

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1148,6 +1148,73 @@ $quote-mark: 35px;
             padding-left: $gs-gutter / 2;
         }
     }
+
+    .content__head--article {
+        @include mq($until: tablet) {
+            display: flex;
+            flex-direction: column;
+        }
+
+        @include mq($from: leftCol) {
+            width: gs-span(8);
+            @supports (display: grid) {
+                margin-left: -($left-column + $gs-gutter);
+                display: grid;
+                grid-template-columns: ($left-column + $gs-gutter) auto;
+                grid-template-areas: 'labels headline' 'meta main-media' '. standfirst';
+
+            }
+        }
+
+        @include mq($from: wide) {
+            @supports (display: grid) {
+                margin-left: -($left-column-wide + $gs-gutter);
+                grid-template-columns: ($left-column-wide + $gs-gutter) auto;
+            }
+        }
+
+        .content__headline-showcase-wrapper {
+            display: none;
+
+            @include mq($from: leftCol) {
+                display: block;
+                grid-area: headline;
+                max-width: gs-span(8);
+            }
+            .content__headline {
+                padding-bottom: $gs-baseline * 2;
+            }
+        }
+        .content__headline-standfirst-wrapper .content__headline {
+            @include mq(leftCol) {
+                display: none;
+            }
+        }
+        .content__headline-standfirst-wrapper {
+            @include mq($until: tablet) {
+                order: 1;
+
+                .content--type-comment & {
+                    order: 0;
+                }
+            }
+
+            @include mq($from: leftCol) {
+                grid-area: standfirst;
+            }
+        }
+
+    }
+    .content__secondary-column {
+        @include mq($from: wide) {
+            padding-top: (aspect-ratio-height(5, 3, gs-span(13)) + gs-height(5));
+            //The image spills into the right column, so we assume it's 5:3 and gs-span(13) wide and use that to set the padding-top.
+        }
+        @include mq($from: leftCol) {
+            padding-top: (aspect-ratio-height(5, 3, gs-span(12)) + gs-height(5));
+            //The image spills into the right column, so we assume it's 5:3 and gs-span(13) wide and use that to set the padding-top.
+        }
+    }
 }
 
 // *************** Analysis ***************

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1203,7 +1203,17 @@ $quote-mark: 35px;
                 grid-area: standfirst;
             }
         }
-
+        .stars {
+            position: absolute;
+            margin: 0;
+            transform: none;
+            z-index: 5;
+            bottom: 0;
+            @include mq(desktop) {
+                bottom: unset;
+                top: 0;
+            }
+        }
     }
     figure > .gs-container {
         margin: 0;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1150,26 +1150,10 @@ $quote-mark: 35px;
     }
 
     .content__head--article {
-        @include mq($until: tablet) {
-            display: flex;
-            flex-direction: column;
-        }
-
-        @include mq($from: leftCol) {
-            width: gs-span(8);
+         @include mq($from: leftCol) {
             @supports (display: grid) {
-                margin-left: -($left-column + $gs-gutter);
-                display: grid;
-                grid-template-columns: ($left-column + $gs-gutter) auto;
                 grid-template-areas: 'labels headline' 'meta main-media' '. standfirst';
 
-            }
-        }
-
-        @include mq($from: wide) {
-            @supports (display: grid) {
-                margin-left: -($left-column-wide + $gs-gutter);
-                grid-template-columns: ($left-column-wide + $gs-gutter) auto;
             }
         }
 
@@ -1191,28 +1175,21 @@ $quote-mark: 35px;
             }
         }
         .content__headline-standfirst-wrapper {
-            @include mq($until: tablet) {
-                order: 1;
-
-                .content--type-comment & {
-                    order: 0;
-                }
-            }
-
             @include mq($from: leftCol) {
                 grid-area: standfirst;
             }
         }
-        .stars {
-            position: absolute;
-            margin: 0;
-            transform: none;
-            z-index: 5;
-            bottom: 0;
-            @include mq(desktop) {
-                bottom: unset;
-                top: 0;
-            }
+
+    }
+    .stars {
+        position: absolute;
+        margin: 0;
+        transform: none;
+        z-index: 5;
+        bottom: 0;
+        @include mq(desktop) {
+            bottom: unset;
+            top: 0;
         }
     }
     figure > .gs-container {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1150,7 +1150,7 @@ $quote-mark: 35px;
     }
 
     .content__head--article {
-         @include mq($from: leftCol) {
+        @include mq($from: leftCol) {
             @supports (display: grid) {
                 grid-template-areas: 'labels headline' 'meta main-media' '. standfirst';
 


### PR DESCRIPTION
## What does this change?
Gets rid of 5:3 -> 5:2 for feature showcase in Garnett and moves media into the new header grid.

## What is the value of this and can you measure success?


## Does this affect other platforms - Amp, Apps, etc?
no
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
nope

## Screenshots
nope

## Tested in CODE?
todo
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
