### PR TITLE
Removes requirement of feature tag for opinion pieces with showcase m…

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -23,7 +23,7 @@
 
         class="@RenderClasses(Map(
             "has-feature-showcase-element" -> (article.tags.isFeature && !article.tags.isComment && article.elements.hasShowcaseMainElement),
-            "has-feature-showcase-opinion" -> (article.tags.isFeature && article.tags.isComment && article.elements.hasShowcaseMainElement),
+            "has-feature-showcase-opinion" -> (article.tags.isComment && article.elements.hasShowcaseMainElement),
             "paid-content" -> isPaidContent,
             "paid-content--white" -> (isPaidContent && ActiveExperiments.isParticipating(CommercialPaidContentTemplate))
         ),


### PR DESCRIPTION
## What does this change?
Removes requirement of feature tag for opinion pieces to display showcase main-media. This is the same behaviour as pre-garnett and makes further sense now as the feature tag has no impact on the visual elements of both the article and its front card for comment pieces.
