### PR TITLE
small tweak to the colour of our red

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -87,8 +87,8 @@ $garnett-neutral-7: #444444;
 $garnett-neutral-8: #eaeaea;
 
 
-$news-garnett-main-1: #e00000; //used for kicker
-$news-garnett-feature: #ad0006; //used for feature head
+$news-garnett-main-1: #c70000; //used for kicker
+$news-garnett-feature: #880105; //used for feature head 
 $news-garnett-media-main-1: #ff4e36; // used for kicker on media
 $news-garnett-highlight: #ffe500;
 
@@ -109,7 +109,7 @@ $lifestyle-garnett-main-1: #bb3b80;
 $lifestyle-garnett-feature: #7d0068;
 $lifestyle-garnett-media-main-1: #ffabdb;
 
-$live-garnett-main-1: $news-garnett-feature;
+$live-garnett-main-1: #ad0006;
 $live-garnett-main-2: #ffbac8;
 $live-garnett-dead-background: #eaeaea;
 $live-garnett-accent: #d65353;

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -111,7 +111,8 @@ $pillars: (
     &.fc-item--gallery .fc-item__kicker,
     &.fc-item--video .fc-item__kicker,
     &.video-playlist__item .fc-item__kicker,
-    &.fc-item--type-immersive .fc-item__kicker
+    &.fc-item--type-immersive .fc-item__kicker,
+    &.fc-item--type-immersive .fc-item__byline
     {
         color: map-get($palette, invertedKicker);
     }


### PR DESCRIPTION
## What does this change?
Darken the colour of the red based on feedback from readers. Makes the byline legible on immersive cards. 

Before
<img width="1014" alt="picture 1043" src="https://user-images.githubusercontent.com/11950919/35568588-72b2a9c6-05c1-11e8-95d6-d58ffa0f0fa6.png">
After
<img width="1038" alt="picture 1042" src="https://user-images.githubusercontent.com/11950919/35568610-7eb17248-05c1-11e8-9978-bff8a8f01926.png">
