### PR TITLE
Post Garnett Epic Tweaks

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -1,5 +1,5 @@
 // @flow
-import quoteSvg from 'svgs/icon/quote.svg';
+import quoteSvg from 'svgs/icon/garnett-quote.svg';
 
 // @flow
 

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -15,10 +15,11 @@
     position: absolute;
 }
 
-.epic__testimonial-quote svg {
+.epic__testimonial-container .epic__testimonial-quote .inline-garnett-quote svg {
     fill: $multimedia-main-2;
-    width: 1.5 * $gs-gutter;
-    height: 1.5 * $gs-gutter;
+    width: $gs-gutter;
+    height: $gs-gutter;
+    padding-left: 10px;
 }
 
 .epic__testimonial-text {
@@ -42,7 +43,7 @@
 
 // Variant 3 - subtle
 
-.epic__testimonial-quote--subtle svg {
+.epic__testimonial-container--subtle .epic__testimonial-quote--subtle .inline-garnett-quote svg {
     fill: $neutral-3;
 }
 

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -13,6 +13,10 @@
             background-color: darken($multimedia-main-2, 5%);
         }
     }
+
+    .contributions__amount-field {
+        margin-top: 0;
+    }
 }
 
 .circles-banner-holdback {

--- a/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
+++ b/static/src/stylesheets/module/experiments/_circles-epic-banner-holdback.scss
@@ -1,5 +1,6 @@
 .contributions__epic--holdback {
     background-color: $comment-support-2;
+    border-color: $multimedia-main-2;
 
     .contributions__highlight {
         background-color: #ffe399;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -115,6 +115,7 @@
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
+    margin-top: $gs-baseline * 2;
 
     // Horizontal alignment
     align-items: left;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -7,7 +7,7 @@
 }
 
 .contributions__epic {
-    border-top: 1px solid $multimedia-main-2;
+    border-top: 1px solid $news-garnett-highlight;
     background-color: $garnett-neutral-3;
     margin-top: $gs-baseline * 2;
     padding: ($gs-baseline / 3) ($gs-gutter / 4) $gs-baseline;


### PR DESCRIPTION
## What does this change?

Makes some tweaks to the style of the epic.

- Applied the new Garnett quote marks.
- Updated the top border to use Garnett yellow, made the holdback variant use the old yellow still.
- Added some spacing to the CTA, but kept the holdback spacing the same.

cc: @Amohkhan

## What is the value of this and can you measure success?

- The epic performs better.

## Does this affect other platforms - Amp, Apps, etc?

Reader Revenue sites.

## Screenshots

**Before:**

![epic-before](https://user-images.githubusercontent.com/5131341/34944174-8199004c-f9f6-11e7-8db8-c6d4f3f0cd6b.png)

**After:**

![epic-after](https://user-images.githubusercontent.com/5131341/34944176-86cf0962-f9f6-11e7-90ef-91d223b1ab4c.png)

**Holdback:**

![epic-holdback](https://user-images.githubusercontent.com/5131341/34944185-8d4ca402-f9f6-11e7-8a48-728c8ac229ca.png)