### PR TITLE
(identity) Ignore channels on [Select all]

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -49,7 +49,7 @@
 }
 
 @channelStepContent = {
-    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" class="js-manage-account__check-allCheckbox__ignore" role="main" method="post">
         @views.html.helper.CSRF.formField
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -30,11 +30,11 @@
     <div class="manage-account__switches">
         <ul>
             <li>
-                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox u-h" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">
+                <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox" style="visibility:hidden;pointer-events:none;" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">
                     <div class="manage-account__switch-content">
                         <input type="checkbox"/>
                         <div class="manage-account__switch-checkbox"></div>
-                        <h3 class="manage-account__switch-title"></h3>
+                        <h3 class="manage-account__switch-title">&nbsp;</h3>
                     </div>
                 </label>
             </li>

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -281,7 +281,7 @@ const bindConsentSwitch = (labelEl: HTMLElement): void => {
     );
 };
 
-const getCheckedAllStatus = (checkboxesEl: HTMLInputElement[]) =>
+const getCheckedAllStatus = (checkboxesEl: HTMLInputElement[]): boolean =>
     checkboxesEl.reduce((acc, checkboxEl) => checkboxEl.checked && acc, true);
 
 const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
@@ -325,11 +325,6 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
         const getTextForStatus = (status: boolean) =>
             status ? LC_UNCHECK_ALL : LC_CHECK_ALL;
 
-        const revealCheckbox = () =>
-            fastdom.write(() => {
-                labelEl.classList.remove('u-h');
-            });
-
         const updateCheckStatus = () =>
             fastdom.write(() => {
                 if (!(checkboxEl instanceof HTMLInputElement)) {
@@ -337,6 +332,8 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                 }
                 checkboxEl.checked = getCheckedAllStatus(wrappedCheckboxEls);
                 titleEl.innerHTML = getTextForStatus(checkboxEl.checked);
+                labelEl.style.visibility = 'visible';
+                labelEl.style.pointerEvents = 'all';
             });
 
         /* TODO:these events get fired as a linear
@@ -369,8 +366,9 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
             ).then(() => removeSpinner(labelEl));
         };
 
-        revealCheckbox();
-        updateCheckStatus();
+        if (getCheckedAllStatus(wrappedCheckboxEls) === false) {
+            updateCheckStatus();
+        }
 
         wrappedCheckboxEls.forEach(wrappedCheckboxEl => {
             wrappedCheckboxEl.addEventListener('change', () =>

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -22,6 +22,7 @@ import {
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
 const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
 const checkAllCheckboxClassName = 'js-manage-account__check-allCheckbox';
+const checkAllIgnoreClassName = 'js-manage-account__check-allCheckbox__ignore';
 
 const LC_CHECK_ALL = 'Select all';
 const LC_UNCHECK_ALL = 'Deselect all';
@@ -309,7 +310,9 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                         $checkbox =>
                             $checkbox.closest(
                                 `.${checkAllCheckboxClassName}`
-                            ) === null
+                            ) === null &&
+                            $checkbox.closest(`.${checkAllIgnoreClassName}`) ===
+                                null
                     );
                 })
             );
@@ -336,10 +339,10 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                 titleEl.innerHTML = getTextForStatus(checkboxEl.checked);
             });
 
-        /* TODO:these events get fired as a linear 
-        timeout to avoid sending the requests 
-        to the server at once as that creates a 
-        race condition on its end. should be changed 
+        /* TODO:these events get fired as a linear
+        timeout to avoid sending the requests
+        to the server at once as that creates a
+        race condition on its end. should be changed
         to a single call that handles checking/unchecking */
         const handleChangeEvent = () => {
             addSpinner(labelEl, 200);


### PR DESCRIPTION
## What does this change?
Tweaks the [Select all] checkbox to ignore the SMS channel checkbox. 

It also removes the whole thing from the page if on load everything is selected, to avoid presenting the user a deselect all checkbox as the first thing there