### PR TITLE
Fixed slimnav from tablet upwards

### DIFF
--- a/static/src/stylesheets/layout/garnett-header/_new-header.scss
+++ b/static/src/stylesheets/layout/garnett-header/_new-header.scss
@@ -232,8 +232,10 @@ from scrolling */
     height: $slim-nav-height + $gs-baseline + $gs-baseline / 2;
 
     .immersive-header-container & {
-        border-bottom: 0;
-        height: 0;
+        @include mq($until: tablet) {
+            border-bottom: 0;
+            height: 0;
+        }
     }
 
     @include mq(tablet) {


### PR DESCRIPTION
Needed to wrap up a specific rule in an MQ to avoid tablet slimnav having a height of 0. 

<img width="1422" alt="screen shot 2018-01-17 at 12 48 40" src="https://user-images.githubusercontent.com/14570016/35043513-d06cf540-fb84-11e7-86fc-8476fafa36cd.png">
