### PR TITLE
Extend circles tests by one week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -102,7 +102,7 @@ trait ABTestSwitches {
     "When ON, the circles design test for the support engagement banner is ACTIVE",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 13), // Tues 13th March (but should be complete by the 8th)
+    sellByDate = new LocalDate(2018, 3, 20), // Tues 20th March
     exposeClientSide = true
   )
 
@@ -112,7 +112,7 @@ trait ABTestSwitches {
     "When ON, epic messaging will direct a share of the audience to the circles version of the support site",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 13), // Tues 13th March (but should be complete by the 8th)
+    sellByDate = new LocalDate(2018, 3, 20), // Tues 20th March
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/support-engagement-banner-circles.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/support-engagement-banner-circles.js
@@ -7,7 +7,7 @@ export const SupportEngagementBannerCircles: AcquisitionsABTest = {
     id: 'SupportEngagementBannerCircles',
     campaignId: 'gdnwb_copts_memco_sandc_circles',
     start: '2018-02-21',
-    expiry: '2018-03-13', // Tues 13th March (but should be complete by the 8th)
+    expiry: '2018-03-20', // Tues 20th March (was expected to be complete by the 8th)
     author: 'JustinPinner',
     description: 'Partition the audience for support frontend circles test',
     successMeasure: 'N/A',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/support-epic-circles.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/support-epic-circles.js
@@ -8,7 +8,7 @@ export const supportEpicCircles = makeABTest({
     campaignId: 'sandc_circles',
 
     start: '2018-02-21',
-    expiry: '2018-03-13', // Tues 13th March (but should be complete by the 8th)
+    expiry: '2018-03-20', // Tues 20th March (was expected to be complete by the 8th)
 
     author: 'Justin Pinner',
     description:


### PR DESCRIPTION
## What does this change?
Extend the circle test switches and test expiry dates by one week.

## What is the value of this and can you measure success?
We're currently at about 50% completion after 9 full days running. Another 9 days (plus some slack to prevent expiring too close to a weekend) should be enough to wrap this up.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
