### PR TITLE
Fix close slots syntax

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -36,12 +36,12 @@ const adFreeSlotRemove = (): Promise<void> => {
     adSlots = adSlots.filter(shouldDisableAdSlotWhenAdFree);
     mpuCandidates = mpuCandidates.filter(shouldDisableAdSlotWhenAdFree);
 
-    return fastdom.write(
-        () => {
-            adSlots.forEach((adSlot: Element) => adSlot.remove());
-            mpuCandidates.forEach((candidate: Element) => candidate.classList.add(mpuHiderClass));
-        }
-    );
+    return fastdom.write(() => {
+        adSlots.forEach((adSlot: Element) => adSlot.remove());
+        mpuCandidates.forEach((candidate: Element) =>
+            candidate.classList.add(mpuHiderClass)
+        );
+    });
 };
 
 export { closeDisabledSlots, adFreeSlotRemove };

--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -37,10 +37,10 @@ const adFreeSlotRemove = (): Promise<void> => {
     mpuCandidates = mpuCandidates.filter(shouldDisableAdSlotWhenAdFree);
 
     return fastdom.write(
-        () => adSlots.forEach((adSlot: Element) => adSlot.remove()),
-        mpuCandidates.forEach((candidate: Element) =>
-            candidate.classList.add(mpuHiderClass)
-        )
+        () => {
+            adSlots.forEach((adSlot: Element) => adSlot.remove());
+            mpuCandidates.forEach((candidate: Element) => candidate.classList.add(mpuHiderClass));
+        }
     );
 };
 


### PR DESCRIPTION
## What does this change?

This fixes a call to `fastdom.promise`; the code wants to do two things in it's payload for fastdom promise but instead it is incorrectly running the second statement as a second parameter to `fastdom.promise`; this second parameter should be a context object, but in this case it is going to be the return of `forEach`  which is `undefined`.