### PR TITLE
Garnett: show media on list media cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list.scss
@@ -25,15 +25,17 @@ x x x x x x x x x x x x x x x x x x x x x x x x
         }
     }
 
-    :not(.fc-container--paid-content) .fc-item__media-wrapper {
-        display: none;
-    }
 
-    .fc-container--paid-content .fc-item__media-wrapper {
-        .fc-item__image-container,
-        .badge {
-            display: none;
+    &:not(.fc-container--paid-content) {
+        @include mq($until: tablet) {
+            &:not(.fc-item--list-media-mobile) .fc-item__media-wrapper {
+                display: none;
+            }
+        }
+        @include mq(tablet) {
+            &:not(.fc-item--list-media-tablet) .fc-item__media-wrapper {
+                display: none;
+            }
         }
     }
-
 }


### PR DESCRIPTION
## What does this change?

https://trello.com/c/QA6m6jgW/305-fronts-media-in-list-item-cards-isnt-visible

`.fc-item--list-media-mobile` and `.fc-item--list-media-tablet` both require `.fc-item__media-wrapper` to have the property `display:block`, however this was overwritten to `display:none` by a chnage in this PR https://github.com/guardian/frontend/pull/18812. 

I've fixed it by adding additional `:not(.fc-item--list-media-mobile)` and `:not(.fc-item--list-media-tablet)` to the changes made in https://github.com/guardian/frontend/pull/18812. 

## What is the value of this and can you measure success?

Show media on list--media cards

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No