### PR TITLE
Update copy in /verify-email

### DIFF
--- a/identity/app/services/ProfileRedirectService.scala
+++ b/identity/app/services/ProfileRedirectService.scala
@@ -22,7 +22,7 @@ sealed abstract class ProfileRedirect(val url: String) {
   def isAllowedFrom(url: String): Boolean
 }
 
-case object RedirectToEmailValidationFromAnywhereButAccountDetails extends ProfileRedirect("/verify-email?isRepermissioningRedirect=true") {
+case object RedirectToEmailValidationFromAnywhereButAccountDetails extends ProfileRedirect("/verify-email") {
   override def isAllowedFrom(url: String): Boolean = !(url contains "account/edit")
 }
 

--- a/identity/app/services/RedirectDecisionService.scala
+++ b/identity/app/services/RedirectDecisionService.scala
@@ -23,12 +23,12 @@ abstract class RedirectDecision(val url: String, protected val redirectAccess: R
 }
 
 case object RedirectToEmailValidation extends RedirectDecision(
-  url = "/verify-email?isRepermissioningRedirect=true",
+  url = "/verify-email",
   redirectAccess = RedirectAccessEmailPrefs
 )
 
 case object RedirectToEmailValidationStrict extends RedirectDecision(
-  url = "/verify-email?isRepermissioningRedirect=true",
+  url = "/verify-email",
   redirectAccess = RedirectAccessAllPages
 )
 

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -2,7 +2,6 @@
     user: com.gu.identity.model.User,
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
-    customMessage: Option[String] = None,
     verifiedReturnUrl: Option[String],
     defaultReturnUrl: String,
     isSignupFlow: Boolean = false
@@ -10,19 +9,27 @@
 
 @import common.LinkTo
 
+@emailBlock = {
+    <div class="identity-forms-email-wrap">
+        <header>@user.getPrimaryEmailAddress</header>
+        <aside>
+            Is the email not correct? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
+        </aside>
+    </div>
+}
+
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
-        <h1 class="identity-title">Confirm your email address</h1>
+        @if(isSignupFlow) {
+            <h1 class="identity-title">Confirm your email address</h1>
+        } else {
+            <h1 class="identity-title">To edit your preferences, you must confirm this is your email address</h1>
+        }
         <div class="identity-forms-message__body">
-            @for(m <- customMessage) {
-                <p>@m</p>
+            @if(isSignupFlow) {
+                <p>To access all your account features and join the Guardian community, we need you to confirm your email address below.</p>
             }
-            <div class="identity-forms-email-wrap">
-                <header>@user.getPrimaryEmailAddress</header>
-                <aside>
-                    Is the email not correct? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
-                </aside>
-            </div>
+            @emailBlock
             <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
         </div>
         <aside class="identity-forms-message__body">

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -21,20 +21,20 @@
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
         @if(isSignupFlow) {
-            <h1 class="identity-title">Confirm your email address</h1>
+            <h1 class="identity-title">Please look in your email inbox</h1>
         } else {
-            <h1 class="identity-title">To edit your preferences, you must confirm this is your email address</h1>
+            <h1 class="identity-title">To continue, you must confirm this is your email address</h1>
         }
         <div class="identity-forms-message__body">
             @if(isSignupFlow) {
-                <p>To access all your account features and join the Guardian community, we need you to confirm your email address below.</p>
+                <p>We have sent you a message because we need to confirm your email address. Please click the link in it.</p>
+            } else {
+                <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
             }
             @emailBlock
-            <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
         </div>
         <aside class="identity-forms-message__body">
-            <p class="identity-forms-message__explainer">Validation links are valid for 30 minutes before expiring.</p>
-            <p>Haven’t received the email or the link has expired?</p>
+            <p class="identity-forms-message__explainer">The link in the email is valid for 30 mins. If you haven’t received an email from us, please check your spam folder, or click below to resend.</p>
             <a class="manage-account__button manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
         </aside>
         @if(isSignupFlow) {

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -22,7 +22,9 @@ GET         /user/id/:id/:activityType              controllers.PublicProfileCon
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
-GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail(isRepermissioningRedirect: Boolean ?= false, isSignupFlow: Boolean ?= false )
+GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail
+
+GET         /complete-registration                  controllers.EmailVerificationController.completeRegistration
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -71,11 +71,12 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
   "Given the plain verify method is called" - Fake {
 
-    "should not render a link using resendEmailValidationEmail" in {
+    "should render the proper view using resendEmailValidationEmail" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       val result = controller.resendEmailValidationEmail()(testRequest)
-      contentAsString(result) should include("Confirm your email address")
+      contentAsString(result) should include("you must confirm this is your email address")
       contentAsString(result) should not include("Exit and go to The Guardian home page")
+      contentAsString(result) should not include("join the Guardian community")
     }
 
     "should resend an email using resendEmailValidationEmail" in {
@@ -84,10 +85,11 @@ class EmailVerificationControllerTest extends path.FreeSpec
       verify(api).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])
     }
 
-    "should render a link using completeRegistration" in {
+    "should render the proper view using completeRegistration" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
       contentAsString(result) should include("Confirm your email address")
+      contentAsString(result) should include("join the Guardian community")
       contentAsString(result) should include("Exit and go to The Guardian home page")
     }
 

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -69,23 +69,27 @@ class EmailVerificationControllerTest extends path.FreeSpec
     play.api.test.Helpers.stubControllerComponents()
   )(testApplicationContext)
 
-  "Given the plain verify method is called" - Fake {
+  "Given resendEmailValidationEmail is called" - Fake {
 
-    "should render the proper view using resendEmailValidationEmail" in {
+    "should render the proper view" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       val result = controller.resendEmailValidationEmail()(testRequest)
       contentAsString(result) should include("you must confirm this is your email address")
-      contentAsString(result) should not include("Exit and go to The Guardian home page")
-      contentAsString(result) should not include("join the Guardian community")
+      contentAsString(result) should not include ("Exit and go to The Guardian home page")
+      contentAsString(result) should not include ("join the Guardian community")
     }
 
-    "should resend an email using resendEmailValidationEmail" in {
+    "should resend an email" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       controller.resendEmailValidationEmail()(testRequest)
       verify(api).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])
     }
 
-    "should render the proper view using completeRegistration" in {
+  }
+
+  "Given completeRegistration is called" - Fake {
+
+    "should render the proper view" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
       contentAsString(result) should include("Confirm your email address")
@@ -93,7 +97,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
       contentAsString(result) should include("Exit and go to The Guardian home page")
     }
 
-    "should not resend an email using completeRegistration" in {
+    "should not resend an email" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
       controller.completeRegistration()(testRequest)
       verify(api, times(0)).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -91,7 +91,6 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "should link to the return url" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://jobs.theguardian.com/test-string-test"))
       val result = controller.completeRegistration()(testRequest)
-      contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should include("test-string-test")
       contentAsString(result) should include("Exit and continue")
     }

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -99,7 +99,8 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
     "should not resend an email" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
-      controller.completeRegistration()(testRequest)
+      val result = controller.completeRegistration()(testRequest)
+      status(result) should be(200)
       verify(api, times(0)).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])
     }
 

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -75,13 +75,6 @@ class EmailVerificationControllerTest extends path.FreeSpec
       val result = controller.resendEmailValidationEmail()(testRequest)
       contentAsString(result) should include("you must confirm this is your email address")
       contentAsString(result) should not include ("Exit and go to The Guardian home page")
