### PR TITLE
Fix /email-newsletters duplicate consent email

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -61,7 +61,8 @@ const submitForm = (
 };
 
 const subscribeToEmail = (buttonEl: HTMLButtonElement): void => {
-    bean.on(buttonEl, 'click', () => {
+    bean.on(buttonEl, 'click', event => {
+        event.preventDefault();
         const form = buttonEl.form;
         if (validate(form)) {
             submitForm(form, buttonEl);


### PR DESCRIPTION
## What does this change?

Form was submitted twice - once by javascript and once by default form submission action.

