### PR TITLE
Jdr richlink news opinion

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -49,7 +49,7 @@ const upgradeRichLink = (el: Element): Promise<void> => {
     if (!link) return Promise.resolve();
 
     const href: string = link.href;
-    const host: string = config.get('page.host');
+    const host: string = config.get('page.host') || 'http://localhost:3000';
     const matches: ?(string[]) = href.split(host);
     const isOnMobile: boolean = isBreakpoint({
         max: 'mobileLandscape',

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -49,7 +49,7 @@ const upgradeRichLink = (el: Element): Promise<void> => {
     if (!link) return Promise.resolve();
 
     const href: string = link.href;
-    const host: string = config.get('page.host') || 'http://localhost:3000';
+    const host: string = config.get('page.host');
     const matches: ?(string[]) = href.split(host);
     const isOnMobile: boolean = isBreakpoint({
         max: 'mobileLandscape',

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -381,7 +381,8 @@
         @include richLink($news-garnett-main-1, $garnett-neutral-3);
     }
 
-    &.rich-link--pillar-opinion {
+    &.rich-link--pillar-opinion,
+    &.tone-comment--item {
         @include richLink($opinion-garnett-main-1, $garnett-neutral-3);
     }
 


### PR DESCRIPTION
## What does this change?
Makes sure rich links for opinion pieces under the news pillar pull in the orange palette 

Before:
<img width="246" alt="screen shot 2018-02-06 at 12 06 36" src="https://user-images.githubusercontent.com/8453924/35858979-44e00cda-0b36-11e8-8d06-6bc76d308e9b.png">

After:
<img width="253" alt="screen shot 2018-02-06 at 12 07 05" src="https://user-images.githubusercontent.com/8453924/35858987-49030fe2-0b36-11e8-94c3-33d2f71266cf.png">
