### PR TITLE
Add new cloudwatch metric to other apps

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -53,7 +53,8 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.HttpTimeoutCountMetric,
-    ContentApiMetrics.ContentApiErrorMetric
+    ContentApiMetrics.ContentApiErrorMetric,
+    ContentApiMetrics.ContentApiRequestsMetric
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -76,7 +76,8 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
 
   val applicationMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,
-    ContentApiMetrics.ContentApiErrorMetric
+    ContentApiMetrics.ContentApiErrorMetric,
+    ContentApiMetrics.ContentApiRequestsMetric
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -51,7 +51,8 @@ trait AppComponents extends FrontendComponents {
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.HttpLatencyTimingMetric,
-    ContentApiMetrics.ContentApiErrorMetric
+    ContentApiMetrics.ContentApiErrorMetric,
+    ContentApiMetrics.ContentApiRequestsMetric
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters


### PR DESCRIPTION
## What does this change?

This adds the new content-api-requests cloudwatch metric to more apps (rss, onwards, article)

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
