### PR TITLE
Amp special report colours

### DIFF
--- a/static/src/stylesheets/amp/_article-tones.scss
+++ b/static/src/stylesheets/amp/_article-tones.scss
@@ -87,3 +87,18 @@
 .content--pillar-lifestyle {
     @include PillarColourOne($lifestyle-garnett-main-1, $lifestyle-garnett-feature);
 }
+
+.tonal--tone-special-report {
+    @include PillarColourOne($story-package-garnett, $story-package-garnett);
+
+    background-color: #eff1f2;
+
+    .content__series-label__link {
+     background-color: $news-garnett-highlight;
+     padding: ($gs-baseline / 4) ($gs-gutter / 4);
+    }
+
+    .content__meta-container .byline-img {
+        background-color: $news-garnett-highlight;
+    }
+}

--- a/static/src/stylesheets/amp/_article-tones.scss
+++ b/static/src/stylesheets/amp/_article-tones.scss
@@ -90,12 +90,11 @@
 
 .tonal--tone-special-report {
     @include PillarColourOne($story-package-garnett, $story-package-garnett);
-
     background-color: #eff1f2;
 
     .content__series-label__link {
-     background-color: $news-garnett-highlight;
-     padding: ($gs-baseline / 4) ($gs-gutter / 4);
+        background-color: $news-garnett-highlight;
+        padding: ($gs-baseline / 4) ($gs-gutter / 4);
     }
 
     .content__meta-container .byline-img {


### PR DESCRIPTION
Basic special report-isation of AMP - cos AMP deserves love too.

# Before
<img width="375" alt="screen shot 2018-03-20 at 16 06 14" src="https://user-images.githubusercontent.com/14570016/37667230-677942e0-2c59-11e8-9735-67828a63e050.png">

# After
<img width="375" alt="screen shot 2018-03-20 at 16 06 25" src="https://user-images.githubusercontent.com/14570016/37667231-67956c04-2c59-11e8-81ea-eed4794a6006.png">
