### PR TITLE
Contribution updates need additional error trap for non-200 responses

### DIFF
--- a/static/src/javascripts/projects/membership/contributions-recurring-tab.js
+++ b/static/src/javascripts/projects/membership/contributions-recurring-tab.js
@@ -98,6 +98,10 @@ const displayContributionUpdateErrorMessage = (): void => {
     $(CONTRIBUTION_UPDATE_ERROR).removeClass(IS_HIDDEN_CLASSNAME);
 };
 
+const hideContributionUpdateErrorMessage = (): void => {
+    $(CONTRIBUTION_UPDATE_ERROR).addClass(IS_HIDDEN_CLASSNAME);
+};
+
 const displayContributionUpdateSuccessMessage = (): void => {
     $(CONTRIBUTION_CHANGE_SUCCESS).removeClass(IS_HIDDEN_CLASSNAME);
 };
@@ -439,6 +443,7 @@ const changeContributionAmountSubmit = (): void => {
     const newAmount = $(CONTRIBUTION_NEW_AMOUNT_FIELD).val();
     toggleAmountChangeInputMode(false);
     hideContributionUpdateSuccessMessage();
+    hideContributionUpdateErrorMessage();
     hideContributionInfo();
     displayLoader();
     fetch(
@@ -457,8 +462,18 @@ const changeContributionAmountSubmit = (): void => {
             },
         }
     )
