### PR TITLE
Support more card types for analysis tone underline.

### DIFF
--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -23,7 +23,7 @@ object IndexHtml {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
     override def criticalCssLink: Html = stacked(
-      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(FaciaCSSFile),
       criticalStyleLink(InlineNavigationCSSFile))
     override def criticalCssInline: Html = criticalStyleInline(
       Html(common.Assets.css.head(Some("facia"))),

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -99,25 +99,6 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
-// reduce type size on q-q-q-q slice if it follows another slice in the same container
-.fc-slice-wrapper + .fc-slice-wrapper {
-    .fc-slice--q-q-q-q {
-        .fc-item--standard-tablet {
-            .fc-item__header {
-                @include mq(tablet) {
-                    @include fs-headline(2, true);
-                }
-            }
-
-            .inline-garnett-quote__svg {
-                height: 16px;
-                width: 8px;
-                margin-right: 8px;
-            }
-        }
-    }
-}
-
 .fc-slice--h14-q-q {
     .has-flex & {
         flex-direction: row-reverse;
@@ -206,16 +187,16 @@ Hence why a greater depth of selector specificity is needed.
                     height: gs-height(2.5);
                     width: gs-height(2.5);
                 }
-            
+
                 .fc-item__avatar__media {
                     height: gs-height(2.5);
                     left: 0 - ($gs-gutter * (2.5 / 6));
                 }
-            
+
                 .fc-item__standfirst {
                     display: none;
                 }
-    
+
                 .fc-item__standfirst-wrapper {
                     padding-right: 0;
                 }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -6,6 +6,7 @@
         background-clip: content-box;
         margin-right: -1 * $factor * $gs-gutter;
     }
+
 }
 
 $pillars: (
@@ -16,24 +17,50 @@ $pillars: (
     lifestyle: $lifestyle-garnett-main-1
 );
 
+.fc-item--type-analysis.fc-item--has-boosted-title {
+    .fc-item__title {
+        background: none !important;
+        // Supporting this would double the CSS load of the page.
+        // Individually disabling would also have an undue css load.
+
+    }
+}
+
 @each $pillar, $pillarColor in $pillars {
     .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
+
         @include garnett-underline($pillarColor, 20px);
 
         @include mq(tablet) {
-            &.fc-item--standard-tablet {
-                @include garnett-underline($pillarColor, 24px);
-            }
-
-            &.fc-item--half-tablet,
+            &.fc-item--standard-tablet,
+            &.fc-item--third-tablet,
+            &.fc-item--full-media-50-tablet,
+            &.fc-item--full-media-75-tablet, &.fc-item--half-tablet,
+            &.fc-item--three-quarters-right-tablet,
             &.fc-item--three-quarters-tall-tablet,
             &.fc-item--three-quarters-tablet {
+                @include garnett-underline($pillarColor, 24px);
+            }
+            &.fc-item--full-media-100-tablet {
                 @include garnett-underline($pillarColor, 28px, .5);
             }
 
-            &.fc-item--full-media-75-tablet {
-                @include garnett-underline($pillarColor, 32px, .5);
+            @include mq(desktop) {
+                &.fc-item--half-tablet,
+                &.fc-item--three-quarters-right-tablet,
+                &.fc-item--three-quarters-tall-tablet,
+                &.fc-item--three-quarters-tablet {
+                    @include garnett-underline($pillarColor, 28px, .5);
+                }
+                &.fc-item--full-media-50-tablet,
+                &.fc-item--full-media-75-tablet {
+                    @include garnett-underline($pillarColor, 32px, .5);
+                }
+                &.fc-item--full-media-100-tablet {
+                    @include garnett-underline($pillarColor, 36px, .5);
+                }
             }
+
         }
 
     }


### PR DESCRIPTION
## What does this change?

The analysis underline was cutting up some headlines, so this accounts for more types of cards and breakpoints. 

## What is the value of this and can you measure success?
garnett bugfix

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
