### PR TITLE
Epic And Banner Colour Holdback Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -126,4 +126,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-circles-epic-banner-holdback",
+    "A holdback for the epic and banner colour changes",
+    owners = Seq(Owner.withGithub("Ap0c")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 2, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -136,4 +136,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-circles-banner-holdback",
+    "A holdback for the banner colour changes",
+    owners = Seq(Owner.withGithub("Ap0c")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 2, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,7 +128,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-circles-epic-holdback",
+    "ab-colour-test-epic-holdback",
     "A holdback for the epic colour changes",
     owners = Seq(Owner.withGithub("Ap0c")),
     safeState = Off,
@@ -138,7 +138,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-circles-banner-holdback",
+    "ab-colour-test-banner-holdback",
     "A holdback for the banner colour changes",
     owners = Seq(Owner.withGithub("Ap0c")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,8 +128,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-circles-epic-banner-holdback",
-    "A holdback for the epic and banner colour changes",
+    "ab-circles-epic-holdback",
+    "A holdback for the epic colour changes",
     owners = Seq(Owner.withGithub("Ap0c")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 2, 15),

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -12,7 +12,7 @@ declare type EngagementBannerTemplateParams = {
     linkUrl: string,
     buttonCaption: string,
     buttonSvg: string,
-}
+};
 
 declare type EngagementBannerParams = {
     minArticles: number,
@@ -25,5 +25,6 @@ declare type EngagementBannerParams = {
     colourStrategy: () => string,
     products: OphanProduct[],
     paypalClass?: string,
-    template?: (templateParams: EngagementBannerTemplateParams) => string
+    template?: (templateParams: EngagementBannerTemplateParams) => string,
+    bannerModifierClass?: string,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -156,7 +156,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         siteMessageCloseBtn: 'hide',
         siteMessageComponentName: params.campaignCode,
         trackDisplay: true,
-        cssModifierClass: colourClass,
+        cssModifierClass: `${colourClass} ${params.bannerModifierClass || ''}`,
     }).show(renderedBanner);
 
     if (messageShown) {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -110,6 +110,17 @@ const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
 const selectSequentiallyFrom = (array: Array<string>): string =>
     array[getVisitCount() % array.length];
 
+const messageModifierClass = (
+    colourClass: string,
+    modifierClass: ?string
+): string => {
+    if (modifierClass) {
+        return `${colourClass} ${modifierClass}`;
+    }
+
+    return colourClass;
+};
+
 const showBanner = (params: EngagementBannerParams): void => {
     if (isBlocked()) {
         return;
@@ -156,7 +167,10 @@ const showBanner = (params: EngagementBannerParams): void => {
         siteMessageCloseBtn: 'hide',
         siteMessageComponentName: params.campaignCode,
         trackDisplay: true,
-        cssModifierClass: `${colourClass} ${params.bannerModifierClass || ''}`,
+        cssModifierClass: messageModifierClass(
+            colourClass,
+            params.bannerModifierClass
+        ),
     }).show(renderedBanner);
 
     if (messageShown) {

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,12 +14,14 @@ import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/te
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicTestimonialsGroup } from 'common/modules/experiments/tests/acquisitions-epic-testimonials-group';
+import { circlesEpicBannerHoldback } from 'common/modules/experiments/tests/circles-epic-banner-holdback';
 
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
+    circlesEpicBannerHoldback,
     acquisitionsEpicUSGunCampaign,
     acquisitionsEpicTestimonialsGroup,
     askFourEarning,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,14 +14,14 @@ import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/te
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicTestimonialsGroup } from 'common/modules/experiments/tests/acquisitions-epic-testimonials-group';
-import { circlesEpicBannerHoldback } from 'common/modules/experiments/tests/circles-epic-banner-holdback';
+import { circlesEpicHoldback } from 'common/modules/experiments/tests/circles-epic-holdback';
 
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
-    circlesEpicBannerHoldback,
+    circlesEpicHoldback,
     acquisitionsEpicUSGunCampaign,
     acquisitionsEpicTestimonialsGroup,
     askFourEarning,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,7 +14,7 @@ import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/te
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicTestimonialsGroup } from 'common/modules/experiments/tests/acquisitions-epic-testimonials-group';
-import { circlesEpicHoldback } from 'common/modules/experiments/tests/circles-epic-holdback';
+import { colourTestEpicHoldback } from 'common/modules/experiments/tests/circles-epic-holdback';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -22,7 +22,7 @@ import { circlesEpicHoldback } from 'common/modules/experiments/tests/circles-ep
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     acquisitionsEpicUSGunCampaign,
-    circlesEpicHoldback,
+    colourTestEpicHoldback,
     acquisitionsEpicTestimonialsGroup,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -21,8 +21,8 @@ import { circlesEpicHoldback } from 'common/modules/experiments/tests/circles-ep
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
-    circlesEpicHoldback,
     acquisitionsEpicUSGunCampaign,
+    circlesEpicHoldback,
     acquisitionsEpicTestimonialsGroup,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -12,7 +12,7 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
     idealOutcome: 'No drop-off in conversions either way',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     audienceCriteria: 'All',
-    audience: 0.1,
+    audience: 0.2,
     audienceOffset: 0,
     // Should always be true, because the banner shows regardless.
     showForSensitive: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -4,7 +4,7 @@ import { makeBannerABTestVariants } from 'common/modules/commercial/contribution
 export const ColourTestBannerHoldback: AcquisitionsABTest = {
     id: 'ColourTestBannerHoldback',
     campaignId: 'colour_test_banner_holdback',
-    start: '2018-01-11',
+    start: '2018-01-12',
     expiry: '2018-02-15',
     author: 'Ap0c',
     description: 'A holdback for the banner colour changes',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -1,9 +1,9 @@
 // @flow
 import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
 
-export const CirclesBannerHoldback: AcquisitionsABTest = {
-    id: 'CirclesBannerHoldback',
-    campaignId: 'circles_banner_holdback',
+export const ColourTestBannerHoldback: AcquisitionsABTest = {
+    id: 'ColourTestBannerHoldback',
+    campaignId: 'colour_test_banner_holdback',
     start: '2018-01-11',
     expiry: '2018-02-15',
     author: 'Ap0c',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -14,6 +14,7 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
     audienceCriteria: 'All',
     audience: 0.1,
     audienceOffset: 0,
+    showForSensitive: true,
     canRun: () => true,
 
     variants: makeBannerABTestVariants([

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -12,8 +12,9 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
     idealOutcome: 'No drop-off in conversions either way',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     audienceCriteria: 'All',
-    audience: 0.1,
+    audience: 1,
     audienceOffset: 0,
+    // Should always be true, because the banner shows regardless.
     showForSensitive: true,
     canRun: () => true,
 
@@ -23,6 +24,11 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
         },
         {
             id: 'holdback',
+            options: {
+                engagementBannerParams: {
+                    bannerModifierClass: 'circles-banner-holdback',
+                },
+            },
         },
     ]),
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -12,7 +12,7 @@ export const ColourTestBannerHoldback: AcquisitionsABTest = {
     idealOutcome: 'No drop-off in conversions either way',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     audienceCriteria: 'All',
-    audience: 0.2,
+    audience: 0.7,
     audienceOffset: 0,
     // Should always be true, because the banner shows regardless.
     showForSensitive: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -12,7 +12,7 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
     idealOutcome: 'No drop-off in conversions either way',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     audienceCriteria: 'All',
-    audience: 1,
+    audience: 0.1,
     audienceOffset: 0,
     // Should always be true, because the banner shows regardless.
     showForSensitive: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -1,0 +1,27 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+
+export const CirclesBannerHoldback: AcquisitionsABTest = {
+    id: 'CirclesBannerHoldback',
+    campaignId: 'circles_banner_holdback',
+    start: '2018-01-05',
+    expiry: '2018-02-15',
+    author: 'Ap0c',
+    description: 'A holdback for the banner colour changes',
+    successMeasure: 'Who knows',
+    idealOutcome: 'No drop-off in conversions either way',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    audienceCriteria: 'All',
+    audience: 0.1,
+    audienceOffset: 0,
+    canRun: () => true,
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'holdback',
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -4,7 +4,7 @@ import { makeBannerABTestVariants } from 'common/modules/commercial/contribution
 export const CirclesBannerHoldback: AcquisitionsABTest = {
     id: 'CirclesBannerHoldback',
     campaignId: 'circles_banner_holdback',
-    start: '2018-01-05',
+    start: '2018-01-11',
     expiry: '2018-02-15',
     author: 'Ap0c',
     description: 'A holdback for the banner colour changes',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-banner-holdback.js
@@ -23,7 +23,7 @@ export const CirclesBannerHoldback: AcquisitionsABTest = {
             id: 'control',
         },
         {
-            id: 'holdback',
+            id: 'variant',
             options: {
                 engagementBannerParams: {
                     bannerModifierClass: 'circles-banner-holdback',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-banner-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-banner-holdback.js
@@ -1,0 +1,48 @@
+// @flow
+import {
+    makeABTest,
+    defaultButtonTemplate,
+} from 'common/modules/commercial/contributions-utilities';
+import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
+import { control } from 'common/modules/commercial/acquisitions-copy';
+
+export const circlesEpicBannerHoldback = makeABTest({
+    id: 'CirclesEpicBannerHoldback',
+    campaignId: 'circles_epic_banner_holdback',
+
+    start: '2018-01-05',
+    expiry: '2018-02-15',
+
+    author: 'Ap0c',
+    description: 'A holdback for the epic and banner colour changes',
+    successMeasure: 'Who knows',
+    idealOutcome: 'No drop-off in conversions either way',
+    audienceCriteria: 'All',
+    audience: 0.1,
+    audienceOffset: 0,
+
+    variants: [
+        {
+            id: 'control',
+            products: [],
+        },
+        {
+            id: 'holdback',
+            products: [],
+            options: {
+                template: function makeControlTemplate(variant) {
+                    return acquisitionsEpicControlTemplate({
+                        copy: control,
+                        componentName: variant.options.componentName,
+                        buttonTemplate: defaultButtonTemplate({
+                            contributeUrl: variant.options.contributeURL,
+                            supportUrl: variant.options.supportURL,
+                        }),
+                        testimonialBlock: variant.options.testimonialBlock,
+                        epicClass: 'contributions__epic--holdback',
+                    });
+                },
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -6,15 +6,15 @@ import {
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { control } from 'common/modules/commercial/acquisitions-copy';
 
-export const circlesEpicBannerHoldback = makeABTest({
-    id: 'CirclesEpicBannerHoldback',
-    campaignId: 'circles_epic_banner_holdback',
+export const circlesEpicHoldback = makeABTest({
+    id: 'CirclesEpicHoldback',
+    campaignId: 'circles_epic_holdback',
 
     start: '2018-01-05',
     expiry: '2018-02-15',
 
     author: 'Ap0c',
-    description: 'A holdback for the epic and banner colour changes',
+    description: 'A holdback for the epic colour changes',
     successMeasure: 'Who knows',
     idealOutcome: 'No drop-off in conversions either way',
     audienceCriteria: 'All',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -10,7 +10,7 @@ export const circlesEpicHoldback = makeABTest({
     id: 'CirclesEpicHoldback',
     campaignId: 'circles_epic_holdback',
 
-    start: '2018-01-05',
+    start: '2018-01-11',
     expiry: '2018-02-15',
 
     author: 'Ap0c',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -6,9 +6,9 @@ import {
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { control } from 'common/modules/commercial/acquisitions-copy';
 
-export const circlesEpicHoldback = makeABTest({
-    id: 'CirclesEpicHoldback',
-    campaignId: 'circles_epic_holdback',
+export const colourTestEpicHoldback = makeABTest({
+    id: 'ColourTestEpicHoldback',
+    campaignId: 'colour_test_epic_holdback',
 
     start: '2018-01-11',
     expiry: '2018-02-15',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -27,7 +27,7 @@ export const circlesEpicHoldback = makeABTest({
             products: [],
         },
         {
-            id: 'holdback',
+            id: 'variant',
             products: [],
             options: {
                 template: function makeControlTemplate(variant) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -10,7 +10,7 @@ export const colourTestEpicHoldback = makeABTest({
     id: 'ColourTestEpicHoldback',
     campaignId: 'colour_test_epic_holdback',
 
-    start: '2018-01-11',
+    start: '2018-01-12',
     expiry: '2018-02-15',
 
     author: 'Ap0c',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -18,7 +18,7 @@ export const colourTestEpicHoldback = makeABTest({
     successMeasure: 'Who knows',
     idealOutcome: 'No drop-off in conversions either way',
     audienceCriteria: 'All',
-    audience: 0.2,
+    audience: 0.5,
     audienceOffset: 0,
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/circles-epic-holdback.js
@@ -18,7 +18,7 @@ export const circlesEpicHoldback = makeABTest({
     successMeasure: 'Who knows',
     idealOutcome: 'No drop-off in conversions either way',
     audienceCriteria: 'All',
-    audience: 0.1,
+    audience: 0.2,
     audienceOffset: 0,
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,4 +1,6 @@
 // @flow
+import { CirclesBannerHoldback } from 'common/modules/experiments/tests/circles-banner-holdback';
+
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [CirclesBannerHoldback];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,6 +1,6 @@
 // @flow
-import { CirclesBannerHoldback } from 'common/modules/experiments/tests/circles-banner-holdback';
+import { ColourTestBannerHoldback } from 'common/modules/experiments/tests/circles-banner-holdback';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [CirclesBannerHoldback];
+> = [ColourTestBannerHoldback];

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -31,4 +31,4 @@
 @import 'module/experiments/embed';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
-
+@import 'module/experiments/_circles-epic-banner-holdback';

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -31,3 +31,4 @@
 @import 'module/experiments/embed';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
+@import 'module/experiments/_circles-epic-banner-holdback';

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -709,9 +709,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
     .message-button-rounded__cta.yellow {
         svg path {
-            fill: #000333;
+            fill: #fff;
         }
-        background-color: #ff9b0b;
+        background-color: #121212;
+        color: #fff;
     }
     .message-button-rounded__cta.purple {
 

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -745,7 +745,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message--membership-prominent.yellow {
     @include site-message-dark-text;
-    background-color: #ffce4b;
+    background-color: #ffe500;
     svg {
         fill: #000000;
     }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -709,10 +709,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
     .message-button-rounded__cta.yellow {
         svg path {
-            fill: #fff;
+            fill: #ffffff;
         }
         background-color: $garnett-neutral-1;
-        color: #fff;
+        color: #ffffff;
     }
     .message-button-rounded__cta.purple {
 

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -550,19 +550,12 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             padding-left: 10px;
         }
         @include mq($from: desktop) {
-            padding-left: 55px;
+            padding-left: 15px;
             padding-right: 40px;
         }
     }
     .site-message__media {
-        vertical-align: top;
-        position: absolute;
-        @include mq($from: mobile) {
-            padding-top: 4px;
-        }
-        @include mq($from: tablet) {
-            padding-top: 1px;
-        }
+        display: none;
     }
     .site-message__close {
         vertical-align: top;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -711,7 +711,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         svg path {
             fill: #fff;
         }
-        background-color: #121212;
+        background-color: $garnett-neutral-1;
         color: #fff;
     }
     .message-button-rounded__cta.purple {
@@ -745,7 +745,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message--membership-prominent.yellow {
     @include site-message-dark-text;
-    background-color: #ffe500;
+    background-color: $news-garnett-highlight;
     svg {
         fill: #000000;
     }

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -5,7 +5,7 @@
         background-color: #ffe399;
     }
 
-    .contributions__contribute--epic {
+    a[href].contributions__contribute--epic {
         background-color: $multimedia-main-2;
 
         &:hover {

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -9,3 +9,18 @@
         background-color: $multimedia-main-2;
     }
 }
+
+.circles-banner-holdback {
+    .message-button-rounded__cta.yellow {
+        svg path {
+            fill: #000333;
+        }
+
+        background-color: #ff9b0b;
+        color: $neutral-1;
+    }
+
+    &.site-message--membership-prominent.yellow {
+        background-color: #ffce4b;
+    }
+}

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -7,6 +7,10 @@
 
     .contributions__contribute--epic {
         background-color: $multimedia-main-2;
+
+        &:hover {
+            background-color: darken($multimedia-main-2, 5%);
+        }
     }
 }
 

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -1,0 +1,11 @@
+.contributions__epic--holdback {
+    background-color: $comment-support-2;
+
+    .contributions__highlight {
+        background-color: #ffe399;
+    }
+
+    .contributions__contribute--epic {
+        background-color: $multimedia-main-2;
+    }
+}

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -49,7 +49,7 @@
 }
 
 .contributions__highlight {
-    background-color: #ffe399;
+    background-color: #ffe500;
     padding: 4px 2px;
     margin-left: -2px;
     margin-right: -2px;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -8,7 +8,7 @@
 
 .contributions__epic {
     border-top: 1px solid $multimedia-main-2;
-    background-color: #f6f6f6;
+    background-color: $garnett-neutral-3;
     margin-top: $gs-baseline * 2;
     padding: ($gs-baseline / 3) ($gs-gutter / 4) $gs-baseline;
 
@@ -49,7 +49,7 @@
 }
 
 .contributions__highlight {
-    background-color: #ffe500;
+    background-color: $news-garnett-highlight;
     padding: 4px 2px;
     margin-left: -2px;
     margin-right: -2px;
@@ -161,7 +161,7 @@
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
-    background-color: #ffe500;
+    background-color: $news-garnett-highlight;
     color: $neutral-1;
     &:hover {
         color: $neutral-1;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -161,7 +161,7 @@
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
-    background-color: $multimedia-main-2;
+    background-color: #ffe500;
     color: $neutral-1;
     &:hover {
         color: $neutral-1;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -162,10 +162,10 @@
 a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
     background-color: $news-garnett-highlight;
-    color: $neutral-1;
+    color: $garnett-neutral-1;
     &:hover {
-        color: $neutral-1;
-        background-color: darken($multimedia-main-2, 5%);
+        background-color: #b3a000;
+        color: $garnett-neutral-1;
     }
 
     &:after {

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -163,6 +163,11 @@ a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
     background-color: $news-garnett-highlight;
     color: $garnett-neutral-1;
+
+    svg path {
+        fill: $garnett-neutral-1; 
+    }
+
     &:hover {
         background-color: #b3a000;
         color: $garnett-neutral-1;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -8,7 +8,7 @@
 
 .contributions__epic {
     border-top: 1px solid $multimedia-main-2;
-    background-color: $comment-support-2;
+    background-color: #f6f6f6;
     margin-top: $gs-baseline * 2;
     padding: ($gs-baseline / 3) ($gs-gutter / 4) $gs-baseline;
 


### PR DESCRIPTION
## What does this change?

This creates the holdback test for the Epic and Banner. The Epic uses 50% of the audience, 25% in the control and 25% in the variant. The Banner uses 70% of the audience, 35% in the control, 35% in the variant.

- Adds two AB test switches, one for the banner and another for the epic.
- Adds a modifier class parameter to the banner, to apply styles for the test group.
- Adds a banner holdback test and an epic holdback test.
- Adds a stylesheet for the test.
- Tweaks the control styles for the test.

## What is the value of this and can you measure success?

Hopefully there's no dip in conversion.

## Does this affect other platforms - Amp, Apps, etc?

Reader revenue platforms.

## Screenshots

**Variant:**

![holdback-epic](https://user-images.githubusercontent.com/5131341/34673000-9d27f788-f478-11e7-98ba-4504906dc122.png)

![holdback-banner](https://user-images.githubusercontent.com/5131341/34672971-7e3b6d3c-f478-11e7-9fdb-1faf44063d30.png)

**Control:**

![control-epic](https://user-images.githubusercontent.com/5131341/34673007-a6c3c308-f478-11e7-96bc-6805b0385cec.png)

![control-banner](https://user-images.githubusercontent.com/5131341/34673003-a11ac42e-f478-11e7-9e56-a766c121fc67.png)

## Tested in CODE?

Not yet.

  
  