### PR TITLE
Remove refs to Stripe module

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
       "raven": "raven-js",
       "EventEmitter": "wolfy87-eventemitter",
       "videojs": "video.js",
-      "stripe": "stripe/stripe.min",
       "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.js",
       "^(.*)\\.html$": "<rootDir>/__mocks__/templateMock.js",
       "ophan/ng": "ophan-tracker-js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,6 @@ module.exports = {
             EventEmitter: 'wolfy87-eventemitter',
             videojs: 'video.js',
 
-            stripe: 'stripe/stripe.min',
             svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),
             'ophan/ng': 'ophan-tracker-js',
             'ophan/embed': 'ophan-tracker-js/build/ophan.embed',


### PR DESCRIPTION
## What does this change?

Most of the weird old checked-in vendor code has gone away, but this reference to stripe remains. This change removes the unused path to stripe in our Webpack and test configs.

## What is the value of this and can you measure success?

Less to code maintain, less confusing codebase

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
