### PR TITLE
[identity] free email changers from identity jail

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -137,8 +137,11 @@ class AuthenticatedActions(
 
       private def decideConsentJourney[A](request: AuthRequest[A]) =
         (userEmailValidated(request), userHasRepermissioned(request)) match {
-          case (false, _) =>
+          case (false, false) =>
             Future.successful(Some(sendUserToValidateEmail(request)))
+
+          case (false, true) =>
+            Future.successful(None)
 
           case (true, false) =>
             Future.successful(Some(sendUserToConsentsJourney(request)))

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -38,6 +38,17 @@
     </div>
 }
 
+@validationRoadblock = {
+    <div class="identity-forms-message identity-forms-message--inline">
+        <h1 class="identity-title">You must verify your email to continue.</h1>
+        <div class="identity-forms-message__body">
+            <p>Please validate your email (@user.primaryEmailAddress) to edit your preferences.</p>
+            <p>If your address seems wrong you can <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="identity : email : reverify-email-change">change it</a>.</p>
+            <a class="manage-account__button identity-forms-message__button" href="@idUrlBuilder.buildUrl("/verify-email", idRequest)" data-link-name="identity : email : reverify-email-resend">Resend me a validation email</a>
+        </div>
+    </div>
+}
+
 <div class="tabs">
 
     <div class="identity-wrapper-for-bg identity-wrapper-for-bg--header">
@@ -77,7 +88,13 @@
 
                         @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
-                        @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated, consentHint))
+                        @content(6, "/email-prefs")(
+                            if(user.statusFields.userEmailValidated.fold(false)(identity)) {
+                                profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated, consentHint)
+                            } else {
+                                validationRoadblock
+                            }
+                        )
                     </div>
                 </div>
             </div>

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -10,6 +10,10 @@ Messages
             margin: 12.5vh auto 17.5vh;
         }
     }
+    &.identity-forms-message--inline {
+        margin-top: $gs-baseline;
+        margin-bottom: $gs-baseline;
+    }
     .identity-title {
         padding-right: $gs-baseline * 2;
     }


### PR DESCRIPTION
## What does this change?
Extremely quirky bugfix where users who change their email would get locked out of the email editing from meaning setting a wrong email locks you out of your account forever

This pr updates the behaviour so users who have repermissioned and validated their email can access all the profile edit pages except for /email-prefs

![screen shot 2018-01-09 at 14 24 27](https://user-images.githubusercontent.com/11539094/34725527-1ede5990-f549-11e7-830c-a50a2e228aa2.png)
