### PR TITLE
Add isSensitive flag to page targeting for ads.

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -197,7 +197,8 @@ object MetaData {
         else CacheTime.NotRecentlyUpdated
       },
       isHosted = apiContent.isHosted,
-      commercial = Some(CommercialProperties.fromContent(apiContent))
+      commercial = Some(CommercialProperties.fromContent(apiContent)),
+      sensitive = fields.sensitive.getOrElse(false)
     )
   }
 }
@@ -234,7 +235,8 @@ final case class MetaData (
   twitterPropertiesOverrides: Map[String, String] = Map(),
   contentWithSlimHeader: Boolean = false,
   commercial: Option[CommercialProperties],
-  isNewRecipeDesign: Boolean = false
+  isNewRecipeDesign: Boolean = false,
+  sensitive: Boolean = false
 ){
   val sectionId = section map (_.value) getOrElse ""
   private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -49,7 +49,8 @@ object JavaScriptPage {
         if (prebidSwitch.isSwitchedOn) JsString("prebid")
         else if (sonobiSwitch.isSwitchedOn) JsString("sonobi")
         else JsString("none")
-      }
+      },
+      "isSensitive" -> JsBoolean(page.metadata.sensitive)
     ) ++ sponsorshipType
 
     val readerRevenueMetaData = Map(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -153,6 +153,7 @@ const buildPageTargeting = once((adFree: ?boolean): Object => {
     const adFreeTargeting: Object = adFree ? { af: 't' } : {};
     const pageTargets: Object = Object.assign(
         {
+            sens: page.isSensitive ? 't' : 'f',
             x: getKruxSegments(),
             pv: config.ophan.pageViewId,
             bp: getBreakpoint(),


### PR DESCRIPTION
By passing up this value in DFP, we can guarantee that we can block sensitive content instantly for advertisers who are incredibly cautious about brand safety.