### PR TITLE
Ignore spaces when validating post codes

### DIFF
--- a/identity/app/form/AddressMapping.scala
+++ b/identity/app/form/AddressMapping.scala
@@ -45,9 +45,11 @@ case class AddressFormData(
       postcode.isEmpty || ZipcodePattern.findFirstIn(postcode).isDefined
   }
 
-   private val PostcodePattern = """^(GIR 0AA)|((([A-Z-[QVX]][0-9][0-9]?)|(([A-Z-[QVX]][A-Z-[IJZ]][0-9][0-9]?)|(([A-Z-[QVX]][0-9][A-HJKSTUW])|([A-Z-[QVX]][A-Z-[IJZ]][0-9][ABEHMNPRVWXY])))) [0-9][A-Z-[CIKMOV]]{2})$""".r
+  private def stripSpacesAndUppercase(string: String) = string.toUpperCase.replaceAllLiterally(" ", "")
+
+  private val PostcodePattern = """^(GIR 0AA)|((([A-Z-[QVX]][0-9][0-9]?)|(([A-Z-[QVX]][A-Z-[IJZ]][0-9][0-9]?)|(([A-Z-[QVX]][0-9][A-HJKSTUW])|([A-Z-[QVX]][A-Z-[IJZ]][0-9][ABEHMNPRVWXY]))))[0-9][A-Z-[CIKMOV]]{2})$""".r
 
   private lazy val isValidUkPostcode = {
-      postcode.isEmpty || PostcodePattern.findFirstIn(postcode.toUpperCase).isDefined
+      postcode.isEmpty || PostcodePattern.findFirstIn(stripSpacesAndUppercase(postcode)).isDefined
   }
 }


### PR DESCRIPTION
## What does this change?

Postcode validation on edit profile

## What is the value of this and can you measure success?

Users won't be annoyed by us not accepting postcodes entered without space characters. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
The issue: 

![screen shot 2018-03-26 at 16 10 04](https://user-images.githubusercontent.com/3636251/37914973-5bc37d06-3110-11e8-91f6-7bc64051e034.png)

The fix: 

![screen shot 2018-03-26 at 16 10 57](https://user-images.githubusercontent.com/3636251/37915009-6c104568-3110-11e8-96b8-9c03fe53d04b.png)

Validation still works as expected (spaces are no longer considered): 
![screen shot 2018-03-26 at 16 11 08](https://user-images.githubusercontent.com/3636251/37915044-7e8562e6-3110-11e8-82ae-9e300ee6da61.png)


## Tested in CODE?

 No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
