### PR TITLE
Lower case AMP pillars

### DIFF
--- a/static/src/stylesheets/amp/header/_header.scss
+++ b/static/src/stylesheets/amp/header/_header.scss
@@ -3,6 +3,7 @@
     position: relative;
     max-width: 600px;
     margin: 0 auto;
+    text-transform: lowercase;
 }
 
 .header__cta-container {


### PR DESCRIPTION
Due to a change I pushed out last week, the pillars on AMP were displaying title case (shock horror). This change restores them to lower case.