### PR TITLE
Add messaging for account errors.

### DIFF
--- a/identity/app/views/profile/membershipForm/details.scala.html
+++ b/identity/app/views/profile/membershipForm/details.scala.html
@@ -1,5 +1,9 @@
 @(user: com.gu.identity.model.User)
 <div class="is-hidden js-mem-info">
+    <div class="manage-account-warning js-mem-warning is-hidden">
+        <h2>Action required</h2>
+        <p class="js-mem-warning-text"></p>
+    </div>
     <ul class="details-list u-unstyled js-mem-details">
         <li class="details-list__item is-hidden js-mem-number-container">
             <div class="fieldset__heading">

--- a/static/src/javascripts/__flow__/types/membership.js
+++ b/static/src/javascripts/__flow__/types/membership.js
@@ -34,6 +34,7 @@ declare type UserDetails = {
         card?: StripeCard,
         account?: {
             accountName: string
-        }
-    }
+        },
+    },
+    alertText?: string
 }

--- a/static/src/javascripts/bootstraps/enhanced/membership.js
+++ b/static/src/javascripts/bootstraps/enhanced/membership.js
@@ -2,8 +2,10 @@
 import { membershipTab } from 'membership/membership-tab';
 import { digitalpackTab } from 'membership/digitalpack-tab';
 import { recurringContributionTab } from 'membership/contributions-recurring-tab';
