### PR TITLE
Fix email fronts without a slash in the name

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -28,7 +28,9 @@ GET            /crosswords/lookup                                               
 # Email paths
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/$listId<[0-9]+>       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
+GET        /email/success                                                       controllers.EmailSignupController.subscriptionResult(result = "success")
+GET        /email/invalid                                                       controllers.EmailSignupController.subscriptionResult(result = "invalid")
+GET        /email/error                                                         controllers.EmailSignupController.subscriptionResult(result = "error")
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -28,9 +28,7 @@ GET            /crosswords/lookup                                               
 # Email paths
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/$listId<[0-9]+>       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/success                                                       controllers.EmailSignupController.subscriptionResult(result = "success")
-GET        /email/invalid                                                       controllers.EmailSignupController.subscriptionResult(result = "invalid")
-GET        /email/error                                                         controllers.EmailSignupController.subscriptionResult(result = "error")
+GET        /email/$result<success|invalid|error>                                controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -33,9 +33,7 @@ GET         /form/embed/:formReference              controllers.FormstackControl
 #Email Footer signup routes
 GET        /email/form/$emailType<article|footer>/$listId<[0-9]+>               controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer>/:listName                     controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/success                                                       controllers.EmailSignupController.subscriptionResult(result = "success")
-GET        /email/invalid                                                       controllers.EmailSignupController.subscriptionResult(result = "invalid")
-GET        /email/error                                                         controllers.EmailSignupController.subscriptionResult(result = "error")
+GET        /email/$result<success|invalid|error>                                controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -33,7 +33,9 @@ GET         /form/embed/:formReference              controllers.FormstackControl
 #Email Footer signup routes
 GET        /email/form/$emailType<article|footer>/$listId<[0-9]+>               controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer>/:listName                     controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
+GET        /email/success                                                       controllers.EmailSignupController.subscriptionResult(result = "success")
+GET        /email/invalid                                                       controllers.EmailSignupController.subscriptionResult(result = "invalid")
+GET        /email/error                                                         controllers.EmailSignupController.subscriptionResult(result = "error")
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()
 

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -175,9 +175,7 @@ GET        /sharecount/*path.json                                               
 # Email paths
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/$listId<[0-9]+>    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listName          controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/success                                                                      controllers.EmailSignupController.subscriptionResult(result = "success")
-GET        /email/invalid                                                                      controllers.EmailSignupController.subscriptionResult(result = "invalid")
-GET        /email/error                                                                        controllers.EmailSignupController.subscriptionResult(result = "error")
+GET        /email/$result<success|invalid|error>                                               controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()
 

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -175,7 +175,9 @@ GET        /sharecount/*path.json                                               
 # Email paths
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/$listId<[0-9]+>    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listName          controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
-GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
+GET        /email/success                                                                      controllers.EmailSignupController.subscriptionResult(result = "success")
+GET        /email/invalid                                                                      controllers.EmailSignupController.subscriptionResult(result = "invalid")
+GET        /email/error                                                                        controllers.EmailSignupController.subscriptionResult(result = "error")
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()
 


### PR DESCRIPTION
## What does this change?
This change removes the route `/email/:result` from all routes files, replacing it with three specific routes for each of the 'success/invalid/error' options matched on in the [`EmailSignupController.subscriptionResult`](https://github.com/guardian/frontend/blob/master/common/app/controllers/EmailSignupController.scala#L86) action.

The motivation for this is to make email fronts without a slash in their name, such as http://theguardian.com/email/social-care-network work. These fronts are currently getting picked up by the EmailSubscriptions controller rather than going through to a front page.

I think this change is safe - there's no need to match on 'email/<anything>' when later on we just return a 404 if <anything> isn't success, invalid or error. Visiting theguardian.com/email/blergh will still deliver a 404 page, just one served by a different route. 

## What is the value of this and can you measure success?
Email fronts without a slash in their name will work, saving Celine from having to manually move 15 fronts to new URLs

## Tested in CODE?
Yes, I tested:
 - https://m.code.dev-theguardian.com/email/uk/daily
 - https://m.code.dev-theguardian.com/email/adult-social-care
 - https://m.code.dev-theguardian.com/email/error
 - https://m.code.dev-theguardian.com/email/success
 - https://m.code.dev-theguardian.com/email/invalid
 - https://preview.code.dev-gutools.co.uk/email/uk/daily
 - https://preview.code.dev-gutools.co.uk/email/adult-social-care
