### PR TITLE
updated video caption icon

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -43,7 +43,7 @@
 
                     @mainVideo.videos.caption.map { caption =>
                         <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                            @fragments.inlineSvg("triangle", "icon", List("rounded-icon", "centered-icon"))
+                            @fragments.inlineSvg("triangle", "icon")
                             @Html(caption)
                         </figcaption>
                     }

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -43,7 +43,7 @@
 
                     @mainVideo.videos.caption.map { caption =>
                         <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                            @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
+                            @fragments.inlineSvg("triangle", "icon", List("rounded-icon", "centered-icon"))
                             @Html(caption)
                         </figcaption>
                     }

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -6,6 +6,6 @@
     "caption--img" -> true,
     "caption--main" -> mainMedia))"
 itemprop="description">
-    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
     @captionText
 </figcaption>

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -6,6 +6,6 @@
     "caption--img" -> true,
     "caption--main" -> mainMedia))"
 itemprop="description">
-    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon"))
     @captionText
 </figcaption>

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -6,6 +6,6 @@
     "caption--img" -> true,
     "caption--main" -> mainMedia))"
 itemprop="description">
-    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon"))
+    @fragments.inlineSvg("triangle", "icon")
     @captionText
 </figcaption>

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -118,7 +118,7 @@
                 </label>
 
                 <figcaption class="caption caption--main caption--img" itemprop="description">
-                    @fragments.inlineSvg("triangle", "icon", List("rounded-icon", "centered-icon", "hide-until-tablet"))
+                    @fragments.inlineSvg("triangle", "icon", List("hide-until-tablet"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))
@@ -126,7 +126,7 @@
                 </figcaption>
             } else {
                 <figcaption class="caption caption--img @if(isMain) {caption--main}" itemprop="description">
-                    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+                    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -126,7 +126,7 @@
                 </figcaption>
             } else {
                 <figcaption class="caption caption--img @if(isMain) {caption--main}" itemprop="description">
-                    @fragments.inlineSvg("triangle", "icon", List("reveal-caption-icon"))
+                    @fragments.inlineSvg("triangle", "icon")
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -62,7 +62,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
         }
 
         if (figcaption.asScala.nonEmpty) {
-            val informationIcon = views.html.fragments.inlineSvg("information", "icon", List("centered-icon", "rounded-icon")).toString()
+            val informationIcon = views.html.fragments.inlineSvg("triangle", "icon").toString()
             figcaption.prepend(informationIcon)
         }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -436,8 +436,11 @@ $quote-mark: 35px;
     }
 
     .caption--img {
-        min-height: 0;
+        min-height: $gs-baseline*3;
         padding-bottom: 0;
+        @include mq(tablet) {
+            min-height: 0;
+        }
         @include mq(leftCol) {
             padding-bottom: $gs-baseline/2;
         }


### PR DESCRIPTION
## What does this change?
updates video caption icon, removes other instances of old i icon, removes unnecessary classes which fixes baseline alignment. Also puts min-height back for mobile captions so that single line captions look correct.

see here 👀
old:
<img width="492" alt="screen shot 2018-02-08 at 11 07 21" src="https://user-images.githubusercontent.com/8453924/35969940-6d826fda-0cc0-11e8-891c-38970abae5b3.png">

New:
<img width="396" alt="screen shot 2018-02-08 at 11 07 30" src="https://user-images.githubusercontent.com/8453924/35969952-717c1e42-0cc0-11e8-95d3-5241f6af032c.png">

