### PR TITLE
Rejig JS module loading slightly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
         "babel-preset-flow"
     ],
     "plugins": [
-        "babel-plugin-transform-object-rest-spread"
+        "babel-plugin-transform-object-rest-spread",
+        "babel-plugin-syntax-dynamic-import"
     ],
     "env": {
         "production": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -24,11 +24,11 @@ const commercialBaselineControl =
     config.get('tests.commercialBaselineControl') === 'control';
 
 // eslint-disable-next-line no-nested-ternary
-const fetchCommercial: Promise<*> = config.get('switches.commercial')
+const fetchCommercial = config.get('switches.commercial')
     ? (markTime('commercial request'), commercialBaselineControl)
       ? import(/* webpackChunkName: "commercial-control" */ 'bootstraps/commercial-control')
       : import(/* webpackChunkName: "commercial" */ 'bootstraps/commercial')
-    : Promise.resolve(() => {});
+    : Promise.resolve({ bootCommercial: () => {} });
 
 const fetchEnhanced = window.guardian.isEnhanced
     ? (markTime('enhanced request'),
@@ -65,7 +65,7 @@ const go = () => {
             },
             () => {
                 Promise.all([
-                    fetchCommercial.then(bootCommercial => {
+                    fetchCommercial.then(({ bootCommercial }) => {
                         markTime('commercial boot');
                         return bootCommercial();
                     }),

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -17,7 +17,23 @@ import { capturePerfTimings } from 'lib/capture-perf-timings';
 // __webpack_public_path__ is a special webpack variable
 // https://webpack.js.org/guides/public-path/#set-value-on-the-fly
 // eslint-disable-next-line camelcase,no-undef
-__webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
+__webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
+
+// Start downloading these ASAP
+const commercialBaselineControl =
+    config.get('tests.commercialBaselineControl') === 'control';
+
+// eslint-disable-next-line no-nested-ternary
+const fetchCommercial: Promise<*> = config.get('switches.commercial')
+    ? (markTime('commercial request'), commercialBaselineControl)
+      ? import(/* webpackChunkName: "commercial-control" */ 'bootstraps/commercial-control')
+      : import(/* webpackChunkName: "commercial" */ 'bootstraps/commercial')
+    : Promise.resolve(() => {});
+
+const fetchEnhanced = window.guardian.isEnhanced
+    ? (markTime('enhanced request'),
+      import(/* webpackChunkName: "enhanced" */ 'bootstraps/enhanced/main'))
+    : Promise.resolve({ bootEnhanced: () => {} });
 
 // kick off the app
 const go = () => {
@@ -27,7 +43,7 @@ const go = () => {
         bootStandard();
 
         // 2. once standard is done, next is commercial
-        if (config.page.isDev) {
+        if (config.get('page.isDev')) {
             window.guardian.adBlockers.onDetect.push(isInUse => {
                 const needsMessage =
                     isInUse && window.console && window.console.warn;
@@ -39,104 +55,33 @@ const go = () => {
             });
         }
 
-        markTime('commercial request');
-        const inCommercialControl =
-            config.tests.commercialBaselineControl === 'control';
-        if (inCommercialControl) {
-            require.ensure(
-                [],
-                // webpack needs the require function to be called 'require'
-                // eslint-disable-next-line no-shadow
-                require => {
-                    raven.context(
-                        { tags: { feature: 'commercial-control' } },
-                        () => {
-                            markTime('commercial boot');
-                            const commercialBoot = config.switches.commercial
-                                ? require('bootstraps/commercial-control')
-                                : Promise.resolve;
-
-                            commercialBoot().then(() => {
-                                // 3. finally, try enhanced
-                                // this is defined here so that webpack's code-splitting algo
-                                // excludes all the modules bundled in the commercial chunk from this one
-                                if (window.guardian.isEnhanced) {
-                                    markTime('enhanced request');
-                                    require.ensure(
-                                        [],
-                                        // webpack needs the require function to be called 'require'
-                                        // eslint-disable-next-line no-shadow
-                                        require => {
-                                            markTime('enhanced boot');
-                                            require('bootstraps/enhanced/main').bootEnhanced();
-
-                                            if (
-                                                document.readyState ===
-                                                'complete'
-                                            ) {
-                                                capturePerfTimings();
-                                            } else {
-                                                window.addEventListener(
-                                                    'load',
-                                                    capturePerfTimings
-                                                );
-                                            }
-                                        },
-                                        'enhanced'
-                                    );
-                                }
-                            });
-                        }
-                    );
+        raven.context(
+            {
+                tags: {
+                    feature: commercialBaselineControl
+                        ? 'commercial-control'
+                        : 'commercial',
                 },
-                'commercial-control'
-            );
-        } else {
-            require.ensure(
-                [],
-                // webpack needs the require function to be called 'require'
-                // eslint-disable-next-line no-shadow
-                require => {
-                    raven.context({ tags: { feature: 'commercial' } }, () => {
+            },
+            () => {
+                Promise.all([
+                    fetchCommercial.then(bootCommercial => {
                         markTime('commercial boot');
-                        const commercialBoot = config.switches.commercial
-                            ? require('bootstraps/commercial')
-                            : Promise.resolve;
-
-                        commercialBoot().then(() => {
-                            // 3. finally, try enhanced
-                            // this is defined here so that webpack's code-splitting algo
-                            // excludes all the modules bundled in the commercial chunk from this one
-                            if (window.guardian.isEnhanced) {
-                                markTime('enhanced request');
-                                require.ensure(
-                                    [],
-                                    // webpack needs the require function to be called 'require'
-                                    // eslint-disable-next-line no-shadow
-                                    require => {
-                                        markTime('enhanced boot');
-                                        require('bootstraps/enhanced/main').bootEnhanced();
-
-                                        if (
-                                            document.readyState === 'complete'
-                                        ) {
-                                            capturePerfTimings();
-                                        } else {
-                                            window.addEventListener(
-                                                'load',
-                                                capturePerfTimings
-                                            );
-                                        }
-                                    },
-                                    'enhanced'
-                                );
-                            }
-                        });
-                    });
-                },
-                'commercial'
-            );
-        }
+                        return bootCommercial();
+                    }),
+                    fetchEnhanced.then(({ bootEnhanced }) => {
+                        markTime('enhanced boot');
+                        return bootEnhanced();
+                    }),
+                ]).then(() => {
+                    if (document.readyState === 'complete') {
+                        capturePerfTimings();
+                    } else {
+                        window.addEventListener('load', capturePerfTimings);
+                    }
+                });
+            }
+        );
     });
 };
 

--- a/static/src/javascripts/bootstraps/commercial-control.js
+++ b/static/src/javascripts/bootstraps/commercial-control.js
@@ -116,7 +116,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export default (): Promise<void> => {
+export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -118,7 +118,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export default (): Promise<void> => {
+export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,6 +111,7 @@ module.exports = {
         }),
 
         new webpack.optimize.CommonsChunkPlugin({
+            name: 'standard',
             chunks: ["commercial", "commercial-control", "enhanced"],
             async: true,
           })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = {
         new webpack.optimize.CommonsChunkPlugin({
             name: 'standard',
             chunks: ["commercial", "commercial-control", "enhanced"],
-            async: true,
+            async: 'post-standard-commons',
           })
 
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,12 @@ module.exports = {
             // add errors to webpack instead of warnings
             failOnError: true,
         }),
+
+        new webpack.optimize.CommonsChunkPlugin({
+            chunks: ["commercial", "commercial-control", "enhanced"],
+            async: true,
+          })
+
     ],
     externals: {
         xhr2: {},

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -16,11 +16,6 @@ module.exports = webpackMerge.smart(config, {
     },
     devtool: 'source-map',
     plugins: [
-        new webpack.optimize.AggressiveMergingPlugin({
-            // delicate number: stops enhanced-no-commercial and enhanced
-            // being merged into one
-            minSizeReduce: 1.6,
-        }),
         new Visualizer({
             filename: './webpack-stats.html',
         }),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -16,6 +16,11 @@ module.exports = webpackMerge.smart(config, {
     },
     devtool: 'source-map',
     plugins: [
+        new webpack.optimize.AggressiveMergingPlugin({
+            // delicate number: stops enhanced-no-commercial and enhanced
+            // being merged into one
+            minSizeReduce: 1.6,
+        }),
         new Visualizer({
             filename: './webpack-stats.html',
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,6 +874,10 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"


### PR DESCRIPTION
## What does this change?

- creates a `commercial*`/`enhanced` commons chunk in webpack
- loads `commercial*`/`enhanced` sooner
- runs `commercial*`/`enhanced` in parallel

also

- makes webpack's `import` usable
- tidies up `boot.js`

## What is the value of this and can you measure success?

`enhanced` no longer needs to wait for `commercial` js to complete, without delaying commercial (hopefully running it sooner).

where the preload header operates this will not make a lot of difference, but where we rely on the JS to load the rest of it, it should.

## before
![screen shot 2018-01-26 at 11 37 35](https://user-images.githubusercontent.com/867233/35438169-65fbacc8-028d-11e8-954e-f0c8dac2ecd9.png)

## after
![screen shot 2018-01-26 at 11 41 25](https://user-images.githubusercontent.com/867233/35438294-e2326070-028d-11e8-8cea-a7cd9dd386e3.png)

