### PR TITLE
Becoming cultured

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -97,7 +97,7 @@ object NavLinks {
   val NBA = NavLink("NBA", "/sport/nba")
   val NHL = NavLink("NHL", "/sport/nhl")
 
-  /* ARTS */
+  /* CULTURE */
   val film = NavLink("Film", "/film")
   val tvAndRadio = NavLink("TV & radio", "/tv-and-radio")
   val music = NavLink("Music", "/music")
@@ -322,8 +322,8 @@ object NavLinks {
     )
   )
 
-  // Arts Pillar
-  val ukArtsPillar = NavLink("Arts", "/culture", longTitle = "Culture home", iconName = "home",
+  // Culture Pillar
+  val ukCulturePillar = NavLink("Culture", "/culture", longTitle = "Culture home", iconName = "home",
     List(
       film,
       music,
@@ -335,7 +335,7 @@ object NavLinks {
       classical
     )
   )
-  val auArtsPillar = ukArtsPillar.copy(
+  val auCulturePillar = ukCulturePillar.copy(
     children = List(
       film, music,
       books,
@@ -346,7 +346,7 @@ object NavLinks {
       classical
     )
   )
-  val usArtsPillar = ukArtsPillar.copy(
+  val usCulturePillar = ukCulturePillar.copy(
     children = List(
       film,
       books,
@@ -358,7 +358,7 @@ object NavLinks {
       games
     )
   )
-  val intArtsPillar = ukArtsPillar.copy(
+  val intCulturePillar = ukCulturePillar.copy(
     children = List(
       books,
       music,

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -80,10 +80,10 @@ case class NavRoot private(children: Seq[NavLink], otherLinks: Seq[NavLink], bra
 object NavRoot {
   def apply(edition: Edition): NavRoot = {
     edition match {
-      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukArtsPillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
-      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usArtsPillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
-      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auArtsPillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
-      case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intArtsPillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
+      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
+      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
+      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
+      case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intCulturePillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
     }
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -32,7 +32,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   }
 
   "Simple menu" should "just return the 5 primary links" in {
-    NavMenu(Uk).pillars should be(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukArtsPillar, ukLifestylePillar))
+    NavMenu(Uk).pillars should be(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar))
   }
 
   "the route `/cities`" should "return the NavLink for cities" in {
@@ -137,7 +137,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
     val subnav = NavMenu.getSubnav(fakePage(), maybeNavLink, parent, pillar)
 
     subnav.parent.isDefined should be(false)
-    subnav.children should be(auArtsPillar.children)
+    subnav.children should be(auCulturePillar.children)
   }
 
   "The section `Indigenous Australians`" should "still be in the pillar News in the Uk edition" in {

--- a/onward/test/NavigationControllerTest.scala
+++ b/onward/test/NavigationControllerTest.scala
@@ -46,7 +46,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     contentAsString(result) should include("\"News\"")
     contentAsString(result) should include("\"Opinion\"")
     contentAsString(result) should include("\"Sport\"")
-    contentAsString(result) should include("\"Arts\"")
+    contentAsString(result) should include("\"Culture\"")
     contentAsString(result) should include("\"Lifestyle\"")
   }
 }

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -98,9 +98,9 @@ $sport-garnett-main-1: #0084c6;
 $sport-garnett-feature: #005689;
 $sport-garnett-media-main-1: #00b2ff;
 
-$arts-garnett-main-1: #ab8958;
-$arts-garnett-feature: #6b5840;
-$arts-garnett-media-main-1: #eacca0;
+$culture-garnett-main-1: #ab8958;
+$culture-garnett-feature: #6b5840;
+$culture-garnett-media-main-1: #eacca0;
 
 $lifestyle-garnett-main-1: #bb3b80;
 $lifestyle-garnett-feature: #7d0068;
@@ -111,8 +111,8 @@ $live-garnett-main-2: #ffbac8;
 $live-garnett-accent: #d65353;
 $live-garnett-sport1: $sport-garnett-feature;
 $live-garnett-sport2: #90dcff;
-$live-garnett-arts1: $arts-garnett-feature;
-$live-garnett-arts2: #e7d4b9;
+$live-garnett-culture1: $culture-garnett-feature;
+$live-garnett-culture2: #e7d4b9;
 $live-garnett-lifestyle1: $lifestyle-garnett-feature;
 $live-garnett-lifestyle2: $live-garnett-main-2;
 

--- a/static/src/stylesheets/amp/header/_header.scss
+++ b/static/src/stylesheets/amp/header/_header.scss
@@ -24,14 +24,17 @@
 
 .header__logo__svg {
     display: block;
-    height: calc(3 / 16 * 170px);
-    width: 170px;
-    margin-bottom: $gs-baseline / 2;
-    margin-right: $gs-gutter / 2;
-    margin-top: $gs-baseline / 2;
+    height: 30px;
+    margin-bottom: $gs-baseline / 4;
+    margin-right: $veggie-burger-small + $gs-gutter / 4;
+    margin-top: 8px;
+    width: 161px;
 
     @include mq(mobileMedium) {
-        height: calc(3 / 16 * 225px);
+        height: 42px;
+        margin-bottom: $gs-baseline / 2;
+        margin-right: $gs-gutter / 2;
+        margin-top: $gs-baseline / 2;
         width: 225px;
     }
 

--- a/static/src/stylesheets/amp/header/_pillar-link.scss
+++ b/static/src/stylesheets/amp/header/_pillar-link.scss
@@ -9,7 +9,7 @@
     cursor: pointer;
 
     @include mq(mobileMedium) {
-        font-size: 18px;
+        font-size: 17px;
     }
 
     &:before {

--- a/static/src/stylesheets/amp/header/_veggie-burger.scss
+++ b/static/src/stylesheets/amp/header/_veggie-burger.scss
@@ -1,16 +1,23 @@
 .veggie-burger {
     background-color: $news-main-2;
-    bottom: -$gs-baseline / 2;
+    top: $gs-baseline / 4;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
     color: $guardian-brand-dark;
     cursor: pointer;
-    height: $veggie-burger-medium;
-    min-width: $veggie-burger-medium;
+    height: $veggie-burger-small;
+    min-width: $veggie-burger-small;
     position: absolute;
     border: 0;
     border-radius: 50%;
     outline: none;
     right: $gutter-small;
+
+    @include mq(mobileMedium) {
+        bottom: -$gs-baseline / 2;
+        height: $veggie-burger-medium;
+        min-width: $veggie-burger-medium;
+        top: auto;
+    }
 
     @include mq(mobileLandscape) {
         right: $gutter-medium;

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -8,7 +8,7 @@
 //         .fc-item__byline {
 //             color: $colour;
 //         }
-// 
+//
 //         .fc-item__kicker {
 //             &:after {
 //                 background-color: $colour;
@@ -151,7 +151,7 @@
 //
 //     //These need to exist for all kickers because of tone on tone action
 //     @include kicker-override(life, $lifestyle-garnett-main-media-1);
-//     @include kicker-override(arts, $arts-garnett-media-main-1);
+//     @include kicker-override(culture, $culture-garnett-media-main-1);
 //     @include kicker-override(sports, $sport-garnett-media-main-1);
 //     @include kicker-override(opinion, $opinion-garnett-media-main-1);
 //     @include kicker-override(news, $news-garnett-media-main-1);

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -151,7 +151,7 @@
 //
 //     //These need to exist for all kickers because of tone on tone action
 //     @include kicker-override(life, $lifestyle-garnett-main-media-1);
-//     @include kicker-override(culture, $culture-garnett-media-main-1);
+//     @include kicker-override(arts, $culture-garnett-media-main-1);
 //     @include kicker-override(sports, $sport-garnett-media-main-1);
 //     @include kicker-override(opinion, $opinion-garnett-media-main-1);
 //     @include kicker-override(news, $news-garnett-media-main-1);

--- a/static/src/stylesheets/layout/garnett-header/_colours.scss
+++ b/static/src/stylesheets/layout/garnett-header/_colours.scss
@@ -36,8 +36,8 @@
     @include PillarColourOne($sport-garnett-main-1);
 }
 
-.new-header--Arts {
-    @include PillarColourOne($arts-garnett-main-1);
+.new-header--Culture {
+    @include PillarColourOne($culture-garnett-main-1);
 }
 
 .new-header--Lifestyle {
@@ -65,8 +65,8 @@
 
     .menu-item:nth-child(4) > .menu-group .menu-item__title:hover,
     .menu-item:nth-child(4) > .menu-group .menu-item__title:focus,
-    .menu-item__title--Arts {
-        color: $arts-garnett-main-1;
+    .menu-item__title--Culture {
+        color: $culture-garnett-main-1;
     }
 
     .menu-item:nth-child(5) > .menu-group .menu-item__title:hover,
@@ -101,11 +101,11 @@
         }
     }
 
-    &.pillar-link--Arts {
-        color: $arts-garnett-main-1;
+    &.pillar-link--Culture {
+        color: $culture-garnett-main-1;
 
         &:after {
-            border-color: $arts-garnett-feature;
+            border-color: $culture-garnett-feature;
         }
     }
 

--- a/static/src/stylesheets/layout/garnett-header/_menu.scss
+++ b/static/src/stylesheets/layout/garnett-header/_menu.scss
@@ -4,7 +4,7 @@
     font-size: 20px;
     left: 0;
     line-height: 1;
-    margin-right: $gutter-small + ($veggie-burger-medium / 2);
+    margin-right: $gutter-small + ($veggie-burger-small / 2);
     padding-bottom: $gs-baseline * 2;
     top: 0;
     z-index: $zindex-main-menu;

--- a/static/src/stylesheets/layout/garnett-header/_new-header.scss
+++ b/static/src/stylesheets/layout/garnett-header/_new-header.scss
@@ -89,9 +89,14 @@ from scrolling */
 
 .new-header__menu-toggle {
     @include mq($until: desktop) {
-        bottom: -$gs-baseline / 2;
         position: absolute;
         right: $gutter-small;
+        top: 24px;
+
+        @include mq(mobileMedium) {
+            bottom: -$gs-baseline / 2;
+            top: auto;
+        }
 
         .new-header--slim & {
             right: $gs-gutter / 2;
@@ -119,8 +124,12 @@ from scrolling */
 .new-header__logo {
     float: right;
     margin-bottom: $gs-baseline + $gs-baseline / 4;
-    margin-right: 5px;
+    margin-right: $gs-gutter / 4 + $veggie-burger-small;
     margin-top: $gs-baseline / 4;
+
+    @include mq(mobileMedium) {
+        margin-right: $gs-gutter / 4;
+    }
 
     @include mq(mobileLandscape) {
         margin-right: 17px;
@@ -199,12 +208,12 @@ from scrolling */
 
 .inline-the-guardian-logo__svg {
     display: block;
-    height: 57px;
-    width: 175px;
+    height: 52px;
+    width: 159px;
 
     @include mq(mobileMedium) {
-        height: 52px;
-        width: 164px;
+        height: 57px;
+        width: 175px;
     }
 
     @include mq(tablet) {

--- a/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
@@ -1,5 +1,5 @@
 .pillar-link {
-    font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
+    font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', TimesNewRoman, serif;
     font-weight: 600;
     color: currentColor;
     cursor: pointer;

--- a/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
@@ -4,7 +4,7 @@
     color: currentColor;
     cursor: pointer;
     display: block;
-    font-size: 14px;
+    font-size: 15px;
     height: $gs-baseline * 2 + $gs-baseline / 2;
     line-height: 1;
     padding: 0 4px;
@@ -12,7 +12,7 @@
     overflow: hidden;
 
     @include mq(mobileMedium) {
-        font-size: 17px;
+        font-size: 16px;
     }
 
     @include mq(tablet) {

--- a/static/src/stylesheets/layout/garnett-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/garnett-header/_subnav-link.scss
@@ -10,7 +10,7 @@
     position: relative;
 
     @include mq(mobileMedium) {
-        font-size: 16px;
+        font-size: 15px;
     }
 
     @include mq(tablet) {

--- a/static/src/stylesheets/layout/garnett-header/_variables.scss
+++ b/static/src/stylesheets/layout/garnett-header/_variables.scss
@@ -1,6 +1,6 @@
 // Specific values for veggie-burger and menu
 $gutter-small: 5px;
-$gutter-medium: 44px;
+$gutter-medium: 46px;
 $gutter-large: 58px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
@@ -14,6 +14,7 @@ $nav-secondary-colour: darken($nav-background-colour, 50%); // Softer accent col
 $nav-darker-colour: darken($nav-background-colour, 5%); // Colour for shaded areas on the BG
 $rule: darken($nav-background-colour, 20%); // All borders on the nav
 
+$veggie-burger-small: 40px;
 $veggie-burger-medium: 48px;
 $veggie-burger-large: 56px;
 

--- a/static/src/stylesheets/layout/garnett-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/garnett-header/_veggie-burger.scss
@@ -3,14 +3,19 @@
     color: $nav-background-colour;
     cursor: pointer;
     display: block;
-    height: $veggie-burger-medium;
-    width: $veggie-burger-medium;
+    height: $veggie-burger-small;
+    width: $veggie-burger-small;
     position: relative;
     border: 0;
     border-radius: 50%;
     outline: none;
     user-select: none;
     z-index: 2;
+
+    @include mq(mobileMedium) {
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+    }
 
     @include mq(tablet) {
         height: $veggie-burger-large;

--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -6,7 +6,7 @@
     font-size: 20px;
     left: 0;
     line-height: 1;
-    margin-right: $gutter-small + ($veggie-burger-medium / 2);
+    margin-right: $gutter-small + ($veggie-burger-small / 2);
     padding-bottom: $gs-baseline * 2;
     top: 0;
     z-index: $zindex-main-menu;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -88,9 +88,14 @@ from scrolling */
 
 .new-header__menu-toggle {
     @include mq($until: desktop) {
-        bottom: -$gs-baseline / 2;
+        top: $gs-baseline / 4;
         position: absolute;
         right: $gutter-small;
+
+        @include mq(mobileMedium) {
+            bottom: -$gs-baseline / 2;
+            top: auto;
+        }
 
         .new-header--slim & {
             right: $gs-gutter / 2;
@@ -132,14 +137,17 @@ from scrolling */
 
 .new-header__logo__svg {
     display: block;
-    height: 34px;
-    margin-bottom: $gs-baseline / 2;
-    margin-right: $gs-gutter / 2;
-    margin-top: $gs-baseline / 2;
-    width: 180px;
+    height: 30px;
+    margin-bottom: $gs-baseline / 4;
+    margin-right: $veggie-burger-small + $gs-gutter / 4;
+    margin-top: 8px;
+    width: 161px;
 
     @include mq(mobileMedium) {
         height: 42px;
+        margin-bottom: $gs-baseline / 2;
+        margin-right: $gs-gutter / 2;
+        margin-top: $gs-baseline / 2;
         width: 225px;
     }
 

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -12,7 +12,7 @@
     overflow: hidden;
 
     @include mq(mobileMedium) {
-        font-size: 18px;
+        font-size: 17px;
     }
 
     @include mq(tablet) {

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -9,7 +9,7 @@
     position: relative;
 
     @include mq(mobileMedium) {
-        font-size: 17px;
+        font-size: 16px;
     }
 
     @include mq(tablet) {

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -10,6 +10,7 @@ $search-and-edition-height-desktop: 42px;
 
 $highlight-blue: #74e7ff;
 
+$veggie-burger-small: 40px;
 $veggie-burger-medium: 48px;
 $veggie-burger-large: 56px;
 

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -4,14 +4,19 @@
     color: $guardian-brand-dark;
     cursor: pointer;
     display: block;
-    height: $veggie-burger-medium;
-    width: $veggie-burger-medium;
+    height: $veggie-burger-small;
+    width: $veggie-burger-small;
     position: relative;
     border: 0;
     border-radius: 50%;
     outline: none;
     user-select: none;
     z-index: 1;
+
+    @include mq(mobileMedium) {
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+    }
 
     @include mq(tablet) {
         height: $veggie-burger-large;

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -782,5 +782,5 @@
 @include immersivePillarColours('news', $news-garnett-media-main-1, $news-garnett-main-1);
 @include immersivePillarColours('opinion', $opinion-garnett-media-main-1, $opinion-garnett-main-1);
 @include immersivePillarColours('sport', $sport-garnett-media-main-1, $sport-garnett-main-1);
-@include immersivePillarColours('culture', $culture-garnett-media-main-1, $culture-garnett-main-1);
+@include immersivePillarColours('arts', $culture-garnett-media-main-1, $culture-garnett-main-1);
 @include immersivePillarColours('lifestyle', $lifestyle-garnett-media-main-1, $lifestyle-garnett-main-1);

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -782,5 +782,5 @@
 @include immersivePillarColours('news', $news-garnett-media-main-1, $news-garnett-main-1);
 @include immersivePillarColours('opinion', $opinion-garnett-media-main-1, $opinion-garnett-main-1);
 @include immersivePillarColours('sport', $sport-garnett-media-main-1, $sport-garnett-main-1);
-@include immersivePillarColours('arts', $arts-garnett-media-main-1, $arts-garnett-main-1);
+@include immersivePillarColours('culture', $culture-garnett-media-main-1, $culture-garnett-main-1);
 @include immersivePillarColours('lifestyle', $lifestyle-garnett-media-main-1, $lifestyle-garnett-main-1);

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -291,9 +291,9 @@
     @include colorPalatte($opinion-garnett-main-1, $opinion-garnett-main-1, $opinion-garnett-media-main-1);
 }
 
-.content--pillar-culture,
-.content--pillar-culture.content--type-comment,
-.content--pillar-culture.content--type-guardianview {
+.content--pillar-arts,
+.content--pillar-arts.content--type-comment,
+.content--pillar-arts.content--type-guardianview {
     @include colorPalatte($culture-garnett-main-1, $culture-garnett-feature, $culture-garnett-media-main-1);
 }
 
@@ -313,7 +313,7 @@
     @include footerPalette($news-garnett-main-1);
 }
 
-.content-footer--pillar-culture {
+.content-footer--pillar-arts {
     @include footerPalette($culture-garnett-feature);
 }
 
@@ -339,8 +339,8 @@
     @include mediaPalatte($opinion-garnett-media-main-1, opinion);
 }
 
-.content--media:not(.paid-content).content--pillar-culture,
-.immersive-main-media__headline-container.content--pillar-culture {
+.content--media:not(.paid-content).content--pillar-arts,
+.immersive-main-media__headline-container.content--pillar-arts {
     @include mediaPalatte($culture-garnett-media-main-1, culture);
 }
 
@@ -380,7 +380,7 @@
         @include richLink($sport-garnett-main-1, $garnett-neutral-3);
     }
 
-    &.rich-link--pillar-culture {
+    &.rich-link--pillar-arts {
         @include richLink($culture-garnett-main-1, $garnett-neutral-3);
     }
 
@@ -412,7 +412,7 @@
             @include richLink(#ffffff, $sport-garnett-feature);
         }
 
-        &.rich-link--pillar-culture {
+        &.rich-link--pillar-arts {
             @include richLink(#ffffff, $culture-garnett-feature);
         }
 

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -291,10 +291,10 @@
     @include colorPalatte($opinion-garnett-main-1, $opinion-garnett-main-1, $opinion-garnett-media-main-1);
 }
 
-.content--pillar-arts,
-.content--pillar-arts.content--type-comment,
-.content--pillar-arts.content--type-guardianview {
-    @include colorPalatte($arts-garnett-main-1, $arts-garnett-feature, $arts-garnett-media-main-1);
+.content--pillar-culture,
+.content--pillar-culture.content--type-comment,
+.content--pillar-culture.content--type-guardianview {
+    @include colorPalatte($culture-garnett-main-1, $culture-garnett-feature, $culture-garnett-media-main-1);
 }
 
 .content--pillar-lifestyle,
@@ -313,8 +313,8 @@
     @include footerPalette($news-garnett-main-1);
 }
 
-.content-footer--pillar-arts {
-    @include footerPalette($arts-garnett-feature);
+.content-footer--pillar-culture {
+    @include footerPalette($culture-garnett-feature);
 }
 
 .content-footer--pillar-lifestyle {
@@ -339,9 +339,9 @@
     @include mediaPalatte($opinion-garnett-media-main-1, opinion);
 }
 
-.content--media:not(.paid-content).content--pillar-arts,
-.immersive-main-media__headline-container.content--pillar-arts {
-    @include mediaPalatte($arts-garnett-media-main-1, arts);
+.content--media:not(.paid-content).content--pillar-culture,
+.immersive-main-media__headline-container.content--pillar-culture {
+    @include mediaPalatte($culture-garnett-media-main-1, culture);
 }
 
 .content--media:not(.paid-content).content--pillar-lifestyle,
@@ -380,8 +380,8 @@
         @include richLink($sport-garnett-main-1, $garnett-neutral-3);
     }
 
-    &.rich-link--pillar-arts {
-        @include richLink($arts-garnett-main-1, $garnett-neutral-3);
+    &.rich-link--pillar-culture {
+        @include richLink($culture-garnett-main-1, $garnett-neutral-3);
     }
 
     &.rich-link--pillar-lifestyle {
@@ -412,8 +412,8 @@
             @include richLink(#ffffff, $sport-garnett-feature);
         }
 
-        &.rich-link--pillar-arts {
-            @include richLink(#ffffff, $arts-garnett-feature);
+        &.rich-link--pillar-culture {
+            @include richLink(#ffffff, $culture-garnett-feature);
         }
 
         &.rich-link--pillar-lifestyle {

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -815,9 +815,9 @@ $pillars: (
         pillarColor: $sport-garnett-feature,
         kickerColor:  $live-garnett-sport2
     ),
-    arts: (
-        pillarColor: $arts-garnett-feature,
-        kickerColor: $live-garnett-arts2,
+    culture: (
+        pillarColor: $culture-garnett-feature,
+        kickerColor: $live-garnett-culture2,
     ),
     lifestyle: (
         pillarColor: $lifestyle-garnett-feature,

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -815,7 +815,7 @@ $pillars: (
         pillarColor: $sport-garnett-feature,
         kickerColor:  $live-garnett-sport2
     ),
-    culture: (
+    arts: (
         pillarColor: $culture-garnett-feature,
         kickerColor: $live-garnett-culture2,
     ),

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -38,18 +38,18 @@ $pillars: (
         cutoutBackground: $sport-garnett-feature,
         invertedKicker: $sport-garnett-media-main-1
     ),
-    arts: (
+    culture: (
         cardBackground: $garnett-neutral-3,
-        lines: $arts-garnett-main-1,
-        kicker: $arts-garnett-main-1,
+        lines: $culture-garnett-main-1,
+        kicker: $culture-garnett-main-1,
         headline: $garnett-neutral-1,
-        featureHeadline: $arts-garnett-feature,
-        byline: $arts-garnett-main-1,
+        featureHeadline: $culture-garnett-feature,
+        byline: $culture-garnett-main-1,
         commentCount: $garnett-neutral-2,
-        headlineIcon: $arts-garnett-main-1,
+        headlineIcon: $culture-garnett-main-1,
         metaText: $garnett-neutral-2,
-        cutoutBackground: $arts-garnett-main-1,
-        invertedKicker: $arts-garnett-media-main-1
+        cutoutBackground: $culture-garnett-main-1,
+        invertedKicker: $culture-garnett-media-main-1
     ),
     lifestyle: (
         cardBackground: $garnett-neutral-3,

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -38,7 +38,7 @@ $pillars: (
         cutoutBackground: $sport-garnett-feature,
         invertedKicker: $sport-garnett-media-main-1
     ),
-    culture: (
+    arts: (
         cardBackground: $garnett-neutral-3,
         lines: $culture-garnett-main-1,
         kicker: $culture-garnett-main-1,

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -13,7 +13,7 @@ $pillars: (
     news:      $news-garnett-main-1,
     opinion:   $opinion-garnett-main-1,
     sport:     $sport-garnett-main-1,
-    arts:   $culture-garnett-main-1,
+    arts:      $culture-garnett-main-1,
     lifestyle: $lifestyle-garnett-main-1
 );
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -13,7 +13,7 @@ $pillars: (
     news:      $news-garnett-main-1,
     opinion:   $opinion-garnett-main-1,
     sport:     $sport-garnett-main-1,
-    arts:      $arts-garnett-main-1,
+    culture:   $culture-garnett-main-1,
     lifestyle: $lifestyle-garnett-main-1
 );
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -13,7 +13,7 @@ $pillars: (
     news:      $news-garnett-main-1,
     opinion:   $opinion-garnett-main-1,
     sport:     $sport-garnett-main-1,
-    culture:   $culture-garnett-main-1,
+    arts:   $culture-garnett-main-1,
     lifestyle: $lifestyle-garnett-main-1
 );
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -80,5 +80,5 @@
 
 @include overide-live-blog-colours(news, $live-garnett-main-1, $live-garnett-main-2);
 @include overide-live-blog-colours(sport, $live-garnett-sport1, $live-garnett-sport2);
-@include overide-live-blog-colours(culture, $live-garnett-culture1, $live-garnett-culture2);
+@include overide-live-blog-colours(arts, $live-garnett-culture1, $live-garnett-culture2);
 @include overide-live-blog-colours(lifestyle, $live-garnett-lifestyle1, $live-garnett-lifestyle2);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -80,5 +80,5 @@
 
 @include overide-live-blog-colours(news, $live-garnett-main-1, $live-garnett-main-2);
 @include overide-live-blog-colours(sport, $live-garnett-sport1, $live-garnett-sport2);
-@include overide-live-blog-colours(arts, $live-garnett-arts1, $live-garnett-arts2);
+@include overide-live-blog-colours(culture, $live-garnett-culture1, $live-garnett-culture2);
 @include overide-live-blog-colours(lifestyle, $live-garnett-lifestyle1, $live-garnett-lifestyle2);

--- a/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
+++ b/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
@@ -36,7 +36,7 @@
     @include fs-headline(2);
     font-style: italic;
 }
-@each $pillar, $palette in (news: $news-garnett-feature, opinion: $opinion-garnett-main-1, sport: $sport-garnett-main-1, culture: $culture-garnett-main-1, lifestyle: $lifestyle-garnett-main-1) {
+@each $pillar, $palette in (news: $news-garnett-feature, opinion: $opinion-garnett-main-1, sport: $sport-garnett-main-1, arts: $culture-garnett-main-1, lifestyle: $lifestyle-garnett-main-1) {
     .right-most-popular__byline--#{$pillar} {
         color: $palette;
     }

--- a/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
+++ b/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
@@ -36,7 +36,7 @@
     @include fs-headline(2);
     font-style: italic;
 }
-@each $pillar, $palette in (news: $news-garnett-feature, opinion: $opinion-garnett-main-1, sport: $sport-garnett-main-1, arts: $arts-garnett-main-1, lifestyle: $lifestyle-garnett-main-1) {
+@each $pillar, $palette in (news: $news-garnett-feature, opinion: $opinion-garnett-main-1, sport: $sport-garnett-main-1, culture: $culture-garnett-main-1, lifestyle: $lifestyle-garnett-main-1) {
     .right-most-popular__byline--#{$pillar} {
         color: $palette;
     }


### PR DESCRIPTION
After some significant drops in traffic, 'arts' is reverting to the name 'culture'. 

Due to the extra characters, I've had to change the design of the header between mobile and mobileMedium. I've made these changes across Garnett and AMP. 

Before this is merged I need to create the AMP garnett variant. (Waiting on https://github.com/guardian/frontend/pull/18736)

This is the box I will tick once that's done: ☐

Smallest breakpoint looks like this:
<img width="319" alt="culture-amp" src="https://user-images.githubusercontent.com/14570016/34779178-51af28d0-f617-11e7-9d8f-1c705db54646.png">
