### PR TITLE
Refresh AB test: Refresh inlines on fronts

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -6,10 +6,10 @@ import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 import config from 'lib/config';
 
-const shouldRefresh = (advert: Advert): ?boolean => {
+const shouldRefresh = (advert: Advert): boolean => {
     const sizeString = advert.size && advert.size.toString();
     const isFluid = sizeString === '0,0';
-    const couldBeVideo = advert.id === 'dfp-ad--inline1';
+    const couldBeVideo = advert.id === 'dfp-ad--inline1' && !config.page.isFront;
 
     return !isFluid && !couldBeVideo && !config.page.hasPageSkin;
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -9,7 +9,8 @@ import config from 'lib/config';
 const shouldRefresh = (advert: Advert): boolean => {
     const sizeString = advert.size && advert.size.toString();
     const isFluid = sizeString === '0,0';
-    const couldBeVideo = advert.id === 'dfp-ad--inline1' && !config.get('page.isFront');
+    const couldBeVideo =
+        advert.id === 'dfp-ad--inline1' && !config.get('page.isFront');
 
     return !isFluid && !couldBeVideo && !config.page.hasPageSkin;
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -9,7 +9,7 @@ import config from 'lib/config';
 const shouldRefresh = (advert: Advert): boolean => {
     const sizeString = advert.size && advert.size.toString();
     const isFluid = sizeString === '0,0';
-    const couldBeVideo = advert.id === 'dfp-ad--inline1' && !config.page.isFront;
+    const couldBeVideo = advert.id === 'dfp-ad--inline1' && !config.get('page.isFront');
 
     return !isFluid && !couldBeVideo && !config.page.hasPageSkin;
 };


### PR DESCRIPTION
Currently, inline1 slots are wholly excluded from refresh. This allow fronts inline1 slots to be refreshed.