### PR TITLE
Immersive series label tag 

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -4,11 +4,13 @@
 @import model.Badges.badgeFor
 @import views.support.RenderClasses
 
+
 <div class="@RenderClasses(Map(
         "content__labels--gallery" -> item.content.isGallery,
         "content__labels--paidgallery" -> (item.content.isGallery && item.content.isPaidContent),
         "content__labels--not-immersive" -> !item.content.isImmersive,
-        "content__labels--column" -> item.content.isColumn
+        "content__labels--column" -> item.content.isColumn,
+        "content__labels--immersive" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined) 
     ), "content__labels")
 ">
     @if(!amp) {

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -595,19 +595,15 @@
             padding: 0;
         }
 
-        .content__labels {
+        .content__labels--immersive {
             margin-left: -$gs-gutter;
-            width: gs-span(3) + ($gs-gutter / 2);
             padding: ($gs-baseline / 4) ($gs-gutter / 2) ($gs-baseline / 4) $gs-gutter;
             position: absolute;
-            top: 0;
             transform: translateY(-100%);
 
             @include mq($from: tablet) {
                 margin-left: -($gs-gutter / 2);
-                min-height: $gs-baseline * 4;
                 padding: ($gs-baseline / 2) ($gs-gutter / 2);
-                width: gs-span(4) + ($gs-gutter / 2);
             }
         }
 
@@ -620,16 +616,12 @@
             }
         }
 
-        .content__series-label--immersive-article {
-            display: block;
-            padding-bottom: $gs-baseline;
-        }
-
         .content__series-label__link {
             color: #ffffff;
+            font-weight: 700;
 
             @include mq(desktop) {
-                font-size: 22px;
+                font-size: 20px;
             }
         }
         .content__main-column {
@@ -832,8 +824,8 @@
 //variable pillar colours
 
 @mixin immersivePillarColours($pillar, $color, $color2) {
-    .content--pillar-#{$pillar}.content--immersive-article {
-        .content__labels {
+    .content--pillar-#{$pillar}.content--immersive-article:not(.paid-content) {
+        .content__labels--immersive {
             background-color: $color2;
         }
         .u-underline {


### PR DESCRIPTION
Created more specificity to prevent styling appearing on empty `content__labels` div. Also excluded these rules from paid content, and added stronger weight to the series tag.

# Before
<img width="767" alt="screen shot 2018-04-03 at 15 38 24" src="https://user-images.githubusercontent.com/14570016/38255963-188f4dda-3755-11e8-96ec-70878515cfb6.png">

# After
<img width="900" alt="screen shot 2018-04-03 at 15 38 29" src="https://user-images.githubusercontent.com/14570016/38255964-18a319d2-3755-11e8-851f-1a5edb0fba6e.png">

# Before
<img width="802" alt="screen shot 2018-04-03 at 15 40 17" src="https://user-images.githubusercontent.com/14570016/38256082-5ea0c3a8-3755-11e8-9854-ea04718d312d.png">

# After
<img width="788" alt="screen shot 2018-04-03 at 15 40 23" src="https://user-images.githubusercontent.com/14570016/38256083-5eb60f24-3755-11e8-8653-70dd795f9dcb.png">
