### PR TITLE
Garnett Launch switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -617,4 +617,24 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 1, 24),
     exposeClientSide = false
   )
+
+  val GarnettLaunch = Switch(
+    SwitchGroup.Feature,
+    "garnett-launch",
+    "when ON, garnett styling will appear on Fronts and articles (this does not work on the navigation)",
+    owners = Seq(Owner.withGithub("NataliaLKB"), Owner.withGithub("blongden73")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 31),
+    exposeClientSide = false
+  )
+
+  val GarnettHeaderLaunch = Switch(
+    SwitchGroup.Feature,
+    "garnett-header-launch",
+    "when ON, garnett styling will appear on the navigation, assuming the new navigation is already live for everyone",
+    owners = Seq(Owner.withGithub("NataliaLKB"), Owner.withGithub("zeftilldeath")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 31),
+    exposeClientSide = false
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -1,6 +1,7 @@
 package experiments
 
 import conf.switches.Owner
+import conf.switches.Switches.{ GarnettLaunch, GarnettHeaderLaunch }
 import experiments.ParticipationGroups._
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
@@ -61,7 +62,9 @@ object GarnettHeader extends Experiment(
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("zeftilldeath")),
   sellByDate = new LocalDate(2018, 2, 1),
   participationGroup = Perc0A
-)
+) {
+  override def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = super.isParticipating || GarnettHeaderLaunch.isSwitchedOn
+}
 
 object Garnett extends Experiment(
   name = "garnett",
@@ -69,7 +72,9 @@ object Garnett extends Experiment(
   owners = Seq(Owner.withName("dotcom.platform")),
   sellByDate = new LocalDate(2018, 2, 1),
   participationGroup= Perc0C
-)
+) {
+  override def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = super.isParticipating || GarnettLaunch.isSwitchedOn
+}
 
 object HideShowMoreButtonExperiment extends Experiment(
   name = "remove-show-more-ab",


### PR DESCRIPTION
_Note:_ This is just for discussion first!

Given the launch will be at 6am, I would really like to avoid a deploy to launch at that time. Other criteria to consider:
* People need to be able to opt in and test Garnett. This includes stakeholders 
* Garnett and GarnettHeader are decidedly different switches and should be able to go out independently of each other (but hopefully that won't happen)

Even though I don't like the idea of effectively having two switches which do the same thing, I think this would cover all the use cases we want.

Can any of you think of a better way?
