### PR TITLE
Reimplement panic shedding

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -35,6 +35,16 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val PanicShedding = Switch(
+    SwitchGroup.Performance,
+    "always-serve-stale",
+    "If this switch is on then all apps will return 304 Not Modified to all requests which are already cached in fastly",
+    owners = Owner.group(SwitchGroup.Performance),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val interactivePressing = Switch(
     SwitchGroup.Performance,
     "interactive-pressing",

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -37,8 +37,8 @@ trait PerformanceSwitches {
 
   val PanicShedding = Switch(
     SwitchGroup.Performance,
-    "always-serve-stale",
-    "If this switch is on then all apps will return 304 Not Modified to all requests which are already cached in fastly",
+    "panic-shedding",
+    "If this switch is on then all apps will return 304 Not Modified to all requests with an If-None-Match header (aka 'serve stale whenever possible')",
     owners = Owner.group(SwitchGroup.Performance),
     safeState = Off,
     sellByDate = never,

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -105,7 +105,7 @@ class ExperimentsFilter(implicit val mat: Materializer, executionContext: Execut
 class PanicSheddingFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     if (Switches.PanicShedding.isSwitchedOn && request.headers.hasHeader("If-None-Match")) {
-      Future.successful(Cached.explicitlyCache(900)(PanicReuseExistingResult(Results.NotModified.withHeaders()).result))
+      Future.successful(Cached(900)(PanicReuseExistingResult(Results.NotModified.withHeaders())))
     } else {
       nextFilter(request)
     }

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -105,7 +105,7 @@ class ExperimentsFilter(implicit val mat: Materializer, executionContext: Execut
 class PanicSheddingFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     if (Switches.PanicShedding.isSwitchedOn && request.headers.hasHeader("If-None-Match")) {
-      Future.successful(Cached(900)(PanicReuseExistingResult(Results.NotModified.withHeaders())))
+      Future.successful(Cached(900)(PanicReuseExistingResult(Results.NotModified))(request))
     } else {
       nextFilter(request)
     }

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -121,8 +121,8 @@ object Filters {
     applicationContext: ApplicationContext,
     executionContext: ExecutionContext
   ): List[EssentialFilter] = List(
-    new PanicSheddingFilter,
     new RequestLoggingFilter,
+    new PanicSheddingFilter,
     new JsonVaryHeadersFilter,
     new ExperimentsFilter,
     new Gzipper,

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -36,7 +36,7 @@ object CacheTime {
 
 object Cached extends implicits.Dates {
 
-  private val cacheableStatusCodes = Seq(200, 404, 304)
+  private val cacheableStatusCodes = Seq(200, 404)
 
   private val tenDaysInSeconds = 864000
 
@@ -45,6 +45,7 @@ object Cached extends implicits.Dates {
   sealed trait CacheableResult { def result: Result }
   case class RevalidatableResult(result: Result, hash: Hash) extends CacheableResult
   case class WithoutRevalidationResult(result: Result) extends CacheableResult
+  case class PanicReuseExistingResult(result: Result) extends CacheableResult
 
   object RevalidatableResult {
     def apply[C](result: Result, content: C)(implicit writeable: Writeable[C]): RevalidatableResult = {
@@ -88,6 +89,7 @@ object Cached extends implicits.Dates {
         case RevalidatableResult(result, hash) =>
           cacheHeaders(seconds, result, Some((hash, ifNoneMatch)))
         case WithoutRevalidationResult(result) => cacheHeaders(seconds, result, None)
+        case PanicReuseExistingResult(result) => cacheHeaders(seconds, result, None)
       }
     } else {
       cacheableResult.result

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -36,7 +36,7 @@ object CacheTime {
 
 object Cached extends implicits.Dates {
 
-  private val cacheableStatusCodes = Seq(200, 404)
+  private val cacheableStatusCodes = Seq(200, 404, 304)
 
   private val tenDaysInSeconds = 864000
 
@@ -105,7 +105,7 @@ object Cached extends implicits.Dates {
     TLDR Surrogate-Control is used by the CDN, Cache-Control by the browser - do *not* add `private` to Cache-Control
     https://docs.fastly.com/guides/tutorials/cache-control-tutorial
   */
-  private def cacheHeaders(maxAge: Int, result: Result, maybeHash: Option[(Hash, Option[String])]) = {
+  private def cacheHeaders(maxAge: Int, result: Result, maybeHash: Option[(Hash, Option[String])]): Result = {
     val now = DateTime.now
     val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
     val surrogateCacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds"


### PR DESCRIPTION
## What does this change?
This adds a switch which, when enabled, causes dotcom to return a 304-Not-Modified to all requests with an `If-None-Match` header, which indicates that it is available in fastly's cache.

The motivation for this is that when our services are struggling we want fastly to take as much load off us as possible.

For those who've followed previous PRs - https://github.com/guardian/frontend/pull/16362 and https://github.com/guardian/frontend/pull/14044 this may seem a bit strange to be adding it back in. The motivation comes from an outage a few weeks ago, where no matter how much we scaled instances were not coping with the quantity of traffic directed at them. This implementation is much simpler - just on or off, rather than trying to detect heavy load.

## Tested in CODE?
Yes - I loaded a dev blog post, switch on panic shedding, made a change to it and launched it and behold! The unmodified page was still served by fastly despite being out of date. I then loaded a newly published (post panic shedding enabling) which missed the cache but still loaded (as expected). Finally, after switching off panic shedding I reloaded the dev blog post and got an updated version
