### PR TITLE
Brought meta info back for paid articles, plus neutral colours in

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -64,12 +64,15 @@
 
 
                             @if(isPaidContent){
+                                @fragments.contentMeta(article, model, amp = amp)
                                 @fragments.mainMedia(article, amp)
+
                             }
 
                             @fragments.witnessCallToAction(article.content)
                             @BodyCleaner(article, article.fields.body, amp = amp)
                             @fragments.witnessCallToAction(article.content)
+
 
                             @fragments.submeta(article, amp)
 

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -66,13 +66,11 @@
                             @if(isPaidContent){
                                 @fragments.contentMeta(article, model, amp = amp)
                                 @fragments.mainMedia(article, amp)
-
                             }
 
                             @fragments.witnessCallToAction(article.content)
                             @BodyCleaner(article, article.fields.body, amp = amp)
                             @fragments.witnessCallToAction(article.content)
-
 
                             @fragments.submeta(article, amp)
 

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -286,8 +286,7 @@
     }
 }
 
-.content--pillar-news,
-.paid-content {
+.content--pillar-news:not(.paid-content) {
     @include colorPalatte($news-garnett-main-1, $news-garnett-feature, $news-garnett-media-main-1);
 }
 // #? There is a lot of :not(.paid-content) to avoid having to override
@@ -319,8 +318,7 @@
     @include colorPalatte($sport-garnett-main-1, $sport-garnett-feature, $sport-garnett-media-main-1);
 }
 
-.content-footer--pillar-news,
-.paid-content {
+.content-footer--pillar-news:not(.paid-content) {
     @include footerPalette($news-garnett-main-1);
 }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1625,6 +1625,19 @@ $quote-mark: 35px;
     .byline-img__img {
         float: none;
     }
-    // *************** Letter page ****************
-    .tonal__header {}
+}
+
+// *************** Commercial overrides ****************
+
+.paid-content {
+    a {
+        color: $garnett-neutral-6;
+    }
+    .social-icon__svg {
+        fill: $garnett-neutral-1;
+    }
+
+    .social-icon:hover {
+        background-color: $garnett-neutral-1;
+    }
 }


### PR DESCRIPTION
## What does this change?
Brought meta info back for paid articles, plus neutral colours in

Before:
<img width="261" alt="screen shot 2018-01-24 at 14 36 00" src="https://user-images.githubusercontent.com/8453924/35337794-fe4e94a2-0113-11e8-8c23-ca9b510129b5.png">

After:
<img width="261" alt="screen shot 2018-01-24 at 14 36 12" src="https://user-images.githubusercontent.com/8453924/35337808-06075120-0114-11e8-9de7-f537b2b19b0c.png">
