### PR TITLE
Further limit the adverts that are eligible to be refreshed: exclude sponsorships

### DIFF
--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -107,6 +107,7 @@ class DataMapper(adUnitService: AdUnitService,
     id = dfpLineItem.getId,
     orderId = dfpLineItem.getOrderId,
     name = dfpLineItem.getName,
+    lineItemType = GuLineItemType.fromDFPLineItemType(dfpLineItem.getLineItemType.getValue),
     startTime = toJodaTime(dfpLineItem.getStartDateTime),
     endTime = {
       if (dfpLineItem.getUnlimitedEndDateTime) None

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -142,6 +142,9 @@ class DfpDataCacheJob(adUnitAgent: AdUnitAgent,
       Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now,
         pageSkinSponsorships))))
 
+      val sponsorshipLineItemIds: List[Long] = data.lineItems.filter(_.lineItemType == Sponsorship).map(_.id).toList
+      Store.putNonRefreshableLineItemIds(stringify(toJson(sponsorshipLineItemIds)))
+
       Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems, data.invalidLineItems))))
 
       Store.putTopAboveNavSlotTakeovers(stringify(toJson(LineItemReport(now,

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -48,6 +48,9 @@ trait Store extends Logging with Dates {
   def putDfpCustomTargetingKeyValues(keyValues: String): Unit ={
     S3.putPublic(dfpCustomTargetingKey, keyValues, defaultJsonEncoding )
   }
+  def putNonRefreshableLineItemIds(lineItemIds: String): Unit = {
+    S3.putPublic(dfpNonRefreshableLineItemIdsKey, lineItemIds, defaultJsonEncoding)
+  }
 
   val now: String = DateTime.now().toHttpDateTimeString
 

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -5,6 +5,7 @@ import com.gu.commercial.display._
 import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
 import common.Edition
 import common.Edition.defaultEdition
+import common.dfp.DfpAgent
 import play.api.libs.json.Json
 
 case class CommercialProperties(
@@ -15,6 +16,7 @@ case class CommercialProperties(
   val isPaidContent: Boolean = branding(defaultEdition).exists(_.isPaid)
   val isFoundationFunded: Boolean = branding(defaultEdition).exists(_.isFoundationFunded)
   def isSponsored(edition: Edition): Boolean = branding(edition).exists(_.isSponsored)
+  val nonRefreshableLineItemIds: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
 
   def branding(edition: Edition): Option[Branding] = for {
     editionBranding <- editionBrandings.find(_.edition == edition)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -409,6 +409,7 @@ class GuardianConfiguration extends Logging {
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v8.json"
+    lazy val dfpNonRefreshableLineItemIdsKey = s"$dfpRoot/non-refreshable-lineitem-ids-v1.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v7.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
     lazy val dfpMobileAppsAdUnitListKey = s"$dfpRoot/mobile-active-ad-units.csv"

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -409,7 +409,7 @@ class GuardianConfiguration extends Logging {
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v8.json"
-    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v6.json"
+    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v7.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
     lazy val dfpMobileAppsAdUnitListKey = s"$dfpRoot/mobile-active-ad-units.csv"
     lazy val dfpFacebookIaAdUnitListKey = s"$dfpRoot/facebookia-active-ad-units.csv"

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -35,8 +35,8 @@ object JavaScriptPage {
     val cardStyle = content.map(_.cardStyle.toneString).getOrElse("")
 
     val nonRefreshableLineItemIds: JsArray = {
-      val ids: Seq[Long] = metaData.commercial.map(x => x.nonRefreshableLineItemIds).toSeq.flatten
-      JsArray(ids map (id => JsString(id.toString)))
+      val ids: Seq[Long] = metaData.commercial.map(_.nonRefreshableLineItemIds) getOrElse Nil
+      JsArray(ids map (id => JsNumber(id)))
     }
 
     val commercialMetaData = Map(

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -34,9 +34,15 @@ object JavaScriptPage {
 
     val cardStyle = content.map(_.cardStyle.toneString).getOrElse("")
 
+    val nonRefreshableLineItemIds: JsArray = {
+      val ids: Seq[Long] = metaData.commercial.map(x => x.nonRefreshableLineItemIds).toSeq.flatten
+      JsArray(ids map (id => JsString(id.toString)))
+    }
+
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
       "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition)),
+      "dfpNonRefreshableLineItemIds" -> nonRefreshableLineItemIds,
       "shouldHideAdverts" -> JsBoolean(page match {
         case c: ContentPage if c.item.content.shouldHideAdverts => true
         case _: CommercialExpiryPage => true

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -79,9 +79,17 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
             advert.id !== 'dfp-ad--inline1' ||
             config.get('page.isFront') ||
             config.get('page.contentType') === 'LiveBlog';
+        const isNonRefreshableLineItem =
+            event.lineItemId &&
+            config
+                .get('page.dfpNonRefreshableLineItemIds', [])
+                .includes(event.lineItemId);
 
         advert.shouldRefresh =
-            isNotFluid && neverHasVideo && !config.page.hasPageSkin;
+            isNotFluid &&
+            neverHasVideo &&
+            !config.page.hasPageSkin &&
+            !isNonRefreshableLineItem;
 
         renderAdvert(advert, event).then(emitRenderEvents);
     }


### PR DESCRIPTION
## Background
We currently have a test running that refreshes ad slots after 30 seconds of being viewable (more information can be found in #19087). However there are some adverts that should not be refreshed. Frustratingly, DFP does not allow us to provide additional/custom metadata that is available on the client-side alongside the advert when it is rendered.

When an advert renders we do get a small amount of fixed metadata, the most useful of which is the lineitem ID.

We already disable refreshing for adverts under the following conditions:
- the ad is a `fluid` size (these are predominantly used by DAP and for sponsorship/takeovers). It might be that this can be removed, given the work in this PR _should_ cover these cases.
- the ad might be an Outstream - read: video - type.

In addition to the above, we want to ensure that LineItems that are of the `Sponsorship` type, do not get refreshed. This is because they are typically takeovers or other directly sold campaigns. It therefore makes no sense to refresh these adverts; for first-impression-takeovers (where the first time a user visits a page, they receive the takeover but on subsequent visits they do not), it _kind of_ breaks the implicit contract that the ads will stay there for the duration of that pageview.

### What's the idea?
Because we don't get LineItem type information when the advert is rendered on the site, we must go the long way round. On the server-side, we can poll DFP to generate a list of all lineitems that are of the `Sponsorship` type and make this available to the client-side. Thus, when an advert is rendered, we can check in the metadata to see which lineitem it served from and then disable the refreshing for that specific advert.

This list of lineitems could be extended at a future date to be smarter and more or less restrictive i.e. ignore all Outstream related lineitems/creatives.

### Technical changes
- our `config` object will now have the key `page.dfpNonRefreshableLineItemIds`, which is a list of ~600 numbers, each representing a line item that shouldn't be refreshed.
- there is a new cached file in our `frontend-store` bucket under `/PROD/commercial/non-refreshable-lineitem-ids.json`. This is `PUT` by our `admin` app, and is read by our `common` app, to update an agent, which is called to build the page `config`.

## What is the value of this and can you measure success?
This was a blocker to increasing the size of the ad test and ultimately to graduating it to production.