### PR TITLE
Deps: Upgrade amphtml-validator version to 1.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "wolfy87-eventemitter": "~4.2.6"
   },
   "devDependencies": {
-    "amphtml-validator": "^1.0.20",
+    "amphtml-validator": "^1.0.21",
     "any-observable": "^0.2.0",
     "autoprefixer": "^7.1.6",
     "aws-sdk": "^2.107.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,9 +192,17 @@ amdefine@>=0.0.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.0.tgz#fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
 
-amphtml-validator@^1.0.10, amphtml-validator@^1.0.20:
+amphtml-validator@^1.0.10:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.20.tgz#5f6a75ca1917844526e5d87f74c1334c0eccb514"
+  dependencies:
+    colors "1.1.2"
+    commander "2.9.0"
+    promise "7.1.1"
+
+amphtml-validator@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.21.tgz#4ebff8ff5ab1bd10f7388f3bdda22ef94ff1b8e7"
   dependencies:
     colors "1.1.2"
     commander "2.9.0"


### PR DESCRIPTION
## What does this change?

Upgrade amphtml-validator version from `1.0.20` to `1.0.21`.
