### PR TITLE
Removed NZ from ROW test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-row-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-row-support.js
@@ -26,7 +26,8 @@ export const AcquisitionsEngagementBannerRowSupport: AcquisitionsABTest = {
     componentType,
     showForSensitive: true,
     canRun: () =>
-        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT',
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT' &&
+        geolocationGetSync() !== 'NZ',
 
     variants: makeBannerABTestVariants([
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-row-support.js
@@ -53,7 +53,8 @@ export const acquisitionsEpicRowSupport = makeABTest({
     audience: 1,
     audienceOffset: 0,
     canRun: () =>
-        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT',
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT' &&
+        geolocationGetSync() !== 'NZ',
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-row-support.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-header-row-support.js
@@ -54,7 +54,8 @@ export const acquisitionsHeaderRowSupport: AcquisitionsABTest = {
     audienceCriteria: 'All ROW transaction web traffic.',
     idealOutcome: 'We get more money when we tailor the destination to the CTA',
     canRun: () =>
-        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT',
+        geolocationGetSupporterPaymentRegion(geolocationGetSync()) === 'INT' &&
+        geolocationGetSync() !== 'NZ',
     variants: [
         {
             id: 'control',


### PR DESCRIPTION
## What does this change?
In membership, NZ is not considered as ROW country so they see a different experience (Header en in NZD and body in GBP). Therefore we should exclude them from the ROW test.


## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
