### PR TITLE
Use auto price granularity for Prebid instead of default (medium)

### DIFF
--- a/static/src/javascripts/projects/commercial-control/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial-control/modules/prebid/prebid.js
@@ -126,6 +126,9 @@ class PrebidService {
                             alwaysUseBid: false,
                         },
                     };
+                    window.pbjs.setConfig({
+                        priceGranularity: 'auto',
+                    });
                     resolve();
                 },
                 'commercial-prebid'

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -127,6 +127,9 @@ class PrebidService {
                 alwaysUseBid: false,
             },
         };
+        window.pbjs.setConfig({
+            priceGranularity: 'auto',
+        });
     }
 
     // Prebid 1.0 supports concurrent bid requests, but for 0.34, each request


### PR DESCRIPTION
This is to get the price granularity we expect from Prebid.
Ie. 5c intervals rather than 10c intervals.

See http://prebid.org/dev-docs/publisher-api-reference.html#autoGranularityBucket
