### PR TITLE
Remove margin, which causes advert to center itself away from label.

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -252,16 +252,13 @@
         clear: left;
     }
 }
-.ad-slot__content {
-    > div {
-        margin: 0 auto;
-    }
-}
+
 .ad-slot--container-inline:not(.ad-slot--fluid) {
     .ad-slot__content {
         margin: 0 auto;
     }
     @include mq(tablet) {
+
         position: relative;
         height: auto;
 


### PR DESCRIPTION
## What does this change?
Adverts have their contents centred, but this doesn't play nicely with the page or the Advertisement label.

I can't see why this is required and I'm _sure_ that changing this bit of CSS couldn't _possibly_ trigger some other rules elsewhere that will make _everything_ look worse.

**Before**
![image](https://user-images.githubusercontent.com/1821099/37593206-106ebfca-2b69-11e8-9d4d-181c10622dde.png)

**After**
![image](https://user-images.githubusercontent.com/1821099/37593220-1b33e250-2b69-11e8-9a0c-1d3e0923795b.png)
