### PR TITLE
Show only SMS in Email Prefs

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -54,7 +54,7 @@
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>
             @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
-                @if(isUsersSmsChannel(consentField, user)) {
+                @if(isSmsChannel(consentField, user)) {
                     <li>
                         @fragments.consentSwitch(consentField = consentField, skin = skin)(messages)
                     </li>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -82,7 +82,7 @@
         <div class="manage-account__switches">
             <ul>
             @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
-                @if(isUsersChannel(consentField, user)) {
+                @if(isSmsChannel(consentField, user)) {
                   <li>
                       @fragments.consentSwitch(consentField)(messages)
                   </li>
@@ -119,7 +119,7 @@
             @channelConsentForm
         } else {
             <p class="identity-title-explainer">
-                Update your <a class="u-underline" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="identity : email : add-channel-info">account details</a> with your phone number or home address to be able to opt in to receiving phone, SMS, and post communications from the Guardian.
+                Update your <a class="u-underline" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayAccountForm.url, idRequest)" data-link-name="identity : email : add-channel-info">account details</a> with your phone number to be able to opt in to receiving SMS communications from the Guardian.
             </p>
         }
     </div>

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -35,7 +35,7 @@ object ConsentChannel {
       }
   }
 
-  def isUsersSmsChannel(consentField: Field, user: User): Boolean =
+  def isSmsChannel(consentField: Field, user: User): Boolean =
     consentField("id").value.exists(_ == TextConsentChannel.id)
 
   def isChannel(consentField: Field): Boolean = {


### PR DESCRIPTION
## What does this change?

Removes phone and post checkboxes from email prefs, while keeping SMS.


## Screenshots

![image](https://user-images.githubusercontent.com/13835317/36667730-caccf3a2-1ae6-11e8-9194-a1336f4b7907.png)

