### PR TITLE
Make the consent journey 1 page

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -39,52 +39,51 @@
     }
 }
 
-@showAgeStep(index: Option[Int]) = @{
-    if(index.contains(0)){
+@showAgeStep(display: Boolean = false) = @{
+    if(display){
         List(ConsentStepHelpLegalText("By clicking the button, you confirm that you are older than 13 years or that you have the consent of your parent or a person holding parental responsibility."))
     } else {
         Nil
     }
 }
 
-@renderStep(step: ConsentStep, index: Option[Int] = None) = {
-    @if(step.show) {
-        @if(index.getOrElse(1) != 0) {
-            <hr class="manage-account-divider">
-        }
-        @(step.banner.map { title =>
-            Html(s"<p class='form__success'>$title</p>")
-        })
-        <fieldset
-            role="dialog"
-            aria-labelledby="consentWizard@{step.name.capitalize}Title"
-        >
-            <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
-            <div class="identity-forms-wrapper">
-                @if(step.help || showAgeStep(index)) {
-                    <div class="identity-forms-wrapper__title">
-                        @((step.help ++ showAgeStep(index)).map(paragraph =>
-                            paragraph match {
-                                case m: ConsentStepHelpLegalText => {
-                                    Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")
-                                }
-                                case m: ConsentStepHelpText => {
-                                    Html(s"<p class='identity-title-explainer'>${m.text}</p>")
-                                }
-                            }
-                        ))
-                    </div>
-                }
-                <div class="identity-forms-wrapper__fields">
-                    @step.content
-                </div>
-            </div>
-
-        </fieldset>
+@renderStep(step: ConsentStep, isFirst: Boolean = false, isLast: Boolean = false) = {
+    @if(!isFirst) {
+        <hr class="manage-account-divider">
     }
+    @(step.banner.map { title =>
+        Html(s"<p class='form__success'>$title</p>")
+    })
+    <fieldset
+        role="dialog"
+        aria-labelledby="consentWizard@{step.name.capitalize}Title"
+    >
+        <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
+        <div class="identity-forms-wrapper">
+            @if(step.help || showAgeStep(isLast)) {
+                <div class="identity-forms-wrapper__title">
+                    @((step.help ++ showAgeStep(isLast)).map(paragraph =>
+                        paragraph match {
+                            case m: ConsentStepHelpLegalText => {
+                                Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")
+                            }
+                            case m: ConsentStepHelpText => {
+                                Html(s"<p class='identity-title-explainer'>${m.text}</p>")
+                            }
+                        }
+                    ))
+                </div>
+            }
+            <div class="identity-forms-wrapper__fields">
+                @step.content
+            </div>
+        </div>
+
+    </fieldset>
 }
 @renderSteps(steps:List[ConsentStep]) = @{
-    steps.zipWithIndex.map{ case (element, index) => renderStep(element, Some(index)) }
+    val displaySteps = steps.filter(_.show)
+    displaySteps.zipWithIndex.map{ case (element, index) => renderStep(element, index == 0, index == (displaySteps.size - 1)) }
 }
 
 @channelStepContent = {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -57,9 +57,9 @@
     >
         <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
         <div class="identity-forms-wrapper">
-            @if(step.help || showAgeStep(isFirst)) {
+            @if(step.help || showAgeStep(display = isFirst)) {
                 <div class="identity-forms-wrapper__title">
-                    @((step.help ++ showAgeStep(isFirst)).map(paragraph =>
+                    @((step.help ++ showAgeStep(display = isFirst)).map(paragraph =>
                         paragraph match {
                             case m: ConsentStepHelpLegalText => {
                                 Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -49,12 +49,13 @@
 
 @renderStep(step: ConsentStep, index: Option[Int] = None) = {
     @if(step.show) {
+        @if(index.getOrElse(1) != 0) {
+            <hr class="manage-account-divider">
+        }
         @(step.banner.map { title =>
             Html(s"<p class='form__success'>$title</p>")
         })
         <fieldset
-            class="identity-wizard__step"
-            data-wizard-step-name="@step.name"
             role="dialog"
             aria-labelledby="consentWizard@{step.name.capitalize}Title"
         >
@@ -305,7 +306,14 @@
 
     <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
+        <div
+            class="identity-wizard__step"
+            data-wizard-step-name="single-test"
+        >
+
         @renderSteps(getStepsForJourney(journey))
+
+        </div>
 
         <form class="identity-wizard__controls" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -41,16 +41,13 @@
 
 @showAgeStep(display: Boolean = false) = @{
     if(display){
-        List(ConsentStepHelpLegalText("By clicking the button, you confirm that you are older than 13 years or that you have the consent of your parent or a person holding parental responsibility."))
+        List(ConsentStepHelpLegalText("By continuing, you confirm that you are older than 13 years or that you have the consent of your parent or a person holding parental responsibility."))
     } else {
         Nil
     }
 }
 
 @renderStep(step: ConsentStep, isFirst: Boolean = false, isLast: Boolean = false) = {
-    @if(!isFirst) {
-        <hr class="manage-account-divider">
-    }
     @(step.banner.map { title =>
         Html(s"<p class='form__success'>$title</p>")
     })
@@ -60,9 +57,9 @@
     >
         <legend id="consentWizard@{step.name.capitalize}Title" class="identity-title identity-title--page-title">@step.title</legend>
         <div class="identity-forms-wrapper">
-            @if(step.help || showAgeStep(isLast)) {
+            @if(step.help || showAgeStep(isFirst)) {
                 <div class="identity-forms-wrapper__title">
-                    @((step.help ++ showAgeStep(isLast)).map(paragraph =>
+                    @((step.help ++ showAgeStep(isFirst)).map(paragraph =>
                         paragraph match {
                             case m: ConsentStepHelpLegalText => {
                                 Html(s"<p class='identity-title-explainer identity-title-explainer--small'>${m.text}</p>")
@@ -245,15 +242,15 @@
         }
         case "thank-you" => {
             List(
-                marketingConsentThankYouStep,
                 emailRepermissionStep,
+                marketingConsentThankYouStep,
                 channelStep
             )
         }
         case "default" => {
             List(
-                marketingConsentStep,
                 emailRepermissionStep,
+                marketingConsentStep,
                 channelStep
             )
         }

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -1,4 +1,9 @@
 .identity-wizard--consent {
+    fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+    }
     .identity-wizard__controls {
         padding: $gs-gutter 0;
         background: #ffffff;

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -3,6 +3,26 @@
         border: 0;
         margin: 0;
         padding: 0;
+        legend {
+            display: block;
+        }
+    }
+    .identity-wizard__step > fieldset:not(:first-child) {
+        margin-top: $gs-gutter * 2;
+        position: relative;
+        legend {
+            padding-top: $gs-gutter * .5
+        }
+        &:before {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            display: block;
+            content: '';
+            height: 1px;
+            background: $garnett-neutral-4;
+        }
     }
     .identity-wizard__controls {
         padding: $gs-gutter 0;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -95,13 +95,8 @@ Messages
 /*
 Wrapper
 */
-.identity-forms-wrapper {
-    border-top: 1px solid $garnett-neutral-4;
-    padding-top: $gs-baseline;
-}
-
 .identity-forms-wrapper__title {
-    margin-bottom: $gs-baseline * 2;
+    margin-bottom: $gs-baseline;
 }
 
 @supports (display: flex) {


### PR DESCRIPTION
## What does this change?
Makes the consents journey just span 1 page with all its options going one after the other

## Screenshots

![screen shot 2018-02-07 at 3 15 33 pm](https://user-images.githubusercontent.com/11539094/35924063-e762dc9c-0c19-11e8-8dc3-1c86b7c5225b.png)