### PR TITLE
Add another type for special reports

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -23,7 +23,7 @@ object GetClasses {
       ("fc-item--pillar-" + item.pillar.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.designType.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
-      ("fc-item--type-guardian-labs", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.branding.exists(_.isPaid)),
+      ("fc-item--paid-content", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.branding.exists(_.isPaid)),
       ("fc-item--has-cutout", item.cutOut.isDefined),
       (TrailCssClasses.toneClassFromStyle(item.cardStyle) + "--item", !experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--has-no-image", !item.hasImage),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -23,6 +23,7 @@ object GetClasses {
       ("fc-item--pillar-" + item.pillar.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.designType.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
+      ("fc-item--type-guardian-labs", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.branding.exists(_.isPaid)),
       ("fc-item--has-cutout", item.cutOut.isDefined),
       (TrailCssClasses.toneClassFromStyle(item.cardStyle) + "--item", !experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--has-no-image", !item.hasImage),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -22,7 +22,7 @@ object GetClasses {
       ("js-fc-item", true),
       ("fc-item--pillar-" + item.pillar.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.designType.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
-      ("fc-item--" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
+      ("fc-item--special-report", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
       ("fc-item--paid-content", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.branding.exists(_.isPaid)),
       ("fc-item--has-cutout", item.cutOut.isDefined),
       (TrailCssClasses.toneClassFromStyle(item.cardStyle) + "--item", !experiments.ActiveExperiments.isParticipating(experiments.Garnett)),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -22,7 +22,7 @@ object GetClasses {
       ("js-fc-item", true),
       ("fc-item--pillar-" + item.pillar.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.designType.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
-      ("fc-item--type-" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
+      ("fc-item--" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
       ("fc-item--paid-content", experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.branding.exists(_.isPaid)),
       ("fc-item--has-cutout", item.cutOut.isDefined),
       (TrailCssClasses.toneClassFromStyle(item.cardStyle) + "--item", !experiments.ActiveExperiments.isParticipating(experiments.Garnett)),

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import layout._
-import model.pressed.{Audio, Gallery, Video}
+import model.pressed.{Audio, Gallery, Video, SpecialReport}
 import slices.{Dynamic, DynamicSlowMPU}
 import play.api.mvc.RequestHeader
 import model.Pillar.RichPillar
@@ -22,6 +22,7 @@ object GetClasses {
       ("js-fc-item", true),
       ("fc-item--pillar-" + item.pillar.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--type-" + item.designType.nameOrDefault, experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
+      ("fc-item--type-" + item.cardStyle.toneString, experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardStyle == SpecialReport),
       ("fc-item--has-cutout", item.cutOut.isDefined),
       (TrailCssClasses.toneClassFromStyle(item.cardStyle) + "--item", !experiments.ActiveExperiments.isParticipating(experiments.Garnett)),
       ("fc-item--has-no-image", !item.hasImage),

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -133,7 +133,7 @@
     // ?# It is very easy to opt out as the below, but
     // it increases the cyclomatic complexity of all selectors.
     // Find a better solution!
-    :not(.paid-content) {
+    &:not(.fc-item--paid-content) {
 
         .fc-item__kicker:before,
         .fc-item__kicker:after {


### PR DESCRIPTION
It would be handy if `DesignType` was extended with a composable subtype, but in the meantime I don't see a better way to detect when an item is a special report.

First part of a fix for https://trello.com/c/em44ZbbR