### PR TITLE
removes border for endslate video svg

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -917,7 +917,10 @@ $ima-controls-height: 70px;
 }
 .end-slate {
     margin-bottom: $gs-baseline*2;
-
+    .fc-item--media .inline-video-icon>svg {
+        border: 0;
+        padding: 0;
+    }
     &.items--media {
         .item {
             width: 25%;


### PR DESCRIPTION
## What does this change?
Removes warped border for endslate video svg

Before:
<img width="699" alt="screen shot 2018-02-14 at 16 40 25" src="https://user-images.githubusercontent.com/8453924/36216129-cd886260-11a5-11e8-81f2-4413841b19e2.png">

After:
<img width="702" alt="screen shot 2018-02-14 at 16 39 57" src="https://user-images.githubusercontent.com/8453924/36216139-d2940020-11a5-11e8-9d6d-949f67baf0c6.png">

