### PR TITLE
Add professional networks newsletters

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -1,5 +1,6 @@
 @import model.Page
-@import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
+@import com.gu.identity.model.EmailNewsletter
+@import com.gu.identity.model.EmailNewsletters._
 @import views.support.`package`.Seq2zipWithRowInfo
 
 @import common.LinkTo
@@ -89,37 +90,28 @@
     </div>
 }
 
+@displayNewslettersByTheme = {
+    @List(
+        "news round ups" -> newsRoundUpEmails,
+        "news by topic"  -> newsEmails,
+        "features"       -> featureEmails,
+        "sport"          -> sportEmails,
+        "culture"        -> cultureEmails,
+        "lifestyle"      -> lifestyleEmails,
+        "commentEmails"  -> commentEmails,
+        "work"           -> workEmails
+    ).map { case (theme, newsletters) =>
+        <div class="newsletters-category" name="@theme">
+            @emailListCategoryList(theme, newsletters)
+        </div>
+    }
+}
+
 <div class="l-side-margins">
 <div class="content">
     <div class="gs-container">
         <div class="newsletters-heading">newsletters</div>
-
-        <div class="newsletters-category" name="news round ups">
-            @emailListCategoryList("news round ups", EmailNewsletters.newsRoundUpEmails)
-        </div>
-
-        <div class="newsletters-category" name="news by topic">
-            @emailListCategoryList("news by topic", EmailNewsletters.newsEmails)
-        </div>
-        <div class="newsletters-category" name="features">
-            @emailListCategoryList("features", EmailNewsletters.featureEmails)
-        </div>
-        <div class="newsletters-category" name="sport">
-            @emailListCategoryList("sport", EmailNewsletters.sportEmails)
-        </div>
-        <div class="newsletters-category" name="culture">
-            @emailListCategoryList("culture", EmailNewsletters.cultureEmails)
-        </div>
-        <div class="newsletters-category" name="lifestyle">
-            @emailListCategoryList("lifestyle", EmailNewsletters.lifestyleEmails)
-        </div>
-        <div class="newsletters-category" name="comment">
-            @emailListCategoryList("comment", EmailNewsletters.commentEmails)
-        </div>
-        <div class="newsletters-category" name="work">
-            @emailListCategoryList("work", EmailNewsletters.workEmails)
-        </div>
-
+        @displayNewslettersByTheme
     </div>
 </div>
 </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -116,6 +116,9 @@
         <div class="newsletters-category" name="comment">
             @emailListCategoryList("comment", EmailNewsletters.commentEmails)
         </div>
+        <div class="newsletters-category" name="work">
+            @emailListCategoryList("work", EmailNewsletters.workEmails)
+        </div>
 
     </div>
 </div>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -29,7 +29,7 @@
 }
 
 <div class="email-subscriptions">
-    @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
+    @List("news", "features", "sport", "culture", "lifestyle", "comment", "work").zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), (startsOpen == true && index == 0))
     }
 </div>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.124"
+  val identityLibVersion = "3.125"
   val awsVersion = "1.11.240"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.46"


### PR DESCRIPTION
## What does this change?

Related PR: https://github.com/guardian/identity/pull/887

Add under a new newsletter theme called `work` the following professional networks newsletters:

Business to Business
list ID: 4207
Sign up for Business View for weekly news and advice to help firms grow, Essential reading for SMEs, entrepreneurs, owners, employees and advisers
Every Thursday

Teacher Network
list ID: 4208
Catch up on the week’s teaching news and highlights from our network, plus the pick of Guardian Jobs listings for educators
Every Sunday

## Screenshots

`/email-prefs`

![image](https://user-images.githubusercontent.com/13835317/36165351-2d14cc2e-10e7-11e8-8fee-cdaac1d7bb62.png)

`/email-newsletters`

![image](https://user-images.githubusercontent.com/13835317/36165342-2359158c-10e7-11e8-8fde-3ac5dd4525e3.png)

@walaura What colour should the new `work` theme be?
