### PR TITLE
Add missing test condition

### DIFF
--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -145,9 +145,10 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
 
       val result = actions.consentsRedirectAction().apply(failTest)(request)
-      val expectedLocation = s"/reauthenticate?INTCMP=email&returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
       whenReady(result) { res =>
         res.header.status shouldBe 303
+        res.header.headers should contain("Location" -> expectedLocation)
       }
     }
   }


### PR DESCRIPTION
## What does this change?
Adds another test condition that was missed initially.  Should have caught this in last PR sorry!

## What is the value of this and can you measure success?
More tests 📈 

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
