### PR TITLE
Garnett: Fix issue where main media overlapped 1st paragraph in articles

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1327,7 +1327,7 @@
         @supports (display: grid) {
             margin-left: -($left-column + $gs-gutter);
             display: grid;
-            grid-template-columns: ($left-column + $gs-gutter) auto;
+            grid-template-columns: ($left-column + $gs-gutter)  1fr;
             grid-template-areas: 'labels headline-standfirst' 'meta main-media';
 
             .content--type-guardianview &,
@@ -1344,7 +1344,7 @@
     @include mq($from: wide) {
         @supports (display: grid) {
             margin-left: -($left-column-wide + $gs-gutter);
-            grid-template-columns: ($left-column-wide + $gs-gutter) auto;
+            grid-template-columns: ($left-column-wide + $gs-gutter) 1fr;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Fixes issue https://trello.com/c/OMUxwm06/211-overlapping-images-on-articles

The fix comes from making the grid columns `headline-standfirst` and `main-media` fill the remaining width of the grid. Replacing `auto` with `1fr` achieved this.

## What is the value of this and can you measure success?

Fixes layout issue in articles

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

No