### PR TITLE
Remove listID's checks as cache no longer an issue

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -29,7 +29,6 @@ object emailLandingPage extends StandalonePage {
 case class EmailForm(
   email: String,
   listName: Option[String],
-  listId: Option[Int],
   referrer: Option[String],
   campaignCode: Option[String])
 
@@ -40,14 +39,7 @@ class EmailFormService(wsClient: WSClient) {
     val idAccessClientToken = Configuration.id.apiClientToken
     val consentMailerUrl = s"${Configuration.id.apiRoot}/consent-email"
 
-    // FIXME: Cached widgets will continue to post listId so have to deal with both until cache clears
-    val listName = (form.listName, form.listId) match {
-      case (None, Some(id)) =>
-        EmailNewsletter(id) orElse EmailNewsletter.fromV1ListId(id) map { _.identityName }
-      case (name, _) => name
-    }
-
-    val consentMailerPayload = JsObject(Json.obj("email" -> form.email, "set-lists" -> List(listName)).fields)
+    val consentMailerPayload = JsObject(Json.obj("email" -> form.email, "set-lists" -> List(form.listName)).fields)
 
     wsClient
       .url(consentMailerUrl)
@@ -62,7 +54,6 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
     mapping(
       "email" -> nonEmptyText.verifying(emailAddress),
       "listName" -> optional[String](of[String]),
-      "listId" -> optional[Int](of[Int]),
       "referrer" -> optional[String](of[String]),
       "campaignCode" -> optional[String](of[String])
     )(EmailForm.apply)(EmailForm.unapply)

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -39,7 +39,6 @@ const classes = {
     form: 'js-email-sub__form',
     inlineLabel: 'js-email-sub__inline-label',
     textInput: 'js-email-sub__text-input',
-    listIdHiddenInput: 'js-email-sub__listid-input',
     listNameHiddenInput: 'js-email-sub__listname-input',
 };
 
@@ -253,13 +252,7 @@ const submitForm = (
 
     return event => {
         const emailAddress = $(`.${classes.textInput}`, $form).val();
-        // FIXME: Cached widgets will continue to post listId so have to deal with both until cache clears
         const listName = $(`.${classes.listNameHiddenInput}`, $form);
-        const listId = $(`.${classes.listIdHiddenInput}`, $form);
-        const listParam =
-            listName && listName.val()
-                ? `&listName=${listName.val()}`
-                : `&listId=${listId.val()}`;
 
         let analyticsInfo;
 
@@ -271,7 +264,7 @@ const submitForm = (
                 emailAddress
             )}&campaignCode=${formData.campaignCode}&referrer=${
                 formData.referrer
-            }${listParam}`;
+            }&listName=${listName.val()}`;
 
             analyticsInfo = `rtrt | email form inline | ${
                 analytics.formType


### PR DESCRIPTION
## What does this change?
- Removes submitting listId's on form submit if they exist. 
- There should never be a need to submit listId's once the cache for the widgets has cleared making this redundant.

## What is the value of this and can you measure success?
- Clean code 
## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
