### PR TITLE
Image expansion

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -76,7 +76,7 @@
 
 @showcaseFeature(captionHtml: => Html) =  {
 
-    @if(isFeature && isShowcase) {
+    @if(isFeature && isShowcase && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
         <div class="gs-container">
             <div class="content__main-column">
                 @captionHtml

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -12,6 +12,7 @@
 /* ==========================================================================
    Global modules
    ========================================================================== */
+@import 'module/_layout-hints';
 @import 'module/content-garnett/_article';
 @import 'module/content-garnett/_content';
 @import 'module/content-garnett/_pillars';
@@ -20,7 +21,6 @@
 @import 'module/content-garnett/live-blog/_live-blog.head';
 @import 'module/_breadcrumbs';
 @import 'module/_social';
-@import 'module/_layout-hints';
 @import 'module/_live-pulse';
 @import 'module/content-garnett/_article-immersive';
 @import 'module/content-garnett/_article-minute';

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -298,17 +298,6 @@
         display: block;
     }
 
-    @include mq(desktop) {
-        &:hover,
-        .article__img-container:hover & {
-            background-color: $media-default;
-
-            &.inline-expand-image {
-                fill: #000000;
-            }
-        }
-    }
-
     @if $old-ie {
         display: none;
     }

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -304,12 +304,15 @@
 }
 
 @include mq(desktop) {
+    .article__fullscreen,
     .gallery__fullscreen {
         opacity: 0;
         transition: opacity .15s ease-out;
+    }
 
-        .gallery__img-container:hover & {
-            opacity: 1;
-        }
+    .article__img-container:hover .article__fullscreen,
+    .gallery__img-container:hover .gallery__fullscreen {
+        opacity: 1;
     }
 }
+

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1148,6 +1148,12 @@ $quote-mark: 35px;
         @include mq(wide) {
             margin: 0 auto;
         }
+
+        .caption--main {
+            padding-left: $gs-gutter / 2;
+        }
+    }
+}
     }
 }
 // *************** Analysis ***************

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1155,16 +1155,6 @@ $quote-mark: 35px;
     }
 }
 
-.has-feature-showcase-element .media-primary.media-primary--showcase,
-.content__head .media-primary { 
-    > a {
-        &:hover,
-        &:focus {
-            cursor: nesw-resize;
-        }
-    }
-}
-
 // *************** Analysis ***************
 
 .content--type-analysis {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1154,8 +1154,17 @@ $quote-mark: 35px;
         }
     }
 }
+
+.has-feature-showcase-element .media-primary.media-primary--showcase,
+.content__head .media-primary { 
+    > a {
+        &:hover,
+        &:focus {
+            cursor: nesw-resize;
+        }
     }
 }
+
 // *************** Analysis ***************
 
 .content--type-analysis {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -463,20 +463,9 @@ $quote-mark: 35px;
         display: block;
     }
 
-    .media-primary .inline-expand-image {
-        display: none;
-    }
-
     .media-primary.media-primary--showcase {
         margin-left: 0;
         margin-right: 0;
-    }
-
-    .article__fullscreen:hover,
-    .article__img-container:hover .article__fullscreen,
-    .article__img-container:hover .gallery__fullscreen,
-    .gallery__fullscreen:hover {
-        background-color: $neutral-4;
     }
 
     .content__headline {


### PR DESCRIPTION
- The "expand" icon is kept hidden and replaced with a similar cursor change to hint at the expected effect
- The caption is set full bleed

@superfrank @paperboyo I suggested the resize cursor to be applied across the board so that the jarring hover effect of the expand+caption icons can be forgotten.