### PR TITLE
Desktop header variant to go out to everyone, but under a switch

### DIFF
--- a/article/app/views/fragments/immersiveGarnettHeader.scala.html
+++ b/article/app/views/fragments/immersiveGarnettHeader.scala.html
@@ -1,7 +1,7 @@
 @()(implicit page: model.ContentPage, request: RequestHeader, applicationContext: model.ApplicationContext)
 
 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
-    @if(experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+    @if(conf.switches.Switches.NewDesktopNavigation.isSwitchedOn) {
         @fragments.header()
     }
     @fragments.immersiveGarnettMainMedia()

--- a/article/app/views/fragments/immersiveHeader.scala.html
+++ b/article/app/views/fragments/immersiveHeader.scala.html
@@ -1,7 +1,7 @@
 @()(implicit page: model.ContentPage, request: RequestHeader, applicationContext: model.ApplicationContext)
 
 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
-    @if(experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+    @if(conf.switches.Switches.NewDesktopNavigation.isSwitchedOn) {
         @fragments.header()
     }
     @fragments.immersiveMainMedia()

--- a/article/app/views/fragments/photoEssayHeader.scala.html
+++ b/article/app/views/fragments/photoEssayHeader.scala.html
@@ -6,7 +6,7 @@
     ("immersive-header-container", page.item.fields.main.nonEmpty),
     ("immersive-header-container--photo-essay", page.item.content.isPhotoEssay)))">
 
-    @if(experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+    @if(conf.switches.Switches.NewDesktopNavigation.isSwitchedOn) {
         @fragments.header()
     }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -495,8 +495,7 @@ import collection.JavaConverters._
         $("header").attribute("role") should be("banner")
         $(".l-footer__secondary").attribute("role") should be("contentinfo")
         $("nav").attribute("aria-label") should not be empty
-        browser.find("nav").index(1).attribute("role") should be("navigation")
-        browser.find("nav").index(1).attribute("aria-label") should not be empty
+        browser.find("nav").attribute("role") should be("navigation")
         $("#article").attribute("role") should be("main")
         $(".related").attribute("aria-labelledby") should be("related-content-head")
       }
@@ -599,44 +598,5 @@ import collection.JavaConverters._
         $(".content").attribute("class") should include("tone-comment")
       }
     }
-
-    scenario("Display breadcrumbs correctly") {
-      Given("I am on a piece of content with a primary nav, secondary nav and a key woro")
-      goTo("/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism") { browser =>
-        import browser._
-        Then("I should see three breadcrumbs")
-        $(".breadcrumb .signposting__item").size() should be(3)
-
-        val link = browser.find(".breadcrumb .signposting__item a", withText().contains("Culture"))
-        link.asScala.length should be > 0
-        val link2 = browser.find(".breadcrumb .signposting__item a", withText().contains("Books"))
-        link2.asScala.length should be > 0
-        val link3 = browser.find(".breadcrumb .signposting__item a", withText().contains("Orwell prize"))
-        link3.asScala.length should be > 0
-      }
-
-      Given("I am on a piece of content with a primary nav and a key woro")
-      goTo("/commentisfree/2013/jan/07/blue-plaque-english-heritage") { browser =>
-        import browser._
-        Then("I should see three breadcrumbs")
-        $(".breadcrumb .signposting__item").size() should be(2)
-
-        val link = browser.find(".breadcrumb .signposting__item a", withText().contains("Opinion"))
-        link.asScala.length should be > 0
-        val link2 = browser.find(".breadcrumb .signposting__item a", withText().contains("Heritage"))
-        link2.asScala.length should be > 0
-      }
-
-      Given("I am on a piece of content with no primary nav and a no key words")
-      goTo("/observer-ethical-awards/shortlist-2014") { browser =>
-        import browser._
-        Then("I should see one breadcrumbs")
-        $(".breadcrumb .signposting__item").size() should be(1)
-
-        val link = browser.find(".breadcrumb .signposting__item a", withText().contains("Observer Ethical Awards"))
-        link.asScala.length should be > 0
-      }
-    }
-
   }
 }

