### PR TITLE
[identity] CSS Bug Hunting 2: Electric Boogaloo

### DIFF
--- a/identity/app/views/profile/cancelRegularContribution.scala.html
+++ b/identity/app/views/profile/cancelRegularContribution.scala.html
@@ -27,7 +27,7 @@
             </select>
         </div>
         <div class="contribution-cancellation__menu__actions">
-            <button type="submit" class="manage-account__button js-cancel-contribution-submit">Confirm</button>
+            <button type="submit" class="manage-account__button manage-account__button--center js-cancel-contribution-submit">Confirm</button>
             <a class="js-cancel-contribution-keep-contributing contribution-cancellation__keep-contributing u-underline">Keep contributing</a>
         </div>
     </div>

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -125,7 +125,7 @@
                                 (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
 
                             <li>
-                                <button id="deleteButton" type="submit" class="manage-account__button delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
+                                <button id="deleteButton" type="submit" class="manage-account__button manage-account__button--center delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
                                 <div id="deleteLoader" class="loading-animation is-updating inline-loading is-hidden"></div>
                             </li>
                         </ul>

--- a/static/src/stylesheets/module/identity/_button.garnett.scss
+++ b/static/src/stylesheets/module/identity/_button.garnett.scss
@@ -80,6 +80,11 @@
         }
     }
 
