### PR TITLE
Use double viewport height to separate ad slots on liveblogs

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -43,11 +43,12 @@ const getSpaceFillerRules = (
     let prevSlot;
     const shouldUpdate: boolean = !!update;
 
+    // Only use a slot if it is double the window height from the previous slot.
     const filterSlot = (slot: SpacefinderItem): boolean => {
         if (!prevSlot) {
             prevSlot = slot;
             return !shouldUpdate;
-        } else if (Math.abs(slot.top - prevSlot.top) >= windowHeight) {
+        } else if (Math.abs(slot.top - prevSlot.top) > windowHeight * 2) {
             prevSlot = slot;
             return true;
         }


### PR DESCRIPTION
There are too many inlines on live blogs currently. Double the vertical height separation to space them out.