### PR TITLE
Enable posting individual consents instead of all at once

### DIFF
--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -90,15 +90,13 @@ case class PrivacyFormData(
       case Some(_) => allowThirdPartyProfiling
     }
 
-    val newConsents = updateConsents(oldUserDO.consents, consents)
-
     UserUpdateDTO(
       statusFields = Some(StatusFields(
         receive3rdPartyMarketing = newReceive3rdPartyMarketing,
         receiveGnmMarketing = newReceiveGnmMarketing,
         allowThirdPartyProfiling = newAllowThirdPartyProfiling
       )),
-      consents = Some(newConsents))
+      consents = Some(consents))
   }
 }
 


### PR DESCRIPTION
## What does this change?

Enable posting individual consents instead of all at once.

Related IDAPI PR: https://github.com/guardian/identity/pull/776

## What is the value of this and can you measure success?

GDPR work.