### PR TITLE
Kill picturefill

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -49,7 +49,6 @@ module.name_mapper='^lodash\(.*\)$' -> 'lodash-amd/compat\1'
 module.name_mapper='^raven' -> 'raven-js'
 module.name_mapper='^EventEmitter' -> 'wolfy87-eventemitter'
 module.name_mapper='^videojs' -> 'video.js'
-module.name_mapper='^stripe' -> 'stripe/stripe.min'
 module.name_mapper='^ophan/ng' -> 'ophan-tracker-js'
 module.name_mapper='^ophan/embed' -> 'ophan-tracker-js/build/ophan.embed'
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -46,7 +46,6 @@ module.name_mapper='^svgs' -> '<PROJECT_ROOT>/static/src/inline-svgs'
 
 # modules that go by different names in webpack
 module.name_mapper='^lodash\(.*\)$' -> 'lodash-amd/compat\1'
-module.name_mapper='^picturefill' -> 'projects/common/utils/picturefill'
 module.name_mapper='^raven' -> 'raven-js'
 module.name_mapper='^EventEmitter' -> 'wolfy87-eventemitter'
 module.name_mapper='^videojs' -> 'video.js'

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     ],
     "moduleNameMapper": {
       "^lodash/(.*)$": "lodash-node/compat/$1",
-      "picturefill": "projects/common/utils/picturefill",
       "raven": "raven-js",
       "EventEmitter": "wolfy87-eventemitter",
       "videojs": "video.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,6 @@ module.exports = {
 
             // #wp-rjs weird old aliasing from requirejs
             lodash: 'lodash-amd/compat',
-            picturefill: 'lib/picturefill',
             raven: 'raven-js',
             EventEmitter: 'wolfy87-eventemitter',
             videojs: 'video.js',


### PR DESCRIPTION
## What does this change?

While we don't include the picturefill module as an explicit dependency, we have several mappings and aliases pointing to non-existent files. This change removes these mappings.

While I was in there, I also removed a reference to Stripe from the flowconfig, another library that was removed. I missed this in #19322 

## What is the value of this and can you measure success?

Fewer odd aliases, cleaner code

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
