### PR TITLE
Add "Guardian Masterclass" links to sub-nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -175,6 +175,17 @@ object NavLinks {
   val ukMasterClasses = NavLink("Masterclasses", "https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader")
   val auEvents = NavLink("Events", "/guardian-live-australia")
   var holidays = NavLink("Holidays", "https://holidays.theguardian.com")
+  val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
+    children = List(
+      NavLink("Journalism", "/guardian-masterclasses/journalism"),
+      NavLink("Digital", "/guardian-masterclasses/digital"),
+      NavLink("Business", "/guardian-masterclasses/business"),
+      NavLink("Creative writing", "/guardian-masterclasses/writing-and-publishing"),
+      NavLink("Wellbeing & Culture", "/guardian-masterclasses/culture"),
+      NavLink("Corporate training", "/guardian-masterclasses/corporate-training"),
+      NavLink("Calendar", "/guardian-masterclasses/calendar")
+    )
+  )
 
   // News Pillar
   val ukNewsPillar = NavLink("News", "/", longTitle = "Headlines", iconName = "home",
@@ -443,7 +454,8 @@ object NavLinks {
     observer,
     digitalNewspaperArchive,
     NavLink("Professional networks", "/guardian-professional"),
-    crosswords
+    crosswords,
+    guardianMasterClasses
   )
   val auOtherLinks = List(
     apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),


### PR DESCRIPTION
## What does this change?

This adds a sub-navigation for "Guardian Masterclasses" as requested in [Trello](https://trello.com/c/1suBWG9f/8-master-classes-should-have-its-own-tertiary-navigation).

**Note**: Guardian Masterclasses, wasn't previously in the navigation. I couldn't find a precedence for adding sub-navigation on a route that wasn't listed in the navigation. I therefore put the link "Guardian masterclasses" at the bottom of the "More..." list, linking through to `theguardian.com/guardian-masterclasses`. Doing this then meant the new sub-navigation began appearing on all `theguardian.com/guardian-masterclasses/*` routes. 

I don't know if there's a way to achieve this without doing this? I'm hoping @NataliaLKB might be able to advise?

A problem with adding "Guardian masterclasses" to the "More..." list is that there's a "Masterclasses" link to the righthand side alongside "Jobs", "Dating", "Holidays" etc, and this link goes through to a completely different [site](https://membership.theguardian.com/masterclasses).

This seems like a UQ issue to me.

## What is the value of this and can you measure success?

Easier to navigate to Guardian Masterclasses pages.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

![picture 135](https://user-images.githubusercontent.com/1590704/36217016-41ab0f06-11a8-11e8-874c-38ade61cacdd.png)

![picture 136](https://user-images.githubusercontent.com/1590704/36217026-4952dbbc-11a8-11e8-8260-1c6934edf2cd.png)

## Tested in CODE?

No