### PR TITLE
Track clicks in /complete-consents

### DIFF
--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -22,12 +22,13 @@
     <section class="identity-forms-message">
         <h1 class="identity-title">Thank you! We've got your preferences</h1>
         <div class="identity-forms-message__body">
-            <p>You can change these anytime by going to My account > <a class="u-underline" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayEmailPrefsForm(false, None).url, idRequest)">Email
-                Preferences</a>.</p>
+            <p>You can change these anytime by going to My account > <a class="u-underline" data-link-name="complete-consents : to-email-prefs" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayEmailPrefsForm(false, None).url, idRequest)">
+                Email Preferences
+            </a>.</p>
             <br/>
         </div>
         @if(!emailPrefsForm.globalError) {
-            <form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
+            <div>
                 @views.html.helper.CSRF.formField
                 <div>
                     <h1 class="identity-title--small">Before you go...</h1>
@@ -43,10 +44,10 @@
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
                     </p>
                 </div>
-            </form>
+            </div>
         }
         <aside class="identity-forms-message__body">
-            <a class="manage-account__button manage-account__button--secondary" href="@LinkTo(returnUrl)">
+            <a class="manage-account__button manage-account__button--secondary" data-link-name="complete-consents : cta-bottom : @LinkTo(returnUrl)" href="@LinkTo(returnUrl)">
                 Go to the theguardian.com
                 @fragments.inlineSvg("arrow-right", "icon")
             </a>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -28,7 +28,7 @@
             <br/>
         </div>
         @if(!emailPrefsForm.globalError) {
-            <div>
+            <form>
                 @views.html.helper.CSRF.formField
                 <div>
                     <h1 class="identity-title--small">Before you go...</h1>
@@ -44,7 +44,7 @@
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
                     </p>
                 </div>
-            </div>
+            </form>
         }
         <aside class="identity-forms-message__body">
             <a class="manage-account__button manage-account__button--secondary" data-link-name="complete-consents : cta-bottom : @LinkTo(returnUrl)" href="@LinkTo(returnUrl)">


### PR DESCRIPTION
## What does this change?
Track clicks on /complete-consents, slightly overzealously (including the final return urls), to have better insights on what exactly is going on with redirections in this page