### PR TITLE
Containers: offset rule by -1px to match body

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -162,7 +162,7 @@ $header-image-size-desktop: 100px;
         height: $gs-gutter * 1.5;
         width: 1px;
         background-color: $garnett-neutral-4;
-        right: -$gs-gutter / 2;
+        right: -$gs-gutter / 2 - 1;
         top: -$gs-baseline / 2;
 
         @include mq($from: leftCol) {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -162,6 +162,8 @@ $header-image-size-desktop: 100px;
         height: $gs-gutter * 1.5;
         width: 1px;
         background-color: $garnett-neutral-4;
+        // Offset by 1px to the right so that it coincides
+        // with the rule in the body of articles
         right: -$gs-gutter / 2 - 1;
         top: -$gs-baseline / 2;
 


### PR DESCRIPTION
The rule in the body is 1px off the left column area (because it is inside the body area).

Tested in articles and fronts.