### PR TITLE
Cloudwatch metric for gross capi request counts

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -70,6 +70,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.ContentApiErrorMetric,
+    ContentApiMetrics.ContentApiRequestsMetric,
     EmailSubsciptionMetrics.EmailSubmission,
     EmailSubsciptionMetrics.EmailFormError,
     EmailSubsciptionMetrics.NotAccepted,

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -122,9 +122,15 @@ object ContentApiMetrics {
   )
 
   val ContentApi404Metric = CountMetric(
+    "content-api-requests",
+    "Number of times the Content API has been called"
+  )
+
+  val ContentApiRequestsMetric = CountMetric(
     "content-api-404",
     "Number of times the Content API has responded with a 404"
   )
+
 }
 
 object FaciaPressMetrics {

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -3,7 +3,7 @@ package contentapi
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
-import common.ContentApiMetrics.{ContentApi404Metric, ContentApiErrorMetric}
+import common.ContentApiMetrics.{ContentApi404Metric, ContentApiErrorMetric, ContentApiRequestsMetric}
 import common.{ContentApiMetrics, Logging}
 import conf.Configuration
 import conf.Configuration.contentApi.previewAuth
@@ -36,6 +36,9 @@ class CapiHttpClient(wsClient: WSClient)(implicit executionContext: ExecutionCon
     val response = request.withHttpHeaders(headers.toSeq: _*).withRequestTimeout(contentApiTimeout).get()
 
     // record metrics
+
+    response.foreach((f)=>{ ContentApiRequestsMetric.increment() })
+
     response.foreach {
       case r if r.status == 404 => ContentApi404Metric.increment()
       case r if r.status == 200 => ContentApiMetrics.HttpLatencyTimingMetric.recordDuration(currentTimeMillis - start)


### PR DESCRIPTION
## What does this change?

Adds a cloudwatch metric (used by applications at the moment) that logs the raw number of CAPI requests made.

## What is the value of this and can you measure success?

So we can actually see if the number of capi requests an app makes goes up, irrespective of the error rate.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
