### PR TITLE
Fix email-prefs errors

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -6,7 +6,15 @@ const formErrorHolderClassName = 'js-errorHolder';
 
 const genericErrorMessage = 'Sorry, something went wrong';
 
-export const push = (error: mixed, action: string = 'none'): Promise<void> =>
+const errors = [];
+
+type IdentityRenderableError = {
+    message: string,
+    action: string,
+    times: number,
+};
+
+const renderError = (error: IdentityRenderableError): Promise<void> =>
     fastdom
         .read(() =>
             window.document.querySelector(`.${formErrorHolderClassName}`)
@@ -14,15 +22,13 @@ export const push = (error: mixed, action: string = 'none'): Promise<void> =>
         .then((errorHolderEl: HTMLElement) =>
             fastdom.write(() => {
                 const errorEl = document.createElement('div');
-                errorEl.innerHTML = `<p>${
-                    error instanceof Error && error.message
-                        ? error.message
-                        : genericErrorMessage
-                }. </p>`;
+                errorEl.innerHTML = `<p>${error.message}${
+                    error.times > 1 ? ` (${error.times} times)` : ``
+                }</p>`;
                 errorEl.className = formErrorClassName;
                 errorHolderEl.appendChild(errorEl);
 
-                switch (action) {
+                switch (error.action) {
                     case 'reload': {
                         const reloadCtaEl = document.createElement('a');
                         reloadCtaEl.innerHTML = 'Refresh this page';
@@ -38,3 +44,46 @@ export const push = (error: mixed, action: string = 'none'): Promise<void> =>
                 }
             })
         );
+
+const renderList = (): Promise<void> =>
+    fastdom
+        .read(() =>
+            window.document.querySelector(`.${formErrorHolderClassName}`)
+        )
+        .then((errorHolderEl: HTMLElement) =>
+            fastdom.write(() => {
+                while (errorHolderEl.firstChild) {
+                    errorHolderEl.removeChild(errorHolderEl.firstChild);
+                }
+            })
+        )
+        .then(() => Promise.all(errors.map(error => renderError(error))))
+        .then(() => Promise.resolve());
+
+export const push = (error: mixed, action: string = 'none'): Promise<void> => {
+    const message =
+        error instanceof Error && error.message
+            ? error.message
+            : genericErrorMessage;
+
+    const isDupeIndex = errors.findIndex(
+        (_: IdentityRenderableError) => _.message === message
+    );
+
+    if (isDupeIndex > -1) {
+        errors.push({
+            message,
+            action,
+            times: errors[isDupeIndex].times + 1,
+        });
+        errors.splice(isDupeIndex, 1);
+    } else {
+        errors.push({
+            message,
+            action,
+            times: 1,
+        });
+    }
+
+    return renderList();
+};

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -22,7 +22,7 @@ const renderError = (error: IdentityRenderableError): Promise<void> =>
         .then((errorHolderEl: HTMLElement) =>
             fastdom.write(() => {
                 const errorEl = document.createElement('div');
-                errorEl.innerHTML = `<p>${error.message}${
+                errorEl.innerHTML = `<p>${error.message}.${
                     error.times > 1 ? ` (${error.times} times)` : ``
                 }</p>`;
                 errorEl.className = formErrorClassName;

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -60,6 +60,10 @@ const renderList = (): Promise<void> =>
         .then(() => Promise.all(errors.map(error => renderError(error))))
         .then(() => Promise.resolve());
 
+export const reset = (): void => {
+    errors.length = 0;
+};
+
 export const push = (error: mixed, action: string = 'none'): Promise<void> => {
     const message =
         error instanceof Error && error.message

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.spec.js
@@ -1,8 +1,7 @@
 // @flow
-import $ from 'lib/$';
-import { push } from './show-errors';
+import { push, reset } from './show-errors';
 
-beforeEach(() => {
+beforeAll(() => {
     if (document.body) {
         document.body.innerHTML = `
             <div class="js-errorHolder"></div>
@@ -10,25 +9,51 @@ beforeEach(() => {
     }
 });
 
-test('renders an error with a custom name', () => {
+beforeEach(() => {
+    reset();
+});
+
+test('renders an error with a custom name', () =>
     push(Error('Test String')).then(() => {
-        expect($(`.js-errorHolder > div > p`).text()).toEqual('Test String. ');
-    });
-});
+        expect(
+            (document.querySelector(`.js-errorHolder > div > p`) || {})
+                .innerHTML
+        ).toEqual('Test String.');
+    }));
 
-test('renders an undefined error', () => {
+test('renders an undefined error', () =>
     push(true).then(() => {
-        expect($(`.js-errorHolder > div > p`).text()).toEqual(
-            'Sorry, something went wrong. '
-        );
-    });
-});
+        expect(
+            (document.querySelector(`.js-errorHolder > div > p`) || {})
+                .innerHTML
+        ).toEqual('Sorry, something went wrong.');
+    }));
 
-test('renders 3 errors', () => {
-    push(true)
-        .then(() => push(true))
-        .then(() => push(true))
+test('renders 3 errors', () =>
+    push(Error('Test 1'))
+        .then(() => push(Error('Test 2')))
+        .then(() => push(Error('Test 3')))
         .then(() => {
-            expect($(`.js-errorHolder`).children().length).toEqual(3);
-        });
-});
+            expect(
+                (document.querySelector(`.js-errorHolder`) || {}).childNodes
+                    .length
+            ).toEqual(3);
+        }));
+
+test('stacks repeated errors', () =>
+    push(Error('Test 1'))
+        .then(() => push(Error('Test 2')))
+        .then(() => push(Error('Test 2')))
+        .then(() => {
+            expect(
+                (document.querySelector(`.js-errorHolder`) || {}).childNodes
+                    .length
+            ).toEqual(2);
+            expect(
+                (
+                    document.querySelector(
+                        `.js-errorHolder > div:nth-child(2) > p`
+                    ) || {}
+                ).innerHTML
+            ).toContain('(2 times)');
+        }));


### PR DESCRIPTION
## What does this change?
Updates the error display javascript so recurrent errors stack on top of each other, avoiding this extremely bad looking behaviour:
![screen_shot_2018-02-07_at_4 30 40_pm](https://user-images.githubusercontent.com/11539094/36597015-aea9473c-189f-11e8-99ac-7e89385079d4.png)

And turning it into this:
![screen shot 2018-02-23 at 1 32 04 pm](https://user-images.githubusercontent.com/11539094/36597014-abe45208-189f-11e8-9236-f68b60baec96.png)
