### PR TITLE
Pageskin ads targeted by series tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ static/riffraff
 
 static/src/stylesheets/icons/*
 
+# emacs temp #
+**~
+
 # Eclipse #
 .project
 .settings/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ static/riffraff
 
 static/src/stylesheets/icons/*
 
+
 # emacs temp #
 **~
 

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -17,7 +17,7 @@ private[dfp] object ApiHelper extends Logging {
       }
     }
 
-    dfpLineItem.getRoadblockingType == RoadblockingType.CREATIVE_SET &&
+    ( dfpLineItem.getRoadblockingType == RoadblockingType.CREATIVE_SET ) &&
       hasA1x1Pixel(dfpLineItem.getCreativePlaceholders)
   }
 

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -47,7 +47,8 @@ case class DfpDataExtractor(
         isR2Only = lineItem.targeting.targetsR2Only,
         targetsAdTest = lineItem.targeting.hasAdTestTargetting,
         adTestValue = lineItem.targeting.adTestValue,
-        keywords = lineItem.targeting.keyValues
+        keywords = lineItem.targeting.keywordValues,
+        series = lineItem.targeting.serieValues
       )
     }
   }

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -7,7 +7,7 @@ case class DfpDataExtractor(
   lineItems: Seq[GuLineItem],
   invalidLineItems: Seq[GuLineItem]) {
 
-  val hasValidLineItems = lineItems.nonEmpty
+  val hasValidLineItems: Boolean = lineItems.nonEmpty
 
   val inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = {
     lineItems.foldLeft(InlineMerchandisingTagSet()) { (soFar, lineItem) =>

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -35,6 +35,14 @@
             }
         </ul>
     }
+    @if(sponsorship.series.nonEmpty) {
+        <small>Series:</small>
+        <ul>
+            @for(serie <- sponsorship.series) {
+                <li>@serie</li>
+            }
+        </ul>
+    }
   </li>
 }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -408,7 +408,7 @@ class GuardianConfiguration extends Logging {
     private lazy val dfpRoot = s"$commercialRoot/dfp"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
-    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v7.json"
+    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v8.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v6.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
     lazy val dfpMobileAppsAdUnitListKey = s"$dfpRoot/mobile-active-ad-units.csv"

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -85,6 +85,7 @@ object CustomTargetSet {
 
   implicit val customTargetSetFormats: Format[CustomTargetSet] = Json.format[CustomTargetSet]
 
+
 }
 
 
@@ -148,13 +149,13 @@ case class GuTargeting(adUnitsIncluded: Seq[GuAdUnit],
                        geoTargetsExcluded: Seq[GeoTarget],
                        customTargetSets: Seq[CustomTargetSet]) {
 
-  val keyValues: Seq[String] = {
-    for {
-      targetSet <- customTargetSets
-      target <- targetSet.targets if target.isKeywordTag
-      targetValue <- target.values
-    } yield targetValue
-  }
+  // This is local pure helper function:
+  private val tagValues = ( ( customTargetSets: Seq[CustomTargetSet],
+                              isGoodTag: CustomTarget => Boolean )
+                             => customTargetSets.flatMap( _.targets ).filter( isGoodTag ).flatMap( _.values ) )
+
+  val serieValues: Seq[String] = tagValues( customTargetSets, _.isSeriesTag )
+  val keywordValues: Seq[String] = tagValues( customTargetSets, _.isKeywordTag )
 
   val adTestValue: Option[String] = {
     val testValues = for {

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -149,10 +149,9 @@ case class GuTargeting(adUnitsIncluded: Seq[GuAdUnit],
                        geoTargetsExcluded: Seq[GeoTarget],
                        customTargetSets: Seq[CustomTargetSet]) {
 
-  // This is local pure helper function:
   private val tagValues = ( ( customTargetSets: Seq[CustomTargetSet],
-                              isGoodTag: CustomTarget => Boolean )
-                             => customTargetSets.flatMap( _.targets ).filter( isGoodTag ).flatMap( _.values ) )
+                              tagFilter: CustomTarget => Boolean )
+                             => customTargetSets.flatMap( _.targets ).filter( tagFilter ).flatMap( _.values ) )
 
   val serieValues: Seq[String] = tagValues( customTargetSets, _.isSeriesTag )
   val keywordValues: Seq[String] = tagValues( customTargetSets, _.isKeywordTag )

--- a/common/app/common/dfp/PageSkinSponsorship.scala
+++ b/common/app/common/dfp/PageSkinSponsorship.scala
@@ -3,12 +3,17 @@ package common.dfp
 import common.{Edition, Logging}
 import play.api.libs.json._
 
+/** A PageSkinSponsorship
+  *   is a special decoration of a DFP LineItem that we need to scan for ourselves,
+  *   because DFP doesn't have this concept.
+ */
 case class PageSkinSponsorship(lineItemName: String,
                                lineItemId: Long,
                                adUnits: Seq[String],
+                              // Targeting properties
                                editions: Seq[Edition],
                                countries: Seq[String],
-                               isR2Only: Boolean,
+                               isR2Only: Boolean, // Legacy platform.
                                targetsAdTest: Boolean,
                                adTestValue: Option[String],
                                keywords: Seq[String])

