### PR TITLE
Always hide byline picture on interactive pages

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -111,7 +111,8 @@ final case class Content(
   lazy val hasTonalHeaderIllustration: Boolean = tags.isLetters
 
   lazy val showCircularBylinePicAtSide: Boolean =
-    cardStyle == Feature || tags.isReview && tags.hasLargeContributorImage && tags.contributors.length == 1 && !tags.isInteractive
+    !tags.isInteractive &&
+      (cardStyle == Feature || tags.isReview && tags.hasLargeContributorImage && tags.contributors.length == 1)
 
   lazy val openGraphImageOrFallbackUrl: String =
     rawOpenGraphImage


### PR DESCRIPTION
## What does this change?

Byline pictures are visible on Interactive pages if and only if they are tagged with a Feature tone. 

This is incorrect. Byline pictures should never appear on interactive pages. This change ensures this.

## What is the value of this and can you measure success?

Less furniture on interactives page: make them consistent, and it looks nicer
