### PR TITLE
Fix server-side test framework, and commercial logging 

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -22,9 +22,7 @@ object CommercialClientLogging extends Experiment(
   owners = Seq(Owner.withGithub("rich-nguyen")),
   sellByDate = new LocalDate(2018, 2, 28),
   participationGroup = Perc1A
-) {
-  override def priorCondition(implicit request: RequestHeader): Boolean = CommercialBaseline.switch.isSwitchedOn
-}
+)
 
 object CommercialPaidContentTemplate extends Experiment(
   name = "commercial-paid-content",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,7 @@ import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
 
 object ActiveExperiments extends ExperimentsDefinition {
-  val allExperiments: Set[Experiment] = Set(
+  override val allExperiments: Set[Experiment] = Set(
     CommercialClientLogging,
     CommercialPaidContentTemplate,
     CommercialBaseline,

--- a/common/app/experiments/ExperimentsDefinition.scala
+++ b/common/app/experiments/ExperimentsDefinition.scala
@@ -11,7 +11,7 @@ trait ExperimentsDefinition {
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     allExperiments
-      .filter(e => e.isParticipating || e.isControl)
+      .filter(e => isParticipating(e) || isControl(e))
       .toSeq.sortBy(_.name)
       .map { e =>
         val value = e.value

--- a/static/src/javascripts/projects/commercial-control/modules/dfp/performance-logging.js
+++ b/static/src/javascripts/projects/commercial-control/modules/dfp/performance-logging.js
@@ -105,7 +105,7 @@ const addEndTimeBaseline = (baselineName: string): void => {
 // This posts the performance log to the beacon endpoint. It is expected that this be called
 // multiple times in a page view, so that partial data is captured, and then topped up as adverts load in.
 const reportTrackingData = (): void => {
-    if (config.tests.commercialClientLogging) {
+    if (config.get('tests.commercialClientLoggingVariant')) {
         const performanceReport = {
             viewId: ophan.viewId,
             tags: performanceLog.tags,

--- a/static/src/javascripts/projects/commercial/modules/dfp/performance-logging.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/performance-logging.js
@@ -105,7 +105,7 @@ const addEndTimeBaseline = (baselineName: string): void => {
 // This posts the performance log to the beacon endpoint. It is expected that this be called
 // multiple times in a page view, so that partial data is captured, and then topped up as adverts load in.
 const reportTrackingData = (): void => {
-    if (config.tests.commercialClientLogging) {
+    if (config.get('tests.commercialClientLoggingVariant')) {
         const performanceReport = {
             viewId: ophan.viewId,
             tags: performanceLog.tags,


### PR DESCRIPTION
There is a nasty side-effect requirement in the server-side tests (this is the [second time](https://github.com/guardian/frontend/pull/18677/commits/357d5f32e01a5fcd9baa32b443b7f65e1ef3b5f4) that this has caused a problem).

The test framework itself has an opportunity to 'touch' all tests, executing `isIn()` for each of them, and thus ensuring that `X-GU-Depends-On-Experiments` is up-to-date, even if your Experiment is not used during server-side rendering (as counter-intuitive as that sounds, it may only be config changes). I've tweaked the `getJavascriptConfig` to do this.