### PR TITLE
Kill (one particular version of) lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "jest-environment-jsdom-global": "^1.0.3",
     "jest-teamcity-reporter": "^0.6.2",
     "listr": "^0.12.0",
-    "lodash": "^3.10.1",
     "lodash-node": "~2.4.1",
     "lodash.capitalize": "^4.2.1",
     "lodash.flatten": "^4.4.0",


### PR DESCRIPTION
## What does this change?

Our lodash strategy is getting out of hand:

**dependencies:**

- "lodash-amd": "~2.4.1"

**devDependencies:**

- "lodash": "^3.10.1"
- "lodash-node": "~2.4.1"
- "lodash.capitalize": "^4.2.1"
- "lodash.flatten": "^4.4.0"
- "lodash.merge": "^4.6.0"
- "lodash.takewhile": "^4.6.0"
- "lodash.uniq": "^4.5.0"

Step 1: kill this version of `lodash` which is not being used.

## What is the value of this and can you measure success?

Less lodash

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
