### PR TITLE
Prefer the better-supported insertBefore vs insertAdjacentElement.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
@@ -49,7 +49,7 @@ const insertSlot = (paras: Element[]): Promise<void> => {
     const slot = createSlot('carrot');
     return fastdom
         .write(() => {
-            if (paras[0].parentNode) {
+            if (paras[0] && paras[0].parentNode) {
                 paras[0].parentNode.insertBefore(slot, paras[0]);
             }
         })

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
@@ -48,7 +48,11 @@ const rules = {
 const insertSlot = (paras: Element[]): Promise<void> => {
     const slot = createSlot('carrot');
     return fastdom
-        .write(() => paras[0].insertAdjacentElement('beforebegin', slot))
+        .write(() => {
+            if (paras[0].parentNode) {
+                paras[0].parentNode.insertBefore(slot, paras[0]);
+            }
+        })
         .then(() => addSlot(slot, true));
 };
 


### PR DESCRIPTION
Firefox versions < 48 don't implement `insertAdjacentElement`, so here we now prefer `insertBefore` which is supported since browsers could render colour. 