### PR TITLE
light orange background now runs to the bottom of container

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -823,7 +823,7 @@ $quote-mark: 35px;
 .content--type-comment {
     .content__main {
         background-color: $opinion-garnett-background;
-        padding-bottom: 1px;
+        padding-bottom: $gs-baseline/2;
 
         .rich-link {
             background-color: $garnett-neutral-5;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -829,6 +829,19 @@ $quote-mark: 35px;
             background-color: $garnett-neutral-5;
         }
 
+        .social--top {
+            background-color: $opinion-garnett-background;
+        }
+
+        .social__item {
+            @include mq(tablet) {
+                padding-bottom: 0;
+            }
+            @include mq(leftCol) {
+                padding-bottom: $gs-baseline/2;
+            }
+        }
+
         .element-pullquote,
         .element-pullquote:after
         {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -823,7 +823,7 @@ $quote-mark: 35px;
 .content--type-comment {
     .content__main {
         background-color: $opinion-garnett-background;
-        height: 100%;
+        padding-bottom: 1px;
 
         .rich-link {
             background-color: $garnett-neutral-5;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -823,6 +823,7 @@ $quote-mark: 35px;
 .content--type-comment {
     .content__main {
         background-color: $opinion-garnett-background;
+        height: 100%;
 
         .rich-link {
             background-color: $garnett-neutral-5;


### PR DESCRIPTION
## What does this change?
Light orange background now runs to the bottom of container on mobile.

Also fixed top social icons to have the light orange background and some padding cleanup for tablet


before:
<img width="321" alt="screen shot 2018-01-19 at 11 24 57" src="https://user-images.githubusercontent.com/8453924/35148997-6a580978-fd0c-11e7-8bd4-62b3e20b82e6.png">
<img width="645" alt="screen shot 2018-01-19 at 11 43 59" src="https://user-images.githubusercontent.com/8453924/35149469-1685ad62-fd0e-11e7-805f-0be420f63be4.png">


after (hard to make out):
<img width="322" alt="screen shot 2018-01-19 at 11 24 39" src="https://user-images.githubusercontent.com/8453924/35149013-70086dea-fd0c-11e7-8f4b-28b3028fafe3.png">
<img width="651" alt="screen shot 2018-01-19 at 11 43 42" src="https://user-images.githubusercontent.com/8453924/35149475-1adf9bd4-fd0e-11e7-931e-375a2339a891.png">
