### PR TITLE
Move Minute to Garnett

### DIFF
--- a/article/app/pages/MinuteHtmlPage.scala
+++ b/article/app/pages/MinuteHtmlPage.scala
@@ -5,14 +5,14 @@ import html.HtmlPage
 import model.ApplicationContext
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
-import views.html.fragments.{immersiveHeader, minuteBody}
+import views.html.fragments.{immersiveGarnettHeader, minuteBody}
 
 object MinuteHtmlPage extends HtmlPage[MinutePage] {
 
     def html(page: MinutePage)(implicit request: RequestHeader, applicationContext: ApplicationContext): Html = {
       implicit val p: MinutePage = page
       StoryHtmlPage.html(
-        header = immersiveHeader(),
+        header = immersiveGarnettHeader(),
         content = minuteBody(page)
       )
     }

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -75,5 +75,63 @@
         @if(isTheMinuteArticle) {
             <div class="content--minute-article--overlay"></div>
         }
+        <div class="@RenderClasses(Map(
+            "immersive-main-media__headline-container--dark" -> (!isTheMinuteArticle && hasMainMedia),
+            "immersive-main-media__headline-container" -> hasMainMedia
+        ))
+        ">
+            <div class="gs-container">
+                @if(!isTheMinuteArticle) {
+                    <div class="content__main-column">
+                        @fragments.meta.metaInline(page.item)
+                    }
+
+            <h1 class="@RenderClasses(Map(
+                "content__headline--minute" -> isTheMinuteArticle,
+                "content__headline--immersive--with-main-media" -> hasMainMedia,
+                "content__headline--advertisement" -> isPaidContent
+            ), "content__headline", "content__headline--immersive", "content__headline--immersive-article")
+            ">
+                @if(isTheMinuteArticle) {
+                    @optSeries.map { series =>
+                    <a href="@LinkTo { /@series.id }" class="logo--minute-article">
+                        <span class="u-h">The Minute - </span>
+                        @fragments.inlineSvg("minute-logo", "logo")
+                    </a>
+                    }.getOrElse {
+                        <div class="logo--minute-article">
+                            <span class="u-h">The Minute - </span>
+                            @fragments.inlineSvg("minute-logo", "logo")
+                        </div>
+                    }
+                }
+                @Html(page.item.trail.headline)
+            </h1>
+
+                @if(isTheMinuteArticle) {
+
+                    @if(page.item.trail.shouldHidePublicationDate) {
+                        @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.fields.firstPublicationDate, page.item.tags.isLiveBlog, page.item.fields.isLive, isTheMinuteArticle)
+                    }
+
+                    @if(page.item.fields.standfirst.isDefined) {
+                        @fragments.standfirst(page.item)
+                    }
+                }
+
+                @if(!isTheMinuteArticle && page.item.fields.standfirst.isDefined) {
+                    <div class="hide-on-mobile">
+                    @fragments.standfirst(page.item)
+                    </div>
+                }
+
+                @if(!isTheMinuteArticle) { </div> }
+            </div>
+        </div>
     </div>
+    @if(page.item.fields.standfirst.isDefined && !isTheMinuteArticle) {
+        <div class="content__wrapper--standfirst mobile-only">
+            @fragments.standfirst(page.item)
+        </div>
+    }
 }

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -74,42 +74,30 @@
 
         @if(isTheMinuteArticle) {
             <div class="content--minute-article--overlay"></div>
-        }
-        <div class="@RenderClasses(Map(
-            "immersive-main-media__headline-container--dark" -> (!isTheMinuteArticle && hasMainMedia),
-            "immersive-main-media__headline-container" -> hasMainMedia
-        ))
-        ">
-            <div class="gs-container">
-                @if(!isTheMinuteArticle) {
-                    <div class="content__main-column">
-                        @fragments.meta.metaInline(page.item)
-                    }
-
-            <h1 class="@RenderClasses(Map(
-                "content__headline--minute" -> isTheMinuteArticle,
-                "content__headline--immersive--with-main-media" -> hasMainMedia,
-                "content__headline--advertisement" -> isPaidContent
-            ), "content__headline", "content__headline--immersive", "content__headline--immersive-article")
+            <div class="@RenderClasses(Map(
+                "immersive-main-media__headline-container" -> hasMainMedia
+            ))
             ">
