### PR TITLE
Add header to change pwd + delete pages

### DIFF
--- a/identity/app/controllers/AccountDeletionController.scala
+++ b/identity/app/controllers/AccountDeletionController.scala
@@ -10,6 +10,7 @@ import idapiclient.{EmailPassword, IdApiClient}
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import actions.AuthenticatedActions
 import conf.IdentityConfiguration
+import pages.IdentityHtmlPage
 import play.api.data.validation.Constraints
 import play.api.data.Form
 import play.api.data.Forms._
@@ -53,7 +54,11 @@ class AccountDeletionController(
   def renderAccountDeletionForm: Action[AnyContent] = csrfAddToken {
     fullAuthWithIdapiUserAction.async { implicit request =>
       val form = accountDeletionForm.bindFromFlash.getOrElse(accountDeletionForm)
-      Future(NoCache(Ok(views.html.profile.deletion.accountDeletion(page, idRequestParser(request), idUrlBuilder, form, Nil, request.user))))
+      Future(NoCache(Ok(
+        IdentityHtmlPage.html(
+          views.html.profile.deletion.accountDeletion(page, idRequestParser(request), idUrlBuilder, form, Nil, request.user)
+        )(page, request, context)
+      )))
     }
   }
 
@@ -69,7 +74,9 @@ class AccountDeletionController(
   }
 
   def renderAccountDeletionConfirmation(autoDeletion: Boolean): Action[AnyContent] = Action.async { implicit request =>
-    Future(NoCache(Ok(accountDeletionConfirm(pageConfirm, autoDeletion))))
+    Future(NoCache(Ok(
+      IdentityHtmlPage.html(accountDeletionConfirm(pageConfirm, autoDeletion))(page, request, context)
+    )))
   }
 
   private def deleteAccount[A](

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -15,6 +15,7 @@ import play.api.i18n.{Messages, MessagesProvider}
 
 import scala.concurrent.Future
 import idapiclient.requests.PasswordUpdate
+import pages.IdentityHtmlPage
 import play.api.http.HttpConfiguration
 
 class ChangePasswordController(
@@ -66,7 +67,11 @@ class ChangePasswordController(
         api.passwordExists(request.user.auth) map {
           result =>
             val pwdExists = result.right.toOption exists {_ == true}
-            NoCache(Ok(views.html.password.changePassword(page = page, idRequest = idRequest, idUrlBuilder = idUrlBuilder, passwordForm = form, passwordExists =  pwdExists)))
+            NoCache(Ok(
+                IdentityHtmlPage.html(
+                  views.html.password.changePassword(page = page, idRequest = idRequest, idUrlBuilder = idUrlBuilder, passwordForm = form, passwordExists =  pwdExists)
+                )(page, request, context)
+            ))
         }
     }
   }
@@ -74,7 +79,11 @@ class ChangePasswordController(
   def renderPasswordConfirmation: Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
-    NoCache(Ok(views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)))
+    NoCache(Ok(
+      IdentityHtmlPage.html(
+        views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)
+      )(page, request, context)
+    ))
   }
 
   def submitForm(): Action[AnyContent] = csrfCheck {

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -9,8 +9,6 @@ passwordExists: Boolean
 @import views.html.fragments.form.inputField
 @import views.html.fragments.registrationFooter
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Change password</h1>
 
@@ -51,4 +49,3 @@ passwordExists: Boolean
 
     @registrationFooter(idRequest, idUrlBuilder)
 </div>
-}

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -5,8 +5,6 @@
 
 @(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
 <div class="identity-wrapper monocolumn-wrapper">
 
     <h1 class="identity-title" data-test-id="password-reset-confirmation">Your password has been changed</h1>
@@ -19,4 +17,3 @@
 
     @registrationFooter(idRequest, idUrlBuilder)
 </div>
-}

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -19,8 +19,6 @@
 
 @emailIsValidated = @{ user.statusFields.userEmailValidated.fold(false)(identity) }
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Are you sure you want to delete your account?</h1>
 
@@ -149,4 +147,3 @@
 
         @registrationFooter(idRequest, idUrlBuilder)
     </div>
-}

--- a/identity/app/views/profile/deletion/accountDeletionConfirm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionConfirm.scala.html
@@ -1,7 +1,5 @@
 @(page: model.Page, isAutoDeletion: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
     <div class="identity-wrapper monocolumn-wrapper">
         @if(isAutoDeletion) {
             <h1 class="identity-title">Your account has been successfully deleted.</h1>
@@ -20,4 +18,3 @@
             </div>
         }
     </div>
-}


### PR DESCRIPTION
## What does this change?

Changes the header on the MMA `delete account` & `update password` pages from the immersive one to the identity one so the logo sits on top of a bar on mobile

(I'm not a huge fan of the visual look of it. might do a separate PR to show the roundel on mobile instead? @zeftilldeath)

![screen shot 2018-01-15 at 06 53 18](https://user-images.githubusercontent.com/11539094/34930776-2acb8394-f9c3-11e7-9f7a-53055816ed19.png)
![screen shot 2018-01-15 at 06 53 09](https://user-images.githubusercontent.com/11539094/34930778-2cafbda6-f9c3-11e7-8866-980eca2560f0.png)
