### PR TITLE
Only fix the size of the ad container for MPUs (for now).

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -69,10 +69,16 @@ sizeCallbacks[adSizes.fluid] = (renderSlotEvent: any, advert: Advert) =>
 /**
  * Trigger sticky scrolling for MPUs in the right-hand article column
  */
-sizeCallbacks[adSizes.mpu] = (_, advert) => {
+sizeCallbacks[adSizes.mpu] = (slotRenderEndedEvent, advert) => {
     if (advert.node.classList.contains('js-sticky-mpu')) {
         stickyMpu(advert.node);
     }
+
+    fastdom.write(() => {
+        const container = advert.node;
+        container.style.width = `${slotRenderEndedEvent.size[0]}px`;
+        container.style.height = `${slotRenderEndedEvent.size[1]}px`;
+    });
 };
 
 /**
@@ -165,25 +171,11 @@ export const renderAdvert = (
                         size = 'fluid';
                     }
 
-                    const applyCallback = Promise.resolve(
+                    return Promise.resolve(
                         sizeCallbacks[size]
                             ? sizeCallbacks[size](slotRenderEndedEvent, advert)
                             : null
                     );
-
-                    const fixContainerSize = fastdom.write(() => {
-                        if (size !== 'fluid') {
-                            const container = advert.node;
-                            container.style.width = `${
-                                slotRenderEndedEvent.size[0]
-                            }px`;
-                            container.style.height = `${
-                                slotRenderEndedEvent.size[1]
-                            }px`;
-                        }
-                    });
-
-                    return Promise.all([applyCallback, fixContainerSize]);
                 }
                 return Promise.resolve(null);
             };


### PR DESCRIPTION
A recent change - #18642 - sought to fix the size of the ad containers based on the size of the ad that has come back.

This has caused problems for adverts that have a nominal size but that are not actually of that size, e.g. fabrics (which are served as 88x87 but are in fact full width).

With this in mind, I have restricted this behaviour to only apply to MPUs, and will take another look tomorrow.