### PR TITLE
Fixes odd spacing for liveblog timestamps

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -569,11 +569,6 @@ $quote-mark: 35px;
         }
     }
 
-    .block-time.published-time {
-        position: relative;
-        line-height: 1;
-    }
-
     // *************** Quote Styles ***************
     .element-pullquote {
         background-color: $garnett-neutral-3;


### PR DESCRIPTION
## What does this change?
Fixes odd spacing for liveblog timestamps - there was a double up of code, the position: relative rule appears later with a more targeted application for non-liveblog article types
