### PR TITLE
Show auto signin banner on identity pages

### DIFF
--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -41,7 +41,10 @@ object IdentityHtmlPage {
       bodyTag(classes = defaultBodyClasses())(
         views.html.layout.identityFlexWrap()(
           skipToMainContent(),
-          views.html.layout.identityHeader(hideNavigation=page.isFlow) when page.metadata.hasSlimHeader,
+          views.html.layout.identityHeader(
+            hideNavigation = page.isFlow,
+            showAutoSigninBanner = request.target.getQueryParameter("isAutoSignIn").getOrElse("false").toBoolean
+          ) when page.metadata.hasSlimHeader,
           header() when !page.metadata.hasSlimHeader
         )(
           content

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -49,9 +49,6 @@
 
 @renderStep(step: ConsentStep, index: Option[Int] = None) = {
     @if(step.show) {
-        @(step.banner.map { title =>
-            Html(s"<p class='form__success'>$title</p>")
-        })
         <fieldset
             class="identity-wizard__step"
             data-wizard-step-name="@step.name"
@@ -155,7 +152,6 @@
         help = List(
             ConsentStepHelpText("Set your preferences: Please let us know if you are interested in any of these products or services.")
         ),
-        banner = Some("Thank you for signing up"),
         content = marketingStepContent,
     )
 }

--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -1,7 +1,10 @@
 @import common.LinkTo
 @import views.support.DropdownMenus.accountDropdownMenu
+@import com.gu.identity.model.User
+@import conf.Configuration
 
-@(hideNavigation: Boolean = false)(implicit page: model.Page, request: RequestHeader)
+@(hideNavigation: Boolean = false, showAutoSigninBanner: Boolean = false)(implicit page: model.Page, request: RequestHeader, user: Option[User] = None)
+
 
 <header class="identity-header" data-component="identity-nav">
     <div class="gs-container identity-header__container">
@@ -51,3 +54,18 @@
         </a>
     </div>
 </header>
+@if(showAutoSigninBanner) {
+    <div class="identity-header-auto-signin">
+        <div class="identity-wrapper monocolumn-wrapper">
+            <div class="form__success">
+                <p>
+                    Thank you. We have signed you in automatically.
+                </p>
+                <p>
+                    On a shared computer?
+                    <a class="u-underline" href="@(Configuration.id.url)/signout">Log out</a>
+                </p>
+            </div>
+        </div>
+    </div>
+}

--- a/identity/app/views/support/fragment/ConsentStep.scala
+++ b/identity/app/views/support/fragment/ConsentStep.scala
@@ -17,7 +17,6 @@ object ConsentStep {
     title: String,
     help: List[ConsentStepHelpTextTrait] = Nil,
     content: Html = Html(""),
-    banner: Option[String] = None,
     show: Boolean = true
   )
 

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -154,3 +154,22 @@ label[for=identity-header-account-menu-fallback]:focus {
     }
 
 }
+
+
+.identity-header-auto-signin {
+    .identity-wrapper {
+        padding-bottom: $gs-gutter / 2;
+    }
+    .form__success {
+        margin-top: 0;
+        @include mq(desktop) {
+            display: flex;
+            justify-content: space-between;
+            @supports (display: flex) {
+                p {
+                    margin: 0;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
When the url parameter `?isAutoSignIn=true` is passed, a banner will appear, thanking the user and offering an option to log out. This will be integrated with an update to consent emails that will in fact automatically sign the users in.

## Screenshots
![screen shot 2018-01-31 at 2 21 10 pm](https://user-images.githubusercontent.com/11539094/35627805-00009b0a-0692-11e8-87cc-0cdbf04479d9.png)
