### PR TITLE
Complete consents never redirect to /consents

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -91,7 +91,12 @@ trait ConsentsJourney
     consentHint: Option[String]): Action[AnyContent] =
     csrfAddToken {
       consentsRedirectAction.async { implicit request =>
-        val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request).getOrElse(returnUrlVerifier.defaultReturnUrl)
+
+        val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request) match {
+          case Some(url) => if (url contains "/consents") returnUrlVerifier.defaultReturnUrl else url
+          case _ => returnUrlVerifier.defaultReturnUrl
+        }
+
         consentCompleteView(
           page,
           returnUrl


### PR DESCRIPTION
## What does this change?
- You should never redirect to /consents page from the complete consents page.

## What is the value of this and can you measure success?
- Stop users getting in a bad loop
