### PR TITLE
Change `ask for help` to `help` in the footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -95,7 +95,7 @@
                                 contact us</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                ask for help</a>
+                                help</a>
                             </li>
                         </ul>
 
@@ -177,7 +177,7 @@
 
                         <ul class="colophon__list">
                             <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                ask for help</a>
+                                help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                 terms &amp; conditions</a>
@@ -271,7 +271,7 @@
                                 securedrop</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                ask for help</a>
+                                help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
                                 information</a>
@@ -312,7 +312,7 @@
                                 securedrop</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/help}">
-                                ask for help</a>
+                                help</a>
                             </li>
                         </ul>
 


### PR DESCRIPTION
## What does this change?
Requested from User help. Just a small wording change.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/37341222-86408f72-26b8-11e8-9784-3b7e8d0f65fd.png)

After:
![image](https://user-images.githubusercontent.com/8774970/37341213-8109b6be-26b8-11e8-958d-f5a085361b28.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
