### PR TITLE
Headline fixes

### DIFF
--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -12,7 +12,7 @@
     <div class="content__header tonal__header">
         <div class="u-cf">
 
-            <h1 class="content__headline @if(article.content.hasTonalHeaderByline) {content__headline--has-byline}" articleprop="headline" @langAttributes(article.content)>
+            <h1 class="content__headline @if(article.content.hasTonalHeaderByline) {content__headline--no-margin-bottom}" articleprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
             </h1>
 

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -18,7 +18,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline no-margin-bottom" itemprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
                 </h1>
             </div>
@@ -33,7 +33,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline @if(article.content.starRating) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>
                     @Html(article.trail.headline)
                 </h1>
 

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -18,7 +18,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline no-margin-bottom" itemprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
                 </h1>
             </div>
@@ -33,7 +33,7 @@
 
             <div class="u-cf">
 
-                <h1 class="content__headline @if(article.content.starRating) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>
+                <h1 class="content__headline @if(article.content.starRating && !article.elements.hasShowcaseMainElement) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>
                     @Html(article.trail.headline)
                 </h1>
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -262,10 +262,12 @@
     @include fs-headlineGarnett(4);
     display: block;
     font-weight: 400;
+    padding-bottom: $gs-baseline * 2;
     padding-top: $gs-baseline / 4;
 
     @include mq(tablet) {
         @include fs-headlineGarnett(6);
+        font-weight: 400;
         padding-bottom: $gs-baseline * 3;
     }
 
@@ -283,7 +285,7 @@
     padding-bottom: $gs-baseline * 6;
 }
 
-.content__headline--has-byline {
+.content__headline--no-margin-bottom {
     padding-bottom: 0;
 }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -459,9 +459,8 @@ $quote-mark: 35px;
         line-height: 0;
         padding: calc((#{$gs-baseline} / 2) - 2px);
         padding-left: $gs-gutter / 2;
-        margin-top: -$gs-baseline / 2;
-        margin-bottom: $gs-baseline;
-        transform: translatey(-$gs-baseline / 2);
+        margin-top: $gs-baseline / 2;
+        margin-bottom: $gs-baseline + $gs-baseline / 2;
         @include mq($from: mobileLandscape) {
             padding-left: $gs-gutter;
         }
@@ -470,10 +469,7 @@ $quote-mark: 35px;
             //magic number used for alignment
             padding-left: 4px;
         }
-        @include mq($from: tablet) {
-            margin-bottom: 0;
-            transform: translatey(-$gs-gutter);
-        }
+
         @include mq($from: leftCol) {
             margin-left: -$gs-gutter / 2;
             padding-left: $gs-gutter / 2;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1284,7 +1284,7 @@ $quote-mark: 35px;
             transform: none;
             z-index: 5;
             bottom: 0;
-            @include mq(desktop) {
+            @include mq(tablet) {
                 bottom: unset;
                 top: 0;
             }


### PR DESCRIPTION
Previous PR left some transforms/negative margins that should have been removed. Now if there's a star rating or a byline, the headline bottom-margin is removed with a modifier.

# Before
<img width="320" alt="screen shot 2018-02-23 at 14 37 35" src="https://user-images.githubusercontent.com/14570016/36600752-0d70f746-18ab-11e8-8d67-f8a065222ee7.png">

# After
<img width="320" alt="screen shot 2018-02-23 at 14 37 18" src="https://user-images.githubusercontent.com/14570016/36600751-0d5e09e2-18ab-11e8-86fc-1aef0fe62137.png">

# Before
<img width="322" alt="screen shot 2018-02-23 at 14 38 04" src="https://user-images.githubusercontent.com/14570016/36600754-0d98bc54-18ab-11e8-9f20-c04a5f05d424.png">

# After
<img width="320" alt="screen shot 2018-02-23 at 14 37 52" src="https://user-images.githubusercontent.com/14570016/36600753-0d84762c-18ab-11e8-9f51-82d82691d31e.png">
