### PR TITLE
Enforce email validation and consent journey on /email-prefs only

### DIFF
--- a/identity/app/services/ProfileRedirectService.scala
+++ b/identity/app/services/ProfileRedirectService.scala
@@ -22,8 +22,8 @@ sealed abstract class ProfileRedirect(val url: String) {
   def isAllowedFrom(url: String): Boolean
 }
 
-case object RedirectToEmailValidationFromAnywhereButAccountDetails extends ProfileRedirect("/verify-email") {
-  override def isAllowedFrom(url: String): Boolean = !(url contains "account/edit")
+case object RedirectToEmailValidationFromEmailPrefs extends ProfileRedirect("/verify-email") {
+  override def isAllowedFrom(url: String): Boolean = url contains "email-prefs"
 }
 
 case object RedirectToConsentsFromEmailPrefs extends ProfileRedirect("/consents/staywithus") {
@@ -53,7 +53,7 @@ class ProfileRedirectService(
   def toConsentsRedirect[A](user: User, request: RequestHeader): Future[ProfileRedirect] = {
     user.statusFields.isUserEmailValidated match {
       case true => Future.successful(NoRedirect)
-      case false => Future.successful(RedirectToEmailValidationFromAnywhereButAccountDetails)
+      case false => Future.successful(RedirectToEmailValidationFromEmailPrefs)
     }
   }
 
@@ -64,7 +64,7 @@ class ProfileRedirectService(
 
     (userEmailValidated, userHasRepermissioned) match {
       case (false, _) =>
-        Future.successful(RedirectToEmailValidationFromAnywhereButAccountDetails)
+        Future.successful(RedirectToEmailValidationFromEmailPrefs)
 
       case (true, false) =>
         Future.successful(RedirectToConsentsFromEmailPrefs)

--- a/identity/test/services/ProfileRedirectServiceTest.scala
+++ b/identity/test/services/ProfileRedirectServiceTest.scala
@@ -87,5 +87,16 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
          res.isAllowedFrom(accountDetailsUrl) shouldBe false
        }
      }
+
+    "don't redirect to email verification if the tab is not /email-prefs" in new TestFixture {
+      val membershipEditUrl = "https://profile.thegulocal.com/membership/edit"
+      val fakeRequest = Request(FakeRequest("GET", membershipEditUrl), AnyContent())
+
+      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, fakeRequest)
+
+      whenReady(result){ res =>
+        res.isAllowedFrom(membershipEditUrl) shouldBe false
+      }
+    }
   }
 }

--- a/identity/test/services/ProfileRedirectServiceTest.scala
+++ b/identity/test/services/ProfileRedirectServiceTest.scala
@@ -73,7 +73,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
     "redirect to email validation if user has not validated their email" in new TestFixture {
       val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, request)
 
-      whenReady(result)( _ shouldBe RedirectToEmailValidationFromAnywhereButAccountDetails)
+      whenReady(result)( _ shouldBe RedirectToEmailValidationFromEmailPrefs)
     }
 
      "don't redirect from account details page even without validated email" in new TestFixture {


### PR DESCRIPTION
## What does this change?
- Only enforce email validation and user to complete the consent journey on the /email-prefs endoint
- All other areas of profile.theguardian will not need email validation or hasRepermissioned = true.

## What is the value of this and can you measure success?
- Less friction for users trying to do things like update card details.

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
