### PR TITLE
Contributions EUR header test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -125,4 +125,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 3, 13), // Tues 13th March (but should be complete by the 8th)
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-header-eur-support",
+    "Points the 'support the guardian' link in the header to the eur version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 17),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,13 +5,13 @@ import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquis
 import { unrulyPerformanceTest } from 'common/modules/experiments/tests/unruly-performance';
 import { commercialLazyLoading } from 'common/modules/experiments/tests/commercial-lazy-loading';
 import { acquisitionsHeaderSubscribeMeansSubscribe } from 'common/modules/experiments/tests/acquisitions-header-subscribe-means-subscribe';
-import { acquisitionsHeaderEURSupport } from 'common/modules/experiments/tests/acquisitions-header-eur-support';
+import { acquisitionsHeaderEurSupport } from 'common/modules/experiments/tests/acquisitions-header-eur-support';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     unrulyPerformanceTest,
     acquisitionsHeaderSubscribeMeansSubscribe,
-    acquisitionsHeaderEURSupport,
+    acquisitionsHeaderEurSupport,
     commercialLazyLoading,
 ].filter(Boolean);
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,11 +5,13 @@ import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquis
 import { unrulyPerformanceTest } from 'common/modules/experiments/tests/unruly-performance';
 import { commercialLazyLoading } from 'common/modules/experiments/tests/commercial-lazy-loading';
 import { acquisitionsHeaderSubscribeMeansSubscribe } from 'common/modules/experiments/tests/acquisitions-header-subscribe-means-subscribe';
+import { acquisitionsHeaderEURSupport } from 'common/modules/experiments/tests/acquisitions-header-eur-support';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     unrulyPerformanceTest,
     acquisitionsHeaderSubscribeMeansSubscribe,
