### PR TITLE
Fix dateline alignment at low breakpoints

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -192,7 +192,6 @@ $quote-mark: 35px;
         padding-bottom: $gs-baseline*1.5;
         @include mq($until: phablet) {
             border-top: 0;
-            vertical-align: top;
         }
     }
 


### PR DESCRIPTION
## What does this change?

The dateline overlaps the byline if the byline is too long. This has been spotted on devices with a narrow viewport, such as on the iPhone 4 and the Viewer tool 

This change prevents this overlap.

## What is the value of this and can you measure success?

Content is visible

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

[Example article](https://www.theguardian.com/fashion/gallery/2018/mar/09/key-trends-from-spring-summer-2018-fashion-shows#)

**Before**

![picture 519](https://user-images.githubusercontent.com/5931528/37352222-aba6dffc-26d4-11e8-8b4c-4570c28296c1.png)

**After**

![picture 520](https://user-images.githubusercontent.com/5931528/37352228-af800a36-26d4-11e8-9ab7-5a2c35447ebb.png)

**Before - larger device**

![picture 522](https://user-images.githubusercontent.com/5931528/37352278-d1fac024-26d4-11e8-907b-e3a54e8f5934.png)

**After - larger device**

![picture 521](https://user-images.githubusercontent.com/5931528/37352273-ce7775d2-26d4-11e8-8465-eeb6ed12fa77.png)

**Before - unaffected article**

![picture 523](https://user-images.githubusercontent.com/5931528/37352439-2f24a67a-26d5-11e8-811e-d9f57a2561c1.png)

**After - unaffected article**

![picture 524](https://user-images.githubusercontent.com/5931528/37352448-362c7ed4-26d5-11e8-86d1-e1f83b259708.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
