### PR TITLE
Use ssl for football api cdn

### DIFF
--- a/sport/app/conf/SportConfiguration.scala
+++ b/sport/app/conf/SportConfiguration.scala
@@ -8,7 +8,7 @@ object SportConfiguration {
   import GuardianConfiguration._
 
   object pa {
-    lazy val footballHost = "http://football-api.gu-web.net/v1.5"
+    lazy val footballHost = "https://football-api.guardianapis.com/v1.5"
     lazy val footballKey = configuration.getMandatoryStringProperty("pa.api.key")
     lazy val cricketKey = configuration.getStringProperty("pa.cricket.api.key")
   }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -73,7 +73,7 @@ class FootballLifecycle(
 class FootballClient(wsClient: WSClient)(implicit executionContext: ExecutionContext) extends PaClient with Http with Logging {
 
   // Runs the API calls via a CDN
-  override lazy val base: String = "http://football-api.gu-web.net/v1.5"
+  override lazy val base: String = "https://football-api.guardianapis.com/v1.5"
 
   override def GET(urlString: String): Future[pa.Response] = {
 


### PR DESCRIPTION
## What does this change?

Use ssl for football api cdn. Part of GDPR requirements for Frontend - all outgoing connections outside the VPC should be encrypted

## What is the value of this and can you measure success?

GDPR, security

## Tested in CODE?

Tested the endpoint in PROD
