### PR TITLE
Set shouldHideReaderRevenue on all content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -232,6 +232,7 @@ final case class Content(
     ("isImmersive", JsBoolean(isImmersive)),
     ("isColumn", JsBoolean(isColumn)),
     ("isPaidContent", JsBoolean(isPaidContent)),
+    ("shouldHideReaderRevenue", JsBoolean(fields.shouldHideReaderRevenue.getOrElse(false))),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
 
   )
@@ -443,7 +444,6 @@ object Article {
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
-      ("shouldHideReaderRevenue", JsBoolean(fields.shouldHideReaderRevenue.getOrElse(false))),
       "videoDuration" -> videoDuration
     ) ++ bookReviewIsbn ++ AtomProperties(content.atoms)
 


### PR DESCRIPTION
The banner was showing on GLabs Paid Content, which it shouldn't be. e.g. https://www.theguardian.com/the-relationship-project/ng-interactive/2018/feb/14/britain-love-more-likely-change-banks-partners-relationships

![picture 112](https://user-images.githubusercontent.com/5122968/36676836-993eb42e-1b04-11e8-9db4-ea7a7031522b.png)

This is because we were setting `shouldHideReaderRevenue` only on articles, not on all content

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
Yes! It will stop the banner showing on those pages

@guardian/contributions 