### PR TITLE
Fix headlines and standfirsts in Minute articles

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -204,10 +204,6 @@
     }
 }
 
-.content--liveblog .content__standfirst--immersive-article {
-    color: #ffffff !important; // override value in content/types.scss
-}
-
 .content__wrapper--standfirst {
     @include content-gutter();
     background-color: rgba(0, 0, 0, .5);

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -13,7 +13,7 @@ $quote-mark: 35px;
 .content--type-comment,
 .content--type-feature,
 .content--type-guardianview,
-.content--type-immersive,
+.content--type-immersive:not(.content--minute-article),
 .content--type-interview,
 .content--type-live,
 .content--type-matchreport,
@@ -466,7 +466,7 @@ $quote-mark: 35px;
         margin-right: 0;
     }
 
-    .content__headline:not(.content__headline--minute) {
+    .content__headline {
         @include fs-headlineGarnett(4);
         font-weight: 400; // magic number correcting line height so vertical alignment apprears even with labels
         padding-top: 3px;


### PR DESCRIPTION
## What does this change?

#18991 broke at least a couple of things, namely

- standfirst colour in liveblog (#19008) and immersive articles (#19018)
- `line-height` and `font-weight` in certain articles

This is a reimplementation of the original change, to make headline and standfirst look great in Minute articles _without breaking anything else_.

This change also unwinds the temporary fix for the standfirst colour in immersive articles (#19018)

## What is the value of this and can you measure success?

Fixes things without breaking other things

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
