### PR TITLE
Changed font size of headline in liveblog

### DIFF
--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -800,11 +800,12 @@ $timeline-width: 15px;
 
 .blog {
     .content__headline {
-        @include fs-headline(5);
+        @include fs-headlineGarnett(4);
 
         @include mq(tablet) {
-            @include fs-headline(7, true);
+            @include fs-headlineGarnett(6, true);
         }
+        font-weight: 400;
     }
 
     .content__section-label {


### PR DESCRIPTION
## What does this change?
Changed the headline size in liveblog.
**Before: 36px** (Desktop) 28px (Mobile)

![before](https://user-images.githubusercontent.com/5967941/35868055-606fdddc-0b53-11e8-8b0f-fc9274bc9c22.png)

**After: 34px** (Desktop) 28px (Mobile)
![after](https://user-images.githubusercontent.com/5967941/35868065-68bbf7c8-0b53-11e8-9d63-9fc6a6bb1567.png)

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No
