### PR TITLE
Extend Garnett switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -602,7 +602,7 @@ trait FeatureSwitches {
     "when ON, garnett styling will appear on Fronts and articles (this does not work on the navigation)",
     owners = Seq(Owner.withGithub("NataliaLKB"), Owner.withGithub("blongden73")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 1, 31),
+    sellByDate = new LocalDate(2018, 2, 8),
     exposeClientSide = false
   )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -61,7 +61,7 @@ object Garnett extends Experiment(
   name = "garnett",
   description = "Users in this experiment will see garnet styling.",
   owners = Seq(Owner.withName("dotcom.platform")),
-  sellByDate = new LocalDate(2018, 2, 1),
+  sellByDate = new LocalDate(2018, 2, 8),
   participationGroup= Perc0C
 ) {
   override def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = super.isParticipating || GarnettLaunch.isSwitchedOn


### PR DESCRIPTION
## What does this change?
Extending for a week as I have been too busy to do the work of removing it

cc @guardian/guardian-frontend-team 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
