### PR TITLE
Add campaign tracking to links in optin alert

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -31,8 +31,11 @@ type Template = {
 };
 
 const targets = {
-    landing: 'https://gu.com/staywithus',
-    journey: `${config.get('page.idUrl')}/consents/staywithus`,
+    landing:
+        'https://gu.com/staywithus?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert',
+    journey: `${config.get(
+        'page.idUrl'
+    )}/consents/staywithus?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert`,
 };
 
 const template: Template = {


### PR DESCRIPTION
Adds the `gdpr-oi-campaign-alert` campaign tag to outgoing links in the Stay With Us alert for newsletter visitors