### PR TITLE
Fix to decenders in match reports being cut off

### DIFF
--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -41,7 +41,7 @@ $football-crest--large: 60px;
 .team__heading {
     font-size: inherit;
     font-weight: normal;
-    line-height: inherit;
+    line-height: 1.3;
     position: relative;
 }
 


### PR DESCRIPTION
## What does this change?
Fix to decenders in match reports being cut off

Before:
<img width="761" alt="screen shot 2018-02-06 at 14 25 42" src="https://user-images.githubusercontent.com/8453924/35864436-ba43816a-0b49-11e8-91f4-bf03b0805ee0.png">

After:
<img width="725" alt="screen shot 2018-02-06 at 14 26 09" src="https://user-images.githubusercontent.com/8453924/35864440-bd97e0c2-0b49-11e8-8fe1-d219f43ccd7b.png">
