### PR TITLE
Garnett: Fix facia timestamp bugs

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -236,6 +236,10 @@ $fc-item-gutter: $gs-gutter / 4;
         .fc-item__timestamp {
             flex: 1;
         }
+        
+        .fc-item__standfirst {
+            padding-bottom: $gs-gutter * .25;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -29,6 +29,10 @@
         .fc-item__meta {
             display: none;
         }
+
+        .fc-item__standfirst {
+            padding-bottom: $gs-gutter * .25;
+        }
     }
 
     .fc-item__container {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -82,6 +82,7 @@
         &.fc-item--fluid-tablet {
             @include mq(tablet) {
                 .fc-item__container > .fc-item__meta {
+                    .fc-item__timestamp,
                     .fc-trail__count--commentcount {
                         display: none;
                     }


### PR DESCRIPTION
## What does this change?

Fixes the following bugs on Garnett facia cards:

https://trello.com/c/ahONx4Bs/250-brief-letters-tablet-up-to-wide-cards-show-date-stamp-twice
https://trello.com/c/muGkgPKH/249-opinion-cards-on-tag-pages-padding-issue

## What is the value of this and can you measure success?

Layout issues

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No