### PR TITLE
Extend header test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "Point the subscribe link in the header to a subscriptions-only version of the support site",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 19),
+    sellByDate = new LocalDate(2018, 3, 26),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
I'm actually working on removing the test and updating the control, but not sure I'll get it out this eve - so might as well extend the switch to avoid breaking the build