### PR TITLE
Simplify and refactor article-body-adverts 

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -43,7 +43,7 @@ if (!commercialFeatures.adFree) {
     commercialModules.push(
         ['cm-prepare-sonobi-tag', prepareSonobiTag, true],
         ['cm-articleAsideAdverts', initArticleAsideAdverts, true],
-        ['cm-articleBodyAdverts', initArticleBodyAdverts],
+        ['cm-articleBodyAdverts', initArticleBodyAdverts, true],
         ['cm-liveblogAdverts', initLiveblogAdverts, true],
         ['cm-stickyTopBanner', initStickyTopBanner]
     );

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -132,23 +132,9 @@ const getRules = (): Object => {
     };
 };
 
-const getLongArticleRules = (): Object => {
-    const longArticleRules: Object = getRules();
-    const viewportHeight: number = getViewport().height;
-    longArticleRules.selectors[' .ad-slot'].minAbove = viewportHeight;
-    longArticleRules.selectors[' .ad-slot'].minBelow = viewportHeight;
-    return longArticleRules;
-};
-
 const addInlineAds = (): Promise<number> =>
-    addArticleAds(2, getRules()).then((countAdded: number) => {
-        if (countAdded === 2) {
-            return addArticleAds(8, getLongArticleRules()).then(
-                innerCountAdded => 2 + innerCountAdded
-            );
-        }
-        return countAdded;
-    });
+    addArticleAds(1, getRules())
+        .then( () => addArticleAds(9, getRules()));
 
 const getInlineMerchRules = (): Object => {
     const inlineMerchRules: Object = getRules();

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -136,8 +136,7 @@ const getRules = (): Object => {
     };
 };
 
