### PR TITLE
Prevent the logback appender from blocking the thread making the log

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import dfp._
 import common.dfp._
 import common._
@@ -78,7 +78,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
-
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
   override lazy val lifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],
     wire[AdminLifecycle],
@@ -96,6 +96,8 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
   lazy val router: Router = wire[Routes]
 
   lazy val appIdentity = ApplicationIdentity("admin")
+
+  def actorSystem: ActorSystem
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[AdminHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonGzipFilter].filters ++ wire[AdminFilters].filters

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,9 +1,10 @@
+import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
 import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.CachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient, SectionsLookUp, SectionsLookUpLifecycle}
@@ -47,6 +48,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
   lazy val emailSignupController = wire[EmailSignupController]
   lazy val surveyPageController = wire[SurveyPageController]
   lazy val signupPageController = wire[SignupPageController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -84,5 +86,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+
+  def actorSystem: ActorSystem
 }
 

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,8 +1,9 @@
+import akka.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{ArchiveController, DevComponentController, HealthCheck}
@@ -30,6 +31,7 @@ trait AppComponents extends FrontendComponents {
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
   lazy val archiveController = wire[ArchiveController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -46,4 +48,6 @@ trait AppComponents extends FrontendComponents {
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+
+  def actorSystem: ActorSystem
 }

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -3,8 +3,9 @@ import app.{FrontendApplicationLoader, FrontendComponents}
 import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import _root_.commercial.targeting.TargetingLifecycle
+import akka.actor.ActorSystem
 import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
@@ -33,6 +34,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -60,4 +62,6 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+
+  def actorSystem: ActorSystem
 }

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -10,7 +10,7 @@ import commercial.model.merchandise.events.{LiveEventAgent, MasterclassAgent}
 import commercial.model.merchandise.jobs.{Industries, JobsAgent}
 import commercial.model.merchandise.travel.TravelOffersAgent
 import common.CloudWatchMetricsLifecycle
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
@@ -57,6 +57,7 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
 
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -73,4 +74,6 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+
+  def actorSystem: ActorSystem
 }

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -42,7 +42,7 @@ class SafeBlockingKinesisAppender(logbackOperations: LogbackOperationsPool) exte
     breaker.withCircuitBreaker {
       Future {
         super.putMessage(message)
-      }(logbackOperations.logbackOperations) // the logbackOperations thread pool is passed explicitly here so blocking on log doesn't affect the logging thread.
+      }(logbackOperations.logbackOperations) // the logbackOperations thread pool is passed explicitly here so blocking on putMessage doesn't affect the logging thread.
     }
     ()
   }

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -1,0 +1,49 @@
+                        package common.Logback
+
+import java.util.concurrent.ThreadPoolExecutor
+
+import akka.actor.ActorSystem
+import akka.dispatch.MessageDispatcher
+import akka.pattern.CircuitBreaker
+import ch.qos.logback.classic.spi.ILoggingEvent
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.gu.logback.appender.kinesis.KinesisAppender
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+// LogbackOperationsPool must be wired as a singleton
+class LogbackOperationsPool(val actorSystem: ActorSystem)  {
+  val logbackOperations: MessageDispatcher = actorSystem.dispatchers.lookup("akka.logback-operations")
+}
+
+class SafeBlockingKinesisAppender(logbackOperations: LogbackOperationsPool) extends KinesisAppender[ILoggingEvent] {
+
+  private val breaker = new CircuitBreaker(
+    logbackOperations.actorSystem.scheduler,
+    maxFailures = 1,
+    callTimeout = 1.seconds,
+    resetTimeout = 10.seconds
+  )(logbackOperations.logbackOperations)
+
+  override protected def createClient(credentials: AWSCredentialsProvider, configuration: ClientConfiguration, executor: ThreadPoolExecutor): AmazonKinesisAsyncClient = {
+    configuration.setMaxErrorRetry(0)
+    configuration.setRetryPolicy(
+      new RetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY.getRetryCondition, PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY, 0, true)
+    )
+    new AmazonKinesisAsyncClient(credentials, configuration, executor)
+  }
+
+  override protected def putMessage(message: String): Unit = {
+    breaker.withCircuitBreaker {
+      Future {
+        super.putMessage(message)
+      }(logbackOperations.logbackOperations)
+    }
+    ()
+  }
+}
+
+

