### PR TITLE
Country instead of surname initials

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -14,7 +14,7 @@ const controlQuoteSvg = quoteSvg.markup;
 
 const controlMessage =
     'I appreciate there not being a paywall: it is more democratic for the media to be available for all and not a commodity to be purchased by a few. I’m happy to make a contribution so others with less means still have access to information.';
-const controlName = 'Thomasine F-R.';
+const controlName = 'Thomasine, Sweden';
 
 export const control: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,


### PR DESCRIPTION
Making a change to Thomasine's testimonial in the Epic. Previously it stated her surname initials and did not include country. We've since made the pattern of presenting contributors' testimonials as "First name, country". So this change will help with consistency across our products and marketing. 