### PR TITLE
Stop DMPUs from pushing down figures in the article body.

### DIFF
--- a/static/src/stylesheets/module/_layout-hints.garnett.scss
+++ b/static/src/stylesheets/module/_layout-hints.garnett.scss
@@ -83,7 +83,6 @@ figure.element.element--showcase {
         @include deport-left;
         position: relative;
         margin-bottom: ($gs-baseline/3)*4;
-        clear: both;
     }
 }
 

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -91,7 +91,6 @@ figure.element.element--showcase {
         @include deport-left;
         position: relative;
         margin-bottom: ($gs-baseline/3)*4;
-        clear: both;
     }
 }
 


### PR DESCRIPTION
### What's a DMPU?
It stands for "Double MPU"

### What's an MPU?
It stands for M- actually, no one knows what it stands for, but it is a 300x250 pixel advert. When we are loading adverts in articles, we might get an MPU or a DMPU, depending on the market demand and price offered.

### What's going wrong?

Despite the fact that adverts being pushed out to the right, they are still part of the main article body and, when we get a long advert, it is pushing down figures in the body and creating a bunch of white space. This is because the `figure` is clearing the float.

We can fix it by removing this float clearing. See screenshots.

### How would you describe this change with a song?
[<img src="https://user-images.githubusercontent.com/1821099/36162703-0fc85120-10df-11e8-896e-81479f5ebedb.png" width="300">](https://open.spotify.com/track/1O8jVjF78N1gXmU7CGoryX?si=dfzyzHZfTByePqhEU_gRNg)
### Screenshots

**Before**
![image](https://user-images.githubusercontent.com/1821099/36160518-4a6d4de0-10d9-11e8-857a-ea7c24d5ec0d.png)

**After**
![image](https://user-images.githubusercontent.com/1821099/36160571-6c68d964-10d9-11e8-9b75-dee3306f7681.png)