### PR TITLE
Tidied comment header byline logic

### DIFF
--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -12,18 +12,15 @@
     <div class="content__header tonal__header">
         <div class="u-cf">
 
-            <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
+            <h1 class="content__headline @if(article.content.hasTonalHeaderByline) {content__headline--has-byline}" articleprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
             </h1>
 
             @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) {
-                <div class="content__headline__byline">
-                    @fragments.meta.bylineImage(article.tags)
-                    @article.trail.byline.map { text =>
-                        <span class="byline-name">@ContributorLinks(text, article.tags.contributors)</span>
-                    }
-                </div>
-            } else if(article.content.hasTonalHeaderByline) {
+                @fragments.meta.bylineImage(article.tags)
+            }
+
+            @if(article.content.hasTonalHeaderByline) {
                 @article.trail.byline.map { text =>
                     <span class="content__headline content__headline--byline">@ContributorLinks(text, article.tags.contributors)</span>
                 }

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -6,8 +6,7 @@
 @import _root_.model.ContentDesignType.RichContentDesignType
 
 
-    <header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
-    @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") { content__head--byline-pic}">
+    <header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)">
     <div class="matchreport">
         <div class="js-score"></div>
         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
@@ -37,16 +36,6 @@
                 <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                     @Html(article.trail.headline)
                 </h1>
