### PR TITLE
Enable multiple Prebid sizes in right ad slot

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -150,7 +150,12 @@ export const bidderConfig: PrebidBidderCriteria = {
         {
             breakpoint: { min: 'mobile' },
             sizes: [[300, 250]],
-            slots: ['dfp-ad--inline', 'dfp-ad--mostpop', 'dfp-ad--right'],
+            slots: ['dfp-ad--inline', 'dfp-ad--mostpop'],
+        },
+        {
+            breakpoint: { min: 'mobile' },
+            sizes: [[300, 250], [300, 600]],
+            slots: ['dfp-ad--right'],
         },
         {
             breakpoint: { min: 'desktop' },
@@ -162,7 +167,12 @@ export const bidderConfig: PrebidBidderCriteria = {
         {
             breakpoint: { min: 'mobile' },
             sizes: [[300, 250]],
-            slots: ['dfp-ad--inline', 'dfp-ad--mostpop', 'dfp-ad--right'],
+            slots: ['dfp-ad--inline', 'dfp-ad--mostpop'],
+        },
+        {
+            breakpoint: { min: 'mobile' },
+            sizes: [[300, 250], [300, 600]],
+            slots: ['dfp-ad--right'],
         },
         {
             breakpoint: { min: 'desktop' },
@@ -175,7 +185,13 @@ export const bidderConfig: PrebidBidderCriteria = {
             geoContinent: 'NA', // North America
             breakpoint: { min: 'mobile' },
             sizes: [[300, 250]],
-            slots: ['dfp-ad--inline', 'dfp-ad--mostpop', 'dfp-ad--right'],
+            slots: ['dfp-ad--inline', 'dfp-ad--mostpop'],
+        },
+        {
+            geoContinent: 'NA', // North America
+            breakpoint: { min: 'mobile' },
+            sizes: [[300, 250], [300, 600]],
+            slots: ['dfp-ad--right'],
         },
         {
             geoContinent: 'NA', // North America


### PR DESCRIPTION
Currently the right ad slot is set only to take 300x250 MPU ads through Prebid.
This change makes it able to take 300x600 DMPU ads as well.
But it also ensures that inline slots still only accept 300x250 ads.
