### PR TITLE
Use https for connections going outside VPC

### DIFF
--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -33,7 +33,7 @@ object SiteLink {
 
 object CapiLink {
 
-  private def tagPage(tagType: String, tagName: String): String = s"http://content.guardianapis.com/tags?type=$tagType&q=$tagName"
+  private def tagPage(tagType: String, tagName: String): String = s"https://content.guardianapis.com/tags?type=$tagType&q=$tagName"
 
   def keywordPage(keyword: String): String = tagPage("keyword", keyword)
 

--- a/commercial/app/model/merchandise/Merchandise.scala
+++ b/commercial/app/model/merchandise/Merchandise.scala
@@ -114,7 +114,7 @@ case class Job(id: Int,
 
   val shortSalaryDescription = StringUtils.abbreviate(salaryDescription, 25).replace("...", "…")
 
-  def listingUrl: String = s"http://jobs.theguardian.com/job/$id"
+  def listingUrl: String = s"https://jobs.theguardian.com/job/$id"
 
   val industries: Seq[String] =
     Industries.sectorIdIndustryMap.filter { case (sectorId, name) => sectorIds.contains(sectorId)}.values.toSeq

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -343,7 +343,6 @@ class GuardianConfiguration extends Logging {
 
   object oas {
     lazy val siteIdHost = configuration.getStringProperty("oas.siteId.host").getOrElse(".guardian.co.uk")
-    lazy val url = configuration.getStringProperty("oas.url").getOrElse("http://oas.theguardian.com/RealMedia/ads/")
   }
 
   object facebook {
@@ -379,7 +378,7 @@ class GuardianConfiguration extends Logging {
   object commercial {
 
     lazy val testDomain =
-      if (environment.isProd) "http://m.code.dev-theguardian.com"
+      if (environment.isProd) "https://m.code.dev-theguardian.com"
       else configuration.getStringProperty("guardian.page.host") getOrElse ""
 
     lazy val dfpAdUnitGuRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
@@ -387,14 +386,8 @@ class GuardianConfiguration extends Logging {
     lazy val dfpMobileAppsAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
 
-    lazy val books_url = configuration.getMandatoryStringProperty("commercial.books_url")
-    lazy val masterclasses_url =
-      configuration.getMandatoryStringProperty("commercial.masterclasses_url")
-    lazy val soulmates_url = configuration.getMandatoryStringProperty("commercial.soulmates_url")
     lazy val soulmatesApiUrl = configuration.getStringProperty("soulmates.api.url")
     lazy val travelFeedUrl = configuration.getStringProperty("travel.feed.url")
-    lazy val guMerchandisingAdvertiserId =
-      configuration.getMandatoryStringProperty("commercial.dfp.guMerchandising.advertiserId")
 
     // root dir relative to S3 bucket
     lazy val commercialRoot = {

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -212,11 +212,7 @@ trait DiscussionApiLike extends Http with Logging {
 }
 
 class DiscussionApi(val wsClient: WSClient) extends DiscussionApiLike {
-  override protected val apiRoot =
-    if (Configuration.environment.isProd)
-      Configuration.discussion.apiRoot
-    else
-      Configuration.discussion.apiRoot.replaceFirst("https://", "http://") // CODE SSL cert is defective and expensive to fix
+  override protected val apiRoot = Configuration.discussion.apiRoot
 
   override protected lazy val clientHeaderValue: String = Configuration.discussion.apiClientHeader
 }

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -18,11 +18,7 @@ object DiscussionApiHttpRecorder extends DefaultHttpRecorder {
 class DiscussionApiStub(val wsClient: WSClient) extends DiscussionApiLike {
   protected val clientHeaderValue: String =""
 
-  protected val apiRoot =
-    if (Configuration.environment.isProd)
-      Configuration.discussion.apiRoot
-    else
-      Configuration.discussion.apiRoot.replaceFirst("https://", "http://") // CODE SSL cert is defective and expensive to fix
+  protected val apiRoot = Configuration.discussion.apiRoot
 
   protected val apiTimeout = conf.Configuration.discussion.apiTimeout
 

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -19,7 +19,7 @@ object PaFeed {
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends Logging {
 
-  private val paEndpoint = "http://cricket.api.press.net/v1"
+  private val paEndpoint = "https://cricket.api.press.net/v1"
   private val credentials = conf.SportConfiguration.pa.cricketKey.map { ("Apikey", _) }
   private val xmlContentType = ("Accept","application/xml")
   private implicit val throttler = new CricketThrottler(actorSystem, materializer)


### PR DESCRIPTION
## What does this change?

Use https for connections going outside VPC and delete unused config properties.

Additional http to https config changes to apply in parameter store after release:
```
/frontend/code/front.config
/frontend/code/frontend.store
/frontend/code/onward/business_data.url
/frontend/code/witness.apiRoot
/frontend/ophan.api.host
/frontend/prod/avatars.image.host
/frontend/prod/front.config
/frontend/prod/frontend.store
/frontend/prod/onward/business_data.url
/frontend/prod/witness.apiRoot
```
still need to work on setting up HTTPS for http://football-api.gu-web.net/v1.5. (We may change the domain)

## What is the value of this and can you measure success?

GDPR requirements for securing connections going outside the VPC.

## Tested in CODE?

I will