### PR TITLE
Add a skin parameter to /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -21,7 +21,8 @@
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
-    consentHint: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+    consentHint: Option[String] = None,
+    skin: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @selectAllCheckbox(id: String) = {
         <label class="manage-account__switch manage-account__switch--no-box js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : @{id} (all) : [action]">
@@ -300,7 +301,7 @@
         },5000);
     </script>
 
-    <div class="identity-wizard identity-wizard--consent u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
+    <div class="identity-wizard identity-wizard--consent @{skin.map(s=>s"identity-wizard--consent--$s")} u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
         <div
             class="identity-wizard__step"
@@ -317,7 +318,7 @@
                 <button
                     type="button"
                     data-link-name="consents : navigation : prev"
-                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev"
+                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev @{skin.map(s=>s"manage-account__button--$s")}"
                 >
                     <span class="u-h">Previous</span>
                     @fragments.inlineSvg("arrow-left-stem", "icon")
@@ -328,7 +329,7 @@
             <button
                 type="button"
                 data-link-name-template="consents : navigation : next : [depth]"
-                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next @{skin.map(s=>s"manage-account__button--$s")}"
             >
                 <div class="manage-account__button-flexwrap">
                     <span>Next</span>
@@ -337,7 +338,7 @@
             </button>
             <button
                 type="submit"
-                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__complete"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__complete @{skin.map(s=>s"manage-account__button--$s")}"
                 data-link-name="consents : navigation : submit"
             >
                 <div class="manage-account__button-flexwrap">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -301,7 +301,7 @@
         },5000);
     </script>
 
-    <div class="identity-wizard identity-wizard--consent @{skin.map(s=>s"identity-wizard--consent--$s")} u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
+    <div class="identity-wizard identity-wizard--consent @{skin.map(s => s"identity-wizard--consent--$s" )} u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
 
         <div
             class="identity-wizard__step"
@@ -318,7 +318,7 @@
                 <button
                     type="button"
                     data-link-name="consents : navigation : prev"
-                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev @{skin.map(s=>s"manage-account__button--$s")}"
+                    class="identity-consent-wizard-button-back identity-consent-wizard__revealable manage-account__button--round manage-account__button js-identity-wizard__prev @{skin.map(s => s"manage-account__button--$s" )}"
                 >
                     <span class="u-h">Previous</span>
                     @fragments.inlineSvg("arrow-left-stem", "icon")
@@ -329,7 +329,7 @@
             <button
                 type="button"
                 data-link-name-template="consents : navigation : next : [depth]"
-                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next @{skin.map(s=>s"manage-account__button--$s")}"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__next @{skin.map(s => s"manage-account__button--$s" )}"
             >
                 <div class="manage-account__button-flexwrap">
                     <span>Next</span>
@@ -338,7 +338,7 @@
             </button>
             <button
                 type="submit"
-                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__complete @{skin.map(s=>s"manage-account__button--$s")}"
+                class="manage-account__button--icon manage-account__button js-identity-consent-wizard__complete @{skin.map(s => s"manage-account__button--$s" )}"
                 data-link-name="consents : navigation : submit"
             >
                 <div class="manage-account__button-flexwrap">


### PR DESCRIPTION
## What does this change?

Adds a new parameter to the consent journey, `skin`, that will apply css classes to buttons and the consent container itself, and may potentially be extended to also add css classes other deeper elements such as checkboxes and such.

This will be used for the opt-in campaign

## What is the value of this and can you measure success?
Instead of having a single css class override this lets the css components keep being their own components and not be overwritten from a single extremely high up class