+import { deleteOldData } from 'common/modules/commercial/user-features';
 
 export const init = (): void => {
+    deleteOldData();
     membershipTab();
     digitalpackTab();
     recurringContributionTab();

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -10,7 +10,7 @@ const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
 const PAYING_MEMBER_COOKIE = 'gu_paying_member';
 const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
-const ACCOUNT_DATA_UPDATE_LINK_COOKIE = 'gu_account_link';
+const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 
 const userHasData = (): boolean => {
     const cookie =
@@ -22,7 +22,7 @@ const userHasData = (): boolean => {
 };
 
 const accountDataUpdateWarning = (): ?string =>
-    getCookie(ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+    getCookie(ACTION_REQUIRED_FOR_COOKIE);
 
 const adFreeDataIsPresent = (): boolean => {
     const cookieVal = getCookie(AD_FREE_USER_COOKIE);
@@ -44,10 +44,10 @@ const persistResponse = (JsonResponse: () => void) => {
         JsonResponse.contentAccess.recurringContributor
     );
 
-    removeCookie(ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+    removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
         addCookie(
-            ACCOUNT_DATA_UPDATE_LINK_COOKIE,
+            ACTION_REQUIRED_FOR_COOKIE,
             JsonResponse.alertAvailableFor
         );
     }
@@ -66,7 +66,7 @@ const deleteOldData = (): void => {
     removeCookie(PAYING_MEMBER_COOKIE);
     removeCookie(RECURRING_CONTRIBUTOR_COOKIE);
     removeCookie(AD_FREE_USER_COOKIE);
-    removeCookie(ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+    removeCookie(ACTION_REQUIRED_FOR_COOKIE);
 };
 
 const requestNewData = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -46,10 +46,7 @@ const persistResponse = (JsonResponse: () => void) => {
 
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
-        addCookie(
-            ACTION_REQUIRED_FOR_COOKIE,
-            JsonResponse.alertAvailableFor
-        );
+        addCookie(ACTION_REQUIRED_FOR_COOKIE, JsonResponse.alertAvailableFor);
     }
 
     if (adFreeDataIsPresent() && !JsonResponse.adFree) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -118,9 +118,8 @@ const refresh = (): Promise<void> => {
 /**
  * Does our _existing_ data say the user is a paying member?
  * This data may be stale; we do not wait for userFeatures.refresh()
- * @returns {boolean}
- * @returns {boolean}
- */ const isPayingMember = (): boolean =>
+ */
+const isPayingMember = (): boolean =>
     // If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
     isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -105,7 +105,8 @@ const userHasDataAfterSignout = (): boolean =>
 
 /**
  * Updates the user's data in a lazy fashion
- */ const refresh = (): Promise<void> => {
+ */
+const refresh = (): Promise<void> => {
     if (isUserLoggedIn() && userNeedsNewFeatureData()) {
         return requestNewData();
     } else if (userHasDataAfterSignout()) {
@@ -140,7 +141,8 @@ const isRecurringContributor = (): boolean =>
     Whenever the checks are updated, please make sure to update
     applyRenderConditions.scala.js too, where the global CSS class, indicating
     the user should not see the revenue messages, is added to the body
-*/ const shouldSeeReaderRevenue = (): boolean =>
+*/
+const shouldSeeReaderRevenue = (): boolean =>
     !isPayingMember() && !isRecentContributor() && !isRecurringContributor();
 
 const isAdFreeUser = (): boolean => adFreeDataIsPresent() && !adFreeDataIsOld();

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -157,5 +157,5 @@ export {
     isRecurringContributor,
     shouldSeeReaderRevenue,
     refresh,
-    deleteOldData
+    deleteOldData,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -44,6 +44,7 @@ const persistResponse = (JsonResponse: () => void) => {
         JsonResponse.contentAccess.recurringContributor
     );
 
+    removeCookie(ACCOUNT_DATA_UPDATE_LINK_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
         addCookie(
             ACCOUNT_DATA_UPDATE_LINK_COOKIE,
@@ -65,6 +66,7 @@ const deleteOldData = (): void => {
     removeCookie(PAYING_MEMBER_COOKIE);
     removeCookie(RECURRING_CONTRIBUTOR_COOKIE);
     removeCookie(AD_FREE_USER_COOKIE);
+    removeCookie(ACCOUNT_DATA_UPDATE_LINK_COOKIE);
 };
 
 const requestNewData = (): Promise<void> =>
@@ -155,4 +157,5 @@ export {
     isRecurringContributor,
     shouldSeeReaderRevenue,
     refresh,
+    deleteOldData
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -8,6 +8,7 @@ import {
     isAdFreeUser,
     isPayingMember,
     isRecurringContributor,
+    accountDataUpdateWarning,
 } from './user-features.js';
 
 jest.mock('projects/common/modules/identity/api', () => ({
@@ -33,6 +34,7 @@ const PERSISTENCE_KEYS = {
     PAYING_MEMBER_COOKIE: 'gu_paying_member',
     RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
     AD_FREE_USER_COOKIE: 'GU_AF1',
+    ACCOUNT_DATA_UPDATE_LINK_COOKIE : 'gu_account_link',
 };
 
 const setAllFeaturesData = opts => {
@@ -54,6 +56,7 @@ const setAllFeaturesData = opts => {
         PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
         expiryDate.getTime().toString()
     );
+    addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE,'test');
 };
 
 const setExpiredAdFreeData = () => {
@@ -71,6 +74,7 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
+    removeCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE);
 };
 
 describe('Refreshing the features data', () => {
@@ -164,6 +168,33 @@ describe('Refreshing the features data', () => {
                 getCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE)
             ).toBeNull();
         });
+    });
+});
+
+describe('The account data update warning getter', () => {
+    it('Is not set when the user is logged out', () => {
+        jest.resetAllMocks();
+        isUserLoggedIn.mockReturnValue(false);
+        expect(accountDataUpdateWarning()).toBe(null);
+    });
+
+    describe('When the user is logged in', () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+            isUserLoggedIn.mockReturnValue(true);
+        });
+
+        it('Is the same when the user has an account data update link cookie', () => {
+            addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE, 'the same');
+            expect(accountDataUpdateWarning()).toBe('the same');
+        });
+
+        it('Is null when the user does not have an account data update link cookie', () => {
+            removeCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+            expect(accountDataUpdateWarning()).toBe(null);
+        });
+
+
     });
 });
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -56,7 +56,7 @@ const setAllFeaturesData = opts => {
         PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
         expiryDate.getTime().toString()
     );
-    addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE, 'test');
+    addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
 };
 
 const setExpiredAdFreeData = () => {
@@ -74,7 +74,7 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+    removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
 };
 
 describe('Refreshing the features data', () => {
@@ -186,14 +186,14 @@ describe('The account data update warning getter', () => {
 
         it('Is the same when the user has an account data update link cookie', () => {
             addCookie(
-                PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE,
+                PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE,
                 'the same'
             );
             expect(accountDataUpdateWarning()).toBe('the same');
         });
 
         it('Is null when the user does not have an account data update link cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE);
+            removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
             expect(accountDataUpdateWarning()).toBe(null);
         });
     });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -34,7 +34,7 @@ const PERSISTENCE_KEYS = {
     PAYING_MEMBER_COOKIE: 'gu_paying_member',
     RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
     AD_FREE_USER_COOKIE: 'GU_AF1',
-    ACCOUNT_DATA_UPDATE_LINK_COOKIE : 'gu_account_link',
+    ACCOUNT_DATA_UPDATE_LINK_COOKIE: 'gu_account_link',
 };
 
 const setAllFeaturesData = opts => {
@@ -56,7 +56,7 @@ const setAllFeaturesData = opts => {
         PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
         expiryDate.getTime().toString()
     );
-    addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE,'test');
+    addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE, 'test');
 };
 
 const setExpiredAdFreeData = () => {
@@ -185,7 +185,10 @@ describe('The account data update warning getter', () => {
         });
 
         it('Is the same when the user has an account data update link cookie', () => {
-            addCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE, 'the same');
+            addCookie(
+                PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE,
+                'the same'
+            );
             expect(accountDataUpdateWarning()).toBe('the same');
         });
 
@@ -193,8 +196,6 @@ describe('The account data update warning getter', () => {
             removeCookie(PERSISTENCE_KEYS.ACCOUNT_DATA_UPDATE_LINK_COOKIE);
             expect(accountDataUpdateWarning()).toBe(null);
         });
-
-
     });
 });
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -34,7 +34,7 @@ const PERSISTENCE_KEYS = {
     PAYING_MEMBER_COOKIE: 'gu_paying_member',
     RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
     AD_FREE_USER_COOKIE: 'GU_AF1',
-    ACCOUNT_DATA_UPDATE_LINK_COOKIE: 'gu_account_link',
+    ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
 };
 
 const setAllFeaturesData = opts => {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -185,10 +185,7 @@ describe('The account data update warning getter', () => {
         });
 
         it('Is the same when the user has an account data update link cookie', () => {
-            addCookie(
-                PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE,
-                'the same'
-            );
+            addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'the same');
             expect(accountDataUpdateWarning()).toBe('the same');
         });
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -1,9 +1,47 @@
 // @flow
 
