### PR TITLE
Populate Most Viewed container on expired pages

### DIFF
--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -55,7 +55,7 @@
 <!--[if (gt IE 9)|(IEMobile)]><!-->
 @if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
 
-    <link rel="stylesheet" id="head-css" data-reload="head@projectName.map("." + _).getOrElse(".content")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(".content") + ".css")" />
+    <link rel="stylesheet" id="head-css" data-reload="head@projectName.map("." + _).getOrElse(s".$ContentCSSFile")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(s".$ContentCSSFile") + ".css")" />
 
     @if(isInteractive) {
         <link rel="stylesheet" id="head-interactive" data-reload="head.interactive" type="text/css" href="@Static("stylesheets/head.interactive.css")" />

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -181,7 +181,8 @@ object RenderOtherStatus {
       id = request.path,
       section = Some(SectionId.fromId("news")),
       webTitle = "This page has been removed",
-      canonicalUrl
+      canonicalUrl,
+      contentType = Some(model.DotcomContentType.Unknown)
     ))
   }
 


### PR DESCRIPTION
## What does this change?

The Most Viewed container appears on expired pages, but is not populated. This is because expired pages do not have a content type, so most of the JavaScript is not loaded.

By setting the content type to `Unknown`, expired pages now receive the same JavaScript as articles, so the Most Viewed container gets populated.

This change also fixes an issue where CSS is not loaded on expired pages in dev

## What is the value of this and can you measure success?

Offers an onward journey for users who hit an expired page. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
