### PR TITLE
Cambridge Analytica always ask epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -185,4 +185,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 4, 24),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-cambridge-analytica-always-ask",
+    "measure the impact of placing an ever-present ask on \"moment\" stories",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 10),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,6 +14,7 @@ import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicEurSupport } from 'common/modules/experiments/tests/acquisitions-epic-eur-support';
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
+import { acquisitionsEpicCambridgeAnalyticaAlwaysAsk } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -38,6 +39,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicCambridgeAnalyticaAlwaysAsk,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
     acquisitionsEpicAudSupport,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask.js
@@ -1,0 +1,62 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { shouldSeeReaderRevenue } from 'common/modules/commercial/user-features';
+import config from 'lib/config';
+
+const abTestName = 'AcquisitionsEpicCambridgeAnalyticaAlwaysAsk';
+
+const tagsMatch = () => {
+    const pageKeywords = config.page.nonKeywordTagIds;
+    if (typeof pageKeywords !== 'undefined') {
+        const keywordList = pageKeywords.split(',');
+        return keywordList.some(
+            x => x === 'news/series/cambridge-analytica-files'
+        );
+    }
+    return false;
+};
+
+const worksWellWithPageTemplate = () =>
+    config.page.contentType === 'Article' &&
+    !config.page.isMinuteArticle &&
+    !(config.page.isImmersive === true);
+
+const isTargetPage = () =>
+    worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
+
+export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTest(
+    {
+        id: abTestName,
+        campaignId: abTestName,
+
+        start: '2018-03-20',
+        expiry: '2018-04-10',
+
+        author: 'Jonathan Rankin',
+        description:
+            'This test aims to measure the impact of placing an ever-present ask on "moment" stories',
+        successMeasure: 'Conversion rate',
+        idealOutcome:
+            'We learn the impact of placing an ever-present ask on "moment" stories',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+        overrideCanRun: true,
+        canRun: () => tagsMatch() && shouldSeeReaderRevenue() && isTargetPage(),
+
+        variants: [
+            {
+                id: 'control',
+                products: [],
+            },
+            {
+                id: 'always_ask',
+                products: [],
+                options: {
+                    isUnlimited: true,
+                },
+            },
+        ],
+    }
+);


### PR DESCRIPTION
## What does this change?
Previously during "moments", we have always stuck on always ask without really understanding, or attempting to measure, the effect. This PR implements an AB test on all Cambridge Analytica stories whereby the control acts as normal (so if the user has seen the epic 4 times in the past month they will not see the epic), and the variant always displays the epic on these stories. 

Ideally we would use the targeting tool to target the articles, but unfortunately, there is a bug with the tool which means we are unable to use it, so we need to manually check the keyword tags to see if the article is a CA story.

@guardian/contributions 