### PR TITLE
Garnett: fix video cards that use fallbackImage

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -125,9 +125,7 @@ data-test-id="facia-card"
                 }
             }
 
-
-
-           case Some(svg@CrosswordSvg(_)) => {
+            case Some(svg@CrosswordSvg(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
                         <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img" alt=""
@@ -152,11 +150,21 @@ data-test-id="facia-card"
             }
 
             case Some(InlineVideo(_, _, _, Some(fallbackImage))) => {
-                @itemImage(
-                    fallbackImage.imageMedia,
-                    inlineImage = containerIndex == 0 && index < 4,
-                    widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
-                )
+                @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
+                    <div class="fc-item__media-wrapper">
+                        @itemImage(
+                            fallbackImage.imageMedia,
+                            inlineImage = containerIndex == 0 && index < 4,
+                            widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
+                        )
+                    </div>
+                } else {
+                    @itemImage(
+                        fallbackImage.imageMedia,
+                        inlineImage = containerIndex == 0 && index < 4,
+                        widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
+                    )
+                }
             }
 
             case Some(InlineImage(images)) => {


### PR DESCRIPTION
## What does this change?

Fixes this bug:

https://trello.com/c/HPhqCrzD/286-theguardiancom-membership-front-tablet-and-desktop-container-with-video-card-breaks-ie-is-weirdly-elongated

Caused by the image in the media card in the lefthand list being unstyled (too big). Wrapping this image in `<div class="fc-item__media-wrapper">...</div>` fixes the layout issue, on this card size and others (it was broken across all card sizes).

## What is the value of this and can you measure success?

Fixes layout issue

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

No

## Tested in CODE?

No