### PR TITLE
Switch the support link in the amp header to the support site

### DIFF
--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -1,23 +1,24 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@import common.{ LinkTo, Edition }
+@import common.{Edition, LinkTo}
 @import navigation.NavMenu
-@import navigation.ReaderRevenueSite.Membership
-@import navigation.UrlHelpers.{getReaderRevenueUrl, AmpHeader}
+@import navigation.UrlHelpers.getContributionOrSupporterUrl
 
 <header class="header"
         role="banner">
     <nav class="header__inner">
 
         <div class="header__cta-container">
+        @defining(Edition(request).id.toLowerCase()) { editionId =>
             <a class="header-cta-item js-acquisition-link"
-               data-link-name="amp : nav : supporter-cta"
-                href="@getReaderRevenueUrl(Membership, AmpHeader)">
+            data-link-name="amp : nav : supporter-cta"
+            href="@getContributionOrSupporterUrl(editionId)">
                 <span class="header-cta-item--circle"></span>
                 <span class="header-cta-item--text">
                     Support The <br>Guardian</span>
                 </span>
             </a>
+        }
         </div>
 
         <a href="@LinkTo{/}"


### PR DESCRIPTION
## What does this change?
When we drove traffic to the support site from the header we didn't update the AMP Header. In the last month, /us/supporter received 6k visits of which 50% are from the AMP header, and /uk/supporter got 8k visits 43% of which are from AMP.

## What is the value of this and can you measure success?
This makes the amp experience consistent with the main site and cuts down on the amount of misdirected traffic

## Does this affect other platforms - Amp, Apps, etc?
Amp only

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Tested in CODE?
Yes
