### PR TITLE
Story package take vi

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -71,7 +71,6 @@
     .fc-item.fc-item--pillar-lifestyle.fc-item--type-comment,
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
     .fc-item.fc-item--type-feature,
-    .fc-item.fc-item--pillar-opinion.fc-item--type-comment .fc-trail__count--commentcount
     {
         background-color: $story-package-garnett;
 
@@ -81,6 +80,9 @@
             .fc-trail__count--commentcount {
                 background-color: darken($story-package-garnett, 5%);
             }
+        }
+        .fc-trail__count--commentcount {
+            background-color: $story-package-garnett;
         }
 
         .fc-item__headline {

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -70,7 +70,7 @@
     .fc-item.fc-item--pillar-sport.fc-item--type-comment,
     .fc-item.fc-item--pillar-lifestyle.fc-item--type-comment,
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item.fc-item--type-feature,
+    .fc-item.fc-item--type-feature
     {
         background-color: $story-package-garnett;
 


### PR DESCRIPTION
## What does this change?
Fixes the background of the comment count in the story package container for opinion cards for ALL pillars. 

Before 
<img width="241" alt="picture 1059" src="https://user-images.githubusercontent.com/11950919/35674530-db9293b2-073c-11e8-9dd6-83c6181e878d.png">

After
<img width="248" alt="picture 1058" src="https://user-images.githubusercontent.com/11950919/35674540-e055b19a-073c-11e8-98e8-21dd09e43469.png">

