### PR TITLE
Move menu toggle checkbox after pillars

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -100,12 +100,6 @@
 
             <div class="popup popup--default popup--search js-search-popup js-search-new is-off"><div class="js-search-placeholder"></div></div>
 
-            <input type="checkbox"
-                id="main-menu-toggle"
-                class="veggie-burger-fallback js-enhance-checkbox u-h"
-                data-link-name="nav2 : veggie-burger : show"
-                aria-controls="main-menu">
-
             <ul class="pillars">
                 @navMenu.pillars.map { link =>
                     <li class="pillars__item">
@@ -120,6 +114,13 @@
                     </li>
                 }
             </ul>
+
+            <input type="checkbox"
+                id="main-menu-toggle"
+                class="veggie-burger-fallback js-enhance-checkbox u-h"
+                data-link-name="nav2 : veggie-burger : show"
+                aria-controls="main-menu"
+            >
 
             <label for="main-menu-toggle"
                    class="js-change-link new-header__menu-toggle"

--- a/static/src/stylesheets/layout/garnett-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/garnett-header/_veggie-burger-fallback.scss
@@ -42,3 +42,11 @@
         }
     }
 }
+
+.veggie-burger-fallback {
+    &:focus {
+        & ~ .new-header__menu-toggle .pillar-link {
+            color: $nav-primary-colour;
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?

By moving the menu toggle checkbox after pillars, this change creates a more natural tab order to the header. 

I have also added a `:focus` colour, to indicate to the user that the link is in focus

## What is the value of this and can you measure success?

More natural tab order, meaning better accessibility

## Screenshots

![jan-17-2018 12-56-54](https://user-images.githubusercontent.com/5931528/35043821-f286f094-fb85-11e7-9bfb-3a6ac9b43e42.gif)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
