### PR TITLE
Newsletter opt-in banner

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -61,7 +61,7 @@ trait IdentitySwitches {
     "If switched on, users coming from newsletters will see UI to opt in to GDPR-compliant marketing",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 1),
+    sellByDate = new LocalDate(2018, 6, 25), // GDPR goes into effect + 1 month
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -55,4 +55,14 @@ trait IdentitySwitches {
     exposeClientSide = false
   )
 
+  val IdentityShowOptInEngagementBanner = Switch(
+    SwitchGroup.Identity,
+    "id-show-opt-in-engagement-banner",
+    "If switched on, users coming from newsletters will see UI to opt in to GDPR-compliant marketing",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 1),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -62,7 +62,11 @@ class DevParametersHttpRequestHandler(
     "t", // specific item targetting
     "0p19G", // Google AMP AB test parameter
     "dll", // Disable lazy loading of ads
-    "iasdebug" // IAS troubleshooting
+    "iasdebug", // IAS troubleshooting
+    "utm_source", // Google Analytics source
+    "utm_medium", // Google Analytics medium
+    "utm_campaign", // Google Analytics campaign
+    "utm_term" // Google Analytics term
   )
 
   val playBugs = Seq("") // (Play 2.5 bug?) request.queryString is returning an empty string when empty

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -40,6 +40,7 @@ import { breakingNewsInit } from 'common/modules/onward/breaking-news';
 import { initPinterest } from 'common/modules/social/pinterest';
 import { hiddenShareToggle } from 'common/modules/social/hidden-share-toggle';
 import { membershipEngagementBannerInit } from 'common/modules/commercial/membership-engagement-banner';
+import { optInEngagementBannerInit } from 'common/modules/identity/global/opt-in-engagement-banner';
 import { initEmail } from 'common/modules/email/email';
 import { init as initEmailArticle } from 'common/modules/email/email-article';
 import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
@@ -252,6 +253,12 @@ const membershipEngagementBanner = (): void => {
     }
 };
 
+const optInEngagementBanner = (): void => {
+    if (config.switches.idShowOptInEngagementBanner) {
+        optInEngagementBannerInit();
+    }
+};
+
 const initialiseEmail = (): void => {
     // Initalise email embedded in page
     initEmail();
@@ -317,6 +324,7 @@ const init = (): void => {
         ['c-pinterest', startPinterest],
         ['c-hidden-share-toggle', hiddenShareToggle],
         ['c-show-membership-engagement-banner', membershipEngagementBanner],
+        ['c-show-opt-in-engagement-banner', optInEngagementBanner],
         ['c-email', initialiseEmail],
         ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -1,0 +1,15 @@
+// @flow
+
+import { getUserFromApi } from 'common/modules/identity/api';
+import { Message } from 'common/modules/ui/message';
+
+const messageCode = 'optin-campaign-jan-18';
+
+export const optInEngagementBannerInit = (): void => {
+    getUserFromApi(user => {
+        console.log(user);
+        if(!user.statusFields.hasRepermissioned) {
+            new Message(messageCode).show('You have to update your email settings. Visit My Account to do this')
+        }
+    });
+}

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -3,13 +3,31 @@
 import { getUserFromApi } from 'common/modules/identity/api';
 import { Message } from 'common/modules/ui/message';
 
-const messageCode = 'optin-campaign-jan-18';
+const messageCode: string = 'optin-campaign-jan-18';
+const medium: string = new URL(window.location.href).searchParams.get(
+    'utm_medium'
+);
+
+type ApiUser = {
+    statusFields: {
+        hasRepermissioned: Boolean,
+    },
+};
+
+const shouldDisplayOptInBanner = (): Promise<void> =>
+    new Promise((accept, reject) => {
+        if (medium === null || medium.toLowerCase() !== 'email')
+            return reject();
+        getUserFromApi((user: ApiUser) => {
+            if (user === null || !user.statusFields.hasRepermissioned) accept();
+            else reject();
+        });
+    });
 
 export const optInEngagementBannerInit = (): void => {
-    getUserFromApi(user => {
-        console.log(user);
-        if(!user.statusFields.hasRepermissioned) {
-            new Message(messageCode).show('You have to update your email settings. Visit My Account to do this')
-        }
+    shouldDisplayOptInBanner().then(() => {
+        new Message(messageCode).show(
+            'You have to update your email settings. Visit My Account to do this'
+        );
     });
-}
+};


### PR DESCRIPTION
## What does this change?
Adds in a switch to show users who (A) come via email and (B.1) have not repermissioned or (B.2) are not logged in (set GDPR-compliant marketing consents) a banner prompting them to repermission. Final-er looking design and copy will come later on a separate PR.

I'm displaying some crude UI this early in to check for possible collisions with the support & cookie banners. I will probably flip this switch on in CODE asap

## What is the value of this and can you measure success?
Readyness for GDPR day

## Screenshots
![screen shot 2018-01-18 at 14 25 31](https://user-images.githubusercontent.com/11539094/35103670-73649bc0-fc5e-11e7-8530-c12da3bad3d3.png)
