### PR TITLE
Add AppNexus targeting to Sonobi bid request

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash-amd": "~2.4.1",
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.9",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#e4f9d97",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#f8d19fd",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -128,6 +128,26 @@ const formatAppNexusTargeting = (obj: Object): string =>
             })
     ).join(',');
 
+const buildAppNexusTargeting = once((pageTargeting: Object): string =>
+    formatAppNexusTargeting({
+        pt1: pageTargeting.url,
+        pt2: pageTargeting.edition,
+        pt3: pageTargeting.ct,
+        pt4: pageTargeting.p,
+        pt5: pageTargeting.k,
+        pt6: pageTargeting.su,
+        pt7: pageTargeting.bp,
+        pt8: pageTargeting.x,
+        pt9: [
+            pageTargeting.gdncrm,
+            pageTargeting.pv,
+            pageTargeting.co,
+            pageTargeting.tn,
+            pageTargeting.slot,
+        ].join('|'),
+    })
+);
+
 const buildPageTargeting = once((adFree: ?boolean): Object => {
     const page: Object = config.page;
     const adFreeTargeting: Object = adFree ? { af: 't' } : {};
@@ -162,23 +182,7 @@ const buildPageTargeting = once((adFree: ?boolean): Object => {
     });
 
     // third-parties wish to access our page targeting, before the googletag script is loaded.
-    page.appNexusPageTargeting = formatAppNexusTargeting({
-        pt1: pageTargeting.url,
-        pt2: pageTargeting.edition,
-        pt3: pageTargeting.ct,
-        pt4: pageTargeting.p,
-        pt5: pageTargeting.k,
-        pt6: pageTargeting.su,
-        pt7: pageTargeting.bp,
-        pt8: pageTargeting.x,
-        pt9: [
-            pageTargeting.gdncrm,
-            pageTargeting.pv,
-            pageTargeting.co,
-            pageTargeting.tn,
-            pageTargeting.slot,
-        ].join('|'),
-    });
+    page.appNexusPageTargeting = buildAppNexusTargeting(pageTargeting);
 
     // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
     page.pageAdTargeting = pageTargeting;
@@ -186,4 +190,4 @@ const buildPageTargeting = once((adFree: ?boolean): Object => {
     return pageTargeting;
 });
 
-export { buildPageTargeting };
+export { buildPageTargeting, buildAppNexusTargeting };

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -60,6 +60,7 @@ export const sonobiBidder: PrebidBidder = {
         ad_unit: config.page.adUnit,
         dom_id: slotId,
         floor: 0.5,
+        appNexusTargeting: config.page.appNexusPageTargeting,
     }),
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -1,6 +1,10 @@
 // @flow
 
 import config from 'lib/config';
+import {
+    buildPageTargeting,
+    buildAppNexusTargeting,
+} from 'commercial/modules/build-page-targeting';
 import type {
     PrebidBidderCriteria,
     PrebidBidder,
@@ -60,7 +64,7 @@ export const sonobiBidder: PrebidBidder = {
         ad_unit: config.page.adUnit,
         dom_id: slotId,
         floor: 0.5,
-        appNexusTargeting: config.page.appNexusPageTargeting,
+        appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
     }),
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8266,9 +8266,9 @@ preact@^8.2.5:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.5.tgz#cbfa3962a8012768159f6d01d46f9c1eb3213c0a"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#e4f9d97":
+"prebid.js@https://github.com/guardian/Prebid.js.git#f8d19fd":
   version "0.34.1"
-  resolved "https://github.com/guardian/Prebid.js.git#e4f9d97bbb73f50e3c9bbe34f4ccd750b94da04b"
+  resolved "https://github.com/guardian/Prebid.js.git#f8d19fdf09cb6895f5c99672f349ba8ace99a3ec"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
Should make new prebid setup functionally equivalent to old Sonobi wrapper setup.

Depends on https://github.com/guardian/Prebid.js/pull/3