### PR TITLE
garnett meta position fix

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -88,7 +88,7 @@
 }
 
 .content__head {
-    @include mq($from: tablet, $until: desktop) {
+    @include mq($from: tablet, $until: leftCol) {
         display: flex;
         flex-direction: column;
     }


### PR DESCRIPTION
## What does this change?
_actually_ puts the meta under media in content pages from tablet -> leftCol