--- a/common/app/common/dfp/PageSkinSponsorship.scala
+++ b/common/app/common/dfp/PageSkinSponsorship.scala
@@ -16,7 +16,9 @@ case class PageSkinSponsorship(lineItemName: String,
                                isR2Only: Boolean, // Legacy platform.
                                targetsAdTest: Boolean,
                                adTestValue: Option[String],
-                               keywords: Seq[String])
+                               keywords: Seq[String],
+                               series: Seq[String]
+)
 
 object PageSkinSponsorship {
   implicit val pageskinSponsorShipFormat: Format[PageSkinSponsorship] = Json.format[PageSkinSponsorship]

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -2,7 +2,7 @@ package common.dfp
 
 import common.Edition
 import com.gu.commercial.display.AdTargetParam.toMap
-import com.gu.commercial.display.MultipleValues
+import com.gu.commercial.display.{AdTargetParamValue, MultipleValues}
 import model.MetaData
 
 trait PageskinAdAgent {
@@ -25,11 +25,21 @@ trait PageskinAdAgent {
       } else Seq.empty
     } else {
       val targetingMap = toMap(metaData.commercial.map(_.adTargeting(edition)).getOrElse(Set.empty))
-      val keywordTargeting = targetingMap.get("k") match {
-        case Some(values: MultipleValues) => values.values.toSeq
-        case _ => Seq.empty
+
+      val targetingMapValues = ((map: Map[String, AdTargetParamValue], key: String) =>
+        map.get(key) match {
+          case Some(values: MultipleValues) => values.values.toSeq
+          case _ => Seq.empty
+        }
+      )
+
+      val keywordTargeting = targetingMapValues( targetingMap , "k" )
+      val seriesTargeting = targetingMapValues( targetingMap , "se" )
+
+      candidates filter { sponsorship =>
+        sponsorship.keywords.intersect(keywordTargeting).nonEmpty ||
+        sponsorship.series.intersect(seriesTargeting).nonEmpty
       }
-      candidates filter { sponsorship => sponsorship.keywords.intersect(keywordTargeting).nonEmpty }
     }
   }
 

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -1,6 +1,8 @@
 package common.dfp
 
-import com.gu.commercial.display.{AdTargetParam, KeywordParam}
+import com.gu.contentapi.client.model.v1.{ Tag, TagType }
+import com.gu.commercial.display.{AdTargetParam, KeywordParam, SeriesParam}
+
 import common.Edition.defaultEdition
 import common.commercial.{CommercialProperties, EditionAdTargeting}
 import common.editions.{Au, Uk, Us}
@@ -15,8 +17,29 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     editionAdTargetings = Set(EditionAdTargeting(defaultEdition, Some(keywordParamSet))),
     prebidIndexSites = None
   )
+
+  val colourSeriesCommercial = CommercialProperties(
+    editionBrandings = Set.empty,
+    prebidIndexSites = None,
+    editionAdTargetings = Set( EditionAdTargeting( defaultEdition, // Uk
+                                                   Some(
+                                                     SeriesParam.from(
+                                                       // This is how we create a new Tag in the code.
+                                                       Tag.apply(
+                                                         id = "new-view-series",
+                                                         `type` =  TagType.Series,
+                                                         webTitle = "Some colour serie",
+                                                         webUrl = "http://www.example.com",
+                                                         apiUrl = "http://api.example.com"
+                                                       ) ).toSet
+                                                   ) )
+    )
+  )
+
   val pressedFrontMeta = MetaData.make("", None, "The title", None, isFront = true, isPressedPage = true)
