### PR TITLE
Add Blockthrough script to a single article behind a switch.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -317,6 +317,16 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val BlockthroughSwitch: Switch = Switch(
+    group = Commercial,
+    name = "blockthrough",
+    description = "Include the blockthrough script for testing the vendors effectiveness at circumventing ad-blocking.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 1),
+    exposeClientSide = false
+   )
+
   val prebidSonobi: Switch = Switch(
     group = Commercial,
     name = "prebid-sonobi",

--- a/common/app/views/fragments/commercial/blockthrough.scala.html
+++ b/common/app/views/fragments/commercial/blockthrough.scala.html
@@ -1,0 +1,7 @@
+@()(implicit request: RequestHeader)
+
+@if(
+    request.path == "/society/2018/feb/04/hospitals-cancelling-urgent-surgery-despite-nhs-bosses-orders-england-cancer-heart-operations"
+) {
+    <script async type="text/javascript" src="https://cdn-theguardian-com.videoplayerhub.com/gallery.js"></script>
+}

--- a/common/app/views/fragments/page/body/bodyTag.scala.html
+++ b/common/app/views/fragments/page/body/bodyTag.scala.html
@@ -1,6 +1,7 @@
 @(classes: Map[String, Boolean])(fragments: Html*)(implicit request: RequestHeader)
 
 @import conf.switches.Switches.OrielAnalyticsSwitch
+@import conf.switches.Switches.BlockthroughSwitch
 
 <body id="top" class="@views.support.RenderClasses(classes)" itemscope itemtype="http://schema.org/WebPage">
 @for(f <- fragments){
@@ -10,4 +11,9 @@
 @if(OrielAnalyticsSwitch.isSwitchedOn) {
     @views.html.fragments.commercial.orielAnalytics()
 }
+
+@if(BlockthroughSwitch.isSwitchedOn) {
+    @views.html.fragments.commercial.blockthrough()
+}
+
 </body>


### PR DESCRIPTION
## What does this change?
This change adds the Blockthrough script behind a script for a single article to allow Blockthrough to verify that the script is firing successfully.

## What is the value of this and can you measure success?
This is the beginning of the commercial team testing the effectiveness of Blockthrough as a vendor in circumventing ad blockers.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

## Screenshots
N/A.
