### PR TITLE
Remove non-garnett markup from content cards

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -7,14 +7,7 @@
 
 @icon = {
     @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon") }
-    @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-        @if(header.isVideo) { @fragments.inlineSvg("video-icon", "icon") }
-        @if(header.isGallery) { @fragments.inlineSvg("camera", "icon") }
-        @if(header.isAudio) { @fragments.inlineSvg("volume-high", "icon") }
-        @if(header.quoted) { @fragments.inlineSvg("quote", "icon") }
-    } else {
-        @if(header.quoted) { @fragments.inlineSvg("garnett-quote", "icon") }
-    }
+    @if(header.quoted) { @fragments.inlineSvg("garnett-quote", "icon") }
 }
 
 @headline() = {
@@ -25,7 +18,7 @@
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @header.kicker match {
-        case Some(kicker) if snapType != Some(FrontendLatestSnap) || experiments.ActiveExperiments.isParticipating(experiments.Garnett) => {
+        case Some(kicker) => {
             @articleLink{<span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span> @headline()}
         }
         case _ => {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -85,11 +85,6 @@ data-test-id="facia-card"
 
 @container(item: layout.ContentCard) = {
     <div class="fc-item__container">
-
-        @if(item.snapStuff.map(_.snapType).contains(FrontendLatestSnap) && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-            @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
-        }
-
         @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, endSlatePath, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
@@ -198,9 +193,6 @@ data-test-id="facia-card"
         }
 
         <div class="fc-item__content @if(item.starRating.isDefined){fc-item__content--has-stars}">
-            @if(item.snapStuff.map(_.snapType) == Some(FrontendLatestSnap) && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-                @kicker(item.header, List("fc-item__kicker--dreamsnap"))
-            }
             <div class="@RenderClasses(Map(
                 ("fc-item__header", true),
                 ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -150,35 +150,25 @@ data-test-id="facia-card"
             }
 
             case Some(InlineVideo(_, _, _, Some(fallbackImage))) => {
-                @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-                    <div class="fc-item__media-wrapper">
-                        @itemImage(
-                            fallbackImage.imageMedia,
-                            inlineImage = containerIndex == 0 && index < 4,
-                            widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
-                        )
-                    </div>
-                } else {
+                <div class="fc-item__media-wrapper">
                     @itemImage(
                         fallbackImage.imageMedia,
                         inlineImage = containerIndex == 0 && index < 4,
                         widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
                     )
-                }
+                </div>
             }
 
             case Some(InlineImage(images)) => {
                 <div class="fc-item__media-wrapper">
-                @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
                     @item.starRating.map { rating =>
                         @starRating(rating)
                     }
-                }
-                @itemImage(
-                    images,
-                    inlineImage = containerIndex == 0 && index < 4,
-                    widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
-                )
+                    @itemImage(
+                        images,
+                        inlineImage = containerIndex == 0 && index < 4,
+                        widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
+                    )
                 </div>
             }
 
@@ -225,74 +215,51 @@ data-test-id="facia-card"
                 }
             </div>
 
-            @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-                @if(item.isMediaLink) {
+            @if(item.isMediaLink) {
+                @standfirst(item)
+            } else {
+                <div class="@RenderClasses(Map(
+                    ("fc-item__standfirst-wrapper", true),
+                    ("fc-item__standfirst-wrapper--timestamp", !item.timeStampDisplay.isEmpty)
+                ))">
                     @standfirst(item)
-                } else {
-                    <div class="@RenderClasses(Map(
-                        ("fc-item__standfirst-wrapper", true),
-                        ("fc-item__standfirst-wrapper--timestamp", !item.timeStampDisplay.isEmpty)
-                    ))">
-                        @standfirst(item)
-                        @meta(item)
+                    @meta(item)
+                </div>
+                @if(item.cardTypes.showCutOut) {
+                    @item.cutOut.map { case cutOut@CutOut(imageUrl, _) =>
+                    <div class="fc-item__avatar">
+                        @image(
+                            classes = Seq("fc-item__avatar__media", cutOut.cssClass),
+                            widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
+                            maybePath = Some(imageUrl)
+                        )
                     </div>
-                    @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardTypes.showCutOut) {
-                        @item.cutOut.map { case cutOut@CutOut(imageUrl, _) =>
-                        <div class="fc-item__avatar">
-                            @image(
-                                classes = Seq("fc-item__avatar__media", cutOut.cssClass),
-                                widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
-                                maybePath = Some(imageUrl)
-                            )
-                        </div>
-                        }
                     }
                 }
-            } else {
-                @standfirst(item)
             }
 
             @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
                 <div class="js-liveblog-blocks fc-item__liveblog-blocks" data-article-id="@item.id"></div>
             }
-            @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
-                @if(item.isMediaLink) {
-                    <div class="fc-item__footer-meta-wrapper">
-                        @mediaMeta(item)
-                        @if(item.sublinks.nonEmpty) {
-                            <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
-                        }
-                    </div>
-                } else {
+            @if(item.isMediaLink) {
+                <div class="fc-item__footer-meta-wrapper">
+                    @mediaMeta(item)
                     @if(item.sublinks.nonEmpty) {
                         <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
                     }
-                }
+                </div>
             } else {
                 @if(item.sublinks.nonEmpty) {
                     <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
                 }
-                @meta(item)
             }
         </div>
-
-        @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardTypes.showCutOut) {
-            @item.cutOut.map { case cutOut@CutOut(imageUrl, _) =>
-            <div class="fc-item__avatar">
-                @image(
-                    classes = Seq("fc-item__avatar__media", cutOut.cssClass),
-                    widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
-                    maybePath = Some(imageUrl)
-                )
-            </div>
-            }
-        }
 
         @if(item.sublinks.nonEmpty) {
             <footer class="fc-item__footer--horizontal">@sublinks(item.sublinks)</footer>
         }
 
-        @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.designType.nameOrDefault == "comment") {
+        @if(item.designType.nameOrDefault == "comment") {
             @meta(item)
         }
 


### PR DESCRIPTION
## What does this change?

Removes non-Garnett markup of Facia cards.

## What is the value of this and can you measure success?

Fewer code branches, less complexity 
