### PR TITLE
[identity] /consents/thank-you

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -29,6 +29,10 @@ trait ConsentsJourney
   def displayConsentsJourneyNewsletters: Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageNewsletters, None)
 
+  /** GET /consents/thank-you */
+  def displayConsentsJourneyThankYou: Action[AnyContent] =
+    displayConsentJourneyForm(ConsentJourneyPageThankYou, None)
+
   /** GET /consents */
   def displayConsentsJourney(consentHint: Option[String] = None): Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint)

--- a/identity/app/controllers/editprofile/editprofile.scala
+++ b/identity/app/controllers/editprofile/editprofile.scala
@@ -15,5 +15,6 @@ package object editprofile {
 
   object ConsentJourneyPageAll extends ConsentJourneyPage("/consents/all", "all")
   object ConsentJourneyPageNewsletters extends ConsentJourneyPage("/consents/newsletters", "newsletters")
+  object ConsentJourneyPageThankYou extends ConsentJourneyPage("/consents/thank-you", "thank-you")
   object ConsentJourneyPageDefault extends ConsentJourneyPage("/consents", "default")
 }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -83,7 +83,7 @@
     )
 }
 
-@consentStepContent = {
+@marketingStepContent = {
     <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
         @views.html.helper.CSRF.formField
         <div class="manage-account__switches manage-account__switches--single-column">
@@ -101,16 +101,28 @@
         </div>
     </form>
 }
-@communicationConsentStep = @{
+@marketingConsentStep = @{
     ConsentStep(
         name = "consent",
-        title = if(journey == "all") {
-            "We need you to consent again to receiving communications from the Guardian"
-        } else {
-            "What would you like to hear about?"
-        },
+        title = "What would you like to hear about?",
         help = List("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
-        content = consentStepContent
+        content = marketingStepContent
+    )
+}
+@marketingConsentRepermissionStep = @{
+    ConsentStep(
+        name = "consent-repermission",
+        title = "We need you to consent again to receiving communications from the Guardian",
+        help = List("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        content = marketingStepContent
+    )
+}
+@marketingConsentThankYouStep = @{
+    ConsentStep(
+        name = "consent-thank-you",
+        title = "Thank you for signing up",
+        help = List("While you are here, you can tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        content = marketingStepContent
     )
 }
 
@@ -189,14 +201,21 @@
         }
         case "all" => {
             List(
-                communicationConsentStep,
+                marketingConsentRepermissionStep,
                 emailRepermissionStep,
                 channelStep
             )
         }
-        case _ => {
+        case "thank-you" => {
             List(
-                communicationConsentStep,
+                marketingConsentThankYouStep,
+                emailRepermissionStep,
+                channelStep
+            )
+        }
+        case "default" => {
+            List(
+                marketingConsentStep,
                 emailRepermissionOrSignupStep,
                 channelStep
             )

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -120,8 +120,8 @@
 @marketingConsentThankYouStep = @{
     ConsentStep(
         name = "consent-thank-you",
-        title = "Thank you for signing up",
-        help = List("While you are here, you can tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        title = "Thank you",
+        help = List("Your email choices have now been recorded. While you're here, feel free to have a look at other Guardian content that might interest you."),
         content = marketingStepContent
     )
 }
@@ -209,7 +209,7 @@
         case "thank-you" => {
             List(
                 marketingConsentThankYouStep,
-                emailRepermissionStep,
+                emailRepermissionOrSignupStep,
                 channelStep
             )
         }

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -69,6 +69,7 @@ POST        /email-prefs                            controllers.editprofile.Edit
 ########################################################################################################################
 GET         /consents/all                           controllers.editprofile.EditProfileController.displayConsentsJourneyAll(consentHint: Option[String])
 GET         /consents/newsletters                   controllers.editprofile.EditProfileController.displayConsentsJourneyNewsletters
+GET         /consents/thank-you                     controllers.editprofile.EditProfileController.displayConsentsJourneyThankYou
 GET         /consents                               controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################


### PR DESCRIPTION
## What does this change?
Adds a `/consents/thank-you` version of the journey with copy for users coming from email repermissioning

## Screenshots
![screen shot 2018-01-05 at 15 08 58](https://user-images.githubusercontent.com/11539094/34614786-86cdcb8e-f22a-11e7-9c94-108a4ba01dad.png)
