### PR TITLE
Update Stripe Roundel

### DIFF
--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -30,7 +30,7 @@ const checkoutHandler = StripeCheckout.configure({
     locale: 'auto',
     name: 'The Guardian',
     allowRememberMe: false,
-    image: 'https://uploads.guim.co.uk/2018/01/10/gu.png',
+    image: 'https://uploads.guim.co.uk/2018/01/15/gu.png',
 });
 
 /* Renders the card details


### PR DESCRIPTION
## What does this change?

Updates the stripe roundel to use the new roundel asset.

## What is the value of this and can you measure success?

Keeps the Stripe popup on-brand.

## Does this affect other platforms - Amp, Apps, etc?

Reader revenue.

## Screenshots

**Before:**

<img width="316" alt="roundel-old" src="https://user-images.githubusercontent.com/5131341/34930841-7cb6c204-f9c3-11e7-8d79-75e13cb3efdf.png">

**After:**

<img width="314" alt="roundel-new" src="https://user-images.githubusercontent.com/5131341/34930847-83109a08-f9c3-11e7-9087-4955a593b9c6.png">

## Tested in CODE?

Yes.
