### PR TITLE
Remove unnecessary padding/margin calculations; allow table to center top-above-nav

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -133,9 +133,8 @@
         display: none;
     }
 
-    padding-left: $left-column-wide + $gs-gutter * 2;
-    margin-left: calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
     text-align: left;
+    display: table;
 
     @include mq(wide) {
 


### PR DESCRIPTION
There are some cases where the top-above-nav slot is not centrally aligned. This is because there is a lot of competing padding and margins applied at different breakpoints.

By removing this padding and these margins, and using the `display: table` to center the ad horizontally, we can be responsive and align the ad regardless of its width.

I've tested this on Browserstack at a bunch of breakpoints and they look good to me.