### PR TITLE
Update 404 errors on identity

### DIFF
--- a/identity/app/views/errors/error.scala.html
+++ b/identity/app/views/errors/error.scala.html
@@ -1,100 +1,91 @@
 @(code: String)
 
 <!DOCTYPE html>
-<!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
-<!--[if IE 7]>    <html class="lt-ie9 lt-ie8" lang="en"> <![endif]-->
-<!--[if IE 8]>    <html class="lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
-    <head>
-        <meta charset="utf-8" />
-        <title>@code | Guardian News &amp; Media</title>
-        <meta name="description" content="" />
-        <meta name="author" content="the Guardian" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <!-- Include core base and module styles -->
-        <link rel="stylesheet" type="text/css" href="https://pasteup.guim.co.uk/css/core.pasteup.min.css" />
-        <!-- Add layout styles for browsers over 30em or less than IE9, but not IE mobile or IE6. -->
-        <link rel="stylesheet" media="all and (min-width: 30em)" type="text/css" href="https://pasteup.guim.co.uk/css/layout.pasteup.min.css" />
-        <!--[if (lt IE 9) & (!IEMobile)]>
-            <link rel="stylesheet" type="text/css" href="https://pasteup.guim.co.uk/css/css/layout.pasteup.min.css" />
-        <![endif]-->
+<html lang="en">
+    <head lang="en" data-page-path="/uk">
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>@code | The Guardian</title>
+        <meta name="description" content="">
+        <meta name="format-detection" content="telephone=no"/>
+        <meta name="HandheldFriendly" content="True"/>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
         <style>
-            .u-unstyled {
-                list-style: none;
-            }
-            .u-unstyled  li {
-                display: block;
-                float:left;
-                width: 40%;
-                padding: 10px 2.5%;
-                margin: 0 2.5%;
-                border-bottom: 1px solid #F4F4EE;
-            }
-            .global-navigation a {
-                display: block; /* Expands touch area of links */
-            }
+            a,abbr,acronym,address,applet,article,aside,audio,b,big,blockquote,body,canvas,caption,center,cite,code,dd,del,details,dfn,div,dl,dt,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,header,hgroup,html,i,iframe,img,ins,kbd,label,legend,li,main,mark,menu,nav,object,ol,output,p,pre,q,ruby,s,samp,section,small,span,strike,strong,sub,summary,sup,table,tbody,td,tfoot,th,thead,time,tr,tt,u,ul,var,video{border:0;font:inherit;margin:0;padding:0;vertical-align:baseline}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section{display:block}body{line-height:1}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:after,blockquote:before,q:after,q:before{content:"";content:none}table{border-collapse:collapse;border-spacing:0}html{box-sizing:border-box}*,:after,:before{box-sizing:inherit}
         </style>
