### PR TITLE
Fix copy in /consents/thank-you

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -153,6 +153,22 @@
     )
 }
 
+@introThankYouStep= @{
+    ConsentStep(
+        name = "intro",
+        title = "Would you like to hear about any of these Guardian products?",
+        help = List(
+            ConsentStepHelpText(
+                "Set your preferences: please let us know if you are interested in any of these products or services."
+            ),
+            ConsentStepHelpText(
+                "You can change your preferences anytime by signing in, clicking My Account, then selecting Email Preferences."
+            )
+        ),
+        content = selectAllCheckboxContent,
+    )
+}
+
 @introStep = @{
     ConsentStep(
         name = "intro",
@@ -228,7 +244,7 @@
                         ConsentBanner(
                             "Thank you"
                         ),
-                        introStep
+                        introThankYouStep
                     ) ++ defaultJourney
 
                 }


### PR DESCRIPTION
## What does this change?
`/consents/thank-you` is the page users land after subscribing to a newsletter. The copy on this page at the moment doesn't make much sense as it asks you to "continue receiving" emails yet you just signed up for one.

This is a quick fix for the copy in this page before we consider more ambitious changes such as sending users to a different page.

![screen shot 2018-03-29 at 11 02 20 am](https://user-images.githubusercontent.com/11539094/38083676-320ad41c-3342-11e8-9ef9-32ef850011d0.png)
![screen shot 2018-03-29 at 11 13 43 am](https://user-images.githubusercontent.com/11539094/38083701-42fc2780-3342-11e8-88c6-b37663c09f87.png)