-  val indexFrontMeta = MetaData.make("", None, "The title", None, isFront = true, commercial = Some(commercialProperties))
+  val colourSeriesMeta = MetaData.make("", None, "The title", None, isFront = true, isPressedPage = false, commercial = Some( colourSeriesCommercial ))
+
+  val sportIndexFrontMeta = MetaData.make("", None, "The title", None, isFront = true, commercial = Some(commercialProperties))
   val articleMeta = MetaData.make("", None, "The title", None)
 
   val examplePageSponsorships = Seq(
@@ -79,14 +102,33 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       adTestValue = None,
       keywords = Seq("sport-keyword"),
       series = Seq.empty
+    ),
+    PageSkinSponsorship(
+      // Modeled after a real test example:
+      // https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=2259406532&lineItemId=4600377077
+      "lineItemName6",
+      4600377077L,
+      Seq("fake-series-adunit"),
+      Seq(Uk),
+      Nil,
+      isR2Only = false,
+      targetsAdTest = false,
+      adTestValue = None,
+      keywords = Seq.empty,
+      series = Seq("new-view-series")
     )
   )
 
+  // WARNING: Despite being called 'TestPageskinAgent',
+  // this is considered 'Production' by the superclass, because 'environmentIsProd' is true.
+  // So only PageSkinSponsorship with targetsAdTest = false will potentially match
   private object TestPageskinAdAgent extends PageskinAdAgent {
     override protected val environmentIsProd: Boolean = true
     override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = examplePageSponsorships
   }
 
+  // NOTE: 'NotProduction' here means 'Test', like in 'Test server'
+  // PageSkinSponsorship with targetsAdTest = true will potentially match
   private object NotProductionTestPageskinAdAgent extends PageskinAdAgent {
     override protected val environmentIsProd: Boolean = false
     override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = examplePageSponsorships
@@ -94,6 +136,10 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
     TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Uk) should be(true)
+  }
+
+  it should "be true for a series front" in {
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/fake-series-adunit/new-view-series", colourSeriesMeta, Uk ) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {
@@ -114,7 +160,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   }
 
   it should "be true for an index front (tag page)" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", indexFrontMeta, defaultEdition) should be(true)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition) should be(true)
   }
 
   "production DfpAgent" should "not recognise adtest targetted line items" in {

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -20,7 +20,8 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   val articleMeta = MetaData.make("", None, "The title", None)
 
   val examplePageSponsorships = Seq(
-    PageSkinSponsorship("lineItemName",
+    PageSkinSponsorship(
+      "lineItemName",
       1234L,
       Seq("business/front"),
       Seq(Uk),
@@ -28,8 +29,11 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       isR2Only = false,
       targetsAdTest = false,
       adTestValue = None,
-      keywords = Seq.empty),
-    PageSkinSponsorship("lineItemName2",
+      keywords = Seq.empty,
+      series = Seq.empty
+    ),
+    PageSkinSponsorship(
+      "lineItemName2",
       12345L,
       Seq("music/front"),
       Nil,
@@ -37,8 +41,11 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       isR2Only = false,
       targetsAdTest = false,
       adTestValue = None,
-      keywords = Seq.empty),
-    PageSkinSponsorship("lineItemName3",
+      keywords = Seq.empty,
+      series = Seq.empty
+    ),
+    PageSkinSponsorship(
+      "lineItemName3",
       123456L,
       Seq("sport"),
       Nil,
@@ -46,8 +53,11 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       isR2Only = false,
       targetsAdTest = false,
       adTestValue = None,
-      keywords = Seq.empty),
-    PageSkinSponsorship("lineItemName4",
+      keywords = Seq.empty,
+      series = Seq.empty
+    ),
+    PageSkinSponsorship(
+      "lineItemName4",
       1234567L,
       Seq("testSport/front"),
       Seq(Uk),
@@ -55,8 +65,11 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       isR2Only = false,
       targetsAdTest = true,
       adTestValue = Some("6"),
-      keywords = Seq.empty),
-    PageSkinSponsorship("lineItemName5",
+      keywords = Seq.empty,
+      series = Seq.empty
+    ),
+    PageSkinSponsorship(
+      "lineItemName5",
       123458L,
       Seq("sport-index"),
       Seq(Uk),
@@ -64,7 +77,9 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       isR2Only = false,
       targetsAdTest = false,
       adTestValue = None,
-      keywords = Seq("sport-keyword"))
+      keywords = Seq("sport-keyword"),
+      series = Seq.empty
+    )
   )
 
   private object TestPageskinAdAgent extends PageskinAdAgent {


### PR DESCRIPTION
## What does this change?

This adds PageSkin targetting by "series" type of tag per card:

https://trello.com/c/VUOsXQti/64-add-series-tag-targeting-for-page-skins