--- a/common/app/common/Logback/LogbackConfig.scala
+++ b/common/app/common/Logback/LogbackConfig.scala
@@ -1,14 +1,14 @@
 package common.Logback
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
+import ch.qos.logback.classic.{LoggerContext, Logger => LogbackLogger}
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.logback.appender.kinesis.KinesisAppender
 import net.logstash.logback.layout.LogstashLayout
-import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.{Logger => PlayLogger}
 
-object LogbackConfig {
+class LogbackConfig(logbackOperationsPool: LogbackOperationsPool) {
 
   lazy val loggingContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
 
@@ -33,7 +33,7 @@ object LogbackConfig {
   }
 
   def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig): KinesisAppender[ILoggingEvent] = {
-    val a = new KinesisAppender[ILoggingEvent]()
+    val a = new SafeBlockingKinesisAppender(logbackOperationsPool)
     a.setName("LoggingKinesisAppender")
     a.setStreamName(appenderConfig.stream)
     a.setRegion(appenderConfig.region)

--- a/common/conf/application.conf
+++ b/common/conf/application.conf
@@ -1,0 +1,10 @@
+akka {
+  logback-operations {
+    executor = "thread-pool-executor"
+    throughput = 10
+    thread-pool-executor {
+      fixed-pool-size = 128
+    }
+  }
+}
+

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -3,7 +3,7 @@ import assets.DiscussionExternalAssetsLifecycle
 import business.StocksDataLifecycle
 import com.softwaremill.macwire._
 import common.DiagnosticsLifecycle
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common.dfp.FaciaDfpAgentLifecycle
 import conf.FootballLifecycle
 import conf.switches.SwitchboardLifecycle
@@ -75,6 +75,7 @@ trait AppComponents
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
   override lazy val blockingOperations = wire[BlockingOperations]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   def actorSystem: ActorSystem
   override def router: Router = wire[Routes]

--- a/diagnostics/app/AppLoader.scala
+++ b/diagnostics/app/AppLoader.scala
@@ -1,7 +1,8 @@
+import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{Assets, AssetsComponents, DiagnosticsControllers, HealthCheck}
@@ -27,6 +28,8 @@ trait Controllers extends DiagnosticsControllers {
 trait AppLifecycleComponents {
   self: FrontendComponents with Controllers =>
 
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
+
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
     wire[DiagnosticsLifecycle],
@@ -34,6 +37,8 @@ trait AppLifecycleComponents {
     wire[CloudWatchMetricsLifecycle],
     wire[CachedHealthCheckLifeCycle]
   )
+
+  def actorSystem: ActorSystem
 }
 
 trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,9 +1,10 @@
+import akka.actor.ActorSystem
 import dev.DevAssetsController
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import controllers.{DiscussionControllers, HealthCheck}
@@ -33,6 +34,7 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -47,4 +49,5 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
+  def actorSystem: ActorSystem
 }

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{Application, HealthCheck}
@@ -16,6 +16,7 @@ import play.api.mvc.EssentialFilter
 import services.ConfigAgentLifecycle
 import router.Routes
 import _root_.commercial.targeting.TargetingLifecycle
+import akka.actor.ActorSystem
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -33,6 +34,7 @@ trait AppComponents extends FrontendComponents {
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val applicationController: Application = wire[Application]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -62,4 +64,5 @@ trait AppComponents extends FrontendComponents {
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Nil
+  def actorSystem: ActorSystem
 }

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -2,7 +2,7 @@ import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common.dfp.FaciaDfpAgentLifecycle
 import concurrent.BlockingOperations
 import conf.switches.SwitchboardLifecycle
@@ -39,6 +39,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val ophanApi = wire[OphanApi]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -62,4 +63,6 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+
+  def actorSystem: ActorSystem
 }

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -1,8 +1,9 @@
+import akka.actor.ActorSystem
 import http.IdentityHttpErrorHandler
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common.CloudWatchMetricsLifecycle
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf._
 import conf.switches.SwitchboardLifecycle
 import controllers.{Assets, HealthCheck, IdentityControllers}
@@ -33,6 +34,8 @@ trait Controllers extends IdentityControllers {
 trait AppLifecycleComponents {
   self: FrontendComponents with Controllers =>
 
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
+
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
     wire[IdentityLifecycle],
@@ -40,6 +43,8 @@ trait AppLifecycleComponents {
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle]
   )
+
+  def actorSystem: ActorSystem
 }
 
 trait AppComponents

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -4,7 +4,7 @@ import app.{FrontendApplicationLoader, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
@@ -58,6 +58,7 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val feedbackController = wire[TechFeedbackController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -83,4 +84,6 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+
+  def actorSystem: ActorSystem
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -1,9 +1,10 @@
+import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
 import commercial.controllers.CommercialControllers
 import commercial.targeting.TargetingLifecycle
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common.dfp.FaciaDfpAgentLifecycle
 import conf.{CachedHealthCheckLifeCycle, FootballLifecycle}
 import conf.switches.SwitchboardLifecycle
@@ -35,6 +36,7 @@ trait PreviewLifecycleComponents extends SportServices with CommercialServices w
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
   override lazy val ophanApi = wire[OphanApi]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],
@@ -48,6 +50,8 @@ trait PreviewLifecycleComponents extends SportServices with CommercialServices w
     wire[RugbyLifecycle],
     wire[TargetingLifecycle]
   )
+
+  def actorSystem: ActorSystem
 }
 
 trait PreviewControllerComponents

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -1,7 +1,8 @@
+import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import contentapi._
@@ -33,6 +34,7 @@ trait AppComponents extends FrontendComponents {
   // Controllers
   lazy val healthCheck = wire[HealthCheck]
   lazy val rssController = wire[RssController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],
@@ -57,4 +59,5 @@ trait AppComponents extends FrontendComponents {
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
+  def actorSystem: ActorSystem
 }

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -4,7 +4,7 @@ import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
-import common.Logback.LogstashLifecycle
+import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, FootballClient, FootballLifecycle}
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
@@ -63,6 +63,7 @@ trait AppComponents extends FrontendComponents
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
+  lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -82,4 +83,5 @@ trait AppComponents extends FrontendComponents
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
+  def actorSystem: ActorSystem
 }


