### PR TITLE
removes unwanted bullets in video onward journey

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -557,6 +557,12 @@ $quote-mark: 35px;
         line-height: 75px;
     }
 
+    .element-atom--media {
+        .fc-item.fc-item--media::before {
+            content: none;
+        }
+    }
+
     // *************** Quote Styles ***************
     .element-pullquote {
         background-color: $garnett-neutral-3;


### PR DESCRIPTION
## What does this change?
removes unwanted bullets in video onward journey

Before:
<img width="622" alt="screen shot 2018-01-19 at 10 58 54" src="https://user-images.githubusercontent.com/8453924/35147790-cd2d34c4-fd07-11e7-866e-677383eff505.png">

After:
<img width="620" alt="screen shot 2018-01-19 at 10 58 24" src="https://user-images.githubusercontent.com/8453924/35147797-d2a990fa-fd07-11e7-92e1-be400ffb3860.png">
