### PR TITLE
Make shouldHideReaderRevenue a top level page property.

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -56,6 +56,7 @@ final case class Content(
   showInRelated: Boolean,
   cardStyle: CardStyle,
   shouldHideAdverts: Boolean,
+  shouldHideReaderRevenue: Boolean,
   witnessAssignment: Option[String],
   isbn: Option[String],
   imdb: Option[String],
@@ -379,6 +380,7 @@ object Content {
       showInRelated = apifields.flatMap(_.showInRelatedContent).getOrElse(false),
       cardStyle = CardStyle.make(cardStyle),
       shouldHideAdverts = apifields.flatMap(_.shouldHideAdverts).getOrElse(false),
+      shouldHideReaderRevenue = apifields.flatMap(_.shouldHideReaderRevenue).getOrElse(false),
       witnessAssignment = references.get("witness-assignment"),
       isbn = references.get("isbn"),
       imdb = references.get("imdb"),
@@ -443,7 +445,6 @@ object Article {
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
-      ("shouldHideReaderRevenue", JsBoolean(fields.shouldHideReaderRevenue.getOrElse(false))),
       "videoDuration" -> videoDuration
     ) ++ bookReviewIsbn ++ AtomProperties(content.atoms)
 

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -52,13 +52,20 @@ object JavaScriptPage {
       }
     ) ++ sponsorshipType
 
+    val readerRevenueMetaData = Map(
+      "shouldHideReaderRevenue" -> JsBoolean(page match {
+        case c: ContentPage if c.item.content.shouldHideReaderRevenue => true
+        case _ => false
+      })
+    )
+
     val javascriptConfig = page match {
       case c: ContentPage => c.getJavascriptConfig
       case s: StandalonePage => s.getJavascriptConfig
       case _ => Map()
     }
 
-    javascriptConfig ++ config ++ commercialMetaData ++ Map(
+    javascriptConfig ++ config ++ commercialMetaData ++ readerRevenueMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
       ("isDev", JsBoolean(!environment.isProd)),


### PR DESCRIPTION
## What does this change?
Adds shouldHideReaderRevenue to the main content object. I figure this field is always useful no matter what the content type so there's no need for it to just be an override. At the moment it is being added to the article content type but nothing else. 

## What is the value of this and can you measure success?
Allows us to hide reader revenue on e.g. interactive pages 

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
Yes!

