### PR TITLE
Remove superfluous JS polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",
     "classnames": "~2.2.0",
+    "core-js": "^2.5.3",
     "curl": "cujojs/curl#0.8.9",
     "domready": "^1.0.8",
     "fastdom": "0.8.5",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -1,10 +1,7 @@
 // @flow
 
 // es7 polyfills not provided by pollyfill.io
-import 'core-js/modules/es7.object.values';
 import 'core-js/modules/es7.object.get-own-property-descriptors';
-import 'core-js/modules/es7.string.pad-start';
-import 'core-js/modules/es7.string.pad-end';
 
 import domready from 'domready';
 import raven from 'lib/raven';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,6 +2396,10 @@ core-js@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
 
+core-js@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
## What does this change?

This change removes some `core-js` polyfills that are now provided by polyfill.io:

- [`Object.values`](https://github.com/Financial-Times/polyfill-service/tree/master/polyfills/Object/values)
- [`String.padStart`](https://github.com/Financial-Times/polyfill-service/tree/master/polyfills/String/prototype/padStart)
- [`String.padEnd`](https://github.com/Financial-Times/polyfill-service/tree/master/polyfills/String/prototype/padEnd)

I have also made `core-js` an explicit dependency of the project. It only appears to be working at the moment because `core-js` happens to be a dependency of other dependencies. This should make installation more deterministic. 

## What is the value of this and can you measure success?

⬆️  determinism
⬇️  code to maintain

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
