### PR TITLE
Deactivate temporary email sign up on first dog on the moon  

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -62,7 +62,7 @@ trait ABTestSwitches {
     "Varies the strategy for lazyloading of adverts",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 3, 30),
+    sellByDate = new LocalDate(2018, 4, 4),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -20,7 +20,7 @@ const pageHasBlanketBlacklist = (): boolean =>
     keywordExists(['US elections 2016', 'Football']) ||
     config.get('page.section') === 'film' ||
     config.get('page.seriesId') === 'world/series/guardian-morning-briefing' ||
-    config.get('page.contentId') === '/profile/first-dog-on-the-moon' ; //temporary to prevent some spammers to annoy us
+    config.get('page.contentId') === '/profile/first-dog-on-the-moon'; //temporary to prevent some spammers to annoy us
     
 const userHasRemoved = (id: string, formType: string): boolean => {
     const currentListPrefs = userPrefs.get(`email-sign-up-${formType}`);

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -20,8 +20,8 @@ const pageHasBlanketBlacklist = (): boolean =>
     keywordExists(['US elections 2016', 'Football']) ||
     config.get('page.section') === 'film' ||
     config.get('page.seriesId') === 'world/series/guardian-morning-briefing' ||
-    config.get('page.contentId') === '/profile/first-dog-on-the-moon'; //temporary to prevent some spammers to annoy us
-    
+    config.get('page.pageId') === '/profile/first-dog-on-the-moon'; // temporary to prevent some spammers to annoy us
+
 const userHasRemoved = (id: string, formType: string): boolean => {
     const currentListPrefs = userPrefs.get(`email-sign-up-${formType}`);
     return !!currentListPrefs && currentListPrefs.includes(id);

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -19,8 +19,9 @@ const pageHasBlanketBlacklist = (): boolean =>
     // Prevent the blanket emails from ever showing on certain keywords or sections
     keywordExists(['US elections 2016', 'Football']) ||
     config.get('page.section') === 'film' ||
-    config.get('page.seriesId') === 'world/series/guardian-morning-briefing';
-
+    config.get('page.seriesId') === 'world/series/guardian-morning-briefing' ||
+    config.get('page.contentId') === '/profile/first-dog-on-the-moon' ; //temporary to prevent some spammers to annoy us
+    
 const userHasRemoved = (id: string, formType: string): boolean => {
     const currentListPrefs = userPrefs.get(`email-sign-up-${formType}`);
     return !!currentListPrefs && currentListPrefs.includes(id);


### PR DESCRIPTION
## What does this change?

Block `/profile/first-dog-on-the-moon` to display to email sign up.

## What is the value of this and can you measure success?

Reduce our current spam complaints