### PR TITLE
Set the gdpr opt-in alert as an experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -4,6 +4,7 @@ import conf.switches.Owner
 import experiments.ParticipationGroups._
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
+import conf.switches.Switches.IdentityShowOptInEngagementBanner
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
@@ -12,7 +13,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialBaseline,
     CommercialAdRefresh,
     MoonLambda,
-    OrielParticipation
+    OrielParticipation,
+    GdprOptinAlert
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -78,3 +80,13 @@ object OrielParticipation extends Experiment(
   sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1C
 )
+
+object GdprOptinAlert extends Experiment(
+  name = "gdpr-optin-alert",
+  description = "Audience who will see the Stay with us alert",
+  owners = Seq(Owner.withGithub("walaura")),
+  sellByDate = new LocalDate(2018, 6, 25), // GDPR goes into effect + 1 month
+  participationGroup = Perc0E
+) {
+  override def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = super.isParticipating || IdentityShowOptInEngagementBanner.isSwitchedOn
+}

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -73,7 +73,7 @@ const optInEngagementBannerInit = (): void => {
             });
             new Message(messageCode, {
                 cssModifierClass: 'gdpr-opt-in',
-                siteMessageComponentName: messageCode
+                siteMessageComponentName: messageCode,
             }).show(templateHtml);
         }
     });

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -52,7 +52,7 @@ const templateHtml: string = `
 
 const shouldDisplayOptInBanner = (): Promise<boolean> =>
     new Promise(decision => {
-        if (config.get('gdprOptinAlertVariant') !== 'variant') {
+        if (config.get('tests.gdprOptinAlertVariant') !== 'variant') {
             return decision(false);
         }
         if (medium === null || medium.toLowerCase() !== 'email')

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -52,7 +52,7 @@ const templateHtml: string = `
 
 const shouldDisplayOptInBanner = (): Promise<boolean> =>
     new Promise(decision => {
-        if (!config.get('switches.idShowOptInEngagementBanner')) {
+        if (config.get('gdprOptinAlertVariant') !== 'variant') {
             return decision(false);
         }
         if (medium === null || medium.toLowerCase() !== 'email')
@@ -73,6 +73,7 @@ const optInEngagementBannerInit = (): void => {
             });
             new Message(messageCode, {
                 cssModifierClass: 'gdpr-opt-in',
+                siteMessageComponentName: messageCode
             }).show(templateHtml);
         }
     });


### PR DESCRIPTION
## What does this change?
Adds a new experiment (`0perc-E`) to enable/disable the optin alert in a per-browser basis. This will let stakeholders preview the alert live in gu.com

This also changes the code controlling how the alert is displayed to use the experiment, using the same concept we used to launch garnett where a switch can make the experiment go live to everybody