### PR TITLE
Garnett: Garnett longwords take 2

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -123,6 +123,11 @@ $fc-item-gutter: $gs-gutter / 4;
     position: relative;
     width: 100%;
 
+    // fix longwords breaking layouts from tablet breakpoint
+    @include mq($from: tablet) {
+        width: 0;
+    }
+
     &:before {
         content: '';
         position: absolute;


### PR DESCRIPTION
## What does this change?

Second attempt to apply the fix reverted in this PR: https://github.com/guardian/frontend/pull/18809

The branch has been updated to only apply the long-word fix (`width: 0`) from the `tablet` breakpoint. Leaving `width:100%` on mobile, and therefore not totally breaking fronts on mobile! 🎉 

## What is the value of this and can you measure success?

Fixes broken layouts

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No
