### PR TITLE
Fix favicon

### DIFF
--- a/applications/app/templates/webAppManifest.scala.js
+++ b/applications/app/templates/webAppManifest.scala.js
@@ -2,70 +2,34 @@
 
 @()(implicit request: RequestHeader)
 
-@if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
+{
+    "name":"The Guardian",
+    "short_name":"The Guardian",
+    "icons":[
     {
-        "name":"The Guardian",
-        "short_name":"The Guardian",
-        "icons":[
-        {
-            "type": "image/png",
-            "sizes": "192x192",
-            "src": "@{JavaScript(Static("images/favicons-garnett/roundel-192x192.png"))}"
-    },
-        {
-            "type": "image/png",
-            "sizes": "152x152",
-            "src": "@{JavaScript(Static("images/favicons-garnett/roundel-152x152.png"))}"
-        },
-        {
-            "type": "image/png",
-            "sizes": "114x114",
-            "src": "@{JavaScript(Static("images/favicons-garnett/roundel-114x114.png"))}"
-        }
-    ],
-        "theme_color": "#e7edef",
-        "background_color": "#121212",
-        "start_url": "/uk?INTCMP=webapp",
-        "display": "browser",
-        "orientation": "portrait",
-        "gcm_sender_id":"660236028602",
-        "gcm_user_visible_only":true,
-        "permissisons" : [
-        "gcm"
-    ]
-    }
-
-} else {
+        "type": "image/png",
+        "sizes": "192x192",
+        "src": "@{JavaScript(Static("images/favicons/roundel-192x192.png"))}"
+},
     {
-        "name":"The Guardian",
-        "short_name":"The Guardian",
-        "icons":[
-        {
-            "type": "image/png",
-            "sizes": "192x192",
-            "src": "@{JavaScript(Static("images/favicons/roundel-192x192.png"))}"
+        "type": "image/png",
+        "sizes": "152x152",
+        "src": "@{JavaScript(Static("images/favicons/roundel-152x152.png"))}"
     },
-        {
-            "type": "image/png",
-            "sizes": "152x152",
-            "src": "@{JavaScript(Static("images/favicons/roundel-152x152.png"))}"
-        },
-        {
-            "type": "image/png",
-            "sizes": "114x114",
-            "src": "@{JavaScript(Static("images/favicons/roundel-114x114.png"))}"
-        }
-    ],
-        "theme_color": "#005689",
-        "background_color": "#ffffff",
-        "start_url": "/uk?INTCMP=webapp",
-        "display": "browser",
-        "orientation": "portrait",
-        "gcm_sender_id":"660236028602",
-        "gcm_user_visible_only":true,
-        "permissisons" : [
-        "gcm"
-    ]
+    {
+        "type": "image/png",
+        "sizes": "114x114",
+        "src": "@{JavaScript(Static("images/favicons/roundel-114x114.png"))}"
     }
-
+],
+    "theme_color": "#005689",
+    "background_color": "#ffffff",
+    "start_url": "/uk?INTCMP=webapp",
+    "display": "browser",
+    "orientation": "portrait",
+    "gcm_sender_id":"660236028602",
+    "gcm_user_visible_only":true,
+    "permissisons" : [
+    "gcm"
+]
 }

--- a/applications/app/templates/webAppManifest.scala.js
+++ b/applications/app/templates/webAppManifest.scala.js
@@ -22,8 +22,8 @@
         "src": "@{JavaScript(Static("images/favicons/roundel-114x114.png"))}"
     }
 ],
-    "theme_color": "#005689",
-    "background_color": "#ffffff",
+    "theme_color": "#e7edef",
+    "background_color": "#121212",
     "start_url": "/uk?INTCMP=webapp",
     "display": "browser",
     "orientation": "portrait",


### PR DESCRIPTION
## What does this change?

https://www.theguardian.com/2015-06-24-manifest.json currently results in a 500 and we get a lot exceptions coming into Kibana for it. When replicating this locally it looks like it's because it's trying to serve up a static asset from favicons-garnett, which doesn't exist, I'm assuming we deleted this after cleaning up from garnett.

The normal favicon assets look correct so I'm removing the if-statement branch code for when garnett is enabled.

@NataliaLKB - I just noticed this duplicates something your most recent cleanup pr, is that going out soon?

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
