### PR TITLE
AMP carousel logo

### DIFF
--- a/article/app/model/structuredData/Organisation.scala
+++ b/article/app/model/structuredData/Organisation.scala
@@ -11,8 +11,8 @@ object Organisation {
     "name" -> "The Guardian",
     "logo" -> Json.obj(
       "@type" -> "ImageObject",
-      "url" -> "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png",
-      "width" -> 300,
+      "url" -> "https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png",
+      "width" -> 190,
       "height" -> 60
     )
   )

--- a/article/app/views/fragments/logo.scala.html
+++ b/article/app/views/fragments/logo.scala.html
@@ -2,8 +2,8 @@
 @(amp: Boolean = false)
 
     <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-        <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
-        <meta itemprop="width" content="300">
+        <meta itemprop="url" content="https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png">
+        <meta itemprop="width" content="190">
         <meta itemprop="height" content="60">
     </div>
     @if(!amp) {

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -26,8 +26,8 @@
         <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
             <meta itemprop="name" content="https://www.theguardian.com#publisher" />
             <span itemprop="logo" itemscope itemtype="http://schema.org/ImageObject">
-                <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png" />
-                <meta itemprop="width" content="300" />
+                <meta itemprop="url" content="https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png" />
+                <meta itemprop="width" content="190" />
                 <meta itemprop="height" content="60" />
             </span>
         </span>


### PR DESCRIPTION
The AMP carousel has our old logo, now it shouldn't anymore. This affects anywhere that our structured data was using the old logo.

# Before
![amp iphoned](https://user-images.githubusercontent.com/14570016/35622681-9fd1d052-0680-11e8-89fe-99a779073fe4.png)

# After
![amp iphone](https://user-images.githubusercontent.com/14570016/35622680-9fbd4a10-0680-11e8-8995-be27c31761e8.png)
