### PR TITLE
Throttle [select all] checkbox

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,7 +30,7 @@
     <div class="manage-account__switches">
         <ul>
             <li>
-                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name="mma switch : (consents - all)" data-wrapper="body">
+                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">
                     <div class="manage-account__switch-content">
                         <input type="checkbox"/>
                         <div class="manage-account__switch-checkbox"></div>

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -335,7 +335,12 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                 checkboxEl.checked = getCheckedAllStatus(wrappedCheckboxEls);
                 titleEl.innerHTML = getTextForStatus(checkboxEl.checked);
             });
-
+        
+        /* TODO:these events get fired as a linear 
+        timeout to avoid sending the requests 
+        to the server at once as that creates a 
+        race condition on its end. should be changed 
+        to a single call that handles checking/unchecking*/
         const handleChangeEvent = () => {
             addSpinner(labelEl, 200);
             Promise.all(

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -335,12 +335,12 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                 checkboxEl.checked = getCheckedAllStatus(wrappedCheckboxEls);
                 titleEl.innerHTML = getTextForStatus(checkboxEl.checked);
             });
-        
+
         /* TODO:these events get fired as a linear 
         timeout to avoid sending the requests 
         to the server at once as that creates a 
         race condition on its end. should be changed 
-        to a single call that handles checking/unchecking*/
+        to a single call that handles checking/unchecking */
         const handleChangeEvent = () => {
             addSpinner(labelEl, 200);
             Promise.all(

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -337,23 +337,28 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
             });
 
         const handleChangeEvent = () => {
-            addSpinner(labelEl, 9999)
-                .then(() => new Promise(accept => setTimeout(accept, 300)))
-                .then(() => removeSpinner(labelEl));
-            wrappedCheckboxEls.forEach(wrappedCheckboxEl => {
-                fastdom
-                    .write(() => {
-                        if (!(checkboxEl instanceof HTMLInputElement)) {
-                            throw new Error(ERR_MALFORMED_HTML);
-                        }
-                        wrappedCheckboxEl.checked = checkboxEl.checked;
-                    })
-                    .then(() => {
-                        wrappedCheckboxEl.dispatchEvent(
-                            new Event('change', { bubbles: true })
-                        );
-                    });
-            });
+            addSpinner(labelEl, 200);
+            Promise.all(
+                wrappedCheckboxEls
+                    .map(($el, i) => [$el, i * 100])
+                    .map(([wrappedCheckboxEl, timeout]) =>
+                        fastdom
+                            .write(() => {
+                                if (!(checkboxEl instanceof HTMLInputElement)) {
+                                    throw new Error(ERR_MALFORMED_HTML);
+                                }
+                                wrappedCheckboxEl.checked = checkboxEl.checked;
+                            })
+                            .then(() => {
+                                setTimeout(() => {
+                                    wrappedCheckboxEl.dispatchEvent(
+                                        new Event('change', { bubbles: true })
+                                    );
+                                    return Promise.resolve();
+                                }, timeout);
+                            })
+                    )
+            ).then(() => removeSpinner(labelEl));
         };
 
         revealCheckbox();


### PR DESCRIPTION
## What does this change?
Extremely hacky fix for a rather nasty bug where the [select all] checkbox in consents would throw the server into a rather nasty race condition.

Next steps are to fix address the root of this behaviour and only send 1 single request but this patches it for today