### PR TITLE
Garnett: add correct bg-color to meta items on comment cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -94,20 +94,6 @@ $pillars: (
         background-color: #ffffff;
     }
 
-    &.fc-item--type-comment {
-        &.fc-item--pillar-news,
-        &.fc-item--pillar-opinion,
-        &.fc-item--pillar-sport,
-        &.fc-item--pillar-arts,
-        &.fc-item--pillar-lifestyle {
-            background-color: $opinion-garnett-background;
-        }
-
-        .fc-item__container.u-faux-block-link--hover {
-            background-color: darken($opinion-garnett-background, 2%);
-        }
-    }
-
     .fc-item__headline {
         color: $headline;
     }
@@ -223,6 +209,18 @@ $pillars: (
     }
 
     &.fc-item--type-comment {
+        &.fc-item--pillar-news,
+        &.fc-item--pillar-opinion,
+        &.fc-item--pillar-sport,
+        &.fc-item--pillar-arts,
+        &.fc-item--pillar-lifestyle {
+            background-color: $opinion-garnett-background;
+        }
+
+        .fc-item__container.u-faux-block-link--hover {
+            background-color: darken($opinion-garnett-background, 2%);
+        }
+
         .fc-item__avatar {
             background-color: map-get($palette, cutoutBackground);
         }
@@ -230,7 +228,7 @@ $pillars: (
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
             color: map-get($palette, commentCount);
-            background-color: map-get($palette, cardBackground);
+            background-color: $opinion-garnett-background;
 
             .inline-icon {
                 fill: map-get($palette, commentCount);
@@ -244,7 +242,7 @@ $pillars: (
 
             .fc-item__timestamp,
             .fc-trail__count--commentcount {
-                background-color: $darkerCardBackground;
+                background-color: darken($opinion-garnett-background, 2%);
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Add correct bg-color to meta items on comment cards

## What is the value of this and can you measure success?

Fixes bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No