### PR TITLE
Garnett: remove bg-color on meta items on comment cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -76,17 +76,6 @@ $pillars: (
 
     &:hover {
         background-color: $darkerCardBackground;
-
-        &.fc-item--type-comment {
-            .fc-item__avatar {
-                background-color: darken(map-get($palette, cutoutBackground), 3%);
-            }
-
-            .fc-item__timestamp,
-            .fc-trail__count--commentcount {
-                background-color: $darkerCardBackground;
-            }
-        }
     }
 
     .fc-item__headline {
@@ -195,6 +184,17 @@ $pillars: (
 
             .inline-icon {
                 fill: map-get($palette, commentCount);
+            }
+        }
+
+        &:hover {
+            .fc-item__avatar {
+                background-color: darken(map-get($palette, cutoutBackground), 3%);
+            }
+
+            .fc-item__timestamp,
+            .fc-trail__count--commentcount {
+                background-color: $darkerCardBackground;
             }
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -96,6 +96,11 @@
                     .fc-item__meta {
                         display: flex;
                     }
+
+                    .fc-item__timestamp,
+                    .fc-trail__count--commentcount {
+                        background-color: transparent;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What does this change?

Fixes this bug https://trello.com/c/HjQf7v7E/277-unnecessary-background-colour-on-fc-itemmeta-area-causes-issues

The `background-colour` applied to the meta items `.fc-item__timestamp` and .fc-trail__count--commentcount` on most `comment` cards isn't required on certain sizes. For these sizes set the `background-color` to `transparent`.

## What is the value of this and can you measure success?

Fixes layout bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No
