### PR TITLE
Update logic for when Advertisement labels are required

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -5,14 +5,30 @@ import popupTemplate from 'raw-loader!commercial/views/ad-feedback-popup.html';
 import tick from 'svgs/icon/tick.svg';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 
-const shouldRenderLabel = adSlotNode =>
-    !(
-        adSlotNode.classList.contains('ad-slot--fluid') ||
-        adSlotNode.classList.contains('ad-slot--frame') ||
-        adSlotNode.classList.contains('gu-style') ||
-        adSlotNode.getAttribute('data-label') === 'false' ||
-        adSlotNode.getElementsByClassName('ad-slot__label').length
+/* creatives can explicitly request to have - or to not have - an 'Advertisment' label added to them
+ by containing a div with the following class followed by true/false.
+ */
+const labelRequiredSuffix = 'js-advertisement-label-required';
+
+const shouldRenderLabel = adSlotNode => {
+    const explicitlyOptedOut =
+        adSlotNode.getElementsByClassName(`${labelRequiredSuffix}-false`)
+            .length > 0;
+    const explicitlyOptedIn =
+        adSlotNode.getElementsByClassName(`${labelRequiredSuffix}-true`)
+            .length > 0;
+
+    return (
+        explicitlyOptedIn ||
+        (!explicitlyOptedOut &&
+            !(
+                adSlotNode.classList.contains('ad-slot--fluid') ||
+                adSlotNode.classList.contains('ad-slot--frame') ||
+                adSlotNode.getAttribute('data-label') === 'false' ||
+                adSlotNode.getElementsByClassName('ad-slot__label').length
+            ))
     );
+};
 
 const renderAdvertLabel = (adSlotNode: any): Promise<null> => {
     if (shouldRenderLabel(adSlotNode)) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
@@ -28,8 +28,22 @@ describe('Rendering advert labels', () => {
             `)
         );
 
-        adverts.guStyle = bonzo(
-            bonzo.create('<div class="js-ad-slot gu-style"></div>')
+        // the override should work regardless of whether the other conditions are true, including an existing label
+        adverts.requiredOverride = bonzo(
+            bonzo.create(`
+                <div class="js-ad-slot">
+                    <div class="ad-slot__label">Advertisement</div>
+                    <div class="js-advertisement-label-required-true"></div>
+                </div>
+            `)
+        );
+
+        adverts.notRequiredOverride = bonzo(
+            bonzo.create(`
+                <div class="js-ad-slot">
+                    <div class="js-advertisement-label-required-false"></div>
+                </div>
+            `)
         );
 
         adverts.frame = bonzo(
@@ -37,25 +51,25 @@ describe('Rendering advert labels', () => {
         );
     });
 
-    it('Can add a label', () =>
+    it(`Can add a label`, () =>
         renderAdvertLabel(adverts.withLabel[0]).then(() => {
             const label = adverts.withLabel[0].querySelector(labelSelector);
             expect(label).not.toBeNull();
         }));
 
-    it('The label has a message', () =>
+    it(`The label has a message`, () =>
         renderAdvertLabel(adverts.withLabel[0]).then(() => {
             const label = adverts.withLabel[0].querySelector(labelSelector);
             expect(label.textContent).toBe('Advertisement');
         }));
 
-    it('Won`t add a label if it has an attribute data-label=`false`', () =>
+    it(`Won't add a label if it has an attribute data-label='false'`, () =>
         renderAdvertLabel(adverts.labelDisabled[0]).then(() => {
             const label = adverts.labelDisabled[0].querySelector(labelSelector);
             expect(label).toBeNull();
         }));
 
-    it('Won`t add a label if the adSlot already has one', () =>
+    it(`Won't add a label if the adSlot already has one`, () =>
         renderAdvertLabel(adverts.alreadyLabelled[0]).then(() => {
             const label = adverts.alreadyLabelled[0].querySelectorAll(
                 labelSelector
@@ -63,15 +77,25 @@ describe('Rendering advert labels', () => {
             expect(label.length).toBe(1);
         }));
 
-    it('Won`t add a label to guStyle ads', () =>
-        renderAdvertLabel(adverts.guStyle[0]).then(() => {
-            const label = adverts.guStyle[0].querySelector(labelSelector);
-            expect(label).toBeNull();
-        }));
-
-    it('Won`t add a label to frame ads', () =>
+    it(`Won't add a label to frame ads`, () =>
         renderAdvertLabel(adverts.frame[0]).then(() => {
             const label = adverts.frame[0].querySelector(labelSelector);
             expect(label).toBeNull();
+        }));
+
+    it(`Won't add a label to ads with explicit no-label override`, () =>
+        renderAdvertLabel(adverts.notRequiredOverride[0]).then(() => {
+            const label = adverts.notRequiredOverride[0].querySelector(
+                labelSelector
+            );
+            expect(label).toBeNull();
+        }));
+
+    it(`Will add a label to ads with explicit label override`, () =>
+        renderAdvertLabel(adverts.requiredOverride[0]).then(() => {
+            const labels = adverts.requiredOverride[0].querySelectorAll(
+                labelSelector
+            );
+            expect(labels.length).toBe(2);
         }));
 });

--- a/static/src/javascripts/projects/commercial/modules/hide-element.js
+++ b/static/src/javascripts/projects/commercial/modules/hide-element.js
@@ -1,0 +1,5 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+
+export const hideElement = <T: Element>(element: T): Promise<T> =>
+    fastdom.write(() => element.classList.add('u-h'));

--- a/static/src/javascripts/projects/commercial/modules/hide-element.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hide-element.spec.js
@@ -1,9 +1,8 @@
 // @flow
 import type { JestMockT } from 'jest';
-import { _ } from './hide.js';
+import { hideElement } from './hide-element.js';
 
 const foolFlow = (mockFn: any) => ((mockFn: any): JestMockT);
-const { hide } = _;
 
 describe('Cross-frame messenger: hide', () => {
     describe('hide function', () => {
@@ -12,7 +11,7 @@ describe('Cross-frame messenger: hide', () => {
             const fallback = document.createElement('div');
             const fakeIframe = document.getElementById('iframe01') || fallback;
             const fakeAdSlot = document.getElementById('slot01') || fallback;
-            return foolFlow(hide(fakeAdSlot)).then(() => {
+            return foolFlow(hideElement(fakeAdSlot)).then(() => {
                 expect(fakeIframe.classList.contains('u-h')).toBe(true);
             });
         });

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.js
@@ -1,26 +1,17 @@
 // @flow
-import fastdom from 'lib/fastdom-promise';
+import { hideElement } from 'commercial/modules/hide-element';
 import type { RegisterListeners } from 'commercial/modules/messenger';
-
-const hide = (adSlot: HTMLElement): ?Promise<any> => {
-    if (!adSlot) {
-        return null;
-    }
-
-    return fastdom.write(() => {
-        adSlot.classList.add('u-h');
-    });
-};
 
 const init = (register: RegisterListeners) => {
     register('hide', (specs, ret, iframe) => {
         if (iframe) {
-            const adSlot = iframe && iframe.closest('.js-ad-slot');
-            return hide(adSlot);
+            const adSlot = iframe.closest('.js-ad-slot');
+
+            if (adSlot) {
+                return hideElement(adSlot);
+            }
         }
     });
 };
-
-export const _ = { hide };
 
 export { init };


### PR DESCRIPTION
## What does this change?
In anticipation of some changes upstream to our DFP native styles, this PR checks for specific markers in the creatives to determine whether an Advertisement label should be rendered or not.

Eventually a lot of this logic will be simplified, but because the systems are being updated separately, the old logic and new logic need to remain in place for the time being.

## What is the value of this and can you measure success?
More determined and explicit rules for when an Advertisement label should be rendered, no longer determined from opaque logic around ad sizes and formats.