### PR TITLE
[minor] wrap article.js in robust

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/article.js
+++ b/static/src/javascripts/bootstraps/enhanced/article.js
@@ -3,6 +3,7 @@
 import config from 'lib/config';
 import qwery from 'qwery';
 import $ from 'lib/$';
+import { catchErrorsWithContext } from 'lib/robust';
 import { isBreakpoint } from 'lib/detect';
 import mediator from 'lib/mediator';
 import { getUrlVars } from 'lib/url';
@@ -51,21 +52,27 @@ const modules = {
         // This event is for older-style quizzes implemented as interactives. See https://github.com/guardian/quiz-builder
         mediator.on('quiz/ophan-event', ophan.record);
     },
+
+    emitReadyEvent() {
+        mediator.emit('page:article:ready');
+    },
 };
 
 const init = () => {
-    initTrails();
-    initLiveblogCommon();
-    modules.initRightHandComponent();
-    modules.initCmpParam();
-    modules.initQuizListeners();
-    upgradeRichLinks();
-    insertTagRichLink();
-    upgradeMembershipEvents();
-    mediator.emit('page:article:ready');
-    handleQuizCompletion();
-    initStoryQuestions();
-    initAtoms();
+    catchErrorsWithContext([
+        ['article-trails', initTrails],
+        ['article-liveblog-common', initLiveblogCommon],
+        ['article-righthand-component', modules.initRightHandComponent],
+        ['article-cmp-param', modules.initCmpParam],
+        ['article-quiz-listeners', modules.initQuizListeners],
+        ['article-rich-links', upgradeRichLinks],
+        ['article-tag-rich-link', insertTagRichLink],
+        ['article-upgrade-membership-events', upgradeMembershipEvents],
+        ['article-mediator-emit-event', modules.emitReadyEvent],
+        ['article-handle-quiz-completion', handleQuizCompletion],
+        ['article-init-story-questions', initStoryQuestions],
+        ['article-init-atoms', initAtoms],
+    ]);
 };
 
 export { init };


### PR DESCRIPTION
## What does this change?
Wraps the loader in `article.js` inside a `catchErrorsWithContext` call to make sure a rogue script can't break everything under it.

## What is the value of this and can you measure success?
Happier codebase, but also i'm gonna add to `article.js` in a bit (move #18941 there) and I don't want it to be able to take the rest of the article JS down.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
Yes but shouldn't be user-facing

## Screenshots
It's yellow instead of red!
![screen shot 2018-01-19 at 11 19 27](https://user-images.githubusercontent.com/11539094/35148698-1c57d452-fd0b-11e7-8632-9a427528bb44.png)
