### PR TITLE
fix immersive cards which have 1 sublink

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -96,6 +96,19 @@
             }
         }
     }
+
+    &.fc-item--has-sublinks-1 {
+        .fc-item__footer--horizontal {
+            display: none;
+        }
+        .fc-item__footer--vertical {
+            display: block;
+
+            .fc-sublinks {
+                margin-left: 0; 
+            }
+        }
+    }
 }
 
 @mixin immersiveLeft() {


### PR DESCRIPTION
## What does this change?

`.fc-item--type-immersive` cards look broken when they have 1 sublink. This PR fixes that.

## What is the value of this and can you measure success?

Fixes broken layout

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

**Before...**

![picture 116](https://user-images.githubusercontent.com/1590704/35004631-b9879408-fae8-11e7-9ebc-d555b95ef2e3.png)

**After...**

![picture 115](https://user-images.githubusercontent.com/1590704/35004640-bf77579a-fae8-11e7-8fb9-b7d689cd8e65.png)

## Tested in CODE?

No