### PR TITLE
Insert custom epic for Australia environment campaign

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,4 +86,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-australia-environment-campaign-2018",
+    "Show a custom Epic for articles with the Australia environment campaign tag",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -174,18 +174,18 @@ const makeABTestVariant = (
     parentTest: EpicABTest
 ): Variant => {
     const trackingCampaignId = `epic_${parentTest.campaignId}`;
-    const campaignCode = getCampaignCode(
-        parentTest.campaignPrefix,
-        parentTest.campaignId,
-        id,
-        parentTest.campaignSuffix
-    );
     const iframeId = `${parentTest.campaignId}_iframe`;
 
     // defaults for options
     const {
         maxViews = defaultMaxViews,
         isUnlimited = false,
+        campaignCode = getCampaignCode(
+            parentTest.campaignPrefix,
+            parentTest.campaignId,
+            id,
+            parentTest.campaignSuffix
+        ),
         contributeURL = addTrackingCodesToUrl({
             base: contributionsBaseURL,
             componentType: parentTest.componentType,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -12,11 +12,13 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { colourTestEpicHoldback } from 'common/modules/experiments/tests/circles-epic-holdback';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
+import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
     colourTestEpicHoldback,
     askFourEarning,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-env-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-env-campaign.js
@@ -1,0 +1,47 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import config from 'lib/config';
+
+const campaignTag = 'environment/series/our-wide-brown-land';
+
+const tagsMatch = () =>
+    config
+        .get('page.nonKeywordTagIds', '')
+        .split(',')
+        .includes(campaignTag);
+
+export const acquisitionsEpicAusEnvCampaign = makeABTest({
+    id: 'AcquisitionsAustraliaEnvironmentCampaign2018',
+    campaignId: 'aus_environment_campaign_2018',
+
+    start: '2018-01-29',
+    expiry: '2018-03-30',
+
+    author: 'Joseph Smith',
+    description: 'Show a custom Epic for articles with the wide brown land tag',
+    successMeasure: 'AV2.0',
+    idealOutcome:
+        'The Australia environment campaign resonates with our readers, and we continue to provide quality reporting on this important issue',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    canRun: tagsMatch,
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION'],
+            options: {
+                campaignCode: 'aus_environment_campaign_2018',
+                isUnlimited: true,
+                usesIframe: true,
+                template: variant =>
+                    `<iframe src="https://interactive.guim.co.uk/embed/2018/this-wide-brown-land/epic/epic.html"
+                        data-component="${variant.options.componentName}"
+                        class="acquisitions-epic-iframe"
+                        id="${variant.options.iframeId}">
+                    </iframe>`,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
Insert custom iframe epic for a fundraising campaign on the environment that the Australian office are running.

This epic will appear on articles with series tag `environment/series/our-wide-brown-land`

# Screenshot

![picture 95](https://user-images.githubusercontent.com/5122968/35524045-31443bac-0518-11e8-9486-548c8db0facb.png)
