### PR TITLE
Repermission Business View newsletter

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.126"
+  val identityLibVersion = "3.127"
   val awsVersion = "1.11.240"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.51"


### PR DESCRIPTION
## What does this change?

Business View subscribers previously existed in Business & Profession business unit. Celine now migrated them to Editorial business unit, so now we can re-permission these subscribers.

Related PR: https://github.com/guardian/identity/pull/930

## What is the value of this and can you measure success?

GDPR


