### PR TITLE
Confirmation modal in /consents

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -242,8 +242,8 @@
             <section class="identity-forms-message">
 
                 <div class="identity-forms-message__body">
-                    You have not selected any emails or Guardian products and services. <br/>
-                    Are you sure you want to continue?
+                    You have not selected any newsletters or Guardian products and services.<br/>
+                    This means you will stop receiving these emails from us. Are you sure you want to continue?
                 </div>
 
                 <footer class="identity-forms-message__options">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -222,7 +222,7 @@
         )
 
         <div class="identity-consent-journey-step identity-consent-journey-step--controls">
-            <form method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
+            <form class="js-identity-consent-journey-form" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
                 <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
                 @views.html.helper.CSRF.formField
                 <div class="identity-consent-journey-step__content">
@@ -237,6 +237,26 @@
                 </div>
             </form>
         </div>
+
+        @confirmModal = {
+            <section class="identity-forms-message">
+
+                <h1 class="identity-title">Are you sure?</h1>
+
+                <div class="identity-forms-message__body">
+                    You have not selected any Guardian products and services.
+                </div>
+
+                <footer class="identity-forms-message__options">
+                    <a class="manage-account__button manage-account__button--secondary manage-account__button--center js-identity-consent-journey-continue" data-link-name="consents : confirm : continue">Continue</a>
+                    <a class="js-identity-modal__closer manage-account__button manage-account__button--main manage-account__button--center" data-link-name="consents : confirm : recheck">Check again</a>
+                </footer>
+
+            </section>
+        }
+
+        @fragments.modal("confirm-consents", confirmModal)
+
     </div>
 
 </div>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -241,15 +241,14 @@
         @confirmModal = {
             <section class="identity-forms-message">
 
-                <h1 class="identity-title">Are you sure?</h1>
-
                 <div class="identity-forms-message__body">
-                    You have not selected any Guardian products and services.
+                    You have not selected any emails or Guardian products and services. <br/>
+                    Are you sure you want to continue?
                 </div>
 
                 <footer class="identity-forms-message__options">
                     <a class="manage-account__button manage-account__button--secondary manage-account__button--center js-identity-consent-journey-continue" data-link-name="consents : confirm : continue">Continue</a>
-                    <a class="js-identity-modal__closer manage-account__button manage-account__button--main manage-account__button--center" data-link-name="consents : confirm : recheck">Check again</a>
+                    <a class="js-identity-modal__closer manage-account__button manage-account__button--main manage-account__button--center" data-link-name="consents : confirm : recheck">Let me look again</a>
                 </footer>
 
             </section>

--- a/identity/app/views/consentJourneyFragments/block.scala.html
+++ b/identity/app/views/consentJourneyFragments/block.scala.html
@@ -31,6 +31,7 @@
         role="group"
         class="
             identity-consent-journey-step
+            identity-consent-journey-step--@{step.name}
             @step.extraClassNames.map(s => s"identity-consent-journey-step--${s}")
         "
         aria-labelledby="consents@{step.name.capitalize}Title"

--- a/identity/app/views/fragments/modal.scala.html
+++ b/identity/app/views/fragments/modal.scala.html
@@ -1,0 +1,17 @@
+@(
+    name: String,
+    contents: Html
+)
+
+<div id="identity-modal--@name" class="identity-modal identity-modal--@name" role="dialog">
+    <div class="identity-modal__wrap">
+        <button class="identity-modal__closer js-identity-modal__closer">
+            <span class="u-h">Close this window</span>
+            @fragments.inlineSvg("cross", "icon")
+        </button>
+        <div class="identity-modal__content">
+            @contents
+        </div>
+    </div>
+    <div class="identity-modal__bg js-identity-modal__closer"></div>
+</div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -55,7 +55,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="#manage-account__modal--newsletterFormat" role="button" class="js-email-subscription__formatFieldsetToggle manage-account__button manage-account__button--mini manage-account__button--icon" data-link-name="identity : email : format">
+                        <a href="#identity-modal--newsletterFormat" role="button" class="js-email-subscription__formatFieldsetToggle manage-account__button manage-account__button--mini manage-account__button--icon" data-link-name="identity : email : format">
                             Change format
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
@@ -90,41 +90,37 @@
         </div>
     </fieldset>
 
-    <div id="manage-account__modal--newsletterFormat" class="manage-account__modal manage-account__modal--newsletterFormat" role="dialog">
-        <div class="manage-account__modalContent">
-            <button class="manage-account__modalCloser js-manage-account__modalCloser">
-                <span class="u-h">Close this window</span>
-                @fragments.inlineSvg("cross", "icon")
-            </button>
-            <fieldset class="fieldset">
-                <div class="fieldset__heading">
-                    <h2 class="form__heading">Formatting</h2>
-                </div>
+    @newsletterModalContents = {
+        <fieldset class="fieldset">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">Formatting</h2>
+            </div>
 
-                <div class="fieldset__fields">
-                    <ul class="u-unstyled">
+            <div class="fieldset__fields">
+                <ul class="u-unstyled">
 
-                        <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
-                            <label class="label" for="htmlPreference">In which format would you like to receive email?</label>
-                            <div class="form-field__note">
-                                HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
-                                <br />
-                                We recommend HTML emails.
-                            </div>
+                    <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
+                        <label class="label" for="htmlPreference">In which format would you like to receive email?</label>
+                        <div class="form-field__note">
+                            HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
+                            <br />
+                            We recommend HTML emails.
+                        </div>
 
-                            @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
+                        @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
 
-                        </li>
+                    </li>
 
-                        <li>
-                            <button type="submit" class="manage-account__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
-                        </li>
-                    </ul>
-                </div>
+                    <li>
+                        <button type="submit" class="manage-account__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
+                    </li>
+                </ul>
+            </div>
 
-            </fieldset>
-        </div>
-        <div class="manage-account__modalBg js-manage-account__modalCloser"></div>
-    </div>
+        </fieldset>
+    }
+
+    @fragments.modal("newsletterFormat",newsletterModalContents)
+
 
 </form>

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -71,9 +71,10 @@ const showJourneyAlert = (journeyEl: HTMLElement): void => {
 };
 
 const submitJourneyAnyway = (buttonEl: HTMLElement): void => {
-    const journeyEl =
-        buttonEl.closest('.identity-consent-journey') ||
-        new Error(ERR_MALFORMED_HTML);
+    const journeyEl = ((buttonEl.closest(
+        '.identity-consent-journey'
+    ): any): HTMLElement);
+    if (!journeyEl) throw new Error(ERR_MALFORMED_HTML);
     buttonEl.addEventListener('click', () => {
         getForm(journeyEl).then(formEl => {
             formEl.submit();

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -3,6 +3,9 @@
 import fastdom from 'lib/fastdom-promise';
 
 import loadEnhancers from './modules/loadEnhancers';
+import { show as showModal } from './modules/modal';
+
+const ERR_MALFORMED_HTML = 'Something went wrong';
 
 const showJourney = (journeyEl: HTMLElement): Promise<void> =>
     fastdom.write(() => journeyEl.classList.remove('u-h'));
@@ -10,9 +13,79 @@ const showJourney = (journeyEl: HTMLElement): Promise<void> =>
 const hideLoading = (loadingEl: HTMLElement): Promise<void> =>
     fastdom.write(() => loadingEl.remove());
 
+const shouldDisplaySectionWarning = (
+    journeyEl: HTMLElement,
+    section: string
+): Promise<boolean> =>
+    fastdom
+        .read(() => [
+            ...journeyEl.querySelectorAll(
+                `.identity-consent-journey-step--${
+                    section
+                } input[type=checkbox]`
+            ),
+        ])
+        .then(checkboxes => ({
+            checked: checkboxes.filter(_ => _.checked === true).length,
+            total: checkboxes.length,
+        }))
+        .then(
+            checkboxInfo =>
+                !(checkboxInfo.total > 0 && checkboxInfo.checked > 0)
+        );
+
+const shouldDisplayNewsletterWarning = (
+    journeyEl: HTMLElement
+): Promise<boolean> => shouldDisplaySectionWarning(journeyEl, 'email');
+
+const shouldDisplayConsentWarning = (
+    journeyEl: HTMLElement
+): Promise<boolean> =>
+    shouldDisplaySectionWarning(journeyEl, 'marketing-consents');
+
+const getForm = (journeyEl: HTMLElement) =>
+    fastdom.read(
+        () =>
+            journeyEl.querySelector('form.js-identity-consent-journey-form') ||
+            new Error(ERR_MALFORMED_HTML)
+    );
+
+const showJourneyAlert = (journeyEl: HTMLElement): void => {
+    getForm(journeyEl).then(formEl => {
+        formEl.addEventListener('submit', ev => {
+            if (ev.isTrusted) {
+                ev.preventDefault();
+                Promise.all([
+                    shouldDisplayNewsletterWarning(journeyEl),
+                    shouldDisplayConsentWarning(journeyEl),
+                ]).then(([emptyNewsletters, emptyMarketing]) => {
+                    if (emptyNewsletters && emptyMarketing) {
+                        showModal('confirm-consents');
+                    } else {
+                        formEl.submit();
+                    }
+                });
+            }
+        });
+    });
+};
+
+const submitJourneyAnyway = (buttonEl: HTMLElement): void => {
+    const journeyEl =
+        buttonEl.closest('.identity-consent-journey') ||
+        new Error(ERR_MALFORMED_HTML);
+    buttonEl.addEventListener('click', () => {
+        getForm(journeyEl).then(formEl => {
+            formEl.submit();
+        });
+    });
+};
+
 const enhanceConsentJourney = (): void => {
     const loaders = [
         ['.identity-consent-journey', showJourney],
+        ['.identity-consent-journey', showJourneyAlert],
+        ['.js-identity-consent-journey-continue', submitJourneyAnyway],
         ['#identityConsentsLoadingError', hideLoading],
     ];
     loadEnhancers(loaders);

--- a/static/src/javascripts/projects/common/modules/identity/email-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-prefs.js
@@ -1,12 +1,9 @@
 // @flow
 
 import reqwest from 'reqwest';
-import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
 
-import {
-    show as showModal
-} from './modules/modal';
+import { show as showModal } from './modules/modal';
 import { push as pushError } from './modules/show-errors';
 import { addUpdatingState, removeUpdatingState } from './modules/button';
 import {
@@ -52,11 +49,7 @@ const bindHtmlPreferenceChange = (buttonEl: HTMLButtonElement): void => {
 };
 
 const modalFormatToggle = (buttonEl: HTMLElement): void => {
-    buttonEl.addEventListener('click', () =>
-        showModal(
-            'newsletterFormat'
-        )
-    );
+    buttonEl.addEventListener('click', () => showModal('newsletterFormat'));
 };
 
 const enhanceEmailPrefs = (): void => {

--- a/static/src/javascripts/projects/common/modules/identity/email-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-prefs.js
@@ -50,9 +50,9 @@ const bindHtmlPreferenceChange = (buttonEl: HTMLButtonElement): void => {
 
 const modalCloserBind = (buttonEl: HTMLElement): void => {
     buttonEl.addEventListener('click', () => {
-        const modalEl: ?Element = buttonEl.closest('.manage-account__modal');
+        const modalEl: ?Element = buttonEl.closest('.identity-modal');
         if (modalEl) {
-            modalEl.classList.remove('manage-account__modal--active');
+            modalEl.classList.remove('identity-modal--active');
         }
     });
 };
@@ -63,12 +63,12 @@ const modalFormatToggle = (buttonEl: HTMLElement): void => {
             .read(
                 () =>
                     document.getElementsByClassName(
-                        'manage-account__modal--newsletterFormat'
+                        'identity-modal--newsletterFormat'
                     )[0]
             )
             .then(modalEl => {
                 fastdom.write(() => {
-                    modalEl.classList.add('manage-account__modal--active');
+                    modalEl.classList.add('identity-modal--active');
                 });
             });
     });
@@ -77,7 +77,7 @@ const modalFormatToggle = (buttonEl: HTMLElement): void => {
 const enhanceEmailPrefs = (): void => {
     const loaders = [
         ['.js-save-button', bindHtmlPreferenceChange],
-        ['.js-manage-account__modalCloser', modalCloserBind],
+        ['.js-identity-modal__closer', modalCloserBind],
         ['.js-email-subscription__formatFieldsetToggle', modalFormatToggle],
     ];
     loadEnhancers(loaders);

--- a/static/src/javascripts/projects/common/modules/identity/email-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-prefs.js
@@ -4,6 +4,9 @@ import reqwest from 'reqwest';
 import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
 
+import {
+    show as showModal
+} from './modules/modal';
 import { push as pushError } from './modules/show-errors';
 import { addUpdatingState, removeUpdatingState } from './modules/button';
 import {
@@ -48,36 +51,17 @@ const bindHtmlPreferenceChange = (buttonEl: HTMLButtonElement): void => {
     );
 };
 
-const modalCloserBind = (buttonEl: HTMLElement): void => {
-    buttonEl.addEventListener('click', () => {
-        const modalEl: ?Element = buttonEl.closest('.identity-modal');
-        if (modalEl) {
-            modalEl.classList.remove('identity-modal--active');
-        }
-    });
-};
-
 const modalFormatToggle = (buttonEl: HTMLElement): void => {
-    buttonEl.addEventListener('click', () => {
-        fastdom
-            .read(
-                () =>
-                    document.getElementsByClassName(
-                        'identity-modal--newsletterFormat'
-                    )[0]
-            )
-            .then(modalEl => {
-                fastdom.write(() => {
-                    modalEl.classList.add('identity-modal--active');
-                });
-            });
-    });
+    buttonEl.addEventListener('click', () =>
+        showModal(
+            'newsletterFormat'
+        )
+    );
 };
 
 const enhanceEmailPrefs = (): void => {
     const loaders = [
         ['.js-save-button', bindHtmlPreferenceChange],
-        ['.js-identity-modal__closer', modalCloserBind],
         ['.js-email-subscription__formatFieldsetToggle', modalFormatToggle],
     ];
     loadEnhancers(loaders);

--- a/static/src/javascripts/projects/common/modules/identity/modules/modal.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/modal.js
@@ -4,7 +4,7 @@ import fastdom from 'lib/fastdom-promise';
 const ERR_MODAL_NOT_FOUND = 'Modal not found';
 const ERR_MODAL_MALFORMED = 'Modal is malformed';
 
-const bindCloserOnce = (modalEl: HTMLElement, name: string): Promise<void[]> =>
+const bindCloserOnce = (modalEl: HTMLElement): Promise<void[]> =>
     fastdom
         .read(() => [...modalEl.querySelectorAll('.js-identity-modal__closer')])
         .then(buttonEls =>
@@ -24,18 +24,18 @@ const bindCloserOnce = (modalEl: HTMLElement, name: string): Promise<void[]> =>
 const getModal = (name: string): Promise<HTMLElement> =>
     fastdom
         .read(() => {
-            const modalEl: HTMLElement = document.querySelector(
+            const modalEl: ?HTMLElement = document.querySelector(
                 `.identity-modal.identity-modal--${name}`
             );
             if (!modalEl) throw new Error(ERR_MODAL_NOT_FOUND);
             return modalEl;
         })
-        .then(modalEl => bindCloserOnce(modalEl, name).then(() => modalEl));
+        .then(modalEl => bindCloserOnce(modalEl).then(() => modalEl));
 
 const getContents = (name: string): Promise<HTMLElement> =>
     getModal(name).then(modalEl =>
         fastdom.read(() => {
-            const contentsEl: HTMLElement = modalEl.querySelector(
+            const contentsEl: ?HTMLElement = modalEl.querySelector(
                 `.identity-modal__content`
             );
             if (!contentsEl) throw new Error(ERR_MODAL_MALFORMED);
@@ -57,4 +57,4 @@ const hide = (name: string): Promise<void> =>
         })
     );
 
-export {hide, show, getContents}
+export { hide, show, getContents };

--- a/static/src/javascripts/projects/common/modules/identity/modules/modal.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/modal.js
@@ -1,0 +1,60 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+
+const ERR_MODAL_NOT_FOUND = 'Modal not found';
+const ERR_MODAL_MALFORMED = 'Modal is malformed';
+
+const bindCloserOnce = (modalEl: HTMLElement, name: string): Promise<void[]> =>
+    fastdom
+        .read(() => [...modalEl.querySelectorAll('.js-identity-modal__closer')])
+        .then(buttonEls =>
+            buttonEls
+                .filter(buttonEl => !buttonEl.dataset.closeIsBound)
+                .map(buttonEl =>
+                    fastdom.write(() => {
+                        buttonEl.dataset.closeIsBound = true;
+                        buttonEl.addEventListener('click', () => {
+                            modalEl.classList.remove('identity-modal--active');
+                        });
+                    })
+                )
+        )
+        .then(_ => Promise.all(_));
+
+const getModal = (name: string): Promise<HTMLElement> =>
+    fastdom
+        .read(() => {
+            const modalEl: HTMLElement = document.querySelector(
+                `.identity-modal.identity-modal--${name}`
+            );
+            if (!modalEl) throw new Error(ERR_MODAL_NOT_FOUND);
+            return modalEl;
+        })
+        .then(modalEl => bindCloserOnce(modalEl, name).then(() => modalEl));
+
+const getContents = (name: string): Promise<HTMLElement> =>
+    getModal(name).then(modalEl =>
+        fastdom.read(() => {
+            const contentsEl: HTMLElement = modalEl.querySelector(
+                `.identity-modal__content`
+            );
+            if (!contentsEl) throw new Error(ERR_MODAL_MALFORMED);
+            return contentsEl;
+        })
+    );
+
+const show = (name: string): Promise<void> =>
+    getModal(name).then(modalEl =>
+        fastdom.read(() => {
+            modalEl.classList.add('identity-modal--active');
+        })
+    );
+
+const hide = (name: string): Promise<void> =>
+    getModal(name).then(modalEl =>
+        fastdom.read(() => {
+            modalEl.classList.remove('identity-modal--active');
+        })
+    );
+
+export {hide, show, getContents}

--- a/static/src/stylesheets/module/identity/_button.scss
+++ b/static/src/stylesheets/module/identity/_button.scss
@@ -151,6 +151,11 @@
     @include identity-button($news-garnett-highlight)
 }
 
+.manage-account__button--secondary {
+    @include identity-button(hsla(0, 100%, 100%, 0));
+    border: 1px solid $garnett-neutral-4;
+}
+
 .manage-account__button--light {
     @extend %manage-account__button--light;
 }

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -47,11 +47,10 @@ Messages
     .identity-forms-message__options {
         display: flex;
         margin-top: $gs-baseline * 2;
-        padding-top: $gs-baseline / 3;
         flex-direction: column;
         align-items: stretch;
         > * {
-            margin-top: $gs-gutter/4;
+            margin-top: $gs-gutter/2;
         }
         @include mq(tablet) {
             justify-content: space-between;
@@ -60,11 +59,11 @@ Messages
     }
     .identity-forms-message__body {
         @include clearfix;
-        margin-top: $gs-baseline * 2;
-        padding-top: $gs-baseline / 3;
-        &:first-of-type {
-            border-top: 1px solid $garnett-neutral-4;
+
+        &:not(:first-child) {
+            margin-top: $gs-baseline * 2;
         }
+
         &.identity-forms-message__body--aside {
             @include fs-textSans(4);
             .manage-account__button {

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -44,11 +44,27 @@ Messages
 .identity-forms-message {
     max-width: gs-span(6);
     margin: 0 auto;
-    .identity-forms-message__body {
-        @include clearfix;
-        border-top: 1px solid $garnett-neutral-4;
+    .identity-forms-message__options {
+        display: flex;
         margin-top: $gs-baseline * 2;
         padding-top: $gs-baseline / 3;
+        flex-direction: column;
+        align-items: stretch;
+        > * {
+            margin-top: $gs-gutter/4;
+        }
+        @include mq(tablet) {
+            justify-content: space-between;
+            flex-direction: row;
+        }
+    }
+    .identity-forms-message__body {
+        @include clearfix;
+        margin-top: $gs-baseline * 2;
+        padding-top: $gs-baseline / 3;
+        &:first-of-type {
+            border-top: 1px solid $garnett-neutral-4;
+        }
         &.identity-forms-message__body--aside {
             @include fs-textSans(4);
             .manage-account__button {

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -358,6 +358,8 @@
 /* Modals
    ========================================================================== */
 
+$modal-close-size: $gs-gutter * 1.75;
+
 .identity-modal {
     position: fixed;
     top: 0;
@@ -394,9 +396,12 @@
     width: 100%;
     position: relative;
     z-index: 10;
-    padding: $gs-gutter;
     margin: auto;
     float: none;
+    padding: ($gs-gutter + $modal-close-size) $gs-gutter/2 $gs-gutter;
+    @include mq(tablet) {
+        padding: $gs-gutter ($gs-gutter*2 + $modal-close-size);
+    }
 }
 
 .identity-modal__content {
@@ -405,16 +410,19 @@
 }
 
 .identity-modal__closer {
-    width: $gs-gutter * 1.75;
-    height: $gs-gutter * 1.75;
+    width: $modal-close-size;
+    height: $modal-close-size;
     color: $identity-main;
     border: 1px solid currentColor;
     border-radius: 100%;
     display: block;
     position: absolute;
     top: $gs-gutter / 2;
-    right: $gs-gutter;
+    right: $gs-gutter / 2;
     background: transparent;
+    @include mq(tablet) {
+        right: $gs-gutter;
+    }
 
     svg {
         position: absolute;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -358,13 +358,13 @@
 /* Modals
    ========================================================================== */
 
-.manage-account__modal {
+.identity-modal {
     border: 1px solid $neutral-8;
     padding: $gs-gutter;
     margin: $gs-gutter;
 }
 
-.js-on .manage-account__modal {
+.js-on .identity-modal {
     position: fixed;
     top: 0;
     left: 0;
@@ -379,12 +379,12 @@
     border: 0;
 }
 
-.js-on .manage-account__modal--active {
+.js-on .identity-modal--active {
     display: block;
     display: flex;
 }
 
-.js-on .manage-account__modalBg {
+.js-on .identity-modal__bg {
     position: fixed;
     top: 0;
     left: 0;
@@ -395,7 +395,7 @@
     z-index: 9;
 }
 
-.js-on .manage-account__modalContent {
+.js-on .identity-modal__wrap {
     max-width: gs-span(10);
     background: #ffffff;
     width: 100%;
@@ -407,11 +407,11 @@
     float: none;
 }
 
-.manage-account__modalCloser {
+.identity-modal__closer {
     display: none;
 }
 
-.js-on .manage-account__modalCloser {
+.js-on .identity-modal__closer {
     width: $gs-gutter * 1.75;
     height: $gs-gutter * 1.75;
     color: $identity-main;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -359,12 +359,6 @@
    ========================================================================== */
 
 .identity-modal {
-    border: 1px solid $neutral-8;
-    padding: $gs-gutter;
-    margin: $gs-gutter;
-}
-
-.js-on .identity-modal {
     position: fixed;
     top: 0;
     left: 0;
@@ -379,12 +373,12 @@
     border: 0;
 }
 
-.js-on .identity-modal--active {
+.identity-modal--active {
     display: block;
     display: flex;
 }
 
-.js-on .identity-modal__bg {
+.identity-modal__bg {
     position: fixed;
     top: 0;
     left: 0;
@@ -395,23 +389,22 @@
     z-index: 9;
 }
 
-.js-on .identity-modal__wrap {
-    max-width: gs-span(10);
+.identity-modal__wrap {
     background: #ffffff;
     width: 100%;
     position: relative;
     z-index: 10;
-    border-top: 1px solid $neutral-1;
-    padding: ($gs-gutter * 3.75) ($gs-gutter * 1) ($gs-gutter * 1);
+    padding: $gs-gutter;
     margin: auto;
     float: none;
 }
 
-.identity-modal__closer {
-    display: none;
+.identity-modal__content {
+    max-width: gs-span(10);
+    margin: auto;
 }
 
-.js-on .identity-modal__closer {
+.identity-modal__closer {
     width: $gs-gutter * 1.75;
     height: $gs-gutter * 1.75;
     color: $identity-main;
@@ -419,7 +412,7 @@
     border-radius: 100%;
     display: block;
     position: absolute;
-    top: $gs-gutter;
+    top: $gs-gutter / 2;
     right: $gs-gutter;
     background: transparent;
 


### PR DESCRIPTION
## What does this change?
Prompt users who didn't check any checkboxes in the consents journey to review their choices before moving on:

![screen shot 2018-02-27 at 1 58 59 pm](https://user-images.githubusercontent.com/11539094/36732916-fc35ce10-1bc6-11e8-90ab-f61626305bd3.png)

I also made modals A Thing, they were only used on /email-prefs before but now i extracted their behaviour into a global file