### PR TITLE
Forward INTCMP during identity redirect faithfully

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -28,10 +28,11 @@ class AuthenticatedActions(
   private def redirectWithReturn(request: RequestHeader, path: String): Result = {
     val returnUrl = identityUrlBuilder.buildUrl(request.uri)
 
-    val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, List(
-      "INTCMP" -> "email",
-      "returnUrl" -> returnUrl
-    ))
+    val params = List("returnUrl" -> returnUrl) ++
+      List("INTCMP", "email") //only forward these if they exist in original query string
+        .flatMap(name => request.getQueryString(name).map(value => name -> value))
+
+    val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, params)
 
     SeeOther(identityUrlBuilder.buildUrl(redirectUrlWithParams))
   }

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -52,7 +52,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(notRecentlyAuthedUser))
 
       val result = actions.manageAccountRedirectAction(originalUrl).apply(failTest)(request)
-      val expectedLocation = s"/reauthenticate?INTCMP=email&returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
       whenReady(result) { res =>
         res.header.status shouldBe 303
         res.header.headers should contain("Location" -> expectedLocation)


### PR DESCRIPTION
## What does this change?
We were incorrectly setting INTCMP to email on every redirect.  This restores previous behaviour of forwarding email and INTCMP parameters.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