--- a/article/test/SectionsNavigationFeatureTest.scala
+++ b/article/test/SectionsNavigationFeatureTest.scala
@@ -12,29 +12,13 @@ import conf.Configuration
 
   feature("Section Navigation") {
 
-    scenario("Links to sections", ArticleComponents) {
-
-      Given("I am on any guardian.co.uk page")
-      goTo("/world/2012/aug/23/australia-mining-boom-end") { browser =>
-
-        Then("I should see a list of top sections")
-
-        val sections = browser.find("#footer-nav li a")
-
-        sections.asScala.length should be > 0
-
-        And("a button to activate that list")
-        browser.$(".navigation-toggle").attribute("href") should include("australia-mining-boom-end#footer-nav")
-      }
-    }
-
     scenario("Link to US edition", ArticleComponents) {
       Given("I am on any guardian.co.uk page")
       goTo("/world/2012/aug/23/australia-mining-boom-end") { browser =>
 
         Then("I should see a link to the US edition")
 
-        val editionLink = browser.el("[data-link-name='switch to US edition']")
+        val editionLink = browser.el("[data-link-name='nav2 : topbar : edition-picker: US']")
 
         editionLink.attribute("href") should be(s"http://localhost:${port}/preference/edition/us")
       }
@@ -46,7 +30,7 @@ import conf.Configuration
 
         Then("I should see a link to the UK edition")
 
-        val editionLink = browser.el("[data-link-name='switch to UK edition']")
+        val editionLink = browser.el("[data-link-name='nav2 : topbar : edition-picker: UK']")
 
         editionLink.attribute("href") should be(s"http://localhost:${port}/preference/edition/uk")
       }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -616,4 +616,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 3, 1),
     exposeClientSide = false
   )
