### PR TITLE
Lab Notes front email

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -96,6 +96,11 @@ case object TheUpsideWeeklyReport extends ArticleEmailMetadata {
   def test(c: ContentPage): Boolean = c.item.tags.series.exists(_.id == "world/series/the-upside-weekly-report")
 }
 
+case object LabNotesFront extends FrontEmailMetadata {
+  val name = "Lab Notes"
+  override val banner = Some("lab-notes.png")
+}
+
 case object CuratedMediaBriefing extends FrontEmailMetadata {
   val name = "Media Briefing"
   override val banner = Some("media-briefing.png")
@@ -272,6 +277,7 @@ object EmailAddons {
     TheUpsideWeeklyReport)
   private val frontEmails = Seq(
     TheFlyer,
+    LabNotesFront,
     CuratedMediaBriefing,
     Opinion,
     TheGuardianTodayUS,


### PR DESCRIPTION
## What does this change?

Connects the existing Lab Notes email banner to the /email/lab-notes email front

## What is the value of this and can you measure success?

We can send 'front emails' with the lab notes banner

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No


## Screenshots

<img src='https://user-images.githubusercontent.com/4561/36856399-d8691390-1d6d-11e8-92f9-646c986be736.png' width=400>


## Tested in CODE?

Tested locally but not on code

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
