### PR TITLE
Fix checkbox focus state in /consents

### DIFF
--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -362,6 +362,10 @@ $identity-header-height: 48px;
         .dropdown__content {
             padding-bottom: 2em;
         }
+        &.dropdown--active .dropdown__content {
+            padding: $gs-baseline/4;
+            margin: $gs-baseline/-4;
+        }
         .inline-dropdown-mask {
             display: none;
         }

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -71,11 +71,19 @@ $checkbox-size: $gs-gutter / 1.25;
     display: flex;
     width: 100%;
 
-    &:hover {
+    &:hover, &:focus {
         .manage-account__switch-checkbox {
             border-color: $identity-main;
         }
+        input:checked + .manage-account__switch-checkbox {
+            box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px $identity-main;
+        }
     }
+
+    input:focus:checked + .manage-account__switch-checkbox {
+        box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px $garnett-neutral-7;
+    }
+
 
     &.manage-account__switch--hinted {
         color: $features-main-1;
@@ -139,9 +147,8 @@ $checkbox-size: $gs-gutter / 1.25;
             }
         }
 
-        input:focus, input:focus + .manage-account__switch-checkbox {
-            outline: 5px auto $identity-main;
-            border-color: $identity-main;
+        input:focus + .manage-account__switch-checkbox {
+            outline: none;
         }
 
         input:checked + .manage-account__switch-checkbox {


### PR DESCRIPTION
## What does this change?
Makes the focused checkboxes go from having a glowing halo

![dsfsdimage](https://user-images.githubusercontent.com/11539094/38244258-02a0f848-3732-11e8-878c-7fc8a2b7f0dc.png)

To a more brand consistent border:

![screen shot 2018-04-03 at 10 42 03 am](https://user-images.githubusercontent.com/11539094/38244278-0dc1c586-3732-11e8-9222-b5de470034ea.png)

This also fixes them looking wonky in the email dropdowns