### PR TITLE
Jobs link and options section cleanup

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -43,28 +43,34 @@
 
         <fieldset class="fieldset">
             <div class="fieldset__heading">
-                <h2 class="form__heading">Options</h2>
+                <h2 class="form__heading">Settings</h2>
             </div>
 
             <div class="fieldset__fields email-subscription__options">
                 <ul class="u-unstyled">
                     <li>
-                        <a href="@buildIdentityUrl("account/edit")" class="manage-account__button manage-account__button--icon manage-account__button--mini" data-link-name="identity : email : update">
-                            Update your email address
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </a>
+                        <p>
+                            <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">
+                                Update your email address
+                            </a>
+                        </p>
                     </li>
                     <li>
-                        <a href="#identity-modal--newsletterFormat" role="button" class="js-email-subscription__formatFieldsetToggle manage-account__button manage-account__button--mini manage-account__button--icon" data-link-name="identity : email : format">
+                        <p>
+                            <a href="https://jobs.theguardian.com/your-jobs/?ActiveSection=JbeList" class="u-underline" data-link-name="identity : jobs : alert-settings">
+                                Edit your Job Alert settings
+                            </a>
+                        </p>
+                    </li>
+                    <li>
+                        <a href="#identity-modal--newsletterFormat" class="u-underline" data-link-name="identity : email : format">
                             Change format
-                            @fragments.inlineSvg("arrow-right", "icon")
                         </a>
                     </li>
                     <li>
-                        <p class="label-like">No longer want to receive any of these emails?</p>
                         <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
                             <span class="email-unsubscribe-all__label js-unsubscribe--basic manage-account__button-flexwrap">
-                                Unsubscribe from all emails
+                                Unsubscribe from all newsletters
                                 @fragments.inlineSvg("cross", "icon")
                             </span>
                             <span class="email-unsubscribe-all__label js-unsubscribe--confirm hide" aria-hidden>

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -450,6 +450,7 @@ $identity-header-height: 48px;
 
     &.email-unsubscribe {
         float: none;
+        margin-top: $gs-baseline;
         &.is-updating {
             svg {
                 display: none;


### PR DESCRIPTION
## What does this change?
- Add link to email-prefs page for editing jobs alerts
- Changes links to text links from buttons
- Remove unnecessary wording before unsubscribe button 

## Screenshots

After: 
![image](https://user-images.githubusercontent.com/14179210/36989122-b8fe5186-2098-11e8-8681-9e8025be4f32.png)

Before:
![image](https://user-images.githubusercontent.com/14179210/36982327-863102fa-2087-11e8-9d63-a880b4e23472.png)


## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
