### PR TITLE
Fix *potential* issue where certain navigation items are not showing as in focus

### DIFF
--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -144,7 +144,7 @@ object NavMenu {
     } else if (isArticleInTagPageSection) {
       commonKeywords.head
     } else if(edition.isEditionalised(page.metadata.sectionId) || page.metadata.isFront) {
-       page.metadata.sectionId
+      page.metadata.id
     } else {
       page.metadata.sectionId
     }


### PR DESCRIPTION
## What does this change?

Whilst working on https://github.com/guardian/frontend/pull/19148 I found items which appeared in the sub-navigation appeared bold inconsistently depending on the page you were looking at:

For example...
"Quick" is bold here: https://www.theguardian.com/crosswords/series/quick
"Project Syndicate" is not bold here: https://www.theguardian.com/business/series/project-syndicate-economists

I assumed this wasn't by design, so made the following change which fixes the issue on 
 on the "Project Syndicate" example above, and other pages where the sub-nav wasn't bold when I'd expect it to be. 

If a page matches this condition `edition.isEditionalised(page.metadata.sectionId) || page.metadata.isFront` then `getSectionOrPageUrl` returns `page.metadata.id` as the URL.

Although this fixes this issue I'd like to discuss potential knock on affects with @NataliaLKB.

## What is the value of this and can you measure success?

Consistent behaviour in the sub navigation.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

... watch this space ...

## Tested in CODE?

... watch this space ...