### PR TITLE
Fix Prebid slot sizes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -170,7 +170,7 @@ export const bidderConfig: PrebidBidderCriteria = {
         {
             editions: ['UK', 'INT'],
             breakpoint: { min: 'mobile' },
-            sizes: [[300, 250], [300, 600]],
+            sizes: [[300, 250]],
             slots: ['dfp-ad--inline', 'dfp-ad--mostpop', 'dfp-ad--right'],
         },
         {


### PR DESCRIPTION
Restrict MPU/DMPU slots to 300x250 because only 'right' can be either.