### PR TITLE
Changed opinion secondary colour

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -93,7 +93,7 @@ $news-garnett-media-main-1: #ff4e36; // used for kicker on media
 $news-garnett-highlight: #ffe500;
 
 $opinion-garnett-main-1: #ed6300;
-$opinion-garnett-feature: #f5be2c;
+$opinion-garnett-feature: #bd5318;
 $opinion-garnett-media-main-1: #ff7f0f;
 $opinion-garnett-background: #fef9f5;
 


### PR DESCRIPTION
I've been meanign to do this for a long time, and it will help with my AMP PR.

I've changed the secondary colour for Opinion to better fit the pattern the other pillars follow:

# Before
<img width="524" alt="screen shot 2018-01-26 at 15 06 09" src="https://user-images.githubusercontent.com/14570016/35446079-8d447f76-02ab-11e8-8b9d-c00e480e2677.png">

# After
<img width="520" alt="screen shot 2018-01-26 at 15 12 43" src="https://user-images.githubusercontent.com/14570016/35446082-8d5d59f6-02ab-11e8-8f63-39d3b7109c35.png">
