### PR TITLE
[garnett] Don't show comment tone if we have analysis design type.

### DIFF
--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -3,9 +3,11 @@
 @import views.html.fragments.langAttributes
 @import views.support.ContributorLinks
 @import views.support.TrailCssClasses.toneClass
+@import _root_.model.ContentDesignType.RichContentDesignType
 
-<header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
-    @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) { content__head--byline-pic}">
+
+    <header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
+    @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") { content__head--byline-pic}">
     <div class="matchreport">
         <div class="js-score"></div>
         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
@@ -36,11 +38,11 @@
                     @Html(article.trail.headline)
                 </h1>
 
-                @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) {
+                @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") {
                     @fragments.meta.bylineImage(article.tags)
                 }
 
-                @if(article.content.hasTonalHeaderByline) {
+                @if(article.content.hasTonalHeaderByline && article.metadata.designType.nameOrDefault != "analysis") {
                     @article.trail.byline.map { text =>
                         <span class="content__headline content__headline--byline">@ContributorLinks(text, article.tags.contributors)</span>
                     }

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -3,6 +3,8 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.ContentOldAgeDescriber
 @import experiments._
+@import _root_.model.ContentDesignType.RichContentDesignType
+
 
 @byline() = {
     @item match {
@@ -28,7 +30,7 @@
 
     @if(!(item.content.isGallery || item.content.isImmersive)) {
 
-        @if(!item.content.hasTonalHeaderByline) {
+        @if(!(item.content.hasTonalHeaderByline && item.metadata.designType.nameOrDefault != "analysis")) {
             <div class="meta__contact-wrap">
             @byline()
         }
@@ -48,7 +50,7 @@
             }
         }
 
-        @if(!item.content.hasTonalHeaderByline) {
+        @if(!(item.content.hasTonalHeaderByline && item.metadata.designType.nameOrDefault != "analysis")) {
         </div>
         }
     }
@@ -85,7 +87,7 @@
     @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
     @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
     @if(item.elements.hasShowcaseMainElement && !item.content.isImmersive){ content__meta-container--showcase}
-    @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
+    @if(item.content.hasTonalHeaderByline && item.metadata.designType.nameOrDefault != "analysis"){ content__meta-container--tonal-header}
     @item.content.contributorBio.map { bio => content__meta-container--bio}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -30,7 +30,7 @@
 
     @if(!(item.content.isGallery || item.content.isImmersive)) {
 
-        @if(!(item.content.hasTonalHeaderByline && item.metadata.designType.nameOrDefault != "analysis")) {
+        @if(!item.content.hasTonalHeaderByline || item.metadata.designType.nameOrDefault == "analysis") {
             <div class="meta__contact-wrap">
             @byline()
         }
@@ -50,7 +50,7 @@
             }
         }
 
-        @if(!(item.content.hasTonalHeaderByline && item.metadata.designType.nameOrDefault != "analysis")) {
+        @if(!item.content.hasTonalHeaderByline || item.metadata.designType.nameOrDefault == "analysis") {
         </div>
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -160,10 +160,6 @@ Hence why a greater depth of selector specificity is needed.
     @include mq(tablet, desktop) {
         .fc-slice__item {
             width: 25%;
-
-            .fc-item__title {
-                @include fs-headline(2, true);
-            }
         }
 
         .fc-slice__item--mpu-candidate {

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -99,6 +99,25 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
+// reduce type size on q-q-q-q slice if it follows another slice in the same container
+.fc-slice-wrapper + .fc-slice-wrapper {
+    .fc-slice--q-q-q-q {
+        .fc-item--standard-tablet {
+            .fc-item__header {
+                @include mq(tablet) {
+                    @include fs-headline(2, true);
+                }
+            }
+
+            .inline-garnett-quote__svg {
+                height: 16px;
+                width: 8px;
+                margin-right: 8px;
+            }
+        }
+    }
+}
+
 .fc-slice--h14-q-q {
     .has-flex & {
         flex-direction: row-reverse;
@@ -161,7 +180,9 @@ Hence why a greater depth of selector specificity is needed.
         .fc-slice__item {
             width: 25%;
         }
-
+        .fc-item__title {
+            @include fs-headline(2, true);
+        }
         .fc-slice__item--mpu-candidate {
             width: 50%;
         }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -31,8 +31,13 @@ $pillars: (
 
         @include garnett-underline($pillarColor, 20px);
 
+        @include mq(desktop) {
+            &.fc-item--standard-tablet {
+                @include garnett-underline($pillarColor, 24px);
+            }
+        }
+
         @include mq(tablet) {
-            &.fc-item--standard-tablet,
             &.fc-item--third-tablet,
             &.fc-item--full-media-50-tablet,
             &.fc-item--full-media-75-tablet, &.fc-item--half-tablet,

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -27,9 +27,37 @@ $pillars: (
 }
 
 @each $pillar, $pillarColor in $pillars {
+
+    .fc-slice-wrapper + .fc-slice-wrapper {
+        .fc-slice--q-q-q-q {
+            .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
+                &.fc-item--standard-tablet {
+                    @include mq(tablet, desktop) {
+                        @include garnett-underline($pillarColor, 20px);
+                    }
+                }
+            }
+        }
+    }
+
+    .fc-slice--t-t-mpu {
+        .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
+            &.fc-item--third-tablet {
+                @include mq(tablet, desktop) {
+                    @include garnett-underline($pillarColor, 20px);
+                }
+            }
+        }
+    }
     .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
 
         @include garnett-underline($pillarColor, 20px);
+
+        @include mq($until: tablet) {
+            &.fc-item--standard-mobile {
+                @include garnett-underline($pillarColor, 24px);
+            }
+        }
 
         @include mq(desktop) {
             &.fc-item--standard-tablet {


### PR DESCRIPTION
## What does this change?
This was going to remove tones from templates. 
⚠️that's dangerous so I rolled that part of the change back⚠️

this just makes the comment logic more complex by never showing comment tone things when we have the analysis design type

## What is the value of this and can you measure success?
Value:
- comment toned analysis pieces aren't so broken

Measure:
- they look nicer
- this doesn't need immediate refactoring

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
