### PR TITLE
Showcase images shouldn't offset sticky mpu container 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -26,26 +26,16 @@ const stickyMpu = (adSlot: HTMLElement) => {
 
     rightSlot = adSlot;
 
-    const referenceElement: any = document.querySelector(
-        config.page.hasShowcaseMainElement
-            ? '.media-primary'
-            : '.js-article__body,.js-liveblog-body-content'
-    );
+    const referenceElement: any = document.querySelector('.js-article__body,.js-liveblog-body-content');
 
     const stickyPixelBoundary: number = 300;
 
-    if (!referenceElement || !adSlot) {
+    if (!referenceElement || !adSlot || config.get('page.hasShowcaseMainElement')) {
         return;
     }
 
     fastdom
-        .read(() => {
-            if (config.page.hasShowcaseMainElement) {
-                return referenceElement.offsetHeight + stickyPixelBoundary;
-            }
-
-            return referenceElement.offsetTop + stickyPixelBoundary;
-        })
+        .read(() => referenceElement.offsetTop + stickyPixelBoundary)
         .then(newHeight =>
             fastdom.write(() => {
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -26,11 +26,17 @@ const stickyMpu = (adSlot: HTMLElement) => {
 
     rightSlot = adSlot;
 
-    const referenceElement: any = document.querySelector('.js-article__body,.js-liveblog-body-content');
+    const referenceElement: any = document.querySelector(
+        '.js-article__body,.js-liveblog-body-content'
+    );
 
     const stickyPixelBoundary: number = 300;
 
-    if (!referenceElement || !adSlot || config.get('page.hasShowcaseMainElement')) {
+    if (
+        !referenceElement ||
+        !adSlot ||
+        config.get('page.hasShowcaseMainElement')
+    ) {
         return;
     }
 


### PR DESCRIPTION
The right slot sticky-mpu container has a parent which has padding for showcase images. This means that the old `offsetHeight` calculation is redundant, and allows the ad slot to stick too far. It should fit neatly based on natural height:

![screen shot 2018-02-22 at 16 34 32](https://user-images.githubusercontent.com/4549425/36551049-99e04046-17ee-11e8-8783-4ea4764749c1.png)
 