### PR TITLE
Fix /email-newsletters form submission

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -44,8 +44,8 @@ const submitForm = (
     buttonEl: HTMLButtonElement
 ): Promise<void> => {
     const email = $('input[name="email"]', form).val();
-    const listId = $('input[name="listId"]', form).val();
-    const formQueryString = `email=${email}&listId=${listId}`;
+    const listName = $('input[name="listName"]', form).val();
+    const formQueryString = `email=${email}&listName=${listName}`;
 
     return fetch(`${config.page.ajaxUrl}/email`, {
         method: 'post',


### PR DESCRIPTION
## What does this change?

https://www.theguardian.com/email-newsletters form submission was broken because `newsletters.js` expected `listId` input which no longer exists in [`newsletterContent.scala.html`](https://github.com/guardian/frontend/blob/master/applications/app/views/signup/newsletterContent.scala.html#L59) form.

## What is the value of this and can you measure success?

Affected approx 2700 submissions per 7 days:

![image](https://user-images.githubusercontent.com/13835317/36259731-169d3884-1257-11e8-838a-ecaff813d930.png)

## Screenshots

![image](https://user-images.githubusercontent.com/13835317/36259794-3f53644c-1257-11e8-9af7-11c4b3bd2e48.png)
