### PR TITLE
extending switch FOREVER

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -342,7 +342,7 @@ trait FeatureSwitches {
     "When ON, articles specified in the badges file will have visual elements added",
     owners = Seq(Owner.withGithub("superfrank")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 1, 16),
+    sellByDate = never,
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?
Extends badge switch

## What is the value of this and can you measure success?
naa

## Does this affect other platforms - Amp, Apps, etc?
naa

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
naa

## Screenshots
naa

## Tested in CODE?
naa

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
