### PR TITLE
mobile header on identity pages

### DIFF
--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -17,8 +17,7 @@
                         aria-controls="my-account-dropdown"
                         data-link-name="identity-nav : menu : toggle"
                         >
-                            @fragments.inlineSvg("profile-36", "icon", List("mobile-only"))
-                            <span class="hide-on-mobile-inline">My account</span>
+                            <span>My account</span>
                         </span>
                     </label>
                     <input type="checkbox" value="open" id="identity-header-account-menu-fallback" class="identity-header__nav-fallback u-h" title="Open Menu" />
@@ -49,6 +48,7 @@
             <span class="u-h">The Guardian - Back to home</span>
             @if(experiments.ActiveExperiments.isParticipating(experiments.GarnettIdentity)){
                 @fragments.inlineSvg("the-guardian-logo", "logo")
+                @fragments.inlineSvg("the-guardian-roundel", "logo")
             } else {
                 @fragments.inlineSvg("guardian-logo-160", "logo")
             }

--- a/static/src/stylesheets/module/identity/_header.garnett.scss
+++ b/static/src/stylesheets/module/identity/_header.garnett.scss
@@ -17,7 +17,7 @@ $gutter: 5px;
         &:after {
             @include multiline(4, $garnett-neutral-4, top);
             content: '';
-            height: 4px * 4;
+            height: 4px * 4; /*height of multiline (4px) times the number of lines (4)*/
             background-color: #ffffff;
             margin-bottom: -1px;
             margin-top: $gutter;

--- a/static/src/stylesheets/module/identity/_header.garnett.scss
+++ b/static/src/stylesheets/module/identity/_header.garnett.scss
@@ -3,17 +3,26 @@ $gutter: 5px;
 .identity-header {
     @include clearfix;
     background-color: $nav-background-colour;
-    padding: $gutter 0 0;
+    padding: ($gutter/2) 0 0;
     color: $nav-primary-colour;
     z-index: 999;
-    &:after {
-        @include multiline(4, $garnett-neutral-4, top);
-        content: '';
-        height: 4px * 4;
-        background-color: #ffffff;
-        margin-bottom: -1px;
-        margin-top: $gutter;
-        width: 100%;
+    border-bottom: 1px solid $rule;
+    height: $slim-nav-height;
+    overflow: visible;
+
+    @include mq(tablet) {
+        border: 0;
+        padding: $gutter 0 0;
+        height: auto;
+        &:after {
+            @include multiline(4, $garnett-neutral-4, top);
+            content: '';
+            height: 4px * 4;
+            background-color: #ffffff;
+            margin-bottom: -1px;
+            margin-top: $gutter;
+            width: 100%;
+        }
     }
     .identity-dropdown {
         position: absolute;
@@ -47,6 +56,11 @@ $gutter: 5px;
 
 .identity-header__links {
     float: left;
+    @include mq($until: tablet) {
+        height: $slim-nav-height - $gutter;
+        display: flex;
+        align-items: center;
+    }
 }
 
 .identity-header__link {
@@ -57,6 +71,22 @@ $gutter: 5px;
 html body .identity-header__logo {
     float: right;
     order: -99;
+
+    .inline-the-guardian-roundel {
+        display: block;
+    }
+    .inline-the-guardian-logo {
+        display: none;
+    }
+
+    @include mq(tablet) {
+        .inline-the-guardian-roundel {
+            display: none;
+        }
+        .inline-the-guardian-logo {
+            display: block;
+        }
+    }
     .inline-the-guardian-logo__svg {
         display: block;
         height: 57px;


### PR DESCRIPTION
## What does this change?
Adds a proper mobile header on identity pages instead of downsizing the desktop one. (The desktop header remains the same)

## What is the value of this and can you measure success?
It looked a bit out of place before

## Screenshots (before/after)
![screen shot 2018-01-15 at 08 12 23](https://user-images.githubusercontent.com/11539094/34932995-15919b3a-f9cd-11e7-973f-cb4c523833aa.png)
![screen shot 2018-01-15 at 08 12 31](https://user-images.githubusercontent.com/11539094/34932996-16c148de-f9cd-11e7-93cf-0d263a9a1305.png)


