### PR TITLE
Reinstate dreamsnap kickers

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -7,7 +7,7 @@
 
 @icon = {
     @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon") }
-    @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett)) { 
+    @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
         @if(header.isVideo) { @fragments.inlineSvg("video-icon", "icon") }
         @if(header.isGallery) { @fragments.inlineSvg("camera", "icon") }
         @if(header.isAudio) { @fragments.inlineSvg("volume-high", "icon") }
@@ -25,7 +25,7 @@
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @header.kicker match {
-        case Some(kicker) if snapType != Some(FrontendLatestSnap) => {
+        case Some(kicker) if snapType != Some(FrontendLatestSnap) || experiments.ActiveExperiments.isParticipating(experiments.Garnett) => {
             @articleLink{<span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span> @headline()}
         }
         case _ => {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -86,7 +86,7 @@ data-test-id="facia-card"
 @container(item: layout.ContentCard) = {
     <div class="fc-item__container">
 
-        @if(item.snapStuff.map(_.snapType).contains(FrontendLatestSnap)) {
+        @if(item.snapStuff.map(_.snapType).contains(FrontendLatestSnap) && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
             @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
         }
 
@@ -208,7 +208,7 @@ data-test-id="facia-card"
         }
 
         <div class="fc-item__content @if(item.starRating.isDefined){fc-item__content--has-stars}">
-            @if(item.snapStuff.map(_.snapType) == Some(FrontendLatestSnap)) {
+            @if(item.snapStuff.map(_.snapType) == Some(FrontendLatestSnap) && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
                 @kicker(item.header, List("fc-item__kicker--dreamsnap"))
             }
             <div class="@RenderClasses(Map(

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -440,7 +440,7 @@ $block-height: 58px;
     }
 }
 
-.fc-item__kicker--dreamsnap {
+.fc-item__kicker--dreamsnap-list {
     display: none;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -440,10 +440,6 @@ $block-height: 58px;
     }
 }
 
-.fc-item__kicker--dreamsnap-list {
-    display: none;
-}
-
 .fc-item__timestamp {
     white-space: nowrap;
 }


### PR DESCRIPTION
## What does this change?

This is the simplest possible change to make Dreamsnaps cards look like non-Dreamsnap cards when Garnett is switched on. 

## What is the value of this and can you measure success?

Dreamsnap kickers are displayed

## Screenshots

### Before

![picture_78](https://user-images.githubusercontent.com/5931528/34944410-5b3d574e-f9f7-11e7-947a-ca0086a6de6e.png)

### After

![picture 449](https://user-images.githubusercontent.com/5931528/34985923-9e59515c-faad-11e7-8e79-63aed4c1de6d.png)

## Tested in CODE?

Noes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
