### PR TITLE
Don't refresh video ads and thus always use 30sec threshold.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -5,12 +5,12 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 
-const shouldRefresh = (advert: Advert): boolean => {
+const shouldRefresh = (advert: Advert): ?boolean => {
     const sizeString = advert.size && advert.size.toString();
     const isFluid = sizeString === '0,0';
-    const isVideo = ['620,1', '620,350'].includes(sizeString);
+    const couldBeVideo = advert.id === 'dfp-ad--inline1';
 
-    return !isFluid && !isVideo;
+    return !isFluid && !couldBeVideo;
 };
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -6,11 +6,11 @@ import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 
 const shouldRefresh = (advert: Advert): boolean => {
-    const fluidSize = '0,0';
-    const videoSizes = ['620,1', '620,350'];
     const sizeString = advert.size && advert.size.toString();
+    const isFluid = sizeString === '0,0';
+    const isVideo = ['620,1', '620,350'].includes(sizeString);
 
-    return sizeString === fluidSize || videoSizes.includes(sizeString);
+    return !isFluid && !isVideo;
 };
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -5,29 +5,19 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 
-const getViewabilityThreshold = (advert: Advert): ?number => {
-    const refreshThresholdMsDefault = 30000;
-    const refreshThresholdMsVideo = 90000;
-
+const shouldRefresh = (advert: Advert): boolean => {
     const fluidSize = '0,0';
-
-    const sizeString = advert.size && advert.size.toString();
     const videoSizes = ['620,1', '620,350'];
+    const sizeString = advert.size && advert.size.toString();
 
-    if (sizeString === fluidSize) {
-        return;
-    } else if (videoSizes.includes(sizeString)) {
-        return refreshThresholdMsVideo;
-    }
-
-    return refreshThresholdMsDefault;
+    return sizeString === fluidSize || videoSizes.includes(sizeString);
 };
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {
     const advert: ?Advert = getAdvertById(event.slot.getSlotElementId());
-    const viewabilityThresholdMs = advert && getViewabilityThreshold(advert);
+    const viewabilityThresholdMs = 30000;
 
-    if (advert && viewabilityThresholdMs) {
+    if (advert && shouldRefresh(advert)) {
         const onDocumentVisible = () => {
             if (!document.hidden) {
                 document.removeEventListener(
@@ -37,10 +27,6 @@ export const onSlotViewable = (event: ImpressionViewableEvent): void => {
                 enableLazyLoad(advert);
             }
         };
-
-        if (viewabilityThresholdMs === -1) {
-            return;
-        }
 
         setTimeout(() => {
             if (document.hidden) {


### PR DESCRIPTION
### What does this change?
We serve video ads through Unruly, but it doesn't look like they are built for refreshing of ads. Since that is an evolving platform and this is just an ad test, it makes sense to just exclude video ads from refreshing.

### How would you summarise this in song?
[<img src="https://user-images.githubusercontent.com/1821099/36211858-499cebca-119a-11e8-9571-19478cda0129.png" width=300/>](https://open.spotify.com/track/5eswq0M0cFIbf6aICMhXOJ?si=SsYZbfn8SYa48QlJ9dYELg)
