### PR TITLE
Football - clean up aggregate scores and grid layout on load

### DIFF
--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -39,7 +39,6 @@
 
             @if(theMatch.isLive || theMatch.isResult){
                 @homeTeam.score.map{score => @fragments.inlineSvg("number-" + score, "numbers", List("team__score")) }
-                @homeTeam.aggregateScore.map{aggScore => @fragments.inlineSvg("number-" + aggScore, "numbers", List("team__agg-score"))}
             }
         </div>
 
@@ -59,11 +58,12 @@
 
             @if(theMatch.isLive || theMatch.isResult){
                 @awayTeam.score.map{score => @fragments.inlineSvg("number-" + score, "numbers", List("team__score")) }
-                @awayTeam.aggregateScore.map{aggScore => @fragments.inlineSvg("number-" + aggScore, "numbers", List("team__agg-score"))}
             }
         </div>
     </div>
-
-    @theMatch.comments.map{ comments => <div class="match-summary__comment">@comments.replace("(", "").replace(")", "")</div>}
+    <div class='match-summary__comments'>
+        @theMatch.homeTeam.aggregateScore.map{homeAggScore => <span class='match-summary__comment'>Aggregate @homeAggScore-@theMatch.awayTeam.aggregateScore</span>}
+        @theMatch.comments.map{ comments => <span class='match-summary__comment'> @comments.replace("(", "").replace(")", "")</span>}
+    </div>
 </@if(link){a}else{div}>
 }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1001,7 +1001,7 @@
 
             .content--type-article.section-football &,
             .content--type-matchreport & {
-                grid-template-areas: 'labels report' '. headline-standfirst' 'meta main-media';
+                grid-template-areas: 'labels headline-standfirst' '. report' 'meta main-media';
             }
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -825,6 +825,10 @@ $quote-mark: 35px;
         }
     }
 
+    .content__head {
+        grid-template-areas: 'labels report' '. headline-standfirst' 'meta main-media';
+    }
+
     .football-tabs .tabs__container {
         margin-bottom: 0;
     }

--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -138,33 +138,10 @@
     }
 }
 
-.team__agg-score {
-    position: absolute;
-    bottom: 0;
-    left: ($garnett-large-button-size * 2) - 12px;
-    width: $garnett-medium-button-size;
-    height: $garnett-medium-button-size;
-    border-radius: $garnett-medium-button-size / 2;
-    background-color: #ffffff;
-
-    @include mq(mobileLandscape) {
-        left: ($garnett-x-large-button-size * 2) - 12px;
-    }
-
-    svg {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        transform: scale(.6);
-        margin: auto;
-    }
-}
-
-.match-summary__comment {
+.match-summary__comments {
     @include fs-textSans(3);
     position: relative;
+    font-style: italic;
     color: $neutral-1;
     padding: 6px 10px;
     border-top: 1px solid mix($neutral-1, $news-garnett-highlight, 20%);
@@ -191,4 +168,10 @@
             width: 1px;
         }
     }
+}
+
+.match-summary__comment + .match-summary__comment {
+    margin-left: $gs-gutter / 4;
+    padding-left: $gs-gutter / 4;
+    border-left: 1px solid mix($neutral-1, $news-garnett-highlight, 20%);
 }


### PR DESCRIPTION
This cleans up a the design and the loading jank for match reports.

Before
![image](https://user-images.githubusercontent.com/1607666/37408404-699f85e8-2772-11e8-83ef-e819dee28fd4.png)

After
![image](https://user-images.githubusercontent.com/1607666/37408418-70c4bb72-2772-11e8-998e-29d743ce8126.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
