### PR TITLE
Make gdpr optin alert more engaging by removing the close button

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -48,6 +48,7 @@ rules:
         - osx-font-smoothing
         - grid-column-gap
         - grid-row-gap
+        - grid-gap
   no-trailing-zero: 1
   no-url-protocols: 0
 

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -5,8 +5,12 @@ import { Message } from 'common/modules/ui/message';
 import { inlineSvg } from 'common/views/svgs';
 import config from 'lib/config';
 import ophan from 'ophan/ng';
+import userPrefs from 'common/modules/user-prefs';
 
 const messageCode: string = 'gdpr-opt-in-jan-18';
+const messageHidAtPref: string = `${messageCode}-hid-at`;
+const messageCloseBtn = 'js-gdpr-oi-close';
+const remindMeLaterInterval = 24 * 60 * 60 * 1000;
 const medium: string = new URL(window.location.href).searchParams.get(
     'utm_medium'
 );
@@ -17,18 +21,55 @@ type ApiUser = {
     },
 };
 
+type Link = {
+    title: string,
+    href: ?string,
+    className: ?(string[]),
+    name: string,
+};
+
+type Template = {
+    image: string,
+    title: string,
+    cta: string,
+    links: Link[],
+};
+
 const targets = {
     landing: 'https://gu.com/staywithus',
     journey: `${config.get('page.idUrl')}/consents/staywithus`,
 };
 
