### PR TITLE
Allow RP auth for newsletter saving

### DIFF
--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -32,7 +32,7 @@ trait EmailsTab
   /** POST /email-prefs */
   def saveEmailPreferencesAjax: Action[AnyContent] =
     csrfCheck {
-      fullAuthWithIdapiUserAction.async { implicit request =>
+      consentAuthWithIdapiUserAction.async { implicit request =>
         newsletterService.savePreferences().map { form  =>
           if (form.hasErrors) {
             val errorsAsJson = Json.toJson(


### PR DESCRIPTION
## What does this change?

## What is the value of this and can you measure success?
Fixes an issue where non-logged-in users who followed a magic link would not be able to resubscribe to newsletters because they do not have full authentication.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
