### PR TITLE
Restrict Prebid analytics to small sample

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -16,6 +16,7 @@ import type {
     PrebidSlotLabel,
 } from 'commercial/modules/prebid/types';
 import {
+    getRandomIntInclusive,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
 } from 'commercial/modules/prebid/utils';
@@ -65,7 +66,12 @@ class PrebidService {
             priceGranularity,
         });
 
-        if (config.switches.prebidAnalytics) {
+        // gather analytics from 0.001% of pageviews
+        const inSample = getRandomIntInclusive(1, 100000) === 1;
+        if (
+            config.switches.prebidAnalytics &&
+            (inSample || config.page.isDev)
+        ) {
             window.pbjs.enableAnalytics([
                 {
                     provider: 'gu',

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -30,3 +30,12 @@ export const stripMobileSuffix = (s: string): string =>
 
 export const stripTrailingNumbersAbove1 = (s: string): string =>
     stripSuffix(s, '([2-9]|\\d{2,})');
+
+export const getRandomIntInclusive = (
+    minimum: number,
+    maximum: number
+): number => {
+    const min = Math.ceil(minimum);
+    const max = Math.floor(maximum);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+};


### PR DESCRIPTION
Initially just want to gather analytics from a very small sample of pageviews, before connecting up the backend to the data lake.
Should be no more than ~ 8000 events a day.