### PR DESCRIPTION
Recently frontend has had severe issues which we believe are a result of blocking logging api calls which occur when the logging Kinesis stream write threshold is exceeded.

From the `kinesis-log4j-appender` documentation

```
Uses a ThreadPoolExecutor backed by a LinkedBlockingQueue. In most cases, this results in the log message simply being added to the in-memory queue. However, if the queue is full, the logging call will block until there is room in the buffer (e.g. some log entries are successfully sent to Amazon Kinesis and removed from the queue).
```

This PR overrides the Kinesis Log4j appender, executing `putMessage`  on an independent thread pool, `logbackOperations`. Also applies a circuit breaker and removes the retry policy from the Kinesis client.

## What is the value of this and can you measure success?

Frontend apps do not become unstable when the Kinesis logging write threshold is exceeded.

## Tested in CODE?

I will, and will run the logging performance test to ensure this fixes the issue.

## Further improvements

Separate Kinesis streams for each app

## Blocked examples

A waiting thread (blocking inside the synchronised function doAppend) from the default dispatcher pool in application, waiting on the Kinesis api:
```
"application-akka.actor.default-dispatcher-4" #14 prio=5 os_prio=0 tid=0x00007fa458011800 nid=0x6a0 waiting on condition [0x00007fa466154000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x000000064fd80498> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
	at java.util.concurrent.LinkedBlockingDeque.putLast(LinkedBlockingDeque.java:396)
	at java.util.concurrent.LinkedBlockingDeque.put(LinkedBlockingDeque.java:649)
	at com.gu.logback.appender.kinesis.helpers.BlockFastProducerPolicy.rejectedExecution(BlockFastProducerPolicy.java:34)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134)
	at com.amazonaws.services.kinesis.AmazonKinesisAsyncClient.putRecordAsync(AmazonKinesisAsyncClient.java:1086)
	at com.gu.logback.appender.kinesis.KinesisAppender.putMessage(KinesisAppender.java:71)
	at com.gu.logback.appender.kinesis.BaseKinesisAppender.append(BaseKinesisAppender.java:165)
	at com.gu.logback.appender.kinesis.BaseKinesisAppender.append(BaseKinesisAppender.java:34)
	at ch.qos.logback.core.AppenderBase.doAppend(AppenderBase.java:82)
	- locked <0x000000064f717780> (a com.gu.logback.appender.kinesis.KinesisAppender)
	at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:51)
	at ch.qos.logback.classic.Logger.appendLoopOnAppenders(Logger.java:270)
	at ch.qos.logback.classic.Logger.callAppenders(Logger.java:257)
	at ch.qos.logback.classic.Logger.buildLoggingEventAndAppend(Logger.java:421)
	at ch.qos.logback.classic.Logger.filterAndLog_0_Or3Plus(Logger.java:383)
	at ch.qos.logback.classic.Logger.info(Logger.java:599)
	at common.Logging.logInfoWithCustomFields(Logging.scala:24)
	at common.Logging.logInfoWithCustomFields$(Logging.scala:23)
	at discussion.api.DiscussionApi.logInfoWithCustomFields(DiscussionApi.scala:214)
	at discussion.util.Http.$anonfun$getJsonOrError$1(Http.scala:23)
	at discussion.util.Http$$Lambda$808/1389315042.apply(Unknown Source)
	at scala.util.Success.$anonfun$map$1(Try.scala:251)
	at scala.util.Success.map(Try.scala:209)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:289)
	at scala.concurrent.Future$$Lambda$389/1405055124.apply(Unknown Source)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)
	at scala.concurrent.impl.Promise$$Lambda$171/872306601.apply(Unknown Source)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$Lambda$555/62478710.apply$mcV$sp(Unknown Source)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:43)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

A blocked thread on the default dispatcher in application, blocking on synchronised logging function `doAppend`:
```
"application-akka.actor.default-dispatcher-3" #13 prio=5 os_prio=0 tid=0x00007fa4e3d56000 nid=0x69f waiting for monitor entry [0x00007fa466255000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at ch.qos.logback.core.AppenderBase.doAppend(AppenderBase.java:63)
	- waiting to lock <0x000000064f717780> (a com.gu.logback.appender.kinesis.KinesisAppender)
	at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:51)
	at ch.qos.logback.classic.Logger.appendLoopOnAppenders(Logger.java:270)
	at ch.qos.logback.classic.Logger.callAppenders(Logger.java:257)
	at ch.qos.logback.classic.Logger.buildLoggingEventAndAppend(Logger.java:421)
	at ch.qos.logback.classic.Logger.filterAndLog_0_Or3Plus(Logger.java:383)
	at ch.qos.logback.classic.Logger.info(Logger.java:599)
	at common.Logging.logInfoWithCustomFields(Logging.scala:24)
	at common.Logging.logInfoWithCustomFields$(Logging.scala:23)
	at discussion.api.DiscussionApi.logInfoWithCustomFields(DiscussionApi.scala:214)
	at discussion.util.Http.$anonfun$getJsonOrError$1(Http.scala:23)
	at discussion.util.Http$$Lambda$808/1389315042.apply(Unknown Source)
	at scala.util.Success.$anonfun$map$1(Try.scala:251)
	at scala.util.Success.map(Try.scala:209)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:289)
	at scala.concurrent.Future$$Lambda$389/1405055124.apply(Unknown Source)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)
	at scala.concurrent.impl.Promise$$Lambda$171/872306601.apply(Unknown Source)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at akka.dispatch.BatchingExecutor$BlockableBatch$$Lambda$555/62478710.apply$mcV$sp(Unknown Source)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:43)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```