### PR TITLE
Remove the billboard max-width to allow for larger billboards.

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -144,10 +144,6 @@
         margin-left: calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
         text-align: left;
 
-        &:not(.ad-slot--fluid):not(.ad-slot--fabric):not(.ad-slot--fluid250) {
-            max-width: 970px;
-        }
-
         .has-page-skin & {
             margin-left: auto;
         }


### PR DESCRIPTION
This basically undoes #15728 - it no longer applies.