### PR TITLE
Avoid invoking prebids requestBids when on a pageSkin

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/display-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-ads.js
@@ -8,8 +8,13 @@ const displayAds = (): void => {
     window.googletag.pubads().enableSingleRequest();
     window.googletag.pubads().collapseEmptyDivs();
     window.googletag.enableServices();
-    // as this is an single request call, only need to make a single display call (to the first ad
-    // slot)
+
+    /*
+     *as this is an single request call, only need to make a single display call (to the first ad
+     * slot)
+     * This will load all adSlots in one go using gpt.js, even though we ask only for the first one,
+     * thanks to 'enableSingleRequest' being set.
+     */
     loadAdvert(dfpEnv.advertsToLoad[0]);
     dfpEnv.advertsToLoad.length = 0;
     pageSkin();

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -1,6 +1,7 @@
 // @flow
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { prebid } from 'commercial/modules/prebid/prebid';
+import config from 'lib/config';
 
 export const loadAdvert = (advert: Advert): void => {
     advert.whenSlotReady
@@ -9,6 +10,11 @@ export const loadAdvert = (advert: Advert): void => {
         })
         .then(() => {
             advert.startLoading();
+            if (config.page.hasPageSkin) {
+                // No point requesting prebid bids. pageSkin slots are all loaded in one
+                // go. See 'fillAdvertSlots' in commercial/modules/dfp/fill-advert-slots.js
+                return Promise.resolve();
+            }
             return prebid.requestBids(advert);
         })
         .then(() => window.googletag.display(advert.id));


### PR DESCRIPTION
## What does this change?

This fixes https://trello.com/c/iC0Sbex9/138-no-prebid-on-page-skinned-fronts

## Does this affect other platforms - Amp, Apps, etc?

Nope.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Tested in CODE?

Tested on dev.

