### PR TITLE
Making changes to the navlists in the uk edition

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -180,12 +180,13 @@ object NavLinks {
     List(
       ukNews,
       world,
-      ukBusiness,
-      football,
-      ukEnvironment,
-      tech,
       politics,
+      football,
+      ukBusiness,
+      ukEnvironment,
+      education,
       science,
+      tech,
       globalDevelopment,
       cities,
       obituaries
@@ -324,13 +325,13 @@ object NavLinks {
   // Arts Pillar
   val ukArtsPillar = NavLink("Arts", "/culture", longTitle = "Culture home", iconName = "home",
     List(
-      tvAndRadio,
-      music,
       film,
-      stage,
+      music,
+      tvAndRadio,
       books,
-      games,
       artAndDesign,
+      stage,
+      games,
       classical
     )
   )
@@ -377,11 +378,11 @@ object NavLinks {
       food,
       recipes,
       ukTravel,
+      health,
+      women,
       loveAndSex,
       beauty,
       home,
-      health,
-      women,
       money,
       cars
     )


### PR DESCRIPTION
## What does this change?
Edits from editorial to the UK edition navigation

I have some outstanding questions regarding this navigation, so I won't merge until those are answered.

## What is the value of this and can you measure success?
Some users have complained about education being too hard to find. This will help surface it.

## Does this affect other platforms - Amp, Apps, etc?
This affects AMP

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
