### PR TITLE
Fix viewability of sticky MPU slot.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -3,7 +3,6 @@
 import qwery from 'qwery';
 import raven from 'lib/raven';
 import fastdom from 'lib/fastdom-promise';
-import mediator from 'lib/mediator';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { adSizes } from 'commercial/modules/ad-sizes';
 import { stickyMpu } from 'commercial/modules/sticky-mpu';
@@ -69,7 +68,7 @@ sizeCallbacks[adSizes.fluid] = (renderSlotEvent: any, advert: Advert) =>
 /**
  * Trigger sticky scrolling for MPUs in the right-hand article column
  */
-sizeCallbacks[adSizes.mpu] = (slotRenderEndedEvent, advert) => {
+sizeCallbacks[adSizes.mpu] = (_, advert) => {
     if (advert.node.classList.contains('js-sticky-mpu')) {
         stickyMpu(advert.node);
     }
@@ -78,8 +77,10 @@ sizeCallbacks[adSizes.mpu] = (slotRenderEndedEvent, advert) => {
 /**
  * Resolve the stickyMpu.whenRendered promise
  */
-sizeCallbacks[adSizes.halfPage] = () => {
-    mediator.emit('page:commercial:sticky-mpu');
+sizeCallbacks[adSizes.halfPage] = (_, advert) => {
+    if (advert.node.classList.contains('js-sticky-mpu')) {
+        stickyMpu(advert.node);
+    }
 };
 
 sizeCallbacks[adSizes.video] = (_, advert) => {

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -36,19 +36,35 @@ const stickyMpu = (adSlot: HTMLElement) => {
     }
 
     fastdom
-        .read(
-            () =>
-                referenceElement[
-                    config.page.hasShowcaseMainElement
-                        ? 'offsetHeight'
-                        : 'offsetTop'
-                ] + adSlot.offsetHeight
+        .read(() => {
+            if (config.page.hasShowcaseMainElement) {
+                return referenceElement.offsetHeight + adSlot.offsetHeight;
+            }
+            const mediaPrimaryElement = document.querySelector(
+                '.media-primary'
+            );
+
+            const primaryMediaHeight =
+                (mediaPrimaryElement &&
+                    mediaPrimaryElement.getBoundingClientRect() &&
+                    mediaPrimaryElement.getBoundingClientRect().height) ||
+                0;
+
+            const primaryMediaOffsetTop =
+                (mediaPrimaryElement && mediaPrimaryElement.offsetTop) || 0;
+
+            return (
+                referenceElement.offsetTop +
+                adSlot.offsetHeight +
+                primaryMediaHeight +
+                primaryMediaOffsetTop
+            );
+        })
+        .then(newHeight =>
+            fastdom.write(() => {
+                (adSlot.parentNode: any).style.height = `${newHeight}px`;
+            })
         )
-        // .then(newHeight =>
-        //     fastdom.write(() => {
-        //         (adSlot.parentNode: any).style.height = `${newHeight}px`;
-        //     })
-        // )
         .then(() => {
             if (noSticky) {
                 // if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -690,9 +690,6 @@ $quote-mark: 35px;
             }
         }
     }
-    .ad-slot-container {
-        height: 710px;
-    }
     // Quote showcase
     .element-pullquote.element--showcase {
         @include mq(mobileLandscape) {


### PR DESCRIPTION
## What does this change?
This changes ensures that the MPU in the right hand slot is viewable (hopefully) as it was prior to Garnett changes.

## What is the value of this and can you measure success?
Improving viewability back to what it was prior to Garnett should hopefully reduce the revenue impact that has been caused.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
### Single MPU
![sticky-mpu-fix](https://user-images.githubusercontent.com/8861681/36206233-8cc4a23c-1189-11e8-83e8-f5c42dea2cbb.gif)

### Double MPU
![sticky-double-mpu-fix](https://user-images.githubusercontent.com/8861681/36206311-d36a18ac-1189-11e8-95f8-3d038eafe396.gif)

### Single MPU for Showcase Main Element Layout.
![sticky-mpu-showcase](https://user-images.githubusercontent.com/8861681/36206791-8998ab06-118b-11e8-8089-7f06a89bdd2e.gif)



## Tested in CODE?
