### PR TITLE
Disable refresh message handler

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
@@ -83,6 +83,7 @@ class Advert {
             loadingMethod: null,
             lazyWaitComplete: null,
         };
+        this.shouldRefresh = false;
 
         this.whenLoaded = new Promise(resolve => {
             this.whenLoadedResolver = resolve;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
@@ -44,6 +44,7 @@ class Advert {
     isRendering: boolean;
     isLoaded: boolean;
     isRendered: boolean;
+    shouldRefresh: boolean;
     whenLoaded: Promise<boolean>;
     whenLoadedResolver: Resolver;
     whenRendered: Promise<boolean>;

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -80,7 +80,8 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
             config.get('page.isFront') ||
             config.get('page.contentType') === 'LiveBlog';
 
-        advert.shouldRefresh = isNotFluid && neverHasVideo && !config.page.hasPageSkin;
+        advert.shouldRefresh =
+            isNotFluid && neverHasVideo && !config.page.hasPageSkin;
 
         renderAdvert(advert, event).then(emitRenderEvents);
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -10,6 +10,7 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { renderAdvert } from 'commercial/modules/dfp/render-advert';
 import { emptyAdvert } from 'commercial/modules/dfp/empty-advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
+import config from 'lib/config';
 
 const recordFirstAdRendered = once(() => {
     fire('/count/ad-render.gif');
@@ -71,6 +72,16 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
         if (event.creativeId !== undefined) {
             dfpEnv.creativeIDs.push(event.creativeId);
         }
+        // Set refresh field based on the outcome of the slot render.
+        const sizeString = advert.size && advert.size.toString();
+        const isNotFluid = sizeString !== '0,0';
+        const neverHasVideo =
+            advert.id !== 'dfp-ad--inline1' ||
+            config.get('page.isFront') ||
+            config.get('page.contentType') === 'LiveBlog';
+
+        advert.shouldRefresh = isNotFluid && neverHasVideo && !config.page.hasPageSkin;
+
         renderAdvert(advert, event).then(emitRenderEvents);
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -4,24 +4,12 @@ import type { ImpressionViewableEvent } from 'commercial/types';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
-import config from 'lib/config';
-
-const shouldRefresh = (advert: Advert): boolean => {
-    const sizeString = advert.size && advert.size.toString();
-    const isNotFluid = sizeString !== '0,0';
-    const neverHasVideo =
-        advert.id !== 'dfp-ad--inline1' ||
-        config.get('page.isFront') ||
-        config.get('page.contentType') === 'LiveBlog';
-
-    return isNotFluid && neverHasVideo && !config.page.hasPageSkin;
-};
 
 export const onSlotViewable = (event: ImpressionViewableEvent): void => {
     const advert: ?Advert = getAdvertById(event.slot.getSlotElementId());
     const viewabilityThresholdMs = 30000;
 
-    if (advert && shouldRefresh(advert)) {
+    if (advert && advert.shouldRefresh) {
         const onDocumentVisible = () => {
             if (!document.hidden) {
                 document.removeEventListener(

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -21,6 +21,11 @@ export const onSlotViewable = (event: ImpressionViewableEvent): void => {
         };
 
         setTimeout(() => {
+            // During the elapsed time, a 'disable-refresh' message may have been posted.
+            // Check the flag again.
+            if (!advert.shouldRefresh) {
+                return;
+            }
             if (document.hidden) {
                 document.addEventListener(
                     'visibilitychange',

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -32,6 +32,7 @@ import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
 import { init as sendClick } from 'commercial/modules/messenger/click';
 import { init as background } from 'commercial/modules/messenger/background';
+import { init as disableRefresh } from 'commercial/modules/messenger/disable-refresh';
 
 initMessenger(
     type,
@@ -42,7 +43,8 @@ initMessenger(
     scroll,
     viewport,
     sendClick,
-    background
+    background,
+    disableRefresh
 );
 
 const setDfpListeners = (): void => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
@@ -1,0 +1,53 @@
+// @flow
+import type { RegisterListeners } from 'commercial/modules/messenger';
+import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
+import type { Advert } from 'commercial/modules/dfp/Advert';
+
+// This message is intended to be used with a DFP creative wrapper.
+// For reference, the wrapper will post a message, with an iFrameId, like so:
+/*
+<script>
+self.addEventListener('message', function onMessage(evt) {
+    var json;
+    try {
+        json = JSON.parse(evt.data);
+    } catch(_) { return; }
+
+    var keys = Object.keys(json);
+    if( keys.length < 2 || !keys.includes('id') || !keys.includes('host') ) return;
+
+    window.parent.postMessage(JSON.stringify({
+        type: 'disable-refresh',
+        value: {},
+        iframeId: json.id,
+        id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444'
+    }), '*');
+
+    self.removeEventListener('message', onMessage);
+});
+</script>
+*/
+
+const findAdvert = (adSlot: HTMLElement): any => {
+    const thing = dfpEnv.adverts.find( (advert: Advert) =>
+        advert.node.isSameNode(adSlot)
+    );
+    return thing;
+};
+
+const init = (register: RegisterListeners) => {
+    register('disable-refresh', (specs, ret, iframe) => {
+        if (iframe) {
+            const adSlot = iframe.closest('.js-ad-slot');
+
+            if (adSlot instanceof HTMLElement) {
+                const advert: ?Advert = findAdvert(adSlot);
+                if (advert) {
+                    advert.shouldRefresh = false;
+                }
+            }
+        }
+    });
+};
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
@@ -28,12 +28,8 @@ self.addEventListener('message', function onMessage(evt) {
 </script>
 */
 
-const findAdvert = (adSlot: HTMLElement): any => {
-    const thing = dfpEnv.adverts.find( (advert: Advert) =>
-        advert.node.isSameNode(adSlot)
-    );
-    return thing;
-};
+const findAdvert = (adSlot: HTMLElement): any =>
+    dfpEnv.adverts.find((advert: Advert) => advert.node.isSameNode(adSlot));
 
 const init = (register: RegisterListeners) => {
     register('disable-refresh', (specs, ret, iframe) => {


### PR DESCRIPTION
This allows adops to add a DFP label to an ad unit, which will mark it as "Do Not Refresh". This DFP label adds a creative wrapper, which will post a `disable-refresh` message that prevents the lazy load from being re-enabled.