### PR TITLE
Pillar colour in CTA hover

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -11,7 +11,7 @@
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> NewDesktopNavigation.isSwitchedOn,
             "new-header--slim" -> page.metadata.hasSlimHeader
-        ), s"new-header--${page.metadata.pillar.nameOrDefault}", "new-header")"
+        ), s"pillar-scheme--${navMenu.currentPillar.map(_.title).getOrElse("")}", "new-header")"
         role="banner">
 
         <nav class="new-header__inner gs-container"

--- a/static/src/stylesheets/layout/garnett-header/_colours.scss
+++ b/static/src/stylesheets/layout/garnett-header/_colours.scss
@@ -28,23 +28,23 @@
     }
 }
 
-.new-header--news {
+.pillar-scheme--News {
     @include PillarColourOne($news-garnett-main-1);
 }
 
-.new-header--opinion {
+.pillar-scheme--Opinion {
     @include PillarColourOne($opinion-garnett-main-1);
 }
 
-.new-header--sport {
+.pillar-scheme--Sport {
     @include PillarColourOne($sport-garnett-main-1);
 }
 
-.new-header--arts {
+.pillar-scheme--Culture {
     @include PillarColourOne($culture-garnett-main-1);
 }
 
-.new-header--lifestyle {
+.pillar-scheme--Lifestyle {
     @include PillarColourOne($lifestyle-garnett-main-1);
 }
 


### PR DESCRIPTION
I've restored the previous pillar logic to the cta hover. Now the hover colour is the pillar you are in.

I've also renamed the class to something more generic so it can be reused in the footer in a future PR.



