### PR TITLE
Fix avatars: Use maybePath as a last resort

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -22,7 +22,7 @@
                 srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />
     }
     <!--[if IE 9]></video><![endif]-->
-    @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).map { src =>
+    @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>
         <img class="@RenderClasses(classes: _*)" alt="" src="@src"/>
     }
 </picture>


### PR DESCRIPTION
My [previous change](https://github.com/guardian/frontend/pull/18905) avoided having an empty `img` element, but this broke avatars as they did not have a valid `src` but many `source`s. Anyway this will fix it.