-const template = {
+const template: Template = {
     image: config.get('images.identity.opt-in'),
-    title: `We’re changing how we communicate with readers. Let us know what emails you want to receive <strong>before 30 April</strong>, or&nbsp;<a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
-        targets.landing
-    }">find&nbsp;out&nbsp;more</a>.`,
+    title: `We’re changing how we communicate with readers. Let us know what emails you want to receive <strong>before 30 April</strong>.`,
     cta: `Opt in now`,
+    links: [
+        {
+            title: 'Find out more',
+            href: targets.landing,
+            className: [],
+            name: 'gdpr-oi-campaign : alert : to-landing',
+        },
+        {
+            title: 'remind me later',
+            className: [messageCloseBtn],
+            name: 'gdpr-oi-campaign : alert : close',
+        },
+    ],
 };
+const linkHtml = (link): string => `
+    <a 
+        ${link.href ? `href="${link.href}"` : ''} 
+        ${
+            link.className.length > 0
+                ? `class="${link.className.join(' ')}"`
+                : ''
+        }
+        data-link-name="${link.name}"
+    >
+        ${link.title}</a>
+`;
 
 const templateHtml: string = `
     <div id="site-message__message">
@@ -39,6 +80,7 @@ const templateHtml: string = `
             <div class="identity-gdpr-oi-alert__body">
                 <div class="identity-gdpr-oi-alert__text">
                     ${template.title}
+                    ${template.links.map(linkHtml).join(' or ')}.
                 </div>
                 <a class="identity-gdpr-oi-alert__cta" target="_blank" href="${
                     targets.journey
@@ -50,13 +92,30 @@ const templateHtml: string = `
         </div>
     </div>`;
 
+const shouldDisplayBasedOnRemindMeLaterInterval = (): boolean => {
+    const hidAt = userPrefs.get(messageHidAtPref);
+    if (!hidAt) return true;
+    return Date.now() > hidAt + remindMeLaterInterval;
+};
+
+const shouldDisplayBasedOnExperimentFlag = (): boolean =>
+    config.get('tests.gdprOptinAlertVariant') === 'variant';
+
+const shouldDisplayBasedOnMedium = (): boolean =>
+    medium !== null && medium.toLowerCase() === 'email';
+
 const shouldDisplayOptInBanner = (): Promise<boolean> =>
     new Promise(decision => {
-        if (config.get('tests.gdprOptinAlertVariant') !== 'variant') {
+        const shouldDisplay = [
+            shouldDisplayBasedOnExperimentFlag(),
+            shouldDisplayBasedOnRemindMeLaterInterval(),
+            shouldDisplayBasedOnMedium(),
+        ];
+
+        if (!shouldDisplay.every(_ => _ === true)) {
             return decision(false);
         }
-        if (medium === null || medium.toLowerCase() !== 'email')
-            return decision(false);
+
         getUserFromApi((user: ApiUser) => {
             if (user === null || !user.statusFields.hasRepermissioned)
                 decision(true);
@@ -64,17 +123,32 @@ const shouldDisplayOptInBanner = (): Promise<boolean> =>
         });
     });
 
+const hide = (msg: Message) => {
+    msg.hide();
+    userPrefs.set(messageHidAtPref, Date.now());
+};
+
 const optInEngagementBannerInit = (): void => {
     shouldDisplayOptInBanner().then((shouldIt: boolean) => {
         if (shouldIt) {
-            ophan.record({
-                component: 'gdpr-oi-campaign-alert',
-                action: 'gdpr-oi-campaign : alert : show',
-            });
-            new Message(messageCode, {
+            const msg = new Message(messageCode, {
                 cssModifierClass: 'gdpr-opt-in',
+                permanent: true,
                 siteMessageComponentName: messageCode,
-            }).show(templateHtml);
+            });
+            const shown = msg.show(templateHtml);
+            if (shown) {
+                ophan.record({
+                    component: 'gdpr-oi-campaign-alert',
+                    action: 'gdpr-oi-campaign : alert : show',
+                });
+                document
+                    .querySelector(`.${messageCloseBtn}`)
+                    .addEventListener('click', ev => {
+                        ev.preventDefault();
+                        hide(msg);
+                    });
+            }
         }
     });
 };

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -53,7 +53,7 @@ const templateHtml: string = `
                     ${template.title}
                 </div>
                 <div class="identity-gdpr-oi-alert__cta-space">
-                    <a data-class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
+                    <a data-link-name="gdpr-oi-campaign : alert : remind-me-later" class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
                         messageCloseBtn
                     }">
                         ${template.remindMeLater}

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -35,7 +35,7 @@ const targets = {
 
 const template: Template = {
     image: config.get('images.identity.opt-in'),
-    title: `We’re changing how we communicate with you. Let us know <strong>before April 30</strong> which emails you wish to continue receiving. <a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
+    title: `We’re changing how we communicate with you. Let us know <strong>before 30 April</strong> which emails you wish to continue receiving. <a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
         targets.landing
     }">Find out more</a> or click Continue.`,
     cta: `Continue`,

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -25,7 +25,7 @@ type Template = {
     image: string,
     title: string,
     cta: string,
-    links: Link[],
+    remindMeLater: string,
 };
 
 const targets = {
@@ -39,7 +39,7 @@ const template: Template = {
         targets.landing
     }">Find out more</a> or click Continue.`,
     cta: `Continue`,
-    remindMeLater: `Remind me later`
+    remindMeLater: `Remind me later`,
 };
 
 const templateHtml: string = `
@@ -119,12 +119,15 @@ const optInEngagementBannerInit = (): void => {
                     component: 'gdpr-oi-campaign-alert',
                     action: 'gdpr-oi-campaign : alert : show',
                 });
-                document
-                    .querySelector(`.${messageCloseBtn}`)
-                    .addEventListener('click', ev => {
-                        ev.preventDefault();
-                        hide(msg);
-                    });
+                const closeButtonEl: ?HTMLElement = document.querySelector(
+                    `.${messageCloseBtn}`
+                );
+                if (!closeButtonEl)
+                    throw new Error('gdpr-oi-campaign : Missing close button');
+                closeButtonEl.addEventListener('click', (ev: MouseEvent) => {
+                    ev.preventDefault();
+                    hide(msg);
+                });
             }
         }
     });

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -21,13 +21,6 @@ type ApiUser = {
     },
 };
 
-type Link = {
-    title: string,
-    href: ?string,
-    className: ?(string[]),
-    name: string,
-};
-
 type Template = {
     image: string,
     title: string,
@@ -42,34 +35,12 @@ const targets = {
 
 const template: Template = {
     image: config.get('images.identity.opt-in'),
-    title: `We’re changing how we communicate with readers. Let us know what emails you want to receive <strong>before 30 April</strong>.`,
-    cta: `Opt in now`,
-    links: [
-        {
-            title: 'Find out more',
-            href: targets.landing,
-            className: [],
-            name: 'gdpr-oi-campaign : alert : to-landing',
-        },
-        {
-            title: 'remind me later',
-            className: [messageCloseBtn],
-            name: 'gdpr-oi-campaign : alert : close',
-        },
-    ],
+    title: `We’re changing how we communicate with you. Let us know <strong>before April 30</strong> which emails you wish to continue receiving. <a data-link-name="gdpr-oi-campaign : alert : to-landing" href="${
+        targets.landing
+    }">Find out more</a> or click Continue.`,
+    cta: `Continue`,
+    remindMeLater: `Remind me later`
 };
-const linkHtml = (link): string => `
-    <a 
-        ${link.href ? `href="${link.href}"` : ''} 
-        ${
-            link.className.length > 0
-                ? `class="${link.className.join(' ')}"`
-                : ''
-        }
-        data-link-name="${link.name}"
-    >
-        ${link.title}</a>
-`;
 
 const templateHtml: string = `
     <div id="site-message__message">
@@ -80,14 +51,20 @@ const templateHtml: string = `
             <div class="identity-gdpr-oi-alert__body">
                 <div class="identity-gdpr-oi-alert__text">
                     ${template.title}
-                    ${template.links.map(linkHtml).join(' or ')}.
                 </div>
