### PR TITLE
[minor] fix tracking for Check all in /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -168,7 +168,7 @@
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul class="manage-account__switches-head">
                 <li>
-                    @selectAllCheckbox("marketing-consents")
+                    @selectAllCheckbox("email-repermission")
                 </li>
             </ul>
             <ul>


### PR DESCRIPTION
## What does this change?
Both [check all] checkboxes in `/consents` have the same event id. this fixes that