### PR TITLE
Oriel one percent

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -75,6 +75,6 @@ object OrielParticipation extends Experiment(
   name = "oriel-participation",
   description = "A slice of the audience who will participate in Oriel ad-blocking technology",
   owners = Seq(Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2018, 6, 30),
+  sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1A
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -69,3 +69,11 @@ object MoonLambda extends Experiment(
   sellByDate = new LocalDate(2018, 2, 28),
   participationGroup = Perc1B
 )
+
+object OrielParticipation extends Experiment(
+  name = "oriel-participation",
+  description = "A slice of the audience who will participate in Oriel ad-blocking technology",
+  owners = Seq(Owner.withGithub("janua")),
+  sellByDate = new LocalDate(2018, 6, 30),
+  participationGroup = Perc1A
+)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -76,5 +76,5 @@ object OrielParticipation extends Experiment(
   description = "A slice of the audience who will participate in Oriel ad-blocking technology",
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 6, 28),
-  participationGroup = Perc1A
+  participationGroup = Perc1C
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialPaidContentTemplate,
     CommercialBaseline,
     CommercialAdRefresh,
-    MoonLambda
+    MoonLambda,
+    OrielParticipation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -11,8 +11,8 @@
 } else {
     @if(
         Configuration.environment.isCode &&
-        ActiveExperiments.isParticipating(OrielParticipation))
-    {
+        ActiveExperiments.isParticipating(OrielParticipation)
+    ) {
         <script async type="text/javascript" src="//f92j5.com/ejihwhhs1nv430sy6u4d51elu49.js"></script>
     }
 }

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -1,15 +1,18 @@
 @()(implicit request: RequestHeader)
 
 @import conf.Configuration
+@import experiments.{ ActiveExperiments, OrielParticipation }
 
 @if(
-    request.path == "/commentisfree/2018/feb/19/cult-women-unreliable-narrators-literature-film-feminism" ||
-    request.path == "/world/2018/feb/19/italys-northern-league-pledges-mass-migrant-deportations" ||
-    request.path == "/uk-news/2018/feb/19/woman-held-in-stoke-on-trent-over-abusive-note-on-ambulance"
+    Configuration.environment.isProd &&
+    ActiveExperiments.isParticipating(OrielParticipation)
 ) {
     <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>
 } else {
-    @if(Configuration.environment.isCode) {
+    @if(
+        Configuration.environment.isCode &&
+        ActiveExperiments.isParticipating(OrielParticipation))
+    {
         <script async type="text/javascript" src="//f92j5.com/ejihwhhs1nv430sy6u4d51elu49.js"></script>
     }
 }


### PR DESCRIPTION
## What does this change?

This adds an experiment that serves the 1 percent variant group the Oriel analytics script. This experiment will also include the future participation; right now it's only used for measuring.