### PR TITLE
Move oriel tag to bodyTag

### DIFF
--- a/common/app/views/fragments/page/body/bodyTag.scala.html
+++ b/common/app/views/fragments/page/body/bodyTag.scala.html
@@ -1,7 +1,13 @@
-@(classes: Map[String, Boolean])(fragments: Html*)
+@(classes: Map[String, Boolean])(fragments: Html*)(implicit request: RequestHeader)
+
+@import conf.switches.Switches.OrielAnalyticsSwitch
 
 <body id="top" class="@views.support.RenderClasses(classes)" itemscope itemtype="http://schema.org/WebPage">
 @for(f <- fragments){
     @f
+}
+
+@if(OrielAnalyticsSwitch.isSwitchedOn) {
+    @views.html.fragments.commercial.orielAnalytics()
 }
 </body>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -93,10 +93,6 @@
         @fragments.inlineJSNonBlocking()
 
         @fragments.analytics.base()
-
-        @if(OrielAnalyticsSwitch.isSwitchedOn) {
-            @fragments.commercial.orielAnalytics()
-        }
     </body>
         @if(context.environment.mode == Dev) {
             <script>


### PR DESCRIPTION
In order for this tag to get included at the bottom of the `body` tag of an article, it needs to be set inside `bodyTagscala.html` instead of `main.scala.html`.

@kelvin-chappell @rich-nguyen 