### PR TITLE
Remove test Prebid values and switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -376,14 +376,4 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
-
-  val testImproveBidder: Switch = Switch(
-    group = Commercial,
-    name = "test-improve-bidder",
-    description = "Test multi-size slots in Improve Digital Prebid adapter",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 14),
-    exposeClientSide = true
-  )
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -70,16 +70,6 @@ const containsMpuOrDmpu = (sizes: PrebidSize[]): boolean =>
 const containsLeaderboardOrBillboard = (sizes: PrebidSize[]): boolean =>
     contains(sizes, [728, 90]) || contains(sizes, [970, 250]);
 
-const getTestImprovePlacementId = (sizes: PrebidSize[]): number => {
-    if (containsMpuOrDmpu(sizes)) {
-        return 1116414;
-    }
-    if (containsLeaderboardOrBillboard(sizes)) {
-        return 1116415;
-    }
-    return -1;
-};
-
 const getImprovePlacementId = (sizes: PrebidSize[]): number => {
     switch (config.page.edition) {
         case 'UK':
@@ -252,9 +242,7 @@ export const trustXBidder: PrebidBidder = {
 export const improveDigitalBidder: PrebidBidder = {
     name: 'improvedigital',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidImproveParams => ({
-        placementId: config.switches.testImproveBidder
-            ? getTestImprovePlacementId(sizes)
-            : getImprovePlacementId(sizes),
+        placementId: getImprovePlacementId(sizes),
         size: getImproveSizeParam(slotId),
     }),
 };


### PR DESCRIPTION
These values were being used to test that multi-size ad slots were working with Prebid.
That has been proven now, so the code is redundant.