### PR TITLE
Fix hosted Galleries and About dropdowns

### DIFF
--- a/static/src/javascripts/projects/commercial-control/modules/hosted/about.js
+++ b/static/src/javascripts/projects/commercial-control/modules/hosted/about.js
@@ -37,7 +37,7 @@ const template = (): string => `
         </div>
     `;
 
-const init = () =>
+export const init = () =>
     fastdom
         .write(() => {
             $(document.body).append(template());
@@ -56,7 +56,3 @@ const init = () =>
                 fastdom.write(() => overlay.classList.add('u-h'));
             });
         });
-
-export default {
-    init,
-};

--- a/static/src/javascripts/projects/commercial-control/modules/hosted/about.spec.js
+++ b/static/src/javascripts/projects/commercial-control/modules/hosted/about.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import hostedAbout from 'commercial-control/modules/hosted/about';
+import { init } from 'commercial-control/modules/hosted/about';
 
 describe('Hosted About Popup', () => {
     beforeEach(() => {
@@ -17,13 +17,11 @@ describe('Hosted About Popup', () => {
     });
 
     it('should exist', () => {
-        expect(hostedAbout).toBeDefined();
-        expect(hostedAbout.init).toBeDefined();
+        expect(init).toBeDefined();
     });
 
     it('should hide popup after initialization', done => {
-        hostedAbout
-            .init()
+        init()
             .then(() => {
                 expect(
                     (document.querySelector(
@@ -36,8 +34,7 @@ describe('Hosted About Popup', () => {
     });
 
     it('should show popup after clicking on the button', done => {
-        hostedAbout
-            .init()
+        init()
             .then(() => {
                 (document.querySelector('.js-hosted-about'): any).click();
                 expect(

--- a/static/src/javascripts/projects/commercial-control/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial-control/modules/hosted/gallery.js
@@ -556,7 +556,7 @@ HostedGallery.prototype.states = {
     },
 };
 
-const init = (): Promise<any> => {
+export const init = (): Promise<any> => {
     if (qwery('.js-hosted-gallery-container').length) {
         return loadCssPromise.then(() => {
             let res;
@@ -578,9 +578,4 @@ const init = (): Promise<any> => {
     }
 
     return Promise.resolve();
-};
-
-export default {
-    init,
-    HostedGallery,
 };

--- a/static/src/javascripts/projects/commercial-control/modules/hosted/gallery.spec.js
+++ b/static/src/javascripts/projects/commercial-control/modules/hosted/gallery.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import interactionTracking from 'common/modules/analytics/interaction-tracking';
 import { noop } from 'lib/noop';
-import HostedGallery from './gallery';
+import { init } from './gallery';
 import { galleryHtml } from './gallery-html';
 
 jest.mock('lib/detect', () => ({
@@ -27,7 +27,7 @@ describe('Hosted Gallery', () => {
         if (document.body) {
             document.body.innerHTML = galleryHtml;
         }
-        HostedGallery.init().then(galleryInstance => {
+        init().then(galleryInstance => {
             gallery = galleryInstance;
             done();
         });

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.js
@@ -37,7 +37,7 @@ const template = (): string => `
         </div>
     `;
 
-const init = () =>
+export const init = () =>
     fastdom
         .write(() => {
             $(document.body).append(template());
@@ -56,7 +56,3 @@ const init = () =>
                 fastdom.write(() => overlay.classList.add('u-h'));
             });
         });
-
-export default {
-    init,
-};

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import hostedAbout from 'commercial/modules/hosted/about';
+import { init } from 'commercial/modules/hosted/about';
 
 describe('Hosted About Popup', () => {
     beforeEach(() => {
@@ -17,13 +17,11 @@ describe('Hosted About Popup', () => {
     });
 
     it('should exist', () => {
-        expect(hostedAbout).toBeDefined();
-        expect(hostedAbout.init).toBeDefined();
+        expect(init).toBeDefined();
     });
 
     it('should hide popup after initialization', done => {
-        hostedAbout
-            .init()
+        init()
             .then(() => {
                 expect(
                     (document.querySelector(
@@ -36,8 +34,7 @@ describe('Hosted About Popup', () => {
     });
 
     it('should show popup after clicking on the button', done => {
-        hostedAbout
-            .init()
+        init()
             .then(() => {
                 (document.querySelector('.js-hosted-about'): any).click();
                 expect(

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -556,7 +556,7 @@ HostedGallery.prototype.states = {
     },
 };
 
-const init = (): Promise<any> => {
+export const init = (): Promise<any> => {
     if (qwery('.js-hosted-gallery-container').length) {
         return loadCssPromise.then(() => {
             let res;
@@ -578,9 +578,4 @@ const init = (): Promise<any> => {
     }
 
     return Promise.resolve();
-};
-
-export default {
-    init,
-    HostedGallery,
 };

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import interactionTracking from 'common/modules/analytics/interaction-tracking';
 import { noop } from 'lib/noop';
-import HostedGallery from './gallery';
+import { init } from './gallery';
 import { galleryHtml } from './gallery-html';
 
 jest.mock('lib/detect', () => ({
@@ -27,7 +27,7 @@ describe('Hosted Gallery', () => {
         if (document.body) {
             document.body.innerHTML = galleryHtml;
         }
-        HostedGallery.init().then(galleryInstance => {
+        init().then(galleryInstance => {
             gallery = galleryInstance;
             done();
         });


### PR DESCRIPTION
## What does this change?

Hosted galleries are currently broken since the move away from AMD (#19014). This change exports `init` functions from the gallery module (and the about module, which is also presumably broken) as named exports rather than as properties of a default export object.

## What is the value of this and can you measure success?

Less broken commercial stuff

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
