### PR TITLE
disable analysis underlines so they don't look bad in ie.

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -25,76 +25,77 @@ $pillars: (
 
     }
 }
+@supports not (-ms-line-break: newspaper) {
+    @each $pillar, $pillarColor in $pillars {
 
-@each $pillar, $pillarColor in $pillars {
+        .fc-slice-wrapper + .fc-slice-wrapper {
+            .fc-slice--q-q-q-q {
+                .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
+                    &.fc-item--standard-tablet {
+                        @include mq(tablet, desktop) {
+                            @include garnett-underline($pillarColor, 20px);
+                        }
+                    }
+                }
+            }
+        }
 
-    .fc-slice-wrapper + .fc-slice-wrapper {
-        .fc-slice--q-q-q-q {
+        .fc-slice--t-t-mpu {
             .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
-                &.fc-item--standard-tablet {
+                &.fc-item--third-tablet {
                     @include mq(tablet, desktop) {
                         @include garnett-underline($pillarColor, 20px);
                     }
                 }
             }
         }
-    }
-
-    .fc-slice--t-t-mpu {
         .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
-            &.fc-item--third-tablet {
-                @include mq(tablet, desktop) {
-                    @include garnett-underline($pillarColor, 20px);
+
+            @include garnett-underline($pillarColor, 20px);
+
+            @include mq($until: tablet) {
+                &.fc-item--standard-mobile {
+                    @include garnett-underline($pillarColor, 24px);
                 }
-            }
-        }
-    }
-    .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
-
-        @include garnett-underline($pillarColor, 20px);
-
-        @include mq($until: tablet) {
-            &.fc-item--standard-mobile {
-                @include garnett-underline($pillarColor, 24px);
-            }
-        }
-
-        @include mq(desktop) {
-            &.fc-item--standard-tablet {
-                @include garnett-underline($pillarColor, 24px);
-            }
-        }
-
-        @include mq(tablet) {
-            &.fc-item--third-tablet,
-            &.fc-item--full-media-50-tablet,
-            &.fc-item--full-media-75-tablet, &.fc-item--half-tablet,
-            &.fc-item--three-quarters-right-tablet,
-            &.fc-item--three-quarters-tall-tablet,
-            &.fc-item--three-quarters-tablet {
-                @include garnett-underline($pillarColor, 24px);
-            }
-            &.fc-item--full-media-100-tablet {
-                @include garnett-underline($pillarColor, 28px, .5);
             }
 
             @include mq(desktop) {
-                &.fc-item--half-tablet,
-                &.fc-item--three-quarters-right-tablet,
-                &.fc-item--three-quarters-tall-tablet,
-                &.fc-item--three-quarters-tablet {
-                    @include garnett-underline($pillarColor, 28px, .5);
-                }
-                &.fc-item--full-media-50-tablet,
-                &.fc-item--full-media-75-tablet {
-                    @include garnett-underline($pillarColor, 32px, .5);
-                }
-                &.fc-item--full-media-100-tablet {
-                    @include garnett-underline($pillarColor, 36px, .5);
+                &.fc-item--standard-tablet {
+                    @include garnett-underline($pillarColor, 24px);
                 }
             }
 
-        }
+            @include mq(tablet) {
+                &.fc-item--third-tablet,
+                &.fc-item--full-media-50-tablet,
+                &.fc-item--full-media-75-tablet, &.fc-item--half-tablet,
+                &.fc-item--three-quarters-right-tablet,
+                &.fc-item--three-quarters-tall-tablet,
+                &.fc-item--three-quarters-tablet {
+                    @include garnett-underline($pillarColor, 24px);
+                }
+                &.fc-item--full-media-100-tablet {
+                    @include garnett-underline($pillarColor, 28px, .5);
+                }
 
+                @include mq(desktop) {
+                    &.fc-item--half-tablet,
+                    &.fc-item--three-quarters-right-tablet,
+                    &.fc-item--three-quarters-tall-tablet,
+                    &.fc-item--three-quarters-tablet {
+                        @include garnett-underline($pillarColor, 28px, .5);
+                    }
+                    &.fc-item--full-media-50-tablet,
+                    &.fc-item--full-media-75-tablet {
+                        @include garnett-underline($pillarColor, 32px, .5);
+                    }
+                    &.fc-item--full-media-100-tablet {
+                        @include garnett-underline($pillarColor, 36px, .5);
+                    }
+                }
+
+            }
+
+        }
     }
 }


### PR DESCRIPTION
…broken in ie.

## What does this change?

Disables the analysis underline in IE because it sometimes does not work and we're unsure why.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
![image](https://user-images.githubusercontent.com/2670496/34928761-7eab59e6-f9b7-11e7-91df-6513da234764.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