-                <a class="identity-gdpr-oi-alert__cta" target="_blank" href="${
-                    targets.journey
-                }" data-link-name="gdpr-oi-campaign : alert : to-consents">
-                    ${template.cta}
-                    ${inlineSvg('arrowWhiteRight')}
-                </a>
+                <div class="identity-gdpr-oi-alert__cta-space">
+                    <a data-class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
+                        messageCloseBtn
+                    }">
+                        ${template.remindMeLater}
+                    </a>
+                    <a class="identity-gdpr-oi-alert__cta" target="_blank" href="${
+                        targets.journey
+                    }" data-link-name="gdpr-oi-campaign : alert : to-consents">
+                        ${template.cta}
+                        ${inlineSvg('arrowWhiteRight')}
+                    </a>
+                </div>
             </div>
         </div>
     </div>`;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1050,7 +1050,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 }
 
 .identity-gdpr-oi-alert__body {
-    margin: $gs-gutter / 4 0 $gs-gutter / 1.25 $gs-gutter;
+    margin: $gs-gutter / 4 $gs-gutter $gs-gutter / 1.25 $gs-gutter;
     max-width: gs-span(6);
     .identity-gdpr-oi-alert__cta {
         margin-left: -.1em;
@@ -1060,7 +1060,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         flex: 1 1 0;
         .identity-gdpr-oi-alert__cta {
             margin-left: $gs-gutter * -.9;
-            margin-right: -$gs-gutter * -.9;
+            width: 90%
         }
     }
 }
@@ -1068,6 +1068,9 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .identity-gdpr-oi-alert__text {
     @include fs-bodyCopy(1);
     margin-bottom: $gs-gutter;
+    a {
+        white-space: nowrap;
+    }
     @include mq(tablet) {
         @include fs-bodyCopy(2, true);
     }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1134,7 +1134,7 @@ a.identity-gdpr-oi-alert__cta {
         &:hover {
             background: none;
             color: $garnett-neutral-1;
-            border: 1px solid $garnett-neutral-6;
+            border: 1px solid darken($garnett-neutral-4, 10%);
         }
     }
     &:hover {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1052,15 +1052,14 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .identity-gdpr-oi-alert__body {
     margin: $gs-gutter / 4 $gs-gutter $gs-gutter / 1.25 $gs-gutter;
     max-width: gs-span(6);
-    .identity-gdpr-oi-alert__cta {
+    .identity-gdpr-oi-alert__cta-space {
         margin-left: -.1em;
         margin-right: -.1em;
     }
     @include mq($until: tablet) {
         flex: 1 1 0;
-        .identity-gdpr-oi-alert__cta {
+        .identity-gdpr-oi-alert__cta-space {
             margin-left: $gs-gutter * -.9;
-            width: 90%
         }
     }
 }
@@ -1096,21 +1095,48 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     }
 }
 
+.identity-gdpr-oi-alert__cta-space {
+    display: grid;
+    grid-auto-flow: row;
+    grid-auto-columns: auto 1fr;
+    grid-gap: $gs-gutter / 4;
+    .identity-gdpr-oi-alert__cta {
+        margin-bottom: $gs-gutter / 4;
+        @supports(display:grid) {
+            margin-bottom: 0;
+        }
+    }
+    @include mq(tablet) {
+        grid-auto-flow: column;
+    }
+}
+
 a.identity-gdpr-oi-alert__cta {
     @include circular;
     @include fs-textSans(3)
     display: inline-flex;
+    white-space: nowrap;
     color: #ffffff;
     text-decoration: none;
     background: $news-garnett-media-main-1;
     font-weight: 800;
-    height: $gs-baseline*3.8;
+    height: $gs-baseline*3.5;
     padding: 0 $gs-gutter;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    width: 100%;
     transition: .125s;
+    box-sizing: border-box;
+    &.identity-gdpr-oi-alert__cta--sub {
+        background: none;
+        color: $garnett-neutral-7;
+        border: 1px solid $garnett-neutral-4;
+        &:hover {
+            background: none;
+            color: $garnett-neutral-1;
+            border: 1px solid $garnett-neutral-6;
+        }
+    }
     &:hover {
         background-color: darken($news-garnett-media-main-1, 5%);
         span {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1102,7 +1102,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     grid-gap: $gs-gutter / 4;
     .identity-gdpr-oi-alert__cta {
         margin-bottom: $gs-gutter / 4;
-        @supports(display:grid) {
+        @supports(display: grid) {
             margin-bottom: 0;
         }
     }


### PR DESCRIPTION
## What does this change?
Changes the gdpr optin close button to a [remind me later] link that closes the alert but only for 24 hours

![screen shot 2018-03-02 at 4 49 46 pm](https://user-images.githubusercontent.com/11539094/36910895-ddd9247e-1e39-11e8-8f41-f3c6605d68ab.png)
