### PR TITLE
Show graphs of Prebid bidder performance

### DIFF
--- a/admin/app/controllers/admin/commercial/DashboardRenderer.scala
+++ b/admin/app/controllers/admin/commercial/DashboardRenderer.scala
@@ -17,7 +17,7 @@ object DashboardRenderer extends Results {
       report: Seq[DfpReportRow] <- CommercialDfpReporting.getReport(reportId)
     } yield {
       val keyValueRows: Seq[KeyValueRevenueRow] = report.flatMap { row =>
-        val fields = row.value.split(",").toSeq
+        val fields = row.fields
         for {
           customCriteria: String    <- fields.lift(0)
           customTargetingId: String <- fields.lift(1)

--- a/admin/app/controllers/admin/commercial/TeamKPIController.scala
+++ b/admin/app/controllers/admin/commercial/TeamKPIController.scala
@@ -1,9 +1,11 @@
 package controllers.admin.commercial
 
 import common.Logging
-import model.ApplicationContext
+import jobs.CommercialDfpReporting
+import model.{ApplicationContext, NoCache}
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import tools.{Chart, ChartFormat, ChartRow}
 
 class TeamKPIController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
   extends BaseController
@@ -16,6 +18,89 @@ class TeamKPIController(val controllerComponents: ControllerComponents)(implicit
   }
 
   def renderPrebidDashboard(): Action[AnyContent] = Action { implicit request =>
-    DashboardRenderer.renderDashboard("prebid", "Sonobi wrapper vs Prebid", "lime", "aqua")
+    case class DataPoint(date: String, bidderName: String, impressionCount: Int, eCpm: Double)
+
+    val dataPoints = (
+      for {
+        report <- CommercialDfpReporting.getCustomReport(CommercialDfpReporting.prebidBidderPerformance)
+      } yield {
+        report.flatMap { row =>
+          val fields = row.fields
+          for {
+            date            <- fields.lift(0)
+            customCriteria  <- fields.lift(1)
+            impressionCount <- fields.lift(3).map(_.toInt)
+            eCpm            <- fields.lift(4).map(_.toDouble / 1000000.0d) // convert DFP micropounds to pounds
+          } yield
+            DataPoint(
+              date = date,
+              bidderName = customCriteria.stripPrefix("hb_bidder="),
+              impressionCount = impressionCount,
+              eCpm = eCpm
+            )
+        }
+      }
+    ).getOrElse(Nil)
+
+    trait BidPerformanceChart extends Chart {
+      val bidderNames = dataPoints.map(_.bidderName).distinct.sorted
+      def labels      = "Date" +: bidderNames
+      def format      = ChartFormat.MultiLine
+    }
+
+    val impressionChart = new BidPerformanceChart {
+      val name = "Number of winning bids"
+      val dataset = dataPoints
+        .groupBy(_.date)
+        .foldLeft(Seq.empty[ChartRow]) {
+          case (acc, (date, points)) =>
+            val impressionCounts = bidderNames.foldLeft(Seq.empty[Double]) { (soFar, label) =>
+              soFar :+ points.find(_.bidderName == label).map(_.impressionCount.toDouble).getOrElse(0d)
+            }
+            acc :+ ChartRow(date, impressionCounts)
+        }
+        .sortBy(_.rowKey)
+    }
+
+    val cpmChart = new BidPerformanceChart {
+      val name = "CPM"
+      val dataset = dataPoints
+        .groupBy(_.date)
+        .foldLeft(Seq.empty[ChartRow]) {
+          case (acc, (date, points)) =>
+            val cpms = bidderNames.foldLeft(Seq.empty[Double]) { (soFar, label) =>
+              soFar :+ points.find(_.bidderName == label).map(_.eCpm).getOrElse(0d)
+            }
+            acc :+ ChartRow(date, cpms)
+        }
+        .sortBy(_.rowKey)
+    }
+
+    val revenueChart = new BidPerformanceChart {
+      val name = "Indicative revenue"
+      val dataset = dataPoints
+        .groupBy(_.date)
+        .foldLeft(Seq.empty[ChartRow]) {
+          case (acc, (date, points)) =>
+            val revenues = bidderNames.foldLeft(Seq.empty[Double]) { (soFar, label) =>
+              soFar :+ points
+                .find(_.bidderName == label)
+                .map { point =>
+                  point.impressionCount * point.eCpm / 1000
+                }
+                .getOrElse(0d)
+            }
+            acc :+ ChartRow(date, revenues)
+        }
+        .sortBy(_.rowKey)
+    }
+
+    NoCache(
+      Ok(
+        views.html.lineCharts(
+          charts = Seq(impressionChart, cpmChart, revenueChart),
+          title = Some("Prebid Bidder Performance"),
+          legendPosition = "bottom"
+        )))
   }
 }

--- a/admin/app/controllers/admin/commercial/TeamKPIController.scala
+++ b/admin/app/controllers/admin/commercial/TeamKPIController.scala
@@ -68,6 +68,7 @@ class TeamKPIController(val controllerComponents: ControllerComponents)(implicit
 
     val cpmChart = new BidPerformanceChart {
       val name = "CPM"
+      override val vAxisTitle = Some("GBP")
       val dataset = dataPoints
         .groupBy(_.date)
         .foldLeft(Seq.empty[ChartRow[LocalDate]]) {
@@ -82,6 +83,7 @@ class TeamKPIController(val controllerComponents: ControllerComponents)(implicit
 
     val revenueChart = new BidPerformanceChart {
       val name = "Indicative revenue"
+      override val vAxisTitle = Some("GBP")
       val dataset = dataPoints
         .groupBy(_.date)
         .foldLeft(Seq.empty[ChartRow[LocalDate]]) {

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -113,7 +113,16 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
     val page: SavedQueryPage = services.reportService.getSavedQueriesByStatement(stmtBuilder.toStatement)
     // page.getResults() may return null.
     val savedQuery: Option[SavedQuery] = Option(page.getResults()).flatMap(_.toList.headOption)
-    savedQuery.map(_.getReportQuery)
+
+    /*
+     * if this is null it means that the report is incompatible with the API version we're using.
+     * Eg. check this for supported date-range types:
+     * https://developers.google.com/doubleclick-publishers/docs/reference/v201711/ReportService.ReportQuery#daterangetype
+     * And supported filter types:
+     * https://developers.google.com/doubleclick-publishers/docs/reference/v201711/ReportService.ReportQuery#statement`
+     * Also see https://developers.google.com/doubleclick-publishers/docs/reporting
+     */
+    savedQuery.flatMap(qry => Option(qry.getReportQuery))
   }
 
   def runReportJob(report: ReportQuery): Seq[String] = {

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -1,6 +1,9 @@
 package jobs
 
+import java.time.LocalDate
+
 import app.LifecycleComponent
+import com.google.api.ads.dfp.axis.v201705._
 import com.gu.Box
 import common.{AkkaAsync, JobScheduler, Logging}
 import dfp.DfpApi
@@ -10,20 +13,36 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object CommercialDfpReporting {
 
-  case class DfpReportRow(value: String)
+  case class DfpReportRow(value: String) {
+    val fields = value.split(",").toSeq
+  }
 
   private val dfpReports = Box[Map[Long, Seq[DfpReportRow]]](Map.empty)
+  private val dfpCustomReports = Box[Map[String, Seq[DfpReportRow]]](Map.empty)
 
   val teamKPIReport = "All ab-test impressions and CPM"
+  val prebidBidderPerformance = "Prebid Bidder Performance"
+
   // These IDs correspond to queries saved in DFP's web console.
   val reportMappings = Map(
     teamKPIReport -> 10060521970L // This report is accessible by the DFP user: "NGW DFP Production"
   )
 
+  private val prebidBidderPerformanceQry = {
+    def toGoogleDate(date: LocalDate) = new Date(date.getYear, date.getMonthValue, date.getDayOfMonth)
+    val prebidBegan = LocalDate.of(2018, 1, 22)
+    val qry = new ReportQuery()
+    qry.setDateRangeType(DateRangeType.CUSTOM_DATE)
+    qry.setStartDate(toGoogleDate(prebidBegan.minusDays(1)))
+    qry.setEndDate(toGoogleDate(LocalDate.now))
+    qry.setDimensions(Array(Dimension.DATE, Dimension.CUSTOM_CRITERIA))
+    qry.setColumns(Array(Column.AD_SERVER_IMPRESSIONS, Column.AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM))
+    qry
+  }
 
   def update(dfpApi: DfpApi)(implicit executionContext: ExecutionContext): Future[Unit] = Future {
     for {
-      (reportName, reportId) <- reportMappings.toSeq
+      (_, reportId) <- reportMappings.toSeq
     } {
       val maybeReport: Option[Seq[DfpReportRow]] = dfpApi.getReportQuery(reportId)
         .map(reportId => {
@@ -37,9 +56,16 @@ object CommercialDfpReporting {
         })
       }
     }
+
+    dfpCustomReports.send(curr =>
+      curr + {
+        prebidBidderPerformance ->
+          dfpApi.runReportJob(prebidBidderPerformanceQry).tail.filter(_.contains("hb_bidder=")).map(DfpReportRow)
+    })
   }
 
   def getReport(reportId: Long): Option[Seq[DfpReportRow]] = dfpReports.get().get(reportId)
+  def getCustomReport(reportName: String): Option[Seq[DfpReportRow]] = dfpCustomReports.get().get(reportName)
 }
 
 class CommercialDfpReportingLifecycle(

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,6 +3,9 @@ package jobs
 import java.time.LocalDate
 
 import app.LifecycleComponent
+import com.google.api.ads.dfp.axis.v201705.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.dfp.axis.v201705.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.dfp.axis.v201705.Dimension.{CUSTOM_CRITERIA, DATE}
 import com.google.api.ads.dfp.axis.v201705._
 import com.gu.Box
 import common.{AkkaAsync, JobScheduler, Logging}
@@ -32,11 +35,11 @@ object CommercialDfpReporting {
     def toGoogleDate(date: LocalDate) = new Date(date.getYear, date.getMonthValue, date.getDayOfMonth)
     val prebidBegan = LocalDate.of(2018, 1, 22)
     val qry = new ReportQuery()
-    qry.setDateRangeType(DateRangeType.CUSTOM_DATE)
+    qry.setDateRangeType(CUSTOM_DATE)
     qry.setStartDate(toGoogleDate(prebidBegan.minusDays(1)))
     qry.setEndDate(toGoogleDate(LocalDate.now))
-    qry.setDimensions(Array(Dimension.DATE, Dimension.CUSTOM_CRITERIA))
-    qry.setColumns(Array(Column.AD_SERVER_IMPRESSIONS, Column.AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM))
+    qry.setDimensions(Array(DATE, CUSTOM_CRITERIA))
+    qry.setColumns(Array(AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM))
     qry
   }
 
@@ -60,7 +63,7 @@ object CommercialDfpReporting {
     dfpCustomReports.send(curr =>
       curr + {
         prebidBidderPerformance ->
-          dfpApi.runReportJob(prebidBidderPerformanceQry).tail.filter(_.contains("hb_bidder=")).map(DfpReportRow)
+          dfpApi.runReportJob(prebidBidderPerformanceQry).filter(_.contains("hb_bidder=")).map(DfpReportRow)
     })
   }
 

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -61,6 +61,7 @@ trait Chart[K] {
   def hasData: Boolean = dataset.nonEmpty
   def format: ChartFormat
   def dualY: Boolean = false
+  def vAxisTitle: Option[String] = None
 
   def formatRowKey(key: K): String
 

--- a/admin/app/views/dateLineCharts.scala.html
+++ b/admin/app/views/dateLineCharts.scala.html
@@ -1,4 +1,4 @@
-@(charts: Seq[tools.Chart[String]], title: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(charts: Seq[tools.Chart[java.time.LocalDate]], title: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Dashboard", isAuthed = true, hasCharts = true) {
 
@@ -13,5 +13,5 @@
         }
     }
 
-    @charts.filter(_.hasData).map{ chart => @fragments.lineChart(chart) }
+    @charts.filter(_.hasData).map{ chart => @fragments.dateLineChart(chart) }
 }

--- a/admin/app/views/dateLineCharts.scala.html
+++ b/admin/app/views/dateLineCharts.scala.html
@@ -1,6 +1,6 @@
 @(charts: Seq[tools.Chart[java.time.LocalDate]], title: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@admin_main("Dashboard", isAuthed = true, hasCharts = true) {
+@admin_main(title.getOrElse("Dashboard"), isAuthed = true, hasCharts = true) {
 
     @title.map{ title =>
         <h3>@title</h3>

--- a/admin/app/views/fragments/dateLineChart.scala.html
+++ b/admin/app/views/fragments/dateLineChart.scala.html
@@ -1,4 +1,4 @@
-@(chart: tools.Chart[String])
+@(chart: tools.Chart[java.time.LocalDate])
 
 @* placeholder for chart *@
 <div id="@chart.id" class="chart @chart.format.cssClass"></div>
@@ -8,19 +8,8 @@
         .draw(google.visualization.arrayToDataTable(@Html(chart.asDataset)), {
             title: '@chart.name',
             colors: [@Html(chart.format.colours.map(c => s"'$c'").mkString(","))],
-            @if(chart.labels.size == 2){
-                legend: "none",
-                vAxis: {title: '@chart.labels(1)'},
-            } else {
-                legend: { position: "in" },
-                @if(chart.dualY){
-                    series: {
-                        0: {targetAxisIndex: 0},
-                        1: {targetAxisIndex: 1}
-                    },
-                }
-            }
-            chartArea: { width: "85%" },
+            legend: { position: 'bottom' },
+            chartArea: { width: '85%' },
             titleTextStyle: {color: '#999'},
             axisTitlesPosition: 'in',
             fontName : 'Georgia',

--- a/admin/app/views/fragments/dateLineChart.scala.html
+++ b/admin/app/views/fragments/dateLineChart.scala.html
@@ -11,8 +11,8 @@
             legend: { position: 'bottom' },
             chartArea: { width: '85%' },
             titleTextStyle: {color: '#999'},
-            axisTitlesPosition: 'in',
             fontName : 'Georgia',
-            smoothLine: true
-    });
+            smoothLine: true,
+            vAxis: {@chart.vAxisTitle.map{ vAxisTitle => title: '@vAxisTitle', } viewWindow: {min: 0}}
+        });
 </script>

--- a/admin/app/views/fragments/lineChart.scala.html
+++ b/admin/app/views/fragments/lineChart.scala.html
@@ -1,4 +1,4 @@
-@(chart: tools.Chart)
+@(chart: tools.Chart, legendPosition: String = "in")
 
 @* placeholder for chart *@
 <div id="@chart.id" class="chart @chart.format.cssClass"></div>
@@ -9,10 +9,10 @@
             title: '@chart.name',
             colors: [@Html(chart.format.colours.map(c => s"'$c'").mkString(","))],
             @if(chart.labels.size == 2){
-                legend: "none",
+                legend: 'none',
                 vAxis: {title: '@chart.labels(1)'},
             } else {
-                legend: { position: "in" },
+                legend: { position: '@legendPosition' },
                 @if(chart.dualY){
                     series: {
                         0: {targetAxisIndex: 0},
@@ -20,7 +20,7 @@
                     },
                 }
             }
-            chartArea: { width: "85%" },
+            chartArea: { width: '85%' },
             titleTextStyle: {color: '#999'},
             axisTitlesPosition: 'in',
             fontName : 'Georgia',

--- a/admin/app/views/lineCharts.scala.html
+++ b/admin/app/views/lineCharts.scala.html
@@ -1,4 +1,4 @@
-@(charts: Seq[tools.Chart], title: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(charts: Seq[tools.Chart], title: Option[String] = None, legendPosition: String = "in")(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Dashboard", isAuthed = true, hasCharts = true) {
 
@@ -13,5 +13,5 @@
         }
     }
 
-    @charts.filter(_.hasData).map{ chart => @fragments.lineChart(chart) }
+    @charts.filter(_.hasData).map{ chart => @fragments.lineChart(chart, legendPosition) }
 }


### PR DESCRIPTION
This is intended to give us a basic idea of progress.
It shows charts of winning bid counts by bidder, CPM by bidder and an indication of revenue by bidder over time.
It starts from 21 Jan, the day before we began the A/B test:
![image](https://user-images.githubusercontent.com/1722550/36100056-cc0d64b2-0ffc-11e8-8f0b-2c58fa56d73d.png)
