### PR TITLE
use full header on comment history

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -257,7 +257,7 @@ final case class MetaData (
 
   val hasSlimHeader: Boolean =
     contentWithSlimHeader ||
-      sectionId == "identity" ||
+      (sectionId == "identity" && !id.startsWith("/user/")) ||
       contentType.exists(c => c == DotcomContentType.Survey || c == DotcomContentType.Signup)
 
   // this is here so it can be included in analytics.

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -10,6 +10,7 @@ import idapiclient.{IdApiClient, Response}
 
 import scala.concurrent.Future
 import com.gu.identity.model.User
+import pages.IdentityHtmlPage
 
 class PublicProfileController(
   idUrlBuilder: IdentityUrlBuilder,
@@ -41,8 +42,9 @@ class PublicProfileController(
         case Right(user) =>
           user.publicFields.displayName.map { displayName =>
             val idRequest = idRequestParser(request)
-            Cached(60)(RevalidatableResult.Ok(views.html.publicProfilePage(
-              page(url, displayName), idRequest, idUrlBuilder, user, activityType)))
+            Cached(60)(RevalidatableResult.Ok(
+              IdentityHtmlPage.html(views.html.publicProfilePage(page(url, displayName), idRequest, idUrlBuilder, user, activityType))(page(url, displayName), request, context)
+            ))
           } getOrElse NotFound(views.html.errors._404())
       }
   }

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -51,16 +51,14 @@ object IdentityHtmlPage {
       bodyTag(classes = defaultBodyClasses())(
         views.html.layout.identityFlexWrap()(
           skipToMainContent(),
-          views.html.layout.identityHeader(hideNavigation=page.isFlow),
+          views.html.layout.identityHeader(hideNavigation=page.isFlow) when page.metadata.hasSlimHeader,
+          header() when !page.metadata.hasSlimHeader
         )(
           content
         )(
           inlineJSNonBlocking(),
-          if(page.isFlow){
-            views.html.layout.identitySkinnyFooter()
-          } else {
-            footer()
-          },
+          views.html.layout.identitySkinnyFooter() when page.isFlow,
+          footer() when !page.isFlow,
           analytics.base()
         )
       ),

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -6,8 +6,6 @@
 )(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.fragments.registrationFooter
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--stretched">
     <div class="identity-layout__header">
         <div class="user-profile u-cf">
@@ -65,4 +63,3 @@
     <div class="js-activity-stream activity-stream-content" data-user-id="@user.id" data-stream-type="@activityType"></div>
     @registrationFooter(idRequest, idUrlBuilder)
 </div>
-}


### PR DESCRIPTION
## What does this change?
Puts the whole header on the user comment history

## What is the value of this and can you measure success?
makes comments feel more like a part of the full website instead of a side page. Also fixes the page rendering wonkily on phones

## Screenshots (before/after)

![screen shot 2018-01-15 at 07 55 56](https://user-images.githubusercontent.com/11539094/34932221-eecee988-f9c9-11e7-949f-94be45f87cc0.png)
![screen shot 2018-01-15 at 07 55 54](https://user-images.githubusercontent.com/11539094/34932225-f05a5f94-f9c9-11e7-9d09-2d67b8e2c2d7.png)
