### PR TITLE
Add oriel to more page types

### DIFF
--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.WeAreHiring
+import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, GalleryPage, Page}
@@ -9,7 +9,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
@@ -37,6 +37,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.WeAreHiring
+import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.ApplicationContext
@@ -14,7 +14,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
 
@@ -39,6 +39,7 @@ object IndexHtml {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
         titleTag(),
         metaData(),
         headContent,

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.WeAreHiring
+import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
 import controllers.InteractivePage
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -10,7 +10,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
@@ -46,6 +46,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.WeAreHiring
+import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.{ApplicationContext, ContributorsListing, PreferencesMetaData, StandalonePage, SubjectsListing, TagIndexPage}
@@ -11,7 +11,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
 import html.HtmlPageHelpers.ContentCSSFile
@@ -43,6 +43,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.WeAreHiring
+import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, PressedPage}
@@ -10,7 +10,7 @@ import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments._
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.stacked
@@ -45,6 +45,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
         titleTag(),
         metaData(),
         frontMeta(),


### PR DESCRIPTION
## What does this change?

This adds the Oriel full integration tag to more pages; fronts, tag pages, interactives and galleries.

## Tested in CODE?

Not yet!