### PR TITLE
[identity] Hide navigation links on consent journey

### DIFF
--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -40,7 +40,7 @@ object IdentityHtmlPage {
       ),
       bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
-        views.html.layout.identityHeader(),
+        views.html.layout.identityHeader(hideNavigation=page.isFlow),
         content,
         inlineJSNonBlocking(),
         footer() when !page.isFlow,

--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -25,23 +25,19 @@
                     <ul class="identity-dropdown" id="my-account-dropdown" aria-hidden="true">
                     @for((item) <- accountDropdownMenu) {
                         <li
-                        class="@{
-                            (List("identity-dropdown__item") ++ item.parentClassList).mkString(" ")
-                        }""
+                            class="@{(List("identity-dropdown__item") ++ item.parentClassList).mkString(" ")}"
                         >
-                        <a
-                        class="@{
-                            (List("identity-dropdown__title") ++ item.classList).mkString(" ")
-                        }"
-                            @if(item.href.isDefined) {
-                                href="@item.href"
-                            }
-                            @if(item.linkName.isDefined) {
-                                data-link-name="identity-nav : menu : @item.linkName"
+                            <a
+                                class="@{(List("identity-dropdown__title") ++ item.classList).mkString(" ")}"
+                                @if(item.href.isDefined) {
+                                    href="@item.href"
                                 }
-                        >
-                        @item.label
-                        </a>
+                                @if(item.linkName.isDefined) {
+                                    data-link-name="identity-nav : menu : @item.linkName"
+                                }
+                            >
+                                @item.label
+                            </a>
                         </li>
                     }
                     </ul>

--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -1,47 +1,53 @@
 @import common.LinkTo
 @import views.support.DropdownMenus.accountDropdownMenu
 
-@()(implicit page: model.Page, request: RequestHeader)
+@(hideNavigation:Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 <header class="identity-header" data-component="identity-nav">
     <div class="gs-container identity-header__container">
 
-        <div class="identity-header__links">
-            <div class="identity-header__link">
-                <label for="identity-header-account-menu-fallback" tabindex="0">
-                    <span
+        @if(!hideNavigation) {
+            <div class="identity-header__links">
+                <div class="identity-header__link">
+                    <label for="identity-header-account-menu-fallback" tabindex="0">
+                        <span
                         role="button"
                         class="identity-header__nav js_identity-header__nav-toggle"
                         aria-expanded="false"
                         aria-controls="my-account-dropdown"
                         data-link-name="identity-nav : menu : toggle"
-                    >
-                        @fragments.inlineSvg("profile-36", "icon", List("mobile-only"))
-                        <span class="hide-on-mobile-inline">My Account</span>
-                    </span>
-                </label>
-                <input type="checkbox" value="open" id="identity-header-account-menu-fallback" class="identity-header__nav-fallback u-h" title="Open Menu" />
-                <ul class="identity-dropdown" id="my-account-dropdown" aria-hidden="true">
+                        >
+                            @fragments.inlineSvg("profile-36", "icon", List("mobile-only"))
+                            <span class="hide-on-mobile-inline">My Account</span>
+                        </span>
+                    </label>
+                    <input type="checkbox" value="open" id="identity-header-account-menu-fallback" class="identity-header__nav-fallback u-h" title="Open Menu" />
+                    <ul class="identity-dropdown" id="my-account-dropdown" aria-hidden="true">
                     @for((item) <- accountDropdownMenu) {
                         <li
-                            class="@{(List("identity-dropdown__item") ++ item.parentClassList).mkString(" ")}""
+                        class="@{
+                            (List("identity-dropdown__item") ++ item.parentClassList).mkString(" ")
+                        }""
                         >
-                            <a
-                                class="@{(List("identity-dropdown__title") ++ item.classList).mkString(" ")}"
-                                @if(item.href.isDefined) {
-                                    href="@item.href"
+                        <a
+                        class="@{
+                            (List("identity-dropdown__title") ++ item.classList).mkString(" ")
+                        }"
+                            @if(item.href.isDefined) {
+                                href="@item.href"
+                            }
+                            @if(item.linkName.isDefined) {
+                                data-link-name="identity-nav : menu : @item.linkName"
                                 }
-                                @if(item.linkName.isDefined) {
-                                    data-link-name="identity-nav : menu : @item.linkName"
-                                }
-                            >
-                            @item.label
-                            </a>
+                        >
+                        @item.label
+                        </a>
                         </li>
                     }
-                </ul>
+                    </ul>
+                </div>
             </div>
-        </div>
+        }
 
         <a href="@LinkTo {/}" data-link-name="site logo" id="logo" class="identity-header__logo" data-component="logo">
             <span class="u-h">The Guardian - Back to home</span>

--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -1,7 +1,7 @@
 @import common.LinkTo
 @import views.support.DropdownMenus.accountDropdownMenu
 
-@(hideNavigation:Boolean = false)(implicit page: model.Page, request: RequestHeader)
+@(hideNavigation: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 <header class="identity-header" data-component="identity-nav">
     <div class="gs-container identity-header__container">

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -26,6 +26,7 @@ $height: $identity-header-height - ($gutter * 2);
 
     .gs-container {
         display: flex;
+        flex-direction: row-reverse;
         justify-content: space-between;
         align-items: center;
         padding-left: $gs-gutter / 2;
@@ -49,6 +50,7 @@ $height: $identity-header-height - ($gutter * 2);
 
 .identity-header__logo {
     float: right;
+    order: -99;
     svg {
         display: block;
         width: 160px;


### PR DESCRIPTION
## What does this change?
Hides the `my account` link on the header in `/consents`

## What is the value of this and can you measure success?
Sort of an anti pattern to trap users in, but doing away with this removes a potential distraction from the main call to action (the button at the bottom) and should increase reperms, even if it's from people mashing continue to get to the end

## Screenshots
![screen shot 2018-01-04 at 13 49 44](https://user-images.githubusercontent.com/11539094/34566439-847a4364-f156-11e7-80d4-43716a73ddaa.png)
