### PR TITLE
Bump version of Prebid

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash-amd": "~2.4.1",
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.9",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#628ea9f",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#5e2a31c",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7199,9 +7199,9 @@ postcss@^6.0.16:
     source-map "^0.6.1"
     supports-color "^5.1.0"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#628ea9f":
+"prebid.js@https://github.com/guardian/Prebid.js.git#5e2a31c":
   version "0.34.1"
-  resolved "https://github.com/guardian/Prebid.js.git#628ea9f1939ac58e599ce9ab9881bafe9a917f40"
+  resolved "https://github.com/guardian/Prebid.js.git#5e2a31ccb120016ec8c16718aa32127acad9fb43"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This incorporates a fix for the JS errors reported by Sentry yesterday.
See https://github.com/guardian/Prebid.js/pull/11