### PR TITLE
Improve facia performance on production machines

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -146,6 +146,7 @@ object FaciaPressMetrics {
   val FrontPressContentSize = SamplerMetric("front-press-content-size", StandardUnit.Bytes)
   val FrontPressContentSizeLite = SamplerMetric("front-press-content-size-lite", StandardUnit.Bytes)
   val FrontDecodingLatency = DurationMetric("front-decoding-latency", StandardUnit.Milliseconds)
+  val FrontDownloadLatency = DurationMetric("front-download-latency", StandardUnit.Milliseconds)
 }
 
 object EmailSubsciptionMetrics {

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.gu.Box
 import com.amazonaws.services.cloudwatch.model.StandardUnit
+import common.{FaciaPressMetrics, StopWatch}
 import model.diagnostics.CloudWatch
 import org.joda.time.DateTime
 import scala.concurrent.Future
@@ -132,6 +133,15 @@ final case class DurationMetric(override val name: String, override val metricUn
   def recordDuration(timeInMillis: Double): Unit = record(DurationDataPoint(timeInMillis, Option(DateTime.now)))
 
   override def isEmpty: Boolean = dataPoints.get().isEmpty
+}
+
+object DurationMetric {
+  def withMetrics[A](metric: DurationMetric)(block: => A): A = {
+    val stopWatch: StopWatch = new StopWatch
+    val result = block
+    FaciaPressMetrics.FrontDownloadLatency.recordDuration(stopWatch.elapsed)
+    result
+  }
 }
 
 case class SampledDataPoint(value: Double, sampleTime: DateTime) extends DataPoint {

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -139,7 +139,7 @@ object DurationMetric {
   def withMetrics[A](metric: DurationMetric)(block: => A): A = {
     val stopWatch: StopWatch = new StopWatch
     val result = block
-    FaciaPressMetrics.FrontDownloadLatency.recordDuration(stopWatch.elapsed)
+    metric.recordDuration(stopWatch.elapsed)
     result
   }
 }

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -56,7 +56,8 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val appIdentity = ApplicationIdentity("facia")
 
   override lazy val appMetrics = ApplicationMetrics(
-    FaciaPressMetrics.FrontDecodingLatency
+    FaciaPressMetrics.FrontDecodingLatency,
+    FaciaPressMetrics.FrontDownloadLatency
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -32,6 +32,7 @@ trait FrontJsonFapi extends Logging {
     blockingOperations.executeBlocking {
       jsonStringOpt.map { jsonString =>
         DurationMetric.withMetrics(FaciaPressMetrics.FrontDecodingLatency) {
+          // This operation is run in the thread pool since it is very CPU intensive
           Json.parse(jsonString).as[PressedPage]
         }
       }

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -28,7 +28,7 @@ trait FrontJsonFapi extends Logging {
     pressedPageFromS3(getAddressForPath(path, LiteType.suffix))
   }
 
-  private def parsePressedPage(jsonStringOpt: Option[String]): Future[Option[PressedPage]] = futureSemaphore.execute {
+  private def parsePressedPage(jsonStringOpt: Option[String])(implicit executionContext: ExecutionContext): Future[Option[PressedPage]] = futureSemaphore.execute {
     blockingOperations.executeBlocking {
       jsonStringOpt.map { jsonString =>
         DurationMetric.withMetrics(FaciaPressMetrics.FrontDecodingLatency) {

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -3,15 +3,17 @@ package controllers.front
 import common.{FaciaPressMetrics, Logging, StopWatch}
 import concurrent.{BlockingOperations, FutureSemaphore}
 import conf.Configuration
+import metrics.DurationMetric
 import model.{FullType, LiteType, PressedPage}
 import play.api.libs.json.Json
 import services.S3
+
 import scala.concurrent.{ExecutionContext, Future}
 
 trait FrontJsonFapi extends Logging {
   lazy val stage: String = Configuration.facia.stage.toUpperCase
   val bucketLocation: String
-  val parallelJsonPresses = 24
+  val parallelJsonPresses = 32
   val futureSemaphore = new FutureSemaphore(parallelJsonPresses)
 
   def blockingOperations: BlockingOperations
@@ -26,17 +28,27 @@ trait FrontJsonFapi extends Logging {
     pressedPageFromS3(getAddressForPath(path, LiteType.suffix))
   }
 
-  private def pressedPageFromS3(path: String)(implicit executionContext: ExecutionContext): Future[Option[PressedPage]] = errorLoggingF(s"FrontJsonFapi.pressedPageFromS3 $path") {
-    futureSemaphore.execute {
-      blockingOperations.executeBlocking {
-        S3.getGzipped(path).map { jsonString =>
-          val stopWatch: StopWatch = new StopWatch
-          val pressedPage = Json.parse(jsonString).as[PressedPage]
-          FaciaPressMetrics.FrontDecodingLatency.recordDuration(stopWatch.elapsed)
-          pressedPage
+  private def parsePressedPage(jsonStringOpt: Option[String]): Future[Option[PressedPage]] = futureSemaphore.execute {
+    blockingOperations.executeBlocking {
+      jsonStringOpt.map { jsonString =>
+        DurationMetric.withMetrics(FaciaPressMetrics.FrontDecodingLatency) {
+          Json.parse(jsonString).as[PressedPage]
         }
       }
     }
+  }
+
+  private def loadPressedPageFromS3(path: String) = blockingOperations.executeBlocking {
+    DurationMetric.withMetrics(FaciaPressMetrics.FrontDownloadLatency) {
+      S3.getGzipped(path)
+    }
+  }
+
+  private def pressedPageFromS3(path: String)(implicit executionContext: ExecutionContext): Future[Option[PressedPage]] = errorLoggingF(s"FrontJsonFapi.pressedPageFromS3 $path") {
+    for {
+      s3FrontData <- loadPressedPageFromS3(path)
+      pressedPage <- parsePressedPage(s3FrontData)
+    } yield pressedPage
   }
 
 }


### PR DESCRIPTION
## What does this change?

This aims to fix the issue where Facia CPU utilisation was low despite handling a lot of front requests and erroring.

Removes IO s3 operation from semaphore pool and adds metric for front s3 download time. 

We should consider pressing HTML pages in Facia-press for all editions * experiments

## What is the value of this and can you measure success?

Facia scales correctly.

## Tested in CODE?

Performance testing on a detached production machine
