### PR TITLE
[identity] Better browser support for /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -278,7 +278,7 @@
     <script>
         setTimeout(function(){
             if(window.identityWizardloadingError) window.identityWizardloadingError.className = window.identityWizardloadingError.className.replace('identity-forms-loading--hide-text','')
-        },2000);
+        },5000);
     </script>
 
     <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -238,6 +238,20 @@
     }
 }
 
+@forceSubmitFallback = {
+    <form method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
+        @views.html.helper.CSRF.formField
+        <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
+        <button
+        type="submit"
+        class="manage-account__button"
+        data-link-name="consents : navigation : submit-force"
+        >
+            <span>Continue</span>
+        </button>
+    </form>
+}
+
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-wizard">
 
     <div class="js-errorHolder manage-account__errors"></div>
@@ -251,21 +265,21 @@
                 Please consider upgrading to one of our <a class="u-underline" href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>. If you need more help please <a href="@LinkTo{/info/tech-feedback}">contact us</a>.
             </p>
         </div>
-        <br/><br/>
-        <form class="identity-wizard__controls" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
-            @views.html.helper.CSRF.formField
-            <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
-            <button
-                type="submit"
-                class="manage-account__button--icon manage-account__button"
-            >
-                <div class="manage-account__button-flexwrap">
-                    <span>Continue</span>
-                    @fragments.inlineSvg("tick-button", "icon")
-                </div>
-            </button>
-        </form>
+        @forceSubmitFallback
     </noscript>
+
+    <div id="identityWizardloadingError" class="identity-forms-loading identity-forms-loading--hide-text u-identity-forms-padded">
+        <div class="identity-forms-loading__spinner is-updating"></div>
+        <div class="identity-forms-loading__text">
+            Loading seems to be taking a while. If you are in a hurry you can skip this and edit your consents later from your email preferences.
+            @forceSubmitFallback
+        </div>
+    </div>
+    <script>
+        setTimeout(function(){
+            if(window.identityWizardloadingError) window.identityWizardloadingError.className = window.identityWizardloadingError.className.replace('identity-forms-loading--hide-text','')
+        },2000);
+    </script>
 
     <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -120,6 +120,9 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
 const showWizard = (wizardEl: HTMLElement): Promise<void> =>
     fastdom.write(() => wizardEl.classList.remove('u-h'));
 
+const hideLoading = (loadingEl: HTMLElement): Promise<void> =>
+    fastdom.write(() => loadingEl.remove());
+
 const bindNextButton = (buttonEl: HTMLElement): void => {
     const wizardEl: ?Element = buttonEl.closest('.identity-wizard--consent');
     if (wizardEl && wizardEl instanceof HTMLElement) {
@@ -163,6 +166,7 @@ const enhanceConsentWizard = (): void => {
         ['.identity-consent-wizard-counter', createEmailConsentCounter],
         ['.identity-wizard--consent', bindEmailConsentCounterToWizard],
         ['.identity-wizard--consent', showWizard],
+        ['#identityWizardloadingError', hideLoading],
         ['.js-identity-consent-wizard__next', bindNextButton],
     ];
     loadEnhancers(loaders);

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -1,18 +1,51 @@
 /*
+Padder
+*/
+@mixin identity-forms-padded {
+    @include mq(tablet) {
+        margin: ($gs-baseline * 4) auto ($gs-baseline * 2)!important;
+        @supports(height: 1vh) {
+            margin: 12.5vh auto 17.5vh!important;
+        }
+    }
+}
+.u-identity-forms-padded {
+    @include identity-forms-padded;
+}
+
+/*
+Loading screen
+*/
+.identity-forms-loading {
+    text-align: center;
+    max-width: gs-span(6);
+    margin: $gs-baseline auto;
+    .identity-forms-loading__spinner {
+        display: inline-block;
+        margin: 0;
+    }
+    .identity-forms-loading__text {
+        @include fs-textSans(2);
+        margin-top: $gs-baseline;
+        .manage-account__button {
+            margin: $gs-baseline auto;
+            float: none;
+        }
+    }
+    &.identity-forms-loading--hide-text .identity-forms-loading__text {
+        display: none;
+    }
+}
+
+
+/*
 Messages
 */
 .identity-forms-message {
     max-width: gs-span(6);
-    margin: 0 auto;
-    @include mq(tablet) {
-        margin: ($gs-baseline * 4) auto ($gs-baseline * 2);
-        @supports(height: 1vh) {
-            margin: 12.5vh auto 17.5vh;
-        }
-    }
-    &.identity-forms-message--inline {
-        margin-top: $gs-baseline;
-        margin-bottom: $gs-baseline;
+    margin: $gs-baseline auto;
+    &:not(.identity-forms-message--inline) {
+        @include identity-forms-padded;
     }
     .identity-title {
         padding-right: $gs-baseline * 2;


### PR DESCRIPTION
## What does this change?
At the moment `/consents` is broken and displays a blank page on a small number of old browsers that can't run the javascript needed to initialise it. This PR adds a visible loading spinner that becomes a `continue` button after 5 seconds. This could potentially also help users on very slow connections so it's a double win.

<div align=center>

![screen shot 2018-01-10 at 14 00 19](https://user-images.githubusercontent.com/11539094/34776994-af676f98-f610-11e7-9147-80ac1c9a37a2.png)

_(the button is misaligned on chrome 14, should display as usual on modern browsers)_

</div>

## What is the value of this and can you measure success?
Let users continue through regardless of browser technology instead of potentially dropping out