### PR TITLE
Membership Engagement Banner CTA test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -88,6 +88,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-banner-cta-contribute",
+    "Test a new CTA for the banner",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 14),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-australia-environment-campaign-2018",
     "Show a custom Epic for articles with the Australia environment campaign tag",
     owners = Seq(Owner.withGithub("joelochlann")),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-cta-contribute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-cta-contribute.js
@@ -1,0 +1,35 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+import { getSync as getGeoLocation } from 'lib/geolocation';
+
+export const AcquisitionsBannerCtaContribute: AcquisitionsABTest = {
+    id: 'AcquisitionsBannerCtaContribute',
+    campaignId: 'acquisitions-banner-cta-contribute',
+    start: '2018-02-14',
+    expiry: '2018-03-14',
+    author: 'jranks123',
+    description: 'A banner cta test',
+    successMeasure: 'AV per impression',
+    idealOutcome: 'New cta wins',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    // Should always be true, because the banner shows regardless.
+    showForSensitive: true,
+    canRun: () => getGeoLocation() === 'US' || getGeoLocation() === 'GB',
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'contribute_cta',
+            options: {
+                engagementBannerParams: {
+                    buttonCaption: 'Make a contribution',
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,6 +1,7 @@
 // @flow
 import { ColourTestBannerHoldback } from 'common/modules/experiments/tests/circles-banner-holdback';
+import { AcquisitionsBannerCtaContribute } from 'common/modules/experiments/tests/acquisitions-banner-cta-contribute';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [ColourTestBannerHoldback];
+> = [AcquisitionsBannerCtaContribute, ColourTestBannerHoldback];


### PR DESCRIPTION
## What does this change?
This is a test to see whether the button CTA text of "Make a contribution" will beat the current control, "Become a Supporter"

Control:
![control](https://user-images.githubusercontent.com/2844554/36209057-94464412-1192-11e8-86fb-a33cb720ea9c.png)

Variant:
![variant](https://user-images.githubusercontent.com/2844554/36209058-945ad76a-1192-11e8-9c82-38fa63456493.png)
