### PR TITLE
Don't darken media container border on hover

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -58,10 +58,6 @@
     &:hover,
     .u-faux-block-link--hover {
         background-color: darken($media-garnett-main-1, 5%);
-
-        .fc-item__container::before {
-            background-color: darken($media-garnett-main-1, 5%);
-        }
     }
 
     .fc-sublink__link {
@@ -108,10 +104,6 @@
     &:hover,
     .u-faux-block-link--hover {
         background-color: darken($media-garnett-main-1, 5%);
-
-        .fc-item__container::before {
-            background-color: darken($media-garnett-main-1, 5%);
-        }
     }
 
     .fc-sublink__link {


### PR DESCRIPTION
## What does this change?

When hovering over a media card, the pillar-specific top border changed colour to match the background colour of the card. This change prevents this from happening, so the border always retains its pillar colour

Fixes https://trello.com/c/5e6CD8zJ

## What is the value of this and can you measure success?

Design consistency

## Screenshots

### Unhovered

![picture 443](https://user-images.githubusercontent.com/5931528/34934809-c17c4dea-f9d3-11e7-8d0e-9f6b810c9a43.png)

### Hovered (broken)

![picture 444](https://user-images.githubusercontent.com/5931528/34934817-c49131d0-f9d3-11e7-99b1-d32c2b2aa620.png)

### Hovered (fixed)

![picture 445](https://user-images.githubusercontent.com/5931528/34934865-dd1a29dc-f9d3-11e7-898c-4fa81e84411b.png)

## Tested in CODE?

Noes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
