### PR TITLE
Contributions AUD engagement banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -165,4 +165,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 4, 24),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-engagement-banner-aud-support",
+    "Points the 'support the guardian' link in the engagement banner to the aud version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 24),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-aud-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-aud-support.js
@@ -1,0 +1,45 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+
+const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName = 'AcquisitionsEngagementBannerAudSupport';
+const AUDsupportURL = 'https://support.theguardian.com/au';
+
+export const AcquisitionsEngagementBannerAudSupport: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-03-01',
+    expiry: '2018-04-17',
+    author: 'Santiago Villa Fernandez',
+    description:
+        'Points the "support the guardian" link in the engagement banner to the aud version of the support site',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'All AUD transaction web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome:
+        'We channel the audience from dotcom to support frontend au correctly',
+    componentType,
+    showForSensitive: true,
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'AU',
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'support_contribute',
+            options: {
+                engagementBannerParams: {
+                    linkUrl: AUDsupportURL,
+                    buttonCaption: 'Support The Guardian',
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,7 +1,12 @@
 // @flow
 import { SupportEngagementBannerCircles } from 'common/modules/experiments/tests/support-engagement-banner-circles';
 import { AcquisitionsEngagementBannerEurSupport } from 'common/modules/experiments/tests/acquisitions-engagement-banner-eur-support';
+import { AcquisitionsEngagementBannerAudSupport } from 'common/modules/experiments/tests/acquisitions-engagement-banner-aud-support';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [SupportEngagementBannerCircles, AcquisitionsEngagementBannerEurSupport];
+> = [
+    SupportEngagementBannerCircles,
+    AcquisitionsEngagementBannerEurSupport,
+    AcquisitionsEngagementBannerAudSupport
+];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -8,5 +8,5 @@ export const membershipEngagementBannerTests: $ReadOnlyArray<
 > = [
     SupportEngagementBannerCircles,
     AcquisitionsEngagementBannerEurSupport,
-    AcquisitionsEngagementBannerAudSupport
+    AcquisitionsEngagementBannerAudSupport,
 ];


### PR DESCRIPTION
## What does this change?
Add engagement banner test for AUD
## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
### Control
<img width="1210" alt="picture 623" src="https://user-images.githubusercontent.com/825398/37162362-f4fcd54e-22ec-11e8-9a0c-54b4fa27bc5d.png">

### Variant
<img width="1220" alt="picture 622" src="https://user-images.githubusercontent.com/825398/37162361-f4d77948-22ec-11e8-9480-d608e02d0ac6.png">

## Tested in CODE?
Not yet
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
