### PR TITLE
Fix Epic Link Colour

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -158,6 +158,7 @@
     }
 }
 
+// Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
     background-color: $multimedia-main-2;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -158,7 +158,7 @@
     }
 }
 
-.contributions__contribute--epic {
+a[href].contributions__contribute.contributions__contribute--epic {
     margin-top: 0;
     background-color: $multimedia-main-2;
     color: $neutral-1;


### PR DESCRIPTION
## What does this change?

Fixes a problem where the pillar colours were overwriting the epic link colour due to specificity issues. Solves it by making the epic rule more specific.

## What is the value of this and can you measure success?

The epic doesn't look broken.
