### PR TITLE
Added header test for AUD

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -155,4 +155,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 4, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-header-aud-support",
+    "Points the 'support the guardian' link in the header to the aud version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 24),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,6 +6,7 @@ import { unrulyPerformanceTest } from 'common/modules/experiments/tests/unruly-p
 import { commercialLazyLoading } from 'common/modules/experiments/tests/commercial-lazy-loading';
 import { acquisitionsHeaderSubscribeMeansSubscribe } from 'common/modules/experiments/tests/acquisitions-header-subscribe-means-subscribe';
 import { acquisitionsHeaderEurSupport } from 'common/modules/experiments/tests/acquisitions-header-eur-support';
+import { acquisitionsHeaderAudSupport } from 'common/modules/experiments/tests/acquisitions-header-aud-support';
 import { spacefinderSimplify } from 'common/modules/experiments/tests/spacefinder-simplify';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
@@ -13,6 +14,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     unrulyPerformanceTest,
     acquisitionsHeaderSubscribeMeansSubscribe,
     acquisitionsHeaderEurSupport,
+    acquisitionsHeaderAudSupport,
     commercialLazyLoading,
     spacefinderSimplify,
 ].filter(Boolean);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-aud-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-aud-support.js
@@ -1,0 +1,72 @@
+// @flow
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+import { updateAcquisitionData } from 'common/modules/commercial/acquisitions-ophan';
+
+const componentType = 'ACQUISITIONS_HEADER';
+const abTestName = 'AcquisitionsHeaderAudSupport';
+const AUDsupportURL = 'https://support.theguardian.com/au';
+
+type variantName = 'control' | 'support_contribute';
+
+const modifySupportTheGuardianLink = (variant: variantName): void => {
+    [...document.querySelectorAll('.js-change-become-member-link')].forEach(
+        supportTheGuardianLink => {
+            if (!(supportTheGuardianLink instanceof HTMLAnchorElement)) {
+                return;
+            }
+
+            let supportTheGuardianURL = new URL(supportTheGuardianLink.href);
+
+            if (variant === 'support_contribute') {
+                supportTheGuardianURL = new URL(AUDsupportURL);
+            }
+
+            const supportTheGuardianUrlWithTestData = updateAcquisitionData(
+                supportTheGuardianURL,
+                {
+                    abTest: {
+                        name: abTestName,
+                        variant,
+                    },
+                }
+            );
+
+            supportTheGuardianLink.href = supportTheGuardianUrlWithTestData.toString();
+        }
+    );
+};
+
+export const acquisitionsHeaderAudSupport: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    componentType,
+    start: '2018-03-01',
+    expiry: '2018-04-24',
+    author: 'Santiago Villa Fernandez',
+    description:
+        'Points the "support the guardian" link in the header to the eur version of the support site',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV 2.0',
+    audienceCriteria: 'All EUR transaction web traffic.',
+    idealOutcome: 'We get more money when we tailor the destination to the CTA',
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'AU',
+    variants: [
+        {
+            id: 'control',
+            test: () => {
+                modifySupportTheGuardianLink('control');
+            },
+        },
+        {
+            id: 'support_contribute',
+            test: () => {
+                modifySupportTheGuardianLink('support_contribute');
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-aud-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-aud-support.js
@@ -51,7 +51,7 @@ export const acquisitionsHeaderAudSupport: AcquisitionsABTest = {
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV 2.0',
-    audienceCriteria: 'All EUR transaction web traffic.',
+    audienceCriteria: 'All AUD transaction web traffic.',
     idealOutcome: 'We get more money when we tailor the destination to the CTA',
     canRun: () =>
         geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'AU',


### PR DESCRIPTION
## What does this change?
Add header test for contributions in AUD.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots
<img width="639" alt="picture 621" src="https://user-images.githubusercontent.com/825398/37159415-bd3c8cbe-22e5-11e8-8863-02d7aeb2765e.png">

## Tested in CODE?
Not yet.
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
