### PR TITLE
Garnett fix: Fix Content Header on Firefox 53 and below

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -153,8 +153,8 @@
      * This temporary fix sets media in articles to 5:3 aspect ratio.
      * https://bugzilla.mozilla.org/show_bug.cgi?id=958714
     **/
-    if(!supportsPercentagePadding()) {
-        docClass += ' fake-percentage-padding';
+    if(supportsPercentagePadding()) {
+        docClass += ' supports-percentage-padding';
     }
 
     documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -87,21 +87,6 @@
     }
 }
 
-// % used for padding-bottom isn't supported on Grid items in FireFox <53.
-// This temporary fix sets media in articles to 5:3 aspect ratio.
-// https://bugzilla.mozilla.org/show_bug.cgi?id=958714
-.fake-percentage-padding {
-    .content__main-column .media-primary .u-responsive-ratio {
-        @include mq(leftCol) {
-            padding-bottom: 0 !important;
-            min-height: gs-span(8) * .6;
-        }
-        @include mq(tablet, desktop) {
-            min-height: gs-span(9) * .6;
-        }
-    }
-}
-
 .content__head {
     @include mq($from: tablet, $until: leftCol) {
         display: flex;
@@ -1033,41 +1018,6 @@
         flex-direction: column;
     }
 
-    @include mq($from: leftCol) {
-        @supports (display: grid) {
-            margin-left: -($left-column + $gs-gutter);
-            display: grid;
-            grid-template-columns: ($left-column + $gs-gutter) 1fr;
-            grid-template-areas: 'labels headline-standfirst' 'meta main-media';
-
-            .content--type-guardianview &,
-            .content--type-comment & {
-                grid-template-areas: 'labels headline' 'meta standfirst' 'meta main-media';
-            }
-
-            .content--type-matchreport & {
-                grid-template-areas: 'labels headline-standfirst' '. report' 'meta main-media';
-            }
-        }
-    }
-
-    @include mq($from: wide) {
-        @supports (display: grid) {
-            margin-left: -($left-column-wide + $gs-gutter);
-            grid-template-columns: ($left-column-wide + $gs-gutter) 1fr;
-        }
-    }
-
-    .content__labels {
-        @include mq($from: leftCol) {
-            @supports (display: grid) {
-                grid-area: labels;
-                position: relative;
-                margin: 0;
-            }
-        }
-    }
-
     .content__headline-standfirst-wrapper {
         @include mq($until: tablet) {
             order: 1;
@@ -1076,28 +1026,6 @@
             .content--type-comment & {
                 order: 0;
             }
-        }
-
-        @include mq($from: leftCol) {
-            grid-area: headline-standfirst;
-        }
-    }
-
-    .media-primary {
-        @include mq($from: leftCol) {
-            grid-area: main-media;
-        }
-    }
-
-    .content__header {
-        @include mq($from: leftCol) {
-            grid-area: headline;
-        }
-    }
-
-    .tonal__standfirst {
-        @include mq($from: leftCol) {
-            grid-area: standfirst;
         }
     }
 
@@ -1115,23 +1043,89 @@
         @include mq($from: leftCol) {
             // adds enough space so that this doesn't clash with the content labels if css gris is not supported
             top: gs-height(3);
+        }
+    }
+}
 
-            @supports (display: grid) {
-                grid-area: meta;
-                position: relative !important;
-                top: 0;
-                margin: 0;
-                align-self: start;
-                height: 0;
+// Apply grid if supported and .supports-percentage-padding class present
+// % used for padding-bottom isn't supported on Grid items in FireFox <53.
+// This temporary fix sets media in articles to 5:3 aspect ratio.
+// https://bugzilla.mozilla.org/show_bug.cgi?id=958714
+@supports (display: grid) {
+    .supports-percentage-padding {
+        .content__head--article {
+            @include mq($from: leftCol) {
+                margin-left: -($left-column + $gs-gutter);
+                display: grid;
+                grid-template-columns: ($left-column + $gs-gutter) 1fr;
+                grid-template-areas: 'labels headline-standfirst' 'meta main-media';
+    
+                .content--type-guardianview &,
+                .content--type-comment & {
+                    grid-template-areas: 'labels headline' 'meta standfirst' 'meta main-media';
+                }
+    
+                .content--type-matchreport & {
+                    grid-template-areas: 'labels headline-standfirst' '. report' 'meta main-media';
+                }
+            }
+        
+            @include mq($from: wide) {
+                margin-left: -($left-column-wide + $gs-gutter);
+                grid-template-columns: ($left-column-wide + $gs-gutter) 1fr;
+            }
+        
+            .content__labels {
+                @include mq($from: leftCol) {
+                    grid-area: labels;
+                    position: relative;
+                    margin: 0;
+                }
+            }
+        
+            .content__headline-standfirst-wrapper {
+                @include mq($from: leftCol) {
+                    grid-area: headline-standfirst;
+                }
+            }
+        
+            .media-primary {
+                @include mq($from: leftCol) {
+                    grid-area: main-media;
+                }
+            }
+        
+            .content__header {
+                @include mq($from: leftCol) {
+                    grid-area: headline;
+                }
+            }
+        
+            .tonal__standfirst {
+                @include mq($from: leftCol) {
+                    grid-area: standfirst;
+                }
+            }
+        
+            .content__meta-container {
+                @include mq($from: leftCol) {
+                    grid-area: meta;
+                    position: relative !important;
+                    top: 0;
+                    margin: 0;
+                    align-self: start;
+                    height: 0;
+                }
+            }
+        
+            /*** position match stats ***/
+            .matchreport {
+                grid-area: report;
             }
         }
     }
-
-    /*** position match stats ***/
-    .matchreport {
-        grid-area: report;
-    }
 }
+
 .paid-content {
     color: $neutral-1;
     .content__head {


### PR DESCRIPTION
## What does this change?

This is an improvement on the fix merged in here: https://github.com/guardian/frontend/pull/18892

It addresses the same issue, but now accommodates varying aspect-ratios of main media rather than 5:3 alone.

On this branch I've extracted all grid related css properties and scoped them within `.supports-percentage-padding` and `@supports (display: grid)`.

On Firefox 53 and below `supports-percentage-padding` will not be added to the body and the grid therefore won't be used to layout the content header.

The impact of not using the grid on the content header is minimal: that the top of `.content__meta-container` won't align with the top of the main media.

## What is the value of this and can you measure success?

Users on firefox 53 and below can see all the body content and media at the correct aspect ratio.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

**Before...**

![picture 113](https://user-images.githubusercontent.com/1590704/34987940-dcf15de0-fab4-11e7-930f-c72c6018eb70.png)

**After...**

![picture 112](https://user-images.githubusercontent.com/1590704/34987953-e311d3da-fab4-11e7-9616-9e75d4f21f92.png)

## Tested in CODE?

No
