### PR TITLE
Paid content: Inline link and caption colour change

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -180,7 +180,7 @@
 
     &.tonal--tone-media {
         .submeta__section-labels .submeta__link {
-            color: $guardian-brand;
+            color: $garnett-neutral-1;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -168,7 +168,7 @@
     }
 
     &.tonal--tone-media .tonal__standfirst a {
-        color: $news-default;
+        color: $garnett-neutral-1;
     }
 
     &.tonal--tone-media .tonal__standfirst {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1094,8 +1094,12 @@
     }
     .content__standfirst,
     .content__dateline,
-    .caption--main {
-        color: $neutral-2-contrasted;
+    .caption--main,
+    .caption {
+        color: $garnett-neutral-7;
+    }
+    .inline-icon {
+        fill: $garnett-neutral-7;
     }
     .element.element-pullquote {
         .pullquote-paragraph {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1101,6 +1101,21 @@
     .inline-icon {
         fill: $garnett-neutral-7;
     }
+    a {
+        color: $garnett-neutral-1;
+    }
+    .u-underline {
+        text-decoration: none !important;
+        border-bottom: 1px solid $garnett-neutral-2;
+        transition: border-color .15s ease-out;
+        &:hover,
+        &:focus {
+            border-color: mix($garnett-neutral-1, $garnett-neutral-1, 50%);
+        }
+        &:active {
+            border-color: $garnett-neutral-1;
+        }
+    }
     .element.element-pullquote {
         .pullquote-paragraph {
             font-family: $f-sans-serif-text;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1683,11 +1683,3 @@ $quote-mark: 35px;
         background: transparent;
     }
 }
-
-// *************** Commercial overrides ****************
-
-.paid-content, .content--media.paid-content {
-    a {
-        color: $garnett-neutral-6;
-    }
-}


### PR DESCRIPTION
## What does this change?
Paid content article page: Changed inline link and caption colour to dark grey so that they can be read better.

**Before:**
![picture 47](https://user-images.githubusercontent.com/5967941/37973126-baab78de-31d1-11e8-9b0b-53052219e223.png)



**After:**
![picture 48](https://user-images.githubusercontent.com/5967941/37973117-b3b5ded4-31d1-11e8-8147-db381bb79f73.png)






## Tested in CODE?
No
