### PR TITLE
24/7 fix for standfirst disappearing

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -184,7 +184,7 @@
     padding-top: .33em;
     padding-bottom: .5rem;
     margin-bottom: 0;
-    color: #ffffff !important; // override value in content/types.scss
+    color: #ffffff;
 
     @include mq(desktop) {
         padding-bottom: 1rem;
@@ -202,6 +202,10 @@
     &.content__standfirst--advertisement {
         font-family: $f-sans-serif-text;
     }
+}
+
+.content--liveblog .content__standfirst--immersive-article {
+    color: #ffffff !important; // override value in content/types.scss
 }
 
 .content__wrapper--standfirst {


### PR DESCRIPTION
## What does this change?

Whack-a-mole on standfirst colours... After #19008 the standfirst in immersive articles is invisible because it's white on white - this is a 24/7 issue because content is disappearing.

@sndrs @SiAdcock Sorry, you might wanna do this properly on Monday.

![image](https://user-images.githubusercontent.com/638051/35470399-d37378a4-0340-11e8-9ff0-847e57446be3.png)

## What is the value of this and can you measure success?

Content disappearing.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![image](https://user-images.githubusercontent.com/638051/35470415-0092308c-0341-11e8-9f9b-e849c913d73a.png)


## Tested in CODE?
No