### PR TITLE
addd js modal classes back in

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -63,7 +63,7 @@
                         </p>
                     </li>
                     <li>
-                        <a href="#identity-modal--newsletterFormat" class="u-underline" data-link-name="identity : email : format">
+                        <a href="#identity-modal--newsletterFormat" class="u-underline js-email-subscription__formatFieldsetToggle" data-link-name="identity : email : format">
                             Change format
                         </a>
                     </li>


### PR DESCRIPTION
## What does this change?
- The email format modal was broken when js classes were removed from the html in this PR https://github.com/guardian/frontend/pull/19277 
- Bug fix for that
