### PR TITLE
Revert "Remove unnecessary padding/margin calculations; allow table to center top-above-nav"

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -133,8 +133,9 @@
         display: none;
     }
 
+    padding-left: $left-column-wide + $gs-gutter * 2;
+    margin-left: calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
     text-align: left;
-    display: table;
 
     @include mq(wide) {
 


### PR DESCRIPTION
Reverts guardian/frontend#19393