### PR TITLE
Fix duplicate class attributes

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -141,7 +141,7 @@
                     Once you have validated, please reload this page and you will be able to delete
                     your account.
                 </p>
-                <a class="u-underline" class="js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
+                <a class="u-underline js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
             </div>
         }
 


### PR DESCRIPTION
## What does this change?
Fixes an issue where the account deletion page resend validation link doesn't work because the required class is no longer added to the element.

## What is the value of this and can you measure success?
The link works again!

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
