### PR TITLE
Safer DFP report query access

### DIFF
--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -139,7 +139,8 @@ class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends Log
   def getReportQuery(reportId: Long): Option[ReportQuery] =
     for {
       session <- SessionWrapper()
-    } yield session.getReportQuery(reportId)
+      query <- session.getReportQuery(reportId)
+    } yield query
 
   def runReportJob(report: ReportQuery): Seq[String] = {
     withDfpSession { session =>

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -111,7 +111,8 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
       .withBindVariableValue("id", reportId)
 
     val page: SavedQueryPage = services.reportService.getSavedQueriesByStatement(stmtBuilder.toStatement)
-    val savedQuery: Option[SavedQuery] = page.getResults().toList.headOption
+    // page.getResults() may return null.
+    val savedQuery: Option[SavedQuery] = Option(page.getResults()).flatMap(_.toList.headOption)
     savedQuery.map(_.getReportQuery)
   }
 

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -103,7 +103,7 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
     services.networkService.getCurrentNetwork.getEffectiveRootAdUnitId
   }
 
-  def getReportQuery(reportId: Long): ReportQuery = {
+  def getReportQuery(reportId: Long): Option[ReportQuery] = {
     // Retrieve the saved query.
     val stmtBuilder = new StatementBuilder()
       .where("id = :id")
@@ -111,8 +111,8 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
       .withBindVariableValue("id", reportId)
 
     val page: SavedQueryPage = services.reportService.getSavedQueriesByStatement(stmtBuilder.toStatement)
-    val savedQuery: SavedQuery = page.getResults(0)
-    savedQuery.getReportQuery
+    val savedQuery: Option[SavedQuery] = page.getResults().toList.headOption
+    savedQuery.map(_.getReportQuery)
   }
 
   def runReportJob(report: ReportQuery): Seq[String] = {

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -17,7 +17,7 @@ object CommercialDfpReporting {
   val teamKPIReport = "All ab-test impressions and CPM"
   // These IDs correspond to queries saved in DFP's web console.
   val reportMappings = Map(
-    teamKPIReport -> 10060521970L
+    teamKPIReport -> 10060521970L // This report is accessible by the DFP user: "NGW DFP Production"
   )
 
 


### PR DESCRIPTION
Wrapping the DFP `ReportService.getSavedQueriesByStatement` return value in an Option to avoid an NPE.

Note, I will update some parameters in the AWS Parameter store to cycle the credentials, which gives our system account access to the DFP reports.