-      contentAsString(result) should not include ("join the Guardian community")
-    }
-
-    "should resend an email" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
-      controller.resendEmailValidationEmail()(testRequest)
-      verify(api).resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])
     }
 
   }
@@ -91,18 +84,9 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "should render the proper view" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
-      contentAsString(result) should include("Confirm your email address")
-      contentAsString(result) should include("join the Guardian community")
+      contentAsString(result) should include("Please look in your email inbox")
       contentAsString(result) should include("Exit and go to The Guardian home page")
     }
-
-    "should not resend an email" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
-      val result = controller.completeRegistration()(testRequest)
-      status(result) should be(200)
-      verify(api, times(0)).resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])
-    }
-
 
     "should link to the return url" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://jobs.theguardian.com/test-string-test"))

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -9,7 +9,6 @@ import model.PhoneNumbers
 import org.mockito.AdditionalAnswers.returnsFirstArg
 import org.mockito.Matchers.{any, anyString, anyVararg, eq => eql}
 import org.mockito.Mockito._
-import org.mockito.{Matchers => MockitoMatchers}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, path}
 import play.api.mvc.{ControllerComponents, Request, RequestHeader}
@@ -39,7 +38,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
 
-  when(api.resendEmailValidationEmail(MockitoMatchers.any[idapiclient.Auth], MockitoMatchers.any[idapiclient.TrackingData], MockitoMatchers.any[Option[String]])) thenReturn Future.successful(Right((): Unit))
+  when(api.resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])) thenReturn Future.successful(Right({}))
 
   val userId: String = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
