### PR TITLE
Prevent most popular from overlapping most viewed on short articles.

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -4,6 +4,7 @@
  Description: Shows popular trails for a given country.
  */
 import qwery from 'qwery';
+import fastdom from 'lib/fastdom-promise';
 import { Component } from 'common/modules/component';
 import mediator from 'lib/mediator';
 import once from 'lodash/functions/once';
@@ -33,12 +34,30 @@ class GeoMostPopular extends Component {
     }
 }
 
-const geoMostPopular = {
-    render: once((): Promise<void> => {
+// we don't want to show most popular on short articles as the sticky right mpu slot will push most popular behind other containers at the bottom.
+const fetchMostPopular = (articleBodyHeight: number): void => {
+    if (articleBodyHeight > 1500) {
         new GeoMostPopular().fetch(
             qwery('.js-components-container'),
             'rightHtml'
         );
+    }
+};
+
+const geoMostPopular = {
+    render: once((): Promise<void> => {
+        fastdom
+            .read(() => {
+                const jsArticleBodyElement = document.querySelector(
+                    '.js-article__body'
+                );
+                return jsArticleBodyElement
+                    ? jsArticleBodyElement.getBoundingClientRect() &&
+                          jsArticleBodyElement.getBoundingClientRect().height
+                    : 0;
+            })
+            .then(fetchMostPopular);
+
         return promise;
     }),
 

--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -35,8 +35,10 @@ class GeoMostPopular extends Component {
 }
 
 // we don't want to show most popular on short articles as the sticky right mpu slot will push most popular behind other containers at the bottom.
+const showMostPopularThreshold = 1500;
+
 const fetchMostPopular = (articleBodyHeight: number): void => {
-    if (articleBodyHeight > 1500) {
+    if (articleBodyHeight > showMostPopularThreshold) {
         new GeoMostPopular().fetch(
             qwery('.js-components-container'),
             'rightHtml'


### PR DESCRIPTION
The nature of the sticky mpu remaining in the viewport for a period of time means that most popular gets pushed further down in the right hand slot. On short articles this causes most popular to get pushed behind most recent. Therefore for short articles I have set a threshold with which the most popular container will only be shown if said threshold is exceeded.

## What does this change?
Removes most popular container on very short articles.

## What is the value of this and can you measure success?
Prevents the most popular container being rendered behind other containers.

## Does this affect other platforms - Amp, Apps, etc?
No.