+
+  // When this switch is deleted, all the old navigation can be deleted as well
+  val NewDesktopNavigation = Switch(
+    SwitchGroup.Feature,
+    "new-desktop-navigation",
+    "When ON, the new desktop navigation will show to all the audience (this is the design with 5 pillars)",
+    owners = Seq(Owner.withGithub("NataliaLKB")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 1, 24),
+    exposeClientSide = false
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   val allExperiments: Set[Experiment] = Set(
     CommercialClientLogging,
     CommercialPaidContentTemplate,
-    ABNewDesktopHeader,
     GarnettHeader,
     GarnettIdentity,
     Garnett,
@@ -47,14 +46,6 @@ object CommercialPaidContentTemplate extends Experiment(
     "/discover-canal-river-trust/2017/oct/20/top-10-waterside-places-to-enjoy-in-autumn"
   )
 }
-
-object ABNewDesktopHeader extends Experiment(
-  name = "ab-new-desktop-header",
-  description = "Users in this experiment will see the new desktop design.",
-  owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("zeftilldeath")),
-  sellByDate = new LocalDate(2018, 2, 1),
-  participationGroup = Perc20A
-)
 
 object GarnettIdentity extends Experiment(
   name = "garnett-identity",

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,6 +1,5 @@
 package navigation
 
-import experiments._
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
@@ -22,55 +21,37 @@ object UrlHelpers {
   case object ManageMyAccountCancel extends Position
 
   def getCampaignCode(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): Option[String] = {
-    val isInHeaderTestControlGroup = ActiveExperiments.isControl(ABNewDesktopHeader)
     val editionId = Edition(request).id.toUpperCase()
 
-    (destination, position, isInHeaderTestControlGroup) match {
-      case (Membership, NewHeader | SideMenu, _) => Some(s"mem_${editionId.toLowerCase()}_web_newheader")
-      case (Membership, OldHeader, true) => Some(s"mem_${editionId.toLowerCase()}_web_newheader_control")
-      case (Membership, OldHeader, false) => Some(s"DOTCOM_HEADER_BECOMEMEMBER_${editionId}")
-      case (Membership, AmpHeader, _) => Some("AMP_HEADER_GU_SUPPORTER")
-      case (Membership, SlimHeaderDropdown, _) => Some(s"NGW_TOPNAV_${editionId}_GU_MEMBERSHIP")
-      case (Membership, Footer, _) => Some(s"NGW_FOOTER_${editionId}_GU_MEMBERSHIP")
+    (destination, position) match {
+      case (Membership, NewHeader | SideMenu) => Some(s"mem_${editionId.toLowerCase()}_web_newheader")
+      case (Membership, OldHeader) => Some(s"DOTCOM_HEADER_BECOMEMEMBER_${editionId}")
+      case (Membership, AmpHeader) => Some("AMP_HEADER_GU_SUPPORTER")
+      case (Membership, SlimHeaderDropdown) => Some(s"NGW_TOPNAV_${editionId}_GU_MEMBERSHIP")
+      case (Membership, Footer) => Some(s"NGW_FOOTER_${editionId}_GU_MEMBERSHIP")
 
-      case (Contribute, NewHeader | OldHeader, _) => Some("gdnwb_copts_co_dotcom_header")
-      case (Contribute, Footer, _) => Some("gdnwb_copts_memco_dotcom_footer")
+      case (Contribute, NewHeader | OldHeader) => Some("gdnwb_copts_co_dotcom_header")
+      case (Contribute, Footer) => Some("gdnwb_copts_memco_dotcom_footer")
 
       // this editionId is lowercase even though the rest of the campaign code is uppercase
       // this is for consistency with the existing campaign code
-      case (Subscribe, SideMenu, _) => Some(s"NGW_NEWHEADER_${editionId.toLowerCase()}_GU_SUBSCRIBE")
-      case (Subscribe, NewHeader, _) => Some(s"subs_${editionId.toLowerCase()}_web_newheader")
-      case (Subscribe, OldHeader, true) => Some(s"subs_${editionId}_web_newheader_control")
-      case (Subscribe, OldHeader, false) => Some(s"NGW_HEADER_${editionId}_GU_SUBSCRIBE")
-      case (Subscribe, SlimHeaderDropdown, _) => Some(s"NGW_TOPNAV_${editionId}_GU_SUBSCRIBE")
-      case (Subscribe, Footer, _) => Some(s"NGW_FOOTER_${editionId}_GU_SUBSCRIBE")
+      case (Subscribe, SideMenu) => Some(s"NGW_NEWHEADER_${editionId.toLowerCase()}_GU_SUBSCRIBE")
+      case (Subscribe, NewHeader) => Some(s"subs_${editionId.toLowerCase()}_web_newheader")
+      case (Subscribe, OldHeader) => Some(s"NGW_HEADER_${editionId}_GU_SUBSCRIBE")
+      case (Subscribe, SlimHeaderDropdown) => Some(s"NGW_TOPNAV_${editionId}_GU_SUBSCRIBE")
+      case (Subscribe, Footer) => Some(s"NGW_FOOTER_${editionId}_GU_SUBSCRIBE")
 
-      case (Support, Footer, _) => Some("gdnwb_copts_memco_dotcom_footer")
-      case (Support, AmpHeader, _) => Some("gdnwb_copts_memco_header_amp")
-      case (Support, ManageMyAccountUpsell, _) => Some(s"DOTCOM_MANAGE_JOIN")
-      case (Support, _, _) => Some("gdnwb_copts_memco_header")
+      case (Support, Footer) => Some("gdnwb_copts_memco_dotcom_footer")
+      case (Support, AmpHeader) => Some("gdnwb_copts_memco_header_amp")
+      case (Support, ManageMyAccountUpsell) => Some(s"DOTCOM_MANAGE_JOIN")
+      case (Support, _) => Some("gdnwb_copts_memco_header")
 
-      case (_, _, _) => None
+      case (_, _) => None
     }
   }
 
-  case class ABTest(name: String, variant: String)
-
-  def getHeaderABTestInfo(implicit request: RequestHeader): Option[ABTest] =
-    if (ActiveExperiments.isControl(ABNewDesktopHeader)) {
-      Some(ABTest("NewDesktopHeader", "control"))
-    } else if (experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
-      Some(ABTest("NewDesktopHeader", "variant"))
-    } else {
-      None
-    }
-
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): String = {
     val campaignCode = getCampaignCode(destination, position)
-    val abTest = position match {
-      case NewHeader | OldHeader => getHeaderABTestInfo
-      case _ => None
-    }
 
     val acquisitionData = Json.obj(
       // GUARDIAN_WEB corresponds to a value in the Thrift enum
@@ -90,11 +71,6 @@ object UrlHelpers {
       // But for now, we're duplicating this value across both fields.
       "componentId" -> c,
       "campaignCode" -> c
-    )) ++ abTest.fold(Json.obj())(ab => Json.obj(
-      "abTest" -> Json.obj(
-        "name" -> ab.name,
-        "variant" -> ab.variant
-      )
     ))
 
     import com.netaporter.uri.dsl._
@@ -141,33 +117,15 @@ object UrlHelpers {
 
   object oldNav {
     def jobsUrl(edition: String)(implicit request: RequestHeader): String =
-      if(ActiveExperiments.isControl(ABNewDesktopHeader)) {
-        s"https://jobs.theguardian.com/?INTCMP=jobs_${edition}_web_newheader_control"
-      } else {
         s"https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_${edition.toUpperCase}_GU_JOBS"
-      }
 
     def soulmatesUrl(edition: String)(implicit request: RequestHeader): String =
-      if(ActiveExperiments.isControl(ABNewDesktopHeader)) {
-        s"https://soulmates.theguardian.com/?INTCMP=soulmates_${edition}_web_newheader_control"
-      } else {
         s"https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_${edition.toUpperCase}_GU_SOULMATES"
-      }
 
     def holidaysUrl(implicit request: RequestHeader): String =
-      if(ActiveExperiments.isControl(ABNewDesktopHeader)) {
-        "https://holidays.theguardian.com/?INTCMP=holidays_uk_web_newheader_control"
-      } else {
         "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"
-      }
 
     def masterclassesUrl(implicit request: RequestHeader): String =
-      if(ActiveExperiments.isControl(ABNewDesktopHeader)) {
-        "https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader_control"
-      } else {
         "https://membership.theguardian.com/masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"
-      }
-
   }
-
 }

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -8,11 +8,11 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContributeUrl}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
-@import conf.switches.Switches.EmailInlineInFooterSwitch
+@import conf.switches.Switches.{ EmailInlineInFooterSwitch, NewDesktopNavigation }
 @import com.gu.identity.model.EmailNewsletters
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
-    @if(!experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader) && !isAmp) {
+    @if(!NewDesktopNavigation.isSwitchedOn && !isAmp) {
         <div class="l-footer__primary hide-on-mobile">
             <div id="footer-nav" class="gs-container">
                 <div class="brand-bar modern-visible u-cf">
@@ -40,7 +40,7 @@
         </div>
     }
 
-    <div class="footer__primary @if(!experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {mobile-only}">
+    <div class="footer__primary @if(!NewDesktopNavigation.isSwitchedOn) {mobile-only}">
 
         @if(!isAmp) {
             @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -11,7 +11,7 @@
 
 @hasSlimHeader = @{page.metadata.hasSlimHeader}
 
-@if(!experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+@if(!conf.switches.Switches.NewDesktopNavigation.isSwitchedOn) {
     <header id="header"
             class="@RenderClasses(Map(
                 "l-header--is-slim l-header--no-navigation" -> hasSlimHeader

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -1,5 +1,5 @@
 @import common.{LinkTo, Localisation}
-@import conf.switches.Switches.ArticleBadgesSwitch
+@import conf.switches.Switches.{ ArticleBadgesSwitch, NewDesktopNavigation }
 @import layout.ContentWidths.MainMedia
 @import model.Badges.badgeFor
 @import model.ContentPage
@@ -24,7 +24,7 @@
         "content", "content--type-immersive", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
         <div class="gs-container immersive-main-media__logo">
-            @if((page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) & !experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+            @if((page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) & !NewDesktopNavigation.isSwitchedOn) {
                 <a href="@LinkTo {/}">
                     <span class="u-h">The Guardian</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -1,5 +1,5 @@
 @import common.{LinkTo, Localisation}
-@import conf.switches.Switches.ArticleBadgesSwitch
+@import conf.switches.Switches.{ ArticleBadgesSwitch, NewDesktopNavigation }
 @import layout.ContentWidths.MainMedia
 @import model.Badges.badgeFor
 @import model.ContentPage
@@ -24,7 +24,7 @@
         "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
         <div class="gs-container immersive-main-media__logo">
-            @if((page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) & !experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+            @if((page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) & !NewDesktopNavigation.isSwitchedOn) {
                 <a href="@LinkTo {/}">
                     <span class="u-h">The Guardian</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,18 +4,19 @@
 @import views.support.RenderClasses
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, getContributionOrSupporterUrl, NewHeader, getSupportOrSubscriptionUrl}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
-@import experiments.{ ABNewDesktopHeader, ActiveExperiments, GarnettHeader}
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, NewDesktopNavigation }
+@import experiments.{ActiveExperiments, GarnettHeader}
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
 <header class="@RenderClasses(Map(
-            "new-header--mvt-desktop" -> ActiveExperiments.isParticipating(ABNewDesktopHeader),
+            "new-header--mvt-desktop" -> NewDesktopNavigation.isSwitchedOn,
             "new-header--slim" -> page.metadata.hasSlimHeader
         ), s"new-header--${navMenu.currentPillar.map(_.title).getOrElse("")}", "new-header")"
         role="banner">
 
         <nav class="new-header__inner gs-container"
             data-component="nav2"
+            role="navigation"
             aria-label="Guardian sections">
 
             @if(!page.metadata.hasSlimHeader) {

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -3,6 +3,8 @@
 @import model.ContentPage
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
+@import conf.switches.Switches.NewDesktopNavigation
+
 @()(implicit page: ContentPage, request: RequestHeader, context: model.ApplicationContext)
 
 @defining((
@@ -26,7 +28,7 @@
         ),
         "content", "tonal", s"tonal--${toneClass(page.item)}")
     ">
-        @if(!experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader)) {
+        @if(!NewDesktopNavigation.isSwitchedOn) {
             <div class="gs-container immersive-main-media__logo">
                 <a href="@LinkTo {/}">
                     <span class="u-h">The Guardian</span>


### PR DESCRIPTION
## What does this change?
The desktop header test is finished and the decision has been made for it to go out to everyone. This is also one less thing to go out on Monday, which is good.

Keeping it under a switch for now, but if this goes well I will remove the switch and all the code for the old navigation. 

More eyes on this the better 😄 .

@joelochlann can you or someone from your team check that the changes I have made in UrlHelpers.scala look good?

## What is the value of this and can you measure success?
All users will now be seeing a consistent nav across mobile and desktop. 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/34794450-956cdcaa-f646-11e7-96bb-4aabfbd942ba.png)
Note, "arts" will change to "culture" in a different PR

## Tested in CODE?
Tested locally. I don't think I need to test in CODE for this 🎈 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
