### PR TITLE
apply video atom card styles to fallback player

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
@@ -45,7 +45,8 @@ Media list item. Looks a bit like this:
         display: block;
     }
 
-    .fc-item__media-wrapper {
+    .fc-item__media-wrapper,
+    .fc-item__video-fallback {
         position: absolute;
         margin-left: $mobile-media-padding;
         width: $image-width;


### PR DESCRIPTION
## What does this change?

Styles were not being correctly applied on the fallback video player, causing the player and headline to split into separate lines.

## What is the value of this and can you measure success?

Makes cards with the fallback video player look like cards with the new player.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
