### PR TITLE
Restore previous label-setting logic.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -5,30 +5,13 @@ import popupTemplate from 'raw-loader!commercial/views/ad-feedback-popup.html';
 import tick from 'svgs/icon/tick.svg';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
-/* creatives can explicitly request to have - or to not have - an 'Advertisment' label added to them
- by containing a div with the following class followed by true/false.
- */
-const labelRequiredSuffix = 'js-advertisement-label-required';
-
-const shouldRenderLabel = adSlotNode => {
-    const explicitlyOptedOut =
-        adSlotNode.getElementsByClassName(`${labelRequiredSuffix}-false`)
-            .length > 0;
-    const explicitlyOptedIn =
-        adSlotNode.getElementsByClassName(`${labelRequiredSuffix}-true`)
-            .length > 0;
-
-    return (
-        explicitlyOptedIn ||
-        (!explicitlyOptedOut &&
-            !(
-                adSlotNode.classList.contains('ad-slot--fluid') ||
-                adSlotNode.classList.contains('ad-slot--frame') ||
-                adSlotNode.getAttribute('data-label') === 'false' ||
-                adSlotNode.getElementsByClassName('ad-slot__label').length
-            ))
+const shouldRenderLabel = adSlotNode =>
+    !(
+        adSlotNode.classList.contains('ad-slot--fluid') ||
+        adSlotNode.classList.contains('ad-slot--frame') ||
+        adSlotNode.getAttribute('data-label') === 'false' ||
+        adSlotNode.getElementsByClassName('ad-slot__label').length
     );
-};
 
 const renderAdvertLabel = (adSlotNode: any): Promise<null> => {
     if (shouldRenderLabel(adSlotNode)) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
@@ -28,24 +28,6 @@ describe('Rendering advert labels', () => {
             `)
         );
 
-        // the override should work regardless of whether the other conditions are true, including an existing label
-        adverts.requiredOverride = bonzo(
-            bonzo.create(`
-                <div class="js-ad-slot">
-                    <div class="ad-slot__label">Advertisement</div>
-                    <div class="js-advertisement-label-required-true"></div>
-                </div>
-            `)
-        );
-
-        adverts.notRequiredOverride = bonzo(
-            bonzo.create(`
-                <div class="js-ad-slot">
-                    <div class="js-advertisement-label-required-false"></div>
-                </div>
-            `)
-        );
-
         adverts.frame = bonzo(
             bonzo.create('<div class="js-ad-slot ad-slot--frame"></div>')
         );
@@ -81,21 +63,5 @@ describe('Rendering advert labels', () => {
         renderAdvertLabel(adverts.frame[0]).then(() => {
             const label = adverts.frame[0].querySelector(labelSelector);
             expect(label).toBeNull();
-        }));
-
-    it(`Won't add a label to ads with explicit no-label override`, () =>
-        renderAdvertLabel(adverts.notRequiredOverride[0]).then(() => {
-            const label = adverts.notRequiredOverride[0].querySelector(
-                labelSelector
-            );
-            expect(label).toBeNull();
-        }));
-
-    it(`Will add a label to ads with explicit label override`, () =>
-        renderAdvertLabel(adverts.requiredOverride[0]).then(() => {
-            const labels = adverts.requiredOverride[0].querySelectorAll(
-                labelSelector
-            );
-            expect(labels.length).toBe(2);
         }));
 });


### PR DESCRIPTION
### Background
This is a tail-between-legs PR that basically reverts #18924.. The hope of the previous PR was to allow creatives to explicitly opt in/out to having an Advertisement label, thus removing all decision making from frontend.

It seems obvious now but, due to these serving in safe frames, we can't inspect the creative once it has rendered into the page and getting the creative to use PostMessage to send a message to hide the label is too slow and results in an ugly flash of the label.

I thought there was a point during the render at which we _could_ inspect it, but I think due in part to the weird ways that Google serves ads in ("safe") iframes, we can't.