### PR TITLE
Hide the Guardian app link on desktop

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -143,8 +143,8 @@
 
                 @navMenu.otherLinks.map { item =>
                     <li class="@RenderClasses(Map(
-                            "hide-from-desktop" -> (item.title == "the guardian app"),
-                            "menu-item--no-border" -> (item.title == "video")
+                            "hide-from-desktop" -> (item.title == "The Guardian app"),
+                            "menu-item--no-border" -> (item.title == "Video")
                         ), "menu-item")"
                         role="menuitem">
 


### PR DESCRIPTION
## What does this change?
We missed something in this PR: https://github.com/guardian/frontend/pull/18611 which meant that the app link is appearing on desktop! It should only appear on Mobile.

## What is the value of this and can you measure success?
No longer showing a broken link on desktop to users

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Mobile:
![image](https://user-images.githubusercontent.com/8774970/34839639-3d090b74-f6fa-11e7-957c-e79a794bae4f.png)

Desktop:
![image](https://user-images.githubusercontent.com/8774970/34839664-5a0ec34e-f6fa-11e7-8c8b-38dc4bc3ea63.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
