### PR TITLE
Epic test for ROW

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -175,4 +175,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 5, 24),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-row-support",
+    "Points the 'support the guardian' link in the epic to the row version of the support site",
+    owners = Seq(Owner.withGithub("svillafe")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 5, 24),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,6 +13,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
+import { acquisitionsEpicRowSupport }  from 'common/modules/experiments/tests/acquisitions-epic-row-support';
 import { acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
@@ -42,6 +43,7 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
     acquisitionsEpicAudSupport,
+    acquisitionsEpicRowSupport,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,7 +13,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
-import { acquisitionsEpicRowSupport }  from 'common/modules/experiments/tests/acquisitions-epic-row-support';
+import { acquisitionsEpicRowSupport } from 'common/modules/experiments/tests/acquisitions-epic-row-support';
 import { acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
@@ -37,7 +37,7 @@ const oneButtonTemplate = (urls: CtaUrls): string => {
         </div>`;
 };
 
-export const acquisitionsEpicAudSupport = makeABTest({
+export const acquisitionsEpicRowSupport = makeABTest({
     id: abTestName,
     campaignId: abTestName,
 
@@ -45,7 +45,7 @@ export const acquisitionsEpicAudSupport = makeABTest({
     expiry: '2018-05-24',
 
     author: 'Santiago Villa Fernandez',
-    description: 'Use the Epic to partition the audience for the AUD test',
+    description: 'Use the Epic to partition the audience for the ROW test',
     successMeasure: 'AV 2.0',
     idealOutcome:
         'We channel an even split of frontend traffic into the correct au version',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
@@ -1,0 +1,71 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+
+import {
+    getSupporterPaymentRegion as geolocationGetSupporterPaymentRegion,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+
+import config from 'lib/config';
+
+import type { CtaUrls } from 'common/modules/commercial/contributions-utilities';
+
+const ROWsupportURL = 'https://support.theguardian.com/int';
+const abTestName = 'AcquisitionsEpicRowSupport';
+
+const oneButtonTemplate = (urls: CtaUrls): string => {
+    const url = urls.supportUrl || '';
+
+    const supportButtonSupport = `
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
+              href="${url}"
+              target="_blank">
+              Support The Guardian
+            </a>
+        </div>`;
+
+    const paymentLogos = `<img class="contributions__payment-logos contributions__contribute--epic-member" src="${config.get(
+        'images.acquisitions.paypal-and-credit-card',
+        ''
+    )}" alt="Paypal and credit card">`;
+
+    return `
+        <div class="contributions__amount-field">
+            ${supportButtonSupport}
+            ${paymentLogos}
+        </div>`;
+};
+
+export const acquisitionsEpicAudSupport = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-03-22',
+    expiry: '2018-05-24',
+
+    author: 'Santiago Villa Fernandez',
+    description: 'Use the Epic to partition the audience for the AUD test',
+    successMeasure: 'AV 2.0',
+    idealOutcome:
+        'We channel an even split of frontend traffic into the correct au version',
+    audienceCriteria: 'ALL ROW transaction web traffic',
+    audience: 1,
+    audienceOffset: 0,
+    canRun: () =>
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT',
+    variants: [
+        {
+            id: 'control',
+            products: [],
+        },
+        {
+            id: 'support_contribute',
+            products: [],
+            options: {
+                supportBaseURL: ROWsupportURL,
+                buttonTemplate: oneButtonTemplate,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
Adds Epic test for ROW.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

### Variant
![picture 666](https://user-images.githubusercontent.com/825398/37826514-a0671184-2e8b-11e8-9dc6-d9e2506ae34d.png)

### Control
![picture 667](https://user-images.githubusercontent.com/825398/37826515-a07eba8c-2e8b-11e8-9bed-2dd7c0a7e739.png)



## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
