### PR TITLE
Opinion Caption Fix

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -840,6 +840,9 @@ $quote-mark: 35px;
         .caption {
             background-color: $opinion-garnett-background;
         }
+        .caption--main {
+            background-color: $garnett-neutral-1;
+        }
     }
 
     .content__head {


### PR DESCRIPTION
## What does this change?
Main caption on opinion pieces

## What is the value of this and can you measure success?
naa

## Does this affect other platforms - Amp, Apps, etc?
naa


## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
<img width="714" alt="screen shot 2018-01-15 at 09 46 54" src="https://user-images.githubusercontent.com/6727874/34936387-15644426-f9d9-11e7-9849-677e6b5c5bae.png">

## Tested in CODE?
YEH BOI
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
