### PR TITLE
Fix redirect on /consents when not logged in

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -66,9 +66,10 @@ class AuthenticatedActions(
       authService.fullyAuthenticatedUser(request) match {
         case Some(user) if user.hasRecentlyAuthenticated =>
           Right(new AuthenticatedRequest(user, request))
-
-        case _ =>
+        case Some(user) =>
           Left(sendUserToReauthenticate(request))
+        case None =>
+          Left(sendUserToSignin(request))
       }
     }
 
@@ -91,7 +92,7 @@ class AuthenticatedActions(
       override val executionContext = ec
 
       def refine[A](request: Request[A]) =
-        authService.consentAuthenticatedUser(request) match {
+        authService.consentCookieAuthenticatedUser(request) match {
           case Some(userFormCookie) =>
             Future.successful(Right(new AuthenticatedRequest(userFormCookie, request)))
 

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -36,11 +36,11 @@ class AuthenticationService(
         hasRecentlyAuthenticated = hasRecentlyAuthenticated(dataFromGuU.getUser, request.cookies.get("SC_GU_LA")))
     }
 
-  /** User has SC_GU_RP or SC_GU_U */
-  def consentAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = {
-    fullyAuthenticatedUser(request)
-      .orElse(consentCookieAuthenticatedUser(request))
-  }
+  def consentCookieAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] =
+    for {
+      scGuRp          <- request.cookies.get("SC_GU_RP")
+      userFromScGuRp  <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
+    } yield AuthenticatedUser(userFromScGuRp, ScGuRp(scGuRp.value))
 
   def userIsFullyAuthenticated(request: RequestHeader): Boolean =
     fullyAuthenticatedUser(request).isDefined
@@ -52,12 +52,4 @@ class AuthenticationService(
         scGuLa.value,
         Minutes.minutes(20).toStandardDuration))
   }
-
-  private def consentCookieAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = {
-    for {
-      scGuRp          <- request.cookies.get("SC_GU_RP")
-      userFromScGuRp  <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
-    } yield AuthenticatedUser(userFromScGuRp, ScGuRp(scGuRp.value))
-  }
-
 }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,7 +30,7 @@
     <div class="manage-account__switches">
         <ul>
             <li>
-                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name="mma switch : (consents - all)" data-wrapper="body">
+                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">
                     <div class="manage-account__switch-content">
                         <input type="checkbox"/>
                         <div class="manage-account__switch-checkbox"></div>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,7 +30,7 @@
     <div class="manage-account__switches">
         <ul>
             <li>
-                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">
+                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name="mma switch : (consents - all)" data-wrapper="body">
                     <div class="manage-account__switch-content">
                         <input type="checkbox"/>
                         <div class="manage-account__switch-checkbox"></div>

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -34,7 +34,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
     val guUCookie = mock[ScGuU]
     val recentlyAuthedUser = AuthenticatedUser(user, guUCookie, true)
     val notRecentlyAuthedUser = AuthenticatedUser(user, guUCookie, false)
-    val mockRepsonse = mock[Response[User]]
+    val mockResponse = mock[Response[User]]
 
     val profileRedirectService = mock[ProfileRedirectService]
     val actions = new AuthenticatedActions(authService, client, new IdentityUrlBuilder(testIdConfig), Helpers.stubControllerComponents(), mock[NewsletterService], mock[IdRequestParser], profileRedirectService)
@@ -42,7 +42,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
 
   }
 
-  "The Consent Journey Redirect Action" should {
+  "The manage my account action" should {
     def failTest: AuthRequest[AnyContent] => Result = _ => fail("Block was invoked")
 
     "redirect to /reauthenticate when the user is not recently authenticated" in new TestFixture {
@@ -58,9 +58,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
         res.header.headers should contain("Location" -> expectedLocation)
       }
     }
-  }
 
-  "The Consent Journey Redirect Action" should {
     "go straight to /email-prefs when a user is recently authenticated and has repermissioned and has valid email" in new TestFixture {
       val originalUrl = "https://profile.thegulocal.com/email-prefs"
       val request = Request(FakeRequest("GET", originalUrl), AnyContent())
@@ -80,6 +78,77 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       whenReady(result)(res => {
         verify(mockFunc).apply(1)
       })
+    }
+  }
+
+  "The consent journey redirect action" should {
+    def failTest: AuthRequest[AnyContent] => Result = _ => fail("Block was invoked")
+
+    "redirect to /signin when the user is not authenticated" in new TestFixture {
+      val originalUrl = "https://profile.thegulocal.com/consents"
+      val request = Request(FakeRequest("GET", originalUrl), AnyContent())
+
+      when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(None)
+      when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
+
+      val result = actions.consentsRedirectAction().apply(failTest)(request)
+      val expectedLocation = s"/signin?INTCMP=email&returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      whenReady(result) { res =>
+        res.header.status shouldBe 303
+        res.header.headers should contain("Location" -> expectedLocation)
+      }
+    }
+
+    "not redirect and return 200 when a user is authenticated via an RP cookie" in new TestFixture {
+      val originalUrl = "https://profile.thegulocal.com/consents"
+      val request = Request(FakeRequest("GET", originalUrl), AnyContent())
+
+      when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(None)
+      when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(Some(userWithRpCookie))
+      when(client.me(any[Auth])).thenReturn(Future(Right(user)))
+      when(profileRedirectService.toConsentsRedirect(any[User], any[RequestHeader])).thenReturn(Future(NoRedirect))
+
+      val mockFunc = mock[Int => Result]
+      when(mockFunc.apply(1)) thenReturn mock[Result]
+      def callMock: AuthRequest[AnyContent] => Result = _ => mockFunc.apply(1)
+
+      val result = actions.consentsRedirectAction().apply(callMock)(request)
+      whenReady(result) { res =>
+        verify(mockFunc).apply(1)
+      }
+    }
+
+    "not redirect and return 200 when a user is authenticated via a GU_U cookie" in new TestFixture {
+      val originalUrl = "https://profile.thegulocal.com/consents"
+      val request = Request(FakeRequest("GET", originalUrl), AnyContent())
+
+      when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(recentlyAuthedUser))
+      when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
+      when(client.me(any[Auth])).thenReturn(Future(Right(user)))
+      when(profileRedirectService.toConsentsRedirect(any[User], any[RequestHeader])).thenReturn(Future(NoRedirect))
+
+      val mockFunc = mock[Int => Result]
+      when(mockFunc.apply(1)) thenReturn mock[Result]
+      def callMock: AuthRequest[AnyContent] => Result = _ => mockFunc.apply(1)
+
+      val result = actions.consentsRedirectAction().apply(callMock)(request)
+      whenReady(result) { res =>
+        verify(mockFunc).apply(1)
+      }
+    }
+
+    "redirect to reauth when a user is authenticated via a GU_U cookie but not recently" in new TestFixture {
+      val originalUrl = "https://profile.thegulocal.com/consents"
+      val request = Request(FakeRequest("GET", originalUrl), AnyContent())
+
+      when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(notRecentlyAuthedUser))
+      when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
+
+      val result = actions.consentsRedirectAction().apply(failTest)(request)
+      val expectedLocation = s"/reauthenticate?INTCMP=email&returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      whenReady(result) { res =>
+        res.header.status shouldBe 303
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this change?
This ensures that reauthentication is not redirected to when trying to reach the consent journey.  

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
