### PR TITLE
Add `isSignupFlow` parameter to `/verify-email`

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -11,6 +11,8 @@ import model.{ApplicationContext, IdentityPage}
 import actions.AuthenticatedActions
 import pages.IdentityHtmlPage
 
+import scala.concurrent.Future
+
 
 class EmailVerificationController(api: IdApiClient,
   authenticatedActions: AuthenticatedActions,
@@ -60,7 +62,10 @@ class EmailVerificationController(api: IdApiClient,
     implicit request =>
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.") else None
-      api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData).map { _ =>
+
+      val future = if(isSignupFlow) Future.successful((): Unit) else api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData)
+
+      future.map { _ =>
         Ok(
           IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage, isSignupFlow))(page, request, context)
         )

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -61,7 +61,7 @@ class EmailVerificationController(api: IdApiClient,
   def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
     implicit request =>
       val idRequest = idRequestParser(request)
-      val customMessage = if (isRepermissioningRedirect) Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.") else None
+      val customMessage = Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.")
 
       val future = if(isSignupFlow) Future.successful((): Unit) else api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData)
 

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -56,13 +56,13 @@ class EmailVerificationController(api: IdApiClient,
       }
   }
 
-  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
+  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
     implicit request =>
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.") else None
       api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData).map { _ =>
         Ok(
-          IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage))(page, request, context)
+          IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage, isSignupFlow))(page, request, context)
         )
       }
   }

--- a/identity/app/views/emailVerified.scala.html
+++ b/identity/app/views/emailVerified.scala.html
@@ -16,7 +16,7 @@
 }
 
 <div class="identity-wrapper monocolumn-wrapper">
