### PR TITLE
Remove a couple of lodash deps from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,6 @@
     "jest-environment-jsdom-global": "^1.0.3",
     "jest-teamcity-reporter": "^0.6.2",
     "listr": "^0.12.0",
-    "lodash.capitalize": "^4.2.1",
-    "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.0",
     "lodash.takewhile": "^4.6.0",
     "lodash.uniq": "^4.5.0",


### PR DESCRIPTION
## What does this change?

These dependencies were removed in #19353, but have mysteriously reappeared, probably due to a poorly-resolved merged conflict in #19352!

This change removes these unused dependencies once and for all.

## What is the value of this and can you measure success?

Fewer dependencies
