### PR TITLE
Adds dark background for media richlinks in opinion articles

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -850,6 +850,10 @@ $quote-mark: 35px;
             background-color: $garnett-neutral-5;
         }
 
+        .rich-link.tone-media--item {
+            background-color: $neutral-1;
+        }
+
         .social--top {
             background-color: $opinion-garnett-background;
         }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -846,14 +846,6 @@ $quote-mark: 35px;
         background-color: $opinion-garnett-background;
         padding-bottom: $gs-baseline/2;
 
-        .rich-link {
-            background-color: $garnett-neutral-5;
-        }
-
-        .rich-link.tone-media--item {
-            background-color: $neutral-1;
-        }
-
         .social--top {
             background-color: $opinion-garnett-background;
         }

--- a/static/src/stylesheets/module/onward-garnett/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward-garnett/_rich-links-enhanced.scss
@@ -106,6 +106,20 @@
     }
 }
 
+// Opinion article specific styles
+//-----------------------
+
+.content--type-guardianview,
+.content--type-comment {
+    .rich-link {
+        background-color: $garnett-neutral-5;
+    }
+
+    .rich-link.tone-media--item {
+        background-color: $neutral-1;
+    }
+}
+
 .blog .element-rich-link {
     float: none;
     width: auto;


### PR DESCRIPTION
## What does this change?
Adds dark background for media richlinks in opinion articles so they are legible 

Before:
<img width="252" alt="screen shot 2018-02-02 at 11 43 43" src="https://user-images.githubusercontent.com/8453924/35732162-57d0de06-0810-11e8-8623-8f1a0c261ed8.png">

After:
<img width="240" alt="screen shot 2018-02-02 at 11 44 02" src="https://user-images.githubusercontent.com/8453924/35732380-1503b4f8-0811-11e8-980f-a49d976fcaa3.png">
