### PR TITLE
Rich link stars

### DIFF
--- a/static/src/stylesheets/module/onward-garnett/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward-garnett/_rich-links-enhanced.scss
@@ -16,8 +16,19 @@
     @include stars();
 
     .stars {
-        padding-top: $gs-baseline / 4;
+        padding: $gs-baseline / 6;
+        display: inline-block;
+        margin-top: $gs-baseline / 2;
+        margin-left: 0;
     }
+
+    .content--article & {
+        .star__item__svg {
+            width: 1em;
+            height: 1em;
+        }
+    }
+
 }
 
 .rich-link__image-container {


### PR DESCRIPTION
## What does this change?
Small tweak to the size of the stars on review rich links. 

Before
<img width="231" alt="picture 1075" src="https://user-images.githubusercontent.com/11950919/35821544-3502554c-0aa1-11e8-8134-769dccf14ce4.png">

After
<img width="241" alt="picture 1074" src="https://user-images.githubusercontent.com/11950919/35821550-3be50bd4-0aa1-11e8-9e22-7ae8e3dd2065.png">
