### PR TITLE
GARNETT- Remove old video overrides and just target the big button

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -261,7 +261,8 @@
     .vjs-volume-level,
     .vjs-volume-level:before,
     .youtube-media-atom__bottom-bar__duration:before,
-    .youtube-media-atom__play-button:before {
+    .youtube-media-atom__play-button:before,
+    .gu-media--show-controls-at-start.vjs-paused .vjs-big-play-button .vjs-control-text:before {
         background: $mediaColor;
     }
 
@@ -278,6 +279,7 @@
     .vjs-playing .vjs-play-control {
         @include icon(pause-icon--#{$pillar});
     }
+
 }
 
 .content--pillar-news {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1043,47 +1043,6 @@ $quote-mark: 35px;
     .submeta__keywords {
         border-bottom: 0;
     }
-    // *************** Video overrides ***************
-    &.content--media--video {
-        .vjs-control-text {
-            // Magic numbers are used here to draw the play arrow and circle as pseudo elements.
-            @include video-play-button-size($vjs-small-button-size);
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
-            user-select: none;
-            @include mq(mobileLandscape) {
-                @include video-play-button-size($vjs-large-button-size);
-            }
-
-            &:before {
-                @include circular;
-                @include video-play-button-size($vjs-small-button-size);
-                content: '';
-                display: block;
-                @include mq(mobileLandscape) {
-                    @include video-play-button-size($vjs-large-button-size);
-                }
-            }
-
-            &:after {
-                content: '';
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-40%, -50%);
-                border-style: solid;
-                border-width: 1em 0 1em 2.4em;
-                border-color: transparent transparent transparent $garnett-neutral-5;
-                @include mq(tablet) {
-                    // 0 border radius on mobile because stock android has a render bug with it here
-                    border-radius: .2em;
-                }
-            }
-        }
-    }
     // *************** Gallery overrides ***************
     &.content--gallery {
         .meta__twitter {


### PR DESCRIPTION
There were some old video overrides for garnett fixing some bug which is now fixed and has been causing some rendering issues. This removes them and sets the pillar colour for the big play button.

## What does this change?
-it makes the big play button on legacy video the pillar colour
-it fixes the video display

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
