### PR TITLE
Set hasRepermissioned as a cookie for the alert to pick up

### DIFF
--- a/static/src/javascripts/lib/cookies.js
+++ b/static/src/javascripts/lib/cookies.js
@@ -1,12 +1,16 @@
 // @flow
-const getShortDomain = (): string => {
-    // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+const getShortDomain = (isCrossSubdomain: ?boolean = false): string => {
     const domain = document.domain || '';
+    // Trim any possible subdomain (will be shared with supporter, identity, etc)
+    if (isCrossSubdomain) {
+        return ['', ...domain.split('.').slice(-2)].join('.');
+    }
+    // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
     return domain.replace(/^(www|m\.code|dev|m)\./, '.');
 };
 
-const getDomainAttribute = (): string => {
-    const shortDomain = getShortDomain();
+const getDomainAttribute = (isCrossSubdomain: ?boolean = false): string => {
+    const shortDomain = getShortDomain(isCrossSubdomain);
     return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
@@ -27,7 +31,12 @@ const removeCookie = (
     }
 };
 
-const addCookie = (name: string, value: string, daysToLive: ?number): void => {
+const addCookie = (
+    name: string,
+    value: string,
+    daysToLive: ?number,
+    isCrossSubdomain: ?boolean = false
+): void => {
     const expires = new Date();
 
     if (daysToLive) {
@@ -39,7 +48,9 @@ const addCookie = (name: string, value: string, daysToLive: ?number): void => {
 
     document.cookie = `${name}=${
         value
-    }; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
+    }; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+        isCrossSubdomain
+    )}`;
 };
 
 const cleanUp = (names: string[]): void => {

--- a/static/src/javascripts/lib/cookies.js
+++ b/static/src/javascripts/lib/cookies.js
@@ -1,5 +1,7 @@
 // @flow
-const getShortDomain = (isCrossSubdomain: ?boolean = false): string => {
+const getShortDomain = (
+    { isCrossSubdomain = false }: { isCrossSubdomain: boolean } = {}
+): string => {
     const domain = document.domain || '';
     // Trim any possible subdomain (will be shared with supporter, identity, etc)
     if (isCrossSubdomain) {
@@ -9,8 +11,10 @@ const getShortDomain = (isCrossSubdomain: ?boolean = false): string => {
     return domain.replace(/^(www|m\.code|dev|m)\./, '.');
 };
 
-const getDomainAttribute = (isCrossSubdomain: ?boolean = false): string => {
-    const shortDomain = getShortDomain(isCrossSubdomain);
+const getDomainAttribute = (
+    { isCrossSubdomain = false }: { isCrossSubdomain: boolean } = {}
+): string => {
+    const shortDomain = getShortDomain({ isCrossSubdomain });
     return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
@@ -35,7 +39,7 @@ const addCookie = (
     name: string,
     value: string,
     daysToLive: ?number,
-    isCrossSubdomain: ?boolean = false
+    isCrossSubdomain: boolean = false
 ): void => {
     const expires = new Date();
 
@@ -48,9 +52,9 @@ const addCookie = (
 
     document.cookie = `${name}=${
         value
-    }; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
-        isCrossSubdomain
-    )}`;
+    }; path=/; expires=${expires.toUTCString()};${getDomainAttribute({
+        isCrossSubdomain,
+    })}`;
 };
 
 const cleanUp = (names: string[]): void => {

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -1,11 +1,13 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
+import userPrefs from 'common/modules/user-prefs';
 
 import loadEnhancers from './modules/loadEnhancers';
 import { show as showModal } from './modules/modal';
 
 const ERR_MALFORMED_HTML = 'Something went wrong';
+const HAS_REPERMISSIONED_LOCALSTORAGE_KEY = 'consents-user-has-repermissioned';
 
 const showJourney = (journeyEl: HTMLElement): Promise<void> =>
     fastdom.write(() => journeyEl.classList.remove('u-h'));
@@ -82,14 +84,20 @@ const submitJourneyAnyway = (buttonEl: HTMLElement): void => {
     });
 };
 
+const setLocalHasRepermissionedFlag = (): void => {
+    /* opt-in-engagement-banner will use this to decide wether to show an alert or not */
+    userPrefs.set(HAS_REPERMISSIONED_LOCALSTORAGE_KEY, true);
+};
+
 const enhanceConsentJourney = (): void => {
     const loaders = [
         ['.identity-consent-journey', showJourney],
         ['.identity-consent-journey', showJourneyAlert],
+        ['.identity-consent-journey', setLocalHasRepermissionedFlag],
         ['.js-identity-consent-journey-continue', submitJourneyAnyway],
         ['#identityConsentsLoadingError', hideLoading],
     ];
     loadEnhancers(loaders);
 };
 
-export { enhanceConsentJourney };
+export { enhanceConsentJourney, HAS_REPERMISSIONED_LOCALSTORAGE_KEY };

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -1,13 +1,13 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import userPrefs from 'common/modules/user-prefs';
+import { addCookie } from 'lib/cookies';
 
 import loadEnhancers from './modules/loadEnhancers';
 import { show as showModal } from './modules/modal';
 
 const ERR_MALFORMED_HTML = 'Something went wrong';
-const HAS_REPERMISSIONED_LOCALSTORAGE_KEY = 'consents-user-has-repermissioned';
+const HAS_REPERMISSIONED_COOKIE_KEY = 'gu_consents_user_has_repermissioned';
 
 const showJourney = (journeyEl: HTMLElement): Promise<void> =>
     fastdom.write(() => journeyEl.classList.remove('u-h'));
@@ -86,7 +86,7 @@ const submitJourneyAnyway = (buttonEl: HTMLElement): void => {
 
 const setLocalHasRepermissionedFlag = (): void => {
     /* opt-in-engagement-banner will use this to decide wether to show an alert or not */
-    userPrefs.set(HAS_REPERMISSIONED_LOCALSTORAGE_KEY, true);
+    addCookie(HAS_REPERMISSIONED_COOKIE_KEY, 'true', null, true);
 };
 
 const enhanceConsentJourney = (): void => {
@@ -100,4 +100,4 @@ const enhanceConsentJourney = (): void => {
     loadEnhancers(loaders);
 };
 
-export { enhanceConsentJourney, HAS_REPERMISSIONED_LOCALSTORAGE_KEY };
+export { enhanceConsentJourney, HAS_REPERMISSIONED_COOKIE_KEY };

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -85,7 +85,7 @@ const submitJourneyAnyway = (buttonEl: HTMLElement): void => {
 };
 
 const setLocalHasRepermissionedFlag = (): void => {
-    /* opt-in-engagement-banner will use this to decide wether to show an alert or not */
+    /* opt-in-engagement-banner will use this to decide whether to show an alert or not */
     addCookie(HAS_REPERMISSIONED_COOKIE_KEY, 'true', null, true);
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -3,6 +3,8 @@
 import { getUserFromApi } from 'common/modules/identity/api';
 import { Message } from 'common/modules/ui/message';
 import { inlineSvg } from 'common/views/svgs';
+import { HAS_REPERMISSIONED_COOKIE_KEY } from 'common/modules/identity/consent-journey';
+import { getCookie } from 'lib/cookies';
 import config from 'lib/config';
 import ophan from 'ophan/ng';
 import userPrefs from 'common/modules/user-prefs';
@@ -75,6 +77,9 @@ const shouldDisplayBasedOnRemindMeLaterInterval = (): boolean => {
     return Date.now() > hidAt + remindMeLaterInterval;
 };
 
+const shouldDisplayBasedOnLocalHasRepermissionedFlag = (): boolean =>
+    getCookie(HAS_REPERMISSIONED_COOKIE_KEY) !== 'true';
+
 const shouldDisplayBasedOnExperimentFlag = (): boolean =>
     config.get('tests.gdprOptinAlertVariant') === 'variant';
 
@@ -87,6 +92,7 @@ const shouldDisplayOptInBanner = (): Promise<boolean> =>
             shouldDisplayBasedOnExperimentFlag(),
             shouldDisplayBasedOnRemindMeLaterInterval(),
             shouldDisplayBasedOnMedium(),
+            shouldDisplayBasedOnLocalHasRepermissionedFlag(),
         ];
 
         if (!shouldDisplay.every(_ => _ === true)) {


### PR DESCRIPTION
## What does this change?
Sets a `hasRepermissioned` cookie so the repermissioning alert doesn't appear for users who repermissioned via a magic link and aren't signed in to the website in later visits.

Sadly `localStorage` doesn't work across subdomains at all, so to make this work i had to edit `lib/cookies.js` to add a flag (off by default) that allows cross-subdomain cookies to be set (In this case from `profile.theguardian.com` to `m.theguardian.com`)

## What is the value of this and can you measure success?
Don't annoy our most loyal users with a potentially irrelevant alert.

## Screenshots
it looks the same as before but it makes the PR prettier
![screen shot 2018-03-05 at 1 05 59 pm](https://user-images.githubusercontent.com/11539094/36976722-8455f5a0-2076-11e8-87c0-2acbe3c7f596.png)
