### PR TITLE
Increased fallback clearance for grid and content labels

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1068,8 +1068,8 @@
         }
 
         @include mq($from: leftCol) {
-            // adds enough space so that this doesn't clash with the content labels if css gris is not supported
-            top: gs-height(3);
+            // adds enough space so that this doesn't clash with the content labels if css grid is not supported
+            top: gs-height(4);
 
             @supports (display: grid) {
                 grid-area: meta;


### PR DESCRIPTION
Cambridge Analytica is such a long series name that on browsers that don't support css grid, it was overlapping the meta area. I've increased the allowance to allow for 4 lines of wrapped text now.

Please ignore the change in colours, just localhost not having the special report class.

# Before
<img width="830" alt="screen shot 2018-03-19 at 14 48 59" src="https://user-images.githubusercontent.com/14570016/37602768-00245190-2b85-11e8-9ba3-32eab64c7968.png">

# After
<img width="829" alt="screen shot 2018-03-19 at 14 48 49" src="https://user-images.githubusercontent.com/14570016/37602770-00576300-2b85-11e8-838a-d6b0cbdb5f8b.png">
