### PR TITLE
Remove/extend switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -102,7 +102,7 @@ trait ABTestSwitches {
     "Point the subscribe link in the header to a subscriptions-only version of the support site",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 1),
+    sellByDate = new LocalDate(2018, 3, 12),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -333,7 +333,7 @@ trait CommercialSwitches {
     description = "Include the blockthrough script for testing the vendors effectiveness at circumventing ad-blocking.",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 1),
+    sellByDate = new LocalDate(2018, 3, 16),
     exposeClientSide = false
    )
 

--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -15,16 +15,6 @@ trait IdentitySwitches {
     exposeClientSide = true
   )
 
-  val IdentityPointToConsentJourneyPage = Switch(
-    SwitchGroup.Identity,
-    "id-point-to-consent-journey-page",
-    "If switched on, several endpoints will redirect qualifying users to the Journey page to repermission",
-    owners = Seq(Owner.withGithub("mario-galic"), Owner.withGithub("walaura")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 1),
-    exposeClientSide = false
-  )
-
   val IdentityShowOptInEngagementBanner = Switch(
     SwitchGroup.Identity,
     "id-show-opt-in-engagement-banner",

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -1,7 +1,6 @@
 package actions
 
 import actions.AuthenticatedActions.AuthRequest
-import conf.switches.Switches.{IdentityPointToConsentJourneyPage}
 import idapiclient.IdApiClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -126,15 +125,12 @@ class AuthenticatedActions(
       override val executionContext = ec
 
       def filter[A](request: AuthRequest[A]) = {
-        if (IdentityPointToConsentJourneyPage.isSwitchedOn)
-          redirectService.toProfileRedirect(request.user, request).map { redirect =>
-            if (redirect.isAllowedFrom(pageId))
-              Some(sendUserToUserRedirectDecision(request, redirect))
-            else
-              None
-          }
-        else
-          Future.successful(None)
+        redirectService.toProfileRedirect(request.user, request).map { redirect =>
+          if (redirect.isAllowedFrom(pageId))
+            Some(sendUserToUserRedirectDecision(request, redirect))
+          else
+            None
+        }
       }
     }
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -5,7 +5,6 @@
 @import services.EmailPrefsData
 @import services.{ProfileRedirect}
 @import controllers.editprofile.ProfileForms
-@import conf.switches.Switches.IdentityPointToConsentJourneyPage
 
 @import services.NoRedirect
 @(
@@ -41,7 +40,7 @@
             data-pushstate-url="@url"
             @dataTestId.map{idValue => data-test-id="@idValue"}
             @{
-                if(redirect.isAllowedFrom(url) && IdentityPointToConsentJourneyPage.isSwitchedOn)
+                if(redirect.isAllowedFrom(url))
                     Html(s"href='${redirect.url}' data-tabs-ignore='true'")
                 else
                     Html(s"href='$url'")

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -69,7 +69,6 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(recentlyAuthedUser))
       when(client.me(any[Auth])).thenReturn(Future(Right(user)))
       when(mockFunc.apply(1)) thenReturn mock[Result]
-      Switches.IdentityPointToConsentJourneyPage.switchOn()
       when(profileRedirectService.toProfileRedirect(any[User], any[RequestHeader])).thenReturn(Future(NoRedirect))
 
       val result = actions.manageAccountRedirectAction(originalUrl).apply(callMock)(request)

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -471,7 +471,7 @@ import scala.concurrent.Future
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
         val result = controller.displayEmailPrefsForm(false, None).apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
+        status(result) should be(303)
         contentAsString(result) should not include (EmailNewsletters.guardianTodayUk.name)
       }
       "display Guardian Today UK newsletter" in new EditProfileFixture {


### PR DESCRIPTION
## What does this change?
- Removes the expired `IdentityPointToConsentJourneyPage` switch and all the checks for it
- Extends `ab-acquisitions-header-subscribe-means-subscribe` switch by 11 days