### PR TITLE
Removed interview from media tone on fronts

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -332,8 +332,7 @@ $pillars: (
         }
     }
 
-    &.fc-item--type-media,
-    &.fc-item--type-interview {
+    &.fc-item--type-media {
         background-color: darken($story-package-garnett, 8%);
 
         .youtube-media-atom__play-button.vjs-control-text {


### PR DESCRIPTION
<img width="1032" alt="screen shot 2018-03-28 at 14 00 13" src="https://user-images.githubusercontent.com/14570016/38030437-8524c7fa-3290-11e8-86fc-bcaf21604b53.png">

That shouldn't be happening