### PR TITLE
Include live blogs in refresh test

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -8,11 +8,13 @@ import config from 'lib/config';
 
 const shouldRefresh = (advert: Advert): boolean => {
     const sizeString = advert.size && advert.size.toString();
-    const isFluid = sizeString === '0,0';
-    const couldBeVideo =
-        advert.id === 'dfp-ad--inline1' && !config.get('page.isFront');
+    const isNotFluid = sizeString !== '0,0';
+    const neverHasVideo =
+        advert.id !== 'dfp-ad--inline1' ||
+        config.get('page.isFront') ||
+        config.get('page.contentType') === 'LiveBlog';
 
-    return !isFluid && !couldBeVideo && !config.page.hasPageSkin;
+    return isNotFluid && neverHasVideo && !config.page.hasPageSkin;
 };
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {


### PR DESCRIPTION
Live blogs never take outstream video, so these inline1 slots should also be included in the AB test for ad refresh.