### PR TITLE
AMP Moved position of main media

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -42,37 +42,15 @@
                 @fragments.guBand()
             }
 
-            @if(amp) {
-                @fragments.headTonal(article, model, isPaidContent, amp = amp)
+            @fragments.mainMedia(article, amp)
 
-                @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                    @fragments.mainMedia(article, amp)
-                }
-            } else {
-                <div class="hide-on-mobile">
-                    @fragments.headTonal(article, model, isPaidContent, amp = amp)
-                </div>
-
-                @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                    @fragments.mainMedia(article, amp)
-                }
-            }
+            @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
                         <div class="js-score"></div>
                         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
-
-                        @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
-                            @fragments.mainMedia(article, amp)
-                        }
-
-                        @if(!amp) {
-                            <div class="mobile-only">
-                                @fragments.headTonal(article, model, isPaidContent, amp = amp)
-                            </div>
-                        }
 
                         @fragments.witnessCallToAction(article.content)
 

--- a/static/src/stylesheets/amp/nav/_veggie-burger.scss
+++ b/static/src/stylesheets/amp/nav/_veggie-burger.scss
@@ -11,6 +11,7 @@
     border-radius: 50%;
     outline: none;
     right: $gutter-small;
+    z-index: 1;
 
     @include mq(mobileMedium) {
         bottom: -$gs-baseline / 2;


### PR DESCRIPTION
Getting AMP more inline with the main website. 

# Before
<img width="362" alt="screen shot 2018-03-26 at 14 35 57" src="https://user-images.githubusercontent.com/14570016/37909614-49997c78-3103-11e8-95f7-63b54b819491.png">

# After
<img width="363" alt="screen shot 2018-03-26 at 14 35 34" src="https://user-images.githubusercontent.com/14570016/37909617-4ac07016-3103-11e8-9255-850f1070c1bf.png">

As far as I can see this template is only used by AMP now. If so, some Garnett files are littered with superfluous AMP conditions. 