### PR TITLE
no more observer series tags for immersives

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -47,7 +47,7 @@
         <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
     </div>
     }.getOrElse {
-        @if(item.content.isFromTheObserver) {
+        @if(item.content.isFromTheObserver && !item.content.isImmersive) {
             <div class="content__series-label">
                 <a class="content__series-label__link" href="https://www.theguardian.com/observer">The Observer</a>
             </div>


### PR DESCRIPTION
## What does this change
Removes observer series tags for immersive templates

Before:
<img width="1400" alt="screen shot 2018-02-12 at 16 27 23" src="https://user-images.githubusercontent.com/8453924/36107380-b8165c2e-1011-11e8-9ab4-5de1d40048b4.png">

After:
<img width="1406" alt="screen shot 2018-02-12 at 16 27 10" src="https://user-images.githubusercontent.com/8453924/36107390-bf0937ae-1011-11e8-9a61-b9bec0efaa3f.png">
