### PR TITLE
Microdata validation fix

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -51,17 +51,19 @@
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
+
+
+                        @if(!isPaidContent) {
+                            @if(article.metadata.designType.nameOrDefault == "comment" ||
+                                article.metadata.designType.nameOrDefault == "guardianview") {
+                                @fragments.articleHeaderCommentGarnett(article, model, amp = amp)
+                            } else {
+                                @fragments.articleHeaderGarnett(article, model, amp = amp)
+                            }
+                        }
+
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
-
-                            @if(!isPaidContent) {
-                                @if(article.metadata.designType.nameOrDefault == "comment" ||
-                                    article.metadata.designType.nameOrDefault == "guardianview") {
-                                    @fragments.articleHeaderCommentGarnett(article, model, amp = amp)
-                                } else {
-                                    @fragments.articleHeaderGarnett(article, model, amp = amp)
-                                }
-                            }
 
 
                             @if(isPaidContent){
@@ -70,6 +72,7 @@
                             }
 
                             @fragments.witnessCallToAction(article.content)
+
                             @BodyCleaner(article, article.fields.body, amp = amp)
                             @fragments.witnessCallToAction(article.content)
 

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -12,7 +12,7 @@
     <div class="content__header tonal__header">
         <div class="u-cf">
 
-            <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+            <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
             </h1>
 

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -19,7 +19,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
                 </h1>
             </div>
@@ -34,7 +34,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline" articleprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                     @Html(article.trail.headline)
                 </h1>
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -37,7 +37,7 @@ import collection.JavaConverters._
         And("The article is marked up with the correct schema")
         val article = el("article[itemtype='http://schema.org/NewsArticle']")
 
-        article.el("[articleprop=headline]").text should
+        article.el("[itemprop=headline]").text should
           be("Liu Xiang pulls up in opening race at second consecutive Olympics")
       }
     }
@@ -299,7 +299,7 @@ import collection.JavaConverters._
         import browser._
 
         Then("It should be rendered as an article")
-        $("[articleprop=headline]").text should be("Birds of Britain | video")
+        $("[itemprop=headline]").text should be("Birds of Britain | video")
       }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -336,6 +336,10 @@
 
     .content__article-body {
         clear: both;
+
+        @include mq(leftCol) {
+            padding-left: $gs-gutter * .5;
+        }
     }
 
     /* Header
@@ -624,6 +628,10 @@
             }
         }
         .content__main-column {
+            &::before {
+                display: none;
+            }
+
             background-color: $garnett-neutral-1;
             z-index: 10;
             position: relative;
@@ -643,6 +651,12 @@
             }
             @include mq($from: desktop) {
                 left: $gs-gutter / 2;
+            }
+            @include mq(leftCol) {
+                margin-left: $left-column + $gs-gutter;
+            }
+            @include mq(wide) {
+                margin-left: $left-column-wide + $gs-gutter;
             }
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -50,15 +50,15 @@
 
     @include mq(desktop) {
         margin-left: 0;
-        margin-right: $right-column + $gs-gutter;
+        margin-right: $right-column + ($gs-gutter * .5);
     }
 
     @include mq(leftCol) {
-        margin-left: $left-column + $gs-gutter;
+        margin-left: $left-column + ($gs-gutter * .5);
     }
 
     @include mq(wide) {
-        margin-left: $left-column-wide + $gs-gutter;
+        margin-left: $left-column-wide + ($gs-gutter * .5);
     }
 
     &.content__main-column--single-column {

--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -1,6 +1,12 @@
 @import '../social-icons';
 
 .content--media {
+    .content__main-column {
+        &::before {
+            display: none;
+        }
+    }
+    
     .content__head__comment-count {
         display: none;
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -388,9 +388,8 @@ $quote-mark: 35px;
         border-color: $garnett-neutral-4;
     }
     // *************** Header and Body Styles ***************
-    .content__article-body {
-        line-height: 1.4;
 
+    .content__main-column {
         &:before {
             @include mq(leftCol) {
                 content: '';
@@ -403,18 +402,27 @@ $quote-mark: 35px;
                 background: $garnett-neutral-4;
             }
         }
+
         @include mq(tablet) {
             padding-left: 0;
+        }
+        @include mq(leftCol) {
+            padding-left: $gs-gutter/2;
+        }
+    }
+
+    .content__article-body {
+        line-height: 1.4;
+
+        @include mq(tablet) {
             margin-left: 0;
             padding-bottom: $gs-baseline*4;
         }
         @include mq(desktop) {
-            padding-left: 0;
             margin-left: 0;
             padding-bottom: $gs-baseline*6;
         }
         @include mq(leftCol) {
-            padding-left: $gs-gutter/2;
             margin-left: -$gs-gutter/2;
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -422,9 +422,6 @@ $quote-mark: 35px;
             margin-left: 0;
             padding-bottom: $gs-baseline*6;
         }
-        @include mq(leftCol) {
-            margin-left: -$gs-gutter/2;
-        }
     }
 
     .content__secondary-column {

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -4,6 +4,10 @@ $block-padding-left: gs-span(1) + $gs-gutter;
    ========================================================================== */
 
 .content__main-column--liveblog {
+    &::before {
+        display: none;
+    }
+
     @include mq(desktop) {
         margin-left: gs-span(4) + $gs-gutter;
         margin-right: 0;

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -32,6 +32,15 @@ $block-padding-left: gs-span(1) + $gs-gutter;
     }
 }
 
+/*
+    have to do this to override specifity from _types.scss
+*/
+.content__main-column.content__main-column--liveblog {
+    @include mq(leftCol) {
+        padding-left: 0;
+    }
+}
+
 /* Header
    ========================================================================== */
 


### PR DESCRIPTION
## What does this change?

Currently the microdata validation tests on PRs are failing. This is because on an article page we expect there to be markup defining an `itemscope="WebPage"` and an `itemscope="NewsArticle"`.

Each `itemscope` has mandatory `itemprop` definitions that should appear inside those scopes.

The test is failing because there should be some markup that defines an element with `itemprop="headline"` somewhere inside the `NewsArticle` scope.

Because the headline is currently inside the "article body" it's not being picked up as inside the correct scope. 

This PR Moves the headline out of the "article body". This means it's recognised as a valid piece of microdata in the `NewsArticle` scope.

Because this changes the HTML structure there were knock on affects to the Garnett article layouts, the `css` changes address these issues.

## What is the value of this and can you measure success?

The indexing API (where we proactively push our articles/liveblogs to Google for faster indexing) will pass our pages when the microdata is valid.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

Yes