### PR TITLE
Add new atom: update dependencies & code

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -35,7 +35,8 @@ final case class Atoms(
     "qanda" -> !qandas.isEmpty,
     "profile" -> !profiles.isEmpty,
     "timeline" -> !timelines.isEmpty,
-    "storyquestions" -> !storyquestions.isEmpty
+    "storyquestions" -> !storyquestions.isEmpty,
+    "explainer" -> !explainers.isEmpty
   )
 }
 
@@ -149,7 +150,8 @@ final case class ExplainerAtom(
   override val id: String,
   labels: Seq[String],
   title: String,
-  body: String
+  body: String,
+  atom: AtomApiAtom
 ) extends Atom
 
 final case class QandaAtom(
@@ -557,7 +559,7 @@ object StoryQuestionsAtom {
 object ExplainerAtom {
   def make(atom: AtomApiAtom): ExplainerAtom = {
     val explainer = atom.data.asInstanceOf[AtomData.Explainer].explainer
-    ExplainerAtom(atom.id, explainer.tags.getOrElse(Nil), explainer.title, explainer.body)
+    ExplainerAtom(atom.id, explainer.tags.getOrElse(Nil), explainer.title, explainer.body, atom)
   }
 }
 

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -4,7 +4,7 @@
 @(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
-@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom}
+@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom}
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
@@ -20,6 +20,7 @@
         case guide: GuideAtom => views.html.fragments.atoms.snippets.guide(guide, isAmp = amp)
         case profile: ProfileAtom if !amp => Html(ArticleAtomRenderer.getHTML(profile.atom))
         case profile: ProfileAtom => views.html.fragments.atoms.snippets.profile(profile, isAmp = amp)
+        case explainer: ExplainerAtom if !amp => Html(ArticleAtomRenderer.getHTML(explainer.atom))
         case _ =>
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "1.3.2"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.9.6",
+    "@guardian/atom-renderer": "0.10.3",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.9.6"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.10.3"
 
   // Fixing transient dependency issue
   // AWS SDK (1.11.181), which kinesis-logback-appender depends on, brings com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat libs in version 2.6.9

--- a/static/src/javascripts/bootstraps/enhanced/atoms.js
+++ b/static/src/javascripts/bootstraps/enhanced/atoms.js
@@ -86,6 +86,17 @@ const initAtoms = () => {
             'storyquestions-atom'
         );
     }
-};
 
+    if (config.get('page.atomTypes.explainer')) {
+        require.ensure(
+            [],
+            require => {
+                require('@guardian/atom-renderer/dist/explainer/article/index.css');
+                const atomMaker = require('@guardian/atom-renderer/dist/explainer/article/index');
+                bootstrapAtom(atomMaker, 'explainer');
+            },
+            'explainer-atom'
+        );
+    }
+};
 export { initAtoms };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@guardian/atom-renderer@0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.9.6.tgz#c1f7162780828ab5554d67763d084c795fdce0bc"
+"@guardian/atom-renderer@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.10.3.tgz#3f8e1529ed11fbb7ea1679f8e384c0e24646f1fd"
   dependencies:
     autoprefixer "^7.1.6"
     css-loader "^0.28.7"


### PR DESCRIPTION
## What does this change?
This updates dependencies and some code associated with atoms, to let us add a new Explainer Atom. 
This is to support legacy explainer atoms in old stories 

## What is the value of this and can you measure success?
Once Capi is updated, these old Explainer atoms should be rendered by Atom Renderer - one of the dependencies of FrontEnd  

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No


## Screenshots
N/A

## Tested in CODE?

