### PR TITLE
The end of the line for #EAEAEA

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -84,7 +84,7 @@ $garnett-neutral-4: #dcdcdc;
 $garnett-neutral-5: #ffffff;
 $garnett-neutral-6: #767676;
 $garnett-neutral-7: #444444;
-$garnett-neutral-8: #eaeaea;
+$garnett-neutral-8: #ededed;
 
 
 $news-garnett-main-1: #c70000; //used for kicker


### PR DESCRIPTION
## What does this change?

Shifts `$garnett-neutral-8` to a very slightly lighter shade of grey.

## What is the value of this and can you measure success?

Zef reports signing Avril Lavigne when seeing the colour code #EAEAEA, which will sadly end now.

## Screenshots

Before & After

![before](https://user-images.githubusercontent.com/4561/35857313-a8c5bc3c-0b30-11e8-82f8-3d97f207a84e.png)
![after before](https://user-images.githubusercontent.com/4561/35857317-aad0d05c-0b30-11e8-9f09-18e9ddfb0e88.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
