### PR TITLE
Update grid on match previews

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1045,6 +1045,7 @@
                 grid-template-areas: 'labels headline' 'meta standfirst' 'meta main-media';
             }
 
+            .content--type-article.section-football &,
             .content--type-matchreport & {
                 grid-template-areas: 'labels headline-standfirst' '. report' 'meta main-media';
             }


### PR DESCRIPTION
Match previews sometimes contain the results table in the header, which currently break the layout.