### PR TITLE
Fix LiveBlog inline adverts

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -89,7 +89,7 @@ const insertAds = (slots: HTMLElement[]): void => {
             classes: 'liveblog-inline',
         });
 
-        adSlots.reverse().forEach(adSlot => {
+        adSlots.forEach(adSlot => {
             if (slots[i] && slots[i].parentNode) {
                 slots[i].parentNode.insertBefore(adSlot, slots[i].nextSibling);
             }


### PR DESCRIPTION
## What does this change?
On some liveblogs, there is a bug where the `div` being added as the advert is actually the BlockThrough `span` rather then the advert container `div`.

This is because `.reverse()` is in-place, hurray for mutable state!

Removing the `reverse` means that the first element is the actual advert container and is then correctly requested.