### PR TITLE
Cambridge Analytica Epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -159,7 +159,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-acquisitions-epic-cambridge-analytica-bespoke-copy",
-    "turn on always ask for CA stories",
+    "Custom copy on Cambridge analytica stories",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 4, 10),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -158,6 +158,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-epic-cambridge-analytica-bespoke-copy",
+    "turn on always ask for CA stories",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 4, 10),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-header-row-support",
     "Points the 'support the guardian' link in the header to the row version of the support site",
     owners = Seq(Owner.withGithub("svillafe")),

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -7,9 +7,12 @@ const controlP1 =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 const controlP2FirstSentence =
     ' If everyone who reads our reporting, who likes it, helps fund it, our future would be much more secure.';
-const controlP2 = (firstSentence: string, currencySymbol: string = getLocalCurrencySymbol()) =>
+const controlP2 = (
+    firstSentence: string,
+    currencySymbol: string = getLocalCurrencySymbol()
+) =>
     `${
-        controlP2FirstSentence
+        firstSentence
     } <strong><span class="contributions__highlight">For as little as ${
         currencySymbol
     }1, you can support the Guardian &ndash; and it only takes a minute. Thank you.</span></strong>`;
@@ -40,8 +43,10 @@ const ctaLinkSentence = (
     }" target="_blank" class="u-underline">make a one-off contribution</a>`;
 };
 
