### PR TITLE
Added special report rules to story package

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -14,9 +14,11 @@
         }
     }
 
-    .fc-sublink--pillar-#{$tone} {
-        .fc-sublink__kicker {
-            color: $colour;
+    .fc-item:not(.fc-item--pillar-special-report) {
+        .fc-sublink--pillar-#{$tone} {
+            .fc-sublink__kicker {
+                color: $colour;
+            }
         }
     }
 }
@@ -131,4 +133,5 @@
     @include kicker-override(sport, $sport-garnett-media-main-1);
     @include kicker-override(opinion, $opinion-garnett-media-main-1);
     @include kicker-override(news, $news-garnett-media-main-1);
+    @include kicker-override(special-report, $news-garnett-highlight);
 }


### PR DESCRIPTION
Special report tones were being overridden in the story package container.

# Before
<img width="1302" alt="screen shot 2018-03-19 at 10 44 53" src="https://user-images.githubusercontent.com/14570016/37591249-cc55d626-2b62-11e8-9351-a8a176e9046f.png">

# After
<img width="1302" alt="screen shot 2018-03-19 at 10 44 39" src="https://user-images.githubusercontent.com/14570016/37591250-cc6c46d6-2b62-11e8-9816-70c744a96734.png">
