### PR TITLE
Opt out of rich link decorum when paid

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -365,7 +365,7 @@
     }
 }
 
-.rich-link {
+.rich-link:not(.rich-link--paidfor) {
     &,
     &.rich-link--pillar-news {
         @include richLink($news-garnett-main-1, $garnett-neutral-3);


### PR DESCRIPTION
## What does this change?

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