-const cambridgeP1 = '&hellip; now is the time to support investigative reporting. The Guardian and Observer have spent a year analysing documents, working with whistleblowers and gathering eyewitness reports to untangle a complex story of elections in the digital age. This took months of painstaking research by a small team of reporters and editors &ndash; and has led to investigations on both sides of the Atlantic. We have received legal threats, including from Facebook, but we are determined to continue publishing stories that expose wrongdoing and the use of people’s data for political purposes – from the US election to Brexit.'
-const cambridgeP2FirstSentence = 'We increasingly need our readers to fund our fearless, independent, investigative reporting. Thank you to the many people who have already supported us financially &ndash; your contribution is what makes stories like this possible. Unlike many news organisations, we have not put up a paywall &ndash; we want to keep our journalism as open as we can.</br>';
+const cambridgeP1 =
+    '&hellip; now is the time to support investigative reporting. The Guardian and Observer have spent a year analysing documents, working with whistleblowers and gathering eyewitness reports to untangle a complex story around data in the digital age. This took months of painstaking research by a small team of reporters and editors &ndash; and has led to investigations on both sides of the Atlantic. <span class="contributions__highlight">We have received legal threats, including from Facebook, but we are determined to continue publishing stories that raise important questions about the use of people’s data in political campaigns</span> &ndash; from the US election to Brexit.';
+const cambridgeP2FirstSentence =
+    'We increasingly need our readers to fund our fearless, independent, investigative reporting. Thank you to the many people who have already supported us financially &ndash; your contribution is what makes stories like this possible. Unlike many news organisations, we have not put up a paywall &ndash; we want to keep our journalism as open as we can.</br></br>';
 
 /*
  Exported instances of AcquisitionsEpicTemplateCopy

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -7,7 +7,7 @@ const controlP1 =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 const controlP2FirstSentence =
     ' If everyone who reads our reporting, who likes it, helps fund it, our future would be much more secure.';
-const controlP2 = (currencySymbol: string = getLocalCurrencySymbol()) =>
+const controlP2 = (firstSentence: string, currencySymbol: string = getLocalCurrencySymbol()) =>
     `${
         controlP2FirstSentence
     } <strong><span class="contributions__highlight">For as little as ${
@@ -40,19 +40,28 @@ const ctaLinkSentence = (
     }" target="_blank" class="u-underline">make a one-off contribution</a>`;
 };
 
+const cambridgeP1 = '&hellip; now is the time to support investigative reporting. The Guardian and Observer have spent a year analysing documents, working with whistleblowers and gathering eyewitness reports to untangle a complex story of elections in the digital age. This took months of painstaking research by a small team of reporters and editors &ndash; and has led to investigations on both sides of the Atlantic. We have received legal threats, including from Facebook, but we are determined to continue publishing stories that expose wrongdoing and the use of people’s data for political purposes – from the US election to Brexit.'
+const cambridgeP2FirstSentence = 'We increasingly need our readers to fund our fearless, independent, investigative reporting. Thank you to the many people who have already supported us financially &ndash; your contribution is what makes stories like this possible. Unlike many news organisations, we have not put up a paywall &ndash; we want to keep our journalism as open as we can.</br>';
+
 /*
  Exported instances of AcquisitionsEpicTemplateCopy
  */
 export const control: AcquisitionsEpicTemplateCopy = {
     heading: controlHeading,
     p1: controlP1,
-    p2: controlP2(),
+    p2: controlP2(controlP2FirstSentence),
 };
 
 export const regulars: AcquisitionsEpicTemplateCopy = {
     heading: controlHeadingRegulars,
     p1: controlP1Regulars,
-    p2: controlP2(),
+    p2: controlP2(controlP2FirstSentence),
+};
+
+export const cambridgeCopy: AcquisitionsEpicTemplateCopy = {
+    heading: controlHeading,
+    p1: cambridgeP1,
+    p2: controlP2(cambridgeP2FirstSentence),
 };
 
 export const liveblogCopy = (

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -15,7 +15,7 @@ import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
 import { acquisitionsEpicRowSupport } from 'common/modules/experiments/tests/acquisitions-epic-row-support';
 import { acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
-import { acquisitionsEpicCambridgeAnalyticaAlwaysAskBespokeCopy } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
+import { acquisitionsEpicCambridgeAnalyticaBespokeCopy } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-bespoke-copy';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -40,7 +40,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    acquisitionsEpicCambridgeAnalyticaAlwaysAskBespokeCopy,
+    acquisitionsEpicCambridgeAnalyticaBespokeCopy,
     acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -15,6 +15,7 @@ import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests
 import { acquisitionsEpicAudSupport } from 'common/modules/experiments/tests/acquisitions-epic-aud-support';
 import { acquisitionsEpicRowSupport } from 'common/modules/experiments/tests/acquisitions-epic-row-support';
 import { acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
+import { acquisitionsEpicCambridgeAnalyticaAlwaysAskBespokeCopy } from 'common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -39,6 +40,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicCambridgeAnalyticaAlwaysAskBespokeCopy,
     acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-bespoke-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-bespoke-copy.js
@@ -1,0 +1,46 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { keywordExists } from 'lib/page';
+import { cambridgeCopy } from 'common/modules/commercial/acquisitions-copy';
+
+const abTestName = 'AcquisitionsEpicCambridgeAnalyticaBespokeCopy';
+
+export const acquisitionsEpicCambridgeAnalyticaBespokeCopy: EpicABTest = makeABTest(
+    {
+        id: abTestName,
+        campaignId: abTestName,
+
+        start: '2018-03-20',
+        expiry: '2018-04-10',
+
+        author: 'Jonathan Rankin',
+        description: 'Always ask on Cambridge analytica stories',
+        successMeasure: 'Conversion rate',
+        idealOutcome:
+            'We learn the impact of placing an ever-present ask on "moment" stories',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+        canRun: () => keywordExists(['Cambridge Analytica']),
+
+        variants: [
+            {
+                id: 'control',
+                products: [],
+                options: {
+                    isUnlimited: true,
+                },
+            },
+            {
+                id: 'bespoke_copy',
+                products: [],
+                options: {
+                    copy: cambridgeCopy,
+                    testimonialBlock: '',
+                    isUnlimited: true,
+                },
+            },
+        ],
+    }
+);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-bespoke-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-bespoke-copy.js
@@ -10,14 +10,15 @@ export const acquisitionsEpicCambridgeAnalyticaBespokeCopy: EpicABTest = makeABT
         id: abTestName,
         campaignId: abTestName,
 
-        start: '2018-03-20',
+        start: '2018-03-23',
         expiry: '2018-04-10',
 
         author: 'Jonathan Rankin',
-        description: 'Always ask on Cambridge analytica stories',
+        description:
+            'A test which tries custom copy on Cambridge analytica stories',
         successMeasure: 'Conversion rate',
         idealOutcome:
-            'We learn the impact of placing an ever-present ask on "moment" stories',
+            'We learn the impact of moment-lead messaging on epic conversion',
 
         audienceCriteria: 'All',
         audience: 1,


### PR DESCRIPTION
## What does this change?
This test tries out some bespoke copy around the  Cambridge Analytica story. It runs on all Cambridge Analytica stories, and both variants are always ask. This test is designed to slot over the `acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal` test (note: this is not really a test, it just ensures that we always show the epic on Cambridge Analytica stories), as we are going to evaluate the test tomorrow and turn it off if it is tanking, and `acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal` will resume it's position

Control:
![control](https://user-images.githubusercontent.com/2844554/37840772-e741b350-2eb5-11e8-8c42-decf1e693fa0.png)

Variant:
<img width="584" alt="screenshot at mar 23 17-19-17" src="https://user-images.githubusercontent.com/2844554/37844020-696cec3e-2ebe-11e8-921e-5ffe91c02828.png">
