### PR TITLE
 Only use viewport height to separate live blog adverts

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -1,5 +1,8 @@
 // @flow
-import type { SpacefinderRules, SpacefinderItem } from 'common/modules/spacefinder';
+import type {
+    SpacefinderRules,
+    SpacefinderItem,
+} from 'common/modules/spacefinder';
 
 import fastdom from 'lib/fastdom-promise';
 import { getBreakpoint } from 'lib/detect';

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -14,7 +14,7 @@ const MAX_ADS = 8; // maximum number of ads to display
 
 let SLOTCOUNTER = 0;
 let WINDOWHEIGHT;
-let firstSlot;
+let firstSlot: ?HTMLElement;
 
 const startListening = () => {
     // eslint-disable-next-line no-use-before-define
@@ -59,6 +59,8 @@ const getSpaceFillerRules = (
         absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * OFFSET,
         minAbove: 0,
         minBelow: 0,
+        clearContentMeta: 0,
+        selectors: {},
         filter: filterSlot,
     };
 };
@@ -90,13 +92,17 @@ const insertAds = (slots: HTMLElement[]): void => {
     }
 };
 
-const fill = (rules: spaceFillerRules): Promise<void> =>
+const fill = (rules: SpacefinderRules): Promise<void> =>
     spaceFiller.fillSpace(rules, insertAds).then(result => {
         if (result && SLOTCOUNTER < MAX_ADS) {
             const el = document.querySelector(
                 `${rules.bodySelector} > .ad-slot`
             );
-            firstSlot = el ? el.previousSibling : null;
+            if (el && el.previousSibling instanceof HTMLElement) {
+                firstSlot = el.previousSibling;
+            } else {
+                firstSlot = null;
+            }
             startListening();
         } else {
             firstSlot = null;

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -1,4 +1,6 @@
 // @flow
+import type { SpacefinderRules, SpacefinderItem } from 'common/modules/spacefinder';
+
 import fastdom from 'lib/fastdom-promise';
 import { getBreakpoint } from 'lib/detect';
 import mediator from 'lib/mediator';
@@ -7,20 +9,8 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { createSlot } from 'commercial/modules/dfp/create-slot';
 import { spaceFiller } from 'common/modules/article/space-filler';
 
-const INTERVAL = 5; // number of posts between ads
 const OFFSET = 1.5; // ratio of the screen height from which ads are loaded
 const MAX_ADS = 8; // maximum number of ads to display
-
-type spaceFillerRules = {
-    bodySelector: string,
-    slotSelector: string,
-    fromBottom: boolean,
-    startAt: Node | null | typeof undefined, // #? I feel this is circumventing the point of Flow
-    absoluteMinAbove: number,
-    minAbove: number,
-    minBelow: number,
-    filter: (slot: { top: number }, index: number) => boolean,
-};
 
 let SLOTCOUNTER = 0;
 let WINDOWHEIGHT;
@@ -46,22 +36,16 @@ const getWindowHeight = (doc = document): number => {
 const getSpaceFillerRules = (
     windowHeight: number,
     update?: boolean
-): spaceFillerRules => {
+): SpacefinderRules => {
     let prevSlot;
-    let prevIndex;
     const shouldUpdate: boolean = !!update;
 
-    const filterSlot = (slot: { top: number }, index: number): boolean => {
-        if (index === 0) {
+    const filterSlot = (slot: SpacefinderItem): boolean => {
+        if (!prevSlot) {
             prevSlot = slot;
-            prevIndex = index;
             return !shouldUpdate;
-        } else if (
-            index - prevIndex >= INTERVAL &&
-            Math.abs(slot.top - prevSlot.top) >= windowHeight
-        ) {
+        } else if (Math.abs(slot.top - prevSlot.top) >= windowHeight) {
             prevSlot = slot;
-            prevIndex = index;
             return true;
         }
         return false;

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -56,9 +56,9 @@ export type SpacefinderRules = {
     // will run each slot through this fn to check if it must be counted in
     filter?: (x: SpacefinderItem) => boolean,
     // will remove slots before this one
-    startAt?: HTMLElement,
+    startAt?: ?HTMLElement,
     // will remove slots from this one on
-    stopAt?: HTMLElement,
+    stopAt?: ?HTMLElement,
     // will reverse the order of slots (this is useful for lazy loaded content)
     fromBottom?: boolean,
 };


### PR DESCRIPTION
We no longer pass `index`, and it seems sensible to keep the logic solely based on viewport.