### PR TITLE
Include top-above-nav mobile slot in Prebid auctions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -16,11 +16,12 @@ import type {
 } from 'commercial/modules/prebid/types';
 import {
     getBreakpointKey,
+    stripMobileSuffix,
     stripTrailingNumbers,
 } from 'commercial/modules/prebid/utils';
 
 const getTrustXAdUnitId = (slotId: string): string => {
-    switch (stripTrailingNumbers(slotId)) {
+    switch (stripTrailingNumbers(stripMobileSuffix(slotId))) {
         case 'dfp-ad--inline':
             return '2960';
         case 'dfp-ad--mostpop':

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -14,7 +14,10 @@ import type {
     PrebidSlot,
     PrebidSlotLabel,
 } from 'commercial/modules/prebid/types';
-import { stripTrailingNumbers } from 'commercial/modules/prebid/utils';
+import {
+    stripMobileSuffix,
+    stripTrailingNumbers,
+} from 'commercial/modules/prebid/utils';
 
 const bidderTimeout = 1500;
 
@@ -68,7 +71,11 @@ class PrebidService {
         }
 
         const adUnits = slots
-            .filter(slot => stripTrailingNumbers(advert.id).endsWith(slot.key))
+            .filter(slot =>
+                stripTrailingNumbers(stripMobileSuffix(advert.id)).endsWith(
+                    slot.key
+                )
+            )
             .map(slot => new PrebidAdUnit(advert, slot))
             .filter(adUnit => !adUnit.isEmpty());
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -9,6 +9,16 @@ export const slots: PrebidSlot[] = [
         labelAll: ['desktop'],
     },
     {
+        key: 'top-above-nav',
+        sizes: [[728, 90]],
+        labelAll: ['tablet'],
+    },
+    {
+        key: 'top-above-nav',
+        sizes: [[300, 250]],
+        labelAll: ['mobile'],
+    },
+    {
         key: 'right',
         sizes: [[300, 250], [300, 600]],
         labelAny: ['mobile', 'tablet', 'desktop'],

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -2,6 +2,11 @@
 
 import { getBreakpoint } from 'lib/detect';
 
+const stripSuffix = (s: string, suffix: string): string => {
+    const re = new RegExp(`${suffix}$`);
+    return s.replace(re, '');
+};
+
 export const getBreakpointKey = (): string => {
     switch (getBreakpoint()) {
         case 'mobile':
@@ -19,6 +24,9 @@ export const getBreakpointKey = (): string => {
             return 'D';
     }
 };
+
+export const stripMobileSuffix = (s: string): string =>
+    stripSuffix(s, '--mobile');
 
 export const stripTrailingNumbers = (s: string): string =>
     s.replace(/\d+$/, '');


### PR DESCRIPTION
This adds configuration for the top-above-nav ad slot at the mobile and tablet breakpoints.

In fronts at the mobile breakpoint, the top-above-nav slot has a slightly different name: `dfp-ad--top-above-nav--mobile` and all the inline slots are named similarly: `dfp-ad--inlineN--mobile`.  So the code now takes this into account.

There's also some refactoring.
