### PR TITLE
styling for meta bios

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -248,6 +248,12 @@ $quote-mark: 35px;
         }
     }
 
+    .meta__bio {
+        border-top: 0;
+        padding-top: 0;
+        padding-bottom: $gs-baseline;
+    }
+
     .content__dateline {
         border: 0;
         min-height: 0;


### PR DESCRIPTION
## What does this change?
spacing fixes for meta bios (not very commonly shown on the site)

before:
<img width="243" alt="screen shot 2018-01-19 at 11 18 15" src="https://user-images.githubusercontent.com/8453924/35148548-845a995a-fd0a-11e7-9f14-5d404803061a.png">

after:
<img width="236" alt="screen shot 2018-01-19 at 11 18 06" src="https://user-images.githubusercontent.com/8453924/35148556-895d7e90-fd0a-11e7-85b6-00f0499a599a.png">


