### PR TITLE
Update tests to use the newly extended GuLineItem model.

### DIFF
--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import concurrent.BlockingOperations
-import common.dfp.{GuAdUnit, GuLineItem, GuTargeting}
+import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
 import com.google.api.ads.dfp.axis.v201802._
 import org.joda.time.DateTime
 import org.scalatest._
@@ -21,6 +21,7 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
       id = 0L,
       orderId = 0L,
       name = "test line item",
+      Sponsorship,
       startTime = DateTime.now.withTimeAtStartOfDay,
       endTime = None,
       isPageSkin = false,

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import common.dfp.{GuLineItem, GuTargeting}
+import common.dfp.{GuLineItem, GuTargeting, Sponsorship}
 import org.joda.time.DateTime
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
@@ -23,6 +23,7 @@ class DfpDataCacheJobTest
       id,
       0L,
       name,
+      Sponsorship,
       startTime = DateTime.now.withTimeAtStartOfDay,
       endTime = None,
       isPageSkin = false,

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -37,6 +37,7 @@ class GuLineItemTest extends FlatSpec with Matchers {
       id = 0L,
       orderId = 0L,
       name = "name",
+      Sponsorship,
       startTime = now,
       endTime,
       isPageSkin = false,


### PR DESCRIPTION
Tests weren't updated in #19385.