### PR TITLE
Backport Garnett spacefinder header rule for control group

### DIFF
--- a/static/src/javascripts/projects/commercial-control/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial-control/modules/article-body-adverts.js
@@ -101,13 +101,17 @@ const getRules = (): Object => {
     return {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: isBreakpoint({
-            max: 'tablet',
-        })
-            ? 300
-            : 700,
+        minAbove: 300,
         minBelow: 300,
         selectors: {
+            ' > header': {
+                minAbove: isBreakpoint({
+                    max: 'tablet',
+                })
+                    ? 300
+                    : 700,
+                minBelow: 0,
+            },
             ' > h2': {
                 minAbove: getBreakpoint() === 'mobile' ? 100 : 0,
                 minBelow: 250,

--- a/static/src/javascripts/projects/commercial-control/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial-control/modules/article-body-adverts.spec.js
@@ -236,7 +236,7 @@ describe('Article Body Adverts', () => {
 
                 return getFirstRulesUsed().then(rules => {
                     // adverts give the top of the page more clearance
-                    expect(rules.minAbove).toEqual(700);
+                    expect(rules.selectors[' > header'].minAbove).toEqual(700);
 
                     // give headings no vertical clearance
                     expect(rules.selectors[' > h2'].minAbove).toEqual(0);


### PR DESCRIPTION
Brings the Garnett spacefinder rule into the commercial control group. The variant is performing so differently that we aren't able to discern forward-facing changes. 