### PR TITLE
Extend "cancel my regular contribution" feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -481,7 +481,7 @@ trait FeatureSwitches {
     "When ON, the edit profile page will include the cancel contribution button",
     owners = Seq(Owner.withGithub("svillafe")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 1, 15),
+    sellByDate = new LocalDate(2018, 2, 15),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extend the cancel my account feature switch

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
N/A
## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
