### PR TITLE
[Identity] Remove sticky nav from consent journey

### DIFF
--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -47,7 +47,9 @@ object IdentityHtmlPage {
         views.html.layout.identityFlexWrap()(
           skipToMainContent(),
           views.html.layout.identityHeader(hideNavigation=page.isFlow),
-          content,
+        )(
+          content
+        )(
           inlineJSNonBlocking(),
           if(page.isFlow){
             views.html.layout.identitySkinnyFooter()

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -44,16 +44,18 @@ object IdentityHtmlPage {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses())(
-        skipToMainContent(),
-        views.html.layout.identityHeader(hideNavigation=page.isFlow),
-        content,
-        inlineJSNonBlocking(),
-        if(page.isFlow){
-          views.html.layout.identitySkinnyFooter()
-        } else {
-          footer()
-        },
-        analytics.base()
+        views.html.layout.identityFlexWrap()(
+          skipToMainContent(),
+          views.html.layout.identityHeader(hideNavigation=page.isFlow),
+          content,
+          inlineJSNonBlocking(),
+          if(page.isFlow){
+            views.html.layout.identitySkinnyFooter()
+          } else {
+            footer()
+          },
+          analytics.base()
+        )
       ),
       devTakeShot()
     )

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -48,7 +48,11 @@ object IdentityHtmlPage {
         views.html.layout.identityHeader(hideNavigation=page.isFlow),
         content,
         inlineJSNonBlocking(),
-        footer() when !page.isFlow,
+        if(page.isFlow){
+          views.html.layout.identitySkinnyFooter()
+        } else {
+          footer()
+        },
         analytics.base()
       ),
       devTakeShot()

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -239,7 +239,7 @@
             <button
                 type="button"
                 data-link-name="consents : navigation : next"
-                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next manage-account__button--icon--rotate-down"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next"
             >
                 <div class="manage-account__button-flexwrap">
                     <span>Next</span>

--- a/identity/app/views/layout/identityFlexWrap.scala.html
+++ b/identity/app/views/layout/identityFlexWrap.scala.html
@@ -1,7 +1,15 @@
-@()(fragments: Html*)
+@()(topFragments: Html*)(contentFragments: Html*)(bottomFragments: Html*)
 
 <div class="identity-header-flex-wrap">
-    @for(f <- fragments){
+    @for(f <- topFragments){
+        @f
+    }
+    <div class="identity-header-flex-wrap__content">
+        @for(f <- contentFragments){
+            @f
+        }
+    </div>
+    @for(f <- bottomFragments){
         @f
     }
 </div>

--- a/identity/app/views/layout/identityFlexWrap.scala.html
+++ b/identity/app/views/layout/identityFlexWrap.scala.html
@@ -1,0 +1,7 @@
+@()(fragments: Html*)
+
+<div class="identity-header-flex-wrap">
+    @for(f <- fragments){
+        @f
+    }
+</div>

--- a/identity/app/views/layout/identitySkinnyFooter.scala.html
+++ b/identity/app/views/layout/identitySkinnyFooter.scala.html
@@ -1,0 +1,9 @@
+@import org.joda.time.LocalDate
+
+@()
+
+<footer class="identity-footer">
+    <div class="gs-container">
+        © @(new LocalDate().getYear) Guardian News and Media Limited or its affiliated companies. All rights reserved.
+    </div>
+</footer>

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -114,30 +114,6 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
     });
 };
 
-const shouldNextButtonScroll = (): Promise<boolean> =>
-    fastdom.read(
-        () =>
-            window.scrollY + window.innerHeight + 100 <
-            (document.body ? document.body.clientHeight : 0)
-    );
-
-const bindScrollForNextButton = (buttonEl: HTMLElement): void => {
-    const check = () =>
-        shouldNextButtonScroll().then(shouldIt =>
-            fastdom.write(() => {
-                buttonEl.classList.toggle(
-                    'manage-account__button--icon--rotate-down',
-                    shouldIt
-                );
-            })
-        );
-
-    mediator.on('window:throttledScroll', debounce(check, 100));
-    window.addEventListener(wizardPageChangedEv, () => {
-        check();
-    });
-};
-
 const showWizard = (wizardEl: HTMLElement): Promise<void> =>
     fastdom.write(() => wizardEl.classList.remove('u-h'));
 
