### PR TITLE
Add intro to /consents/newsletters

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -128,7 +128,7 @@
 @emailRepermissionStep() = @{
     ConsentStep(
         name = "email",
-        title = "Newsletters",
+        title = "Email Newsletters",
         help = List(
             ConsentStepHelpText("The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.")
         ),
@@ -156,7 +156,7 @@
 @introStep = @{
     ConsentStep(
         name = "intro",
-        title = "Please select the emails you wish to receive",
+        title = "Please select the emails you wish to continue receiving",
         help = List(
             ConsentStepHelpText(
                 "You can change your preferences anytime by signing in, clicking My Account, then selecting Email Preferences."
@@ -187,17 +187,20 @@
         @renderBlocks(
             journey match {
                 case NewsletterConsentsJourney => {
-                    List(
-                        if(emailRepermissionStep.show) {
+                    if(emailRepermissionStep.show) {
+                        List(
+                            introGdprCampaignStep,
                             emailRepermissionStep
-                        } else {
+                        )
+                    } else {
+                        List(
                             ConsentStep(
                                 name = "error",
                                 title = "Sorry",
                                 content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
                             )
-                        }
-                    )
+                        )
+                    }
                 }
                 case ThankYouConsentsJourney => {
                     List(


### PR DESCRIPTION
## What does this change?

Adds intro to `/consents/newsletters` emphasising to user we are asking to re-subscribe to newsletters.

Change header from _Newsletters_ to _Email Newsletters_.

## What is the value of this and can you measure success?

Userhelp flagged complaints.

## Screenshots

![image](https://user-images.githubusercontent.com/13835317/37097893-7440cef2-2214-11e8-826a-e822eb2bfeac.png)

