### PR TITLE
don't preload video content

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/videojs-options.js
+++ b/static/src/javascripts/projects/common/modules/video/videojs-options.js
@@ -18,7 +18,7 @@ const defaults = {
     // If you are going to set autoplay to any other value, note it breaks
     // `preload="auto"` on < Chrome 35 and `preload="metadata"` on old Safari
     autoplay: false,
-    preload: 'metadata',
+    preload: 'none',
     techOrder: ['html5'],
     notSupportedMessage: 'This video is no longer available.',
 };


### PR DESCRIPTION
## What does this change?
We set preload to [`metadata`](https://developers.google.com/web/fundamentals/media/video#preload) to get the browser to work out the duration of a video as the information in CAPI can be a bit flaky at source (issue - https://github.com/guardian/pluto/issues/12).

`preload="metadata"` causes the browser to make a small request on load, it appears something has recently changed in Chrome* as its making multiple byte range requests for media, resulting in heavy page weights.

As we're not publishing new content to the old player anymore and the duration is hidden behind a mouse over, lets `preload="none"` which has the result of us using the CAPI data, until user interaction where the browser will update the value.

*additionally it could be our vcl for the cdn. Either way, I think this is the fastest way to provide value whilst further investigation is performed.

## What is the value of this and can you measure success?
Lighter pages, e.g https://www.theguardian.com/global-development/2018/feb/15/teodora-del-carmen-vasquezs-alvadoran-woman-jailed-after-suffering-stillbirth-walks-free

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots
### Player chrome on page load, after js fully loaded
#### Before
![before](https://user-images.githubusercontent.com/836140/36697275-7c46b030-1b3e-11e8-8675-ee610933a55a.gif)


#### After
![after](https://user-images.githubusercontent.com/836140/36697284-8326a4dc-1b3e-11e8-9fd9-f8fb4d757f23.gif)


### Network requests on page load, after js fully loaded
#### Before
<img width="526" alt="screen shot 2018-02-26 at 21 40 26" src="https://user-images.githubusercontent.com/836140/36697155-23d1a6c6-1b3e-11e8-9d5b-5904953ceb29.png">


#### After
<img width="528" alt="screen shot 2018-02-26 at 21 41 58" src="https://user-images.githubusercontent.com/836140/36697162-2bd1f27c-1b3e-11e8-8a22-3c4b2112adc4.png">


## Tested in CODE?
Nope.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
