### PR TITLE
Simplify canRun checks

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -76,7 +76,7 @@ declare type InitEpicABTest = {
     overrideCanRun?: boolean,
     useTargetingTool?: boolean,
     showToContributorsAndSupporters?: boolean,
-    canRun?: () => boolean,
+    canRun?: (test: EpicABTest) => boolean,
     pageCheck?: (page: Object) => boolean,
 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -90,7 +90,7 @@ const getTestimonialBlock = (
     testimonialParameters: AcquisitionsEpicTestimonialTemplateParameters
 ) => acquisitionsTestimonialBlockTemplate(testimonialParameters);
 
-const defaultPageCheck = (page: Object): boolean =>
+const pageCanDisplayEpic = (page: Object): boolean =>
     page.contentType === 'Article' && !page.isMinuteArticle;
 
 const shouldShowReaderRevenue = (
@@ -399,7 +399,7 @@ const makeABTest = ({
     useTargetingTool = false,
     showToContributorsAndSupporters = false,
     canRun = () => true,
-    pageCheck = defaultPageCheck,
+    pageCheck = pageCanDisplayEpic,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -407,10 +407,11 @@ const makeABTest = ({
         showForSensitive: true,
         canRun() {
             if (overrideCanRun) {
-                return doTagsMatch(this) && canRun();
+                return doTagsMatch(this) && canRun(this);
             }
 
-            const testCanRun = typeof canRun === 'function' ? canRun() : true;
+            const testCanRun =
+                typeof canRun === 'function' ? canRun(this) : true;
             const canEpicBeDisplayed = defaultCanEpicBeDisplayed(this);
 
             return testCanRun && canEpicBeDisplayed;
@@ -467,7 +468,6 @@ const makeBannerABTestVariants = (
 export {
     shouldShowReaderRevenue,
     defaultCanEpicBeDisplayed,
-    defaultPageCheck,
     getTestimonialBlock,
     makeABTest,
     defaultButtonTemplate,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -90,7 +90,7 @@ const getTestimonialBlock = (
     testimonialParameters: AcquisitionsEpicTestimonialTemplateParameters
 ) => acquisitionsTestimonialBlockTemplate(testimonialParameters);
 
-const pageCanDisplayEpic = (page: Object): boolean =>
+const isCompatibleWithEpic = (page: Object): boolean =>
     page.contentType === 'Article' && !page.isMinuteArticle;
 
 const shouldShowReaderRevenue = (
@@ -107,7 +107,7 @@ const shouldShowReaderRevenue = (
     );
 };
 
-const defaultCanEpicBeDisplayed = (test: EpicABTest): boolean => {
+const shouldShowEpic = (test: EpicABTest): boolean => {
     const worksWellWithPageTemplate = test.pageCheck(config.get('page'));
 
     const storedGeolocation = geolocationGetSync();
@@ -399,7 +399,7 @@ const makeABTest = ({
     useTargetingTool = false,
     showToContributorsAndSupporters = false,
     canRun = () => true,
-    pageCheck = pageCanDisplayEpic,
+    pageCheck = isCompatibleWithEpic,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -412,7 +412,7 @@ const makeABTest = ({
 
             const testCanRun =
                 typeof canRun === 'function' ? canRun(this) : true;
-            const canEpicBeDisplayed = defaultCanEpicBeDisplayed(this);
+            const canEpicBeDisplayed = shouldShowEpic(this);
 
             return testCanRun && canEpicBeDisplayed;
         },
@@ -467,7 +467,7 @@ const makeBannerABTestVariants = (
 
 export {
     shouldShowReaderRevenue,
-    defaultCanEpicBeDisplayed,
+    shouldShowEpic,
     getTestimonialBlock,
     makeABTest,
     defaultButtonTemplate,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask.js
@@ -1,28 +1,8 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
-import { shouldSeeReaderRevenue } from 'common/modules/commercial/user-features';
-import config from 'lib/config';
+import { keywordExists } from 'lib/page';
 
 const abTestName = 'AcquisitionsEpicCambridgeAnalyticaAlwaysAsk';
-
-const tagsMatch = () => {
-    const pageKeywords = config.page.nonKeywordTagIds;
-    if (typeof pageKeywords !== 'undefined') {
-        const keywordList = pageKeywords.split(',');
-        return keywordList.some(
-            x => x === 'news/series/cambridge-analytica-files'
-        );
-    }
-    return false;
-};
-
-const worksWellWithPageTemplate = () =>
-    config.page.contentType === 'Article' &&
-    !config.page.isMinuteArticle &&
-    !(config.page.isImmersive === true);
-
-const isTargetPage = () =>
-    worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
 
 export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTest(
     {
@@ -42,8 +22,7 @@ export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTes
         audienceCriteria: 'All',
         audience: 1,
         audienceOffset: 0,
-        overrideCanRun: true,
-        canRun: () => tagsMatch() && shouldSeeReaderRevenue() && isTargetPage(),
+        canRun: () => keywordExists(['Cambridge Analytica']),
 
         variants: [
             {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -5,18 +5,7 @@ import {
 } from 'common/modules/commercial/user-features';
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { addTrackingCodesToUrl } from 'common/modules/commercial/acquisitions-ophan';
-import config from 'lib/config';
 import { acquisitionsEpicThankYouTemplate } from 'common/modules/commercial/templates/acquisitions-epic-thank-you';
-
-const isTargetReader = () => isPayingMember() || isRecentContributor();
-
-const worksWellWithPageTemplate = () =>
-    config.page.contentType === 'Article' &&
-    !config.page.isMinuteArticle &&
-    !(config.page.isImmersive === true);
-
-const isTargetPage = () =>
-    worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
 
 export const acquisitionsEpicThankYou = makeABTest({
     id: 'AcquisitionsEpicThankYou',
@@ -35,11 +24,9 @@ export const acquisitionsEpicThankYou = makeABTest({
     audience: 1,
     audienceOffset: 0,
 
-    overrideCanRun: true,
+    showToContributorsAndSupporters: true,
 
-    canRun() {
-        return isTargetReader() && isTargetPage();
-    },
+    canRun: () => isPayingMember() || isRecentContributor(),
 
     useLocalViewLog: true,
 


### PR DESCRIPTION
### Changes

- No need to `overrideCanRun` for Cambridge Analytica and Thank You tests. These previously duplicated a portion of the default epic checks. This is unnecessary - if you don't `overrideCanRun`, you get all that for free and you can add further conditions in your `canRun`.
- Use `keywordExists(['Cambridge Analytica'])` to check for Cambridge Analytica stories. The series tag is only on some of the relevant stories, whereas the keyword tag is on all
- Pass the test object into `canRun` in case a custom one needs to access properties of the test. (This was something I thought I needed myself. It turned out otherwise, but I left it in because it seems like to could come in handy)

### Why?
Aside from adding to the noise, overriding the canRun unnecessarily is potentially dangerous. The `isImmersive` check that's been deleted is not actually present in the normal epic check, and luckily so - it would've prevented the epic showing on the huge Cambridge Analytica story on Sunday! So copying logic that we don't need to risks us accidentally setting up the wrong conditions for a new test.

