### PR TITLE
Change /email-newsletters success feedback to envelope

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -40,7 +40,7 @@
                     <div class="signup-confirmation is-hidden js-signup-confirmation">
                         @fragments.inlineSvg("envelope", "icon")
                         <div class="signup-confirmation__message">
-                            <h3 class="signup-confirmation--success">You've subscribed!</h3>
+                            <h3 class="signup-confirmation--success">Check your Inbox!</h3>
                         </div>
                     </div>
 

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -38,7 +38,7 @@
 
 
                     <div class="signup-confirmation is-hidden js-signup-confirmation">
-                        @fragments.inlineSvg("tick", "icon")
+                        @fragments.inlineSvg("envelope", "icon")
                         <div class="signup-confirmation__message">
                             <h3 class="signup-confirmation--success">You've subscribed!</h3>
                         </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -7,18 +7,6 @@
 
 @(signupPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@newsletterSignup(route: String, listId: String, emailName: String) = {
-    <iframe src="/email/form/@route/@listId"
-        data-form-title="Sign up for @emailName"
-        data-form-description=""
-        data-form-campaign-code="newsletters-page"
-        scrolling="no"
-        seamless frameborder="0"
-        class="iframed--overflow-hidden newsletter-card__iframe js-email-sub__iframe"
-        data-form-success-desc="">
-    </iframe>
-}
-
 @emailListCategoryList(theme: String, emailListings: List[EmailNewsletter]) = {
     <div class="newsletters-category__heading">
         @theme


### PR DESCRIPTION
## What does this change?

Changes the success feedback when user subscribes to newsletters at https://www.theguardian.com/email-newsletters to indicate extra step of clicking on consent mail in their inbox similar to how it is done in the email widget in the footer of homepage.

## What is the value of this and can you measure success?

Better representative feedback.

## Screenshots

Before

![image](https://user-images.githubusercontent.com/13835317/36267969-37d65b46-126d-11e8-8c22-d482d6b38d17.png)

After

![image](https://user-images.githubusercontent.com/13835317/36267993-41f95dda-126d-11e8-95bc-1ea011c20a84.png)
