### PR TITLE
Add blockthrough placements to existing ad slots.

### DIFF
--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -2,6 +2,7 @@
     id: Int,
     isMobile: Boolean = false
 )(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @commonSizes = @{Seq("1,1", "2,2", "300,250", "fluid")}

--- a/article/app/views/fragments/articleAsideSlot.scala.html
+++ b/article/app/views/fragments/articleAsideSlot.scala.html
@@ -3,7 +3,8 @@
     articleAsideOptionalSizes: Seq[String],
     isSticky: Boolean = true
 
-)
+)(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn && shouldShowAds) {

--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -7,17 +7,27 @@
     outOfPage: Boolean = false,
     optId: Option[String] = None,
     optClassNames: Option[String] = None
-)(placeholderContent: Html)
+)(placeholderContent: Html)(implicit request: RequestHeader)
+
+@import views.support.Commercial
+@import implicits.Requests._
 
 <div
     id="dfp-ad--@optId.getOrElse(name)"
     class="js-ad-slot ad-slot ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ") @optClassNames"
     data-link-name="ad slot @name"
     data-name="@name"
-    @if(!showLabel){ data-label="false" }
-    @if(!refresh){ data-refresh="false" }
-    @if(outOfPage){ data-out-of-page="true" }
-    @sizeMapping.map{ case(breakpoint, sizes) =>
+    @if(!showLabel) { data-label="false" }
+    @if(!refresh) { data-refresh="false" }
+    @if(outOfPage) { data-out-of-page="true" }
+    @sizeMapping.map { case(breakpoint, sizes) =>
         data-@breakpoint="@sizes.mkString("|")"
     }
-    >@placeholderContent</div>
+    >@placeholderContent
+
+    @if(!request.isAmp) {
+        @Commercial.getBlockthroughElementUid(name).map { uid =>
+            <span class="bt-uid-tg" uid="@uid" style="display: none !important"></span>
+        }
+    }
+</div>

--- a/common/app/views/fragments/commercial/commercialComponent.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponent.scala.html
@@ -1,3 +1,5 @@
+@()(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -1,4 +1,5 @@
-@(isPaidContent: Boolean, hasPageSkin: Boolean = false)
+@(isPaidContent: Boolean, hasPageSkin: Boolean = false)(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/commercial/pageSkin.scala.html
+++ b/common/app/views/fragments/commercial/pageSkin.scala.html
@@ -1,3 +1,5 @@
+@()(implicit request: RequestHeader)
+
 @fragments.commercial.standardAd(
     "pageskin-inread",
     Seq("page-skin"),

--- a/common/app/views/fragments/commercial/standardAd.scala.html
+++ b/common/app/views/fragments/commercial/standardAd.scala.html
@@ -5,7 +5,8 @@
     showLabel: Boolean = true,
     refresh: Boolean = true,
     outOfPage: Boolean = false
-)
+)(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/commercial/survey.scala.html
+++ b/common/app/views/fragments/commercial/survey.scala.html
@@ -1,3 +1,5 @@
+@()(implicit request: RequestHeader)
+
 @fragments.commercial.standardAd(
     "survey",
     Seq.empty[String],

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,6 +1,6 @@
-@import views.support.Commercial.topAboveNavSlot
+@()(implicit page: model.Page, request: RequestHeader)
 
-@()(implicit page: model.Page)
+@import views.support.Commercial.topAboveNavSlot
 
 <div class="@topAboveNavSlot.cssClasses(page.metadata)">
   @fragments.commercial.standardAd(

--- a/common/app/views/fragments/items/facia_cards/sliceSlot.scala.html
+++ b/common/app/views/fragments/items/facia_cards/sliceSlot.scala.html
@@ -1,7 +1,5 @@
-@(
-    id: Int,
-    isMobile: Boolean = false
-)
+@(id: Int, isMobile: Boolean = false)(implicit request: RequestHeader)
+
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn) {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -4,6 +4,7 @@ import com.gu.commercial.branding._
 import common.Edition
 import common.commercial._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer, PaidCard}
+import model.DotcomContentType.Signup
 import model.{Page, PressedPage}
 import org.apache.commons.lang.StringEscapeUtils._
 import play.api.libs.json.JsBoolean
@@ -23,7 +24,7 @@ object Commercial {
   def shouldShowAds(page: Page): Boolean = page match {
     case c: model.ContentPage if c.item.content.shouldHideAdverts => false
     case p: model.Page if p.metadata.sectionId == "identity" => false
-    case s: model.SimplePage if s.metadata.contentType == "Signup" => false
+    case s: model.SimplePage if s.metadata.contentType.contains(Signup) => false
     case e: model.ContentPage if e.item.content.seriesName.contains("Newsletter sign-ups") => false
     case _: model.CommercialExpiryPage => false
     case _ => true
@@ -42,6 +43,14 @@ object Commercial {
     }
 
     s"/guardian-labs$glabsUrlSuffix"
+  }
+
+  def getBlockthroughElementUid(slotName: String): Option[String] = {
+    slotName match {
+      case "right" => Some("5a9858a84f-157")
+      case "top-above-nav" => Some("5a98585772-157")
+      case _ => None
+    }
   }
 
   def isPaidContent(page: Page): Boolean = page.metadata.commercial.exists(_.isPaidContent)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -675,9 +675,9 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomType <- Some(bodyElement.attr("data-atom-type"))
       } {
-        findAtom(atomId).fold { 
-          atomContainer.remove() 
-        } { atomData => 
+        findAtom(atomId).fold {
+          atomContainer.remove()
+        } { atomData =>
           if(mediaWrapper.contains(MediaWrapper.MainMedia)){
             atomContainer.addClass("element-atom--main-media")
           }
@@ -709,7 +709,7 @@ object setSvgClasses {
   }
 }
 
-case class CommercialMPUForFronts(isNetworkFront: Boolean) extends HtmlCleaner {
+case class CommercialMPUForFronts(isNetworkFront: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
   override def clean(document: Document): Document = {
 
     def isNetworkFrontWithThrasher(element: Element, index: Int): Boolean = {
@@ -749,7 +749,7 @@ case class CommercialMPUForFronts(isNetworkFront: Boolean) extends HtmlCleaner {
   }
 }
 
-case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boolean, hasPageSkin: Boolean) extends HtmlCleaner {
+case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boolean, hasPageSkin: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
 
   override def clean(document: Document): Document = {
 

--- a/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
+++ b/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
@@ -2,7 +2,7 @@ package views.support.cleaner
 
 import org.scalatest.{FlatSpec, Matchers}
 import StringCleaner._
-
+import play.api.test.FakeRequest
 import views.support.CommercialMPUForFronts
 
 class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
@@ -12,7 +12,7 @@ class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
     try source.mkString finally source.close()
   }
 
-  val body = getFileContent("fixtures/CommercialMPUForFronts.html").cleanWith(CommercialMPUForFronts(true))
+  val body = getFileContent("fixtures/CommercialMPUForFronts.html").cleanWith(CommercialMPUForFronts(true)(FakeRequest()))
 
   it should "insert MPUs into applicable slices, and give them unique IDs" in {
     val desktopMPUs = body.getElementsByClass("fc-slice__item--mpu-candidate")

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
@@ -15,6 +15,18 @@ const inlineDefinition = {
     },
 };
 
+const adSlotToBlockthroughUids = {
+    inline1: '5a98587091-157',
+    inline2: '5a98587869-157',
+    inline3: '5a98587f21-157',
+    inline4: '5a985885d5-157',
+    inline5: '5a98588c9c-157',
+    inline6: '5a985892ed-157',
+    inline7: '5a985899d4-157',
+    inline8: '5a9858a114-157',
+    mostpop: '5a9d5c1d72-157',
+};
+
 const adSlotDefinitions = {
     im: {
         label: false,
@@ -99,6 +111,19 @@ const createAdSlotElement = (
     Object.keys(attrs).forEach(attr => {
         adSlot.setAttribute(attr, attrs[attr]);
     });
+
+    const blockthroughUid = adSlotToBlockthroughUids[`${name}`];
+
+    if (blockthroughUid) {
+        const blockthroughAdSlot: HTMLSpanElement = document.createElement(
+            'span'
+        );
+        blockthroughAdSlot.className = 'bt-uid-tg';
+        blockthroughAdSlot.setAttribute('uid', blockthroughUid);
+        blockthroughAdSlot.setAttribute('style', 'display: none !important');
+        adSlot.appendChild(blockthroughAdSlot);
+    }
+
     return adSlot;
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.spec.js
@@ -19,7 +19,8 @@ const inline1Html = `
     data-link-name="ad slot inline1"
     data-name="inline1"
     data-mobile="1,1|2,2|300,250|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|620,350|fluid"></div>
+    data-desktop="1,1|2,2|300,250|620,1|620,350|fluid"><span class="bt-uid-tg" uid="5a98587091-157" style="display: none !important"></span>
+</div>
 `;
 
 jest.mock('lib/config', () => ({ page: { edition: 'UK' } }));


### PR DESCRIPTION
This PR add's span tags of the form `<span class='bt-uid-tg' uid='SOME_ID' style='display: none !important'></span>` within the elements of our existing ad slots so that Blockthrough may target them.