### PR TITLE
Spacial report

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -32,7 +32,7 @@
                   <a class="content__section-label__link"
                       data-link-name="article section"
                       href="@LinkTo {/@item.content.sectionLabelLink}">
-                      <span>
+                      <span class="label__link-wrapper">
                           @Html(Localisation(item.content.sectionLabelName))
                       </span>
                   </a>
@@ -49,7 +49,7 @@
             ), "content__series-label")
           ">
             <a class="content__series-label__link" href="@LinkTo {/@series.id}">
-                <span>
+                <span class="label__link-wrapper">
                     @series.name
                 </span>
             </a>

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -32,7 +32,9 @@
                   <a class="content__section-label__link"
                       data-link-name="article section"
                       href="@LinkTo {/@item.content.sectionLabelLink}">
+                      <span>
                           @Html(Localisation(item.content.sectionLabelName))
+                      </span>
                   </a>
               </div>
           }
@@ -46,7 +48,11 @@
                 "content__series-label--column" -> item.content.isColumn
             ), "content__series-label")
           ">
-            <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
+            <a class="content__series-label__link" href="@LinkTo {/@series.id}">
+                <span>
+                    @series.name
+                </span>
+            </a>
         </div>
 
         @if(item.content.isColumn && !amp) {

--- a/static/src/stylesheets/layout/nav/_subnav-link.scss
+++ b/static/src/stylesheets/layout/nav/_subnav-link.scss
@@ -14,7 +14,7 @@
     }
 
     @include mq(tablet) {
-        font-size: 17px;
+        font-size: 16px;
         height: 42px;
         line-height: 42px;
     }

--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -2,7 +2,7 @@
     width: 33px;
     margin-top: 2px;
 
-    @include mq($until: desktop) {
+    @include mq($until: leftCol) {
         float: left;
         margin-right: $gs-gutter / 4;
     }

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -1,11 +1,18 @@
 .content--pillar-special-report:not(.content--type-immersive):not(.content--media) {
+    background-color: #eff1f2;
+
     .content__headline--byline .tone-colour {
         background-color: $news-garnett-highlight;
     }
 
     .content__series-label__link,
     .content__section-label__link {
-        background-color: $news-garnett-highlight;
+        box-shadow: -3px 0 0 0 $news-garnett-highlight, 3px 0 0 0 $news-garnett-highlight;
+
+        span {
+        	background: $news-garnett-highlight;
+        	position: relative;
+        }
     }
 
     .content__section-label__link {
@@ -13,7 +20,24 @@
         position: relative;
     }
 
-    background-color: #eff1f2;
+    .content__series-label {
+        @include mq(leftCol) {
+            margin-top: -2px;
+        }
+    }
+
+    .badge-slot {
+        @include mq(leftCol) {
+            margin-left: -3px;
+        }
+    }
+
+    .content__labels {
+        @include mq(leftCol) {
+            margin-bottom: $gs-baseline / 2;
+            padding-left: 3px;
+        }
+    }
 }
 
 .content--immersive.content--pillar-special-report:not(.immersive-main-media__gallery):not(.paid-content):not(.content--gallery):not(.content--minute-article) {

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -10,8 +10,8 @@
         box-shadow: -3px 0 0 0 $news-garnett-highlight, 3px 0 0 0 $news-garnett-highlight;
 
         span {
-        	background: $news-garnett-highlight;
-        	position: relative;
+            background: $news-garnett-highlight;
+            position: relative;
         }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -8,15 +8,10 @@
     .content__series-label__link,
     .content__section-label__link {
         box-shadow: -3px 0 0 0 $news-garnett-highlight, 3px 0 0 0 $news-garnett-highlight;
-
-        span {
-            background: $news-garnett-highlight;
-            position: relative;
-        }
     }
 
-    .content__section-label__link {
-        // Prevents descenders being clipped
+    .label__link-wrapper {
+        background: $news-garnett-highlight;
         position: relative;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -190,14 +190,13 @@
 }
 
 .content__section-label {
-    @include fs-header(1);
-    float: left;
+    @include fs-header(2);
+    display: inline;
     padding-right: $gs-gutter/3;
 
     @include mq(leftCol) {
         @include fs-header(4);
         line-height: get-line-height(header, 2);
-        float: none;
         padding-right: 0;
     }
 
@@ -211,19 +210,19 @@
 }
 
 .content__series-label {
+    display: inline;
     font-family: $f-serif-headline;
-    font-size: 15px;
-    float: left;
+    font-size: 16px;
+    line-height: 19px;
 
     @include mq($until: tablet) {
         font-weight: 800;
     }
 
     @include mq(leftCol) {
-        @include fs-headline(3);
-        float: none;
+        @include fs-headline(2);
+        display: block;
     }
-
 }
 
 .content__series-label--immersive-article {
@@ -235,16 +234,12 @@
 }
 
 @include mq(leftCol, wide) {
-    .content__section-label,
     .container__meta__title {
         font-size: 20px;
         line-height: 24px;
     }
 
     .content__series-label {
-        @include font-size(18, 22);
-        display: block;
-
         .content--interactive & {
             font-size: 20px !important;
             line-height: 24px !important;


### PR DESCRIPTION
The highlighting of the series and section labels in special-report tone was problematic and far too tight to the text. Further more the difference in font-size between the two is too slight in my opinion. Also changed to inline rather than floats so the text aligns on the baseline at tablet breakpoints.

# Before
<img width="533" alt="screen shot 2018-03-21 at 15 19 02" src="https://user-images.githubusercontent.com/14570016/37718724-4e93da48-2d1b-11e8-81e1-74c80cb30cb0.png">

# After
<img width="655" alt="screen shot 2018-03-21 at 15 17 41" src="https://user-images.githubusercontent.com/14570016/37718619-0938b392-2d1b-11e8-93cc-be701f34af13.png">


# Before
<img width="978" alt="screen shot 2018-03-21 at 15 14 30" src="https://user-images.githubusercontent.com/14570016/37718489-b3a1f470-2d1a-11e8-8d15-99585e0f14cc.png">

# After
<img width="978" alt="screen shot 2018-03-21 at 15 15 13" src="https://user-images.githubusercontent.com/14570016/37718490-b3be672c-2d1a-11e8-8a38-bc85e744faaf.png">

# Before
<img width="744" alt="screen shot 2018-03-21 at 15 16 13" src="https://user-images.githubusercontent.com/14570016/37718567-e5c377c6-2d1a-11e8-9497-9c245592b3af.png">

# After
<img width="741" alt="screen shot 2018-03-21 at 15 15 55" src="https://user-images.githubusercontent.com/14570016/37718566-e5ae7790-2d1a-11e8-84c5-24bbd21481ed.png">
