### PR TITLE
Check perfMark[0] is not undefined or null

### DIFF
--- a/static/src/javascripts/lib/user-timing.js
+++ b/static/src/javascripts/lib/user-timing.js
@@ -26,7 +26,7 @@ const getMarkTime = (label: string): ?number => {
     if (performanceAPI && 'getEntriesByName' in performanceAPI) {
         const perfMark = performanceAPI.getEntriesByName(label, 'mark');
 
-        if (perfMark && 'startTime' in perfMark[0]) {
+        if (perfMark && perfMark[0] && 'startTime' in perfMark[0]) {
             return perfMark[0].startTime;
         }
     } else if (label in timings) {


### PR DESCRIPTION
## What does this change?

Fixes [runtime error where `perfMark[0]` is undefined or `null`](https://sentry.io/the-guardian/client-side-prod/issues/397212561/) 

## What is the value of this and can you measure success?
Less errors reported 


## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No
