### PR TITLE
[minor] Fix identity button padding

### DIFF
--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -446,7 +446,7 @@
     color: #ffffff;
     cursor: pointer;
     float: left;
-    padding: 0 $gs-gutter;
+    padding: (($gs-gutter * 2) - get-line-height(textSans, 2))/2 $gs-gutter;
     min-width: $gs-baseline * 14;
     white-space: nowrap;
     text-overflow: clip;
@@ -516,6 +516,8 @@
 }
 
 .manage-account__button--icon {
+    padding-top: 0;
+    padding-bottom: 0;
     &, & > .manage-account__button-flexwrap {
         justify-content: space-between;
     }

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -450,7 +450,7 @@
     color: #ffffff;
     cursor: pointer;
     float: left;
-    padding:  $padding-vertical $padding-horizontal;
+    padding: $padding-vertical $padding-horizontal;
     min-width: $gs-baseline * 14;
     white-space: nowrap;
     text-overflow: clip;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -438,15 +438,19 @@
 }
 
 .manage-account__button {
-    @include fs-textSans(2);
+    $font-size: 2;
+    $height: $gs-gutter * 2;
+    $padding-vertical: ($height - get-line-height(textSans, $font-size))/2;
+    $padding-horizontal: $gs-gutter;
+    @include fs-textSans($font-size);
     background-color: $identity-main;
-    height: $gs-gutter * 2;
+    height: $height;
     border-radius: 100px;
     border: 0;
     color: #ffffff;
     cursor: pointer;
     float: left;
-    padding: (($gs-gutter * 2) - get-line-height(textSans, 2))/2 $gs-gutter;
+    padding:  $padding-vertical $padding-horizontal;
     min-width: $gs-baseline * 14;
     white-space: nowrap;
     text-overflow: clip;


### PR DESCRIPTION
## What does this change?
Fixes some buttons in identity who had `display:flex` overridden via css and thus had its text aligned to the top instead of to the middle. [Bug](https://trello.com/c/hpiOh0BG/207-button-styling-problem-on-membership-tab).

## Screenshots
![img_3084](https://user-images.githubusercontent.com/11539094/34606819-bfb97852-f208-11e7-8b25-e9f02b56330f.jpg)

  