### PR TITLE
Garnett: fixing clock icon in media onward

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -28,7 +28,7 @@
 .fc-item--type-media {
     background-color: $media-garnett-main-1;
 
-    .inline-icon__svg {
+    .inline-icon__svg:not(.inline-clock__svg) {
         padding: 5px;
         border-radius: 50%;
     }


### PR DESCRIPTION
## What does this change?
There was some blanket svg styling which was breaking the clock icon. This excludes the clock icon.

https://trello.com/c/7SqgTE5y/302-onwards-journey-time-bug