### PR TITLE
[identity] let non js users 'repermission'

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -262,12 +262,26 @@
     <noscript>
         <div class="form__error">
             <p>
-                Setting your preferences requires a browser with Javascript enabled.
+                Setting your communication preferences requires a browser with Javascript enabled.
             </p>
             <p>
                 Please consider upgrading to one of our <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
             </p>
         </div>
+        <br/><br/>
+        <form class="identity-wizard__controls" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
+            @views.html.helper.CSRF.formField
+            <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
+            <button
+                type="submit"
+                class="manage-account__button--icon manage-account__button"
+            >
+                <div class="manage-account__button-flexwrap">
+                    <span>Continue</span>
+                    @fragments.inlineSvg("tick-button", "icon")
+                </div>
+            </button>
+        </form>
     </noscript>
 
     <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">


### PR DESCRIPTION
## What does this change?
Minor bugfix for the reperm flow. lets users with js disabled complete the repermission journey (without collecting any consents sadly)

![screen shot 2018-01-08 at 13 18 15](https://user-images.githubusercontent.com/11539094/34672615-0679c3bc-f477-11e7-8fe2-c5557c873915.png)