### PR TITLE
Add tracking to manage my account links

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -18,6 +18,8 @@ object UrlHelpers {
   case object SideMenu extends Position
   case object AmpHeader extends Position
   case object Footer extends Position
+  case object ManageMyAccountUpsell extends Position
+  case object ManageMyAccountCancel extends Position
 
   def getCampaignCode(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): Option[String] = {
     val isInHeaderTestControlGroup = ActiveExperiments.isControl(ABNewDesktopHeader)
@@ -45,6 +47,7 @@ object UrlHelpers {
 
       case (Support, Footer, _) => Some("gdnwb_copts_memco_dotcom_footer")
       case (Support, AmpHeader, _) => Some("gdnwb_copts_memco_header_amp")
+      case (Support, ManageMyAccountUpsell, _) => Some(s"DOTCOM_MANAGE_JOIN")
       case (Support, _, _) => Some("gdnwb_copts_memco_header")
 
       case (_, _, _) => None
@@ -77,6 +80,7 @@ object UrlHelpers {
       "source" -> "GUARDIAN_WEB",
       "componentType" -> (position match {
         case NewHeader | OldHeader | AmpHeader | SideMenu | SlimHeaderDropdown => "ACQUISITIONS_HEADER"
+        case ManageMyAccountUpsell | ManageMyAccountCancel => "ACQUISITIONS_MANAGE_MY_ACCOUNT"
         case Footer => "ACQUISITIONS_FOOTER"
       })
     ) ++ campaignCode.fold(Json.obj())(c => Json.obj(

--- a/identity/app/views/profile/cancelRegularContribution.scala.html
+++ b/identity/app/views/profile/cancelRegularContribution.scala.html
@@ -1,3 +1,6 @@
+@import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountCancel}
+@import navigation.ReaderRevenueSite.Support
+
 @(user: com.gu.identity.model.User)
 <ul class="details-list details-list--lower u-unstyled contribution-cancellation">
     <li class="details-list__item">
@@ -5,7 +8,7 @@
     </li>
     <div class="contribution-cancellation__section js-cancellation-form">
         <h3 class="manage-account-header contribution-cancellation__title">Cancel contribution</h3>
-        <p>Your contribution funds and supports the Guardian independent journalism. Remember you can contribute again at any time by making a <a href="@(conf.Configuration.id.supportUrl)">one-off or monthly contribution</a>.</p>
+        <p>Your contribution funds and supports the Guardian independent journalism. Remember you can contribute again at any time by making a <a href="@getReaderRevenueUrl(Support, ManageMyAccountCancel)">one-off or monthly contribution</a>.</p>
         <p>We would really value your feedback please take a moment to tell us why you are cancelling</p>
         <div>
             <select class="js-cancel-contribution-selector contribution-cancellation__selector">

--- a/identity/app/views/profile/cancelRegularContribution.scala.html
+++ b/identity/app/views/profile/cancelRegularContribution.scala.html
@@ -1,7 +1,7 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountCancel}
 @import navigation.ReaderRevenueSite.Support
 
-@(user: com.gu.identity.model.User)
+@(user: com.gu.identity.model.User)(implicit request: RequestHeader)
 <ul class="details-list details-list--lower u-unstyled contribution-cancellation">
     <li class="details-list__item">
         <span><a class="js-cancel-contribution-link contribution-cancellation__main-link">Cancel contribution</a></span>

--- a/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
+++ b/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
@@ -1,8 +1,11 @@
+@import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountUpsell}
+@import navigation.ReaderRevenueSite.Support
+
 <div class="manage-account-up-sell is-hidden js-contribution-up-sell">
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Support us with a contribution</h2>
     </div>
     <p class="manage-account-up-sell__content">Help us deliver the independent journalism the world needs. Support the Guardian's quality, investigative journalism by making a contribution.</p>
 
-    <a href="@(conf.Configuration.id.supportUrl)/?INTCMP=DOTCOM_MANAGE_JOIN" class="manage-account__button" data-link-name="Join today">Make a contribution</a>
+    <a href="@getReaderRevenueUrl(Support, ManageMyAccountUpsell)" class="manage-account__button" data-link-name="Join today">Make a contribution</a>
 </div>

--- a/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
+++ b/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
@@ -1,6 +1,8 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountUpsell}
 @import navigation.ReaderRevenueSite.Support
 
+@()(implicit request: RequestHeader)
+
 <div class="manage-account-up-sell is-hidden js-contribution-up-sell">
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Support us with a contribution</h2>

--- a/identity/app/views/profile/contributionForm/recurringDetails.scala.html
+++ b/identity/app/views/profile/contributionForm/recurringDetails.scala.html
@@ -1,7 +1,7 @@
 @import conf.switches.Switches.ProfileShowCancelContributor
 @import conf.switches.Switches.ProfileShowChangeContributionAmount
 
-@(user: com.gu.identity.model.User)
+@(user: com.gu.identity.model.User)(implicit request: RequestHeader)
 <div class="is-hidden js-contribution-info">
     <ul class="details-list u-unstyled js-contribution-details">
         <li class="details-list__item">

--- a/identity/app/views/profile/digitalPackForm/upsell.scala.html
+++ b/identity/app/views/profile/digitalPackForm/upsell.scala.html
@@ -1,6 +1,8 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountUpsell}
 @import navigation.ReaderRevenueSite.Subscribe
 
+@()(implicit request: RequestHeader)
+
 <div class="manage-account-up-sell is-hidden js-dig-up-sell">
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Try the Guardian Digital Pack</h2>

--- a/identity/app/views/profile/digitalPackForm/upsell.scala.html
+++ b/identity/app/views/profile/digitalPackForm/upsell.scala.html
@@ -1,7 +1,10 @@
+@import navigation.UrlHelpers.{getReaderRevenueUrl, ManageMyAccountUpsell}
+@import navigation.ReaderRevenueSite.Subscribe
+
 <div class="manage-account-up-sell is-hidden js-dig-up-sell">
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Try the Guardian Digital Pack</h2>
     </div>
     <p class="manage-account-up-sell__content">Enjoy the Guardian and Observer's digital pack on the tube, in the park, on a beach, or wherever it’s convenient for you. The digital pack brings you the biggest stories every day and special sections for big events on iPad, Android and Kindle Fire tablets.</p>
-    <a href="@(conf.Configuration.id.subscribeUrl)" class="manage-account__button" data-link-name="Join today">Get your 2 week free trial</a>
+    <a href="@getReaderRevenueUrl(Subscribe, ManageMyAccountUpsell)" class="manage-account__button" data-link-name="Join today">Get your 2 week free trial</a>
 </div>


### PR DESCRIPTION
There were a few reader revenue links in the Manage My Account section which didn't have the `acquisitionData` tracking param so would have been erroneously counted as off platform.

Numbers are probably very small for these but it's worth trying to make the data as accurate as possible

Plus the more frequently we use `getReaderRevenueUrl` the more likely it is that it will be correctly used as the example for the next time someone adds a reader revenue link!

@guardian/contributions 
  