### PR TITLE
Wait for polyfills if they’re taking a while

### DIFF
--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -22,6 +22,7 @@
 function guardianPolyfilled() {
     try {
         window.guardian.polyfilled = true;
+        window.guardian.onPolyfilled();
     } catch (e) {};
 }
 


### PR DESCRIPTION
## What does this change?

restores the `onPolyfilled` event handling for times when the app is ready to go before polyfills are ready. 

just to connect the PRs, was removed previously in #16553
