### PR TITLE
Ensure banner close button is always visible

### DIFF
--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -539,8 +539,9 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 
 .site-message--membership-prominent {
+    max-height: 80%;
+
     .site-message__message {
-        max-height: 80%;
         padding-right: 45px;
         @include mq($until: tablet) {
             padding-left: 5px;


### PR DESCRIPTION
## What does this change?
This CSS tweak guarantees that the close button is always visible on the engagement banner, no matter how thin the screen