### PR TITLE
AMP - Add id field on amp-youtube element 

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -43,6 +43,7 @@
                 <div class="u-responsive-ratio u-responsive-ratio--hd">
                 @page.video.youtubeId.map { youtubeId =>
                     <amp-youtube
+                    id="gu-video-youtube-@{page.video.mediaId}"
                     data-videoid="@youtubeId"
                     data-param-modestbranding="1"
                     data-param-showinfo="0"

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -4,7 +4,8 @@
 
 @for(asset <- media.activeAssets.headOption) {
     <amp-youtube
-    data-videoid="@asset.id"
+    id="gu-video-youtube-@{media.id}"
+    data-videoid="@{asset.id}"
     layout="responsive"
     width="16" height="9" data-param-rel="0" data-param-showinfo="0">
     </amp-youtube>

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -88,6 +88,7 @@ class AtomCleanerTest extends FlatSpec
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc, youTubeAtom, amp = true)
     result.select("amp-youtube").attr("data-videoid") should be("nQuN9CUsdVg")
+    result.select("amp-youtube").attr("id") should be("gu-video-youtube-887fb7b4-b31d-4a38-9d1f-26df5878cf9c")
   }
 
   "Youtube template" should "include endslate path" in {


### PR DESCRIPTION
## What does this change?

To track video events on AMP page, only [few variables](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-video-analytics.md#common-variables) are available, and unfortunately `data-video-id` is not one of them. The associated changes add a new `id` field on `amp-youtube` element, that will be used by [new ophan amp tracking](https://github.com/guardian/ophan/pull/2705).  
  
## What is the value of this and can you measure success?

Correctly tracking `play` and `stop` events on youtube video embed on AMP rendered pages.

## Does this affect other platforms - Amp, Apps, etc?

Only `AMP`

## Tested in CODE?

Tested locally and does not seems to break AMP page validatiion
