### PR TITLE
Container colour fixes

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/cpScottHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/cpScottHeader.scala.html
@@ -3,10 +3,12 @@
 @import fragments.inlineSvg
 @import views.support.{ImgSrc, Item140}
 
-<img src="@ImgSrc("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/22/1421924658711/CPScottcutout.png", Item140)"
-     role="presentation"
-     class="fc-cp-scott__portrait"
-/>
+<div class="fc-cp-scott__avatar">
+    <img src="@ImgSrc("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/1/22/1421924658711/CPScottcutout.png", Item140)"
+        role="presentation"
+        class="fc-cp-scott__portrait"
+    />
+</div>
 
 <div class="fc-cp-scott__text">
     <div class="fc-cp-scott__quote"><span class="fc-cp-scott__quote-line">@inlineSvg("quote", "icon", Nil)Comment is free&hellip;</span>

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -579,7 +579,7 @@ $header-image-size-desktop: 100px;
 
     &,
     a {
-        color: $guardian-brand-dark;
+        color: $garnett-neutral-1;
     }
 
     @include fs-header(4);

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -286,7 +286,7 @@ $header-image-size-desktop: 100px;
     }
 
     a {
-        color: $news-garnett-main-1;
+        color: $garnett-neutral-7;
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_cp-scott.scss
+++ b/static/src/stylesheets/module/facia-garnett/_cp-scott.scss
@@ -18,8 +18,20 @@ $cp-scott-width-tablet: 80px;
 }
 
 .fc-cp-scott__portrait {
-    float: right;
     width: $cp-scott-width-mobile;
+
+    @include mq(tablet) {
+        width: $cp-scott-width-tablet;
+    }
+}
+
+.fc-cp-scott__avatar {
+    float: right;
+    width: $cp-scott-width-mobile - 10;
+    height: $cp-scott-width-mobile - 10;
+    border-radius: 100%;
+    overflow: hidden;
+    background-color: darken($opinion-garnett-background, 5);
 
     @include mq($until: mobileLandscape) {
         position: absolute;
@@ -30,7 +42,9 @@ $cp-scott-width-tablet: 80px;
     @include mq(tablet) {
         margin-top: -$gs-baseline / 2;
         margin-bottom: $gs-baseline / 2;
-        width: $cp-scott-width-tablet;
+        width: $cp-scott-width-tablet - 10;
+        height: $cp-scott-width-tablet - 10;
+        margin-left: -1px;
     }
 
     @include mq(leftCol) {

--- a/static/src/stylesheets/module/facia-garnett/_cp-scott.scss
+++ b/static/src/stylesheets/module/facia-garnett/_cp-scott.scss
@@ -3,7 +3,7 @@ $cp-scott-width-tablet: 80px;
 
 .fc-cp-scott__quote {
     display: block;
-    color: $neutral-2;
+    color: $garnett-neutral-6;
 }
 
 .fc-cp-scott__quote-line {
@@ -14,6 +14,7 @@ $cp-scott-width-tablet: 80px;
 
 .fc-cp-scott__citation {
     display: block;
+    color: $garnett-neutral-1;
 }
 
 .fc-cp-scott__portrait {


### PR DESCRIPTION
## What does this change?

Removes blue from the CP Scott quote in the opinion front, and circles his avatar — as he would have wanted.

Also switches the 

## What is the value of this and can you measure success?

People really love it when colours are used consistently.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

Also no


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
