### PR TITLE
Border top and bottom removed for interactive elements

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1500,7 +1500,6 @@ $quote-mark: 35px;
 .interactive.element--showcase,
 .interactive.element--supporting {
     background: $garnett-neutral-5;
-    padding-top: $gs-baseline/4;
 }
 
 .paid-content {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1501,10 +1501,6 @@ $quote-mark: 35px;
 .interactive.element--supporting {
     background: $garnett-neutral-5;
     padding-top: $gs-baseline/4;
-    @include mq(leftCol) {
-        border-top: 1px solid $garnett-neutral-4;
-        border-bottom: 1px solid $garnett-neutral-4;
-    }
 }
 
 .paid-content {


### PR DESCRIPTION
## What does this change?
Interactives will add borders top and bottom to their supporting images. This means we no longer need to.

## What is the value of this and can you measure success?
naa
## Does this affect other platforms - Amp, Apps, etc?
naa
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
![screen shot 2018-01-15 at 13 30 08](https://user-images.githubusercontent.com/6727874/34944656-63d0c0de-f9f8-11e7-97cb-8f41f998ffbc.png)

## Tested in CODE?
yep
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
