### PR TITLE
move meta under media on garnett content pages...

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -88,8 +88,10 @@
 }
 
 .content__head {
-    display: flex;
-    flex-direction: column;
+    @include mq($from: tablet, $until: desktop) {
+        display: flex;
+        flex-direction: column;
+    }
 }
 
 .content__hr {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -87,6 +87,11 @@
     }
 }
 
+.content__head {
+    display: flex;
+    flex-direction: column;
+}
+
 .content__hr {
     border: 0;
     margin: 0;
@@ -474,6 +479,11 @@
     min-height: gs-height(1);
     position: relative;
     margin-bottom: $gs-baseline;
+
+    @include mq($from: tablet, $until: leftCol) {
+        // move meta below image
+        order: 1;
+    }
 
     @include mq(leftCol) {
         position: absolute;


### PR DESCRIPTION
...between `tablet` and `leftCol` BPs

## What does this change?

moves meta under media on garnett content pages between `tablet` and `leftCol` BPs