### PR TITLE
Show header on newsletter signup page

### DIFF
--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -14,12 +14,12 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, SignUpCSSFile}
 
 object NewsletterHtmlPage extends HtmlPage[SimplePage] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
+    override def criticalCssLink: Html = criticalStyleLink(SignUpCSSFile)
     override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(Some("signup"))))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
@@ -44,6 +44,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         message(),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        guardianHeaderHtml(),
         breakingNewsDiv(),
         newsletterContent(page),
         footer(),

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -42,4 +42,5 @@ object HtmlPageHelpers {
   def FaciaCSSFile(implicit request: RequestHeader): String = "facia.garnett"
   def ContentCSSFile(implicit request: RequestHeader): String = "content.garnett"
   def RichLinksCSSFile(implicit request: RequestHeader): String = "rich-links.garnett"
+  def SignUpCSSFile(implicit request: RequestHeader): String = "signup"
 }

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -7,7 +7,7 @@
     @include mq($from: tablet) {
         font-size: 60px;
         padding-top: $gs-baseline * 2;
-  }
+    }
 }
 
 .newsletter-card__signup {


### PR DESCRIPTION
## What does this change?

- Adds the Guardian header to newsletter signup pages, the header applied is "slim".
- Locally the route `/email-newsletters` was unstyled, this is because `criticalCssLink` (only used locally) was incorrectly set to load `head.content.garnett.css` instead of `head.signup.css`, this fixes that.

Here's the [Trello](https://trello.com/c/jhXNDDtt/36-headerless-newsletters-page) card for this work.

## What is the value of this and can you measure success?

You can navigate from the newsletter signup page now!

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

![picture 129](https://user-images.githubusercontent.com/1590704/36106064-306386d8-100e-11e8-8a30-f67a9b7ba7c9.png)

## Tested in CODE?

Yes
