### PR TITLE
Standardising content & series labels, galleries and submeta

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -3,24 +3,24 @@
 @import views.support.TrailCssClasses.toneClass
 
 @* Manually placing tonal__head--tone-media as temporary fix to ensute special report tones have it *@
-<header class="content__head tonal__head tonal__head--tone-media tonal__head--@toneClass(gallery.item)">
+<header class="tonal__head tonal__head--tone-media tonal__head--@toneClass(gallery.item)">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@
     <h1 class="is-hidden" itemprop="headline">@Html(gallery.item.trail.headline)</h1>
 
     <div class="gs-container">
-        @fragments.commercial.badge(gallery.item, gallery)
+        <div class="content__main-column content__main-column--gallery">
+            @fragments.commercial.badge(gallery.item, gallery)
 
-        @fragments.contentMeta(gallery.item, gallery)
+            @fragments.contentMeta(gallery.item, gallery)
 
-        @if(gallery.item.fields.standfirst.isDefined) {
-            <div class="tonal__standfirst">
-                @fragments.standfirst(gallery.item)
-            </div>
-        }
+            @if(gallery.item.fields.standfirst.isDefined) {
+                <div class="tonal__standfirst">
+                    @fragments.standfirst(gallery.item)
+                </div>
+            }
 
             <div class="content__meta-container gallery__meta-container">
-
                 @if(!gallery.item.content.hasTonalHeaderByline) {
                     @fragments.meta.byline(gallery.item.trail.byline, gallery.item.tags)
                 }
@@ -33,7 +33,7 @@
                 @if(!gallery.item.trail.shouldHidePublicationDate) {
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }
-
             </div>
+        </div>
     </div>
 </header>

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -24,22 +24,23 @@
 
     <div class="@RenderClasses("immersive-main-media__headline-container--dark", "immersive-main-media__headline-container", "content--pillar-news", s"content--pillar-${page.metadata.pillar.nameOrDefault}")">
         <div class="gs-container">
-            @fragments.meta.metaInline(page.item)
+            <div class="content__main-column content__main-column--gallery">
+                @fragments.meta.metaInline(page.item)
 
-            <h1 class="@RenderClasses(
-                Map("content__headline--paidgallery" -> isPaidContent(page)),
-                "content__headline", "content__headline--immersive", "content__headline--gallery", "content__headline--immersive--with-main-media"
-                )">
-                @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
-                @Html(page.item.trail.headline)
-            </h1>
+                <h1 class="@RenderClasses(
+                    Map("content__headline--paidgallery" -> isPaidContent(page)),
+                    "content__headline", "content__headline--immersive", "content__headline--gallery", "content__headline--immersive--with-main-media"
+                    )">
+                    @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
+                    @Html(page.item.trail.headline)
+                </h1>
 
-            @if(page.item.content.hasTonalHeaderByline) {
-                @page.item.trail.byline.map { text =>
-                    <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
+                @if(page.item.content.hasTonalHeaderByline) {
+                    @page.item.trail.byline.map { text =>
+                        <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
+                    }
                 }
-            }
-
+            </div>
         </div>
     </div>
 </div>

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -43,7 +43,7 @@ category: Common
     min-height: 45px; // Height of social + padding + 1px border to ensure layout is kept when opening overlay
 }
 
