### PR TITLE
Improve click reporting for identity pages

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -303,7 +303,7 @@
             <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
             <button
                 type="button"
-                data-link-name="consents : navigation : next"
+                data-link-name-template="consents : navigation : next : [depth]"
                 class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next"
             >
                 <div class="manage-account__button-flexwrap">

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -22,7 +22,7 @@
     )
 }
 
-<label class="@views.support.RenderClasses(classes)" data-originally-checked="@field.value">
+<label class="@views.support.RenderClasses(classes)" data-originally-checked="@field.value" data-link-name-template="mma switch : @title : [action]">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -126,6 +126,15 @@ const hideLoading = (loadingEl: HTMLElement): Promise<void> =>
 const bindNextButton = (buttonEl: HTMLElement): void => {
     const wizardEl: ?Element = buttonEl.closest('.identity-wizard--consent');
     if (wizardEl && wizardEl instanceof HTMLElement) {
+        window.addEventListener(wizardPageChangedEv, ev => {
+            if (ev.target === wizardEl) {
+                buttonEl.dataset.linkName = buttonEl.dataset.linkNameTemplate.replace(
+                    '[depth]',
+                    `${ev.detail.positionName} : step #${ev.detail.position}`
+                );
+            }
+        });
+
         buttonEl.addEventListener('click', (ev: Event) => {
             ev.preventDefault();
             getWizardInfoObject(wizardEl).then(wizardInfo =>

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.js
@@ -14,9 +14,24 @@ const checkboxShouldUpdate = (
     return false;
 };
 
+const updateDataLink = (labelEl: HTMLElement, checked): Promise<any> =>
+    fastdom.write(() => {
+        labelEl.dataset.linkName = labelEl.dataset.linkNameTemplate.replace(
+            '[action]',
+            checked ? 'untick' : 'tick'
+        );
+    });
+
 export const getInfo = (labelEl: HTMLElement): Promise<any> =>
     fastdom
         .read((): ?HTMLElement => labelEl.querySelector('input'))
+        .then((checkboxEl: HTMLInputElement) => {
+            labelEl.addEventListener('change', () => {
+                updateDataLink(labelEl, checkboxEl.checked);
+            });
+            updateDataLink(labelEl, checkboxEl.checked);
+            return checkboxEl;
+        })
         .then((checkboxEl: HTMLInputElement) => ({
             checked: checkboxEl.checked,
             name: checkboxEl.name,


### PR DESCRIPTION
## What does this change?
Send analytics events on checkbox clicks (there's no events at the moment) and report the depth the next button gets clicked at in `/consents`.

This will help us know how many email subs we get per page, as well as better understand if/when dropouts in `/consents` happen