### PR TITLE
Fix prout

### DIFF
--- a/admin/app/model/deploys/RiffRaff.scala
+++ b/admin/app/model/deploys/RiffRaff.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class RiffRaffDeployTags(vcsRevision: String)
+case class RiffRaffDeployTags(vcsRevision: Option[String])
 object RiffRaffDeployTags { implicit val format = Json.format[RiffRaffDeployTags] }
 
 case class RiffRaffDeploy(uuid: String,
@@ -43,7 +43,7 @@ class RiffRaffService(httpClient: HttpLike) {
         case 200 =>
           (response.json \ "response" \ "results").validate[List[RiffRaffDeploy]] match {
             case JsSuccess(listOfDeploys, _) => Right(listOfDeploys)
-            case JsError(error) => Left(ApiErrors(List(ApiError("Invalid JSON from RiffRaff API", 500))))
+            case JsError(error) => Left(ApiErrors(List(ApiError(s"Invalid JSON from RiffRaff API: $error", 500))))
           }
         case statusCode => Left(ApiErrors(List(ApiError(s"Invalid status code from RiffRaff: $statusCode", 500 ))))
       }


### PR DESCRIPTION
## What does this change?
[Prout](https://github.com/guardian/prout) relies on [this](https://frontend.gutools.co.uk/deploys?stage=PROD&pageSize=35) page to determine if a build is on PROD or not. That page is generated by hitting the [riffraff api](https://riffraff.gutools.co.uk/docs/riffraff/api.md) and deserializing the result. Unfortunately, we made vcsRevision a required field, which meant that the deserialization failed for [this](https://riffraff.gutools.co.uk/deployment/view/ae188f9e-c2c5-4c51-a235-e58c78f15cc4) deploy, resulting in that whole page throwing an error, and Prout not working. This change makes that field optional, thus solving the problem, hooray!

## What is the value of this and can you measure success?
Prout working
## Tested in CODE?
will do
