### PR TITLE
fix side scroll on articles

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article.scss
+++ b/static/src/stylesheets/module/content-garnett/_article.scss
@@ -1,15 +1,5 @@
 .media-primary {
-    margin: 0 $gs-gutter * -.5;
     position: relative;
-
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter / -1;
-        margin-right: $gs-gutter / -1;
-    }
-    @include mq(phablet) {
-        margin-left: 0;
-        margin-right: 0;
-    }
 }
 
 .content__main-column--article {


### PR DESCRIPTION
## What does this change?

remove padding on `.media-primary` in garnett, to kill the sideways scroll it creates in articles.