### PR TITLE
Fix Trustx bidder not firing on inline slots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -18,7 +18,8 @@ import type {
 } from 'commercial/modules/prebid/types';
 
 const getTrustXAdUnitId = (slotId: string): string => {
-    switch (slotId) {
+    const slotIdStripTrailingNumbers = slotId.replace(/\d+$/, '');
+    switch (slotIdStripTrailingNumbers) {
         case 'dfp-ad--inline':
             return '2960';
         case 'dfp-ad--mostpop':


### PR DESCRIPTION
This fixes a bug where the bidder was trying to match an inline slot name exactly rather than matching its base.  So it was never matching and never firing.