### PR TITLE
Hidden pesky underlines on expanded nav BUG

### DIFF
--- a/static/src/stylesheets/layout/garnett-header/_menu.scss
+++ b/static/src/stylesheets/layout/garnett-header/_menu.scss
@@ -79,7 +79,6 @@
 
 .menu__inner {
     box-sizing: border-box;
-    background-color: $nav-background-colour;
 
     @include mq($until: desktop) {
         &.gs-container {
@@ -88,6 +87,7 @@
     }
 
     @include mq(desktop) {
+        background-color: $nav-background-colour;
         margin-top: -20px ;
         padding: 0 $gs-gutter;
 

--- a/static/src/stylesheets/layout/garnett-header/_menu.scss
+++ b/static/src/stylesheets/layout/garnett-header/_menu.scss
@@ -79,6 +79,7 @@
 
 .menu__inner {
     box-sizing: border-box;
+    background-color: $nav-background-colour;
 
     @include mq($until: desktop) {
         &.gs-container {

--- a/static/src/stylesheets/layout/garnett-header/_new-header.scss
+++ b/static/src/stylesheets/layout/garnett-header/_new-header.scss
@@ -146,6 +146,8 @@ from scrolling */
     @include mq(desktop) {
         margin-bottom: -34px;
         margin-top: 5px;
+        position: relative;
+        z-index: $zindex-main-menu + 1;
     }
 
     body:not(.has-page-skin) & {

--- a/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/garnett-header/_pillar-link.scss
@@ -58,11 +58,6 @@
         transition: transform 150ms ease-out;
     }
 
-    .is-not-modern &:after {
-        // Hides active and hover underlines from masking text on pillars in non-js
-        content: none;
-    }
-
     &:hover,
     &:focus {
         text-decoration: none;
@@ -76,10 +71,6 @@
         &:not(.pillar-link--dropdown):hover,
         &:not(.pillar-link--dropdown):focus {
             text-decoration: underline;
-        }
-
-        &:after {
-            content: none;
         }
     }
 
@@ -99,12 +90,6 @@
 .pillar-link--current-section {
     &:after {
         transform: translateY(-4px)
-    }
-
-    .new-header--open & {
-        &:after {
-            content: none;
-        }
     }
 }
 


### PR DESCRIPTION
In firefox if you clicked "More" the underline of the current pillar would overlap the menu text like this (It seemed to be before JS loaded):

![unnamed](https://user-images.githubusercontent.com/14570016/35049248-447682fa-fb97-11e7-995b-c879ec0cb06b.jpg)

After looking into complicated approaches I've arrived on a simpler one that works for no js too. A background colour to the menu so you can't see the underline anuway.