### PR TITLE
Upgrade to React v0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",
-    "react": "0.13.2",
+    "react": "^0.14.9",
     "reqwest": "2.0.5",
     "tcp-ping": "^0.1.1",
     "video.js": "~5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7638,15 +7638,16 @@ react-dom@^0.14.0:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.8.tgz#0f1c547514263f771bd31814a739e5306575069e"
 
-react@0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.13.2.tgz#a1c7cec5e7be080c4e249b20740d4d4cd18880ca"
-  dependencies:
-    envify "^3.0.0"
-
 react@^0.14.0:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react/-/react-0.14.8.tgz#078dfa454d4745bcc54a9726311c2bf272c23684"
+  dependencies:
+    envify "^3.0.0"
+    fbjs "^0.6.1"
+
+react@^0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.14.9.tgz#9110a6497c49d44ba1c0edd317aec29c2e0d91d1"
   dependencies:
     envify "^3.0.0"
     fbjs "^0.6.1"


### PR DESCRIPTION
## What does this change?

Upgrades to React v0.14

## What is the value of this and can you measure success?

This is the minimum possible change to fix the high severity security vulnerability identified by Snyk in React v0.13

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

- [ ] Test in CODE

Mostly, surprisingly, okay, but breaks the preferences page. We will probably need to JSXify preferences and the accessibility component (just to be sure) before merging this upgrade.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
