### PR TITLE
Footer to point to the new help front

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -121,7 +121,7 @@
                             <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
                                 contact us</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                            <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
                                 ask for help</a>
                             </li>
                         </ul>
@@ -203,7 +203,7 @@
 
 
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                            <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
                                 ask for help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
@@ -297,7 +297,7 @@
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
                                 securedrop</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                            <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
                                 ask for help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
@@ -338,7 +338,7 @@
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
                                 securedrop</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                            <li class="colophon__item"><a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/help}">
                                 ask for help</a>
                             </li>
                         </ul>


### PR DESCRIPTION
## What does this change?

The footer should no longer go directly to the tech feedback form, but instead to the new help front.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