-const addInlineAds = (): Promise<number> =>
-    addArticleAds(1, getRules()).then(() => addArticleAds(9, getRules()));
+const addInlineAds = (): Promise<number> => addArticleAds(10, getRules());
 
 const getInlineMerchRules = (): Object => {
     const inlineMerchRules: Object = getRules();

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -171,8 +171,10 @@ const addInlineMerchAd = (): Promise<any> =>
 const waitForMerch = (countAdded: number): Promise<void> =>
     countAdded === 1 ? trackAdRender('dfp-ad--im') : Promise.resolve();
 
-export const init = (): Promise<boolean> => {
+export const init = (start: () => void, stop: () => void): Promise<boolean> => {
+    start();
     if (!commercialFeatures.articleBodyAdverts) {
+        stop();
         return Promise.resolve(false);
     }
 
@@ -190,11 +192,15 @@ export const init = (): Promise<boolean> => {
         // we must wait for DFP to return, since if the merch
         // component is empty, it might completely change the
         // positions where we insert those MPUs.
-        im.then(waitForMerch).then(addInlineAds);
+        im.then(waitForMerch)
+            .then(addInlineAds)
+            .then(stop);
+
         return im;
     }
 
-    addInlineAds();
+    addInlineAds()
+        .then(stop);
     return Promise.resolve(true);
 };
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -1,6 +1,6 @@
 // @flow
 import config from 'lib/config';
-import { isBreakpoint, getBreakpoint, getViewport } from 'lib/detect';
+import { isBreakpoint, getBreakpoint } from 'lib/detect';
 import fastdom from 'lib/fastdom-promise';
 import type { SpacefinderItem } from 'common/modules/spacefinder';
 import { spaceFiller } from 'common/modules/article/space-filler';
@@ -34,8 +34,12 @@ const getSlotTypeForMobile = (): string =>
 
 const getSlotTypeForDesktop = (): string => 'inline';
 
-const getSlotName = replaceTopSlot ? getSlotNameForMobile : getSlotNameForDesktop;
-const getSlotType = replaceTopSlot ? getSlotTypeForMobile : getSlotTypeForDesktop;
+const getSlotName = replaceTopSlot
+    ? getSlotNameForMobile
+    : getSlotNameForDesktop;
+const getSlotType = replaceTopSlot
+    ? getSlotTypeForMobile
+    : getSlotTypeForDesktop;
 
 type Sizes = { desktop: Array<AdSize> };
 
@@ -133,8 +137,7 @@ const getRules = (): Object => {
 };
 
 const addInlineAds = (): Promise<number> =>
-    addArticleAds(1, getRules())
-        .then( () => addArticleAds(9, getRules()));
+    addArticleAds(1, getRules()).then(() => addArticleAds(9, getRules()));
 
 const getInlineMerchRules = (): Object => {
     const inlineMerchRules: Object = getRules();
@@ -176,15 +179,15 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
         // we must wait for DFP to return, since if the merch
         // component is empty, it might completely change the
         // positions where we insert those MPUs.
-        im.then(waitForMerch)
+        im
+            .then(waitForMerch)
             .then(addInlineAds)
             .then(stop);
 
         return im;
     }
 
-    addInlineAds()
-        .then(stop);
+    addInlineAds().then(stop);
     return Promise.resolve(true);
 };
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -20,9 +20,9 @@ type AdSize = {
 /* bodyAds is a counter that keeps track of the number of inline MPUs
  * inserted dynamically. */
 let bodyAds: number;
-let replaceTopSlot: boolean;
-let getSlotName: () => string;
-let getSlotType: () => string;
+const replaceTopSlot: boolean = isBreakpoint({
+    max: 'phablet',
+});
 
 const getSlotNameForMobile = (): string =>
     bodyAds === 1 ? 'top-above-nav' : `inline${bodyAds - 1}`;
@@ -33,6 +33,9 @@ const getSlotTypeForMobile = (): string =>
     bodyAds === 1 ? 'top-above-nav' : 'inline';
 
 const getSlotTypeForDesktop = (): string => 'inline';
+
+const getSlotName = replaceTopSlot ? getSlotNameForMobile : getSlotNameForDesktop;
+const getSlotType = replaceTopSlot ? getSlotTypeForMobile : getSlotTypeForDesktop;
 
 type Sizes = { desktop: Array<AdSize> };
 
@@ -179,11 +182,6 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
     }
 
     bodyAds = 0;
-    replaceTopSlot = isBreakpoint({
-        max: 'phablet',
-    });
-    getSlotName = replaceTopSlot ? getSlotNameForMobile : getSlotNameForDesktop;
-    getSlotType = replaceTopSlot ? getSlotTypeForMobile : getSlotTypeForDesktop;
 
     if (config.page.hasInlineMerchandise) {
         const im = addInlineMerchAd();

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -112,10 +112,7 @@ describe('Article Body Adverts', () => {
         it('inserts up to ten adverts when DFP returns empty merchandising components', () => {
             // The 0 is for addInlineMerchAd, failing to add a merchandising component.
             spaceFillerStub.mockReturnValueOnce(Promise.resolve(0));
-            // The 2 is for addInlineAds, adding adverts using standard getRules().
-            spaceFillerStub.mockReturnValueOnce(Promise.resolve(2));
-            // The 8 is for addInlineAds again, adding adverts using getLongArticleRules().
-            spaceFillerStub.mockReturnValueOnce(Promise.resolve(8));
+            spaceFillerStub.mockReturnValueOnce(Promise.resolve(10));
 
             getBreakpoint.mockReturnValue('tablet');
 
@@ -141,16 +138,6 @@ describe('Article Body Adverts', () => {
     describe('Non-merchandising adverts', () => {
         beforeEach(() => {
             config.page.hasInlineMerchandise = false; // exclude IM components from count
-        });
-
-        describe('On mobiles and desktops', () => {
-            it('inserts up to ten adverts', () => {
-                spaceFillerStub.mockReturnValueOnce(Promise.resolve(2));
-                spaceFillerStub.mockReturnValueOnce(Promise.resolve(8));
-                return _.addInlineAds().then(countAdded => {
-                    expect(countAdded).toEqual(10);
-                });
-            });
         });
 
         describe('Spacefinder rules', () => {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -8,6 +8,7 @@ import {
     getBreakpoint as getBreakpoint_,
     isBreakpoint as isBreakpoint_,
 } from 'lib/detect';
+import { noop } from 'lib/noop';
 
 const getViewport: any = getViewport_;
 const getBreakpoint: any = getBreakpoint_;
@@ -39,7 +40,7 @@ jest.mock('lib/config', () => ({ page: {} }));
 
 const spaceFillerStub: JestMockFn<*, *> = (spaceFiller.fillSpace: any);
 const getFirstRulesUsed = () =>
-    init().then(() => {
+    init(noop, noop).then(() => {
         const firstCall = spaceFillerStub.mock.calls[0];
         return firstCall[0];
     });
@@ -59,14 +60,14 @@ describe('Article Body Adverts', () => {
 
     it('should exit if commercial feature disabled', () => {
         commercialFeatures.articleBodyAdverts = false;
-        return init().then(executionResult => {
+        return init(noop, noop).then(executionResult => {
             expect(executionResult).toBe(false);
             expect(spaceFillerStub).not.toHaveBeenCalled();
         });
     });
 
     it('should call space-filler`s insertion method with the correct arguments', () =>
-        init().then(() => {
+        init(noop, noop).then(() => {
             expect(spaceFillerStub).toHaveBeenCalled();
             const firstCallArgs = spaceFillerStub.mock.calls[0];
             const rulesArg = firstCallArgs[0];
@@ -87,7 +88,7 @@ describe('Article Body Adverts', () => {
         });
 
         it('its first call to space-filler uses the inline-merch rules', () =>
-            init().then(() => {
+            init(noop, noop).then(() => {
                 const firstCallArgs = spaceFillerStub.mock.calls[0];
                 const rules = firstCallArgs[0];
 
@@ -100,7 +101,7 @@ describe('Article Body Adverts', () => {
             const paragraph = document.createElement('p');
             fixture.appendChild(paragraph);
 
-            return init().then(() => {
+            return init(noop, noop).then(() => {
                 const firstCall = spaceFillerStub.mock.calls[0];
                 const writer = firstCall[1];
                 writer([paragraph]);

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -150,26 +150,6 @@ describe('Article Body Adverts', () => {
                     expect(countAdded).toEqual(10);
                 });
             });
-
-            it('inserts the third+ adverts with greater vertical spacing', () =>
-                // We do not want the same ad-density on long-read
-                // articles that we have on shorter pieces
-                init().then(() => {
-                    expect(spaceFillerStub).toHaveBeenCalledTimes(2);
-                    const longArticleInsertCalls = spaceFillerStub.mock.calls.slice(
-                        2
-                    );
-                    const longArticleInsertRules = longArticleInsertCalls.map(
-                        call => call[0]
-                    );
-                    longArticleInsertRules.forEach(ruleset => {
-                        const adSlotSpacing = ruleset.selectors[' .ad-slot'];
-                        expect(adSlotSpacing).toEqual({
-                            minAbove: 1300,
-                            minBelow: 1300,
-                        });
-                    });
-                }));
         });
 
         describe('Spacefinder rules', () => {


### PR DESCRIPTION
## What does this change?
In anticipation of further spacefinder AB tests this PR:

- Ensures that the performance timings (sent to the data-lake) capture the true duration that it takes to insert adverts into the body. Currently only the time taken to insert the inline-merch slot is tracked.

- Removes "long article" rules for inline2 and onwards.

- Removes the requirement for inline1 and inline2 to have succeeded before trying to place further inline ads.

## What is the value of this and can you measure success?
Allows a few more inline2 .. inline10 ads to be placed in articles and simplifies the spacefinder logic a bit.