### PR TITLE
Update opt-in alert copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -11,7 +11,7 @@ const medium: string = new URL(window.location.href).searchParams.get(
     'utm_medium'
 );
 
-type ApiUser = {
+type ApiUser = {Nicer opt-in engagement alert
     statusFields: {
         hasRepermissioned: Boolean,
     },
@@ -24,10 +24,10 @@ const targets = {
 
 const template = {
     image: config.get('images.identity.opt-in'),
-    title: `We’re changing how we communicate with readers. Let us know what emails you want to receive <strong>before 30 April</strong>, or <a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
+    title: `We’re changing how we communicate with readers. Let us know what emails you want to receive <strong>before 30 April</strong>, or&nbsp;<a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
         targets.landing
-    }">find out more</a>.`,
-    cta: `Opt in again`,
+    }">find&nbsp;out&nbsp;more</a>.`,
+    cta: `Opt in now`,
 };
 
 const templateHtml: string = `

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -11,7 +11,7 @@ const medium: string = new URL(window.location.href).searchParams.get(
     'utm_medium'
 );
 
-type ApiUser = {Nicer opt-in engagement alert
+type ApiUser = {
     statusFields: {
         hasRepermissioned: Boolean,
     },


### PR DESCRIPTION
## What does this change?
Update the copy on the opt-in engagement alert to not line-break awkwardly and mirror the CTA from the larger campaign
