### PR TITLE
Always display sms channel on consent journey

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -54,7 +54,7 @@
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>
             @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
-                @if(isUsersChannel(consentField, user)) {
+                @if(isUsersSmsChannel(consentField, user)) {
                     <li>
                         @fragments.consentSwitch(consentField = consentField, skin = skin)(messages)
                     </li>
@@ -70,7 +70,7 @@
         name = "channels",
         title = "How else can we get in touch with you?",
         content = channelStepContent,
-        show = channelsProvidedBy(user).nonEmpty
+        show = true
     )
 }
 

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -35,6 +35,9 @@ object ConsentChannel {
       }
   }
 
+  def isUsersSmsChannel(consentField: Field, user: User): Boolean =
+    consentField("id").value.exists(_ == TextConsentChannel.id)
+
   def isChannel(consentField: Field): Boolean = {
     consentField("id").value.exists { id => channelsIds.contains(id) }
   }


### PR DESCRIPTION
## What does this change?

Narrow cookie is unable to read private phone number so to prevent opening access we just show sms channel to everyone on consent journey.

## What is the value of this and can you measure success?

## Screenshots

![image](https://user-images.githubusercontent.com/13835317/36554491-560a4ba6-17f7-11e8-8907-be26e0a1a892.png)

