### PR TITLE
Add tests to /consents

### DIFF
--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -1,0 +1,191 @@
+package controllers
+
+import actions.AuthenticatedActions
+import com.gu.identity.cookie.GuUCookieData
+import com.gu.identity.model.Consent.Supporter
+import com.gu.identity.model.{EmailNewsletters, _}
+import controllers.editprofile.EditProfileController
+import form._
+import idapiclient.responses.Error
+import idapiclient.{Auth, TrackingData, _}
+import model.{Countries, PhoneNumbers}
+import org.joda.time.format.ISODateTimeFormat
+import org.mockito.Mockito._
+import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest._
+import org.scalatestplus.play.ConfiguredServer
+import play.api.http.HttpConfiguration
+import play.api.mvc._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services._
+import test._
+
+import scala.concurrent.Future
+
+@DoNotDiscover class ConsentsJourneyControllerTest extends WordSpec with WithTestExecutionContext
+  with Matchers
+  with MockitoSugar
+  with OptionValues
+  with ScalaFutures
+  with WithTestApplicationContext
+  with WithTestCSRF
+  with ConfiguredServer {
+
+  trait ConsentsJourneyFixture {
+
+    val controllerComponent: ControllerComponents = play.api.test.Helpers.stubControllerComponents()
+    val idUrlBuilder = mock[IdentityUrlBuilder]
+    val api = mock[IdApiClient]
+    val idRequestParser = mock[IdRequestParser]
+    val authService = mock[AuthenticationService]
+    val idRequest = mock[IdentityRequest]
+    val trackingData = mock[TrackingData]
+    val returnUrlVerifier = mock[ReturnUrlVerifier]
+    val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+    val httpConfiguration = HttpConfiguration.createWithDefaults()
+
+    val userId: String = "123"
+    val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
+    val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
+    val authenticatedUser = AuthenticatedUser(user, testAuth, true)
+    val phoneNumbers = PhoneNumbers
+
+    val redirectDecisionService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponent)
+    val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser, redirectDecisionService)
+
+    val profileFormsMapping = ProfileFormsMapping(
+      new AccountDetailsMapping,
+      new PrivacyMapping,
+      new ProfileMapping
+    )
+
+    when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
+    when(api.me(testAuth)) thenReturn Future.successful(Right(user))
+
+    when(idRequest.trackingData) thenReturn trackingData
+    when(idRequest.returnUrl) thenReturn None
+    when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
+
+    when(returnUrlVerifier.defaultReturnUrl) thenReturn "http://1234.67"
+    when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[RequestHeader])) thenReturn None
+    when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
+    when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(()))
+
+    lazy val controller = new EditProfileController(
+      idUrlBuilder,
+      redirectDecisionService,
+      authenticatedActions,
+      api,
+      idRequestParser,
+      csrfCheck,
+      csrfAddToken,
+      returnUrlVerifier,
+      newsletterService,
+      profileFormsMapping,
+      testApplicationContext,
+      httpConfiguration,
+      controllerComponent
+    )
+  }
+
+  "ConsentsJourney" when {
+
+    "using any journey" should {
+
+      "have a js fallback" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include ("consents : navigation : submit-force")
+        contentAsString(result) should include ("noscript")
+        contentAsString(result) should include ("identity-forms-loading--hide-text")
+      }
+
+      "have a normal submit button" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include ("consents : navigation : submit\"")
+      }
+
+      "contain the legal age disclaimer" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include ("older than 13 years")
+      }
+
+    }
+
+
+    "using displayConsentsJourney" should {
+
+      "have consent checkboxes" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include (xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording))
+      }
+
+      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
+        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
+        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
+
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
+      }
+
+    }
+
+
+    "using displayConsentsJourneyThankYou" should {
+
+      "thank you" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include ("form__success")
+        contentAsString(result) should include ("Thank you")
+      }
+
+      "have consent checkboxes" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include (xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording))
+      }
+
+      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
+        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
+        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
+
+        val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
+      }
+
+    }
+
+
+    "using displayConsentsJourneyNewsletters" should {
+
+      "not have consent checkboxes" in new ConsentsJourneyFixture {
+        val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should not include xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording)
+      }
+
+      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
+        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
+        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
+
+        val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
+      }
+
+    }
+
+  }
+}

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -10,6 +10,7 @@ import idapiclient.{Auth, TrackingData, _}
 import model.{Countries, PhoneNumbers}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
+import MockitoMatchers._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest._
@@ -19,6 +20,7 @@ import play.api.mvc._
 import play.api.test.Helpers._
 import services._
 import test._
+
 
 import scala.concurrent.Future
 
@@ -33,7 +35,7 @@ import scala.concurrent.Future
 
   trait ConsentsJourneyFixture {
 
-    val controllerComponent: ControllerComponents = play.api.test.Helpers.stubControllerComponents()
+    val controllerComponent: ControllerComponents = stubControllerComponents()
     val idUrlBuilder = mock[IdentityUrlBuilder]
     val api = mock[IdApiClient]
     val idRequestParser = mock[IdRequestParser]
@@ -59,17 +61,17 @@ import scala.concurrent.Future
       new ProfileMapping
     )
 
