### PR TITLE
Removed reliance on absolute positioning email fronts

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -34,19 +34,6 @@
                     }
                 } )
             }
-
-            @card.mediaTypeIcon.map { mediaType: String =>
-                @card.pillar.map( pillar => {
-                    pillar.name match {
-                        case "News" => icon(mediaType + "-news", isLarge, "media-icon")
-                        case "Opinion" => icon(mediaType + "-opinion", isLarge, "media-icon")
-                        case "Sport" => icon(mediaType + "-sport", isLarge, "media-icon")
-                        case "Arts" => icon(mediaType + "-culture", isLarge, "media-icon")
-                        case "Lifestyle" => icon(mediaType + "-lifestyle", isLarge, "media-icon")
-                        case _ => icon(mediaType, isLarge, "media-icon")
-                    }
-                })
-            }
             @RemoveOuterParaHtml(card.header.headline)
         </a>
     }
@@ -63,8 +50,24 @@
             }
         }
     }
+
     @if(isLast) {
         @row(Seq("fc__pad")) { }
+    }
+
+    @card.mediaTypeIcon.map { mediaType: String =>
+        @row(Seq("media-icon-wrapper")) {
+            @card.pillar.map( pillar => {
+                pillar.name match {
+                    case "News" => icon(mediaType + "-news", isLarge, "media-icon")
+                    case "Opinion" => icon(mediaType + "-opinion", isLarge, "media-icon")
+                    case "Sport" => icon(mediaType + "-sport", isLarge, "media-icon")
+                    case "Arts" => icon(mediaType + "-culture", isLarge, "media-icon")
+                    case "Lifestyle" => icon(mediaType + "-lifestyle", isLarge, "media-icon")
+                    case _ => icon(mediaType, isLarge, "media-icon")
+                }
+            })
+        }
     }
 }
 

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -111,8 +111,7 @@ $container-color: #ffffff;
     padding-bottom: 26px;
 
     .tone-media & {
-        // Space for icon
-        padding-bottom: 42px;
+        padding-bottom: 0;
     }
 }
 
@@ -120,7 +119,8 @@ $container-color: #ffffff;
 .headline,
 .byline,
 .trail-text,
-.review-stars {
+.review-stars,
+.media-icon-wrapper {
     font-weight: normal;
     padding: 3px $gutter 0;
 }
@@ -155,17 +155,16 @@ $container-color: #ffffff;
     padding: 3px 5px;
 }
 
+.media-icon-wrapper {
+    padding-bottom: 6px;
+}
+
 // td
 .trail-text {
     font-family: Georgia, serif;
     font-size: 14px;
     line-height: 18px;
     padding: $gutter $gutter 26px;
-
-    .tone-media & {
-        // Space for icon
-        padding-bottom: 42px;
-    }
 }
 
 .fc--large {
@@ -184,10 +183,7 @@ $container-color: #ffffff;
 }
 
 .media-icon {
-    bottom: 6px;
     height: 28px;
-    left: $gutter;
-    position: absolute;
 }
 
 $email-tones: (

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -119,8 +119,7 @@ $container-color: #ffffff;
 .headline,
 .byline,
 .trail-text,
-.review-stars,
-.media-icon-wrapper {
+.review-stars {
     font-weight: normal;
     padding: 3px $gutter 0;
 }
@@ -156,7 +155,7 @@ $container-color: #ffffff;
 }
 
 .media-icon-wrapper {
-    padding-bottom: 6px;
+    padding: 3px $gutter 6px;
 }
 
 // td


### PR DESCRIPTION
Media cards on email fronts used absolute positioning for icons, this works in limited email clients. Instead, I have placed them beneath headlines in a new cell. Better across clients.

# Before
<img width="361" alt="screen shot 2018-04-04 at 09 40 35" src="https://user-images.githubusercontent.com/14570016/38297429-506a9b5a-37ec-11e8-9843-c788701742ad.png">

# After
<img width="361" alt="screen shot 2018-04-04 at 09 40 51" src="https://user-images.githubusercontent.com/14570016/38297430-5084db1e-37ec-11e8-83ab-0f2e67ac986e.png">
