### PR TITLE
Show img with external link in facia email card

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -108,7 +108,7 @@
                 case ExternalLink => {
                     @faciaCardWithoutTrailText(
                         card = card,
-                        withImage = false,
+                        withImage = layoutStyle.image,
                         largeHeadline = false,
                         isBranded = isBranded
                     )

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -66,6 +66,21 @@
 }
 
 
+@faciaCardExternal(card: ContentCard, withImage: Boolean, isBranded: Boolean) = {
+    @imgFromCard(card).filter(_ => withImage).fold {
+        @faciaCard(classesForCard(card), isBranded) {
+            @headline(card, isLast = true)
+        }
+    } { img =>
+        @faciaCard(classesForCard(card), isBranded) {
+            <tr valign="top">
+                @row(Seq("no-pad")){@img}
+                @headline(card, isLast = true)
+            </tr>
+        }
+    }
+}
+
 @faciaCardWithTrailText(card: ContentCard, withImage: Boolean, largeHeadline: Boolean, isBranded: Boolean) = {
     @faciaCard(classesForCard(card, withImage), isBranded) {
         @if(withImage) {
@@ -106,10 +121,9 @@
         case layoutStyle: EmailFaciaCard => {
             @card.cardStyle match {
                 case ExternalLink => {
-                    @faciaCardWithTrailText(
+                    @faciaCardExternal(
                         card = card,
                         withImage = layoutStyle.image,
-                        largeHeadline = false,
                         isBranded = isBranded
                     )
                 }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -67,17 +67,11 @@
 
 
 @faciaCardExternal(card: ContentCard, withImage: Boolean, isBranded: Boolean) = {
-    @imgFromCard(card).filter(_ => withImage).fold {
-        @faciaCard(classesForCard(card), isBranded) {
-            @headline(card, isLast = true)
+    @faciaCard(classesForCard(card), isBranded) {
+        @if(withImage) {
+            @row(Seq("no-pad")){@imgFromCard(card)}
         }
-    } { img =>
-        @faciaCard(classesForCard(card), isBranded) {
-            <tr valign="top">
-                @row(Seq("no-pad")){@img}
-                @headline(card, isLast = true)
-            </tr>
-        }
+        @headline(card, isLast = true)
     }
 }
 

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -106,7 +106,7 @@
         case layoutStyle: EmailFaciaCard => {
             @card.cardStyle match {
                 case ExternalLink => {
-                    @faciaCardWithoutTrailText(
+                    @faciaCardWithTrailText(
                         card = card,
                         withImage = layoutStyle.image,
                         largeHeadline = false,


### PR DESCRIPTION
## What does this change?

Unlike editorial fronts, email fronts do not display images added to links to an external site.

This change displays the image in a card with a link to an external site. These cards always take the "medium" layout, even if the container is set to a different layout.

Trails will never appear for cards with external links

## What is the value of this and can you measure success?

Allows us to display images on cards with links to external sites

## Does this affect other platforms - Amp, Apps, etc?

Nooo, just email

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

Nooo

## Screenshots

### External link with image

![picture 501](https://user-images.githubusercontent.com/5931528/36844650-86165c5a-1d4b-11e8-8f6d-55330ed2a989.png)

![picture 507](https://user-images.githubusercontent.com/5931528/36851456-26b798e4-1d61-11e8-98d9-544794b78af2.png)


### External link without image

![picture 505](https://user-images.githubusercontent.com/5931528/36844643-7b89a756-1d4b-11e8-998a-61f98f807579.png)

## Tested in CODE?

- [x] Test on Litmus against CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
