### PR TITLE
Removed the cancel my contribution switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -463,14 +463,4 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
-
-  val ProfileShowCancelContributor = Switch(
-    SwitchGroup.Feature,
-    "profile-show-cancel-contributor",
-    "When ON, the edit profile page will include the cancel contribution button",
-    owners = Seq(Owner.withGithub("svillafe")),
-    safeState = On,
-    sellByDate = new LocalDate(2018, 2, 15),
-    exposeClientSide = true
-  )
 }

--- a/identity/app/views/profile/contributionForm/recurringDetails.scala.html
+++ b/identity/app/views/profile/contributionForm/recurringDetails.scala.html
@@ -1,5 +1,3 @@
-@import conf.switches.Switches.ProfileShowCancelContributor
-
 @(user: com.gu.identity.model.User)(implicit request: RequestHeader)
 <div class="is-hidden js-contribution-info">
     <ul class="details-list u-unstyled js-contribution-details">
@@ -86,10 +84,10 @@
     <div class="js-contribution-paypal is-hidden" data-product="contribution">
         @views.html.profile.payPal()
     </div>
-    @if(ProfileShowCancelContributor.isSwitchedOn) {
-        <div class="js-contribution-cancel is-hidden" data-product="contribution">
-           @views.html.profile.cancelRegularContribution(user)
-        </div>
-    }
+
+    <div class="js-contribution-cancel is-hidden" data-product="contribution">
+       @views.html.profile.cancelRegularContribution(user)
+    </div>
+
 
 </div>


### PR DESCRIPTION
## What does this change?

Remove a switch for 'cancel my account' feature, which is something that we want to keep


## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
We need to test in code before merging.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
