### PR TITLE
Garnett: Prevent layout jumping on facia cards with comment count

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -102,9 +102,6 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
     return fastdom.write(() => {
         containers.forEach(container => {
             container.insertAdjacentHTML('beforeend', html);
-            if (container.classList.contains('fc-item__meta')) {
-                container.classList.add('fc-item__meta--enhanced-comments');
-            }
         });
         el.removeAttribute(ATTRIBUTE_NAME);
         el.classList.remove('u-h');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -102,6 +102,9 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
     return fastdom.write(() => {
         containers.forEach(container => {
             container.insertAdjacentHTML('beforeend', html);
+            if (container.classList.contains('fc-item__meta')) {
+                container.classList.add('fc-item__meta--enhanced-comments');
+            }
         });
         el.removeAttribute(ATTRIBUTE_NAME);
         el.classList.remove('u-h');

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -349,6 +349,24 @@ $block-height: 58px;
     }
 }
 
+// reserve space for comment count on commentable card
+.fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+    min-height: 17px;
+    min-width: 40px;
+
+    .fc-trail__count--commentcount {
+        display: flex;
+        flex-direction: row;
+
+        &::before {
+            content: '';
+            display: block;
+            flex-grow: 1;
+            height: 100%;
+        } 
+    }
+}
+
 .fc-item__container > .fc-item__meta {
     display: none;
 }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -351,10 +351,18 @@ $block-height: 58px;
 
 // reserve space for comment count on commentable card
 .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
-    min-height: 17px;
-    min-width: 40px;
+    min-height: 17px; // 14px height + 3px margin-top of inline-icon
+
+    &::before {
+        content: '';
+        height: 100%;
+        min-width: calc(3ch + 14px); // 14px height of inline-icon
+    }
 
     .fc-trail__count--commentcount {
+        position: absolute;
+        right: 0;
+        bottom: 0;
         display: flex;
         flex-direction: row;
 
@@ -366,6 +374,8 @@ $block-height: 58px;
         } 
     }
 }
+
+
 
 .fc-item__container > .fc-item__meta {
     display: none;

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -352,17 +352,9 @@ $block-height: 58px;
 // reserve space for comment count on commentable card
 .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
     min-height: 17px; // 14px height + 3px margin-top of inline-icon
-
-    &::before {
-        content: '';
-        height: 100%;
-        min-width: calc(3ch + 14px); // 14px height of inline-icon
-    }
+    min-width: calc(3ch + 14px); // 14px height of inline-icon
 
     .fc-trail__count--commentcount {
-        position: absolute;
-        right: 0;
-        bottom: 0;
         display: flex;
         flex-direction: row;
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -351,8 +351,8 @@ $block-height: 58px;
 
 // reserve space for comment count on commentable card
 .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
-    min-height: 17px; // 14px height + 3px margin-top of inline-icon
-    min-width: calc(3ch + 14px); // 14px height of inline-icon
+    min-height: 17px; // 17px = 14px height + 3px margin-top of inline-icon
+    min-width: calc(3ch + 16px); // 16px = 14px height + 2px padding-right of inline-icon
 
     .fc-trail__count--commentcount {
         display: flex;


### PR DESCRIPTION
## What does this change?

Prevent layout jumping on facia cards with comment counts by reserving a min-height/width for comment count wrapper (`.fc-item__meta`).

## What is the value of this and can you measure success?

See above ☝️ 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

No
  