### PR TITLE
Make the guardian witness button a bit less old style.

### DIFF
--- a/static/src/stylesheets/module/external/_witness.scss
+++ b/static/src/stylesheets/module/external/_witness.scss
@@ -85,12 +85,12 @@
     position: relative;
     float: left;
     padding-left: $gs-gutter * 2 - 2px;
-    color: $news-support-1;
     font-family: $f-serif-headline;
     font-size: get-font-size(header, 1);
     font-weight: normal;
     white-space: nowrap;
     margin-right: 0;
+    border: 0;
 
     @include mq($from: desktop) {
         &.button--large {
@@ -121,16 +121,11 @@
 
     .element-witness--source & {
         @include font($f-serif-text, 700, 16, 16);
-        color: $news-support-2;
     }
 
 }
 .witness-logo__witness {
     margin-left: -3px;
-
-    .witness__button & {
-        color: $news-support-1;
-    }
 
     .element-witness--source & {
         color: $neutral-2;


### PR DESCRIPTION
## What does this change?
the witness button now looks like:
![image](https://user-images.githubusercontent.com/2670496/34931486-fcb9b99a-f9c6-11e7-9e8a-d625e580cf68.png)

## What is the value of this and can you measure success?
just a bit tidier, respects pillars.

## Does this affect other platforms - Amp, Apps, etc?
witness.
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