+    &.manage-account__button--center {
+        text-align: center;
+        justify-content: center;
+    }
+
     &-half--left {
         width: $gs-baseline*5;
         border-top-right-radius: 0;

--- a/static/src/stylesheets/module/identity/_button.garnett.scss
+++ b/static/src/stylesheets/module/identity/_button.garnett.scss
@@ -94,6 +94,8 @@
         text-align: center;
         justify-content: center;
         border-right: 1px solid #ffffff;
+        padding-left: $gs-baseline / 2;
+        padding-right: 0;
     }
 
     &-half--right {
@@ -104,6 +106,8 @@
         float: right;
         justify-content: center;
         text-align: center;
+        padding-left: 0;
+        padding-right: $gs-baseline / 2;
     }
 
     .disabled {

--- a/static/src/stylesheets/module/identity/_button.garnett.scss
+++ b/static/src/stylesheets/module/identity/_button.garnett.scss
@@ -7,7 +7,7 @@
 }
 
 .manage-account__button {
-    $font-size: 3;
+    $font-size: 5;
     $height: $gs-baseline * 3;
     $padding-vertical: ($height - get-line-height(textSans, $font-size))/2;
     $padding-horizontal: $gs-gutter;

--- a/static/src/stylesheets/module/identity/_button.garnett.scss
+++ b/static/src/stylesheets/module/identity/_button.garnett.scss
@@ -136,12 +136,17 @@
 }
 
 .manage-account__button--mini {
-    @extend %manage-account__button--light;
     @include fs-textSans(1);
     min-width: $gs-baseline * 20;
     display: inline-flex;
-    height: $gs-gutter * 1.5;
-    line-height: .8;
+    height: $gs-gutter * 1.2;
+    line-height: $gs-gutter * 1.2;
+    padding-left: $gs-gutter / 1.6;
+    padding-right: $gs-gutter / 1.6;
+    .inline-icon {
+        width: $gs-gutter * 1.2;
+        height: $gs-gutter * 1.2;
+    }
 }
 
 %manage-account__button--light {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -88,17 +88,25 @@ $identity-header-height: 48px;
 .nav--registration {
     margin-top: ($gs-baseline/3)*8;
     font-size: 14px;
-    text-align: center;
+
+    .nav__item {
+        display: block;
+        margin-bottom: $gs-baseline / 4;
+    }
 
     @include mq(tablet) {
         font-size: 16px;
+        text-align: center;
+        .nav__item {
+            display: inline;
+            margin: 0;
+        }
+        .nav__item + .nav__item:before {
+            content: '\b7';
+            margin-left: 4px;
+            margin-right: 9px;
+        }
     }
-}
-
-.nav--registration .nav__item + .nav__item:before {
-    content: '\b7';
-    margin-left: 4px;
-    margin-right: 9px;
 }
 
 .social-signin {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -517,3 +517,18 @@ $identity-header-height: 48px;
     margin-top: 0;
     vertical-align: middle;
 }
+
+
+
+
+
+/* AS Overrides
+   ========================================================================== */
+
+.identity-wrapper .activity-stream__item {
+    a {
+        color: $identity-main;
+        @extend %u-underline;
+    }
+
+}

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -525,10 +525,11 @@ $identity-header-height: 48px;
 /* AS Overrides
    ========================================================================== */
 
-.identity-wrapper .activity-stream__item {
+.identity-wrapper .activity-stream__item,
+.identity-wrapper .activity-stream__empty {
     a {
-        color: $identity-main;
         @extend %u-underline;
+        color: $identity-main;
     }
 
 }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -478,7 +478,7 @@ $identity-header-height: 48px;
 .email-subscription__options {
 
     > ul > li:not(:last-child) {
-        margin-bottom: $gs-gutter / 2;
+        margin-bottom: $gs-gutter / 4;
     }
 
     .manage-account__button {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -320,6 +320,16 @@ $identity-header-height: 48px;
     margin-top: 3em;
 }
 
+@mixin pillar-dropdown ($pillar, $colour) {
+    &[data-dropdown-label=#{$pillar}] .dropdown__button {
+        color: $colour;
+    }
+    &[data-dropdown-label=#{$pillar}]:hover .dropdown__button,
+    &[data-dropdown-label=#{$pillar}] .dropdown__button:focus {
+        color: darken($colour, 15%);
+    }
+}
+
 .dropdown-styled.dropdown--email-subscription {
     @supports (transform: rotate(45deg)) {
         border-color: $neutral-6;
@@ -328,21 +338,11 @@ $identity-header-height: 48px;
             color: $identity-main;
         }
         @if($identity-main == $garnett-neutral-1) {
-            &[data-dropdown-label='News'] .dropdown__button {
-                color: $news-garnett-main-1;
-            }
-            &[data-dropdown-label='Sport'] .dropdown__button {
-                color: $sport-garnett-main-1;
-            }
-            &[data-dropdown-label='Culture'] .dropdown__button {
-                color: $culture-garnett-main-1;
-            }
-            &[data-dropdown-label='Lifestyle'] .dropdown__button {
-                color: $lifestyle-garnett-main-1;
-            }
-            &[data-dropdown-label='Comment'] .dropdown__button {
-                color: $opinion-garnett-main-1;
-            }
+            @include pillar-dropdown('News', $news-garnett-main-1);
+            @include pillar-dropdown('Sport', $sport-garnett-main-1);
+            @include pillar-dropdown('Culture', $culture-garnett-main-1);
+            @include pillar-dropdown('Lifestyle', $lifestyle-garnett-main-1);
+            @include pillar-dropdown('Comment', $opinion-garnett-main-1);
         }
         .dropdown__label {
             @include fs-bodyHeading(3);

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -334,13 +334,10 @@
 .manage-account-divider {
     display: block;
     width: 100%;
-    border-top: 1px solid #d9d9d9;
+    border-top: 1px solid $neutral-5;
     border-bottom: 0;
-    margin-bottom: gs-span(.5);
     transform: scaleX(3);
-    @include mq(desktop) {
-        margin-top: gs-span(1);
-    }
+    margin-top: $gs-baseline;
 }
 
 /* Modals

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -103,7 +103,7 @@ $checkbox-size: $gs-gutter / 1.25;
     &.is-just-updated {
         &:before {
             animation: manage-account__switch-anim-loaded .5s 1 both;
-            background-color: $identity-support;
+            background-color: $status-positive;
             opacity: 1;
         }
     }

--- a/static/src/stylesheets/module/identity/_wrapper.garnett.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.garnett.scss
@@ -31,7 +31,7 @@
     border-bottom: 1px solid $neutral-5;
     overflow: hidden;
     .tabs__container {
-        margin: $gs-gutter * 2 auto 0 -1px;
+        margin: $gs-gutter auto 0 -1px;
         .tabs__tab a {
             font-weight: 400!important;
             /*text can't fit otherwise*/

--- a/static/src/stylesheets/module/identity/_wrapper.garnett.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.garnett.scss
@@ -15,13 +15,12 @@
         color: $identity-main;
     }
     .monocol-wrapper {
-        @include mq($until: desktop) {
-            padding: 0 $gs-gutter;
-        }
         max-width: gs-span(10);
         margin: auto;
-        padding-bottom: $gs-gutter * 2;
-        padding-top: $gs-gutter / 2;
+        padding: ($gs-gutter/ 2) $gs-gutter;
+        @include mq(desktop) {
+            padding-bottom: $gs-gutter * 2;
+        }
     }
     .tabs__content {
         border: 0;

--- a/static/src/stylesheets/module/identity/_wrapper.garnett.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.garnett.scss
@@ -31,7 +31,7 @@
     border-bottom: 1px solid $neutral-5;
     overflow: hidden;
     .tabs__container {
-        margin: $gs-gutter auto 0 -1px;
+        margin: ($gs-gutter * 1.5) auto 0 -1px;
         .tabs__tab a {
             font-weight: 400!important;
             /*text can't fit otherwise*/


### PR DESCRIPTION
## What does this change?
Followup to #18795 to get the missing items up & running, here are the things that have changed!

- Fix the account footer to stack the links on smaller screens instead of centering them and breaking them weirdly, extra important after the underlines because those render weirdly
- Center the text in _some_ buttons (in gt style). I could lie and say this is a rule for the ones with no icons that are not part of a list of buttons but honestly I just centered the ones that looked weird
- Underline links in comment activity
- Add a couple of missing underlines on phone numbers
- Fix the text size in gt buttons (they were still tinier than they should)
- Tweak the sizing of elements in profileForms gt a bit so it's _slightly_ tighter. Mostly to avoid the top area being a vast sea of white space, which is rather inconvenient
- The small buttons in `/email-prefs`? Those are now _smaller_ but also use normal styles so less code there
- Remove `$identity-support`. This was only used as a lighter blue after ticking a checkbox. I now used `$status-positive` instead. This does make it green but looks kinda cool