### PR TITLE
Revert "body of the article should have the appropriate meta data on it"

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -50,7 +50,7 @@
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
-                        <div class="content__article-body from-content-api js-article__body"
+                        <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
 
                             @if(!isPaidContent) {
@@ -69,10 +69,7 @@
                             }
 
                             @fragments.witnessCallToAction(article.content)
-
-                            <div itemprop="@bodyType(model)">
-                                @BodyCleaner(article, article.fields.body, amp = amp)
-                            </div>
+                            @BodyCleaner(article, article.fields.body, amp = amp)
                             @fragments.witnessCallToAction(article.content)
 
                             @fragments.submeta(article, amp)

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -200,16 +200,16 @@ import collection.JavaConverters._
 
     }
 
-    scenario("Article body", ArticleComponents) {
-
-      Given("I am on an article entitled 'New Viking invasion at Lindisfarne'")
-      goTo("/uk/the-northerner/2012/aug/07/lindisfarne-vikings-northumberland-heritage-holy-island") { browser =>
-        import browser._
-
-        Then("I should see the body of the article")
-        $("[itemprop=articleBody]").text should startWith("This week Lindisfarne celebrates its long and frequently bloody Viking heritage")
-      }
-    }
+//    scenario("Article body", ArticleComponents) {
+//
+//      Given("I am on an article entitled 'New Viking invasion at Lindisfarne'")
+//      goTo("/uk/the-northerner/2012/aug/07/lindisfarne-vikings-northumberland-heritage-holy-island") { browser =>
+//        import browser._
+//
+//        Then("I should see the body of the article")
+//        $("[itemprop=articleBody]").text should startWith("This week Lindisfarne celebrates its long and frequently bloody Viking heritage")
+//      }
+//    }
 
     scenario("Article aside MPU", ArticleComponents) {
 
@@ -353,18 +353,18 @@ import collection.JavaConverters._
 
 
 
-    scenario("Review body", ArticleComponents) {
-
-      // Nb, The schema.org markup for a review body is different to an article body
-
-      Given("I am on a review entitled 'Phill Jupitus is Porky the Poet in 27 Years On - Edinburgh festival review'")
-      goTo("/culture/2012/aug/07/phill-jupitus-edinburgh-review") { browser =>
-        import browser._
-
-        Then("I should see the star body")
-        $("[itemprop=reviewBody]").text should startWith("What's so funny?")
-      }
-    }
+//    scenario("Review body", ArticleComponents) {
+//
+//      // Nb, The schema.org markup for a review body is different to an article body
+//
+//      Given("I am on a review entitled 'Phill Jupitus is Porky the Poet in 27 Years On - Edinburgh festival review'")
+//      goTo("/culture/2012/aug/07/phill-jupitus-edinburgh-review") { browser =>
+//        import browser._
+//
+//        Then("I should see the star body")
+//        $("[itemprop=reviewBody]").text should startWith("What's so funny?")
+//      }
+//    }
 
     scenario("correct placeholder for ad is rendered") {
 


### PR DESCRIPTION
This reverts commit af37a48f4dbc2db89aa3a084b4822feb7af4fe3d.

Spacefinder uses a specific CSS selector to find candidate elements in the article body; adding this metadata div causes that selector to break.

Whilst a workaround is sorted, we can revert this to reinstantiate inline ads (sorry).