### PR TITLE
Sync up border colours on identity

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -187,9 +187,13 @@ $sport-away:             #003f64;
 // Stati
 // =============================================================================
 
-$status-positive:        $success;
-$status-neutral:         $neutral-2;
-$status-negative:        $error;
+$status-positive-garnett:   #bbce00;
+$status-neutral-garnett:    $garnett-neutral-6
+$status-negative-garnett:   $error
+
+$status-positive:           $success;
+$status-neutral:            $neutral-2;
+$status-negative:           $error;
 
 // Quiz colours
 // =============================================================================

--- a/static/src/stylesheets/module/identity/_button.garnett.scss
+++ b/static/src/stylesheets/module/identity/_button.garnett.scss
@@ -111,7 +111,7 @@
     }
 
     .disabled {
-        background-color: $neutral-4;
+        background-color: $garnett-neutral-4;
     }
 }
 

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -3,7 +3,7 @@
         padding: $gs-gutter 0;
         background: #ffffff;
         margin-top: $gs-gutter * 2;
-        border-top: 1px solid $neutral-5;
+        border-top: 1px solid $garnett-neutral-4;
         justify-content: space-between;
         z-index: $zindex-sticky;
         @include mq($until: tablet) {

--- a/static/src/stylesheets/module/identity/_dropdown.scss
+++ b/static/src/stylesheets/module/identity/_dropdown.scss
@@ -2,7 +2,7 @@
     @include fs-textSans(3);
     background: $neutral-8;
     list-style: none;
-    box-shadow: 0 1px 0 .5px $neutral-5;
+    box-shadow: 0 1px 0 .5px $garnett-neutral-4;
     margin: 0;
     padding: 0;
     color: $neutral-1;
@@ -17,7 +17,7 @@
     display: block;
     padding: ($gs-gutter / 2) 0;
     margin: 0 ($gs-gutter / 2) -1px;
-    border-bottom: 1px solid $neutral-5;
+    border-bottom: 1px solid $garnett-neutral-4;
     text-decoration: none;
     color: currentColor;
     white-space: nowrap;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -51,7 +51,7 @@ Messages
         padding-right: $gs-baseline * 2;
     }
     .identity-forms-message__body {
-        border-top: 1px solid $neutral-5;
+        border-top: 1px solid $garnett-neutral-4;
         margin-top: $gs-baseline * 2;
         padding-top: $gs-baseline / 2;
         padding-right: $gs-baseline * 2;
@@ -67,7 +67,7 @@ Messages
 Wrapper
 */
 .identity-forms-wrapper {
-    border-top: 1px solid $neutral-5;
+    border-top: 1px solid $garnett-neutral-4;
     padding-top: $gs-baseline;
 }
 

--- a/static/src/stylesheets/module/identity/_header.garnett.scss
+++ b/static/src/stylesheets/module/identity/_header.garnett.scss
@@ -7,7 +7,7 @@ $gutter: 5px;
     color: $nav-primary-colour;
     z-index: 999;
     &:after {
-        @include multiline(4, $rule, top);
+        @include multiline(4, $garnett-neutral-4, top);
         content: '';
         height: 4px * 4;
         background-color: #ffffff;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -302,7 +302,7 @@ $identity-header-height: 48px;
 /* Email subscriptions
    ========================================================================== */
 .email-subscription {
-    border-top: 1px solid $neutral-5;
+    border-top: 1px solid $garnett-neutral-4;
     margin-bottom: $gs-baseline*2;
     padding-top: $gs-baseline/3;
 
@@ -440,7 +440,7 @@ $identity-header-height: 48px;
         display: inherit;
         margin-top: 0;
         font-size: 0;
-        background-color: $neutral-5;
+        background-color: $garnett-neutral-4;
         background-repeat: no-repeat;
         background-position: center;
         background-size: 40px;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -334,7 +334,7 @@
 .manage-account-divider {
     display: block;
     width: 100%;
-    border-top: 1px solid $neutral-5;
+    border-top: 1px solid $garnett-neutral-4;
     border-bottom: 0;
     transform: scaleX(3);
     margin-top: $gs-baseline;

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -49,8 +49,8 @@ $checkbox-size: $gs-gutter / 1.25;
 
 .manage-account__switch {
     @include fs-bodyCopy(1, true);
-    background-color: $neutral-8;
-    border-top: 1px solid $neutral-4;
+    background-color: $garnett-neutral-3;
+    border-top: 1px solid $garnett-neutral-4;
     overflow: hidden;
     position: relative;
     display: flex;
@@ -103,7 +103,7 @@ $checkbox-size: $gs-gutter / 1.25;
     &.is-just-updated {
         &:before {
             animation: manage-account__switch-anim-loaded .5s 1 both;
-            background-color: $status-positive;
+            background-color: #bbce00;
             opacity: 1;
         }
     }

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -103,7 +103,7 @@ $checkbox-size: $gs-gutter / 1.25;
     &.is-just-updated {
         &:before {
             animation: manage-account__switch-anim-loaded .5s 1 both;
-            background-color: #bbce00;
+            background-color: $status-positive-garnett;
             opacity: 1;
         }
     }

--- a/static/src/stylesheets/module/identity/_wrapper.garnett.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.garnett.scss
@@ -32,7 +32,7 @@
 }
 
 .identity-wrapper-for-bg.identity-wrapper-for-bg--header {
-    border-bottom: 1px solid $neutral-5;
+    border-bottom: 1px solid $garnett-neutral-4;
     overflow: hidden;
     .tabs__container {
         margin: ($gs-gutter * 1.5) auto 0 -1px;


### PR DESCRIPTION
## What does this change?
Replace a couple CSS variables with the garnett variables over at identity

🎈 Borders are just an unnoticeable tad darker (`$gt-neutral-4` instead of `$neutral-5`)
🎈 Underlines on the header are `$gt-neutral-4` too
🎈 Consent checkboxes go lime green for a split second on success

<div align=center>

![screen shot 2018-01-15 at 06 32 52](https://user-images.githubusercontent.com/11539094/34929813-f3153274-f9bd-11e7-972b-cb49769c677f.png)
