### PR TITLE
Change size and placement of video button on fronts

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -275,9 +275,8 @@
 @mixin video-icon-size($buttonSize, $iconSize) {
     border-radius: 50%;
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    bottom: $buttonSize / 5;
+    left: $buttonSize / 5;
     transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
     user-select: none;
     width: $buttonSize;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -67,7 +67,7 @@
 
     &:hover ~ .youtube-media-atom__overlay .youtube-media-atom__play-button {
         transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
-        transform: translate(-50%, -50%) scale(1.12);
+        transform: scale(1.12);
         transform-origin: center;
     }
 
@@ -296,21 +296,18 @@
     .fc-item--three-quarters-tablet &,
     .fc-item--half-tablet & {
         @include video-icon-size($garnett-large-button-size, $garnett-large-button-icon);
-        @include mq($from: mobileLandscape) {
-            @include video-icon-size($garnett-x-large-button-size, $garnett-x-large-button-icon);
-        }
     }
 
     .fc-item--third-tablet & {
         @include video-icon-size($garnett-large-button-size, $garnett-large-button-icon);
         @include mq($from: mobileLandscape, $until: tablet) {
-            @include video-icon-size($garnett-x-large-button-size, $garnett-x-large-button-icon);
+            @include video-icon-size($garnett-medium-button-size, $garnett-medium-button-icon);
         }
     }
 
     .fc-item--standard-tablet & {
         @include mq($from: tablet) {
-            @include video-icon-size($garnett-medium-button-size, $garnett-medium-button-icon);
+            @include video-icon-size($garnett-small-button-size, $garnett-small-button-icon);
         }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -99,7 +99,7 @@ $ima-controls-height: 70px;
     }
 
     &:hover .vjs-control-text {
-        transform: translate(-50%, -50%) scale(1.15);
+        transform: scale(1.15);
 
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -186,6 +186,9 @@ $pillars: (
         fill: map-get($palette, invertedKicker);
     }
 
+    &.video-playlist__item .video-overlay__duration {
+        color: map-get($palette, invertedKicker);
+    }
 
     &.fc-item--type-media,
     &.fc-item--type-interview {


### PR DESCRIPTION
## What does this change?
The size and placement of the video icons on fronts. We were getting a lot of people wearing buttons on their faces, this moves them to a more sensible place.

## Before
![image](https://user-images.githubusercontent.com/1607666/37176543-a9ef5f38-22ea-11e8-9415-7c54d959bffd.png)

![image](https://user-images.githubusercontent.com/1607666/37176560-b7cacaca-22ea-11e8-9a9b-d702680ec1d8.png)

## After
![image](https://user-images.githubusercontent.com/1607666/37176593-d33dcd7a-22ea-11e8-96b7-d3d211227f96.png)

![image](https://user-images.githubusercontent.com/1607666/37176577-c31a40e0-22ea-11e8-923a-40cbcab712d1.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
