### PR TITLE
Garnett: fix colours of membership front buttons

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_containers.scss
+++ b/static/src/stylesheets/module/facia-garnett/_containers.scss
@@ -48,17 +48,13 @@
 
 .fc-container {
     .button--primary {
-        background-color: $garnett-neutral-1;
-        border-color: $garnett-neutral-1;
-
-        &:hover {
-            background-color: darken($garnett-neutral-1, 5%);
-        }
-
-        &:focus {
-            background-color: darken($garnett-neutral-1, 5%);
-            border-color: darken($garnett-neutral-1, 5%);
-        }
+        @include button-colour(
+            $garnett-neutral-1,
+            #ffffff
+        );
+        @include button-hover-colour(
+            darken($garnett-neutral-1, 10%)
+        );
     }
 }
 


### PR DESCRIPTION
## What does this change?

The buttons on the [membership front](https://www.theguardian.com/membership) are actually links, so take the link colour for the header description.

This change ensures the colour for text in primary buttons is white. I have used the button colour mixins to make the code more declarative.
