### PR TITLE
Changed grid fallback for article headers

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1085,6 +1085,7 @@
         grid-area: report;
     }
 }
+// Prevents badge overlapping meta in paidfor template when css grid is not supported
 .content__subhead {
     .content__meta-container {
         @include mq($from: leftCol) {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1069,8 +1069,6 @@
             // adds enough space so that this doesn't clash with the content labels if css gris is not supported
             top: gs-height(3);
 
-            position: static !important;
-
             @supports (display: grid) {
                 grid-area: meta;
                 position: relative !important;
@@ -1085,6 +1083,13 @@
     /*** position match stats ***/
     .matchreport {
         grid-area: report;
+    }
+}
+.content__subhead {
+    .content__meta-container {
+        @include mq($from: leftCol) {
+            top: 0;
+        }
     }
 }
 .paid-content {


### PR DESCRIPTION
A css change [here](https://github.com/guardian/frontend/pull/19244) resulted in articles having a large gap between standfirst and main media:

![1](https://user-images.githubusercontent.com/14570016/36907790-68c9c1b4-1e31-11e8-8853-a3e0915d15b4.png)

This is all related to the slight template differences between paidfor and article. CSS grid fallback of absolute positioned meta container was looking different between templates because of the containing `content__subhead`. I've taken this into account with the fallback.
