### PR TITLE
Added epic test for AUD

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -175,4 +175,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 4, 24),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-aud-support",
+    "Points the 'support the guardian' link in the epic to the aud version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 24),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,6 +13,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicEurSupport } from 'common/modules/experiments/tests/acquisitions-epic-eur-support';
+import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
 import { supportEpicCircles } from 'common/modules/experiments/tests/support-epic-circles';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
@@ -40,6 +41,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
+    acquisitionsEpicAudSupport,
     acquisitionsEpicEurSupport,
     supportEpicCircles,
     askFourEarning,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aud-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aud-support.js
@@ -1,0 +1,71 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+
+import config from 'lib/config';
+
+import type { CtaUrls } from 'common/modules/commercial/contributions-utilities';
+
+const AUDsupportURL = 'https://support.theguardian.com/au';
+const abTestName = 'AcquisitionsEpicAudSupport';
+
+const oneButtonTemplate = (urls: CtaUrls): string => {
+    const url = urls.supportUrl || '';
+
+    const supportButtonSupport = `
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
+              href="${url}"
+              target="_blank">
+              Support the Guardian
+            </a>
+        </div>`;
+
+    const paymentLogos = `<img class="contributions__payment-logos contributions__contribute--epic-member" src="${config.get(
+        'images.acquisitions.paypal-and-credit-card',
+        ''
+    )}" alt="Paypal and credit card">`;
+
+    return `
+        <div class="contributions__amount-field">
+            ${supportButtonSupport}
+            ${paymentLogos}
+        </div>`;
+};
+
+export const acquisitionsEpicAudSupport = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-03-01',
+    expiry: '2018-04-17',
+
+    author: 'Santiago Villa Fernandez',
+    description: 'Use the Epic to partition the audience for the AUD test',
+    successMeasure: 'AV 2.0',
+    idealOutcome:
+        'We channel an even split of frontend traffic into the correct au version',
+    audienceCriteria: 'ALL AUD transaction web traffic',
+    audience: 1,
+    audienceOffset: 0,
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'AU',
+    variants: [
+        {
+            id: 'control',
+            products: [],
+        },
+        {
+            id: 'support_contribute',
+            products: [],
+            options: {
+                supportBaseURL: AUDsupportURL,
+                buttonTemplate: oneButtonTemplate,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
Adding the EPIC test for AUD
## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
### Variant
![picture 626](https://user-images.githubusercontent.com/825398/37201921-fd687fbe-2380-11e8-8599-20f60fc673a5.png)

### Control
![picture 627](https://user-images.githubusercontent.com/825398/37201922-fd805148-2380-11e8-8e1c-ca78634b2ad6.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
