### PR TITLE
[identity] Update legal copy

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -6,7 +6,7 @@
 @import form.IdFormHelpers.nonInputFields
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.fragment.Switch._
-@import views.support.fragment.ConsentStep
+@import views.support.fragment.ConsentStep._
 @import views.support.fragment.ConsentChannel._
 @import conf.switches.Switches.IdentityShowCommunicationChannelConsents
 @import common.LinkTo
@@ -43,10 +43,17 @@
                 @if(step.help) {
                     <div class="identity-forms-wrapper__title">
                         @step.help.map(paragraph =>
-                            Html(s"<p class='identity-title-explainer'>$paragraph</p>")
+                            paragraph match {
+                                case m: ConsentStepHelpLegalText => {
+                                    Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")
+                                }
+                                case m: ConsentStepHelpText => {
+                                    Html(s"<p class='identity-title-explainer'>${m.text}</p>")
+                                }
+                            }
                         )
                         @if(index.contains(0)) {
-                            <p class='identity-title-explainer'>
+                            <p class='identity-title-explainer identity-title-explainer--small'>
                                 By continuing you are confirming that you are aged over 13.
                             </p>
                         }
@@ -85,7 +92,9 @@
     ConsentStep(
         name = "channels",
         title = "How else can we get in touch with you?",
-        help = List("Besides email, are there any other ways you would like us to get in touch with you?"),
+        help = List(
+            ConsentStepHelpText("Besides email, are there any other ways you would like us to get in touch with you?")
+        ),
         content = channelStepContent,
         show = IdentityShowCommunicationChannelConsents.isSwitchedOn && channelsProvidedBy(user).nonEmpty
     )
@@ -115,7 +124,7 @@
     ConsentStep(
         name = "consent",
         title = "What would you like to hear about?",
-        help = List("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        help = List(ConsentStepHelpText("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.")),
         content = marketingStepContent
     )
 }
@@ -123,7 +132,9 @@
     ConsentStep(
         name = "consent-repermission",
         title = "We need you to consent again to receiving communications from the Guardian",
-        help = List("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful."),
+        help = List(
+            ConsentStepHelpText("Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.")
+        ),
         content = marketingStepContent
     )
 }
@@ -131,7 +142,9 @@
     ConsentStep(
         name = "consent-thank-you",
         title = "Thank you",
-        help = List("Your email choices have now been recorded. While you're here, feel free to have a look at other Guardian content that might interest you."),
+        help = List(
+            ConsentStepHelpText("Your email choices have now been recorded. While you're here, feel free to have a look at other Guardian content that might interest you.")
+        ),
         content = marketingStepContent
     )
 }
@@ -160,7 +173,10 @@
     ConsentStep(
         name = "email",
         title = "Your existing newsletters",
-        help = List("You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.","The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements."),
+        help = List(
+            ConsentStepHelpText("You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them."),
+            ConsentStepHelpLegalText("The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.")
+        ),
         content = emailRepermissionStepContent,
         show = onlySubscribedToV1Newsletters.nonEmpty
     )
@@ -180,7 +196,10 @@
     ConsentStep(
         name = "email-signup",
         title = "Your newsletters",
-        help = List("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.","The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements."),
+        help = List(
+            ConsentStepHelpText("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below."),
+            ConsentStepHelpLegalText("The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.")
+        ),
         content = emailSignupStepContent,
         show = true
     )

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -54,7 +54,7 @@
                         )
                         @if(index.contains(0)) {
                             <p class='identity-title-explainer identity-title-explainer--small'>
-                                By continuing you are confirming that you are aged over 13.
+                                By continuing you confirm that you are aged 13 or over.
                             </p>
                         }
                     </div>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -160,7 +160,7 @@
     ConsentStep(
         name = "email",
         title = "Your existing newsletters",
-        help = List("You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them."),
+        help = List("You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.","The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements."),
         content = emailRepermissionStepContent,
         show = onlySubscribedToV1Newsletters.nonEmpty
     )
@@ -180,7 +180,7 @@
     ConsentStep(
         name = "email-signup",
         title = "Your newsletters",
-        help = List("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below."),
+        help = List("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.","The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements."),
         content = emailSignupStepContent,
         show = true
     )

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -197,7 +197,7 @@
         name = "email-signup",
         title = "Your newsletters",
         help = List(
-            ConsentStepHelpText("Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below."),
+            ConsentStepHelpText("Our regular newsletters help you get closer to our quality, independent journalism. Pick the issues and topics that interest you below."),
             ConsentStepHelpLegalText("The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.")
         ),
         content = emailSignupStepContent,

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,6 +30,14 @@
     }
 }
 
