### PR TITLE
Update links to teamcity to reference shared teamcity

### DIFF
--- a/docs/03-dev-howtos/10-testing-platform.md
+++ b/docs/03-dev-howtos/10-testing-platform.md
@@ -28,7 +28,7 @@ The simplest way to do that is to spin up a new Auto scaling Group in environmen
 1. delete the ASG and Launch config
 
 ## Building a branch with frontend
-1. click the ... icon next to Run in [dotcom frontend](https://teamcity.gu-web.net/viewType.html?buildTypeId=dotcom_frontend) build
+1. click the ... icon next to Run in [dotcom frontend](https://teamcity.gutools.co.uk/viewType.html?buildTypeId=dotcom_master) build
 1. change the BranchName in the parameters screen to your branch
 1. run the build - it will create the build and upload to riffraff
 1. deploy the build with riffraff to TEST

--- a/tools/amp-validation/README.md
+++ b/tools/amp-validation/README.md
@@ -2,7 +2,7 @@
 
 Utility that uses the amphtml-validator to validate AMP endpoints.
 
-Mainly for running on teamcity, the [build steps](https://teamcity.gu-web.net/admin/editBuildRunners.html?id=buildType:dotcom_AmpValidation) do the following:
+Mainly for running on teamcity, the [build steps](https://teamcity.gutools.co.uk/viewType.html?buildTypeId=dotcom_AmpValidation) do the following:
 
 - `npm i` (where `cwd` is `tools/amp-validation`)
 - `npm start` (where `cwd` is `tools/amp-validation`)


### PR DESCRIPTION
## What does this change?
Simple docs changes to remove references to teamcity.gu-web.net (which is currently being dismantled by cloudformation)