-        // eslint-disable-next-line no-use-before-define
-        .then(recurringContributionTab(true))
+        .then(resp => {
+            hideLoader();
+            if (resp.status === 200) {
+                // eslint-disable-next-line no-use-before-define
+                recurringContributionTab(true);
+            } else {
+                displayContributionUpdateErrorMessage();
+                throw new Error(
+                    'Members Data API returned non-200 result for contribution-update-amount'
+                );
+            }
+        })
         .catch(err => {
             hideLoader();
             hideContributionUpdateSuccessMessage();

--- a/static/src/javascripts/projects/membership/contributions-recurring-tab.js
+++ b/static/src/javascripts/projects/membership/contributions-recurring-tab.js
@@ -487,18 +487,12 @@ const changeContributionAmountSubmit = (): void => {
 const changeAmountButtonOnClick = (): void => {
     const currentAmount = $(CURRENT_CONTRIBUTION_AMOUNT).text();
     toggleAmountChangeInputMode(true);
-    setupEditableNewAmountField(
-        formatAmount(
-            currentAmount,
-            ''
-        ).toString()
-    );
+    setupEditableNewAmountField(formatAmount(currentAmount, '').toString());
 };
 
 const changeAmountCancelButtonOnClick = (): void => {
     toggleAmountChangeInputMode(false);
 };
-
 
 const populateUserDetails = (contributorDetails: ContributorDetails): void => {
     const isMonthly = contributorDetails.subscription.plan.interval === 'month';
@@ -563,20 +557,29 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
             CHANGE_CONTRIBUTION_AMOUNT_BUTTON
         );
         if (changeAmountButton) {
-            changeAmountButton.addEventListener('click', changeAmountButtonOnClick);
+            changeAmountButton.addEventListener(
+                'click',
+                changeAmountButtonOnClick
+            );
         }
         const changeAmountCancelButton = document.querySelector(
             CHANGE_CONTRIBUTION_AMOUNT_CANCEL
         );
         if (changeAmountCancelButton) {
-            changeAmountCancelButton.addEventListener('click', changeAmountCancelButtonOnClick);
+            changeAmountCancelButton.addEventListener(
+                'click',
+                changeAmountCancelButtonOnClick
+            );
         }
 
         const changeAmountConfirmButton = document.querySelector(
             CHANGE_CONTRIBUTION_AMOUNT_SUBMIT
         );
         if (changeAmountConfirmButton) {
-            changeAmountConfirmButton.addEventListener('click', changeContributionAmountSubmit);
+            changeAmountConfirmButton.addEventListener(
+                'click',
+                changeContributionAmountSubmit
+            );
         }
     }
 

--- a/static/src/javascripts/projects/membership/contributions-recurring-tab.js
+++ b/static/src/javascripts/projects/membership/contributions-recurring-tab.js
@@ -381,9 +381,9 @@ const validatePriceChangeInput = (): void => {
     hideInvalidNumberWarning();
 
     if (fieldVal && Number(fieldVal)) {
-        const currentVal = Number(currentAmount);
+        const currentVal = Number(currentAmount) / 100;
         const newVal = Number(fieldVal);
-        if (newVal >= 5 && newVal <= 2000 && newVal !== currentVal) {
+        if (newVal >= 2 && newVal <= 2000 && newVal !== currentVal) {
             enablePriceChangeConfirmButton();
         } else {
             disablePriceChangeConfirmButton();
@@ -395,7 +395,7 @@ const validatePriceChangeInput = (): void => {
             displayHighContributionWarningMessage();
         } else if (newVal === currentVal) {
             displayContributionNoChangeWarning();
-        } else if (newVal < 5) {
+        } else if (newVal < 2) {
             displayContributionTooLowWarning();
         }
     } else {
@@ -484,6 +484,22 @@ const changeContributionAmountSubmit = (): void => {
         });
 };
 
+const changeAmountButtonOnClick = (): void => {
+    const currentAmount = $(CURRENT_CONTRIBUTION_AMOUNT).text();
+    toggleAmountChangeInputMode(true);
+    setupEditableNewAmountField(
+        formatAmount(
+            currentAmount,
+            ''
+        ).toString()
+    );
+};
+
+const changeAmountCancelButtonOnClick = (): void => {
+    toggleAmountChangeInputMode(false);
+};
+
+
 const populateUserDetails = (contributorDetails: ContributorDetails): void => {
     const isMonthly = contributorDetails.subscription.plan.interval === 'month';
     const intervalText = isMonthly ? 'Monthly' : 'Annual';
@@ -513,7 +529,7 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
     );
 
     $(CURRENT_CONTRIBUTION_AMOUNT).text(
-        contributorDetails.subscription.nextPaymentPrice / 100
+        contributorDetails.subscription.nextPaymentPrice
     );
 
     $(CONTRIBUTION_GLYPH).text(glyph);
@@ -527,7 +543,7 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
     );
 
     $(CONTRIBUTION_TOO_LOW_WARNING).text(
-        `Please enter an amount of ${formatAmount(500, glyph)} or more`
+        `Please enter an amount of ${formatAmount(200, glyph)} or more`
     );
 
     $(CONTRIBUTION_TOO_HIGH_WARNING).text(
@@ -547,32 +563,20 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
             CHANGE_CONTRIBUTION_AMOUNT_BUTTON
         );
         if (changeAmountButton) {
-            changeAmountButton.addEventListener('click', () => {
-                toggleAmountChangeInputMode(true);
-                setupEditableNewAmountField(
-                    formatAmount(
-                        contributorDetails.subscription.nextPaymentPrice,
-                        ''
-                    ).toString()
-                );
-            });
+            changeAmountButton.addEventListener('click', changeAmountButtonOnClick);
         }
         const changeAmountCancelButton = document.querySelector(
             CHANGE_CONTRIBUTION_AMOUNT_CANCEL
         );
         if (changeAmountCancelButton) {
-            changeAmountCancelButton.addEventListener('click', () => {
-                toggleAmountChangeInputMode(false);
-            });
+            changeAmountCancelButton.addEventListener('click', changeAmountCancelButtonOnClick);
         }
 
         const changeAmountConfirmButton = document.querySelector(
             CHANGE_CONTRIBUTION_AMOUNT_SUBMIT
         );
         if (changeAmountConfirmButton) {
-            changeAmountConfirmButton.addEventListener('click', () => {
-                changeContributionAmountSubmit();
-            });
+            changeAmountConfirmButton.addEventListener('click', changeContributionAmountSubmit);
         }
     }
 


### PR DESCRIPTION
## What does this change?
When is an error not an error? When it's a non-200. Sometimes the backend fails to complete the contribution update, but the frontend misses the fact that it's an error because it got a response of some description.

This adds a second line of defence to identify that the response is a non-200 and update the UI appropriately.

## What is the value of this and can you measure success?
A contributor is not mislead about the status of their update. They should only see the success message if everything completed, obvs.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Tested in CODE?
YES

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

  