### PR TITLE
Support Prebid DMPUs in inline ad slots below inline1 in articles

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -115,10 +115,17 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
 
 // Improve has to have single size as parameter if slot doesn't accept multiple sizes,
 // because it uses same placement ID for multiple slot sizes and has no other size information
-const getImproveSizeParam = (slotId: string): PrebidImproveSizeParam =>
-    slotId === 'dfp-ad--mostpop' || slotId.startsWith('dfp-ad--inline')
+const getImproveSizeParam = (slotId: string): PrebidImproveSizeParam => {
+    const key = stripTrailingNumbersAbove1(stripMobileSuffix(slotId));
+    const isInlineNotDesktopArticle =
+        key.endsWith('inline') &&
+        !(getBreakpointKey() === 'D' && config.page.contentType === 'Article');
+    return key.endsWith('mostpop') ||
+        key.endsWith('inline1') ||
+        isInlineNotDesktopArticle
         ? { w: 300, h: 250 }
         : {};
+};
 
 const sonobiBidder: PrebidBidder = {
     name: 'sonobi',

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -22,6 +22,7 @@ import {
 
 const getTrustXAdUnitId = (slotId: string): string => {
     switch (stripTrailingNumbersAbove1(stripMobileSuffix(slotId))) {
+        case 'dfp-ad--inline1':
         case 'dfp-ad--inline':
             return '2960';
         case 'dfp-ad--mostpop':

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -17,11 +17,11 @@ import type {
 import {
     getBreakpointKey,
     stripMobileSuffix,
-    stripTrailingNumbers,
+    stripTrailingNumbersAbove1,
 } from 'commercial/modules/prebid/utils';
 
 const getTrustXAdUnitId = (slotId: string): string => {
-    switch (stripTrailingNumbers(stripMobileSuffix(slotId))) {
+    switch (stripTrailingNumbersAbove1(stripMobileSuffix(slotId))) {
         case 'dfp-ad--inline':
             return '2960';
         case 'dfp-ad--mostpop':

--- a/static/src/javascripts/projects/commercial/modules/prebid/labels.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/labels.js
@@ -25,6 +25,12 @@ switch (getBreakpointKey()) {
     // do nothing
 }
 
+if (config.page.contentType === 'Article') {
+    slotLabels.push('article');
+} else {
+    slotLabels.push('non-article');
+}
+
 const bidLabels: PrebidBidLabel[] = [];
 
 switch (config.page.edition) {

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -16,7 +16,7 @@ import type {
 } from 'commercial/modules/prebid/types';
 import {
     stripMobileSuffix,
-    stripTrailingNumbers,
+    stripTrailingNumbersAbove1,
 } from 'commercial/modules/prebid/utils';
 
 const bidderTimeout = 1500;
@@ -72,9 +72,9 @@ class PrebidService {
 
         const adUnits = slots
             .filter(slot =>
-                stripTrailingNumbers(stripMobileSuffix(advert.id)).endsWith(
-                    slot.key
-                )
+                stripTrailingNumbersAbove1(
+                    stripMobileSuffix(advert.id)
+                ).endsWith(slot.key)
             )
             .map(slot => new PrebidAdUnit(advert, slot))
             .filter(adUnit => !adUnit.isEmpty());

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -30,15 +30,26 @@ class PrebidAdUnit {
 
     constructor(advert: Advert, slot: PrebidSlot) {
         this.code = advert.id;
-        this.bids = bidders.map((bidder: PrebidBidder) => ({
-            bidder: bidder.name,
-            params: bidder.bidParams(advert.id, slot.sizes),
-            labelAny: bidder.labelAny,
-            labelAll: bidder.labelAll,
-        }));
+        this.bids = bidders.map((bidder: PrebidBidder) => {
+            const bid: PrebidBid = {
+                bidder: bidder.name,
+                params: bidder.bidParams(advert.id, slot.sizes),
+            };
+            if (bidder.labelAny) {
+                bid.labelAny = bidder.labelAny;
+            }
+            if (bidder.labelAll) {
+                bid.labelAll = bidder.labelAll;
+            }
+            return bid;
+        });
         this.mediaTypes = { banner: { sizes: slot.sizes } };
-        this.labelAny = slot.labelAny ? slot.labelAny : [];
-        this.labelAll = slot.labelAll ? slot.labelAll : [];
+        if (slot.labelAny) {
+            this.labelAny = slot.labelAny;
+        }
+        if (slot.labelAll) {
+            this.labelAll = slot.labelAll;
+        }
     }
 
     isEmpty() {

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -24,6 +24,11 @@ export const slots: PrebidSlot[] = [
         labelAny: ['mobile', 'tablet', 'desktop'],
     },
     {
+        key: 'inline1',
+        sizes: [[300, 250]],
+        labelAny: ['mobile', 'tablet', 'desktop'],
+    },
+    {
         key: 'inline',
         sizes: [[300, 250]],
         labelAny: ['mobile', 'tablet', 'desktop'],

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -30,8 +30,18 @@ export const slots: PrebidSlot[] = [
     },
     {
         key: 'inline',
+        sizes: [[300, 250], [300, 600]],
+        labelAll: ['desktop', 'article'],
+    },
+    {
+        key: 'inline',
         sizes: [[300, 250]],
-        labelAny: ['mobile', 'tablet', 'desktop'],
+        labelAll: ['desktop', 'non-article'],
+    },
+    {
+        key: 'inline',
+        sizes: [[300, 250]],
+        labelAny: ['mobile', 'tablet'],
     },
     {
         key: 'mostpop',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -38,21 +38,10 @@ export const slots: PrebidSlot[] = [
         sizes: [[300, 250]],
         labelAll: ['desktop', 'non-article'],
     },
-    // following won't work yet because of https://github.com/prebid/Prebid.js/issues/2263
-    // {
-    //     key: 'inline',
-    //     sizes: [[300, 250]],
-    //     labelAny: ['tablet', 'mobile'],
-    // },
     {
         key: 'inline',
         sizes: [[300, 250]],
-        labelAll: ['tablet'],
-    },
-    {
-        key: 'inline',
-        sizes: [[300, 250]],
-        labelAll: ['mobile'],
+        labelAny: ['tablet', 'mobile'],
     },
     {
         key: 'mostpop',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -38,10 +38,21 @@ export const slots: PrebidSlot[] = [
         sizes: [[300, 250]],
         labelAll: ['desktop', 'non-article'],
     },
+    // following won't work yet because of https://github.com/prebid/Prebid.js/issues/2263
+    // {
+    //     key: 'inline',
+    //     sizes: [[300, 250]],
+    //     labelAny: ['tablet', 'mobile'],
+    // },
     {
         key: 'inline',
         sizes: [[300, 250]],
-        labelAny: ['mobile', 'tablet'],
+        labelAll: ['tablet'],
+    },
+    {
+        key: 'inline',
+        sizes: [[300, 250]],
+        labelAll: ['mobile'],
     },
     {
         key: 'mostpop',

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -34,7 +34,12 @@ export type PrebidSlotKey =
     | 'inline'
     | 'mostpop';
 
-export type PrebidSlotLabel = 'mobile' | 'tablet' | 'desktop';
+export type PrebidSlotLabel =
+    | 'mobile'
+    | 'tablet'
+    | 'desktop'
+    | 'article'
+    | 'non-article';
 
 export type PrebidBidLabel = 'edn-UK' | 'edn-INT' | 'geo-NA';
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -27,7 +27,12 @@ export type PrebidImproveParams = {
     size: PrebidImproveSizeParam,
 };
 
-export type PrebidSlotKey = 'top-above-nav' | 'right' | 'inline' | 'mostpop';
+export type PrebidSlotKey =
+    | 'top-above-nav'
+    | 'right'
+    | 'inline1'
+    | 'inline'
+    | 'mostpop';
 
 export type PrebidSlotLabel = 'mobile' | 'tablet' | 'desktop';
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -28,5 +28,5 @@ export const getBreakpointKey = (): string => {
 export const stripMobileSuffix = (s: string): string =>
     stripSuffix(s, '--mobile');
 
-export const stripTrailingNumbers = (s: string): string =>
-    s.replace(/\d+$/, '');
+export const stripTrailingNumbersAbove1 = (s: string): string =>
+    stripSuffix(s, '([2-9]|\\d{2,})');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -1,0 +1,20 @@
+// @flow
+import { stripMobileSuffix, stripTrailingNumbersAbove1 } from './utils';
+
+describe('Utils', () => {
+    test('stripMobileSuffix', () => {
+        expect(stripMobileSuffix('top-above-nav--mobile')).toBe(
+            'top-above-nav'
+        );
+        expect(stripMobileSuffix('inline1--mobile')).toBe('inline1');
+    });
+
+    test('stripTrailingNumbersAbove1', () => {
+        expect(stripTrailingNumbersAbove1('inline1')).toBe('inline1');
+        expect(stripTrailingNumbersAbove1('inline2')).toBe('inline');
+        expect(stripTrailingNumbersAbove1('inline10')).toBe('inline');
+        expect(stripTrailingNumbersAbove1('inline23')).toBe('inline');
+        expect(stripTrailingNumbersAbove1('inline101')).toBe('inline');
+        expect(stripTrailingNumbersAbove1('inline456')).toBe('inline');
+    });
+});


### PR DESCRIPTION
Previously Prebid could only provide MPUs in inline slots.

This change allows Prebid to bid for DMPUs in inline slots inline2 and beyond, in articles on desktop only.  This is particularly applicable to long reads.

I've submitted an [issue](https://github.com/prebid/Prebid.js/issues/2263) to the Prebid codebase about the way labels don't quite seem to work as expected.  Once that's fixed the code will be slightly more concise.  I haven't tried to work out what the fix might be.
