### PR TITLE
Update background.js module to parallax more efficiently and correctly

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -10,6 +10,8 @@ type AdSpec = {
     backgroundImage: string,
     backgroundRepeat: string,
     backgroundPosition: string,
+    backgroundSize: string,
+    transform: string,
 };
 
 type SpecStyles = {

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -26,6 +26,9 @@ type Background = {
     background: HTMLElement,
 };
 
+const IntersectionObserver = window.IntersectionObserver;
+const IntersectionObserverEntry = window.IntersectionObserverEntry;
+
 const getStylesFromSpec = (specs: AdSpec): SpecStyles =>
     Object.keys(specs).reduce((result, key) => {
         if (key !== 'scrollType') {
@@ -137,38 +140,35 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
         return Promise.resolve({ backgroundParent, background });
     };
 
-    let updateQueued = false;
-
     const onScroll = (
         backgroundParent: HTMLElement,
         background: HTMLElement
     ) => {
-        if (!updateQueued) {
-            updateQueued = true;
-            fastdom.read(() => {
-                updateQueued = false;
-                const rect = backgroundParent.getBoundingClientRect();
-                const dy = Math.floor(0.3 * rect.top) + 20;
+        fastdom.read(() => {
+            // We update the style in a read batch because the DIV
+            // has been promoted to its own layer and is also
+            // strictly self-contained. Also, without doing that
+            // the animation is extremely jittery.
+            const rect = backgroundParent.getBoundingClientRect();
+            const backgroundHeight = rect.height;
+            const windowHeight = window.innerHeight;
 
-                // We update the style in a read batch because the DIV
-                // has been promoted to its own layer and is also
-                // strictly self-contained. Also, without doing that
-                // the animation is extremely jittery.
+            // we should scroll at a rate such that we don't run out of background (when non-repeating)
+            const dy = rect.bottom / (windowHeight + backgroundHeight) * 130;
 
-                // #? Flow does not currently list backgroundPositionY in
-                // CSSStyleDeclaration: https://github.com/facebook/flow/issues/396
-                // ...So we have to use a more convoluted hack-around:
-                (background.style: any).backgroundPositionY = `${dy}%`;
-            });
-        }
+            // #? Flow does not currently list backgroundPositionY in
+            // CSSStyleDeclaration: https://github.com/facebook/flow/issues/396
+            // ...So we have to use a more convoluted hack-around:
+            (background.style: any).backgroundPositionY = `${dy}%`;
+        });
     };
 
-    return getBackground()
-        .then(({ backgroundParent, background }) =>
-            updateStyles(backgroundParent, background)
-        )
-        .then(({ backgroundParent, background }) => {
+    const onIntersect = (entries: Array<IntersectionObserverEntry>): void => {
+        entries.filter(entry => entry.isIntersecting).forEach(entry => {
             if (!backgroundAlreadyExists) {
+                const backgroundParent = entry.target;
+                const background = backgroundParent.firstChild;
+
                 addEventListener(
                     window,
                     'scroll',
@@ -181,6 +181,17 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
                 onScroll(backgroundParent, background);
             }
         });
+    };
+
+    const observer = new IntersectionObserver(onIntersect, {
+        rootMargin: '10px',
+    });
+
+    return getBackground()
+        .then(({ backgroundParent, background }) =>
+            updateStyles(backgroundParent, background)
+        )
+        .then(({ backgroundParent }) => observer.observe(backgroundParent));
 };
 
 const init = (register: RegisterListeners): void => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
@@ -9,6 +9,8 @@ const adSpec = {
     backgroundImage: 'image',
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'absolute',
+    backgroundSize: 'contain',
+    transform: 'translate3d(0,0,0)',
 };
 
 describe('Cross-frame messenger: setBackground', () => {
@@ -46,5 +48,7 @@ describe('Cross-frame messenger: getStylesFromSpec', () => {
         expect(specStyles.backgroundImage).toBe('image');
         expect(specStyles.backgroundRepeat).toBe('no-repeat');
         expect(specStyles.backgroundPosition).toBe('absolute');
+        expect(specStyles.backgroundSize).toBe('contain');
+        expect(specStyles.transform).toBe('translate3d(0,0,0)');
     });
 });


### PR DESCRIPTION
## Background
Ads can send messages (via `PostMessage`) to our [messenger](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/commercial/modules/messenger.js#L106) module. One of these can be a `background` message, which requests a parallax background be 'behind' the ad.

Currently, depending on where the user is when the ad is loaded, the parallax effect can scroll past the end of the background image, leaving a blank background, which looks pretty bad (see screenshots below).

## What does this change?
- Ensures that the parallax scrolling listener is only added once the ad is scrolled into view (via our Polyfilled IntersectionObserver).
- The calculation for how quickly the parallax effect should scroll has been fixed to be as fast as possible without running out of background.
- The type definition for `AdSpec` has been extended to cover all the properties that are provided when `background.js` is called.

## What is the value of this and can you measure success?
Our parallax ad formats look better.

## Screenshots
**Before**
![parallax-before](https://user-images.githubusercontent.com/1821099/34771571-e19ff0a2-f5fc-11e7-8a51-ff1781b6f079.gif)

**After**
![parallax-after](https://user-images.githubusercontent.com/1821099/34771577-e6ce8502-f5fc-11e7-9c8c-94795b46a64b.gif)
