### PR TITLE
Increase Prebid analytics sample size

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -66,8 +66,8 @@ class PrebidService {
             priceGranularity,
         });
 
-        // gather analytics from 0.001% of pageviews
-        const inSample = getRandomIntInclusive(1, 100000) === 1;
+        // gather analytics from 0.01% of pageviews
+        const inSample = getRandomIntInclusive(1, 10000) === 1;
         if (
             config.switches.prebidAnalytics &&
             (inSample || config.page.isDev)


### PR DESCRIPTION
Because currently only logging ~ 4 events per hour.
