### PR TITLE
Garnett Opinion Type size changed

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -913,9 +913,12 @@ $quote-mark: 35px;
     }
 
     .content__headline {
-        @include fs-headlineGarnett(6);
+        @include fs-headlineGarnett(5);
         font-weight: 100;
         padding-bottom: 0;
+        @include mq(mobileMedium) {
+            @include fs-headlineGarnett(6);
+        }
         @include mq(tablet) {
             @include fs-headlineGarnett(7);
         }
@@ -925,7 +928,10 @@ $quote-mark: 35px;
     }
 
     .content__head--byline-pic .content__header .content__headline__byline {
-        @include fs-headlineGarnett(6);
+        @include fs-headlineGarnett(5);
+        @include mq(mobileMedium) {
+            @include fs-headlineGarnett(6);
+        }
         @include mq(tablet) {
             @include fs-headlineGarnett(7);
         }


### PR DESCRIPTION

## What does this change?
Stops the name from breaking at 320px
## What is the value of this and can you measure success?
naa
## Does this affect other platforms - Amp, Apps, etc?
naa
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

![screen shot 2018-01-15 at 15 06 24](https://user-images.githubusercontent.com/6727874/34948726-e501cdb2-fa05-11e7-8030-9f8058cf6578.png)
## Tested in CODE?
YEP

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
