### PR TITLE
Shows tags for analysis pieces

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -803,7 +803,6 @@ $quote-mark: 35px;
         }
     }
 }
-
 // *************** Feature overides *************
 
 .content--type-feature {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -803,6 +803,13 @@ $quote-mark: 35px;
         }
     }
 }
+
+// *************** Analysis overides *************
+.content--type-analysis {
+    .content__labels.content__labels--not-immersive {
+        display: block;
+    }
+}
 // *************** Feature overides *************
 
 .content--type-feature {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -804,12 +804,6 @@ $quote-mark: 35px;
     }
 }
 
-// *************** Analysis overides *************
-.content--type-analysis {
-    .content__labels.content__labels--not-immersive {
-        display: block;
-    }
-}
 // *************** Feature overides *************
 
 .content--type-feature {
@@ -1401,10 +1395,6 @@ $quote-mark: 35px;
         @include mq(leftCol) {
             margin-bottom: $gs-baseline/2;
         }
-    }
-
-    .content__labels--not-immersive {
-        display: none;
     }
 
     .content__headline {


### PR DESCRIPTION
## What does this change?
Makes tags for analysis pieces visible, were hidden for some odd reason

Before:
<img width="897" alt="screen shot 2018-02-01 at 15 29 44" src="https://user-images.githubusercontent.com/8453924/35686723-db608c64-0764-11e8-9b19-fef5591f9db6.png">

After:
<img width="891" alt="screen shot 2018-02-01 at 15 29 34" src="https://user-images.githubusercontent.com/8453924/35686731-e042bc5c-0764-11e8-893f-1467cfa31688.png">
