### PR TITLE
Fix embed.theguardian.com video player

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -276,3 +276,47 @@
         display: none;
     }
 }
+
+
+// this has been pasted here from container--video.scss to make the styling work on embed.theguardian.com videos
+// the videos will just have a black play button
+.youtube-media-atom__play-button {
+    background-color: $garnett-neutral-1;
+    border-radius: 50%;
+    color: transparent;
+}
+.vjs-big-play-button .vjs-control-text,
+.youtube-media-atom__play-button.vjs-control-text {
+    // Sets a base play button/icon size for all video players
+    @include video-icon-size($garnett-x-large-button-size, $garnett-x-large-button-icon);
+
+    // Sets specific play button/icon size for fronts depending on layout
+    .fc-item--full-media-75-tablet &,
+    .fc-item--full-media-50-tablet &,
+    .fc-item--three-quarters-tablet &,
+    .fc-item--half-tablet & {
+        @include video-icon-size($garnett-large-button-size, $garnett-large-button-icon);
+        @include mq($from: mobileLandscape) {
+            @include video-icon-size($garnett-x-large-button-size, $garnett-x-large-button-icon);
+        }
+    }
+
+    .fc-item--third-tablet & {
+        @include video-icon-size($garnett-large-button-size, $garnett-large-button-icon);
+        @include mq($from: mobileLandscape, $until: tablet) {
+            @include video-icon-size($garnett-x-large-button-size, $garnett-x-large-button-icon);
+        }
+    }
+
+    .fc-item--standard-tablet & {
+        @include mq($from: tablet) {
+            @include video-icon-size($garnett-medium-button-size, $garnett-medium-button-icon);
+        }
+    }
+
+    .fc-item--list-media-mobile & {
+        @include mq($until: tablet) {
+            @include video-icon-size($garnett-small-button-size, $garnett-small-button-icon);
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
The player on embed.theguardian.com currently [looks terrible](https://embed.theguardian.com/embed/atom/media/6e5e6b8c-35ac-4384-9130-1f033aabbe98) as a side effect of https://github.com/guardian/frontend/pull/19181 This player is used in the iPad edition, and has also been spotted on the site (I'm not certain what the logic for this is though).

This change makes the required styles from container--videos available in _youtube.scss (which is included in embed.theguardian.com videso) to fix this. 

## Screenshots
![screen shot 2018-03-07 at 10 32 00](https://user-images.githubusercontent.com/3606555/37087646-d1441284-21f2-11e8-934d-c40e339945d9.png)

## Tested in CODE?
Yes