### PR TITLE
garnett: stop chrome nav hover bug

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -7,6 +7,10 @@
         height: gs-height($size);
         width: gs-height($size);
 
+        // chrome bug means the border radius is disabled while
+        // main nav transitions on hover. this stops that.
+        contain: paint;
+
         @include mq($from: tablet) {
             top: auto;
             bottom: $gs-baseline / 2;


### PR DESCRIPTION
## What does this change?

a bug in chrome means the border radius on comment cutouts is temporarily disabled while nav items transition on `:hover`. this prevents that (hat tip to @regiskuckaertz)

## What is the value of this and can you measure success?

calmer screens