### PR TITLE
Garnett: Garnett long words

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -121,7 +121,7 @@ $fc-item-gutter: $gs-gutter / 4;
     display: flex;
     flex-direction: column;
     position: relative;
-    width: 0px;
+    width: 0;
 
     &:before {
         content: '';

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -121,7 +121,7 @@ $fc-item-gutter: $gs-gutter / 4;
     display: flex;
     flex-direction: column;
     position: relative;
-    width: 100%;
+    width: 0px;
 
     &:before {
         content: '';

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -34,7 +34,7 @@
             display: none;
         }
 
-        .fc-item__standfirst {
+        .fc-item__standfirst-wrapper {
             padding-bottom: $gs-gutter * .25;
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -9,7 +9,6 @@
 
     .fc-item__content {
         background-color: $immersive-garnett-main-1;
-        z-index: 1;
     }
 
     //Todo better way to get this immersive card type to set the height when sublinks. This is fixed height enough to fit two lines of sublink
@@ -29,6 +28,8 @@
     }
 
     .fc-item__media-wrapper {
+        position: static;
+
         img {
             object-fit: cover;
         }


### PR DESCRIPTION
## What does this change?

Very long words  break card layouts on fronts in Garnett because the card width grows to match the content. This fix prevents the card from resizing, the word now wraps without hyphens. This same solution fixed the issue in pre-garnett facia cards.

https://trello.com/c/rppIqkS0/293-long-words-break-card-widths-on-fronts

## What is the value of this and can you measure success?

Fixes layout issue

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

No