-.social {
+.social:not(.social--bottom) {
     overflow-y: hidden;
     height: 32px;
 }

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -1,7 +1,23 @@
 .submeta {
-    border-top: 1px dotted $neutral-5;
+    @include multiline(4, $garnett-neutral-4, top);
     margin-top: $gs-baseline;
-    padding-top: $gs-baseline / 2;
+    padding-top: $gs-baseline * 1.5;
+
+    .content--media:not(.paid-content)  & {
+        @include multiline(4, $garnett-neutral-7, top);
+
+        .submeta__keywords {
+            border-color: $garnett-neutral-7;
+        }
+    }
+
+    .paid-content & {
+        @include multiline(4, $garnett-neutral-6, top);
+
+        .submeta__keywords {
+            border-color: $garnett-neutral-6;
+        }
+    }
 }
 
 .submeta--borderless-bottom .submeta__keywords {
@@ -10,25 +26,22 @@
 
 .submeta__label {
     @include fs-textSans(1);
-    color: $neutral-2;
+    color: $garnett-neutral-2;
     display: block;
-    margin-bottom: -($gs-baseline / 4);
+    margin-top: -($gs-baseline / 4);
 }
 
 .submeta__keywords {
-    border-bottom: 1px dotted $neutral-5;
-    padding-bottom: $gs-baseline;
-    min-height: $gs-baseline * 2;
+    border-bottom: 1px solid $garnett-neutral-4;
     margin-bottom: $gs-baseline / 2;
+    padding-bottom: $gs-baseline;
 }
 
-.submeta__links {
+
+// Nesting 'article' overrides from-content-api ul rules
+article .submeta__links {
     font-size: 0;
-    list-style: none;
-    overflow: hidden;
-    margin-bottom: 0;
-    margin-left: -$gs-gutter / 4;
-    margin-top: 0;
+    margin: 0 0 0 (-$gs-gutter / 4);
 }
 
 .submeta__link-item {
@@ -37,20 +50,18 @@
 
 .submeta__link {
     @include trailing-slash-link;
-    font-weight: bold;
 
     .submeta__keywords & {
         @include fs-textSans(4);
-        color: $neutral-2;
     }
 
     .submeta__section-labels & {
-        @include fs-textSans(5);
+        @include fs-headline(2);
     }
 
     &:after {
         @include trailing-slash;
-        color: $neutral-5;
+        color: $garnett-neutral-4;
     }
 }
 
@@ -62,13 +73,8 @@
 }
 
 .submeta__share {
+    float: left;
     margin-bottom: $gs-baseline / 2;
-
-    @include mq(tablet) {
-        float: left;
-        margin-right: $gs-gutter / 2;
-        margin-bottom: 0;
-    }
 }
 
 .submeta__syndication {
@@ -76,11 +82,8 @@
 
     @include mq(desktop) {
         @include fs-textSans(1);
-        padding-top: $gs-baseline/2;
+        padding-top: $gs-baseline / 2;
         display: inline-block;
-        height: 32px;
         float: right;
-        line-height: 15px;
-        margin-bottom: 0;
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -67,7 +67,6 @@
     }
 
     &.content__main-column--media,
-    &.content__main-column--gallery,
     &.content__main-column--wide {
         @include mq(desktop) {
             max-width: none;
@@ -170,7 +169,8 @@
     }
 }
 
-.content__labels--not-immersive {
+.content__labels--not-immersive,
+.content__labels--gallery {
     @include mq($from: phablet, $until: tablet) {
         margin-left: $gs-gutter;
     }
@@ -949,7 +949,6 @@
 
 // This section below makes the meta align with the image on leftCol, and has the main media first on mobile.
 .content__head--article {
-
     @include mq($until: tablet) {
         display: flex;
         flex-direction: column;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -205,10 +205,6 @@
     }
 }
 
-.content__section-label--gallery {
-    margin-right: $gs-gutter / 4;
-}
-
 .content__series-label {
     display: inline;
     font-family: $f-serif-headline;
@@ -225,10 +221,6 @@
     }
 }
 
-.content__series-label--immersive-article {
-    font-weight: bold;
-}
-
 .content__series-label__link {
     color: $neutral-2;
 }
@@ -237,13 +229,6 @@
     .container__meta__title {
         font-size: 20px;
         line-height: 24px;
-    }
-
-    .content__series-label {
-        .content--interactive & {
-            font-size: 20px !important;
-            line-height: 24px !important;
-        }
     }
 }
 

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -47,26 +47,6 @@
     }
 }
 
-.content__labels--gallery {
-    border: 0;
-    width: auto;
-    float: none;
-
-    .content__section-label {
-        margin-right: $gs-gutter / 4;
-    }
-
-    .content__series-label {
-        font-weight: normal;
-    }
-
-    .content__series-label,
-    .content__section-label {
-        @include fs-header(1, $size-only: true);
-        float: left;
-    }
-}
-
 .content__labels--paidgallery {
     .content__section-label__link {
         color: $paid-article-brand;

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -18,6 +18,7 @@
     }
 
     .gallery__meta-container {
+        // TODO: remove the need for important by restructuring _types.scss
         background-image: none !important;
         .byline,
         .content__dateline {

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -1,33 +1,10 @@
-.gallery__main-content .content__meta-container,
-.content__standfirst--gallery {
-    @include mq(desktop) {
-        margin-left: gs-span(2) + $gs-gutter;
-        max-width: gs-span(8);
-
-    }
-    @include mq(leftCol) {
-        margin-left: gs-span(3) + $gs-baseline/2;
-
-    }
-}
-
-.content__labels--gallery,
-.content__headline--gallery {
-    @include mq(desktop) {
-        margin-left: gs-span(3) + $gs-gutter;
-        max-width: gs-span(8);
-
-    }
-    @include mq(leftCol) {
-        margin-left: gs-span(3) + $gs-baseline/2;
-    }
-
-}
-
-
 .gallery__main-content {
     .content__meta-container {
         position: relative;
+        margin-left: 0;
+        min-height: auto;
+        margin-bottom: $gs-baseline;
+        max-width: gs-span(8);
         width: auto;
     }
 
@@ -35,11 +12,33 @@
         display: flex;
         justify-content: space-between;
     }
+
+    .tonal__standfirst {
+        max-width: gs-span(8);
+    }
+
+    .gallery__meta-container {
+        background-image: none !important;
+        .byline,
+        .content__dateline {
+            background-image: none;
+            border: 0;
+            padding-top: 0;
+        }
+    }
+}
+
+.content__labels--gallery {
+    @include mq(leftCol) {
+        margin-left: -($left-column-wide + $gs-gutter);
+        width: $left-column-wide;
+    }
 }
 
 // Overriding the default for media tones
 .tonal--tone-media .content__headline--gallery {
     font-weight: 200;
+    max-width: gs-span(8);
     padding-top: 0;
 
     @include mq($until: tablet) {

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -23,7 +23,7 @@
 
     @include mq(desktop) {
         margin-left: gs-span(3) + $gs-gutter;
-        margin-right: -$gs-gutter;
+        padding-left: 0 !important;
     }
 }
 
@@ -173,15 +173,6 @@
     width: 100%;
 }
 
-.gallery__meta-container {
-    .byline,
-    .content__dateline {
-        border: 0;
-        min-height: 0;
-        padding: 0;
-    }
-}
-
 .gallery__main-content {
     .content__head {
         padding-bottom: $gs-baseline;
@@ -189,12 +180,6 @@
 
     .content--immersive .content__main {
         padding-top: 0;
-    }
-
-    .content__meta-container {
-        border: 0;
-        min-height: auto;
-        margin-bottom: $gs-baseline;
     }
 
     .meta__comment-count--top {
@@ -223,12 +208,6 @@
         border: 0;
     }
 
-    .meta__extras {
-        border-top: 1px dotted $media-mute;
-        border-bottom: 1px dotted $media-mute;
-        margin-top: $gs-baseline / 2;
-    }
-
     // Reset the styles from _content.scss
     .meta__numbers {
         position: relative;
@@ -242,7 +221,8 @@
     }
 
     .meta__social {
-        border: 0;
+        background-image: none !important;
+        border-bottom: 0;
     }
 
     .badge--alt {
@@ -300,4 +280,3 @@
         opacity: 1;
     }
 }
-

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -20,91 +20,6 @@ $quote-mark: 35px;
 .content--type-media,
 .content--type-review,
 .content--type-quiz {
-    // *************** Meta and Social ***************
-    .submeta {
-        @include multiline(4, $garnett-neutral-4, top);
-        border-top: 0;
-        padding-top: $gs-baseline * 1.5;
-    }
-
-    .submeta--borderless-bottom .submeta__keywords {
-        border-bottom: 0;
-    }
-
-    .submeta__section-labels {
-        padding-top: $gs-baseline / 4;
-    }
-
-    .submeta__label {
-        font-size: 12px;
-        line-height: 16px;
-        color: $neutral-2;
-        display: block;
-        margin-bottom: -($gs-baseline / 4);
-        margin-top: -($gs-baseline / 4);
-    }
-
-    .submeta__keywords {
-        padding-top: $gs-baseline / 6;
-        padding-bottom: $gs-baseline / 2;
-        border-bottom: solid 1px $garnett-neutral-4;
-        margin-bottom: $gs-baseline / 2;
-    }
-
-    .submeta__links {
-        font-size: 0;
-        line-height: 0;
-        list-style: none;
-        overflow: hidden;
-        margin-bottom: 0;
-        margin-left: -$gs-gutter / 4;
-        margin-top: 0;
-    }
-
-    .submeta__link-item,
-    .syndication__item {
-        &:before {
-            content: none!important;
-            // I can't seem to override this behaviour without the important statment
-        }
-    }
-
-    .submeta__link {
-        @include trailing-slash-link;
-        font-weight: 400;
-        line-height: 22px;
-
-        &:after {
-            @include trailing-slash;
-            color: $garnett-neutral-4;
-        }
-
-        .submeta__keywords & {
-            font-size: 15px;
-            color: $neutral-2;
-        }
-
-        .submeta__section-labels & {
-            font-size: 16px;
-            line-height: 22px;
-        }
-    }
-
-    .submeta__section-labels .submeta__link {
-        @include fs-headline(2);
-        font-weight: 400;
-    }
-
-    .submeta__badge {
-        float: right;
-        margin-top: -$gs-baseline;
-        margin-left: $gs-gutter / 2;
-    }
-
-    .social {
-        overflow-y: visible;
-    }
-
     .content__header,
     .content__headline,
     .content__meta-container,
@@ -314,10 +229,6 @@ $quote-mark: 35px;
     .meta__extras {
         order: 5;
         border: 0;
-    }
-
-    .social {
-        margin-bottom: $gs-baseline/2;
     }
 
     .block-share__item,
@@ -1221,14 +1132,6 @@ $quote-mark: 35px;
     .byline span {
         display: inline;
     }
-
-    .submeta {
-        @include multiline(4, $garnett-neutral-7, top);
-    }
-
-    .submeta__keywords {
-        border-bottom: 0;
-    }
 }
 
 // For legacy videos, shows play circle and icon
@@ -1547,13 +1450,8 @@ $quote-mark: 35px;
         @include multiline(3, $garnett-neutral-6, top);
     }
 
-    .submeta {
-        @include multiline(4, $garnett-neutral-6, top);
-    }
-
     .social-icon,
-    .block-share__item,
-    .submeta__keywords {
+    .block-share__item {
         border-color: $garnett-neutral-6;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1170,13 +1170,6 @@ $quote-mark: 35px;
         font-style: normal;
     }
 
-    .content__labels {
-        padding-top: $gs-baseline/2;
-        @include mq(phablet) {
-            border-color: $garnett-neutral-6;
-        }
-    }
-
     .tonal__standfirst {
         @include mq($until: tablet) {
             max-width: gs-span(8);
@@ -1187,18 +1180,6 @@ $quote-mark: 35px;
     .content__standfirst {
         @include mq(mobileMedium) {
             max-width: 100%;
-        }
-    }
-
-    .content__standfirst--gallery {
-        @include mq(desktop) {
-            margin-left: gs-span(2) + $gs-gutter;
-            max-width: gs-span(8);
-
-        }
-        @include mq(leftCol) {
-            margin-left: gs-span(3) + $gs-baseline/2;
-
         }
     }
 
@@ -1247,105 +1228,6 @@ $quote-mark: 35px;
 
     .submeta__keywords {
         border-bottom: 0;
-    }
-    // *************** Gallery overrides ***************
-    &.content--gallery {
-        .content__main {
-            padding-bottom: 0;
-        }
-
-        .gallery:before {
-            content: none;
-        }
-
-        .content__main-column--gallery {
-            &:before {
-                @include mq(leftCol) {
-                    content: '';
-                    position: absolute;
-                    top: 0;
-                    bottom: 0;
-                    left: 0;
-                    height: 100%;
-                    width: 1px;
-                    background: $garnett-neutral-7;
-                }
-            }
-            @include mq(tablet) {
-                padding-left: 0;
-                padding-bottom: $gs-baseline*4;
-            }
-            @include mq(desktop) {
-                padding-left: 0;
-                padding-bottom: $gs-baseline*6;
-            }
-            @include mq(leftCol) {
-                margin-left: gs-span(3) - $gs-gutter/2;;
-                padding-left: $gs-gutter/2;
-            }
-        }
-
-        .meta__twitter {
-            margin-top: $gs-baseline / 2;
-
-            .button:focus,
-            .button:hover {
-                border-width: 0;
-            }
-        }
-
-        .content__dateline {
-            background-image: none;
-        }
-
-        .meta__extras {
-            border: 0;
-        }
-
-        .u-underline[href] {
-            color: $garnett-neutral-4;
-        }
-
-        .meta__numbers,
-        .meta__social {
-            background-image: none;
-            padding-top: 0;
-
-            &::before {
-                content: none;
-            }
-        }
-
-        .gallery__meta-container {
-            background-image: none;
-        }
-
-        .gallery:before,
-        .gallery__divider {
-            border-color: $garnett-neutral-7;
-        }
-
-        .submeta {
-            @include mq(desktop) {
-                max-width: gs-span(8);
-            }
-        }
-    }
-}
-
-.gallery__main-content {
-    .content__series-label__link {
-        color: $garnett-neutral-5;
-    }
-
-    .gallery__most-popular {
-        background-color: $garnett-neutral-1;
-    }
-
-    .container__title:after,
-    .fc-container__header__title--sticky:after,
-    .fc-container__header__title:after {
-        background-color: $garnett-neutral-7;
     }
 }
 

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -811,37 +811,6 @@ $timeline-width: 15px;
     }
 }
 
-.blog {
-    .content__headline {
-        @include fs-headlineGarnett(4);
-
-        @include mq(tablet) {
-            @include fs-headlineGarnett(6, true);
-        }
-        font-weight: 400;
-    }
-
-    .content__section-label {
-        @include mq(desktop) {
-            @include fs-header(3);
-            float: none;
-        }
-    }
-
-    .content__series-label {
-        @include mq(desktop) {
-            @include fs-headline(3);
-            float: none;
-        }
-    }
-
-    .content__secondary-column {
-        @include mq($until: wide) {
-            display: none;
-        }
-    }
-}
-
 .ad-slot--liveblog-inline {
     @include mq(tablet) {
         margin: 0 0 $gs-baseline;

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -149,7 +149,7 @@
 
 /* some atoms can contain share-items, which are wrappend into ul.social, and
    therefore we have to exclude them from the default CAPI list styling */
-.from-content-api ul:not(.social),
+.from-content-api ul:not(.social):not(.submeta__links):not(.syndication--bottom),
 .content__standfirst ul {
     list-style: none;
 


### PR DESCRIPTION
Sorry about this being 3 parts. I stopped when I realised how mad that was, but everything was interconnected.

1. Firstly in trying to do something else I realised we are treating the same information differently across different templates - resulting in lots of duplicated and superfluous css. This is in relation to the content section and series labels.

For example, live blogs had custom sized lables. I have standardised them across template types.

# Before
![screen shot 2018-03-28 at 10 51 00](https://user-images.githubusercontent.com/14570016/38021936-0f302fd6-3276-11e8-804f-25127da946c9.png)

# After
![screen shot 2018-03-28 at 10 51 15](https://user-images.githubusercontent.com/14570016/38021937-0f4bf1f8-3276-11e8-8018-3c8f4f4d2936.png)

2. This then led me on to spotting how differently we treat labels in the gallery template, so I have standardised that to be more consistent with the rest of our page templates:

# Before
![screen shot 2018-03-28 at 10 49 31](https://user-images.githubusercontent.com/14570016/38021810-c715b356-3275-11e8-9c47-17aa69e68873.png)

# After
![screen shot 2018-03-28 at 10 49 40](https://user-images.githubusercontent.com/14570016/38021811-c72b67c8-3275-11e8-9e07-24595ea94e91.png)

3. Finally - I have lifted all of the social--bottom code from _types back to where it belongs, in so deleting a lot of duplicated code and overrides. The result looks the same but is a hell of a lot cleaner and therefore easier to edit in the future. 

There is lots lots lots more I want to do, but I have reached a point with this pr where I should stop before I touch anything else.

