### PR TITLE
Pass return url into verification email from JS button

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -73,7 +73,8 @@ class EmailVerificationController(api: IdApiClient,
       else
         api.resendEmailValidationEmail(
           request.user.auth,
-          idRequest.trackingData
+          idRequest.trackingData,
+          verifiedReturnUrlAsOpt
         ).map(_ =>
           verificationEmailResentPage
         )

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -154,8 +154,10 @@ class IdApiClient(
   def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[Unit]] =
     post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extractUnit
 
-  def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] =
-    post("user/send-validation-email", Some(auth), Some(trackingParameters)) map extractUnit
+  def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {
+    val extraParams = returnUrlOpt.map(url => List("returnUrl" -> url))
+    httpClient.POST(apiUrl("user/send-validation-email"), None, buildParams(Some(auth), Some(trackingParameters), extraParams), buildHeaders(Some(auth))) map extractUnit
+  }
 
   def deleteTelephone(auth: Auth): Future[Response[Unit]] =
     delete("user/me/telephoneNumber", Some(auth)) map extractUnit

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -39,7 +39,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
 
-  when(api.resendEmailValidationEmail(MockitoMatchers.any[idapiclient.Auth], MockitoMatchers.any[idapiclient.TrackingData])) thenReturn Future.successful(Right((): Unit))
+  when(api.resendEmailValidationEmail(MockitoMatchers.any[idapiclient.Auth], MockitoMatchers.any[idapiclient.TrackingData], MockitoMatchers.any[Option[String]])) thenReturn Future.successful(Right((): Unit))
 
   val userId: String = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -164,11 +164,11 @@ export const getUserEmailSignUps = (): Promise<any> => {
 };
 
 export const sendValidationEmail = (): any => {
-    const returnEndpoint = '/email-prefs';
+    const defaultReturnEndpoint = '/email-prefs';
     const endpoint = '/user/send-validation-email';
     const returnUrl = getUrlVars().returnUrl
         ? decodeURIComponent(getUrlVars().returnUrl)
-        : (idApiRoot || '') + returnEndpoint;
+        : (idApiRoot || '') + defaultReturnEndpoint;
 
     const request = ajax({
         url: (idApiRoot || '') + endpoint,

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -7,6 +7,7 @@ import { getCookie as getCookieByName } from 'lib/cookies';
 import mediator from 'lib/mediator';
 import { local } from 'lib/storage';
 import { mergeCalls } from 'common/modules/async-call-merger';
+import { getUrlVars } from 'lib/url';
 
 let userFromCookieCache = null;
 
@@ -163,13 +164,19 @@ export const getUserEmailSignUps = (): Promise<any> => {
 };
 
 export const sendValidationEmail = (): any => {
+    const returnEndpoint = '/email-prefs';
     const endpoint = '/user/send-validation-email';
+    const returnUrl = getUrlVars().returnUrl
+        ? decodeURIComponent(getUrlVars().returnUrl)
+        : idApiRoot + returnEndpoint;
+
     const request = ajax({
         url: (idApiRoot || '') + endpoint,
         type: 'jsonp',
         crossOrigin: true,
         data: {
             method: 'post',
+            trackingReturnUrl: returnUrl,
         },
     });
 

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -15,6 +15,7 @@ const cookieName = 'GU_U';
 const signOutCookieName = 'GU_SO';
 const fbCheckKey = 'gu.id.nextFbCheck';
 let idApiRoot = null;
+let profileRoot = null;
 
 export type IdentityUser = {
     id: number,
@@ -28,6 +29,7 @@ export type IdentityUser = {
 export const init = (): void => {
     idApiRoot = config.get('page.idApiUrl');
     mediator.emit('module:identity:api:loaded');
+    profileRoot = config.page.idUrl;
 };
 
 export const decodeBase64 = (str: string): string =>
@@ -168,7 +170,7 @@ export const sendValidationEmail = (): any => {
     const endpoint = '/user/send-validation-email';
     const returnUrl = getUrlVars().returnUrl
         ? decodeURIComponent(getUrlVars().returnUrl)
-        : (idApiRoot || '') + defaultReturnEndpoint;
+        : (profileRoot || '') + defaultReturnEndpoint;
 
     const request = ajax({
         url: (idApiRoot || '') + endpoint,
@@ -176,7 +178,7 @@ export const sendValidationEmail = (): any => {
         crossOrigin: true,
         data: {
             method: 'post',
-            trackingReturnUrl: returnUrl,
+            returnUrl,
         },
     });
 

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -168,7 +168,7 @@ export const sendValidationEmail = (): any => {
     const endpoint = '/user/send-validation-email';
     const returnUrl = getUrlVars().returnUrl
         ? decodeURIComponent(getUrlVars().returnUrl)
-        : idApiRoot + returnEndpoint;
+        : (idApiRoot || '') + returnEndpoint;
 
     const request = ajax({
         url: (idApiRoot || '') + endpoint,


### PR DESCRIPTION
## What does this change?
 - Ensures we pass the returnUrl into the verify email link sent from the button on the /verify-email page. 
This is the JS button part of https://github.com/guardian/identity/pull/913

## What is the value of this and can you measure success?
- Ensures people end up where they were originally going when hitting the profil.theguardian pages.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
