### PR TITLE
Add debug logging to email subscription related calls

### DIFF
--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -1,6 +1,6 @@
 package idapiclient
 
-import com.gu.identity.model.{EmailList , Subscriber, User}
+import com.gu.identity.model.{EmailList, Subscriber, User}
 
 import scala.concurrent.{ExecutionContext, Future}
 import idapiclient.responses.{AccountDeletionResult, CookiesResponse, Error, HttpResponse}
@@ -10,6 +10,7 @@ import net.liftweb.json.JsonAST.JValue
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
 import idapiclient.requests.{DeletionBody, PasswordUpdate, TokenPassword}
+import org.slf4j.LoggerFactory
 import play.api.libs.ws.WSClient
 
 class IdApiClient(
@@ -20,6 +21,7 @@ class IdApiClient(
 
   private val apiRootUrl: String = conf.apiRoot
   private val clientAuth: Auth = ClientAuth(conf.apiClientToken)
+  private val exactTargetLogger = LoggerFactory.getLogger("exactTarget")
 
   import idJsonBodyParser.{extractUnit, extract, jsonField}
 
@@ -141,10 +143,12 @@ class IdApiClient(
   }
 
   def addSubscription(userId: String, emailList: EmailList, auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] = {
+    exactTargetLogger.debug(s"Subscribing $userId to listId: ${emailList.listId}")
     post(urlJoin("useremails", userId, "subscriptions"), Some(auth), Some(trackingParameters), Some(write(emailList))) map extractUnit
   }
 
   def deleteSubscription(userId: String, emailList: EmailList, auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] = {
+    exactTargetLogger.debug(s"Unubscribing $userId to listId: ${emailList.listId}")
     delete(urlJoin("useremails", userId, "subscriptions"), Some(auth), Some(trackingParameters), Some(write(emailList))) map extractUnit
   }
 

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -148,7 +148,7 @@ class IdApiClient(
   }
 
   def deleteSubscription(userId: String, emailList: EmailList, auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] = {
-    exactTargetLogger.debug(s"Unubscribing $userId to listId: ${emailList.listId}")
+    exactTargetLogger.debug(s"Unsubscribing $userId to listId: ${emailList.listId}")
     delete(urlJoin("useremails", userId, "subscriptions"), Some(auth), Some(trackingParameters), Some(write(emailList))) map extractUnit
   }
 

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -15,6 +15,8 @@
         </encoder>
     </appender>
 
+    <logger name="exactTarget" level="DEBUG" />
+
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
     </root>


### PR DESCRIPTION
## What does this change?

Logs a debug message when calling IDAPI for email subs. 

## What is the value of this and can you measure success?

No

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No