### PR TITLE
Send Prebid Sonobi deals to ad server

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -58,16 +58,8 @@ class PrebidService {
                 alwaysUseBid: false,
             },
             sonobi: {
-                // for Jetstream
+                // for Jetstream deals
                 alwaysUseBid: true,
-                adserverTargeting: [
-                    {
-                        key: 'hb_deal_sonobi',
-                        val(bidResponse) {
-                            return bidResponse.dealId;
-                        },
-                    },
-                ],
             },
         };
         window.pbjs.setConfig({


### PR DESCRIPTION
We don't need to send any custom key-values for Sonobi deals, just switching on `alwaysUseBid` should be enough.
