### PR TITLE
Fix right hand slot

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -98,17 +98,13 @@ const getRules = (): Object => {
     return {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: 300, // a nominal value, the ' > header' rule is expected to separate insertions from the top.
+        minAbove: isBreakpoint({
+            max: 'tablet',
+        })
+            ? 300
+            : 700,
         minBelow: 300,
         selectors: {
-            ' > header': {
-                minAbove: isBreakpoint({
-                    max: 'tablet',
-                })
-                    ? 300
-                    : 700,
-                minBelow: 0,
-            },
             ' > h2': {
                 minAbove: getBreakpoint() === 'mobile' ? 100 : 0,
                 minBelow: 250,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -230,7 +230,7 @@ describe('Article Body Adverts', () => {
 
                 return getFirstRulesUsed().then(rules => {
                     // adverts give the top of the page more clearance
-                    expect(rules.selectors[' > header'].minAbove).toEqual(700);
+                    expect(rules.minAbove).toEqual(700);
 
                     // give headings no vertical clearance
                     expect(rules.selectors[' > h2'].minAbove).toEqual(0);

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -29,7 +29,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
     const referenceElement: any = document.querySelector(
         config.page.hasShowcaseMainElement
             ? '.media-primary'
-            : '.content__article-body,.js-liveblog-body-content'
+            : '.js-article__body,.js-liveblog-body-content'
     );
     if (!referenceElement || !adSlot) {
         return;
@@ -40,25 +40,8 @@ const stickyMpu = (adSlot: HTMLElement) => {
             if (config.page.hasShowcaseMainElement) {
                 return referenceElement.offsetHeight + adSlot.offsetHeight;
             }
-            const mediaPrimaryElement = document.querySelector(
-                '.media-primary'
-            );
 
-            const primaryMediaHeight =
-                (mediaPrimaryElement &&
-                    mediaPrimaryElement.getBoundingClientRect() &&
-                    mediaPrimaryElement.getBoundingClientRect().height) ||
-                0;
-
-            const primaryMediaOffsetTop =
-                (mediaPrimaryElement && mediaPrimaryElement.offsetTop) || 0;
-
-            return (
-                referenceElement.offsetTop +
-                adSlot.offsetHeight +
-                primaryMediaHeight +
-                primaryMediaOffsetTop
-            );
+            return referenceElement.offsetTop + adSlot.offsetHeight;
         })
         .then(newHeight =>
             fastdom.write(() => {


### PR DESCRIPTION
## What does this change?
The following change fixed the right hand slot to improve viewability after a Garnett change: https://github.com/guardian/frontend/pull/19138. The subsequent change here: https://github.com/guardian/frontend/pull/19174 to move the header outside of the article body element has caused this to break again.

As a result: https://github.com/guardian/frontend/pull/19086 must also now be reverted.
