### PR TITLE
Updating JS to hide more button after border was added subnav

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -392,7 +392,8 @@ const showMoreButton = (): void => {
             if (els) {
                 const { moreButton, lastChildRect, subnavRect } = els;
 
-                if (subnavRect.top === lastChildRect.top) {
+                // +1 to compensate for the border top on the subnav
+                if (subnavRect.top + 1 === lastChildRect.top) {
                     fastdom.write(() => {
                         moreButton.classList.add('is-hidden');
                     });


### PR DESCRIPTION
## What does this change?
After there was a border added to the subnav, this bit of JS wasn't working anymore.

The more button should be hidden when there are not more items.

## What is the value of this and can you measure success?
Returning to expected behaviour

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/38250880-d4e48df0-3747-11e8-8294-6b3eb62e3647.png)

![image](https://user-images.githubusercontent.com/8774970/38250899-dc4619a6-3747-11e8-850c-a47c483e876d.png)


After:
![image](https://user-images.githubusercontent.com/8774970/38250864-c9d3fd88-3747-11e8-9254-f9d4f63b0221.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
