### PR TITLE
Don't use fastdom for reading & writing href

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,6 +1,5 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
-import fastdom from 'lib/fastdom-promise';
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -51,16 +50,10 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     const links = [...document.getElementsByClassName(ACQUISITION_LINK_CLASS)];
 
     links.forEach(el => {
-        fastdom.read(() => el.getAttribute('href')).then(link => {
-            if (link) {
-                fastdom.write(() => {
-                    el.setAttribute(
-                        'href',
-                        addReferrerDataToAcquisitionLink(link)
-                    );
-                });
-            }
-        });
+        const link = el.getAttribute('href');
+        if (link) {
+            el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
+        }
     });
 };
 


### PR DESCRIPTION
I hit an interesting problem when writing some code which was modifying the href on acquisitions links.

By wrapping my own reads & writes to the href attribute in fastdom callbacks, I made it impossible for my own code to successfully modify the href, since another bit of code (the code changed in this PR) was trying to do the same thing. The order in which things occurred was:

1. Read href (A)
2. Read href (B)
3. Write href (A)
4. Write href (B)

Code at location B (the code I'm changing in this PR) overwrites the changes from location A since the value it read in at step 2 is out of date by step 4. It's rather like a [classic race condition](https://www.javacodegeeks.com/2014/08/java-concurrency-tutorial-atomicity-and-race-conditions.html) - though arguably not actual race condition here since we're in a single-threaded environment and there's no variability in the order of these events. It's just that the use of fastdom promises made their order very unintuitive.

## So do we actually need fastdom here?

Probably not - I realised that there's no point in using it here since reading & writing the href attribute on links doesn't trigger layout (which makes sense, since the href of a link isn't actually rendered on the screen).

I've actually checked this empirically. Here's what happens when changing the **size** of a link. You can see layout is triggered:

(https://jsbin.com/ducekuqudi/edit?html,css,js,output)
<img width="1287" alt="picture 101" src="https://user-images.githubusercontent.com/5122968/35940229-62656e06-0c46-11e8-9859-ca5eff673a3a.png">

But when changing the **href** of a link there's no layout:

 (https://jsbin.com/bubiqufexi/1/edit?html,css,js,output)
<img width="1232" alt="picture 100" src="https://user-images.githubusercontent.com/5122968/35940224-5cd5a6b8-0c46-11e8-95eb-75cbbef3e490.png">

## Questions
I'd be interested to hear from clientside devs about this one. My main questions are:
- Has anyone come across this pitfall of fastdom? Is there a workaround or best practice to avoid it?
- Do people agree that we should be more discriminating in our use of fastdom? Should we do more to educate people about its original aim (to avoid layout thrashing) and refer people to [this list](https://gist.github.com/paulirish/5d52fb081b3570c81e3a) when considering if they need it?