### PR TITLE
Bump fapi client to 2.5.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.135"
   val awsVersion = "1.11.240"
   val capiVersion = "11.51"
-  val faciaVersion = "2.5.3"
+  val faciaVersion = "2.5.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
This version fixes an issue with capi preview requests if a collection's backfill path contains a leading slash - https://github.com/guardian/facia-scala-client/pull/204

Tested in CODE (facia-press)