### PR TITLE
update video end-slate appearance

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -990,7 +990,7 @@ $ima-controls-height: 70px;
     padding-right: $gs-gutter/2;
 
     &.fc-item {
-        width: 25%;
+        max-width: 25%;
         background-color: transparent;
         margin-left: 0;
         margin-right: 0;


### PR DESCRIPTION
## What does this change?
When there's only one item, it goes full width and doesn't look great. This makes each item `max-width: 25%`, which, given there's a maximum of 4 items in this container, should be perfect.

## What is the value of this and can you measure success?
You can see what you're clicking on.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Yep.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/836140/37524196-06a579c4-2921-11e8-8e98-c7950812226b.png)


After (single item):
![image](https://user-images.githubusercontent.com/836140/37524183-f9c09932-2920-11e8-9290-b478f1dab96d.png)


After (up to 4 items):
![image](https://user-images.githubusercontent.com/836140/37524171-edb1c530-2920-11e8-8144-e46a75637c9c.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
