### PR TITLE
Use minAbove against the Garnett header element

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -101,7 +101,7 @@ const getRules = (): Object => {
     return {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: 300,  // a nominal value, the ' > header' rule is expected to separate insertions from the top.
+        minAbove: 300, // a nominal value, the ' > header' rule is expected to separate insertions from the top.
         minBelow: 300,
         selectors: {
             ' > header': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -101,7 +101,7 @@ const getRules = (): Object => {
     return {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: 300,
+        minAbove: 300,  // a nominal value, the ' > header' rule is expected to separate insertions from the top.
         minBelow: 300,
         selectors: {
             ' > header': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -101,13 +101,17 @@ const getRules = (): Object => {
     return {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: isBreakpoint({
-            max: 'tablet',
-        })
-            ? 300
-            : 700,
+        minAbove: 300,
         minBelow: 300,
         selectors: {
+            ' > header': {
+                minAbove: isBreakpoint({
+                    max: 'tablet',
+                })
+                    ? 300
+                    : 700,
+                minBelow: 0,
+            },
             ' > h2': {
                 minAbove: getBreakpoint() === 'mobile' ? 100 : 0,
                 minBelow: 250,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -233,7 +233,7 @@ describe('Article Body Adverts', () => {
 
                 return getFirstRulesUsed().then(rules => {
                     // adverts give the top of the page more clearance
-                    expect(rules.minAbove).toEqual(700);
+                    expect(rules.selectors[' > header'].minAbove).toEqual(700);
 
                     // give headings no vertical clearance
                     expect(rules.selectors[' > h2'].minAbove).toEqual(0);


### PR DESCRIPTION
Adds a spacefinder rule for the Garnett `<header>`. The header is now pushing the body (the `.js-article__body` element) "top offset" far away from the first `<p>` offset, which causes the existing rules to pass for inserting an ad slot at the top of the body.