### PR TITLE
Fix Prebid deprecation warning

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -79,3 +79,11 @@ export type PrebidPriceBucket = {
 export type PrebidPriceGranularity = {
     buckets: PrebidPriceBucket[],
 };
+
+export type PrebidBanner = {
+    sizes: PrebidSize[],
+};
+
+export type PrebidMediaTypes = {
+    banner: PrebidBanner,
+};


### PR DESCRIPTION
Since v1, a deprecation warning appears in the dev console:

`WARNING: Usage of adUnits.sizes will eventually be deprecated.  Please define size dimensions within the corresponding area of the mediaTypes.<object> (eg mediaTypes.banner.sizes).`

This change moves `adUnit.sizes` to `adUnit.mediaTypes.banner.sizes`.
