### PR TITLE
Finally fix the top-above-nav ad slot sizing and spacing

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -89,7 +89,6 @@
     transform: translate3d(0, 0, 0);
     contain: layout;
     z-index: $zindex-popover;
-    width: 100%;
     position: fixed;
     top: 0;
 }
@@ -103,8 +102,6 @@
     text-align: center;
 
     .ad-slot__label {
-        /* this is the minimum width of possible ads sizes */
-        width: 728px;
         border-top: 0;
         padding: 0;
         height: $gs-row-height/2;
@@ -116,8 +113,6 @@
 
     .has-page-skin & {
         @include mq(wide) {
-            width: auto !important;
-            padding-left: 0 !important;
             text-align: center;
         }
     }
@@ -135,13 +130,6 @@
 
     text-align: left;
     display: table;
-
-    @include mq(wide) {
-
-        .has-page-skin & {
-            margin-left: auto;
-        }
-    }
 
     &.ad-slot--fabric {
         > .ad-slot__label {
@@ -170,7 +158,9 @@
                 }
             }
         }
+    }
 
+    &.ad-slot--fluid {
         width: 100%;
     }
 
@@ -404,7 +394,7 @@
     margin: 0;
 
     &:not(.ad-slot--im):not(.ad-slot--carrot) {
-        width: auto;
+        width: 100%;
     }
 
     &.ad-slot--commercial-component-high {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -133,9 +133,8 @@
         display: none;
     }
 
-    padding-left: $left-column-wide + $gs-gutter * 2;
-    margin-left: calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
     text-align: left;
+    display: table;
 
     @include mq(wide) {
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -171,6 +171,8 @@
                 }
             }
         }
+
+        width: 100%;
     }
 
     .ad-slot__label {


### PR DESCRIPTION
This is the final - FINAL - PR for fixing the top-above-nav ad slot. Currently the Advertisement label is misaligned on a number of breakpoints and the ad is also misaligned.

Previous attempts to fix this can be seen in #19410.

The reason I had to revert #19410 is because fluid ads had no width applied to them, I have covered this use case in this PR and hopefully that is the last bug under a bug under a bug under a bug in this area of frontend.