### PR TITLE
Contributions EUR engagement banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -125,4 +125,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 3, 13), // Tues 13th March (but should be complete by the 8th)
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-engagement-banner-eur-support",
+    "Points the 'support the guardian' link in the engagement banner to the eur version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 17),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
@@ -6,12 +6,13 @@ import {
 } from 'lib/geolocation';
 
 const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const campaignId = 'AcquisitionsEurSupport';
 const abTestName = 'AcquisitionsEngagementBannerEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 
 export const AcquisitionsEngagementBannerEurSupport: AcquisitionsABTest = {
     id: abTestName,
-    campaignId: abTestName,
+    campaignId,
     start: '2018-03-01',
     expiry: '2018-04-17',
     author: 'Santiago Villa Fernandez',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
@@ -3,7 +3,7 @@ import { makeBannerABTestVariants } from 'common/modules/commercial/contribution
 import {
     getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
     getSync as geolocationGetSync,
-} from 'lib/geolocation'
+} from 'lib/geolocation';
 
 const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
 const abTestName = 'AcquisitionsEngagementBannerEurSupport';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
@@ -6,13 +6,12 @@ import {
 } from 'lib/geolocation';
 
 const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
-const campaignId = 'AcquisitionsEurSupport';
 const abTestName = 'AcquisitionsEngagementBannerEurSupport';
 const EURsupportURL = 'https://support.theguardian.com/eu';
 
 export const AcquisitionsEngagementBannerEurSupport: AcquisitionsABTest = {
     id: abTestName,
-    campaignId,
+    campaignId: abTestName,
     start: '2018-03-01',
     expiry: '2018-04-17',
     author: 'Santiago Villa Fernandez',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-eur-support.js
@@ -1,0 +1,45 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation'
+
+const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName = 'AcquisitionsEngagementBannerEurSupport';
+const EURsupportURL = 'https://support.theguardian.com/eu';
+
+export const AcquisitionsEngagementBannerEurSupport: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-03-01',
+    expiry: '2018-04-17',
+    author: 'Santiago Villa Fernandez',
+    description:
+        'Points the "support the guardian" link in the engagement banner to the eur version of the support site',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'All EUR transaction web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome:
+        'We channel the audience from dotcom to support frontend eu correctly',
+    componentType,
+    showForSensitive: true,
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'EU',
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'support_contribute',
+            options: {
+                engagementBannerParams: {
+                    linkUrl: EURsupportURL,
+                    buttonCaption: 'Support The Guardian',
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -6,4 +6,8 @@ import { AcquisitionsEngagementBannerEurSupport } from 'common/modules/experimen
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [AcquisitionsBannerCtaContribute, SupportEngagementBannerCircles, AcquisitionsEngagementBannerEurSupport];
+> = [
+    AcquisitionsBannerCtaContribute,
+    SupportEngagementBannerCircles,
+    AcquisitionsEngagementBannerEurSupport,
+];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -2,7 +2,8 @@
 
 import { AcquisitionsBannerCtaContribute } from 'common/modules/experiments/tests/acquisitions-banner-cta-contribute';
 import { SupportEngagementBannerCircles } from 'common/modules/experiments/tests/support-engagement-banner-circles';
+import { AcquisitionsEngagementBannerEurSupport } from 'common/modules/experiments/tests/acquisitions-engagement-banner-eur-support';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [AcquisitionsBannerCtaContribute, SupportEngagementBannerCircles];
+> = [AcquisitionsBannerCtaContribute, SupportEngagementBannerCircles, AcquisitionsEngagementBannerEurSupport];


### PR DESCRIPTION
# Related PRs
https://github.com/guardian/frontend/pull/19279
https://github.com/guardian/frontend/pull/19263
## What does this change?
Add test for engagement banner
## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
Not yet 
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
