### PR TITLE
Fix quote icon on media cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-media.scss
@@ -28,7 +28,8 @@
 .fc-item--type-media {
     background-color: $media-garnett-main-1;
 
-    .inline-icon__svg:not(.inline-clock__svg) {
+    .inline-icon__svg:not(.inline-clock__svg,
+                          .inline-garnett-quote__svg) {
         padding: 5px;
         border-radius: 50%;
     }


### PR DESCRIPTION
## What does this change?

Media icons in media cards get a circle and some padding around them. This was wrongly affecting the quote icon in media cards, that's not meant to get that padding. So I removed it.

The icon might do with a little more padding to the right, but I thought it better to leave that to a subsequent PR, as that should go for all quote icons.

## What is the value of this and can you measure success?

See before after screenshots

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

Before
<img width="426" alt="before" src="https://user-images.githubusercontent.com/4561/35056126-e23f37fa-fba8-11e7-930e-ebcad41cafd2.png">

After
<img width="426" alt="after" src="https://user-images.githubusercontent.com/4561/35056131-e5514b04-fba8-11e7-8488-752bea635c6f.png">



## Tested in CODE?

No

CC @blongden73 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