+    acquisitionsHeaderEURSupport,
     commercialLazyLoading,
 ].filter(Boolean);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -6,7 +6,6 @@ import {
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
-const campaignId = 'AcquisitionsEurSupport';
 const abTestName = 'AcquisitionsHeaderEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 
@@ -42,7 +41,7 @@ const modifySupportTheGuardianLink = (variant: variantName): void => {
 
 export const acquisitionsHeaderEurSupport: AcquisitionsABTest = {
     id: abTestName,
-    campaignId,
+    campaignId: abTestName,
     componentType,
     start: '2018-03-01',
     expiry: '2018-04-17',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -6,6 +6,7 @@ import {
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
+const campaignId =  'AcquisitionsEurSupport'
 const abTestName = 'AcquisitionsHeaderEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 
@@ -41,7 +42,7 @@ const modifySupportTheGuardianLink = (variant: variantName): void => {
 
 export const acquisitionsHeaderEurSupport: AcquisitionsABTest = {
     id: abTestName,
-    campaignId: abTestName,
+    campaignId,
     componentType,
     start: '2018-03-01',
     expiry: '2018-04-17',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -39,7 +39,7 @@ const modifySupportTheGuardianLink = (variant: variantName): void => {
     );
 };
 
-export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {
+export const acquisitionsHeaderEurSupport: AcquisitionsABTest = {
     id: abTestName,
     campaignId: abTestName,
     componentType,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -1,0 +1,68 @@
+// @flow
+import { getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion } from 'lib/geolocation';
+import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
+
+const componentType = 'ACQUISITIONS_HEADER';
+const abTestName = 'AcquisitionsHeaderEURSupport';
+const EURsupportURL = 'https://support.theguardian.com/eu';
+
+type variantName = 'control' | 'support_contribute';
+
+const modifySupportTheGuardianLink = (variant: variantName): void => {
+    [...document.querySelectorAll('.js-change-become-member-link')].forEach(
+        supportTheGuardianLink => {
+            if (!(supportTheGuardianLink instanceof HTMLAnchorElement)) {
+                return;
+            }
+
+            let supportTheGuardianURL = new URL(supportTheGuardianLink.href);
+
+            if (variant === 'support_contribute') {
+                supportTheGuardianURL = new URL(EURsupportURL);
+            }
+
+            const supportTheGuardianUrlWithTestData = updateAcquisitionData(
+                supportTheGuardianURL,
+                {
+                    abTest: {
+                        name: abTestName,
+                        variant,
+                    },
+                }
+            );
+
+            supportTheGuardianLink.href = supportTheGuardianUrlWithTestData.toString();
+    });
+};
+
+export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    componentType,
+    start: '2018-03-07',
+    expiry: '2018-04-17',
+    author: 'Santiago Villa Fernandez',
+    description:
+        'Points the "support the guardian" link in the header to the eur version of the support site',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV 2.0',
+    audienceCriteria: 'All EUR transaction web traffic.',
+    dataLinkNames: '',
+    idealOutcome: 'We get more money when we tailor the destination to the CTA',
+    canRun: () => geolocationGetSupporterPaymentRegion() === 'EU',
+    variants: [
+        {
+            id: 'control',
+            test: () => {
+                modifySupportTheGuardianLink('control');
+            },
+        },
+        {
+            id: 'support_contribute',
+            test: () => {
+                modifySupportTheGuardianLink('support_contribute');
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -6,7 +6,7 @@ import {
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
-const campaignId =  'AcquisitionsEurSupport';
+const campaignId = 'AcquisitionsEurSupport';
 const abTestName = 'AcquisitionsHeaderEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -6,7 +6,7 @@ import {
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
-const campaignId =  'AcquisitionsEurSupport'
+const campaignId =  'AcquisitionsEurSupport';
 const abTestName = 'AcquisitionsHeaderEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -6,7 +6,7 @@ import {
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
-const abTestName = 'AcquisitionsHeaderEURSupport';
+const abTestName = 'AcquisitionsHeaderEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 
 type variantName = 'control' | 'support_contribute';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -43,7 +43,7 @@ export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {
     id: abTestName,
     campaignId: abTestName,
     componentType,
-    start: '2018-03-07',
+    start: '2018-03-01',
     expiry: '2018-04-17',
     author: 'Santiago Villa Fernandez',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -32,7 +32,7 @@ const modifySupportTheGuardianLink = (variant: variantName): void => {
             );
 
             supportTheGuardianLink.href = supportTheGuardianUrlWithTestData.toString();
-    });
+        });
 };
 
 export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -53,7 +53,6 @@ export const acquisitionsHeaderEurSupport: AcquisitionsABTest = {
     audienceOffset: 0,
     successMeasure: 'AV 2.0',
     audienceCriteria: 'All EUR transaction web traffic.',
-    dataLinkNames: '',
     idealOutcome: 'We get more money when we tailor the destination to the CTA',
     canRun: () =>
         geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'EU',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-eur-support.js
@@ -1,5 +1,8 @@
 // @flow
-import { getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion } from 'lib/geolocation';
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
 import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
 
 const componentType = 'ACQUISITIONS_HEADER';
@@ -32,7 +35,8 @@ const modifySupportTheGuardianLink = (variant: variantName): void => {
             );
 
             supportTheGuardianLink.href = supportTheGuardianUrlWithTestData.toString();
-        });
+        }
+    );
 };
 
 export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {
@@ -50,7 +54,8 @@ export const acquisitionsHeaderEURSupport: AcquisitionsABTest = {
     audienceCriteria: 'All EUR transaction web traffic.',
     dataLinkNames: '',
     idealOutcome: 'We get more money when we tailor the destination to the CTA',
-    canRun: () => geolocationGetSupporterPaymentRegion() === 'EU',
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'EU',
     variants: [
         {
             id: 'control',


### PR DESCRIPTION
# Related PRs:
https://github.com/guardian/frontend/pull/19268
https://github.com/guardian/frontend/pull/19279

## What does this change?
Added test for EUR Header


## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots

## Tested in CODE?
Not yet