-                @if(isTheMinuteArticle) {
-                    @optSeries.map { series =>
-                    <a href="@LinkTo { /@series.id }" class="logo--minute-article">
-                        <span class="u-h">The Minute - </span>
-                        @fragments.inlineSvg("minute-logo", "logo")
-                    </a>
-                    }.getOrElse {
-                        <div class="logo--minute-article">
+                <div class="gs-container">
+
+                    <h1 class="@RenderClasses(Map(
+                        "content__headline--immersive--with-main-media" -> hasMainMedia,
+                        "content__headline--advertisement" -> isPaidContent
+                    ), "content__headline", "content__headline--immersive", "content__headline--immersive-article", "content__headline--minute")
+                    ">
+                        @optSeries.map { series =>
+                        <a href="@LinkTo { /@series.id}" class="logo--minute-article">
                             <span class="u-h">The Minute - </span>
                             @fragments.inlineSvg("minute-logo", "logo")
-                        </div>
-                    }
-                }
-                @Html(page.item.trail.headline)
-            </h1>
-
-                @if(isTheMinuteArticle) {
-
+                        </a>
+                        }.getOrElse {
+                            <div class="logo--minute-article">
+                                <span class="u-h">The Minute - </span>
+                                @fragments.inlineSvg("minute-logo", "logo")
+                            </div>
+                        }
+                        @Html(page.item.trail.headline)
+                    </h1>
                     @if(page.item.trail.shouldHidePublicationDate) {
                         @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.fields.firstPublicationDate, page.item.tags.isLiveBlog, page.item.fields.isLive, isTheMinuteArticle)
                     }
@@ -117,21 +105,8 @@
                     @if(page.item.fields.standfirst.isDefined) {
                         @fragments.standfirst(page.item)
                     }
-                }
-
-                @if(!isTheMinuteArticle && page.item.fields.standfirst.isDefined) {
-                    <div class="hide-on-mobile">
-                    @fragments.standfirst(page.item)
-                    </div>
-                }
-
-                @if(!isTheMinuteArticle) { </div> }
+                </div>
             </div>
-        </div>
+        }
     </div>
-    @if(page.item.fields.standfirst.isDefined && !isTheMinuteArticle) {
-        <div class="content__wrapper--standfirst mobile-only">
-            @fragments.standfirst(page.item)
-        </div>
-    }
 }

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -72,9 +72,11 @@
             }
         </div>
 
+
         @if(isTheMinuteArticle) {
             <div class="content--minute-article--overlay"></div>
         }
+
         <div class="@RenderClasses(Map(
                 "immersive-main-media__headline-container--dark" -> (!isTheMinuteArticle && hasMainMedia),
                 "immersive-main-media__headline-container" -> hasMainMedia

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -72,11 +72,9 @@
             }
         </div>
 
-
         @if(isTheMinuteArticle) {
             <div class="content--minute-article--overlay"></div>
         }
-
         <div class="@RenderClasses(Map(
                 "immersive-main-media__headline-container--dark" -> (!isTheMinuteArticle && hasMainMedia),
                 "immersive-main-media__headline-container" -> hasMainMedia

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -466,7 +466,7 @@ $quote-mark: 35px;
         margin-right: 0;
     }
 
-    &:not(.content__headline--minute).content__headline {
+    .content__headline:not(.content__headline--minute) {
         @include fs-headlineGarnett(4);
         font-weight: 400; // magic number correcting line height so vertical alignment apprears even with labels
         padding-top: 3px;
@@ -524,7 +524,7 @@ $quote-mark: 35px;
         }
     }
 
-    &:not(.content__standfirst--immersive-minute-article).content__standfirst {
+    .content__standfirst:not(.content__standfirst--immersive-minute-article) {
         @include fs-bodyCopy(2);
         font-weight: 700;
         line-height: 20px;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -466,7 +466,7 @@ $quote-mark: 35px;
         margin-right: 0;
     }
 
-    .content__headline {
+    &:not(.content__headline--minute).content__headline {
         @include fs-headlineGarnett(4);
         font-weight: 400; // magic number correcting line height so vertical alignment apprears even with labels
         padding-top: 3px;
@@ -524,7 +524,7 @@ $quote-mark: 35px;
         }
     }
 
-    .content__standfirst {
+    &:not(.content__standfirst--immersive-minute-article).content__standfirst {
         @include fs-bodyCopy(2);
         font-weight: 700;
         line-height: 20px;


### PR DESCRIPTION
## What does this change?

Currently, Minute articles use the old `immersiveHeader` and hence old `immersiveMainMedia`.

This change moves Minute articles over to `immersiveGarnettHeader` and `immersiveGarnettMainMedia`. I have moved some of the markup across from `immersiveMainMedia` to support headline and standfirst styles. 

## What is the value of this and can you measure success?

One fewer use of the old `immersiveHeader` and `immersiveMainMedia`, almost ready to be deleted.

Fixes https://trello.com/c/nRRltj8d

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
