### PR TITLE
Stop bundling to AMD in webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,28 +9,26 @@
         "production": {
             "presets": [
                 ["babel-preset-env", {
-                    "modules": "amd"
+                    "modules": false
                 }]
             ],
             "plugins": [
                 ["babel-plugin-transform-runtime", {
                     "polyfill": false
                 }],
-                "babel-plugin-add-module-exports",
                 "babel-plugin-transform-class-properties",
             ],
         },
         "development": {
             "presets": [
                 ["babel-preset-env", {
-                    "modules": "amd"
+                    "modules": false
                 }]
             ],
             "plugins": [
                 ["babel-plugin-transform-runtime", {
                     "polyfill": false
                 }],
-                "babel-plugin-add-module-exports",
                 "babel-plugin-transform-class-properties",
             ],
         },

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -54,7 +54,7 @@ const go = () => {
                             markTime('commercial boot');
                             const commercialBoot = config.switches.commercial
                                 ? require('bootstraps/commercial-control')
-                                      .bootCommerical
+                                      .bootCommercial
                                 : Promise.resolve;
 
                             commercialBoot().then(() => {
@@ -101,7 +101,7 @@ const go = () => {
                     raven.context({ tags: { feature: 'commercial' } }, () => {
                         markTime('commercial boot');
                         const commercialBoot = config.switches.commercial
-                            ? require('bootstraps/commercial').bootCommerical
+                            ? require('bootstraps/commercial').bootCommercial
                             : Promise.resolve;
 
                         commercialBoot().then(() => {

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -54,6 +54,7 @@ const go = () => {
                             markTime('commercial boot');
                             const commercialBoot = config.switches.commercial
                                 ? require('bootstraps/commercial-control')
+                                      .bootCommerical
                                 : Promise.resolve;
 
                             commercialBoot().then(() => {
@@ -100,7 +101,7 @@ const go = () => {
                     raven.context({ tags: { feature: 'commercial' } }, () => {
                         markTime('commercial boot');
                         const commercialBoot = config.switches.commercial
-                            ? require('bootstraps/commercial')
+                            ? require('bootstraps/commercial').bootCommerical
                             : Promise.resolve;
 
                         commercialBoot().then(() => {

--- a/static/src/javascripts/bootstraps/commercial-control.js
+++ b/static/src/javascripts/bootstraps/commercial-control.js
@@ -116,7 +116,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export default (): Promise<void> => {
+export const bootCommerical = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [

--- a/static/src/javascripts/bootstraps/commercial-control.js
+++ b/static/src/javascripts/bootstraps/commercial-control.js
@@ -116,7 +116,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export const bootCommerical = (): Promise<void> => {
+export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -118,7 +118,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export default (): Promise<void> => {
+export const bootCommerical = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -118,7 +118,7 @@ const loadModules = (): Promise<void> => {
     });
 };
 
-export const bootCommerical = (): Promise<void> => {
+export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');
     catchErrorsWithContext([
         [


### PR DESCRIPTION
## What does this change?

we don't need this now, it's left from requirejs conversion.

## What is the value of this and can you measure success?

smaller bundles, less code to parse.