### PR TITLE
Remove BGcolour from the opinion byline img

### DIFF
--- a/static/src/stylesheets/amp/_article-tones.scss
+++ b/static/src/stylesheets/amp/_article-tones.scss
@@ -19,7 +19,7 @@
     }
 
     .bullet:before,
-    .byline-img {
+    .content__meta-container .byline-img {
         background-color: $bright;
     }
 
@@ -53,7 +53,8 @@
         color: $dark;
     }
 
-    .bullet:before {
+    .bullet:before,
+    .content__meta-container .byline-img {
         background-color: $bright;
     }
 


### PR DESCRIPTION
## What does this change?

This remove the background colour from the opinion byline image on AMP article page.
But keep the feature byline image.

Before:
![picture 36](https://user-images.githubusercontent.com/5967941/36490493-49026e34-1720-11e8-979e-e8b6fc4765d9.png)

After:
![picture 37](https://user-images.githubusercontent.com/5967941/36490553-6a3ec958-1720-11e8-86c2-33e363b5fe76.png)


## Does this affect other platforms - Amp, Apps, etc?

This is AMP article page.

