### PR TITLE
Contrast in header tones

### DIFF
--- a/static/src/stylesheets/layout/nav/_variables.scss
+++ b/static/src/stylesheets/layout/nav/_variables.scss
@@ -10,7 +10,7 @@ $search-and-edition-height-desktop: 42px;
 
 $nav-background-colour: #e9eff1; // BG of the nav & menu
 $nav-primary-colour: $garnett-neutral-1; // Colour of most non pillar text
-$nav-secondary-colour: darken($nav-background-colour, 50%); // Softer accent colour for text
+$nav-secondary-colour: #5D5F5F; // Softer accent colour for text (65% opacity of neural-1)
 $nav-darker-colour: darken($nav-background-colour, 5%); // Colour for shaded areas on the BG
 $rule: darken($nav-background-colour, 20%); // All borders on the nav
 

--- a/static/src/stylesheets/layout/nav/_variables.scss
+++ b/static/src/stylesheets/layout/nav/_variables.scss
@@ -10,7 +10,7 @@ $search-and-edition-height-desktop: 42px;
 
 $nav-background-colour: #e9eff1; // BG of the nav & menu
 $nav-primary-colour: $garnett-neutral-1; // Colour of most non pillar text
-$nav-secondary-colour: #5D5F5F; // Softer accent colour for text (65% opacity of neural-1)
+$nav-secondary-colour: #5d5f5f; // Softer accent colour for text (65% opacity of neural-1)
 $nav-darker-colour: darken($nav-background-colour, 5%); // Colour for shaded areas on the BG
 $rule: darken($nav-background-colour, 20%); // All borders on the nav
 


### PR DESCRIPTION
A generated colour in the header vars was not passing accessibility.

# before
<img width="322" alt="screen shot 2018-02-07 at 12 30 02" src="https://user-images.githubusercontent.com/14570016/35916584-c07f638c-0c02-11e8-9f90-63523e68b645.png">

# after
<img width="280" alt="screen shot 2018-02-07 at 12 29 52" src="https://user-images.githubusercontent.com/14570016/35916586-c220b01a-0c02-11e8-8e6c-0f6ce03accfb.png">
