### PR TITLE
[minor] fix tracking for Check all in /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -23,8 +23,8 @@
     availableLists: EmailNewsletters,
     consentHint: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
-@selectAllCheckbox(id: String) = @{
-        <label class="manage-account__switch manage-account__switch--no-box js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : @id (all) : [action]">
+@selectAllCheckbox(id: String) = {
+        <label class="manage-account__switch manage-account__switch--no-box js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : @{id} (all) : [action]">
             <div class="manage-account__switch-content">
                 <input type="checkbox"/>
                 <div class="manage-account__switch-checkbox"></div>


### PR DESCRIPTION
## What does this change?
Both [check all] checkboxes in `/consents` have the same event id again (#18990). This fixes that