### PR TITLE
Garnett: Fix link and layout issues on immersive cards (plus small comment card fix)

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -34,7 +34,7 @@
             display: none;
         }
 
-        .fc-item__standfirst {
+        .fc-item__standfirst-wrapper {
             padding-bottom: $gs-gutter * .25;
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -9,7 +9,6 @@
 
     .fc-item__content {
         background-color: $immersive-garnett-main-1;
-        z-index: 1;
     }
 
     //Todo better way to get this immersive card type to set the height when sublinks. This is fixed height enough to fit two lines of sublink
@@ -29,6 +28,8 @@
     }
 
     .fc-item__media-wrapper {
+        position: static;
+
         img {
             object-fit: cover;
         }


### PR DESCRIPTION
## What does this change?

Fixes a few issues:

Immersive links:
https://trello.com/c/o1n4AnBg/269-links-on-immersive-cards-dont-work-on-certain-parts-of-the-card

Immersive background image:
https://trello.com/c/24fWYxGM/283-immersive-article-background-image-failing-to-cover-container

Standfirst and comment count misaligned on comment cards:
https://trello.com/c/lfqX63vD/284-standfirst-and-comment-count-misaligned-on-comment-cards

## What is the value of this and can you measure success?

Garnett layout fixes

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No
