### PR TITLE
Fix css in change password confirm page

### DIFF
--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -11,6 +11,7 @@ import play.api.data.validation._
 import play.api.data.Forms._
 import play.api.data.format.Formats._
 import form.Mappings
+import pages.IdentityHtmlPage
 import play.api.http.HttpConfiguration
 import utils.SafeLogging
 
@@ -64,18 +65,26 @@ class ResetPasswordController(
 
   def requestNewToken: Action[AnyContent] = Action { implicit request =>
     val idRequest = idRequestParser(request)
-    Ok(views.html.password.resetPasswordRequestNewToken(page, idRequest, idUrlBuilder, requestPasswordResetForm))
+    Ok(IdentityHtmlPage.html(
+      views.html.password.resetPasswordRequestNewToken(page, idRequest, idUrlBuilder, requestPasswordResetForm)
+    )(page, request, context))
   }
 
   def renderEmailSentConfirmation: Action[AnyContent] = Action { implicit request =>
     val idRequest = idRequestParser(request)
-    Ok(views.html.password.emailSent(page, idRequest, idUrlBuilder))
+    Ok(IdentityHtmlPage.html(
+      views.html.password.emailSent(page, idRequest, idUrlBuilder)
+    )(page, request, context))
   }
 
   def renderResetPassword(token: String): Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val boundForm = passwordResetForm.bindFromFlash.getOrElse(passwordResetForm)
-    NoCache(Ok(views.html.password.resetPassword(page, idRequest, idUrlBuilder, boundForm, token)))
+    NoCache(Ok(
+      IdentityHtmlPage.html(
+        views.html.password.resetPassword(page, idRequest, idUrlBuilder, boundForm, token)
+      )(page, request, context)
+    ))
   }
 
   def resetPassword(token : String): Action[AnyContent] = Action.async { implicit request =>
@@ -120,7 +129,9 @@ class ResetPasswordController(
   def renderPasswordResetConfirmation: Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
-    Ok(views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn))
+    Ok(IdentityHtmlPage.html(
+      views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)
+    )(page, request, context))
   }
 
   def processUpdatePasswordToken( token : String): Action[AnyContent] = Action.async { implicit request =>

--- a/identity/app/views/password/emailSent.scala.html
+++ b/identity/app/views/password/emailSent.scala.html
@@ -2,8 +2,6 @@
 
 @import views.html.fragments.registrationFooter
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Now check your email</h1>
 
@@ -12,4 +10,3 @@
 
     @registrationFooter(idRequest, idUrlBuilder)
 </div>
-}

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -6,8 +6,6 @@
 
     @emailAddress = @{ resetPasswordForm("email-address").value }
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Please enter your new password for @emailAddress</h1>
 
@@ -37,4 +35,3 @@
 
         @registrationFooter(idRequest, idUrlBuilder)
     </div>
-}

--- a/identity/app/views/password/resetPasswordRequestNewToken.scala.html
+++ b/identity/app/views/password/resetPasswordRequestNewToken.scala.html
@@ -4,8 +4,6 @@
 @import views.html.fragments.form.inputField
 @import views.html.fragments.registrationFooter
 
-@mainLegacy(page, projectName = Option("identity")){
-}{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Oh no! The reset password link has expired</h1>
     <p>Enter your email address and we'll send you another.</p>
@@ -37,4 +35,3 @@
 
     @registrationFooter(idRequest, idUrlBuilder)
 </div>
-}


### PR DESCRIPTION
## What does this change?
Adds some styling and headers and footers to `https://profile.theguardian.com/password/reset-confirmation` which at the moment looks like this:
<img width="489" alt="screen shot 2018-01-25 at 8 44 27 pm" src="https://user-images.githubusercontent.com/11539094/35411421-99fe9878-0210-11e8-8b06-4f2746490742.png">
