### PR TITLE
Fix badge in browsers without grid

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1069,6 +1069,8 @@
             // adds enough space so that this doesn't clash with the content labels if css gris is not supported
             top: gs-height(3);
 
+            position: static !important;
+
             @supports (display: grid) {
                 grid-area: meta;
                 position: relative !important;


### PR DESCRIPTION
## What does this change?

Fix badges on commercial pages that don't support grid.

## Screenshots

![broken](https://user-images.githubusercontent.com/445472/36800296-1ad16c54-1ca7-11e8-8aae-0ee8d2a5f918.png)

![fixed](https://user-images.githubusercontent.com/445472/36800297-1ae851c6-1ca7-11e8-8744-3473db02e4b1.png)

## Tested in CODE?

Yes
