### PR TITLE
Don't redirect to default consent journey if returnUrl was already a journey

### DIFF
--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -101,11 +101,18 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
     "when the api call succeeds" - {
       when(api.validateEmail(eql(token), any())).thenReturn(Future.successful(Right(())))
-      val result = controller.verify(token)(testRequest)
 
       "should redirect to default consent journey" in {
+        val result = controller.verify(token)(testRequest)
         status(result) should be(SEE_OTHER)
         redirectLocation(result).get should include("/consents?")
+      }
+
+      "should redirect to original returnUrl if it was already a consent journey" in {
+        when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://profile.theguardian.com/consents/staywithus"))
+        val result = controller.verify(token)(testRequest)
+        status(result) should be(SEE_OTHER)
+        redirectLocation(result).get should include("/consents/staywithus")
       }
     }
 


### PR DESCRIPTION
## What does this change?
Sometimes the returnUrl after email validation will be a version of the consent journey (unvalidated users trying to hit the /staywithus journey) - this PR ensures we just go straight there instead of hitting the default journey first.

## What is the value of this and can you measure success?
We don't push people through the journey twice.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
