### PR TITLE
Give Commercial baseline control bucket correct Prebid config

### DIFF
--- a/static/src/javascripts/projects/commercial-control/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial-control/modules/prebid/bidder-config.js
@@ -1,12 +1,42 @@
 // @flow
 
 import config from 'lib/config';
+import { getBreakpoint } from 'lib/detect';
+import {
+    buildAppNexusTargeting,
+    buildPageTargeting,
+} from 'common/modules/commercial/build-page-targeting';
 import type {
-    PrebidBidderCriteria,
     PrebidBidder,
+    PrebidBidderCriteria,
     PrebidIndexExchangeParams,
     PrebidSonobiParams,
 } from 'commercial-control/modules/prebid/types';
+
+const getBreakpointKey = (): string => {
+    switch (getBreakpoint()) {
+        case 'mobile':
+        case 'mobileMedium':
+        case 'mobileLandscape':
+        case 'phablet':
+            return 'M';
+        case 'tablet':
+            return 'T';
+        case 'desktop':
+        case 'leftCol':
+        case 'wide':
+            return 'D';
+        default:
+            return 'D';
+    }
+};
+
+const getIndexSiteId = (): string => {
+    const site = config.page.pbIndexSites.find(
+        s => s.bp === getBreakpointKey()
+    );
+    return site ? site.id : '';
+};
 
 export const bidderConfig: PrebidBidderCriteria = {
     sonobi: [
@@ -45,13 +75,14 @@ export const sonobiBidder: PrebidBidder = {
         ad_unit: config.page.adUnit,
         dom_id: slotId,
         floor: 0.5,
+        appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
     }),
 };
 
 export const indexExchangeBidder: PrebidBidder = {
     name: 'indexExchange',
     bidParams: (): PrebidIndexExchangeParams => ({
-        id: config.page.adUnit,
-        siteID: '208206',
+        id: '185406',
+        siteID: getIndexSiteId(),
     }),
 };


### PR DESCRIPTION
Prebid config should initially be the same in all the Commercial baseline variants while we're establishing parity with the Morpheus config. 