### PR TITLE
Remove the width on containers and fix padding on subtitle

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -103,7 +103,7 @@ $header-image-size-desktop: 100px;
 }
 
 .fc-container__header {
-    @include mq($until: tablet) {
+    @include mq($until: leftCol) {
         overflow: hidden;
 
         .fc-container__header__title {
@@ -112,7 +112,7 @@ $header-image-size-desktop: 100px;
         }
 
         .fc-container__header__description {
-            margin-top: 2px;
+            margin-top: 5px;
             text-align: left;
         }
 
@@ -137,12 +137,6 @@ $header-image-size-desktop: 100px;
     padding-bottom: $gs-baseline/3;
     line-height: get-line-height(header, 2);
     color: $garnett-neutral-1;
-
-    @include mq(tablet, leftCol) {
-        float: left;
-        width: gs-span(4);
-        margin-bottom: $gs-baseline;
-    }
 
     @include mq(leftCol, wide) {
         @include font-size(20px, 24px);


### PR DESCRIPTION
## What does this change?
from tablet to leftcol, fc-container__header had a width which makes "website of the year" hover in empty space
## What is the value of this and can you measure success?
this fixes that by removing the width (and alters vertical padding for the new typeface)
## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
