### PR TITLE
Fix media overlapping text in Firefox 53 and below 

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -92,6 +92,34 @@
         return getCookieValue('gu_paying_member') === 'true';
     }
 
+    function get_browser() {
+        var ua=navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []; 
+        if(/trident/i.test(M[1])){
+            tem=/\brv[ :]+(\d+)/g.exec(ua) || []; 
+            return {name:'IE',version:(tem[1]||'')};
+            }   
+        if(M[1]==='Chrome'){
+            tem=ua.match(/\bOPR|Edge\/(\d+)/)
+            if(tem!=null)   {return {name:'Opera', version:tem[1]};}
+            }   
+        M=M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];
+        if((tem=ua.match(/version\/(\d+)/i))!=null) {M.splice(1,1,tem[1]);}
+        return {
+          name: M[0],
+          version: M[1]
+        };
+     }
+
+    function supportsPercentagePadding() {
+        var firefoxMatch = navigator.userAgent.match(/Firefox\/([0-9]+)\./) || [];
+
+        if (firefoxMatch.length && parseInt(firefoxMatch[1], 10) < 54) {
+            return false;
+        }
+
+        return true;
+    }
+
     // http://modernizr.com/download/#-svg
     if (!!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect) {
         docClass += ' svg';
@@ -136,6 +164,15 @@
 
     if (isRecentContributor()) {
         docClass += ' is-recent-contributor';
+    }
+
+    /**
+     * % used for padding-bottom isn't supported on Grid items in FireFox <53.
+     * This temporary fix sets media in articles to 5:3 aspect ratio.
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=958714
+    **/
+    if(!supportsPercentagePadding()) {
+        docClass += ' fake-percentage-padding';
     }
 
     documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -92,24 +92,6 @@
         return getCookieValue('gu_paying_member') === 'true';
     }
 
-    function get_browser() {
-        var ua=navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []; 
-        if(/trident/i.test(M[1])){
-            tem=/\brv[ :]+(\d+)/g.exec(ua) || []; 
-            return {name:'IE',version:(tem[1]||'')};
-            }   
-        if(M[1]==='Chrome'){
-            tem=ua.match(/\bOPR|Edge\/(\d+)/)
-            if(tem!=null)   {return {name:'Opera', version:tem[1]};}
-            }   
-        M=M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];
-        if((tem=ua.match(/version\/(\d+)/i))!=null) {M.splice(1,1,tem[1]);}
-        return {
-          name: M[0],
-          version: M[1]
-        };
-     }
-
     function supportsPercentagePadding() {
         var firefoxMatch = navigator.userAgent.match(/Firefox\/([0-9]+)\./) || [];
 

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -95,7 +95,7 @@
     function supportsPercentagePadding() {
         var firefoxMatch = navigator.userAgent.match(/Firefox\/([0-9]+)\./) || [];
 
-        if (firefoxMatch.length && parseInt(firefoxMatch[1], 10) < 54) {
+        if (firefoxMatch.length === 2 && parseInt(firefoxMatch[1], 10) < 54) {
             return false;
         }
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -87,6 +87,18 @@
     }
 }
 
+.fake-percentage-padding {
+    .content__main-column .media-primary .u-responsive-ratio {
+        @include mq(leftCol) {
+            padding-bottom: 0 !important;
+            min-height: gs-span(8) * .6;
+        }
+        @include mq(tablet, desktop) {
+            min-height: gs-span(9) * .6;
+        }
+    }
+}
+
 .content__head {
     @include mq($from: tablet, $until: leftCol) {
         display: flex;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -87,6 +87,9 @@
     }
 }
 
+// % used for padding-bottom isn't supported on Grid items in FireFox <53.
+// This temporary fix sets media in articles to 5:3 aspect ratio.
+// https://bugzilla.mozilla.org/show_bug.cgi?id=958714
 .fake-percentage-padding {
     .content__main-column .media-primary .u-responsive-ratio {
         @include mq(leftCol) {


### PR DESCRIPTION
## What does this change?

Currently in Firefox <53 the first few paragraphs in an article are obscured by the main media. This is because the media's container doesn't expand to include the height of the media. This is caused by a bug in older versions of Firefox that means `padding-bottom` cannot be used to force the height of an element used as part of a CSS `grid`.

To get around this I'm forcing the aspect-ratio of media items in articles on firefox <53 to be 5:3 aspect ratio.

More details can be found here:
https://bugzilla.mozilla.org/show_bug.cgi?id=958714
https://rachelandrew.co.uk/archives/2017/12/20/how-should-we-resolve-percentage-margins-and-padding-on-grid-and-flex-items/

The first paragraph in the example below starts with the sentence "Dozens of Scotland's...".

Before:

![picture 111](https://user-images.githubusercontent.com/1590704/34948221-789e9a48-fa04-11e7-9058-6c1dd0ec5aba.png)

After:

![picture 110](https://user-images.githubusercontent.com/1590704/34948228-7f11bc66-fa04-11e7-984d-a1464f636d53.png)

## What is the value of this and can you measure success?

Fixes broken layout

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

No

## Tested in CODE?

No