+        <style class="webfont" data-cache-name="GuardianEgyptianWeb"
+        data-cache-file-woff2="https://assets.guim.co.uk/fonts/a24c7bea5a91ee87d0868f0d587c6129/GuardianEgyptianWeb.woff2.json"
+        data-cache-file-hinted-cleartype-woff2="https://assets.guim.co.uk/fonts/fb32696c02620a1b503e233c1359e2f8/GuardianEgyptianWebCleartypeHinted.woff2.json"
+        data-cache-file-hinted-auto-woff2="https://assets.guim.co.uk/fonts/1513269d7c379805b57784bb334a331f/GuardianEgyptianWebAutoHinted.woff2.json"
+        data-cache-file-woff="https://assets.guim.co.uk/fonts/a551aab8b1ccfcfd32edd37a27fc1823/GuardianEgyptianWeb.woff.json"
+        data-cache-file-hinted-cleartype-woff="https://assets.guim.co.uk/fonts/f4ec7dfc5cc01960abe6bc0a42714ec9/GuardianEgyptianWebCleartypeHinted.woff.json"
+        data-cache-file-hinted-auto-woff="https://assets.guim.co.uk/fonts/c9dd78499c869cc0c77c91e6a4d8d0e5/GuardianEgyptianWebAutoHinted.woff.json"
+        data-cache-file-ttf="https://assets.guim.co.uk/fonts/a0e077ccafc42d20b07a3f234a06b576/GuardianEgyptianWeb.ttf.json"
+        data-cache-file-hinted-cleartype-ttf="https://assets.guim.co.uk/fonts/2738675136670257aaa1a48b6921c04f/GuardianEgyptianWebCleartypeHinted.ttf.json"
+        data-cache-file-hinted-auto-ttf="https://assets.guim.co.uk/fonts/1204ca5411e8d3fb8c0f9cb90400957c/GuardianEgyptianWebAutoHinted.ttf.json"></style>
+        <style class="webfont" data-cache-name="GuardianTextEgyptianWeb"
+        data-cache-file-woff2="https://assets.guim.co.uk/fonts/6346d1630192a48efa70115ac5489385/GuardianTextEgyptianWeb.woff2.json"
+        data-cache-file-hinted-cleartype-woff2="https://assets.guim.co.uk/fonts/8d3034bcc2dd6f8ba03a5496b6a3cddd/GuardianTextEgyptianWebCleartypeHinted.woff2.json"
+        data-cache-file-hinted-auto-woff2="https://assets.guim.co.uk/fonts/62213ae07a282d6c2136198a76894c6a/GuardianTextEgyptianWebAutoHinted.woff2.json"
+        data-cache-file-woff="https://assets.guim.co.uk/fonts/01646f0b7c1d3d901953fdc1f1b21656/GuardianTextEgyptianWeb.woff.json"
+        data-cache-file-hinted-cleartype-woff="https://assets.guim.co.uk/fonts/32e8c8ddc07777cbd710b6fa15f27b4c/GuardianTextEgyptianWebCleartypeHinted.woff.json"
+        data-cache-file-hinted-auto-woff="https://assets.guim.co.uk/fonts/54fda71fc837d03fc120e3788f4f7a29/GuardianTextEgyptianWebAutoHinted.woff.json"
+        data-cache-file-ttf="https://assets.guim.co.uk/fonts/92a4950d56b8777c064cb600ac6b4b6d/GuardianTextEgyptianWeb.ttf.json"
+        data-cache-file-hinted-cleartype-ttf="https://assets.guim.co.uk/fonts/ec8c18e20d0903e22bbe6362dc4bbcaf/GuardianTextEgyptianWebCleartypeHinted.ttf.json"
+        data-cache-file-hinted-auto-ttf="https://assets.guim.co.uk/fonts/1833d0aae865199889b87d2cf67162cd/GuardianTextEgyptianWebAutoHinted.ttf.json"></style>
+        <style class="webfont" data-cache-name="GuardianTextSansWeb"
+        data-cache-file-woff2="https://assets.guim.co.uk/fonts/e98740f460023b3b3b3137589c40db35/GuardianTextSansWeb.woff2.json"
+        data-cache-file-hinted-cleartype-woff2="https://assets.guim.co.uk/fonts/31443178085917965e0fd5b89ecff788/GuardianTextSansWebCleartypeHinted.woff2.json"
+        data-cache-file-hinted-auto-woff2="https://assets.guim.co.uk/fonts/1e08730fbd3200a61dfa77d9e6d645b6/GuardianTextSansWebAutoHinted.woff2.json"
+        data-cache-file-woff="https://assets.guim.co.uk/fonts/68a6b1dc3e7af0aa14a2a0ba3839eea3/GuardianTextSansWeb.woff.json"
+        data-cache-file-hinted-cleartype-woff="https://assets.guim.co.uk/fonts/997e56e52c9d9f28ab60a9786694af4b/GuardianTextSansWebCleartypeHinted.woff.json"
+        data-cache-file-hinted-auto-woff="https://assets.guim.co.uk/fonts/73e92258e322d31f85cea2ffbf02cbb0/GuardianTextSansWebAutoHinted.woff.json"
+        data-cache-file-ttf="https://assets.guim.co.uk/fonts/71a960886bc7e0d7d7c9b3483b347ab0/GuardianTextSansWeb.ttf.json"
+        data-cache-file-hinted-cleartype-ttf="https://assets.guim.co.uk/fonts/1ec1f70d7bd618abc7ad43fd7e22d7f2/GuardianTextSansWebCleartypeHinted.ttf.json"
+        data-cache-file-hinted-auto-ttf="https://assets.guim.co.uk/fonts/3a59896fe9b9cee9b2f5d3b7a086d481/GuardianTextSansWebAutoHinted.ttf.json"></style>
+        <style>
+            .css-9c6blz{background-color:#fff;color:#333;font-family:"Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;-webkit-font-feature-settings:kern;font-feature-settings:kern;-webkit-font-kerning:normal;font-kerning:normal;line-height:1.5;text-rendering:optimizeLegibility;}.css-17t49mt{display:block;height:auto;width:100%;}.css-1pusbiz{border:0px;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0px;position:absolute;width:1px;}.css-1rc3z3n{display:block;margin:6px 0 36px auto;max-width:295px;width:55%;position:relative;z-index:1;}@@media (min-width: 46.25em){.css-1rc3z3n{width:295px;}}@@media (min-width: 61.25em){.css-1rc3z3n{margin-bottom:-94px;}}.css-fsw9jh{display:block;height:80%;max-width:350px;width:100%;}@@media (min-width: 46.25em){.css-fsw9jh{height:auto;max-width:100%;width:350px;}}@@media (min-width: 61.25em){.css-fsw9jh{width:378px;}}@@media (min-width: 71.25em){.css-fsw9jh{width:567px;}}.css-1pmqqor{color:var(--colour-garnett-neutral-1);font-family:"Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;font-size:28px;font-weight:200;line-height:1.15;margin-bottom:12px;max-width:540px;}@@media (min-width: 46.25em){.css-1pmqqor{font-size:42px;}}.css-1hw4e4y{border-bottom:2px solid #aabfc7;color:var(--colour-garnett-neutral-1);padding-bottom:3px;text-decoration:none;-webkit-transition:border-color .3s;transition:border-color .3s;}.css-1hw4e4y:hover{border-color:var(--colour-garnett-neutral-1);}.css-7c37t2{color:var(--colour-garnett-neutral-1);font-family:"Guardian Text Egyptian Web", Georgia, serif;font-size:15px;margin-bottom:24px;max-width:220px;}@@media (min-width: 46.25em){.css-7c37t2{font-size:18px;max-width:300px;}}@@media (min-width: 46.25em){.css-11dwdsg{margin-left:160px;}}@@media (min-width: 61.25em){.css-11dwdsg{margin-left:320px;}}@@media (min-width: 71.25em){.css-11dwdsg{margin-left:480px;}}.css-1ezq6pu{-webkit-box-sizing:border-box;box-sizing:border-box;margin:0 auto;padding:0 10px 24px;position:relative;}@@media (min-width: 46.25em){.css-1ezq6pu{padding:0 20px;width:740px;}}@@media (min-width: 61.25em){.css-1ezq6pu{width:980px;}}@@media (min-width: 71.25em){.css-1ezq6pu{width:1140px;}}@@media (min-width: 81.25em){.css-1ezq6pu{width:1300px;}}.css-10oc3or{display:none;}.css-9b24cv:before{content:'';background:#e7edef;position:fixed;top:0px;right:0px;bottom:0px;left:0px;z-index:-1;}.css-7i3bfb{fill:currentColor;height:40px;position:absolute;right:5px;top:50%;-webkit-transform:translate(0, -50%);transform:translate(0, -50%);-webkit-transition:-webkit-transform .3s;transition:-webkit-transform .3s; transition: transform .3s; transition: transform .3s, -webkit-transform .3s;width:40px;}.css-722269{background-color:#ffe500;border-radius:9999px;-webkit-box-sizing:border-box;box-sizing:border-box;color:#121212;display:inline-block;font-family:"Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;font-size:16px;line-height:42px;padding:0 45px 0 20px;position:relative;text-decoration:none;-webkit-transition:background-color .3s;transition:background-color .3s;}.css-722269:hover{background-color:#edd600;}.css-722269:hover > svg{-webkit-transform:translate(5px, -50%);transform:translate(5px, -50%);}
+        </style>
+        <script>
+        window.guardian={"config":{"bundleUrl":"","polyfillioUrl":"https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill","beaconUrl":"//beacon.gu-web.net","fontDefinitions":[{"typeFace":"GuardianEgyptianWeb","fileTypes":[{"fileType":"woff2","endpoint":"https://assets.guim.co.uk/fonts/a24c7bea5a91ee87d0868f0d587c6129/GuardianEgyptianWeb.woff2.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/fb32696c02620a1b503e233c1359e2f8/GuardianEgyptianWebCleartypeHinted.woff2.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/1513269d7c379805b57784bb334a331f/GuardianEgyptianWebAutoHinted.woff2.json"}]},{"fileType":"woff","endpoint":"https://assets.guim.co.uk/fonts/a551aab8b1ccfcfd32edd37a27fc1823/GuardianEgyptianWeb.woff.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/f4ec7dfc5cc01960abe6bc0a42714ec9/GuardianEgyptianWebCleartypeHinted.woff.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/c9dd78499c869cc0c77c91e6a4d8d0e5/GuardianEgyptianWebAutoHinted.woff.json"}]},{"fileType":"ttf","endpoint":"https://assets.guim.co.uk/fonts/a0e077ccafc42d20b07a3f234a06b576/GuardianEgyptianWeb.ttf.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/2738675136670257aaa1a48b6921c04f/GuardianEgyptianWebCleartypeHinted.ttf.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/1204ca5411e8d3fb8c0f9cb90400957c/GuardianEgyptianWebAutoHinted.ttf.json"}]}]},{"typeFace":"GuardianTextEgyptianWeb","fileTypes":[{"fileType":"woff2","endpoint":"https://assets.guim.co.uk/fonts/6346d1630192a48efa70115ac5489385/GuardianTextEgyptianWeb.woff2.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/8d3034bcc2dd6f8ba03a5496b6a3cddd/GuardianTextEgyptianWebCleartypeHinted.woff2.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/62213ae07a282d6c2136198a76894c6a/GuardianTextEgyptianWebAutoHinted.woff2.json"}]},{"fileType":"woff","endpoint":"https://assets.guim.co.uk/fonts/01646f0b7c1d3d901953fdc1f1b21656/GuardianTextEgyptianWeb.woff.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/32e8c8ddc07777cbd710b6fa15f27b4c/GuardianTextEgyptianWebCleartypeHinted.woff.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/54fda71fc837d03fc120e3788f4f7a29/GuardianTextEgyptianWebAutoHinted.woff.json"}]},{"fileType":"ttf","endpoint":"https://assets.guim.co.uk/fonts/92a4950d56b8777c064cb600ac6b4b6d/GuardianTextEgyptianWeb.ttf.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/ec8c18e20d0903e22bbe6362dc4bbcaf/GuardianTextEgyptianWebCleartypeHinted.ttf.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/1833d0aae865199889b87d2cf67162cd/GuardianTextEgyptianWebAutoHinted.ttf.json"}]}]},{"typeFace":"GuardianTextSansWeb","fileTypes":[{"fileType":"woff2","endpoint":"https://assets.guim.co.uk/fonts/e98740f460023b3b3b3137589c40db35/GuardianTextSansWeb.woff2.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/31443178085917965e0fd5b89ecff788/GuardianTextSansWebCleartypeHinted.woff2.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/1e08730fbd3200a61dfa77d9e6d645b6/GuardianTextSansWebAutoHinted.woff2.json"}]},{"fileType":"woff","endpoint":"https://assets.guim.co.uk/fonts/68a6b1dc3e7af0aa14a2a0ba3839eea3/GuardianTextSansWeb.woff.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/997e56e52c9d9f28ab60a9786694af4b/GuardianTextSansWebCleartypeHinted.woff.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/73e92258e322d31f85cea2ffbf02cbb0/GuardianTextSansWebAutoHinted.woff.json"}]},{"fileType":"ttf","endpoint":"https://assets.guim.co.uk/fonts/71a960886bc7e0d7d7c9b3483b347ab0/GuardianTextSansWeb.ttf.json","hintTypes":[{"hintType":"cleartype","endpoint":"https://assets.guim.co.uk/fonts/1ec1f70d7bd618abc7ad43fd7e22d7f2/GuardianTextSansWebCleartypeHinted.ttf.json"},{"hintType":"auto","endpoint":"https://assets.guim.co.uk/fonts/3a59896fe9b9cee9b2f5d3b7a086d481/GuardianTextSansWebAutoHinted.ttf.json"}]}]}]}};'use strict';window.guardianPolyfilled=function(){try{window.guardian.polyfilled=true;}catch(e){}};(function(document,window){var src=void 0;var script=void 0;var pendingScripts=[];var scripts=[window.guardian.config.polyfillioUrl,window.guardian.config.bundleUrl];var firstScript=document.scripts[0];var firstScriptParent=firstScript.parentNode;if(!firstScriptParent){return;}var stateChange=function stateChange(){var pendingScript=void 0;while(pendingScripts[0]&&pendingScripts[0].readyState==='loaded'){pendingScript=pendingScripts.shift();pendingScript.onreadystatechange=null;firstScriptParent.insertBefore(pendingScript,firstScript);}};while(scripts.length){src=scripts.shift();if('async'in firstScript){script=document.createElement('script');script.async=false;script.src=src;if(document.head){document.head.appendChild(script);}}else if(firstScript.readyState){script=document.createElement('script');pendingScripts.push(script);script.onreadystatechange=stateChange;script.src=src;}else{document.write('<script src="'+src+'" defer></'+'script'+'>');}}})(document,window);'use strict';function _toConsumableArray(arr){if(Array.isArray(arr)){for(var i=0,arr2=Array(arr.length);i<arr.length;i++){arr2[i]=arr[i];}return arr2;}else{return Array.from(arr);}}(function(document,window){var ua=navigator.userAgent;var fontHinting=function(){var windowsNT=/Windows NT (\d\.\d+)/.exec(ua);var hinting='Off';try{if(windowsNT){var version=parseFloat(windowsNT[1]);if(version>=5.1&&version<=6.1){if(/Chrome/.exec(ua)&&version<6.0){hinting='Auto';}else{hinting='Cleartype';}}}}catch(e){}return hinting;}();var loadFontsFromStorage=function loadFontsFromStorage(){try{if('localStorage'in window){var fontStorageKey=function fontStorageKey(fontName){var fontHash=arguments.length>1&&arguments[1]!==undefined?arguments[1]:'';return'gu.fonts.'+fontName+'.'+fontHash;};var fontFormat=function(){var formatStorageKey='gu.fonts.format';var format=localStorage.getItem(formatStorageKey);var supportsWoff2=function supportsWoff2(){if('FontFace'in window){try{var f=new window.FontFace('t','url("data:application/font-woff2,") format("woff2")',{});f.load().catch(function(){});if(f.status==='loading'){return true;}}catch(e){}}if(!/edge\/([0-9]+)/.test(ua.toLowerCase())){var browser=/(chrome|firefox)\/([0-9]+)/.exec(ua.toLowerCase());var woff2Browsers={chrome:36,firefox:39};return!!browser&&woff2Browsers[browser[1]]<parseInt(browser[2],10);}return false;};if(format&&/value/.test(format)){format=JSON.parse(format).value;localStorage.setItem(formatStorageKey,format);}if(!format){if(supportsWoff2()){format='woff2';}else if(ua.indexOf('android')>-1){format='ttf';}else{format='woff';}localStorage.setItem(formatStorageKey,format);}return format;}();var useFont=function useFont(el,css){el.innerHTML=css;};var saveFont=function saveFont(fontName,fontHash,css){var i=0;var totalItems=localStorage.length-1;for(;i<totalItems;i+=1){var key=localStorage.key(i);if(key&&key.indexOf(fontStorageKey(fontName))!==-1){localStorage.removeItem(key);break;}}localStorage.setItem(fontStorageKey(fontName,fontHash),JSON.stringify({value:css}));};var fetchFont=function fetchFont(url,el,fontName,fontHash){var xhr=new XMLHttpRequest();window.guFont=function(fontData){return fontData.css;};xhr.open('GET',url,true);xhr.onreadystatechange=function(){if(xhr.readyState===4&&xhr.status===200){var css=eval(xhr.responseText);useFont(el,css);saveFont(fontName,fontHash,css);}};xhr.send();};var fonts=document.getElementsByClassName('webfont');var hinting=fontHinting==='Off'?'':'hinted-'+fontHinting+'-';var urlAttribute='data-cache-file-'+hinting+fontFormat;[].concat(_toConsumableArray(fonts)).forEach(function(font){var fontURL=font.getAttribute(urlAttribute);if(fontURL){var fontInfo=fontURL.match(/fonts\/([^/]*?)\/?([^/]*)\.(woff2|woff|ttf).json$/);if(fontInfo&&fontInfo.length>=3){var fontName=fontInfo[2];var fontHash=fontInfo[1];var fontData=localStorage.getItem(fontStorageKey(fontName,fontHash));if(fontData){useFont(font,JSON.parse(fontData).value);}else{fetchFont(fontURL,font,fontName,fontHash);}}}});return true;}}catch(e){}return false;};var loadFontsAsynchronously=function loadFontsAsynchronously(){try{var scripts=document.getElementsByTagName('script');var thisScript=scripts[scripts.length-1];var fonts=document.createElement('link');fonts.rel='stylesheet';fonts.className='webfonts';fonts.href=window.guardian.config.stylesheets.fonts['hinting'+fontHinting].kerningOn;window.setTimeout(function(){var parentNode=thisScript.parentNode;if(parentNode){parentNode.insertBefore(fonts,thisScript);}});}catch(e){}};var fontSmoothingEnabled=function fontSmoothingEnabled(){try{if(document.cookie.indexOf('GU_fonts_smoothing')!==-1&&window.location.hash!=='#check-smoothing'){return document.cookie.indexOf('GU_fonts_smoothing=on')!==-1;}var saveFontSmoothing=function saveFontSmoothing(state){document.cookie='GU_fonts_smoothing= \''+(state?'on':'off')+'; domain='+window.location.hostname+'; path=/; max-age='+60*60*24*30;};if(/Windows NT (\d\.\d+)/.exec(ua)&&!/MSIE|Trident/.exec(ua)){try{var canvasNode=document.createElement('canvas');canvasNode.width=35;canvasNode.height=35;canvasNode.style.display='none';if(document.documentElement){document.documentElement.appendChild(canvasNode);}var ctx=canvasNode.getContext('2d');ctx.textBaseline='top';ctx.font='32px Arial';ctx.fillStyle='black';ctx.strokeStyle='black';ctx.fillText('@@@@',0,0);for(var x=0;x<=16;++x){for(var y=0;y<=16;++y){var alpha=ctx.getImageData(x,y,1,1).data[3];if(alpha>0&&alpha<255){saveFontSmoothing(true);return true;}}}}catch(e){}saveFontSmoothing(false);return false;}return true;}catch(e){}};var fontCookie='GU_fonts=off; domain='+window.location.hostname+'; path=/';var disableFonts=function disableFonts(){document.cookie=fontCookie+'; max-age='+60*60*24*365;};var enableFonts=function enableFonts(){document.cookie=fontCookie+'; expires=Thu, 01 Jan 1970 00:00:00 GMT';};var checkUserFontDisabling=function checkUserFontDisabling(){if(window.location.hash==='#fonts-off'){disableFonts();}else if(window.location.hash==='#fonts-on'||window.location.hash==='#check-smoothing'){enableFonts();}};var fontsEnabled=document.cookie.indexOf('GU_fonts=off')===-1;var loadFonts=function loadFonts(){checkUserFontDisabling();if(fontsEnabled){if(fontSmoothingEnabled()){if(!loadFontsFromStorage()){loadFontsAsynchronously();}}else{disableFonts();}}};loadFonts();})(document,window);
+    </script>
     </head>
