### PR TITLE
Revert "Garnett - gallery - added letter break to the caption"

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -93,7 +93,6 @@
     position: relative;
     border: 0;
     width: inherit;
-    word-break: break-all;
 
     @include mq($until: desktop) {
         margin-bottom: $gs-baseline * 2;
@@ -301,3 +300,4 @@
         opacity: 1;
     }
 }
+


### PR DESCRIPTION
Reverts guardian/frontend#18749
https://trello.com/c/f8eVxiaL/301-galleries-captions-are-wrapping-strangely

(tested in code)