-
-                @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") {
-                    @fragments.meta.bylineImage(article.tags)
-                }
-
-                @if(article.content.hasTonalHeaderByline && article.metadata.designType.nameOrDefault != "analysis") {
-                    @article.trail.byline.map { text =>
-                        <span class="content__headline content__headline--byline">@ContributorLinks(text, article.tags.contributors)</span>
-                    }
-                }
 
                 @if(article.content.hasTonalHeaderIllustration) {
                     <span class="content__head__illustration hide-on-mobile">@fragments.inlineSvg("illustration-letters", "icon")</span>

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -89,7 +89,7 @@
 
 // % used for padding-bottom isn't supported on Grid items in FireFox <53
 // unless explicit width is set on the element with padding-bottom.
-// .force-percentage-padding ensures width is explicitly set so padding-bottom 
+// .force-percentage-padding ensures width is explicitly set so padding-bottom
 // works on responsive-ratio media.
 // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
 .force-percentage-padding {
@@ -259,30 +259,14 @@
 }
 
 .content__headline {
-    @include fs-headline(5);
-    padding-top: $gs-baseline/6;
-    padding-bottom: $gs-baseline*2;
+    @include fs-headlineGarnett(4);
+    display: block;
+    font-weight: 400;
+    padding-top: $gs-baseline / 4;
 
-    @include mq($until: tablet) {
-        padding-top: $gs-baseline / 3;
-    }
-
-    @include mq(mobileLandscape) {
-        @include fs-headline(7, true);
-    }
-
-    @include mq(leftCol) {
-        padding-top: $gs-baseline/2;
-        padding-bottom: $gs-row-height;
-    }
-
-    a {
-        &,
-        &:hover,
-        &:active,
-        &:focus {
-            color: $neutral-1;
-        }
+    @include mq(tablet) {
+        @include fs-headlineGarnett(6);
+        padding-bottom: $gs-baseline * 3;
     }
 
     em {
@@ -295,14 +279,12 @@
 }
 
 .content__headline--byline {
-    display: block;
-    padding-top: 0;
-    margin-top: -$gs-baseline*2;
-    padding-bottom: $gs-baseline*2;
+    font-style: italic;
+    padding-bottom: $gs-baseline * 6;
+}
 
-    @include mq(leftCol) {
-        margin-top: -$gs-row-height;
-    }
+.content__headline--has-byline {
+    padding-bottom: 0;
 }
 
 .content__headline--kicker {
@@ -316,66 +298,29 @@
 .content__head--byline-pic {
     overflow: hidden;
 
-    .byline-img {
-        float: right;
-        height: $gs-baseline * 12.5;
-        z-index: 2;
-
-        @include mq($until: mobileLandscape) {
-            margin-left: -(gs-span(1) + $gs-gutter);
-            margin-right: -($gs-gutter * 2);
-        }
-
-        @include mq(mobileLandscape) {
-            position: absolute;
+    .content__header {
+        .byline-img {
             bottom: 0;
-            right: gs-span(3);
-            width: 0;
-            height: 80%;
-        }
+            float: right;
+            height: 150px;
+            margin-right: -$gs-gutter;
+            right: -$gs-gutter*2;
+            shape-outside: polygon(0 130px, 0 150px, 180px 150px, 180px 0, 20px 0, 20px 96px);
+            width: auto;
 
-        @include mq(phablet) {
-            height: gs-span(2.5);
-        }
+            @include mq(mobileLandscape) {
+                height: $gs-baseline * 15;
+                right: gs-span(3) - $gs-gutter;
+            }
 
-        @include mq(desktop) {
-            right: gs-span(1) + $gs-gutter;
+            @include mq(desktop) {
+                shape-outside: polygon(0 160px, 0 180px, 216px 180px, 216px 0, 36px 0, 24px 121px, 0 128px);
+            }
         }
     }
 
     .byline-img__img {
         height: 100%;
-    }
-
-    .content__head__comment-count {
-        position: absolute;
-        bottom: 0;
-
-        @include mq(desktop) {
-            position: static;
-        }
-    }
-
-    .content__header {
-        .content__main-column {
-            @include mq(mobileLandscape) {
-                min-height: gs-height(5);
-            }
-
-            @include mq(desktop) {
-                min-height: gs-height(4);
-            }
-        }
-
-        .content__headline {
-            @include mq(mobileLandscape) {
-                padding-right: gs-span(2) + $gs-gutter;
-            }
-
-            @include mq(desktop) {
-                padding-right: $gs-gutter*2;
-            }
-        }
     }
 }
 

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -34,7 +34,7 @@
         color: $garnett-neutral-8;
     }
 
-    .byline-img,
+    .content__meta-container .byline-img,
     .gu-media-wrapper--video .vjs-big-play-button .vjs-control-text {
         background: $mediaColor;
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -197,7 +197,7 @@ $quote-mark: 35px;
         }
     }
 
-    .byline-img {
+    .content__meta-container .byline-img {
         max-width: gs-span(1);
         float: left;
         border-top: 0;
@@ -450,18 +450,6 @@ $quote-mark: 35px;
     &:not(.paid-content) .media-primary.media-primary--showcase {
         margin-left: 0;
         margin-right: 0;
-    }
-
-    .content__headline {
-        @include fs-headlineGarnett(4);
-        font-weight: 400; // magic number correcting line height so vertical alignment apprears even with labels
-        padding-top: 3px;
-        padding-bottom: $gs-baseline*2;
-        @include mq(tablet) {
-            @include fs-headlineGarnett(6);
-            font-weight: 400;
-            padding-bottom: $gs-baseline*3;
-        }
     }
 
     //Review stars
@@ -936,64 +924,20 @@ $quote-mark: 35px;
         }
     }
 
-
     .content__header {
         @include multiline(8, $garnett-neutral-4);
         position: relative;
-        padding-bottom: $gs-baseline*6;
     }
 
     .content__headline {
         @include fs-headlineGarnett(5);
         font-weight: 100;
-        padding-bottom: 0;
         @include mq(mobileMedium) {
             @include fs-headlineGarnett(6);
         }
         @include mq(tablet) {
             @include fs-headlineGarnett(7);
         }
-        @include mq(leftCol) {
-            padding-bottom: 38px;
-        }
-    }
-
-    .content__head--byline-pic .content__header .content__headline__byline {
-        @include fs-headlineGarnett(5);
-        @include mq(mobileMedium) {
-            @include fs-headlineGarnett(6);
-        }
-        @include mq(tablet) {
-            @include fs-headlineGarnett(7);
-        }
-    }
-
-    .content__headline--byline {
-        font-style: italic;
-        margin-left: 0;
-        padding-top: $gs-baseline*2;
-        @include mq(mobileLandscape) {
-            padding-left: $gs-gutter;
-        }
-        @include mq(phablet) {
-            padding-top: 0;
-            padding-left: 0;
-        }
-        @include mq(tablet) {
-            padding-top: 28px;
-        }
-        @include mq(leftCol) {
-            padding-top: 0;
-        }
-    }
-
-    .content__headline--byline a {
-        text-decoration: none;
-        border-bottom: 0;
-    }
-
-    .content__headline--byline span:hover {
-        color: $neutral-3;
     }
 
     .content__standfirst {
@@ -1008,35 +952,12 @@ $quote-mark: 35px;
         }
 
     }
-    .content__headline__byline {
-        overflow: visible;
-    }
 
     .meta__image {
         float: none;
         margin-right: -$gs-gutter;
         @include mq(phablet) {
             margin-right: 0;
-        }
-    }
-
-    .content__head--byline-pic .byline-img {
-
-        @include mq(mobileLandscape) {
-            height: $gs-baseline*15;
-        }
-    }
-
-    .byline-img {
-        position: absolute;
-        bottom: 0;
-        right: -$gs-gutter*2;
-        background: none!important;
-        margin: 0;
-        background-image: none;
-        max-width: none;
-        @include mq(mobileLandscape) {
-            right: gs-span(3) - $gs-gutter;
         }
     }
 
@@ -1627,51 +1548,6 @@ $quote-mark: 35px;
 
     .element .caption {
         background: transparent;
-    }
-}
-
-// *************** By line cutouts ****************
-
-.content__head--byline-pic .content__header {
-    padding-bottom: 0;
-
-    .content__headline {
-        padding-right: 0;
-        padding-bottom: 0;
-        width: auto;
-        float: none;
-    }
-
-    .content__headline__byline {
-        @include fs-headline(5);
-        @include mq(mobileLandscape) {
-            @include fs-headline(7, true);
-        }
-        overflow: hidden;
-        font-style: italic;
-        font-weight: 100;
-        padding: 0 $gs-gutter / 2;
-        @include mq(mobileLandscape) {
-            padding: 0 $gs-gutter;
-        }
-        @include mq(phablet) {
-            padding: 0;
-        }
-    }
-
-    .byline-img {
-        position: static;
-        float: right;
-        width: auto;
-        margin-right: -$gs-gutter;
-        shape-outside: polygon(0 130px, 0 150px, 180px 150px, 180px 0, 20px 0, 20px 96px);
-        @include mq(desktop) {
-            shape-outside: polygon(0 160px, 0 180px, 216px 180px, 216px 0, 36px 0, 24px 121px, 0 128px);
-        }
-    }
-
-    .byline-img__img {
-        float: none;
     }
 }
 


### PR DESCRIPTION
In the process of creating a new article type, I hit some stumbling blocks with the comment headers. It seems there were two bylines, that looked the same but had a tonne of repeating/overriding code. Most of which was not necessary. 

It boiled down to there being a `content__headline--byline` and a `content__headline__byline`. Furthermore, bylines had lots of breakpoint specific negative margins, I've removed them and just hidden the padding on the header IF there's a byline. Modifier actually needed to do very little. This involved un-nesting lots of things. Found a lot of superfluous un-used lines of CSS in the process... way more than I wanted to see.

I'm haunted 👻 

# before
![screen shot 2018-02-22 at 14 42 44](https://user-images.githubusercontent.com/14570016/36544598-c24975e4-17de-11e8-8ae9-a4393e6e0e6e.png)

# after
![screen shot 2018-02-22 at 14 42 18](https://user-images.githubusercontent.com/14570016/36544574-b64121d4-17de-11e8-9929-dd76699e3c5b.png)

# before
![screen shot 2018-02-22 at 14 44 41](https://user-images.githubusercontent.com/14570016/36544686-f8ba2484-17de-11e8-8854-59c2f22b266e.png)

# after
![screen shot 2018-02-22 at 14 44 26](https://user-images.githubusercontent.com/14570016/36544685-f8a3cb1c-17de-11e8-9ff4-bf42e3896153.png)
