### PR TITLE
Change switches around Oriel

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -11,11 +11,11 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring, orielScriptTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, orielScriptTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.ContentCSSFile
-import conf.switches.Switches.{ WeAreHiring, OrielFullIntegration }
+import conf.switches.Switches.WeAreHiring
 
 object ContentHtmlPage extends HtmlPage[Page] {
 
@@ -46,7 +46,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, GalleryPage, Page}
@@ -37,7 +37,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.ApplicationContext
@@ -39,7 +39,7 @@ object IndexHtml {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         headContent,

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import controllers.InteractivePage
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -46,7 +46,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.{ApplicationContext, ContributorsListing, PreferencesMetaData, StandalonePage, SubjectsListing, TagIndexPage}
@@ -43,7 +43,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -42,7 +42,7 @@ object StoryHtmlPage {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         lotameScriptTag() when ActiveExperiments.isParticipating(LotameParticipation),
         titleTag(),
         metaData(),

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -373,7 +373,7 @@ trait CommercialSwitches {
     description = "This is a short test to test the integration between Oriel and Sonobi",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 16),
+    sellByDate = new LocalDate(2018, 6, 28),
     exposeClientSide = false
   )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -317,16 +317,6 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val OrielFullIntegration: Switch = Switch(
-    group = Commercial,
-    name = "oriel-full-integration",
-    description = "Include a tag dropped at the start of <head> for full Oriel integration",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 6, 28),
-    exposeClientSide = false
-  )
-
   val BlockthroughSwitch: Switch = Switch(
     group = Commercial,
     name = "blockthrough",

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -2,16 +2,19 @@
 
 @import conf.Configuration
 @import experiments.{ ActiveExperiments, OrielParticipation }
+@import conf.switches.Switches.OrielAnalyticsSwitch
 
 @if(
     Configuration.environment.isProd &&
-    ActiveExperiments.isParticipating(OrielParticipation)
+    OrielAnalyticsSwitch.isSwitchedOn &&
+    !ActiveExperiments.isParticipating(OrielParticipation)
 ) {
     <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>
 } else {
     @if(
         Configuration.environment.isCode &&
-        ActiveExperiments.isParticipating(OrielParticipation)
+        OrielAnalyticsSwitch.isSwitchedOn &&
+        !ActiveExperiments.isParticipating(OrielParticipation)
     ) {
         <script async type="text/javascript" src="//f92j5.com/ejihwhhs1nv430sy6u4d51elu49.js"></script>
     }

--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -7,14 +7,14 @@
 @if(
     Configuration.environment.isProd &&
     OrielAnalyticsSwitch.isSwitchedOn &&
-    !ActiveExperiments.isParticipating(OrielParticipation)
+    ActiveExperiments.isParticipating(OrielParticipation)
 ) {
     <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>
 } else {
     @if(
         Configuration.environment.isCode &&
         OrielAnalyticsSwitch.isSwitchedOn &&
-        !ActiveExperiments.isParticipating(OrielParticipation)
+        ActiveExperiments.isParticipating(OrielParticipation)
     ) {
         <script async type="text/javascript" src="//f92j5.com/ejihwhhs1nv430sy6u4d51elu49.js"></script>
     }

--- a/common/app/views/fragments/page/body/bodyTag.scala.html
+++ b/common/app/views/fragments/page/body/bodyTag.scala.html
@@ -7,7 +7,7 @@
     @f
 }
 
-@if(OrielAnalyticsSwitch.isSwitchedOn) {
+@if(OrielAnalyticsSwitch.isSwitchedOn && ) {
     @views.html.fragments.commercial.orielAnalytics()
 }
 

--- a/common/app/views/fragments/page/body/bodyTag.scala.html
+++ b/common/app/views/fragments/page/body/bodyTag.scala.html
@@ -1,14 +1,10 @@
 @(classes: Map[String, Boolean])(fragments: Html*)(implicit request: RequestHeader)
 
-@import conf.switches.Switches.OrielAnalyticsSwitch
-
 <body id="top" class="@views.support.RenderClasses(classes)" itemscope itemtype="http://schema.org/WebPage">
 @for(f <- fragments){
     @f
 }
 
-@if(OrielAnalyticsSwitch.isSwitchedOn && ) {
-    @views.html.fragments.commercial.orielAnalytics()
-}
+@views.html.fragments.commercial.orielAnalytics()
 
 </body>

--- a/common/app/views/fragments/page/head/orielScriptTag.scala.html
+++ b/common/app/views/fragments/page/head/orielScriptTag.scala.html
@@ -3,11 +3,11 @@
 @import experiments.{ ActiveExperiments, OrielParticipation }
 @import common.commercial.OrielCache
 @import play.twirl.api.HtmlFormat
-@import conf.switches.Switches.orielSonobiIntegration
+@import conf.switches.Switches.{orielSonobiIntegration, OrielAnalyticsSwitch}
 
 
 @if(
-    ActiveExperiments.isParticipating(OrielParticipation) ||
+    (OrielAnalyticsSwitch.isSwitchedOff && ActiveExperiments.isParticipating(OrielParticipation)) ||
             (orielSonobiIntegration.isSwitchedOn && request.path == "/environment/2018/mar/11/labrador-switch-energy-suppliers")
 ) {
     @OrielCache.cache.get().getLoaderScript.map { loaderScript => <script>@HtmlFormat.raw(loaderScript)</script> }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{OrielFullIntegration, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, PressedPage}
@@ -45,7 +45,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        orielScriptTag() when OrielFullIntegration.isSwitchedOn,
+        orielScriptTag(),
         titleTag(),
         metaData(),
         frontMeta(),


### PR DESCRIPTION
## What does this change?

This removes the `OrielFullIntegration` in place of using the internal switch from the AB test `OrielParticipation` via `isParticipating`.

This also adds a guard around the analytics tag; if the experiment is on AND the current user is participating, then the user can either only get the analytics tags OR the full integration tag but not both; if both get included on the page they this is subject to double counting.