### PR TITLE
Change the OrielApiKey to Option for dev builds

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -239,7 +239,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object oriel {
-    lazy val orielApiKey = configuration.getMandatoryStringProperty("oriel.api.key")
+    lazy val orielApiKey = configuration.getStringProperty("oriel.api.key")
     lazy val orielCacheTimeInMinutes: Int = if (environment.isProd) 60 else 5
   }
 


### PR DESCRIPTION
## What does this change?

This changes the type of `orielApiKey` in configuration to `Option[String]`. In DEV, there is no key setup so we want to handle the situation where there is no API key setup for the environment.