### PR TITLE
Jdr image caption

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -118,7 +118,7 @@
                 </label>
 
                 <figcaption class="caption caption--main caption--img" itemprop="description">
-                    @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon", "hide-until-tablet"))
+                    @fragments.inlineSvg("triangle", "icon", List("rounded-icon", "centered-icon", "hide-until-tablet"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -126,7 +126,7 @@
                 </figcaption>
             } else {
                 <figcaption class="caption caption--img @if(isMain) {caption--main}" itemprop="description">
-                    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+                    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))

--- a/static/src/inline-svgs/icon/triangle.svg
+++ b/static/src/inline-svgs/icon/triangle.svg
@@ -1,1 +1,1 @@
-<svg width="11" height="11" viewBox="0 0 11 11"><path fill-rule="evenodd" d="M5.5 0L11 11H0z"/></svg>
+<svg width="11" height="10" viewBox="0 0 11 10"><path fill-rule="evenodd" d="M5.5 0L11 10H0z"/></svg>

--- a/static/src/inline-svgs/icon/triangle.svg
+++ b/static/src/inline-svgs/icon/triangle.svg
@@ -1,0 +1,1 @@
+<svg width="11" height="11" viewBox="0 0 11 11"><path fill-rule="evenodd" d="M5.5 0L11 11H0z"/></svg>

--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -6,7 +6,7 @@ $caption-button-size: 32px;
     width: $caption-button-size;
     height: $caption-button-size;
     z-index: 1;
-    background-color: rgba($neutral-1, .4);
+    background-color: rgba($neutral-1, .6);
     border-radius: 50%;
 
     &:hover {

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -43,7 +43,8 @@
     .commentcount2__heading span,
     .old-article-message .old-article-message--clock svg,
     .social-icon svg,
-    .social-icon__svg {
+    .social-icon__svg,
+    .inline-triangle {
         fill: $kickerColor;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -446,7 +446,7 @@ $quote-mark: 35px;
         }
     }
     .caption--main.caption--img {
-        @include mq($until:leftCol) {
+        @include mq($until: leftCol) {
             padding-bottom: $gs-baseline/2;
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -435,30 +435,40 @@ $quote-mark: 35px;
         padding-top: $gs-baseline/2;
     }
 
-    .reveal-caption {
-        display: block!important;
-        right: $gs-gutter/2;
-        bottom: $gs-gutter/2;
+    // .reveal-caption {
+    //     display: block!important;
+    //     right: $gs-gutter/2;
+    //     bottom: $gs-gutter/2;
+    //
+    //     &:hover {
+    //         cursor: pointer;
+    //     }
+    // }
 
-        &:hover {
-            cursor: pointer;
-        }
-    }
+    // .caption--main.caption--img {
+    //     position: absolute;
+    //     left: 0;
+    //     right: 0;
+    //     bottom: 0;
+    //     background: rgba(22, 22, 22, .8);
+    //     color: #ffffff;
+    //     padding: 6px 40px 12px 10px;
+    //     max-width: 100%;
+    //     display: none;
+    // }
+    //
+    // .reveal-caption__checkbox:checked ~ .caption--main {
+    //     display: block;
+    // }
 
     .caption--main.caption--img {
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(22, 22, 22, .8);
-        color: #ffffff;
-        padding: 6px 40px 12px 10px;
-        max-width: 100%;
-        display: none;
-    }
+        min-height: 0;
+        padding-bottom: $gs-baseline/2;
+        svg {
+            position: relative;
+        }
 
-    .reveal-caption__checkbox:checked ~ .caption--main {
-        display: block;
+
     }
 
     &:not(.paid-content) .media-primary.media-primary--showcase {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -435,40 +435,20 @@ $quote-mark: 35px;
         padding-top: $gs-baseline/2;
     }
 
-    // .reveal-caption {
-    //     display: block!important;
-    //     right: $gs-gutter/2;
-    //     bottom: $gs-gutter/2;
-    //
-    //     &:hover {
-    //         cursor: pointer;
-    //     }
-    // }
-
-    // .caption--main.caption--img {
-    //     position: absolute;
-    //     left: 0;
-    //     right: 0;
-    //     bottom: 0;
-    //     background: rgba(22, 22, 22, .8);
-    //     color: #ffffff;
-    //     padding: 6px 40px 12px 10px;
-    //     max-width: 100%;
-    //     display: none;
-    // }
-    //
-    // .reveal-caption__checkbox:checked ~ .caption--main {
-    //     display: block;
-    // }
-
-    .caption--main.caption--img {
+    .caption--img {
         min-height: 0;
-        padding-bottom: $gs-baseline/2;
+        padding-bottom: 0;
+        @include mq(leftCol) {
+            padding-bottom: $gs-baseline/2;
+        }
         svg {
             position: relative;
         }
-
-
+    }
+    .caption--main.caption--img {
+        @include mq($until:leftCol) {
+            padding-bottom: $gs-baseline/2;
+        }
     }
 
     &:not(.paid-content) .media-primary.media-primary--showcase {
@@ -790,10 +770,6 @@ $quote-mark: 35px;
         }
     }
 
-    .element .caption {
-        background: #ffffff;
-    }
-
     .quoted {
         .inline-garnett-quote {
             position: absolute;
@@ -890,12 +866,6 @@ $quote-mark: 35px;
             color: $garnett-neutral-1;
         }
 
-        .caption {
-            background-color: $opinion-garnett-background;
-        }
-        .caption--main {
-            background-color: $garnett-neutral-1;
-        }
     }
 
     .content__head {
@@ -1330,7 +1300,11 @@ $quote-mark: 35px;
         }
 
         .caption--main {
-            padding-left: $gs-gutter / 2;
+            max-width: gs-span(8);
+            // @include mq($from:leftCol) {
+            //     width: gs-span(4);
+            //     float: right;
+            // }
         }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1292,7 +1292,6 @@ $quote-mark: 35px;
     }
 }
 // *************** Feature showcase overrides ***************
-
 .has-feature-showcase-element {
     .media-primary.media-primary--showcase {
         @include mq(wide) {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1301,10 +1301,6 @@ $quote-mark: 35px;
 
         .caption--main {
             max-width: gs-span(8);
-            // @include mq($from:leftCol) {
-            //     width: gs-span(4);
-            //     float: right;
-            // }
         }
     }
 


### PR DESCRIPTION
## What does this change?
Shows main media image caption from phablet up, swaps out 'i' icon with triangle for all captions, increases opacity for mobile toggle.

This doesn't have special styling for showcase or immersive, to be looked at separately 

Before:
<img width="635" alt="screen shot 2018-02-07 at 15 39 01" src="https://user-images.githubusercontent.com/8453924/35925317-53abd590-0c1d-11e8-8c66-7f22f7bdb997.png">


After:
<img width="687" alt="screen shot 2018-02-07 at 15 38 47" src="https://user-images.githubusercontent.com/8453924/35925273-377b286c-0c1d-11e8-8982-3a9c65fc07c4.png">

<img width="1085" alt="screen shot 2018-02-07 at 15 41 46" src="https://user-images.githubusercontent.com/8453924/35925381-703f9eda-0c1d-11e8-8be6-66eb5a75b3e6.png">

