### PR TITLE
Makes sure the right colour is pulled in for richlink quote svg

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -213,7 +213,7 @@
         color: inherit;
     }
 
-    .inline-garnett-quote__svg {
+    .inline-garnett-quote svg {
         height: get-font-size(headline, 3);
         width: get-font-size(headline, 3) * .5;
         margin-right: get-font-size(headline, 3) * .5;


### PR DESCRIPTION
## What does this change?
Makes sure the right colour is pulled in for richlink quote svg

Before:
<img width="248" alt="screen shot 2018-02-06 at 12 58 10" src="https://user-images.githubusercontent.com/8453924/35860847-7aeec4c2-0b3d-11e8-8959-2a514a037999.png">

After:
<img width="242" alt="screen shot 2018-02-06 at 12 58 28" src="https://user-images.githubusercontent.com/8453924/35860852-7fab15e2-0b3d-11e8-9129-9eecdce14eb4.png">

