### PR TITLE
stop standard tablet getting styled as an immersive card

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -130,15 +130,22 @@ $pillars: (
         }
     }
 
+    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__kicker,
     &.fc-item--list-media-tablet.fc-item--type-immersive .fc-item__kicker,
     &.fc-item--list-tablet.fc-item--type-immersive .fc-item__kicker
     {
         color: map-get($palette, kicker);
     }
 
+    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__standfirst {
+        color: $garnett-neutral-1;
+    }
+
+    &.fc-item--standard-tablet.fc-item--type-immersive .inline-icon,
+    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__meta,
     &.fc-item--list-media-tablet.fc-item--type-immersive .inline-icon,
-    &.fc-item--list-tablet.fc-item--type-immersive .inline-icon,
     &.fc-item--list-media-tablet.fc-item--type-immersive .fc-item__meta,
+    &.fc-item--list-tablet.fc-item--type-immersive .inline-icon,
     &.fc-item--list-tablet.fc-item--type-immersive .fc-item__meta
     {
         fill: $garnett-neutral-6;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -28,10 +28,6 @@
         }
     }
 
-    &.fc-item--standard-tablet .fc-item__content {
-        position: absolute;
-    }
-
     .fc-item__headline {
         color: #ffffff;
     }
@@ -51,10 +47,6 @@
         @include mq($from: tablet) {
             margin-top: $gs-baseline * 2;
         }
-    }
-
-    &.fc-item--standard-tablet .fc-item__standfirst {
-        display: none;
     }
 
     .fc-sublink__title {
@@ -105,7 +97,7 @@
             display: block;
 
             .fc-sublinks {
-                margin-left: 0; 
+                margin-left: 0;
             }
         }
     }
@@ -188,7 +180,6 @@
             }
         }
 
-        &.fc-item--standard-tablet,
         &.fc-item--third-tablet,
         &.fc-item--half-tablet,
         &.fc-item--full-media-100-tablet,


### PR DESCRIPTION
## What does this change?
As per request from fronts editors. I have removed the styling for immersive cards when they get down to the standard card size. 

**Before**
![picture 1163](https://user-images.githubusercontent.com/11950919/36914484-62912fb2-1e45-11e8-9040-1ca9297eef2d.png)

**After**
![picture 1164](https://user-images.githubusercontent.com/11950919/36914473-5a9678f8-1e45-11e8-9dbd-1494988aed66.png)


