### PR TITLE
Turn always ask always on for Cambridge Analytica stories

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -148,8 +148,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-epic-cambridge-analytica-always-ask",
-    "measure the impact of placing an ever-present ask on \"moment\" stories",
+    "ab-acquisitions-epic-cambridge-analytica-always-ask-final",
+    "turn on always ask for CA stories",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 4, 10),

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,7 +13,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
-import { acquisitionsEpicCambridgeAnalyticaAlwaysAsk } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask';
+import { acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -38,7 +38,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    acquisitionsEpicCambridgeAnalyticaAlwaysAsk,
+    acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
     acquisitionsEpicAudSupport,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final.js
@@ -2,9 +2,9 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { keywordExists } from 'lib/page';
 
-const abTestName = 'AcquisitionsEpicCambridgeAnalyticaAlwaysAsk';
+const abTestName = 'AcquisitionsEpicCambridgeAnalyticaAlwaysAskFinal';
 
-export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTest(
+export const acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal: EpicABTest = makeABTest(
     {
         id: abTestName,
         campaignId: abTestName,
@@ -13,8 +13,7 @@ export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTes
         expiry: '2018-04-10',
 
         author: 'Jonathan Rankin',
-        description:
-            'This test aims to measure the impact of placing an ever-present ask on "moment" stories',
+        description: 'Always ask on Cambridge analytica stories',
         successMeasure: 'Conversion rate',
         idealOutcome:
             'We learn the impact of placing an ever-present ask on "moment" stories',
@@ -25,10 +24,6 @@ export const acquisitionsEpicCambridgeAnalyticaAlwaysAsk: EpicABTest = makeABTes
         canRun: () => keywordExists(['Cambridge Analytica']),
 
         variants: [
-            {
-                id: 'control',
-                products: [],
-            },
             {
                 id: 'always_ask',
                 products: [],


### PR DESCRIPTION
## What does this change?
The results of the test were positive so we are rolling out always ask to be always on for Cambridge Analytica stories. 

The test has been renamed to ensure that everyone gets reassigned into the always ask variant