### PR TITLE
Oriel Sonobi test page

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -376,4 +376,14 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val orielSonobiIntegration: Switch = Switch(
+    group = Commercial,
+    name = "oriel-sonobi-integration-test",
+    description = "This is a short test to test the integration between Oriel and Sonobi",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 3, 16),
+    exposeClientSide = false
+  )
 }

--- a/common/app/views/fragments/page/head/orielScriptTag.scala.html
+++ b/common/app/views/fragments/page/head/orielScriptTag.scala.html
@@ -3,9 +3,12 @@
 @import experiments.{ ActiveExperiments, OrielParticipation }
 @import common.commercial.OrielCache
 @import play.twirl.api.HtmlFormat
+@import conf.switches.Switches.orielSonobiIntegration
+
 
 @if(
-    ActiveExperiments.isParticipating(OrielParticipation)
+    ActiveExperiments.isParticipating(OrielParticipation) ||
+            (orielSonobiIntegration.isSwitchedOn && request.uri == "/environment/2018/mar/11/labrador-switch-energy-suppliers")
 ) {
     @OrielCache.cache.get().getLoaderScript.map { loaderScript => <script>@HtmlFormat.raw(loaderScript)</script> }
 }


### PR DESCRIPTION
## What does this change?

This adds an Oriel - Sonobi integration switch. This means we can turn on the integration on production for one URL to test the pipes between everyone.

This is still pending an answer on whether we need the analytics integration for Oriel turned on or not. If so, there will be slightly more work in this PR, if not then this can be merged as is.

Right now, I am not sure which URL to use and this is subject to change.
