### PR TITLE
Update Prebid price granularity

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -14,6 +14,7 @@ import {
     sonobiBidder,
     trustXBidder,
 } from 'commercial/modules/prebid/bidder-config';
+import { priceGranularity } from 'commercial/modules/prebid/price-config';
 import type {
     PrebidAdSlotCriteria,
     PrebidBid,
@@ -156,7 +157,8 @@ class PrebidService {
             },
         };
         window.pbjs.setConfig({
-            priceGranularity: 'auto',
+            bidderTimeout,
+            priceGranularity,
         });
     }
 
@@ -181,7 +183,6 @@ class PrebidService {
                         window.pbjs.que.push(() => {
                             window.pbjs.requestBids({
                                 adUnits: [adUnit],
-                                timeout: bidderTimeout,
                                 bidsBackHandler() {
                                     window.pbjs.setTargetingForGPTAsync([
                                         adUnit.code,

--- a/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
@@ -21,7 +21,7 @@ export const priceGranularity: PrebidPriceGranularity = {
         },
         {
             min: 20,
-            max: 30,
+            max: 40,
             increment: 10,
         },
     ],

--- a/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
@@ -1,0 +1,28 @@
+// @flow
+
+import type { PrebidPriceGranularity } from 'commercial/modules/prebid/types';
+
+export const priceGranularity: PrebidPriceGranularity = {
+    buckets: [
+        {
+            min: 0,
+            max: 5,
+            increment: 0.05,
+        },
+        {
+            min: 5,
+            max: 10,
+            increment: 0.1,
+        },
+        {
+            min: 10,
+            max: 20,
+            increment: 0.5,
+        },
+        {
+            min: 20,
+            max: 30,
+            increment: 10,
+        },
+    ],
+};

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -61,3 +61,14 @@ export type PrebidAdSlotCriteria = {
 export type PrebidBidderCriteria = {
     [bidder: string]: PrebidAdSlotCriteria[],
 };
+
+export type PrebidPriceBucket = {
+    precision?: number,
+    min: number,
+    max: number,
+    increment: number,
+};
+
+export type PrebidPriceGranularity = {
+    buckets: PrebidPriceBucket[],
+};


### PR DESCRIPTION
This adds an extra price bucket at $30.
Apart from that it's the same as the _auto_ granularity described [here](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity).

I've also moved the bid timeout to config, rather than passing it into every auction individually.
