### PR TITLE
Fix 'Select all' in /consents enabling users to spam requests

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -308,10 +308,12 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
     ]).then(([[checkboxEl, titleEl], wrappedCheckboxEls]) => {
         const getTextForStatus = (status: boolean) =>
             status ? LC_UNCHECK_ALL : LC_CHECK_ALL;
+
         const revealCheckbox = () =>
             fastdom.write(() => {
                 labelEl.classList.remove('u-h');
             });
+
         const updateCheckStatus = () =>
             fastdom.write(() => {
                 if (!(checkboxEl instanceof HTMLInputElement)) {
@@ -322,6 +324,9 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
             });
 
         const handleChangeEvent = () => {
+            addSpinner(labelEl, 9999)
+                .then(() => new Promise(accept => setTimeout(accept, 300)))
+                .then(() => removeSpinner(labelEl));
             wrappedCheckboxEls.forEach(wrappedCheckboxEl => {
                 fastdom
                     .write(() => {

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.js
@@ -70,7 +70,10 @@ export const flip = (labelEl: HTMLElement): Promise<any> =>
             });
         });
 
-export const addSpinner = (labelEl: HTMLElement): Promise<any> =>
+export const addSpinner = (
+    labelEl: HTMLElement,
+    latencyTimeout: number = 500
+): Promise<any> =>
     fastdom
         .write(() => {
             labelEl.classList.add('is-updating');
@@ -88,7 +91,7 @@ export const addSpinner = (labelEl: HTMLElement): Promise<any> =>
                             }
                             labelEl.classList.add('is-taking-a-long-time');
                         });
-                    }, 300)
+                    }, latencyTimeout)
                 )
                 .toString();
         });


### PR DESCRIPTION
## What does this change?
Adds a static 300ms cooldown timer to the `select all` checkbox in `/consents` so clicking on it a lot can't spam the backend with a lot of requests at once