### PR TITLE
add complete-consent GET endpoint and include accordian on page

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -36,6 +36,10 @@ trait ConsentsJourney
   def displayConsentsJourney(consentHint: Option[String] = None): Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint)
 
+  /** GET /complete-consents */
+  def displayConsentComplete: Action[AnyContent] =
+    displayConsentComplete(ConsentJourneyPageDefault, None)
+
   /** POST /complete-consents */
   def submitRepermissionedFlag: Action[AnyContent] =
     csrfCheck {
@@ -49,17 +53,15 @@ trait ConsentsJourney
               request.user.id,
               UserUpdateDTO(consents = Some(newConsents), statusFields = Some(StatusFields(hasRepermissioned = Some(true)))),
               request.user.auth
-            ).map {
+            ).flatMap {
               case Left(idapiErrors) =>
                 logger.error(s"Failed to set hasRepermissioned flag for user ${request.user.id}: $idapiErrors")
-                InternalServerError(Json.toJson(idapiErrors))
+                Future.successful(InternalServerError(Json.toJson(idapiErrors)))
 
               case Right(updatedUser) =>
                 logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
                 val page = IdentityPage("/complete-consents", "Complete Consents", isFlow = true)
-                Ok(IdentityHtmlPage.html(
-                  views.html.completeConsents(idRequestParser(request), idUrlBuilder, returnUrl)
-                )(page, request, context))
+                consentCompleteView(page, returnUrl)
             }
           }
         )
@@ -84,6 +86,35 @@ trait ConsentsJourney
       }
     }
 
+  private def displayConsentComplete(
+    page: ConsentJourneyPage,
+    consentHint: Option[String]): Action[AnyContent] =
+    csrfAddToken {
+      consentsRedirectAction.async { implicit request =>
+        val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request).getOrElse(returnUrlVerifier.defaultReturnUrl)
+        consentCompleteView(
+          page,
+          returnUrl
+        )
+      }
+    }
+
+  private def consentCompleteView(
+   page: IdentityPage,
+   returnUrl : String)(implicit request: AuthRequest[AnyContent]): Future[Result] = {
+
+    newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
+      Ok(IdentityHtmlPage.html(
+        views.html.completeConsents(
+          idRequestParser(request),
+          idUrlBuilder,
+          returnUrl,
+          emailFilledForm,
+          newsletterService.getEmailSubscriptions(emailFilledForm),
+          EmailNewsletters.all)
+      )(page, request, context))
+    }
+  }
 
   private def consentJourneyView(
     page: IdentityPage,

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,20 +1,39 @@
+@import com.gu.identity.model.EmailNewsletters
+@import services.EmailPrefsData
+
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
-    returnUrl: String
-)(implicit request: RequestHeader)
+    returnUrl: String,
+    emailPrefsForm: Form[EmailPrefsData],
+    emailSubscriptions: List[String],
+    availableLists: EmailNewsletters,
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import common.LinkTo
 
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
-        <h1 class="identity-title">Thank you for letting us know your preferences</h1>
+        <h1 class="identity-title">Thank you! We've got your preferences</h1>
         <div class="identity-forms-message__body">
-            <p>You can change your preferences anytime by signing in to your account and visiting <a class="u-underline" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayEmailPrefsForm(false, None).url, idRequest)">Email Preferences</a>.</p>
+            <p>You can change these anytime by going to My account > <a class="u-underline" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayEmailPrefsForm(false, None).url, idRequest)">Email
+                Preferences</a>.</p>
+            <br/>
+        </div>
+        <div>
+            <h1 class="identity-title--small">Before you go...</h1>
+            <div class="identity-forms-message__body">
+                <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
+                <p>Why not take a few seconds to see whether there is anything here for you?</p>
+            </div>
+            @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
+            <p class="identity-title-explainer identity-title-explainer--small">
+                The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
+            </p>
         </div>
         <aside class="identity-forms-message__body">
-            <a class="manage-account__button manage-account__button--main" href="@LinkTo(returnUrl)">
-                Continue
+            <a class="manage-account__button manage-account__button--secondary" href="@LinkTo(returnUrl)">
+                Go to the theguardian.com
                 @fragments.inlineSvg("arrow-right", "icon")
             </a>
         </aside>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -37,7 +37,6 @@
                     </div>
                     <div class="fieldset__fields">
                         @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
-                        <div hidden>@radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)</div>
                     </div>
                     <p class="identity-title-explainer identity-title-explainer--small">
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,5 +1,7 @@
 @import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
+@import form.IdFormHelpers.nonInputFields
+@import views.html.fragments.form.radioField
 
 @(
     idRequest: services.IdentityRequest,
@@ -35,7 +37,10 @@
                         <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
                         <p>Why not take a few seconds to see whether there is anything here for you?</p>
                     </div>
-                    @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
+                    <div class="fieldset__fields">
+                        @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
+                        <div hidden>@radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)</div>
+                    </div>
                     <p class="identity-title-explainer identity-title-explainer--small">
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
                     </p>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -37,6 +37,7 @@
                     </div>
                     <div class="fieldset__fields">
                         @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
