### PR TITLE
Add Oriel analytics

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -316,4 +316,14 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2018, 2, 21),
     exposeClientSide = true
   )
+
+  val OrielAnalyticsSwitch: Switch = Switch(
+    group = Commercial,
+    name = "oriel-analytics",
+    description = "Include TrustX adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 2, 21),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -320,10 +320,10 @@ trait CommercialSwitches {
   val OrielAnalyticsSwitch: Switch = Switch(
     group = Commercial,
     name = "oriel-analytics",
-    description = "Include TrustX adapter in Prebid auctions",
+    description = "Include the analytics script for Oriel to monitor ad-blocking",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = new LocalDate(2018, 2, 21),
-    exposeClientSide = true
+    exposeClientSide = false
   )
 }

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -1,0 +1,10 @@
+@()(implicit request: RequestHeader)
+
+@import conf.switches.Switches.OrielAnalyticsSwitch
+
+@if(
+    OrielAnalyticsSwitch.isSwitchedOn &&
+    request.path == "/society/2018/feb/04/hospitals-cancelling-urgent-surgery-despite-nhs-bosses-orders-england-cancer-heart-operations"
+) {
+    <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>
+}

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -1,9 +1,6 @@
 @()(implicit request: RequestHeader)
 
-@import conf.switches.Switches.OrielAnalyticsSwitch
-
 @if(
-    OrielAnalyticsSwitch.isSwitchedOn &&
     request.path == "/society/2018/feb/04/hospitals-cancelling-urgent-surgery-despite-nhs-bosses-orders-england-cancer-heart-operations"
 ) {
     <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @(projectName: Option[String] = None)(head: Html)(body: Html)(implicit page: model.Page, request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, commercial}
-@import conf.switches.Switches.{BreakingNewsSwitch, SurveySwitch}
+@import conf.switches.Switches.{BreakingNewsSwitch, SurveySwitch, OrielAnalyticsSwitch}
 @import model.Page.getContent
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
@@ -94,7 +94,9 @@
 
         @fragments.analytics.base()
 
-        @fragments.commercial.orielAnalytics()
+        @if(OrielAnalyticsSwitch.isSwitchedOn) {
+            @fragments.commercial.orielAnalytics()
+        }
     </body>
         @if(context.environment.mode == Dev) {
             <script>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -93,6 +93,8 @@
         @fragments.inlineJSNonBlocking()
 
         @fragments.analytics.base()
+
+        @fragments.commercial.orielAnalytics()
     </body>
         @if(context.environment.mode == Dev) {
             <script>


### PR DESCRIPTION
## What does this change?

This adds the Oriel analytics script to the bottom of the `body` tag. It is behind a switch and currently is only set to appear on the path `/society/2018/feb/04/hospitals-cancelling-urgent-surgery-despite-nhs-bosses-orders-england-cancer-heart-operations`.

## What is the value of this and can you measure success?

This allows us to measure the issue and impact of ad-blocking.

## Does this affect other platforms - Amp, Apps, etc?

Only web.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Not yet.

@JonNorman @kelvin-chappell @rich-nguyen 