### PR TITLE
Create one Nashorn renderer per round robin actor

### DIFF
--- a/common/app/rendering/core/JavascriptEngine.scala
+++ b/common/app/rendering/core/JavascriptEngine.scala
@@ -7,9 +7,8 @@ import jdk.nashorn.api.scripting.{JSObject, NashornScriptEngineFactory}
 
 import scala.util.Try
 
-object JavascriptEngine {
-
-  type EvalResult = JSObject
+class JavascriptEngine {
+  import JavascriptEngine.EvalResult
 
   private val shared: ScriptEngine = new NashornScriptEngineFactory().getScriptEngine()
 
@@ -34,4 +33,8 @@ object JavascriptEngine {
       .invokeMethod(obj, method, args:_*)
       .asInstanceOf[String]
   }
+}
+
+object JavascriptEngine {
+  type EvalResult = JSObject
 }


### PR DESCRIPTION
## What does this change?

I don't trust that Nashorn is thread safe after seeing this exception when running multiple tests together. The exception goes away when running the test on its own.

I saw this error when adding WithTestRenderer for every individual Archive test case, creating multiple round robin routers relying on the same Nashorn renderer

```
[info] - should not redirect a random URL that contains the word century *** FAILED ***
[info]   java.lang.NullPointerException:
[info]   at java.lang.invoke.MethodHandleImpl$ArrayAccessor.getElementL(MethodHandleImpl.java:130)
[info]   at jdk.nashorn.internal.scripts.Script$Recompilation$74$7092AAAI$\^eval\_.L:141#exports(<eval>:147)
[info]   at jdk.nashorn.internal.scripts.Script$Recompilation$73$2386AAA$\^eval\_.L:64#$export(<eval>:70)
[info]   at jdk.nashorn.internal.scripts.Script$Recompilation$6$165207AAA$\^eval\_.L:2762(<eval>:2828)
[info]   at jdk.nashorn.internal.runtime.ScriptFunctionData.invoke(ScriptFunctionData.java:643)
[info]   at jdk.nashorn.internal.runtime.ScriptFunction.invoke(ScriptFunction.java:494)
[info]   at jdk.nashorn.internal.runtime.ScriptRuntime.apply(ScriptRuntime.java:393)
[info]   at jdk.nashorn.internal.objects.NativeFunction.call(NativeFunction.java:192)
[info]   at jdk.nashorn.internal.scripts.Script$Recompilation$3$904I$\^eval\_.frontend#__webpack_require__(<eval>:43)
[info]   at jdk.nashorn.internal.scripts.Script$Recompilation$5$161379AAA$\^eval\_.L:2726(<eval>:2727)
```

## What is the value of this and can you measure success?

Attempt to fix issues with Nashorn renderer

## Tested in CODE?
locally
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