-import { isPayingMember } from 'common/modules/commercial/user-features';
+import {
+    isPayingMember,
+    accountDataUpdateWarning,
+} from 'common/modules/commercial/user-features';
 import fastdom from 'lib/fastdom-promise';
+import { Message } from 'common/modules/ui/message';
+import config from 'lib/config';
+import bean from 'bean';
 
 const initMembership = (): void => {
+    const accountDataUpdateWarningLink = accountDataUpdateWarning();
+    if (accountDataUpdateWarningLink) {
+        const gaTracker = config.get('googleAnalytics.trackers.editorial');
+        const newMessage = new Message('membership-action-required', {
+            cssModifierClass: 'membership-action-required',
+            trackDisplay: true,
+            siteMessageLinkName: 'membership-action-required',
+            siteMessageComponentName: 'membership-action-required',
+            customJs: () => {
+                bean.on(document, 'click', '.js-site-message-close', () => {
+                    window.ga(
+                        `${gaTracker}.send`,
+                        'click',
+                        'in page',
+                        'membership action required | banner hidden'
+                    );
+                });
+
+                window.ga(
+                    `${gaTracker}.send`,
+                    'element view',
+                    'internal',
+                    'membership action required | banner impression'
+                );
+            },
+        });
+        newMessage.show(
+            `An action is needed on your Guardian account. Please <a href='${
+                accountDataUpdateWarningLink
+            }'>update your details</a>`
+        );
+    }
     if (isPayingMember()) {
         fastdom
             .read(() => document.getElementsByClassName('js-become-member'))

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -8,39 +8,48 @@ import fastdom from 'lib/fastdom-promise';
 import { Message } from 'common/modules/ui/message';
 import config from 'lib/config';
 import bean from 'bean';
+import mediator from 'lib/mediator';
 
-const initMembership = (): void => {
-    const accountDataUpdateWarningLink = accountDataUpdateWarning();
-    if (accountDataUpdateWarningLink) {
-        const gaTracker = config.get('googleAnalytics.trackers.editorial');
-        const newMessage = new Message('membership-action-required', {
-            cssModifierClass: 'membership-action-required',
-            trackDisplay: true,
-            siteMessageLinkName: 'membership-action-required',
-            siteMessageComponentName: 'membership-action-required',
-            customJs: () => {
-                bean.on(document, 'click', '.js-site-message-close', () => {
-                    window.ga(
-                        `${gaTracker}.send`,
-                        'click',
-                        'in page',
-                        'membership action required | banner hidden'
-                    );
-                });
-
+const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
+    const gaTracker = config.get('googleAnalytics.trackers.editorial');
+    const newMessage = new Message('membership-action-required', {
+        cssModifierClass: 'membership-action-required',
+        trackDisplay: true,
+        siteMessageLinkName: 'membership-action-required',
+        siteMessageComponentName: 'membership-action-required',
+        customJs: () => {
+            bean.on(document, 'click', '.js-site-message-close', () => {
                 window.ga(
                     `${gaTracker}.send`,
-                    'element view',
-                    'internal',
-                    'membership action required | banner impression'
+                    'click',
+                    'in page',
+                    'membership action required | banner hidden'
                 );
-            },
+            });
+
+            window.ga(
+                `${gaTracker}.send`,
+                'element view',
+                'internal',
+                'membership action required | banner impression'
+            );
+        },
+    });
+    newMessage.show(
+        `An action is needed on your Guardian account. Please <a href='${
+            accountDataUpdateWarningLink
+        }'>update your details</a>`
+    );
+};
+
+const initMembership = (): void => {
+    const updateLink = accountDataUpdateWarning();
+    if (updateLink) {
+        mediator.on('modules:onwards:breaking-news:ready', breakingShown => {
+            if (!breakingShown) {
+                showAccountDataUpdateWarningMessage(updateLink);
+            }
         });
-        newMessage.show(
-            `An action is needed on your Guardian account. Please <a href='${
-                accountDataUpdateWarningLink
-            }'>update your details</a>`
-        );
     }
     if (isPayingMember()) {
         fastdom

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -76,7 +76,7 @@ const populateUserDetails = (userDetails: UserDetails): void => {
     const glyph = userDetails.subscription.plan.currency;
     let notificationTypeSelector;
 
-    if (userDetails.alertText != null && userDetails.alertText !== '') {
+    if (userDetails.alertText) {
         showWarning(userDetails.alertText);
     }
 

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -38,6 +38,13 @@ const MEMBER_INFO = '.js-mem-info';
 const LOADER = '.js-mem-loader';
 const IS_HIDDEN_CLASSNAME = 'is-hidden';
 const ERROR = '.js-mem-error';
+const WARNING = '.js-mem-warning';
+const WARNING_TEXT = '.js-mem-warning-text';
+
+const showWarning = (message: string): void => {
+    $(WARNING_TEXT).text(message);
+    $(WARNING).removeClass(IS_HIDDEN_CLASSNAME);
+};
 
 const hideLoader = (): void => {
     $(LOADER).addClass(IS_HIDDEN_CLASSNAME);
@@ -68,6 +75,10 @@ const populateUserDetails = (userDetails: UserDetails): void => {
     const intervalText = isMonthly ? 'Monthly' : 'Annual';
     const glyph = userDetails.subscription.plan.currency;
     let notificationTypeSelector;
+    console.log(userDetails);
+    if (userDetails.alertText != null) {
+        showWarning(userDetails.alertText);
+    }
 
     $(MEMBERSHIP_TIER).text(userDetails.tier);
     $(PACKAGE_COST).text(

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -75,8 +75,8 @@ const populateUserDetails = (userDetails: UserDetails): void => {
     const intervalText = isMonthly ? 'Monthly' : 'Annual';
     const glyph = userDetails.subscription.plan.currency;
     let notificationTypeSelector;
-    console.log(userDetails);
-    if (userDetails.alertText != null) {
+
+    if (userDetails.alertText != null || userDetails.alertText !== '') {
         showWarning(userDetails.alertText);
     }
 

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -76,7 +76,7 @@ const populateUserDetails = (userDetails: UserDetails): void => {
     const glyph = userDetails.subscription.plan.currency;
     let notificationTypeSelector;
 
-    if (userDetails.alertText != null || userDetails.alertText !== '') {
+    if (userDetails.alertText != null && userDetails.alertText !== '') {
         showWarning(userDetails.alertText);
     }
 

--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -51,6 +51,7 @@ export const display = (
     const $button = $('.js-manage-account-change-card', $parent);
     const $updating = $('.js-updating', $parent);
     const stripePublicKey = maybeKey || config.get('page.stripePublicToken');
+    const gaTracker = config.get('googleAnalytics.trackers.editorial');
 
     /*  show/hide
      *   once we've sent the token, we don't want to change the state of the dots until we redisplay
@@ -125,6 +126,12 @@ export const display = (
             .then(json => {
                 const newCard = json;
                 display($parent, newCard);
+                window.ga(
+                    `${gaTracker}.send`,
+                    'action required',
+                    'change details',
+                    'membership action required | change successful'
+                );
             })
             .catch(() => {
                 $parent.text(
@@ -167,6 +174,13 @@ export const display = (
             window.addEventListener('popstate', () => {
                 checkoutHandler.close();
             });
+
+            window.ga(
+                `${gaTracker}.send`,
+                'action required',
+                'change details',
+                'membership action required | change start'
+            );
         };
     };
 

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -31,3 +31,4 @@
 @import 'module/experiments/embed';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
+@import 'module/experiments/_update-account';

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -1,0 +1,17 @@
+.site-message--membership-action-required {
+    color: $garnett-neutral-5;
+    background: $garnett-neutral-1;
+    &:after {
+        @include multiline(3, $garnett-neutral-7, top);
+        content: '';
+        display: block;
+        height: 4px * 3; /*height of multiline (4px) times the number of lines (4)*/
+        margin-bottom: -1px;
+        width: 100%;
+    }
+    a {
+        color: $garnett-neutral-5;
+        font-weight: 900;
+    }
+
+}

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -5,7 +5,7 @@
         @include multiline(3, $garnett-neutral-7, top);
         content: '';
         display: block;
-        height: 4px * 3; /*height of multiline (4px) times the number of lines (4)*/
+        height: 4px * 3; /*height of multiline (4px) times the number of lines (3)*/
         margin-bottom: -1px;
         width: 100%;
     }

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -12,6 +12,7 @@
     a {
         color: $garnett-neutral-5;
         font-weight: 900;
+        text-decoration: underline;
     }
 
 }

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -12,6 +12,23 @@
         min-height: 200px;
         margin-top: $gs-baseline*4;
     }
+    /* Warning
+    ========================================================================== */
+    .manage-account-warning {
+        border: 0;
+        padding: $gutter 0 0;
+        height: auto;
+        &:after {
+            @include multiline(4, $garnett-neutral-4, top);
+            content: '';
+            display: block;
+            height: 4px * 4; /*height of multiline (4px) times the number of lines (4)*/
+            background-color: #ffffff;
+            margin-bottom: -1px;
+            margin-top: $gutter;
+            width: 100%;
+        }
+    }
 
     /* Up sell
     ========================================================================== */


### PR DESCRIPTION
## What does this change?
When we check members-data-api to see what membership a reader might have, we also check to see if anything is wrong. And if so, we show a helpful message like so:
![image](https://user-images.githubusercontent.com/2670496/36381264-f976f654-157c-11e8-8bcc-bb88f317427f.png)

The messaging is deliberately nonspecific.

The link will then send them to the right page in profile.theguardian.com which will display:
![image](https://user-images.githubusercontent.com/2670496/36381919-129d44ba-157f-11e8-809d-e5caccefb564.png)


## What is the value of this and can you measure success?
We're tracking use of this in GA. We're expecting this to increase the rate of individual data fixes for membership users. If this is successful, then this will be added to other products and other data issues.

This functionality is a test, which will be managed from members-data-api. 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
(inline)
## Tested in CODE?
(todo)
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@paulbrown1982 