### PR TITLE
Extend subscribe header test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "Point the subscribe link in the header to a subscriptions-only version of the support site",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 12),
+    sellByDate = new LocalDate(2018, 3, 19),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
The test is complete with no significant difference so I'm going to switch it off. But a decision on the new control is still pending so I'm also going to extend the switch, just for a week...