### PR TITLE
Tags on fronts

### DIFF
--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -51,6 +51,7 @@ article .submeta__links,
 
 .submeta__link {
     @include trailing-slash-link;
+    color: $garnett-neutral-1;
 
     .submeta__keywords & {
         @include fs-textSans(4);

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -39,7 +39,8 @@
 
 
 // Nesting 'article' overrides from-content-api ul rules
-article .submeta__links {
+article .submeta__links,
+.submeta__links {
     font-size: 0;
     margin: 0 0 0 (-$gs-gutter / 4);
 }


### PR DESCRIPTION
Necessary specificity excluded tag pages from much-needed margins.

# Before
<img width="1175" alt="screen shot 2018-03-29 at 11 46 14" src="https://user-images.githubusercontent.com/14570016/38084990-d2e553ae-3346-11e8-972e-2b6f3d3bcde5.png">

# After
<img width="1191" alt="screen shot 2018-03-29 at 11 46 04" src="https://user-images.githubusercontent.com/14570016/38084989-d2ccdd38-3346-11e8-8786-41057cbcf9ae.png">
