### PR TITLE
Removing `women` from the tag list making it bold in the subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -545,7 +545,6 @@ object NavLinks {
     "music/classicalmusicandopera",
     "lifeandstyle/food-and-drink",
     "tone/recipes",
-    "lifeandstyle/women",
     "lifeandstyle/health-and-wellbeing",
     "lifeandstyle/family",
     "lifeandstyle/home-and-garden",


### PR DESCRIPTION
## What does this change?
Trello Card: https://trello.com/c/PSFCmLGk/14-remove-women-from-tag-list-in-nav

This is requested from Caspar and Peter Martin. The tag `women` being treated as a section is a contentious issue in editorial and this is a quick fix in the nav to address it.

There is a wider discussion about the behaviour of the subnav which I can update on when I know more. Trello card for that: https://trello.com/c/D0traEeg/7-navigation-subnav-behaviour.

## What is the value of this and can you measure success?
- An article which is tagged with multiple things, women being one of the tags isn't being highlighted as `women` anymore in the nav. 
- Editorial are happier?

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/35625978-210b5eda-068c-11e8-8c1b-ad4d9bc979ea.png)

After:
![image](https://user-images.githubusercontent.com/8774970/35625963-166f7d4e-068c-11e8-8454-a98e9020ebfa.png)


## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
