### PR TITLE
Tidy build log

### DIFF
--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -52,6 +52,7 @@ object IndexPage {
     case _ => None
   }
 
+  //noinspection ScalaStyle
   def makeFront(indexPage: IndexPage, edition: Edition)(implicit context: ApplicationContext): Front = {
     val isCartoonPage = indexPage.isTagWithId("type/cartoon")
     val isReviewPage = indexPage.isTagWithId("tone/reviews")

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -152,7 +152,7 @@ trait Index extends ConciergeRepository with Collections {
     IndexPage(page = section, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None, commercial)
   }
 
-  private def tag(response: ItemResponse, page: Int) = {
+  private def tag(response: ItemResponse, page: Int): Option[IndexPage] = {
     val tag = response.tag map { Tag.make(_, pagination(response)) }
     val leadContentCutOff = DateTime.now - QueryDefaults.leadContentMaxAge
     val editorsPicks = response.editorsPicks.getOrElse(Nil).map(IndexPageItem(_))

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -46,7 +46,6 @@ object ProjectSettings {
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases"),
       Resolver.sonatypeRepo("releases"),
-      "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Guardian Editorial Tools Bintray" at "https://dl.bintray.com/guardian/editorial-tools",
       Resolver.bintrayRepo("guardian", "ophan"),

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -40,8 +40,7 @@ object ProjectSettings {
   val frontendDependencyManagementSettings = Seq(
     ivyXML :=
       <dependencies>
-        <exclude org="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
-        <exclude org="org.specs2"><!-- because someone thinks it is acceptable to have this as a prod dependency --></exclude>
+        <exclude org="commons-logging" module="commons-logging"><!-- Conflicts with jcl-over-slf4j in Play. --></exclude>
       </dependencies>,
 
     resolvers ++= Seq(


### PR DESCRIPTION
## What does this change?
The interesting bit of this change is the removal of github as resolver for the project. I've also attempted to fix the ivy `<exclude>` blocks in our project settings file. This should get rid of hundreds of warnings in our build log that look like this:
```
[Step 5/6] Skipped generating '<exclusion/>' for commons-logging#*. Dependency exclusion should have both 'org' and 'module' to comply with Maven POM's schema.
Skipped generating '<exclusion/>' for org.specs2#*. Dependency exclusion should have both 'org' and 'module' to comply with Maven POM's schema.
[18:01:08][Step 5/6] [warn] Skipped generating '<exclusion/>' for commons-logging#*. Dependency exclusion should have both 'org' and 'module' to comply with Maven POM's schema.
[18:01:08][Step 5/6] [warn] Skipped generating '<exclusion/>' for org.specs2#*. Dependency exclusion should have both 'org' and 'module' to comply with Maven POM's schema.
```

Other stuff is just tiny random syntax changes and a thing to make IndexPage.scala more readable in intellij!

## What is the value of this and can you measure success?
Hopefully ever so slightly faster builds!

