### PR TITLE
Send all Sonobi Prebid data to DFP

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -132,6 +132,9 @@ class PrebidService {
             standard: {
                 alwaysUseBid: false,
             },
+            sonobi: {
+                alwaysUseBid: true, // for Jetstream
+            },
         };
         window.pbjs.setConfig({
             priceGranularity: 'auto',

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -133,7 +133,16 @@ class PrebidService {
                 alwaysUseBid: false,
             },
             sonobi: {
-                alwaysUseBid: true, // for Jetstream
+                // for Jetstream
+                alwaysUseBid: true,
+                adserverTargeting: [
+                    {
+                        key: 'hb_deal_sonobi',
+                        val(bidResponse) {
+                            return bidResponse.dealId;
+                        },
+                    },
+                ],
             },
         };
         window.pbjs.setConfig({


### PR DESCRIPTION
Send losing Sonobi bids to DFP, as well as winning bids, so that they can be matched against Jetstream line items.