### PR TITLE
Ensure that Spacefinder test, leaves enough space for DMPUs and Most Popular

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Alters the rules for inserting ads on desktop breakpoints.",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 17),
+    sellByDate = new LocalDate(2018, 4, 24),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -57,11 +57,13 @@ const insertAdAtPara = (
 let previousAllowedCandidate;
 
 // this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
-const filterNearbyCandidates = (candidate: SpacefinderItem): boolean => {
+const filterNearbyCandidates = (maximumAdHeight: number) => (
+    candidate: SpacefinderItem
+): boolean => {
     if (
         !previousAllowedCandidate ||
         Math.abs(candidate.top - previousAllowedCandidate.top) -
-            adSizes.mpu.height >=
+            maximumAdHeight >=
             adSlotClassSelectorSizes.minBelow
     ) {
         previousAllowedCandidate = candidate;
@@ -90,7 +92,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minBelow: 400,
             },
         },
-        filter: filterNearbyCandidates,
+        filter: filterNearbyCandidates(adSizes.mpu.height),
     };
 
     const relaxedRules = {
@@ -101,7 +103,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
         selectors: {
             ' .ad-slot': adSlotClassSelectorSizes,
         },
-        filter: filterNearbyCandidates,
+        filter: filterNearbyCandidates(adSizes.halfPage.height),
     };
 
     const rules = inTestVariant && !isInline1 ? relaxedRules : defaultRules;
@@ -148,7 +150,7 @@ const addMobileInlineAds = (): Promise<number> => {
                 minBelow: 400,
             },
         },
-        filter: filterNearbyCandidates,
+        filter: filterNearbyCandidates(adSizes.mpu.height),
     };
 
     const insertAds = (paras: HTMLElement[]): Promise<number> => {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -74,12 +74,13 @@ const filterNearbyCandidates = (maximumAdHeight: number) => (
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const variant = getVariant(spacefinderSimplify, 'variant');
+    const isImmersive = config.get('page.isImmersive');
     const inTestVariant = variant && isInVariant(spacefinderSimplify, variant);
 
     const defaultRules = {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: inTestVariant ? 300 : 700,
+        minAbove: inTestVariant && !isImmersive ? 300 : 700,
         minBelow: 700,
         selectors: {
             ' > h2': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -98,7 +98,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const relaxedRules = {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
-        minAbove: 700,
+        minAbove: 1000,
         minBelow: 700,
         selectors: {
             ' .ad-slot': adSlotClassSelectorSizes,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
@@ -1,20 +1,24 @@
 // @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const spacefinderSimplify: ABTest = {
     id: 'SpacefinderSimplify',
-    start: '2018-03-05',
-    expiry: '2018-04-17',
+    start: '2018-04-10',
+    expiry: '2018-04-24',
     author: 'Jon Norman',
     description:
         'This test alters the rules for inserting ads on desktop breakpoints.',
     audience: 0.1,
     audienceOffset: 0.7,
     successMeasure: 'No negative impact on attention time',
-    audienceCriteria: 'All web traffic.',
+    audienceCriteria: 'All web traffic from the UK',
     dataLinkNames: '',
     idealOutcome:
         'We increase the number of ads in articles whilst understanding any aesthetic issues that arise.',
-    canRun: () => true,
+    canRun: () => {
+        const geolocation = geolocationGetSync();
+        return geolocation === 'GB';
+    },
     variants: [
         {
             id: 'variant',


### PR DESCRIPTION
## What does this change?
We have a test live (with the switch currently turned off) that seeks to relax the rules of Spacefinder when inserting article inline adverts on desktop.

When we turned this on, we spotted two issues:

1. The inline2 (i.e. the first inline ad to be floated right on desktop) can clash with the most popular widget.
**Change**: we increase the minAbove for inline2 ads and onwards to ensure that they will clear the "most popular" widget.

2. When filtering the list of candidates that spacefinder returns, we need to ensure that, in the variant, we leave enough room for DMPUs (i.e. 300x600 sized ads) to appear.
**Change**: parameterise the filtering function to allow for a variable threshold for checking candidate elements.

## What is the value of this and can you measure success?
We can turn the test back on.