### PR TITLE
Fixing bylines with cutouts on articles

### DIFF
--- a/static/src/stylesheets/module/_media.scss
+++ b/static/src/stylesheets/module/_media.scss
@@ -24,7 +24,6 @@ Nicole Sullivan's OOCSS CSS markup extraction pattern.
 }
 
 .media__img {
-    float: left;
     margin-right: 15px;
 }
 


### PR DESCRIPTION
## What does this change?
Not sure why there is a float left to begin with, but this code hasn't been touched in 5 years! It definitely looks broken with it so I am deleting it, but I am really unsure of how this didn't look broken before today.

## What is the value of this and can you measure success?
Looks less broken?

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Mobile Before:
<img src="https://user-images.githubusercontent.com/8774970/34874824-7f10c4e2-f792-11e7-9418-70ea18839257.png" style="width: 200px;"/>

Mobile After:
<img src="https://user-images.githubusercontent.com/8774970/34874794-5dc60c34-f792-11e7-943e-3b9a772c9c47.png" style="width: 200px;"/>

Desktop Before:
![image](https://user-images.githubusercontent.com/8774970/34874809-742d403c-f792-11e7-9ea9-8cdadd73048a.png)

Desktop After:
![image](https://user-images.githubusercontent.com/8774970/34874800-65a17a60-f792-11e7-9b84-2bd75d538d0d.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