-    when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
+    when(authService.fullyAuthenticatedUser(any[RequestHeader])) thenReturn Some(authenticatedUser)
     when(api.me(testAuth)) thenReturn Future.successful(Right(user))
 
     when(idRequest.trackingData) thenReturn trackingData
     when(idRequest.returnUrl) thenReturn None
-    when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
+    when(idRequestParser.apply(any[RequestHeader])) thenReturn idRequest
 
     when(returnUrlVerifier.defaultReturnUrl) thenReturn "http://1234.67"
-    when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[RequestHeader])) thenReturn None
-    when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
-    when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(()))
+    when(returnUrlVerifier.getVerifiedReturnUrl(any[RequestHeader])) thenReturn None
+    when(api.userEmails(anyString(), any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
+    when(api.updateUserEmails(anyString(), any[Subscriber], any[Auth], any[TrackingData])) thenReturn Future.successful(Right(()))
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,
@@ -131,14 +133,14 @@ import scala.concurrent.Future
             "returnUrl" -> returnUrlVerifier.defaultReturnUrl
           )
 
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
+        when(api.saveUser(any[String], any[UserUpdateDTO], any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitRepermissionedFlag.apply(fakeRequest)
         status(result) should be(303)
 
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
-        verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
+        verify(api).saveUser(eq(userId), userUpdateCapture.capture(), eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
         userUpdate.statusFields.get.hasRepermissioned should equal(Some(true))
       }
@@ -156,7 +158,7 @@ import scala.concurrent.Future
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
         val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+        when(api.userEmails(anyString(), any[TrackingData]))
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
         val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
@@ -184,7 +186,7 @@ import scala.concurrent.Future
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
         val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+        when(api.userEmails(anyString(), any[TrackingData]))
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
         val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
@@ -205,7 +207,7 @@ import scala.concurrent.Future
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
         val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
+        when(api.userEmails(anyString(), any[TrackingData]))
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
         val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -140,7 +140,7 @@ import scala.concurrent.Future
         status(result) should be(303)
 
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
-        verify(api).saveUser(eq(userId), userUpdateCapture.capture(), eq(testAuth))
+        verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
         userUpdate.statusFields.get.hasRepermissioned should equal(Some(true))
       }

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -6,10 +6,8 @@ import com.gu.identity.model.Consent.Supporter
 import com.gu.identity.model.{EmailNewsletters, _}
 import controllers.editprofile.EditProfileController
 import form._
-import idapiclient.responses.Error
 import idapiclient.{Auth, TrackingData, _}
 import model.{Countries, PhoneNumbers}
-import org.joda.time.format.ISODateTimeFormat
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
 import org.scalatest.concurrent.ScalaFutures
@@ -18,7 +16,6 @@ import org.scalatest._
 import org.scalatestplus.play.ConfiguredServer
 import play.api.http.HttpConfiguration
 import play.api.mvc._
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services._
 import test._
@@ -123,7 +120,7 @@ import scala.concurrent.Future
       "have consent checkboxes" in new ConsentsJourneyFixture {
         val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording))
+        contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
       }
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
@@ -151,7 +148,7 @@ import scala.concurrent.Future
       "have consent checkboxes" in new ConsentsJourneyFixture {
         val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording))
+        contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
       }
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
@@ -172,7 +169,7 @@ import scala.concurrent.Future
       "not have consent checkboxes" in new ConsentsJourneyFixture {
         val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
-        contentAsString(result) should not include xml.Utility.escape(com.gu.identity.model.Consent.Events.latestWording.wording)
+        contentAsString(result) should not include xml.Utility.escape(Supporter.latestWording.wording)
       }
 
       "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {

--- a/identity/test/package.scala
+++ b/identity/test/package.scala
@@ -5,6 +5,7 @@ import java.io.File
 import common.GuardianConfiguration
 import conf.{IdConfig, IdentityConfiguration}
 import controllers.EditProfileControllerTest
+import controllers.ConsentsJourneyControllerTest
 import filters.StrictTransportSecurityHeaderFilterTest
 import org.scalatest.Suites
 import play.api.i18n.I18nComponents
@@ -35,7 +36,8 @@ object Fake extends FakeApp
 
 class IdentityTestSuite extends Suites(
   new EditProfileControllerTest,
-  new StrictTransportSecurityHeaderFilterTest
+  new StrictTransportSecurityHeaderFilterTest,
+  new ConsentsJourneyControllerTest
 ) with SingleServerSuite {
   override lazy val port: Int = 19010
 }


### PR DESCRIPTION
## What does this change?
Adds a couple of integration-ish tests to the consents journey to make sure it all works. it mostly tests for

- Submit buttons being there
- The steps should contain the core elements
- A `hasRepermissioned` flag gets set on submit
- The CSRF token & return url are being put in the form

## What is the value of this and can you measure success?
This is gonna be used A LOT for the opt in campaign it better not break

## Screenshots
![screen shot 2018-02-15 at 12 45 45 pm](https://user-images.githubusercontent.com/11539094/36257289-2a2b0b78-124e-11e8-9628-943ae8b093e8.png)
