### PR TITLE
Revert "Unignore spacefinder errors"

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -25,6 +25,7 @@ const sentryOptions = {
 
     ignoreErrors: [
         "Can't execute code from a freed script",
+        /There is no space left matching rules from/gi,
         'Top comments failed to load:',
         'Comments failed to load:',
         /InvalidStateError/gi,


### PR DESCRIPTION
Reverts guardian/frontend#19170

This change made no impact on the number of filtered errors. It did lead to a much higher number of accepted errors though, implying that filtered errors on Sentry are not actually those that are ignored by Raven.

The plot thickens