-    <body>
-        <div class="fluid-wrap">
-            <div class="topbar">
-                <div class="topbar-menu-container">
-                    <ul class="topbar-menu pull-left">
-                        <li><a href="/">home</a></li>
-                    </ul>
-                </div>
+    <body class="css-9c6blz">
+        <div class="css-9b24cv">
+            <div class="css-1ezq6pu"><a href="https://www.theguardian.com/" class="css-1rc3z3n">
+                <svg viewBox="0 0 297 95" class="css-17t49mt">
+                    <path fill="#121212"
+                    d="M66.8 50.7l5-2.6V8.4H68l-9.3 12.4h-1L58.2 7h40.5l.6 13.8h-1.1L89 8.4h-3.9V48l5 2.7V52H66.9v-1.3zm37-1.8V5L100 3.5v-.9L114.2.1h1.5v20.8l.3-.4a19 19 0 0 1 12.2-4.5c6.2 0 9 3.5 9 10v23l3.3 1.7V52H122v-1.3l3.4-1.8V26c0-3.6-1.6-5-4.6-5a7.8 7.8 0 0 0-4.9 1.6V49l3.3 1.8V52h-18.5v-1.2zm48.4-13.4c.4 7.2 3.6 12.8 11.4 12.8 3.7 0 6.3-1.7 8.8-3v1.5a17.4 17.4 0 0 1-13.6 6.2c-12 0-18-6.6-18-18.1 0-11.3 6.6-18.3 17.4-18.3 10.2 0 15.5 5 15.5 18.4v.4zm-.2-1.7l10.5-.7c0-9-1.5-15-4.6-15-3.3 0-5.9 7-5.9 15.6M0 69.6c0-19.1 12.7-26 26.8-26 6 0 11.6 1 14.8 2.3l.3 13.4h-1.4l-8.3-13a12.2 12.2 0 0 0-5.2-.8c-7.5 0-11.3 8.7-11.2 22.9.1 17 3 24.7 10 24.7a10.7 10.7 0 0 0 4.1-.7V74.2l-4.5-2.6V70h22v1.7l-4.5 2.5v18A49.2 49.2 0 0 1 26.2 95C10.2 95 0 87.5 0 69.6m47.1-9v-1L62 57l1.6.1v29c0 3.6 1.7 4.6 4.5 4.6a6 6 0 0 0 4.8-2.2v-26l-4-1.8v-1.2L83.6 57l1.4.2v33.3l4 1.6v1.1L74.4 95l-1.4-.1v-4.4h-.4A16.4 16.4 0 0 1 61.5 95C54.4 95 51 90.8 51 84.5v-22zm94.5-3.7l1.2.1v10.8h.4c1.6-7.9 5-10.8 9.3-10.8a4.7 4.7 0 0 1 1.8.3v11a12.6 12.6 0 0 0-3-.3 18.6 18.6 0 0 0-8 1.6v21.2l3.4 1.9V94h-19.3v-1.3l3.5-1.9v-29l-4-1.2v-1zm37.1.9V46.5l-4-1.5v-.9l15-2.7 1.3.2v48.8l4.2 1.5V93l-14.8 2-1.1-.1v-4h-.4a13.1 13.1 0 0 1-9.8 4.1c-8 0-13.9-6.1-13.9-18.7 0-13.2 6.9-19.7 17.2-19.7a14.7 14.7 0 0 1 6.3 1.2m0 31.2V60a5.5 5.5 0 0 0-4-1.3c-4 .1-6.5 6.2-6.5 16.9 0 9.6 1.8 15 7 14.8a5.2 5.2 0 0 0 3.5-1.3M211.5 57h1.3v34l3.4 1.8V94H197v-1.3l3.4-1.9V62.4l-4-1.7v-1.1zm1.4-9.2a6.4 6.4 0 0 1-6.6 6.3 6.3 6.3 0 1 1 0-12.6 6.5 6.5 0 0 1 6.6 6.3m46.3 43.1V62l-4-1.4v-1.4l14.7-2.8 1.5.2v4.3h.4a19.4 19.4 0 0 1 12.5-4.7c6.4 0 9.3 3 9.3 9.8v24.8l3.4 1.9V94h-19.2v-1.3l3.5-1.9v-24c0-3.8-1.6-5.3-4.7-5.3a8 8 0 0 0-5 1.7v27.6l3.3 1.9V94h-19.1v-1.3zm-21.3-18V68c0-7.3-1.5-9.6-6-9.6a11.8 11.8 0 0 0-1.6 0l-8 11h-1.1v-10a43.3 43.3 0 0 1 13.5-2.4c9.8 0 15.5 2.7 15.5 11v23.5l3.5 1v.9a15 15 0 0 1-7.2 1.6c-4.9 0-7.2-1.6-8.3-4.2h-.3c-2 2.8-5 4.3-9.6 4.3-5.8 0-9.8-3.6-9.8-9.9 0-6 3.8-9.4 11.5-10.8zm0 16.2V74.5l-2.4.2c-3.9.3-5.2 2.7-5.2 8.2 0 5.9 1.9 7.4 4.6 7.4a3.6 3.6 0 0 0 3-1.3M109.7 72.7V68c0-7.3-1.6-9.7-6.1-9.7a11.8 11.8 0 0 0-1.5.2L94 69.2h-1v-10a43.3 43.3 0 0 1 13.4-2.3c9.8 0 15.5 2.7 15.5 11v23.5l3.5 1v.9a15 15 0 0 1-7.2 1.6c-4.9 0-7.2-1.6-8.3-4.2h-.3c-2 2.8-5 4.3-9.5 4.3-5.9 0-9.8-3.6-9.8-9.9 0-6 3.7-9.4 11.4-10.8zm0 16.3V74.5l-2.5.2c-3.8.3-5.2 2.7-5.2 8.2 0 5.9 2 7.4 4.6 7.4a3.6 3.6 0 0 0 3-1.3"></path>
+                </svg>
+                <span class="css-1pusbiz">The Guardian</span></a>
+                @if(code=="404") {
+                    <svg viewBox="0 0 416.5 198" class="css-fsw9jh">
+                        <path
+                        d="M70.9 195.2h56.4v-2.8l-26.4-.3v-56.7h34.5v-3.1h-34.5V2.6h-3.1L0 132.4v3.1h97.3v56.7l-26.4.3zm-67-62.8v-.3L97 8.7h.3v123.7zm204.5 65.3c46.1 0 71.2-37 71.2-99S254.6 0 208.4 0s-71.2 37-71.2 98.7 25 99 71.2 99zm0-3.1c-44.2 0-67.3-35.9-67.3-95.9s23.1-95.6 67.3-95.6 67.3 35.3 67.3 95.6-23.1 95.9-67.3 95.9zm143.6.6h56.4v-2.8l-26.4-.3v-56.7h34.5v-3.1H382V2.6h-3.1l-97.8 129.8v3.1h97.3v56.7l-26.4.3zm-67-62.8v-.3L378.1 8.7h.3v123.7z"
+                        fill="#aabfc7"></path>
+                    </svg>
+                } else {
+                    <svg viewBox="0 0 416.5 198" class="css-fsw9jh">
+                    </svg>
+                }
+                <div class="css-11dwdsg">
+                        <h1 class="css-1pmqqor">
+                            @(code match{
+                                case "404" => Html("Sorry – the page you have requested does not exist")
+                                case _ => Html("Sorry - we haven’t been able to serve the page you asked for")
+                            })
+                        </h1>
+                    <p class="css-7c37t2">You may have followed an outdated link, or have mistyped a URL. If you believe this to
+                        be an error, please <a href="https://www.theguardian.com/info/tech-feedback" class="css-1hw4e4y">report
+                        it</a>.</p><a href="https://www.theguardian.com/" class="css-722269">Go to The Guardian home page
+                        <svg width="30" height="30" viewBox="0 0 30 30" class="css-7i3bfb">
+                            <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
+                        </svg>
+                    </a></div>
             </div>
