### PR TITLE
Commons vote atom

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -28,9 +28,10 @@ final case class Atoms(
   qandas: Seq[QandaAtom],
   guides: Seq[GuideAtom],
   profiles: Seq[ProfileAtom],
-  timelines: Seq[TimelineAtom]
+  timelines: Seq[TimelineAtom],
+  commonsdivisions: Seq[CommonsDivisionAtom]
 ) {
-  val all: Seq[Atom] = quizzes ++ media ++ interactives ++ recipes ++ reviews ++ storyquestions ++ explainers ++ qandas ++ guides ++ profiles ++ timelines
+  val all: Seq[Atom] = quizzes ++ media ++ interactives ++ recipes ++ reviews ++ storyquestions ++ explainers ++ qandas ++ guides ++ profiles ++ timelines ++ commonsdivisions
 
   def atomTypes: Map[String, Boolean] = Map(
     "guide" -> !guides.isEmpty,
@@ -38,7 +39,8 @@ final case class Atoms(
     "profile" -> !profiles.isEmpty,
     "timeline" -> !timelines.isEmpty,
     "storyquestions" -> !storyquestions.isEmpty,
-    "explainer" -> !explainers.isEmpty
+    "explainer" -> !explainers.isEmpty,
+    "commonsdivision" -> !commonsdivisions.isEmpty
   )
 }
 
@@ -209,6 +211,12 @@ final case class TimelineItem(
   toDate: Option[Long]
 )
 
+final case class CommonsDivisionAtom(
+  override val id: String,
+  atom: AtomApiAtom,
+  data: atomapi.commonsdivision.CommonsDivision
+) extends Atom
+
 object Atoms extends common.Logging {
 
   def articleConfig = ArticleConfiguration(
@@ -216,7 +224,7 @@ object Atoms extends common.Logging {
   )
 
   def extract[T](
-    atoms: Option[Seq[AtomApiAtom]], 
+    atoms: Option[Seq[AtomApiAtom]],
     extractFn: AtomApiAtom => T
   ): Seq[T] = {
     try {
@@ -259,6 +267,8 @@ object Atoms extends common.Logging {
 
       val timelines = extract(atoms.timelines, atom => {TimelineAtom.make(atom)})
 
+      val commonsdivisions = extract(atoms.commonsdivisions, atom => {CommonsDivisionAtom.make(atom)})
+
       Atoms(
         quizzes = quizzes,
         media = media,
@@ -270,7 +280,8 @@ object Atoms extends common.Logging {
         qandas = qandas,
         guides = guides,
         profiles = profiles,
-        timelines = timelines
+        timelines = timelines,
+        commonsdivisions = commonsdivisions
       )
     }
   }
@@ -615,4 +626,11 @@ object TimelineItem {
     item.body,
     item.toDate
   )
+}
+
+object CommonsDivisionAtom {
+  def make(atom: AtomApiAtom): CommonsDivisionAtom = {
+    val commonsdivision = atom.data.asInstanceOf[AtomData.CommonsDivision].commonsDivision
+    CommonsDivisionAtom(atom.id, atom, commonsdivision)
+  }
 }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -4,7 +4,7 @@
 @(model: _root_.model.content.Atom, config: ArticleConfiguration, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
-@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom}
+@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom, CommonsDivisionAtom}
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
@@ -21,6 +21,7 @@
         case profile: ProfileAtom if !amp => Html(ArticleAtomRenderer.getHTML(profile.atom, config))
         case profile: ProfileAtom => views.html.fragments.atoms.snippets.profile(profile, isAmp = amp)
         case explainer: ExplainerAtom if !amp => Html(ArticleAtomRenderer.getHTML(explainer.atom, config))
+        case commonsdivision: CommonsDivisionAtom if !amp => Html(ArticleAtomRenderer.getHTML(commonsdivision.atom, config))
         case _ =>
     }
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -50,7 +50,8 @@ class AtomCleanerTest extends FlatSpec
     qandas = Nil,
     guides = Nil,
     profiles = Nil,
-    timelines = Nil
+    timelines = Nil,
+    commonsdivisions = Nil
   )
 )
   def doc: Document = Jsoup.parse( s"""<figure class="element element-atom">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "1.3.2"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.11.1",
+    "@guardian/atom-renderer": "0.12.2",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.11.1"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.12.2"
 
   // Fixing transient dependency issue
   // AWS SDK (1.11.181), which kinesis-logback-appender depends on, brings com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat libs in version 2.6.9

--- a/static/src/javascripts/bootstraps/standard/atoms.js
+++ b/static/src/javascripts/bootstraps/standard/atoms.js
@@ -11,9 +11,9 @@ const bootstrapAtom = <A>(atomMaker: AtomMaker<A>, atomType: AtomType) => {
             if (typeof atom === 'string') {
                 // eslint-disable-next-line no-console
                 console.log(
-                    `Failed to initialise atom [${
-                        atomType
-                    }/${atomDom.getAttribute('data-atom-id') || ''}]: ${atom}`
+                    `Failed to initialise atom [${atomType}/${atomDom.getAttribute(
+                        'data-atom-id'
+                    ) || ''}]: ${atom}`
                 );
             } else if ('requestIdleCallback' in window) {
                 requestIdleCallback(() => {
@@ -96,6 +96,18 @@ const initAtoms = () => {
                 bootstrapAtom(atomMaker, 'explainer');
             },
             'explainer-atom'
+        );
+    }
+
+    if (config.get('page.atomTypes.commonsdivision')) {
+        require.ensure(
+            [],
+            require => {
+                require('@guardian/atom-renderer/dist/commonsdivision/article/index.css');
+                const atomMaker = require('@guardian/atom-renderer/dist/commonsdivision/article/index');
+                bootstrapAtom(atomMaker, 'commonsdivision');
+            },
+            'commonsdivision-atom'
         );
     }
 };

--- a/static/src/javascripts/bootstraps/standard/atoms.js
+++ b/static/src/javascripts/bootstraps/standard/atoms.js
@@ -11,9 +11,9 @@ const bootstrapAtom = <A>(atomMaker: AtomMaker<A>, atomType: AtomType) => {
             if (typeof atom === 'string') {
                 // eslint-disable-next-line no-console
                 console.log(
-                    `Failed to initialise atom [${atomType}/${atomDom.getAttribute(
-                        'data-atom-id'
-                    ) || ''}]: ${atom}`
+                    `Failed to initialise atom [${
+                        atomType
+                    }/${atomDom.getAttribute('data-atom-id') || ''}]: ${atom}`
                 );
             } else if ('requestIdleCallback' in window) {
                 requestIdleCallback(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@guardian/atom-renderer@0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.11.1.tgz#e5a88d76155bf02096fa378f2c4c633c85c1e46b"
+"@guardian/atom-renderer@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.12.2.tgz#65645eda8a6b84878d82592657504345d76d0a5a"
   dependencies:
     autoprefixer "^7.1.6"
     css-loader "^0.28.7"


### PR DESCRIPTION
## What does this change?
Supports rendering of a new type of atom for displaying Commons votes. Primarily intended for use in politics live.

## Does this affect other platforms - Amp, Apps, etc?
Not rendered in AMP.
Corresponding apps change to come.

## Screenshots
#### Unexpanded:
<img width="630" alt="picture 7" src="https://user-images.githubusercontent.com/1513454/35745039-d3e9bd54-0839-11e8-9873-eb665a7a52a3.png">


#### Expanded:
<img width="630" alt="picture 8" src="https://user-images.githubusercontent.com/1513454/35745722-3461a3fc-083c-11e8-8aba-a725e497f089.png">


## Tested in CODE?
Yes