@@ -146,19 +122,9 @@ const bindNextButton = (buttonEl: HTMLElement): void => {
     if (wizardEl && wizardEl instanceof HTMLElement) {
         buttonEl.addEventListener('click', (ev: Event) => {
             ev.preventDefault();
-            shouldNextButtonScroll().then(shouldIt => {
-                if (shouldIt) {
-                    scrollTo(
-                        window.scrollY + window.innerHeight * 0.75,
-                        250,
-                        'linear'
-                    );
-                } else {
-                    getWizardInfoObject(wizardEl).then(wizardInfo =>
-                        setPosition(wizardEl, wizardInfo.position + 1)
-                    );
-                }
-            });
+            getWizardInfoObject(wizardEl).then(wizardInfo =>
+                setPosition(wizardEl, wizardInfo.position + 1)
+            );
         });
     } else {
         throw new Error(ERR_IDENTITY_CONSENT_WIZARD_MISSING);
@@ -195,7 +161,6 @@ const enhanceConsentWizard = (): void => {
         ['.identity-wizard--consent', bindEmailConsentCounterToWizard],
         ['.identity-wizard--consent', showWizard],
         ['.js-identity-consent-wizard__next', bindNextButton],
-        ['.js-identity-consent-wizard__next', bindScrollForNextButton],
     ];
     loadEnhancers(loaders);
 };

--- a/static/src/stylesheets/head.identity.scss
+++ b/static/src/stylesheets/head.identity.scss
@@ -18,7 +18,7 @@
 
 @import 'module/identity/_header';
 @import 'module/identity/_forms';
-
+@import 'module/identity/_footer';
 @import 'module/identity/_manage-account-tab';
 @import 'module/identity/_formstack';
 @import 'module/identity/_dropdown';

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -2,10 +2,6 @@
     .identity-wizard__controls {
         padding: $gs-gutter 0;
         background: #ffffff;
-        position: sticky;
-        bottom: 0;
-        left: 0;
-        right: 0;
         margin-top: $gs-gutter * 2;
         border-top: 1px solid $neutral-5;
         justify-content: space-between;

--- a/static/src/stylesheets/module/identity/_footer.scss
+++ b/static/src/stylesheets/module/identity/_footer.scss
@@ -1,0 +1,6 @@
+.identity-footer {
+    @include fs-textSans(1);
+    background: $neutral-1;
+    color: $neutral-3;
+    padding: $gs-gutter;
+}

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -101,3 +101,12 @@ $height: $identity-header-height - ($gutter * 2);
         transition: transform 250ms ease-out;
     }
 }
+
+.identity-header-flex-wrap {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    & > div:not(.identity-header):not(.identity-footer) {
+        flex: 1 1 auto;
+    }
+}

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -106,7 +106,8 @@ $height: $identity-header-height - ($gutter * 2);
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-    & > div:not(.identity-header):not(.identity-footer) {
+    align-items: stretch;
+    & > .identity-header-flex-wrap__content {
         flex: 1 1 auto;
     }
 }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -59,7 +59,6 @@ $identity-header-height: 48px;
     max-width: gs-span(6);
     padding-bottom: $gs-baseline*4;
     padding-top: $gs-baseline * 2;
-    width: 100%;
 
     &.identity-wrapper--with-wizard {
         padding-bottom: 0;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -59,6 +59,7 @@ $identity-header-height: 48px;
     max-width: gs-span(6);
     padding-bottom: $gs-baseline*4;
     padding-top: $gs-baseline * 2;
+    width: 100%;
 
     &.identity-wrapper--with-wizard {
         padding-bottom: 0;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -526,11 +526,6 @@
             height: 28px;
         }
     }
-    &.manage-account__button--icon--rotate-down {
-        .inline-icon {
-            transform: rotate(90deg);
-        }
-    }
 }
 
 .manage-account__button--light {


### PR DESCRIPTION
## What does this change?
Changes the bottom navbar from the consents journey so it remains static at the end of the dialogs instead of scrolling with the screen. 

Since this was the only thing in the way of the page having a footer (and it looked really unfinished without one, which doesn't inspire trust) i put one up as well.

## What is the value of this and can you measure success?
Less unintended clicks, cleaner code (the sticky bar had fancy js to go with it), hopefully more reperms with ticked off boxes.

## Screenshots
![screen shot 2018-01-04 at 14 54 51](https://user-images.githubusercontent.com/11539094/34568993-545e5040-f15f-11e7-8bfb-b1a99511b897.png)
![screen shot 2018-01-04 at 15 00 44](https://user-images.githubusercontent.com/11539094/34569235-111285bc-f160-11e7-8f22-a818bf3f9507.png)

  