### PR TITLE
Fix ga tracking for membership account messaging

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -21,6 +21,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
             bean.on(document, 'click', '.js-site-message-close', () => {
                 window.ga(
                     `${gaTracker}.send`,
+                    'event',
                     'click',
                     'in page',
                     'membership action required | banner hidden'
@@ -29,6 +30,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
 
             window.ga(
                 `${gaTracker}.send`,
+                'event',
                 'element view',
                 'internal',
                 'membership action required | banner impression'

--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -128,6 +128,7 @@ export const display = (
                 display($parent, newCard);
                 window.ga(
                     `${gaTracker}.send`,
+                    'event',
                     'action required',
                     'change details',
                     'membership action required | change successful'
@@ -177,6 +178,7 @@ export const display = (
 
             window.ga(
                 `${gaTracker}.send`,
+                'event',
                 'action required',
                 'change details',
                 'membership action required | change start'


### PR DESCRIPTION
 ## What does this change?
The call to window.ga to properly fire an event
## What is the value of this and can you measure success?
Correct ga tracking for this messaging.
## Does this affect other platforms - Amp, Apps, etc?
No.
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
Forthcoming.
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
