### PR TITLE
Apply correct colour to liveblog standfirst

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -184,7 +184,7 @@
     padding-top: .33em;
     padding-bottom: .5rem;
     margin-bottom: 0;
-    color: #ffffff;
+    color: #ffffff !important;
 
     @include mq(desktop) {
         padding-bottom: 1rem;

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -184,7 +184,7 @@
     padding-top: .33em;
     padding-bottom: .5rem;
     margin-bottom: 0;
-    color: #ffffff !important;
+    color: #ffffff !important; // override value in content/types.scss
 
     @include mq(desktop) {
         padding-bottom: 1rem;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -524,7 +524,7 @@ $quote-mark: 35px;
         }
     }
 
-    .content__standfirst:not(.content__standfirst--immersive-minute-article) {
+    .content__standfirst {
         @include fs-bodyCopy(2);
         font-weight: 700;
         line-height: 20px;


### PR DESCRIPTION
## What does this change?

Liveblog standfirsts are currently black due to the extra specificity added to the standfirst selector in #18991   

This change reduces the specificity in the more generic selector, and moves the overriding burden to the immersive styles.

## What is the value of this and can you measure success?

Standfirst takes correct colour

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

😱 

<img width="797" alt="picture 454" src="https://user-images.githubusercontent.com/5931528/35444324-1bb5be60-02a6-11e8-8629-5d70fe82f987.png">


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