-    <div class="identity-forms-message">
+    <div class="identity-forms-message u-identity-forms-padded">
         <h1 class="identity-title">@getTitle</h1>
         <div class="identity-forms-message__body">
             @if(state.isValidated){

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -5,7 +5,7 @@
     customMessage: Option[String] = None
 )(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@import views.html.fragments.registrationFooter
+@import common.LinkTo
 
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
@@ -17,15 +17,15 @@
             <div class="identity-forms-email-wrap">
                 <header>@user.getPrimaryEmailAddress</header>
                 <aside>
-                    Is the email not correct? <a  href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="identity : email : update-email-from-error">Change it here</a>
+                    Is the email not correct? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
                 </aside>
             </div>
             <p><strong>We have sent a link to this email address. Please check your inbox and follow the instructions.</strong></p>
         </div>
-        <aside class="identity-forms-message__body">
+        <aside class="identity-forms-message__body identity-forms-message__body--aside">
             <p class="identity-forms-message__explainer">Validation links are valid for 30 minutes before expiring.</p>
             <p>Haven’t received the email or the link has expired?</p>
-            <a class="manage-account__button manage-account__button--center js-id-send-validation-email" data-link-name="Resend confirmation email">Resend confirmation email</a>
+            <a class="manage-account__button manage-account__button--light manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
         </aside>
     </section>
 </div>

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -21,15 +21,15 @@
                     Is the email not correct? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
                 </aside>
             </div>
-            <p><strong>We have sent a link to this email address. Please check your inbox and follow the instructions.</strong></p>
+            <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
         </div>
-        <aside class="identity-forms-message__body identity-forms-message__body--aside">
+        <aside class="identity-forms-message__body">
             <p class="identity-forms-message__explainer">Validation links are valid for 30 minutes before expiring.</p>
             <p>Haven’t received the email or the link has expired?</p>
-            <a class="manage-account__button manage-account__button--light manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
+            <a class="manage-account__button manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
         </aside>
         @if(isSignupFlow) {
-            <footer class="identity-forms-message__body identity-forms-message__body--aside">
+            <footer class="identity-forms-message__body">
                 <a class="u-underline" href="@LinkTo {/}" data-link-name="mma : verify-email : exit-to-gu">
                     Exit and go to The Guardian home page</a>
             </footer>

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -2,7 +2,8 @@
     user: com.gu.identity.model.User,
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
-    customMessage: Option[String] = None
+    customMessage: Option[String] = None,
+    isSignupFlow: Boolean = false
 )(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
@@ -27,5 +28,11 @@
             <p>Haven’t received the email or the link has expired?</p>
             <a class="manage-account__button manage-account__button--light manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
         </aside>
+        @if(isSignupFlow) {
+            <footer class="identity-forms-message__body identity-forms-message__body--aside">
+                <a class="u-underline" href="@LinkTo {/}" data-link-name="mma : verify-email : exit-to-gu">
+                    Exit and go to The Guardian home page</a>
+            </footer>
+        }
     </section>
 </div>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -22,7 +22,7 @@ GET         /user/id/:id/:activityType              controllers.PublicProfileCon
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
-GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false)
+GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false)
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -48,6 +48,7 @@ Messages
         @include identity-forms-padded;
     }
     .identity-forms-message__body {
+        @include clearfix;
         border-top: 1px solid $garnett-neutral-4;
         margin-top: $gs-baseline * 2;
         padding-top: $gs-baseline / 2;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -43,40 +43,36 @@ Messages
 */
 .identity-forms-message {
     max-width: gs-span(6);
-    margin: $gs-baseline auto;
-    &:not(.identity-forms-message--inline) {
-        @include identity-forms-padded;
-    }
+    margin: 0 auto;
     .identity-forms-message__body {
         @include clearfix;
         border-top: 1px solid $garnett-neutral-4;
         margin-top: $gs-baseline * 2;
-        padding-top: $gs-baseline / 2;
+        padding-top: $gs-baseline / 3;
         &.identity-forms-message__body--aside {
             @include fs-textSans(4);
             .manage-account__button {
                 @include fs-textSans(4);
             }
         }
-    }
-    .identity-forms-message__explainer {
-        opacity: .75;
+
+        > .manage-account__button:last-child {
+            margin: ($gs-baseline/2) 0 0;
+        }
+
+        .identity-forms-email-wrap {
+            margin: ($gs-baseline*4) 0;
+        }
+
     }
     .identity-forms-message__button {
         margin: $gs-baseline * 2 auto;
         float: none;
         display: flex;
     }
-
-    .identity-forms-email-wrap {
-        margin-bottom: ($gs-baseline/3)*2;
-     }
 }
 
 .identity-forms-email-wrap {
-    background-color: $garnett-neutral-3;
-    border-top: 1px solid $garnett-neutral-4;
-    padding: $gs-gutter / 4;
 
     header {
         @include fs-headline(3);

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -51,6 +51,9 @@ Messages
         border-top: 1px solid $garnett-neutral-4;
         margin-top: $gs-baseline * 2;
         padding-top: $gs-baseline / 2;
+        &.identity-forms-message__body--aside {
+            @include fs-textSans(4);
+        }
     }
     .identity-forms-message__explainer {
         opacity: .75;
@@ -78,7 +81,7 @@ Messages
     }
 
     aside {
-        @include fs-textSans(3);
+        @include fs-textSans(2);
         opacity: .75;
         margin-top: $gs-gutter / 4;
     }

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -53,6 +53,9 @@ Messages
         padding-top: $gs-baseline / 2;
         &.identity-forms-message__body--aside {
             @include fs-textSans(4);
+            .manage-account__button {
+                @include fs-textSans(4);
+            }
         }
     }
     .identity-forms-message__explainer {
@@ -81,7 +84,7 @@ Messages
     }
 
     aside {
-        @include fs-textSans(2);
+        @include fs-textSans(4);
         opacity: .75;
         margin-top: $gs-gutter / 4;
     }


### PR DESCRIPTION
## What does this change?
Adds a new parameter to `/verify-email` called `isSignupFlow`, meant to be used to land users on this page from the signup flow, it does the following:

- Removes the email auto-sending, as users will already have been sent one from identity-frontend
- Adds a link back to The Guardian at the very bottom

## Can i see it
![screen shot 2018-01-26 at 3 12 40 pm](https://user-images.githubusercontent.com/11539094/35446527-e9a1e58c-02ac-11e8-859d-4d38609c5d47.png)
