### PR TITLE
Remove last page link from pagination on tag page

### DIFF
--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -28,11 +28,11 @@
 }
 
 @paginationLink(pageNo: Int) = {
-    <a class="button button--small button--tertiary pagination__action @actionClass @if(pageNo == 1){ pagination__action--first }"
+    <a class="button button--small button--tertiary pagination__action @actionClass @if(pageNo == 1){pagination__action--first}"
        href="@paginated(pageNo)"
        data-page="@pageNo"
        data-link-name="Pagination view page @pageNo"
-       aria-label="@ariaContext @if(pageNo == 1){ first } page">@pageNo</a>
+       aria-label="@ariaContext @if(pageNo == 1){first} page">@pageNo</a>
 }
 
 @* don't show pagination if this is the only page *@

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -26,20 +26,6 @@
     <span class="pagination__text">…</span>
 }
 
-@paginationExtreme(pageNo: Option[Int], dir: String) = {
-    @pageNo.map { p =>
-       <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
-        href="@paginated(p)"
-        data-page="@p"
-        data-link-name="Pagination view page @p"
-        aria-label="@ariaContext @dir page">@p</a>
-
-      @if(dir == "first") {
-          @paginationDivider
-      }
-    }
-}
-
 @* don't show pagination if this is the only page *@
 @if(pagination.lastPage > 1) {
     @if(showFull) {
@@ -53,7 +39,15 @@
             @paginationPointer(pagination.previous, "prev")
 
             @if(pagination.currentPage - 2 > 1) {
-                @paginationExtreme(pagination.previous.map(_ => 1), "first")
+                pagination.previous.map(_ => 1).map { p =>
+                    <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
+                    href="@paginated(p)"
+                    data-page="@p"
+                    data-link-name="Pagination view page @p"
+                    aria-label="@ariaContext @dir page">@p</a>
+            
+                    @paginationDivider
+                }
             }
         }
 

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -32,7 +32,7 @@
        href="@paginated(pageNo)"
        data-page="@pageNo"
        data-link-name="Pagination view page @pageNo"
-       aria-label="@ariaContext @dir page">@pageNo</a>
+       aria-label="@ariaContext @if(pageNo == 1){ first } page">@pageNo</a>
 }
 
 @* don't show pagination if this is the only page *@

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -9,6 +9,7 @@
   ariaContext: Option[String] = None)(implicit request: RequestHeader)
 
 @paginated(pageNum: Int) = {@common.LinkTo(pagePaths.pathFor(pageNum))}
+
 @paginationPointer(pageNo: Option[Int], dir: String) = {
     @pageNo.map { p =>
         <a class="button button--small button--tertiary pagination__action--static @actionClass"
@@ -26,6 +27,14 @@
     <span class="pagination__text">…</span>
 }
 
+@paginationLink(pageNo: Int, paginationActionClass: Option[String]) = {
+    <a class="button button--small button--tertiary pagination__action @actionClass @if(pageNo == 1){ pagination__action--first }"
+       href="@paginated(pageNo)"
+       data-page="@pageNo"
+       data-link-name="Pagination view page @pageNo"
+       aria-label="@ariaContext @dir page">@pageNo</a>
+}
+
 @* don't show pagination if this is the only page *@
 @if(pagination.lastPage > 1) {
     @if(showFull) {
@@ -39,15 +48,8 @@
             @paginationPointer(pagination.previous, "prev")
 
             @if(pagination.currentPage - 2 > 1) {
-                pagination.previous.map(_ => 1).map { p =>
-                    <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
-                    href="@paginated(p)"
-                    data-page="@p"
-                    data-link-name="Pagination view page @p"
-                    aria-label="@ariaContext @dir page">@p</a>
-            
-                    @paginationDivider
-                }
+                @paginationLink(1)
+                @paginationDivider
             }
         }
 
@@ -55,11 +57,7 @@
             @if(pageNum == pagination.currentPage) {
                 <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page" tabindex="0">@pageNum</span>
             } else {
-                <a class="button button--small button--tertiary pagination__action @actionClass"
-                data-page="@pageNum"
-                href="@paginated(pageNum)"
-                data-link-name="Pagination view page @pageNum"
-                aria-label="@ariaContext page @pageNum">@pageNum</a>
+                @paginationLink(pageNum)
             }
         }
 

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -27,7 +27,7 @@
     <span class="pagination__text">…</span>
 }
 
-@paginationLink(pageNo: Int, paginationActionClass: Option[String]) = {
+@paginationLink(pageNo: Int) = {
     <a class="button button--small button--tertiary pagination__action @actionClass @if(pageNo == 1){ pagination__action--first }"
        href="@paginated(pageNo)"
        data-page="@pageNo"

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -70,7 +70,9 @@
         }
 
         @if(pagination.lastPage > 5) {
-            @paginationDivider
+            @if(pagination.next.isDefined) {
+                @paginationDivider
+            }
 
             @paginationPointer(pagination.next, "next")
         }

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -62,7 +62,6 @@
         }
 
         @pagination.pages.map{ pageNum =>
-
             @if(pageNum == pagination.currentPage) {
                 <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page" tabindex="0">@pageNum</span>
             } else {
@@ -75,10 +74,6 @@
         }
 
         @if(pagination.lastPage > 5) {
-            @if(pagination.currentPage + 2 < pagination.lastPage) {
-                @paginationExtreme(Some(pagination.lastPage), "last")
-            }
-
             @paginationPointer(pagination.next, "next")
         }
         </div>

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -28,11 +28,7 @@
 
 @paginationExtreme(pageNo: Option[Int], dir: String) = {
     @pageNo.map { p =>
-        @if(dir == "last") {
-            @paginationDivider
-        }
-
-        <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
+       <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
         href="@paginated(p)"
         data-page="@p"
         data-link-name="Pagination view page @p"
@@ -74,6 +70,8 @@
         }
 
         @if(pagination.lastPage > 5) {
+            @paginationDivider
+
             @paginationPointer(pagination.next, "next")
         }
         </div>


### PR DESCRIPTION
## What does this change?

Remove last page link from pagination on tag pages.

This was an action that came out of an incident retro, Details can be found [here](https://docs.google.com/document/d/1OxXCRn0CUhBwuDO1obNkJ4M-MFD90CdwUfvd1nnriw4/edit?ts=5a70c012#).

The corresponding Trello card is [here](https://trello.com/c/K2hAExgU/30-remove-last-pagination-link-in-tag-pages).

## What is the value of this and can you measure success?

Should lighten load on CAPI.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

Before...

![picture 131](https://user-images.githubusercontent.com/1590704/36154030-0959d8b6-10c8-11e8-9f1d-99d451ced878.png)

After...

![picture 130](https://user-images.githubusercontent.com/1590704/36154046-109a3d64-10c8-11e8-9a8d-9753a147288f.png)

## Tested in CODE?

Yes