### PR TITLE
Display error message on expired videos

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -14,6 +14,14 @@
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
 
+@videoJsError() = @{
+    <div class="vjs-error-display vjs-modal-dialog">
+        <div class="vjs-modal-dialog-content">
+        This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
+        </div>
+    </div>
+}
+
 @defining(media.activeAssets.headOption) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
 @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
@@ -66,13 +74,9 @@
           }
         }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
-            @if(bestPosterImage.isDefined && expired) {
+            @if(!bestPosterImage.isDefined && expired) {
                 <div class="youtube-media-atom__overlay">
-                    <div class="vjs-error-display vjs-modal-dialog">
-                        <div class="vjs-modal-dialog-content">
-                            This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
-                        </div>
-                    </div>
+                    @videoJsError()
                 </div>
             }
             @bestPosterImage.map { image =>
@@ -103,11 +107,7 @@
                         }
                     }
                 } else {
-                    <div class="vjs-error-display vjs-modal-dialog">
-                        <div class="vjs-modal-dialog-content">
-                            This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
-                        </div>
-                    </div>
+                    @videoJsError()
                 }
                 </div>
             }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -66,6 +66,15 @@
           }
         }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
+            @if(bestPosterImage.isDefined && expired) {
+                <div class="youtube-media-atom__overlay">
+                    <div class="vjs-error-display vjs-modal-dialog">
+                        <div class="vjs-modal-dialog-content">
+                            This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
+                        </div>
+                    </div>
+                </div>
+            }
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestSrcFor(image))">
 
@@ -104,7 +113,7 @@
             }
         }
         </div>
-}
+    }
 }
 
 @if(displayCaption & !mediaWrapper.contains(ImmersiveMainMedia)) {


### PR DESCRIPTION
## What does this change?

When videos expire, we usually see an overlay suggesting why the video can't be displayed (introduced in #15789). This currently only happens when the video has a poster image. If the video doesn't have a poster image, we see a black rectangle where the video ought to appear, and no explanation as to why it didn't.

This change ensures an error message appears even when the video doesn't have a poster image.

## What is the value of this and can you measure success?

Better user experience

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

### Before

![picture 474](https://user-images.githubusercontent.com/5931528/36155201-9f50ffcc-10cb-11e8-952a-b3a748013573.png)

### After

![picture 473](https://user-images.githubusercontent.com/5931528/36155218-aba65966-10cb-11e8-97bf-3680a43a646e.png)


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