+@showAgeStep(index: Option[Int]) = @{
+    if(index.contains(0)){
+        List(ConsentStepHelpLegalText("By continuing you confirm that you are aged 13 or over."))
+    } else {
+        Nil
+    }
+}
+
 @renderStep(step: ConsentStep, index: Option[Int] = None) = {
     @if(step.show) {
         <fieldset
@@ -40,9 +48,9 @@
         >
             <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
             <div class="identity-forms-wrapper">
-                @if(step.help) {
+                @if(step.help || showAgeStep(index)) {
                     <div class="identity-forms-wrapper__title">
-                        @step.help.map(paragraph =>
+                        @((step.help ++ showAgeStep(index)).map(paragraph =>
                             paragraph match {
                                 case m: ConsentStepHelpLegalText => {
                                     Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")
@@ -51,12 +59,7 @@
                                     Html(s"<p class='identity-title-explainer'>${m.text}</p>")
                                 }
                             }
-                        )
-                        @if(index.contains(0)) {
-                            <p class='identity-title-explainer identity-title-explainer--small'>
-                                By continuing you confirm that you are aged 13 or over.
-                            </p>
-                        }
+                        ))
                     </div>
                 }
                 <div class="identity-forms-wrapper__fields">

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -26,7 +26,12 @@
     <fieldset class="fieldset fieldset--manage-account-noborder">
         <div class="fieldset__heading">
             <h2 class="form__heading">Your newsletters</h2>
-            <p class="form__note">Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.</p>
+            <p class="form__note">
+                Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
+            </p>
+            <p class="form__note">
+                The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
+            </p>
         </div>
         <div class="fieldset__fields">
             @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -29,7 +29,7 @@
             <p class="form__note">
                 Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
             </p>
-            <p class="form__note">
+            <p class="identity-title-explainer identity-title-explainer--small">
                 The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
             </p>
         </div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -27,7 +27,7 @@
         <div class="fieldset__heading">
             <h2 class="form__heading">Your newsletters</h2>
             <p class="form__note">
-                Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below.
+                Our regular newsletters help you get closer to our quality, independent journalism. Pick the issues and topics that interest you below.
             </p>
             <p class="identity-title-explainer identity-title-explainer--small">
                 The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.

--- a/identity/app/views/support/fragment/ConsentStep.scala
+++ b/identity/app/views/support/fragment/ConsentStep.scala
@@ -2,10 +2,22 @@ package views.support.fragment
 
 import play.twirl.api.Html
 
-case class ConsentStep (
-  name: String,
-  title: String,
-  help: List[String] = List(),
-  content: Html = Html(""),
-  show: Boolean = true,
-)
+
+object ConsentStep {
+
+  sealed trait ConsentStepHelpTextTrait
+
+  case class ConsentStepHelpLegalText(text: String) extends ConsentStepHelpTextTrait
+
+  case class ConsentStepHelpText(text: String) extends ConsentStepHelpTextTrait
+
+
+  case class ConsentStep(
+                          name: String,
+                          title: String,
+                          help: List[ConsentStepHelpTextTrait] = Nil,
+                          content: Html = Html(""),
+                          show: Boolean = true,
+                        )
+
+}

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -132,6 +132,10 @@ $identity-header-height: 48px;
 .identity-title-explainer {
     @include fs-bodyCopy(1);
     margin-bottom: $gs-baseline;
+    &.identity-title-explainer--small {
+        @include fs-textSans(1);
+        color: $neutral-2;
+    }
 }
 
 .identity-title--public-profile {


### PR DESCRIPTION
## What does this change?
Adds the copy from legal to newsletters. Changes the over 13 text in `/consents`. Makes legal text smaller and greyish where possible.

- [x] Should we remove the previous copy or just keep 2 paragraphs? It's _very_ long.

![screen shot 2018-01-05 at 17 23 41](https://user-images.githubusercontent.com/11539094/34620383-331fe310-f23d-11e7-9177-b70ab97780d6.png)

Line height on the left is all over the place because most of this is actually from pasteup let's talk about that after the GDPR launch

  
  
  