### PR TITLE
Reinstating secondary column rules on liveblog

### DIFF
--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -817,6 +817,12 @@ $timeline-width: 15px;
     }
 }
 
+.blog .content__secondary-column {
+    @include mq($until: wide) {
+        display: none;
+    }
+}
+
 $pillars: (
     news: (
         pillarColor: $news-garnett-main-1,


### PR DESCRIPTION
## What does this change?
The secondary column on liveblogs should be display none until we reach the wide breakpoint. This rule was accidentally deleted [here](https://github.com/guardian/frontend/pull/19436/files#diff-1cfc66b98c73c7aa53d82b554ffa4359L838). This is reinstating it.

## What is the value of this and can you measure success?
Fixes a bug!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
before:
![image](https://user-images.githubusercontent.com/8774970/38088030-52b2c6e2-3352-11e8-85f8-54c506f6061b.png)

after:
![image](https://user-images.githubusercontent.com/8774970/38088047-60815c16-3352-11e8-94a8-195ba05e52c0.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
