### PR TITLE
Extend acquisitions switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "Show a custom Epic for articles with the US gun campaign tag",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 1, 16),
+    sellByDate = new LocalDate(2018, 1, 23),
     exposeClientSide = true
   )
 
@@ -122,7 +122,7 @@ trait ABTestSwitches {
     "Test changing the epic testimonial each view",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 1, 16),
+    sellByDate = new LocalDate(2018, 1, 23),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the acquisition switches so as to not break the build