### PR TITLE
Garnett: Fix white space issue beneath article main media

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1412,6 +1412,7 @@
                 top: 0;
                 margin: 0;
                 align-self: start;
+                height: 0;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Fixes this bug in Garnett articles:

https://trello.com/c/YyHfyiVQ/246-feature-article-leftcol-and-wide-only-meta-stuff-in-left-column-pushes-the-start-of-the-body-copy-down-too-far

The height of `.content__meta-container` in the left column was creating the whitespace in the righthand column. Setting the height of `.content__meta-container` to `0` removed the whitespace in the righthand column. The appearance of `.content__meta-container` in the lefthand column is unchanged as it's overflowing content is still visible.

## What is the value of this and can you measure success?

Fixes layout bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No