### PR TITLE
Remove identity narrow header hack

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -257,7 +257,6 @@ final case class MetaData (
 
   val hasSlimHeader: Boolean =
     contentWithSlimHeader ||
-      (sectionId == "identity" && !id.startsWith("/user/")) ||
       contentType.exists(c => c == DotcomContentType.Survey || c == DotcomContentType.Signup)
 
   // this is here so it can be included in analytics.


### PR DESCRIPTION
## What does this change?
Removes an ugly hack introduced in #18872 to make comment pages such as [this](https://profile.theguardian.com/user/id/18209077?page=1) have the full header while keeping the skinny one in identity

This is no longer needed as all of identity (except for comment history which should keep using the full one) now uses a different header template altogether.