### PR TITLE
Unignore spacefinder errors

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -25,7 +25,6 @@ const sentryOptions = {
 
     ignoreErrors: [
         "Can't execute code from a freed script",
-        /There is no space left matching rules from/gi,
         'Top comments failed to load:',
         'Comments failed to load:',
         /InvalidStateError/gi,


### PR DESCRIPTION
## What does this change?

We have noticed a large uptick in blacklisted errors in Sentry. There has been some work recently around Spacefinder and the positioning of ads. This change records Spacefinder errors in Sentry, rather than explicitly ignoring them.

## What is the value of this and can you measure success?

This change will help us determine whether the uptick is due to an increase in Spacefinder errors, or something else.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

![picture 483](https://user-images.githubusercontent.com/5931528/36373381-e5ad5d92-155f-11e8-9ea9-220cedca2935.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
