### PR TITLE
AMP: Changes to match up with mobile web

### DIFF
--- a/static/src/stylesheets/amp/header-garnett/_header-cta-item.scss
+++ b/static/src/stylesheets/amp/header-garnett/_header-cta-item.scss
@@ -8,7 +8,8 @@
     padding: ($gs-baseline / 2 + $gs-baseline / 4) ($gs-gutter) ($gs-baseline / 4);
     position: relative;
     font-size: 13px;
-    line-height: 1;
+    line-height: 1.2;
+    text-align: center;
 
     .guardian-egyptian-loaded & {
         font-family: 'Guardian Egyptian Web', Georgia, serif;

--- a/static/src/stylesheets/amp/header-garnett/_pillar-link.scss
+++ b/static/src/stylesheets/amp/header-garnett/_pillar-link.scss
@@ -10,7 +10,7 @@
     cursor: pointer;
 
     @include mq(mobileMedium) {
-        font-size: 17px;
+        font-size: 16px;
     }
 
     &:before {


### PR DESCRIPTION
The AMP header had a wrong font size and a tiny couple of visual differences with the mobile web header.

# Before
<img width="360" alt="screen shot 2018-01-16 at 11 12 33" src="https://user-images.githubusercontent.com/14570016/34986191-8ffd11ce-faae-11e7-9797-46e32f9402a0.png">

# After
<img width="360" alt="screen shot 2018-01-16 at 11 13 35" src="https://user-images.githubusercontent.com/14570016/34986192-9010200c-faae-11e7-8d44-e6135ee6172d.png">
