### PR TITLE
Show the full size glab logo on mobile breakpoints

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -99,7 +99,7 @@
 
         .inline-glabs-logo > svg {
             width: 75px;
-            height: 31px;
+            height: 47px;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Show the full GLab logo on mobile web.

Before:

![picture 26](https://user-images.githubusercontent.com/5967941/36268410-4b418f60-126e-11e8-8583-9386c79c98aa.png)

After:

![picture 25](https://user-images.githubusercontent.com/5967941/36268425-54938bea-126e-11e8-98df-3fae6dfa43e0.png)



## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

This bug only appears on Glab container on fronts.