-            <img src="https://static-secure.guim.co.uk/static/60ed206dbccc8b808a7792d47862f9cfb7cd3d67/common/images/logos/the-guardian/titlepiece.gif" alt="The Guardian" />
-            <div class="fluid-row margin-top">
-                <div class="col-12 start-col margin-bottom">
-                    <h1>Sorry - we haven’t been able to serve the page you asked for.</h1>
-                </div>
-            </div><!-- /.row -->
-
-            <div class="fluid-row margin-top">
-                <div class="col-12 start-col">
-                    <div class="hd zone-border zone-border-medium">
-                        <h2 class="sub-heading">@code</h2>
-                    </div>
-                    <p>You may have followed a broken or outdated link, or there may be an error on our site.</p>
-                    <p>Please follow one of the links below to continue exploring.</p>
-                    <nav>
-                        <ul role="navigation" class="u-unstyled global-navigation">
-                            <li><a href="/">home</a></li>
-                            <li class="zone-news"><a href="/uk" class="zone-color">UK</a></li>
-                            <li class="zone-news"><a href="/world" class="zone-color">world</a></li>
-                            <li class="zone-sport"><a href="/sport" class="zone-color">sport</a></li>
-                            <li class="zone-sport"><a href="/football" class="zone-color">football</a></li>
-                            <li class="zone-comment"><a href="/commentisfree" class="zone-color">comment</a></li>
-                            <li class="zone-culture"><a href="/culture" class="zone-color">culture</a></li>
-                            <li class="zone-business"><a href="/business" class="zone-color">economy</a></li>
-                            <li class="zone-lifeandstyle"><a href="/lifeandstyle" class="zone-color">life</a></li>
-                            <li class="zone-lifeandstyle"><a href="/fashion" class="zone-color">fashion</a></li>
-                            <li class="zone-environment"><a href="/environment" class="zone-color">environment</a></li>
-                            <li><a href="/technology" class="zone-color">tech</a></li>
-                            <li><a href="/money" class="zone-color">money</a></li>
-                            <li><a href="/travel" class="zone-color">travel</a></li>
-                            <li><a href="https://soulmates.guardian.co.uk/" class="zone-color">soulmates</a></li>
-                            <li><a href="http://m.jobs.guardian.co.uk/" class="zone-color" target="_blank">jobs</a></li>
-                            <li><a href="/guardian-masterclasses" class="zone-color" target="_blank">masterclasses</a></li>
-                        </ul>
-                    </nav>
-                </div><!-- /.col-12 -->
-
-            </div><!-- /.row -->
-
-            <div class="footer zone-border zone-border-medium margin-top">
-                <ul class="inline with-separators">
-                    <li><a href="/help">Help</a></li>
-                    <li><a href="/help/contact-us">Contact us</a></li>
-                    <li><a target="_blank" href="https://www.surveymonkey.com/s/theguardian-beta-feedback">Feedback</a></li>
-                    <li><a href="/help/terms-of-service">Terms &amp; conditions</a></li>
-                    <li><a href="/help/privacy-policy">Privacy policy</a></li>
-                </ul>
-                <p><small>&copy; Guardian News and Media Limited or its affiliated companies. All rights reserved. Registered in England and Wales. No. 908396. Registered office: PO Box 68164, Kings Place, 90 York Way, London N1P 2AP</small></p>
-            </div>
-        </div><!-- /.fluid-wrap -->
-
+            <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create','UA-78705427-1','auto');ga('set','dimension3','theguardian.com');ga('set','dimension14','@code');ga('send','pageview');
+    </script>
+            <img src="//beacon.gu-web.net/count/40x.gif" alt rel="nofollow" class="css-10oc3or"/></div>
     </body>
 </html>


### PR DESCRIPTION
## What does this change?
Replaces the old 404 error with a static copy of the current 404 error, for errored requests within `profile.theguardian.com`

## What is the value of this and can you measure success?
A bit of brand alignment

## Screenshots
![screen shot 2018-01-24 at 12 31 44 pm](https://user-images.githubusercontent.com/11539094/35332455-e98e9424-0102-11e8-96a6-254abeaf4c56.png)
![screen shot 2018-01-24 at 12 31 35 pm](https://user-images.githubusercontent.com/11539094/35332459-ebc56e02-0102-11e8-8fd5-a82341c60ea7.png)
