### PR TITLE
profile upsell copy changes

### DIFF
--- a/identity/app/views/profile/digitalPackForm/upsell.scala.html
+++ b/identity/app/views/profile/digitalPackForm/upsell.scala.html
@@ -7,7 +7,7 @@
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Try the Guardian Digital Pack</h2>
     </div>
-    <p class="manage-account-up-sell__content">Enjoy the Guardian and Observer's digital pack on the tube, in the park, on a beach, or wherever it’s convenient for you. The digital pack brings you the biggest stories every day and special sections for big events on iPad, Android and Kindle Fire tablets.</p>
+    <p class="manage-account-up-sell__content">Enjoy access to our Daily Edition app, the digital version of the UK Guardian and Observer newspaper specifically adapted to your iPad, as well as access to the advert-free Guardian app premium tier, available on Apple and Android.</p>
     <a href="@getReaderRevenueUrl(Subscribe, ManageMyAccountUpsell)" class="manage-account__button manage-account__button--icon" data-link-name="Join today">
         Get your 2 week free trial
         @fragments.inlineSvg("arrow-right", "icon")

--- a/identity/app/views/profile/membershipForm/upsell.scala.html
+++ b/identity/app/views/profile/membershipForm/upsell.scala.html
@@ -2,7 +2,7 @@
     <div class="manage-account-up-sell__heading">
         <h2 class="manage-account-header">Join Guardian Membership</h2>
     </div>
-    <p class="manage-account-up-sell__content">We're bringing the Guardian to life through live events and meet-ups. Join and be part of the conversations that matter</p>
+    <p class="manage-account-up-sell__content">We're bringing the Guardian to life through behind-the-scenes insights from our newsroom and specially curated emails written for our supporters. You can also enjoy access to the advert-free Guardian app premium tier. Join us and be part of the conversation.</p>
     <a href="@(conf.Configuration.id.membershipUrl)/join?INTCMP=DOTCOM_MANAGE_JOIN" class="manage-account__button manage-account__button--icon" data-link-name="Join today">
         Join today
         @fragments.inlineSvg("arrow-right", "icon")


### PR DESCRIPTION
## What does this change?
New upsell text in profile "Membership" and "Digital pack" tabs
## What is the value of this and can you measure success?
This will make the copy more relevant to global markets
## Does this affect other platforms - Amp, Apps, etc?
no
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
no

## Screenshots
Membership:

<img width="1404" alt="membership-copy" src="https://user-images.githubusercontent.com/15324270/37717145-ecb30ce8-2d17-11e8-8a2e-7c391f2daf9f.png">

Digital Pack:

<img width="1512" alt="digipack-copy" src="https://user-images.githubusercontent.com/15324270/37717213-fe2975ca-2d17-11e8-9794-888c71fb61dd.png">

## Tested in CODE?
yes
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