@@ -47,7 +46,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val authenticatedUser = AuthenticatedUser(user, testAuth, true)
   val phoneNumbers = PhoneNumbers
 
-  when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
+  when(authService.fullyAuthenticatedUser(any[RequestHeader])) thenReturn Some(authenticatedUser)
   when(api.me(testAuth)) thenReturn Future.successful(Right(user))
 
   val redirectDecisionService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponent)
@@ -55,9 +54,9 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
   val EmailValidatedMessage = "Your email address has been validated."
   when(identityUrlBuilder.buildUrl(anyString(), anyVararg[(String, String)]())) thenAnswer returnsFirstArg()
-  when(idRequestParser.apply(MockitoMatchers.any[Request[_]])) thenReturn idRequest
-  when(authenticationService.userIsFullyAuthenticated(MockitoMatchers.any[Request[_]])) thenReturn true
-  when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(Some("http://www.theguardian.com/football"))
+  when(idRequestParser.apply(any[Request[_]])) thenReturn idRequest
+  when(authenticationService.userIsFullyAuthenticated(any[Request[_]])) thenReturn true
+  when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("http://www.theguardian.com/football"))
 
   val controller = new EmailVerificationController(
     api,
@@ -72,7 +71,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   "Given resendEmailValidationEmail is called" - Fake {
 
     "should render the proper view" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
+      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       val result = controller.resendEmailValidationEmail()(testRequest)
       contentAsString(result) should include("you must confirm this is your email address")
       contentAsString(result) should not include ("Exit and go to The Guardian home page")
@@ -80,9 +79,9 @@ class EmailVerificationControllerTest extends path.FreeSpec
     }
 
     "should resend an email" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
+      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       controller.resendEmailValidationEmail()(testRequest)
-      verify(api).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])
+      verify(api).resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])
     }
 
   }
@@ -90,7 +89,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   "Given completeRegistration is called" - Fake {
 
     "should render the proper view" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
+      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
       contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should include("join the Guardian community")
@@ -98,15 +97,15 @@ class EmailVerificationControllerTest extends path.FreeSpec
     }
 
     "should not resend an email" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(None)
+      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
       status(result) should be(200)
-      verify(api, times(0)).resendEmailValidationEmail(MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData], MockitoMatchers.any[Option[String]])
+      verify(api, times(0)).resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])
     }
 
 
     "should link to the return url" in {
-      when(returnUrlVerifier.getVerifiedReturnUrl(MockitoMatchers.any[Request[_]])).thenReturn(Some("https://jobs.theguardian.com/test-string-test"))
+      when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://jobs.theguardian.com/test-string-test"))
       val result = controller.completeRegistration()(testRequest)
       contentAsString(result) should include("Confirm your email address")
       contentAsString(result) should include("test-string-test")


### PR DESCRIPTION
## What does this change?
This makes the copy in `/verify-email` more generic and adds a new `/complete-registration` endpoint to handle new signup journeys ([pr in id-front](https://github.com/guardian/identity-frontend/pull/300))

I've also cleaned up all the query parameters since we don't need them anymore.

The design differences between each are due to the signup journey being grey, in the same style as the signin/signup pages

## Screenshots
![screen shot 2018-02-23 at 2 41 28 pm](https://user-images.githubusercontent.com/11539094/36600586-9b004f90-18aa-11e8-8bec-dd61da059381.png)
![screen shot 2018-02-23 at 2 41 30 pm](https://user-images.githubusercontent.com/11539094/36600589-9d2a7c50-18aa-11e8-8290-9ed29bd0921a.png)
