### PR TITLE
Football - Vertical badge alignment

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -741,6 +741,7 @@ $quote-mark: 35px;
     }
 
     .football-tabs .tabs__container {
+        margin-top: $gs-baseline;
         margin-bottom: 0;
     }
 }

--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -92,7 +92,6 @@
     border-radius: $garnett-x-large-button-size / 2;
     background-color: $garnett-neutral-5;
     box-sizing: border-box;
-    padding: 8px;
     overflow: hidden;
 
     @include mq(mobileLandscape) {
@@ -102,10 +101,15 @@
 }
 
 .team__crest {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    top: 8px;
+    max-width: calc(100% - 16px);
+    max-height: calc(100% - 16px);
     margin: auto;
     display: block;
-    max-height: 100%;
-    max-width: 100%;
 }
 
 .team__score {

--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -3,7 +3,6 @@
     display: block;
     color: $neutral-1;
     background-color: $news-garnett-highlight;
-    margin-bottom: $gs-baseline;
 
     &:before {
         @include mq(phablet) {


### PR DESCRIPTION
Flags are a weird shape, also internationals sometimes don't get the tabs. This fixes the rendering of both of them (now that all international games are over for another month)

## Before
![image](https://user-images.githubusercontent.com/1607666/38056684-23ff6f8c-32ab-11e8-9e06-f2765ca83717.png)

## After
![image](https://user-images.githubusercontent.com/1607666/38056691-2c1f455c-32ab-11e8-8599-7d88b5675196.png)