+                        <div hidden>@radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)</div>
                     </div>
                     <p class="identity-title-explainer identity-title-explainer--small">
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -26,11 +26,9 @@
                 Preferences</a>.</p>
             <br/>
         </div>
-        <form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
-            @views.html.helper.CSRF.formField
-            @if(emailPrefsForm.globalError.isDefined) {
-                <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
-            }
+        @if(!emailPrefsForm.globalError) {
+            <form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
+                @views.html.helper.CSRF.formField
                 <div>
                     <h1 class="identity-title--small">Before you go...</h1>
                     <div class="identity-forms-message__body">
@@ -45,7 +43,8 @@
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
                     </p>
                 </div>
-        </form>
+            </form>
+        }
         <aside class="identity-forms-message__body">
             <a class="manage-account__button manage-account__button--secondary" href="@LinkTo(returnUrl)">
                 Go to the theguardian.com

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -12,6 +12,10 @@
 
 @import common.LinkTo
 
+@buildIdentityUrl(endpoint: String) = {
+@idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
+}
+
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
         <h1 class="identity-title">Thank you! We've got your preferences</h1>
@@ -20,19 +24,23 @@
                 Preferences</a>.</p>
             <br/>
         </div>
-        @if(!emailPrefsForm.hasGlobalErrors) {
-            <div>
-                <h1 class="identity-title--small">Before you go...</h1>
-                <div class="identity-forms-message__body">
-                    <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
-                    <p>Why not take a few seconds to see whether there is anything here for you?</p>
+        <form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
+            @views.html.helper.CSRF.formField
+            @if(emailPrefsForm.globalError.isDefined) {
+                <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
+            }
+                <div>
+                    <h1 class="identity-title--small">Before you go...</h1>
+                    <div class="identity-forms-message__body">
+                        <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
+                        <p>Why not take a few seconds to see whether there is anything here for you?</p>
+                    </div>
+                    @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
+                    <p class="identity-title-explainer identity-title-explainer--small">
+                        The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
+                    </p>
                 </div>
-                @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
-                <p class="identity-title-explainer identity-title-explainer--small">
-                    The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
-                </p>
-            </div>
-        }
+        </form>
         <aside class="identity-forms-message__body">
             <a class="manage-account__button manage-account__button--secondary" href="@LinkTo(returnUrl)">
                 Go to the theguardian.com

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -20,17 +20,19 @@
                 Preferences</a>.</p>
             <br/>
         </div>
-        <div>
-            <h1 class="identity-title--small">Before you go...</h1>
-            <div class="identity-forms-message__body">
-                <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
-                <p>Why not take a few seconds to see whether there is anything here for you?</p>
+        @if(!emailPrefsForm.hasGlobalErrors) {
+            <div>
+                <h1 class="identity-title--small">Before you go...</h1>
+                <div class="identity-forms-message__body">
+                    <p>Did you know that we have <b>more than 40</b> different email services that focus on a range of diverse topics - from politics and the latest tech to documentaries, football and scientific breakthroughs.</p>
+                    <p>Why not take a few seconds to see whether there is anything here for you?</p>
+                </div>
+                @fragments.emailListCategories(emailPrefsForm, availableLists, emailSubscriptions)(request, messages)
+                <p class="identity-title-explainer identity-title-explainer--small">
+                    The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
+                </p>
             </div>
-            @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
-            <p class="identity-title-explainer identity-title-explainer--small">
-                The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
-            </p>
-        </div>
+        }
         <aside class="identity-forms-message__body">
             <a class="manage-account__button manage-account__button--secondary" href="@LinkTo(returnUrl)">
                 Go to the theguardian.com

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -71,4 +71,5 @@ GET         /consents/thank-you                     controllers.editprofile.Edit
 GET         /consents/staywithus                    controllers.editprofile.EditProfileController.displayConsentsJourneyGdprCampaign
 GET         /consents                               controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
+GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete
 ########################################################################################################################


### PR DESCRIPTION
## What does this change?
- Adds the newsletter Accordion to the complete consents page
- Adds a GET /compete-consents endpoint

@katyabeer

1. This will give us another chance to get more Newsletter consents after completing the consent journey. 
2. As this now has it's own GET endpoint we will be able to redirect the consent confirmation links to this page, which will make more sense than the current /consents/thank-you page.

## What is the value of this and can you measure success?
- more newsletter sign ups! 

## Screenshots
Before: 
![image](https://user-images.githubusercontent.com/14179210/37605128-7a7b962e-2b8a-11e8-90b1-17488e4fef6a.png)

After: 

![image](https://user-images.githubusercontent.com/14179210/37609534-41b88bde-2b95-11e8-96eb-f01eb38c221d.png)
![image](https://user-images.githubusercontent.com/14179210/37609578-5a207bd2-2b95-11e8-9190-27e8d8f18359.png)

If we fail to get newsletters lists we won't render the accordion 
![image](https://user-images.githubusercontent.com/14179210/37652304-f824cb60-2c32-11e8-8d87-2775f9e43f1b.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
