### PR TITLE
Increase size of Prebid test buckets

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -95,5 +95,5 @@ object Prebid extends Experiment(
   description = "Users in this experiment will have a Prebid header-bidding experience.",
   owners = group(Commercial),
   sellByDate = new LocalDate(2018, 2, 21),
-  participationGroup = Perc5A
+  participationGroup = Perc10A
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -95,5 +95,5 @@ object Prebid extends Experiment(
   description = "Users in this experiment will have a Prebid header-bidding experience.",
   owners = group(Commercial),
   sellByDate = new LocalDate(2018, 2, 21),
-  participationGroup = Perc5A
+  participationGroup = Perc5B
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -95,5 +95,5 @@ object Prebid extends Experiment(
   description = "Users in this experiment will have a Prebid header-bidding experience.",
   owners = group(Commercial),
   sellByDate = new LocalDate(2018, 2, 21),
-  participationGroup = Perc5B
+  participationGroup = Perc5A
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -95,5 +95,5 @@ object Prebid extends Experiment(
   description = "Users in this experiment will have a Prebid header-bidding experience.",
   owners = group(Commercial),
   sellByDate = new LocalDate(2018, 2, 21),
-  participationGroup = Perc2C
+  participationGroup = Perc5A
 )

--- a/common/app/experiments/ParticipationGroups.scala
+++ b/common/app/experiments/ParticipationGroups.scala
@@ -26,6 +26,7 @@ object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {
   case object Perc2D extends ParticipationGroup("X-GU-Experiment-2perc-D")
   case object Perc2E extends ParticipationGroup("X-GU-Experiment-2perc-E")
   case object Perc5A extends ParticipationGroup("X-GU-Experiment-5perc-A")
+  case object Perc5B extends ParticipationGroup("X-GU-Experiment-5perc-B")
   case object Perc10A extends ParticipationGroup("X-GU-Experiment-10perc-A")
   case object Perc20A extends ParticipationGroup("X-GU-Experiment-20perc-A")
   case object Perc50 extends ParticipationGroup("X-GU-Experiment-50perc")
@@ -33,4 +34,3 @@ object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {
   override val values: immutable.IndexedSeq[ParticipationGroup] = findValues
 
 }
-

--- a/common/app/experiments/ParticipationGroups.scala
+++ b/common/app/experiments/ParticipationGroups.scala
@@ -26,7 +26,6 @@ object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {
   case object Perc2D extends ParticipationGroup("X-GU-Experiment-2perc-D")
   case object Perc2E extends ParticipationGroup("X-GU-Experiment-2perc-E")
   case object Perc5A extends ParticipationGroup("X-GU-Experiment-5perc-A")
-  case object Perc5B extends ParticipationGroup("X-GU-Experiment-5perc-B")
   case object Perc10A extends ParticipationGroup("X-GU-Experiment-10perc-A")
   case object Perc20A extends ParticipationGroup("X-GU-Experiment-20perc-A")
   case object Perc50 extends ParticipationGroup("X-GU-Experiment-50perc")
@@ -34,3 +33,4 @@ object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {
   override val values: immutable.IndexedSeq[ParticipationGroup] = findValues
 
 }
+


### PR DESCRIPTION
From 2% to <del>5%</del> 10%.

<del>The `HideShowMoreButtonExperiment` is using the same buckets but the two tests are unlikely to have much impact on each other.</del>
