### PR TITLE
Make sure we're in Garnett before showing stars.

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -161,9 +161,11 @@ data-test-id="facia-card"
 
             case Some(InlineImage(images)) => {
                 <div class="fc-item__media-wrapper">
+                @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
                     @item.starRating.map { rating =>
                         @starRating(rating)
                     }
+                }
                 @itemImage(
                     images,
                     inlineImage = containerIndex == 0 && index < 4,


### PR DESCRIPTION
## What does this change?
Stars were showing in the image without needing Garnett flag.
## What is the value of this and can you measure success?
bugfix
## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
