### PR TITLE
Garnett fix: Fix Content Header on Firefox 53 and below

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -92,14 +92,14 @@
         return getCookieValue('gu_paying_member') === 'true';
     }
 
-    function supportsPercentagePadding() {
+    function forcePercentagePadding() {
         var firefoxMatch = navigator.userAgent.match(/Firefox\/([0-9]+)\./) || [];
 
         if (firefoxMatch.length === 2 && parseInt(firefoxMatch[1], 10) < 54) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     // http://modernizr.com/download/#-svg
@@ -148,13 +148,14 @@
         docClass += ' is-recent-contributor';
     }
 
-    /**
+    /**     
      * % used for padding-bottom isn't supported on Grid items in FireFox <53.
-     * This temporary fix sets media in articles to 5:3 aspect ratio.
+     * unless explicit width set on item with padding-bottom.
+     * this sets width of responsive media explicitly so padding-bottom works
      * https://bugzilla.mozilla.org/show_bug.cgi?id=958714
     **/
-    if(!supportsPercentagePadding()) {
-        docClass += ' fake-percentage-padding';
+    if(forcePercentagePadding()) {
+        docClass += ' force-percentage-padding';
     }
 
     documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -148,12 +148,11 @@
         docClass += ' is-recent-contributor';
     }
 
-    /**     
-     * % used for padding-bottom isn't supported on Grid items in FireFox <53.
-     * unless explicit width set on item with padding-bottom.
-     * this sets width of responsive media explicitly so padding-bottom works
-     * https://bugzilla.mozilla.org/show_bug.cgi?id=958714
-    **/
+    // % used for padding-bottom isn't supported on Grid items in FireFox <53
+    // unless explicit width is set on the element with padding-bottom.
+    // .force-percentage-padding ensures width is explicitly set so padding-bottom 
+    // works on responsive-ratio media.
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
     if(forcePercentagePadding()) {
         docClass += ' force-percentage-padding';
     }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -99,7 +99,6 @@
             @include mq(leftCol) {
                 min-width: gs-span(8);
             }
-    
             @include mq(tablet, desktop) {
                 min-width: gs-span(9);
             }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -48,6 +48,7 @@
         }
     }
 
+    
     @include mq(desktop) {
         margin-left: 0;
         margin-right: $right-column + $gs-gutter;
@@ -88,16 +89,19 @@
 }
 
 // % used for padding-bottom isn't supported on Grid items in FireFox <53.
-// This temporary fix sets media in articles to 5:3 aspect ratio.
+// unless explicit width set on item with padding-bottom.
+// this sets width of responsive media explicitly so padding-bottom works
 // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
-.fake-percentage-padding {
-    .content__main-column .media-primary .u-responsive-ratio {
-        @include mq(leftCol) {
-            padding-bottom: 0 !important;
-            min-height: gs-span(8) * .6;
-        }
-        @include mq(tablet, desktop) {
-            min-height: gs-span(9) * .6;
+.force-percentage-padding {
+    .content__main-column .content__head--article .media-primary .u-responsive-ratio {
+        @supports (display: grid) {
+            @include mq(leftCol) {
+                min-width: gs-span(8);
+            }
+    
+            @include mq(tablet, desktop) {
+                min-width: gs-span(9);
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -88,9 +88,10 @@
     }
 }
 
-// % used for padding-bottom isn't supported on Grid items in FireFox <53.
-// unless explicit width set on item with padding-bottom.
-// this sets width of responsive media explicitly so padding-bottom works
+// % used for padding-bottom isn't supported on Grid items in FireFox <53
+// unless explicit width is set on the element with padding-bottom.
+// .force-percentage-padding ensures width is explicitly set so padding-bottom 
+// works on responsive-ratio media.
 // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
 .force-percentage-padding {
     .content__main-column .content__head--article .media-primary .u-responsive-ratio {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -48,7 +48,6 @@
         }
     }
 
-    
     @include mq(desktop) {
         margin-left: 0;
         margin-right: $right-column + $gs-gutter;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -96,10 +96,10 @@
     .content__main-column .content__head--article .media-primary .u-responsive-ratio {
         @supports (display: grid) {
             @include mq(leftCol) {
-                min-width: gs-span(8);
+                width: gs-span(8);
             }
             @include mq(tablet, desktop) {
-                min-width: gs-span(9);
+                width: gs-span(9);
             }
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -96,10 +96,10 @@
     .content__main-column .content__head--article .media-primary .u-responsive-ratio {
         @supports (display: grid) {
             @include mq(leftCol) {
-                width: gs-span(8);
+                min-width: gs-span(8);
             }
             @include mq(tablet, desktop) {
-                width: gs-span(9);
+                min-width: gs-span(9);
             }
         }
     }


### PR DESCRIPTION
## What does this change?

This is an improvement on the fix merged in here: https://github.com/guardian/frontend/pull/18892

It addresses the same issue, but now accommodates varying aspect-ratios of main media rather than 5:3 alone.

On Firefox 53 and below `.force-percentage-padding` will be added to the `html` element.

If `.force-percentage-padding` is applied then we explicitly set the width of `.u-responsive-ratio` to be equal to the width of `.content__main-column`. Doing this ensures that the `padding-botton` applied to `.u-responsive-ratio` works as expected.

## What is the value of this and can you measure success?

Users on firefox 53 and below can see all the body content and media at the correct aspect ratio.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

**Before...**

Current fix forces height of image container to be 5:3 using width of central (copy) column as the 5 value...

![picture 126](https://user-images.githubusercontent.com/1590704/35290349-e3e720b4-0061-11e8-8ff1-a7b75905f665.png)

**After...**

New fix allows true aspect ratio of image...

![picture 125](https://user-images.githubusercontent.com/1590704/35290356-e82fc270-0061-11e8-8f9e-172e592472d5.png)

## Tested in CODE?

No
