### PR TITLE
No takeover refresh

### DIFF
--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -45,7 +45,7 @@
     <h1>Pageskins</h1>
     <p>Pages will squish to accommodate pageskins according to these criteria:</p>
     <ol>
-        <li>The Ad Unit must be a <em>front</em></li>
+        <li>The Ad Unit must be a <em>front</em>, including the final "/ng" ad unit</li>
         <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
         <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
         <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -4,13 +4,14 @@ import type { ImpressionViewableEvent } from 'commercial/types';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
+import config from 'lib/config';
 
 const shouldRefresh = (advert: Advert): ?boolean => {
     const sizeString = advert.size && advert.size.toString();
     const isFluid = sizeString === '0,0';
     const couldBeVideo = advert.id === 'dfp-ad--inline1';
 
-    return !isFluid && !couldBeVideo;
+    return !isFluid && !couldBeVideo && !config.page.hasPageSkin;
 };
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {


### PR DESCRIPTION
This adds a check so that the existing ads refresh test don't reload ads on takeover pages. https://github.com/guardian/frontend/pull/19087

For this to work, those takeovers must be understood through `hasPageSkin` config, so adding a reminder to the admin page to target the correct `ng` ad unit.