### PR TITLE
Rejig football header

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -55,9 +55,6 @@
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
-                            <div class="js-score"></div>
-                            <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
-
                             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
                                 @fragments.headTonalGarnett(article, model, isPaidContent, amp = amp)
                             }

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -11,6 +11,10 @@
     @badgeFor(article).map { badge => content__head--is-badged
         @badge.classModifier.map(modifier => s"content__head--$modifier")
     }">
+    <div class="matchreport">
+        <div class="js-score"></div>
+        <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
+    </div>
 
     @fragments.meta.metaInline(article, amp)
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1333,6 +1333,10 @@
             .content--type-comment & {
                 grid-template-areas: 'labels headline' 'meta standfirst' '. main-media';
             }
+
+            .content--type-matchreport & {
+                grid-template-areas: 'labels headline-standfirst' '. report' 'meta main-media';
+            }
         }
     }
 
@@ -1407,5 +1411,10 @@
                 align-self: start;
             }
         }
+    }
+
+    /*** position match stats ***/
+    .matchreport {
+        grid-area: report;
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -11,6 +11,7 @@ $quote-mark: 35px;
 .content--type-article,
 .content--type-comment,
 .content--type-feature,
+.content--type-matchreport,
 .content--type-live,
 .content--type-media,
 .content--type-review {


### PR DESCRIPTION
Arrange elements into a specific grid.

There is work to do at the tablet breakpoint, but this is true for all articles, not only football ones. Will do that in a separate PR.