### PR TITLE
Link to returnUrl in /verify-email

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -58,7 +58,7 @@ class EmailVerificationController(api: IdApiClient,
       }
   }
 
-  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean, returnUrl: Option[String]): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
+  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
     implicit request =>
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.") else None

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -58,13 +58,15 @@ class EmailVerificationController(api: IdApiClient,
       }
   }
 
-  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
+  def resendEmailValidationEmail(isRepermissioningRedirect: Boolean, isSignupFlow: Boolean, returnUrl: Option[String]): Action[AnyContent] = fullAuthWithIdapiUserAction.async {
     implicit request =>
       val idRequest = idRequestParser(request)
       val customMessage = if (isRepermissioningRedirect) Some("To access all your account features and join the Guardian community, we need you to confirm your email address below.") else None
 
+      val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
+
       val verificationEmailResentPage =
-        Ok(IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage, isSignupFlow))(page, request, context))
+        Ok(IdentityHtmlPage.html(views.html.verificationEmailResent(request.user, idRequest, idUrlBuilder, customMessage, verifiedReturnUrlAsOpt, returnUrlVerifier.defaultReturnUrl, isSignupFlow))(page, request, context))
 
       if (isSignupFlow)
         Future.successful(verificationEmailResentPage)

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -71,7 +71,12 @@ class EmailVerificationController(api: IdApiClient,
       if (isSignupFlow)
         Future.successful(verificationEmailResentPage)
       else
-        api.resendEmailValidationEmail(request.user.auth, idRequest.trackingData).map(_ => verificationEmailResentPage)
+        api.resendEmailValidationEmail(
+          request.user.auth,
+          idRequest.trackingData
+        ).map(_ =>
+          verificationEmailResentPage
+        )
   }
 }
 

