### PR TITLE
Extend article json endpoint with full content fields data

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -114,8 +114,11 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
         else if (request.isAmp) views.html.articleAMP(article)
         else ArticleHtmlPage.html(article)
       }
-      val jsonResponse = () => views.html.fragments.articleBody(article)
-      renderFormat(htmlResponse, jsonResponse, article, Switches.all)
+
+      val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+
+      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+      renderFormat(htmlResponse, jsonResponse, article)
   }
 
   def renderLiveBlog(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
@@ -157,7 +160,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   def renderJson(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      mapModel(path) {
+      mapModel(path, if (request.isGuuiJson) Some(ArticleBlocks) else None) {
         render(path, _)
       }
     }

--- a/article/app/model/ContentFields.scala
+++ b/article/app/model/ContentFields.scala
@@ -1,0 +1,14 @@
+package model
+
+import play.api.libs.json.{Json, Writes}
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+import views.{BodyCleaner, MainCleaner}
+
+case class ContentFields(fields: Fields, cleanedMainBlockHtml: String, cleanedBodyHtml: String)
+object ContentFields {
+  def apply(article: Article, isAmp: Boolean = false)(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
+    new ContentFields(article.fields, MainCleaner.apply(article, amp = isAmp).body, BodyCleaner.apply(article, amp = isAmp).body)
+
+  implicit val contentFieldsWrites: Writes[ContentFields] = Json.writes[ContentFields]
+}

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -84,7 +84,7 @@
 
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
-                            @BodyCleaner(article, article.fields.body, amp = amp)
+                            @BodyCleaner(article, amp = amp)
 
                             @* A value for the image field is required for AMP article
                             WORKAROUND: if the article doesn't contain any image we insert the metadata of the fallback logo,

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -78,7 +78,8 @@
                                 @fragments.contentMeta(article, model, amp = amp)
                             }
 
-                            @BodyCleaner(article, article.fields.body, amp = amp)
+                            @BodyCleaner(article, amp = amp)
+
                             @fragments.witnessCallToAction(article.content)
 
                             @fragments.submeta(article, amp)

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -55,7 +55,7 @@
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                              data-test-id="article-review-body" @langAttributes(article.content)>
-                            @BodyCleaner(article, article.fields.body, amp = amp)
+                            @BodyCleaner(article, amp = amp)
                             @fragments.submeta(article)
 
                         </div>

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -8,7 +8,7 @@
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
     <div class="media-primary">
-        @MainCleaner(article, article.fields.main, amp)
+        @MainCleaner(article, amp)
     </div>
 } else {
     @if(!article.hasVideoAtTop) {

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -28,7 +28,7 @@
 
                         <div class="js-article__body--minute-article u-cf from-content-api" itemprop="{articleBody}">
                         <div class="gs-container gs-container--minute-article">
-                        @BodyCleaner(article, article.fields.body, amp = false)
+                        @BodyCleaner(article, amp = false)
                         </div>
                         </div>
                     </div>

--- a/article/app/views/fragments/photoEssayBody.scala.html
+++ b/article/app/views/fragments/photoEssayBody.scala.html
@@ -36,7 +36,7 @@
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="articleBody"
                              data-test-id="article-review-body" @langAttributes(article.content)>
-                            @BodyCleaner(article, article.fields.body, amp = false)
+                            @BodyCleaner(article, amp = false)
                         </div>
 
                         @fragments.witnessCallToAction(article.content)

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -95,6 +95,16 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
   def renderFormat(html: () => Html, cacheTime: Integer)(implicit request: RequestHeader, context: ApplicationContext): Result = {
     renderFormat(html, html, cacheTime)
   }
+
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => List[(String, Any)], page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result =
+    Cached(page) {
+      if (request.isJson)
+        JsonComponent(page, jsonResponse():_*)
+      else if (request.isEmail)
+        RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse()) else htmlResponse())
+      else
+        RevalidatableResult.Ok(htmlResponse())
+    }
 }
 
 

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -19,6 +19,9 @@ trait Requests {
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 
+    // parameter for moon/guui new rendering layer project.
+    lazy val isGuuiJson: Boolean = isJson && r.getQueryString("guui").isDefined
+
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -1,7 +1,8 @@
 package model
 
 import com.gu.contentapi.client.model.v1.Asset
-import views.support.{Orientation, Naked, ImgSrc}
+import play.api.libs.json.{Json, Writes}
+import views.support.{ImgSrc, Naked, Orientation}
 
 object Helpers {
   def assetFieldsToMap(asset: Asset): Map[String, String] =
@@ -39,6 +40,7 @@ object ImageAsset {
       mimeType = asset.mimeType,
       url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
+  implicit val imageAssetWrites: Writes[ImageAsset] = Json.writes[ImageAsset]
 }
 
 case class ImageAsset(
@@ -89,6 +91,7 @@ object VideoAsset {
         case _ => None
       }.orElse(asset.file) )
   }
+  implicit val videoAssetWrites: Writes[VideoAsset] = Json.writes[VideoAsset]
 }
 
 case class VideoAsset(
@@ -122,6 +125,7 @@ object AudioAsset {
       mimeType = asset.mimeType,
       url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
+  implicit val audioAssetWrites: Writes[AudioAsset] = Json.writes[AudioAsset]
 }
 
 case class AudioAsset(

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -2,8 +2,9 @@ package model
 
 import com.gu.contentapi.client.model.v1.AssetType
 import org.joda.time.Duration
-import com.gu.contentapi.client.model.v1.{Element => ApiElement, ElementType, AssetType}
+import com.gu.contentapi.client.model.v1.{AssetType, ElementType, Element => ApiElement}
 import org.apache.commons.math3.fraction.Fraction
+import play.api.libs.json.{Json, Writes}
 
 object ElementProperties {
   def make(capiElement: ApiElement, index: Int): ElementProperties = {
@@ -53,6 +54,7 @@ object ImageMedia {
   def make(crops: Seq[ImageAsset]): ImageMedia = ImageMedia(
     allImages = crops
   )
+  implicit val imageMediaWrites: Writes[ImageMedia] = Json.writes[ImageMedia]
 }
 final case class ImageMedia(allImages: Seq[ImageAsset]) {
 

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -40,11 +40,6 @@ object Sponsorship {
 
 object BlockElement {
 
-  implicit object BlockElementFormat extends Format[Seq[BlockElement]] {
-    def reads(json: JsValue): JsResult[Seq[BlockElement]] = JsSuccess(Seq.empty)
-    def writes(els: Seq[BlockElement]): JsValue = JsArray(Seq(JsNull))
-  }
-
   def make(element: ApiBlockElement): Option[BlockElement] = {
     element.`type` match {
       case Text => Some(TextBlockElement(element.textTypeData.flatMap(_.html)))
@@ -104,4 +99,21 @@ object BlockElement {
     ) collect { case (k, Some (v) ) => (k, v) }
     } getOrElse Map()
   }
+
+  implicit val textBlockElementWrites: Writes[TextBlockElement] = Json.writes[TextBlockElement]
+  implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
+  implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
+  implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
+  implicit val VideoBlockElementWrites: Writes[VideoBlockElement] = Json.writes[VideoBlockElement]
+  implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
+  implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
+  implicit val SponsorshipWrites: Writes[Sponsorship] = new Writes[Sponsorship] {
+    def writes(sponsorship: Sponsorship): JsObject = Json.obj(
+      "sponsorName" -> sponsorship.sponsorName,
+      "sponsorLogo" -> sponsorship.sponsorLogo,
+      "sponsorLink" -> sponsorship.sponsorLink,
+      "sponsorshipType" -> sponsorship.sponsorshipType.name)
+  }
+  implicit val RichLinkBlockElementWrites: Writes[RichLinkBlockElement] = Json.writes[RichLinkBlockElement]
+  val blockElementWrites: Writes[BlockElement] = Json.writes[BlockElement]
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -17,7 +17,8 @@ import model.meta.{Guardian, LinkedData, PotentialAction, WebPage}
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import com.github.nscala_time.time.Implicits._
-import play.api.libs.json.{JsBoolean, JsString, JsValue}
+import play.api.libs.json._
+import play.api.libs.json.JodaWrites.JodaDateTimeWrites
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
@@ -52,7 +53,6 @@ object Fields {
   // For content published before then, we need handle it as we did before, taking
   // the sensitive flag to mean "don't display reader revenue asks"
   private val shouldHideReaderRevenueCutoffDate = new DateTime("2017-07-10T12:00:00.000Z")
-
   def make(apiContent: contentapi.Content): Fields = {
     Fields (
       trailText = apiContent.fields.flatMap(_.trailText),
@@ -86,6 +86,8 @@ object Fields {
       case None => false
     }
   }
+
+  implicit val fieldsWrites: Writes[Fields] =  Json.writes[Fields]
 }
 
 final case class Fields(


### PR DESCRIPTION
This change adds an extra block to [the article .json endpoint](https://www.theguardian.com/world/2018/mar/08/sexist-agendas-finally-exposed-international-womens-day.json) when the `guui` query parameter is added. The block contains the full `Content` model - fetched from the content api then deserialised into dotcoms models. The interesting part of this is block elements, which have been available in the content api for a long time, but unused in the frontend project (except for live blogs). The aim is for the new rendering layer to make use of the extra structure provided by blocks. 

As well as the full `Content` model the new block also contains cleaned versions (using [these](https://github.com/guardian/frontend/blob/master/article/app/views/package.scala) cleaners) of the body block and main block, as currently used in our existing templates. 

To make this possible I've had to add json Writes to every class in the  `Content` tree. In one case - `MembershipPlaceholder` where the content API thrift model was being used as part of one of dotcom models I've had to replace it with our own model (as otherwise play json can't serialise it) cleanly.

Follow up: try to somehow tidy all the various `renderFormat` functions in common so that there's less duplicated code. Do live blogs...

## What is the value of this and can you measure success?
Should be useful for the new rendering layer!
## Does this affect other platforms - Amp, Apps, etc?
No - just the article .json endpoint

## Tested in CODE?
Yes - changes are needed to fastly too...