### PR TITLE
Add stay with us campaign to feedback form

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -29,6 +29,7 @@
                                             <label for="feedback-category">Please choose a service below </label>
                                             <select name="category" id="feedback-category" class="feedback__select">
                                                 <option value="nothing">Please choose a category first...</option>
+                                                <option value="feedback-form-stay-with-us">Stay With Us campaign issues/questions</option>
                                                 <option value="feedback-form-account">Help with my Guardian account</option>
                                                 <option value="feedback-form-website">Report a problem/give feedback on your website</option>
                                                 <option value="feedback-form-jobs">Unsubscribe from Jobs alerts/have other issues with my jobs account</option>

--- a/onward/app/views/fragments/feedbackForms.scala.html
+++ b/onward/app/views/fragments/feedbackForms.scala.html
@@ -1,5 +1,10 @@
 @()(implicit request: RequestHeader)
 
+<div id="feedback-form-stay-with-us" class="feedback__blurb">
+    <p>This option is for questions related to the <a href="https://www.theguardian.com/staywithus">Stay with us</a> campaign. If you have received an email or on-site request to update your preferences you can see the frequently asked questions about this campaign by clicking <a href="https://www.theguardian.com/staywithus">this link</a>.</p>
+    <p>If you are getting in contact for another reason please select another option from the dropdown menu above.</p>
+</div>
+
 <div id="feedback-form-account" class="feedback__blurb">
     <p>This is for queries about accessing or managing your Guardian account on the website or apps, most of which can be edited <a href="https://profile.theguardian.com/account/edit">here</a></p>
     <p>Please note that queries about payment and billing should be sent to the relevant membership or subscription team using this form.</p>


### PR DESCRIPTION
## What does this change?

Adds a category for the new stay with us campaign to the userhelp form

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