--- a/identity/app/services/ReturnUrlVerifier.scala
+++ b/identity/app/services/ReturnUrlVerifier.scala
@@ -19,7 +19,8 @@ class ReturnUrlVerifier(conf: IdConfig) extends SafeLogging {
     request
       .getQueryString("returnUrl")
       .orElse(request.headers.get("Referer")
-    )
+        .filterNot(_.startsWith(conf.url))
+      )
   )
 
   def getVerifiedReturnUrl(returnUrl: Option[String]): Option[String] = {
@@ -35,7 +36,7 @@ class ReturnUrlVerifier(conf: IdConfig) extends SafeLogging {
 
   def hasVerifiedReturnUrl(returnUrl: String): Boolean = Try(new URI(returnUrl).getHost)
     .map(uri =>
-      uri.startsWith(conf.url) || validUris.contains(uri) || isValidDomain(uri)
+      validUris.contains(uri) || isValidDomain(uri)
     ).getOrElse(false)
 
   private def isValidDomain(domain: String) = returnUrlDomains.exists(validDomain =>

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -3,6 +3,8 @@
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     customMessage: Option[String] = None,
+    verifiedReturnUrl: Option[String],
+    defaultReturnUrl: String,
     isSignupFlow: Boolean = false
 )(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -30,8 +32,12 @@
         </aside>
         @if(isSignupFlow) {
             <footer class="identity-forms-message__body">
-                <a class="u-underline" href="@LinkTo {/}" data-link-name="mma : verify-email : exit-to-gu">
-                    Exit and go to The Guardian home page</a>
+                <a class="u-underline" href="@LinkTo {@verifiedReturnUrl.getOrElse(defaultReturnUrl)}" data-link-name="mma : verify-email : exit-to-gu">
+                    @(verifiedReturnUrl match {
+                        case Some(_) => "Exit and continue"
+                        case None => "Exit and go to The Guardian home page"
+                    })
+                </a>
             </footer>
         }
     </section>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -22,7 +22,7 @@ GET         /user/id/:id/:activityType              controllers.PublicProfileCon
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
-GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false)
+GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false, returnUrl : Option[String] )
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -22,7 +22,7 @@ GET         /user/id/:id/:activityType              controllers.PublicProfileCon
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
-GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false, returnUrl : Option[String] )
+GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false )
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -57,20 +57,22 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
   "Given the plain verify method is called" - Fake {
 
+    when(idRequestParser.apply(testRequest)) thenReturn idRequest
+
     "should not render a link if it's not a sign up" in {
-      val result = controller.resendEmailValidationEmail(true, false, None)(testRequest)
+      val result = controller.resendEmailValidationEmail(true, false, None)(idRequest)
       contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should not include("Exit and go to The Guardian home page")
     }
 
     "should render a link if it's a sign up" in {
-      val result = controller.resendEmailValidationEmail(true, true, None)(testRequest)
+      val result = controller.resendEmailValidationEmail(true, true, None)(idRequest)
       contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should include("Exit and go to The Guardian home page")
     }
 
     "should link to the return url" in {
-      val result = controller.resendEmailValidationEmail(true, true, Some("https://jobs.theguardian.com/test-string-test"))(testRequest)
+      val result = controller.resendEmailValidationEmail(true, true, Some("https://jobs.theguardian.com/test-string-test"))(idRequest)
       contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should include("test-string-test")
       contentAsString(result) should include("Exit and continue")

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -35,14 +35,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val testRequest = TestRequest()
   val authService = mock[AuthenticationService]
   val trackingData = mock[TrackingData]
-  val idRequest = IdentityRequest(
-    trackingData,
-    None,
-    None,
-    None,
-    None,
-    false
-  )
+  val idRequest = mock[IdentityRequest]
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
 

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -35,9 +35,18 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val testRequest = TestRequest()
   val authService = mock[AuthenticationService]
   val trackingData = mock[TrackingData]
-  val idRequest = mock[IdentityRequest]
+  val idRequest = IdentityRequest(
+    trackingData,
+    None,
+    None,
+    None,
+    None,
+    false
+  )
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+
+  when(api.resendEmailValidationEmail(MockitoMatchers.any[idapiclient.Auth], MockitoMatchers.any[idapiclient.TrackingData])) thenReturn Future.successful(Right((): Unit))
 
   val userId: String = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
@@ -45,7 +54,6 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val authenticatedUser = AuthenticatedUser(user, testAuth, true)
   val phoneNumbers = PhoneNumbers
 
-  when(idRequest.trackingData) thenReturn trackingData
   when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
   when(api.me(testAuth)) thenReturn Future.successful(Right(user))
 
@@ -54,7 +62,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
   val EmailValidatedMessage = "Your email address has been validated."
   when(identityUrlBuilder.buildUrl(anyString(), anyVararg[(String, String)]())) thenAnswer returnsFirstArg()
-  when(idRequestParser.apply(testRequest)) thenReturn idRequest
+  when(idRequestParser.apply(MockitoMatchers.any[Request[_]])) thenReturn idRequest
   when(authenticationService.userIsFullyAuthenticated(MockitoMatchers.any[Request[_]])) thenReturn true
   when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(Some("http://www.theguardian.com/football"))
 

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -12,12 +12,13 @@ import org.scalatest.{Matchers, path}
 import play.api.mvc.{ControllerComponents, Request}
 import play.api.test.Helpers._
 import services._
-import test.{Fake, TestRequest, WithTestApplicationContext, WithTestIdConfig}
+import test._
 
 import scala.concurrent.Future
 
 class EmailVerificationControllerTest extends path.FreeSpec
   with Matchers
+  with WithTestExecutionContext
   with WithTestApplicationContext
   with MockitoSugar
   with WithTestIdConfig {

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -46,7 +46,29 @@ class EmailVerificationControllerTest extends path.FreeSpec
     identityUrlBuilder,
     returnUrlVerifier,
     play.api.test.Helpers.stubControllerComponents()
-  )
+  )(testApplicationContext)
+
+  "Given the plain verify method is called" - Fake {
+
+    "should not render a link if it's not signup" in {
+      val result = controller.resendEmailValidationEmail(true, false, None)(testRequest)
+      contentAsString(result) should include("Confirm your email address")
+      contentAsString(result) should not include("Exit and go to The Guardian home page")
+    }
+
+    "should render a link if it's a signup" in {
+      val result = controller.resendEmailValidationEmail(true, true, None)(testRequest)
+      contentAsString(result) should include("Confirm your email address")
+      contentAsString(result) should include("Exit and go to The Guardian home page")
+    }
+
+    "should link to the returnurl" in {
+      val result = controller.resendEmailValidationEmail(true, true, Some("https://jobs.theguardian.com/test-string-test"))(testRequest)
+      contentAsString(result) should include("Confirm your email address")
+      contentAsString(result) should include("test-string-test")
+      contentAsString(result) should include("Exit and continue")
+    }
+  }
 
   "Given the verify method is called" - Fake {
     val token = "myToken"


### PR DESCRIPTION
## What does this change?
Changes the footer link in `/verify-email?isSignupFlow=true` to whatever `returnUrl` it gets(or the guardian homepage otherwise). This PR also expands the valid return url matching to include all valid urls in `identity-frontend`, such as jobs and membership.

[📎 Related PR](https://github.com/guardian/identity-frontend/pull/287/files)

## Screenshots (notice the status bar!)
![screen shot 2018-01-29 at 2 36 09 pm](https://user-images.githubusercontent.com/11539094/35515731-d2fb25d0-0501-11e8-9dc3-012a692bbcdc.png)
