### PR TITLE
Float left is needed by geo most pop

### DIFF
--- a/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
+++ b/static/src/stylesheets/module/onward-garnett/_right-hand-most-popular.scss
@@ -72,6 +72,7 @@
         margin-right: $gs-gutter/2;
         overflow: hidden;
         position: relative;
+        float: left;
 
         img {
             position: absolute;

--- a/static/src/stylesheets/module/onward/_right-hand-most-popular.scss
+++ b/static/src/stylesheets/module/onward/_right-hand-most-popular.scss
@@ -47,6 +47,7 @@
         height: $gs-baseline*6;
         padding-top: 3px;
         margin-right: $gs-gutter/2;
+        float: left;
 
         img {
             width: 100%;


### PR DESCRIPTION
## What does this change?
Whoops! I broke geo most pop while fixing something else in #https://github.com/guardian/frontend/pull/18816

## What is the value of this and can you measure success?
Fixing 🐛 🐛 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/34877915-e43fb2c6-f79f-11e7-872e-47a805ee0263.png)


After:
![image](https://user-images.githubusercontent.com/8774970/34877892-c8cb5a90-f79f-11e7-8dd4-ae4d1c1e4f51.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
