### PR TITLE
Consent modal logic fix

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -177,9 +177,7 @@
     <section class="identity-forms-message">
         <h1 class="identity-header">Are you sure?</h1>
 
-        @if(onlySubscribedToV1Newsletters.isEmpty) {
-
-            <div>
+            <div class="identity-forms-message-no-reminder__body">
                 <p>Looks like you haven't selected any newsletters or Guardian products and services.</p>
 
                 <p>This means you'll stop receiving <b>all</b> emails from us other than service communication.</p>
@@ -188,16 +186,15 @@
 
                 <p><b>Are you sure you want to unsubscribe from all Guardian emails?</b></p>
             </div>
-        }else {
 
-            <div class="identity-forms-message__body">
-                <p>You've chosen not to recieve the following emails from the Guardian:</p>
+            <div class="identity-forms-message-reminder__body identity-forms-message-reminder__body--inactive">
+                <p>You've chosen not to receive the following emails from the Guardian:</p>
 
                 <div class="identity-consent-journey-modal__reminder"></div>
 
                 <p>Are you sure you want to unsubscribe from these email services?</p>
             </div>
-        }
+
         <footer class="identity-forms-message__options">
             <a class="js-identity-modal__closer manage-account__button manage-account__button--main manage-account__button--center" data-link-name="consents : confirm : recheck">Let me look again</a>
             <a class="manage-account__button manage-account__button--secondary manage-account__button--center js-identity-consent-journey-continue" data-link-name="consents : confirm : continue">Unsubscribe me</a>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -177,7 +177,7 @@
     <section class="identity-forms-message">
         <h1 class="identity-header">Are you sure?</h1>
 
-            <div class="identity-forms-message-no-reminder__body">
+            <div class="identity-consent-journey-modal-message identity-consent-journey-modal-message--inactive identity-consent-journey-modal-message--no-reminder">
                 <p>Looks like you haven't selected any newsletters or Guardian products and services.</p>
 
                 <p>This means you'll stop receiving <b>all</b> emails from us other than service communication.</p>
@@ -187,7 +187,7 @@
                 <p><b>Are you sure you want to unsubscribe from all Guardian emails?</b></p>
             </div>
 
-            <div class="identity-forms-message-reminder__body identity-forms-message-reminder__body--inactive">
+            <div class="identity-consent-journey-modal-message identity-consent-journey-modal-message--inactive  identity-consent-journey-modal-message--reminder">
                 <p>You've chosen not to receive the following emails from the Guardian:</p>
 
                 <div class="identity-consent-journey-modal__reminder"></div>

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -101,7 +101,7 @@ const showJourney = (journeyEl: HTMLElement): Promise<void> =>
 const hideLoading = (loadingEl: HTMLElement): Promise<void> =>
     fastdom.write(() => loadingEl.remove());
 
-const uncheckedBoxes = (
+const getCheckboxInfo = (
     journeyEl: HTMLElement,
     section: string
 ): Promise<Array<Object>> =>
@@ -124,8 +124,8 @@ const showJourneyAlert = (journeyEl: HTMLElement): void => {
             if (ev.isTrusted) {
                 ev.preventDefault();
                 Promise.all([
-                    uncheckedBoxes(journeyEl, 'email'),
-                    uncheckedBoxes(journeyEl, 'marketing-consents'),
+                    getCheckboxInfo(journeyEl, 'email'),
+                    getCheckboxInfo(journeyEl, 'marketing-consents'),
                 ])
                     .then(checkboxes => {
                         const allCheckboxes = [].concat(...checkboxes);

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -115,3 +115,11 @@
         background-size: contain;
     }
 }
+
+.identity-forms-message-reminder__body--inactive {
+    display: none;
+}
+
+.identity-forms-message-no-reminder__body--inactive {
+    display: none;
+}

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -116,10 +116,7 @@
     }
 }
 
-.identity-forms-message-reminder__body--inactive {
+.identity-consent-journey-modal-message--inactive {
     display: none;
 }
 
-.identity-forms-message-no-reminder__body--inactive {
-    display: none;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,7 +5690,7 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.capitalize@^4.1.0, lodash.capitalize@^4.2.1:
+lodash.capitalize@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
 
@@ -5701,10 +5701,6 @@ lodash.clonedeep@^4.3.2:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
-
-lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
 lodash.get@^3.7.0:
   version "3.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,7 +5690,7 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.capitalize@^4.1.0:
+lodash.capitalize@^4.1.0, lodash.capitalize@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
 
@@ -5701,6 +5701,10 @@ lodash.clonedeep@^4.3.2:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
 lodash.get@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
## What does this change?
- Consent modal reminder was not picking up the consents so it looked like users hadn't selected anything when they had. 
- This ensures the modal displays the correct message if some things / nothing is selected in the consent journey

## Screenshots

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
