### PR TITLE
Add CSRF token to email widget

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -61,7 +61,7 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging {
   }
 }
 
-class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
+class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck, csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
   val emailFormService = new EmailFormService(wsClient)
 
   val emailForm: Form[EmailForm] = Form(
@@ -78,22 +78,26 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
     Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
   }
 
-  def renderForm(emailType: String, listId: Int): Action[AnyContent] = Action { implicit request =>
-    val identityName = EmailNewsletter(listId)
-      .orElse(EmailNewsletter.fromV1ListId(listId))
-      .map(_.identityName)
+  def renderForm(emailType: String, listId: Int): Action[AnyContent] = csrfAddToken {
+    Action { implicit request =>
+      val identityName = EmailNewsletter(listId)
+        .orElse(EmailNewsletter.fromV1ListId(listId))
+        .map(_.identityName)
 
-    identityName match {
-      case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-      case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      identityName match {
+        case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      }
     }
   }
 
-  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = Action { implicit request =>
-    val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
-    id match {
-      case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-      case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = csrfAddToken {
+    Action { implicit request =>
+      val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
+      id match {
+        case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      }
     }
   }
 

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -78,28 +78,26 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
     Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
   }
 
-  def renderForm(emailType: String, listId: Int): Action[AnyContent] = csrfAddToken {
-    Action { implicit request =>
-      val identityName = EmailNewsletter(listId)
-        .orElse(EmailNewsletter.fromV1ListId(listId))
-        .map(_.identityName)
+  def renderForm(emailType: String, listId: Int): Action[AnyContent] = Action { implicit request =>
+    val identityName = EmailNewsletter(listId)
+      .orElse(EmailNewsletter.fromV1ListId(listId))
+      .map(_.identityName)
 
-      identityName match {
-        case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
-      }
+    identityName match {
+      case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+      case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
     }
   }
 
-  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = csrfAddToken {
-    Action { implicit request =>
-      val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
-      id match {
-        case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
-      }
+
+  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = Action { implicit request =>
+    val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
+    id match {
+      case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+      case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
     }
   }
+
 
   def subscriptionResult(result: String): Action[AnyContent] = Action { implicit request =>
     Cached(7.days)(result match {

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -61,7 +61,7 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging {
   }
 }
 
-class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck, val csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
+class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
   val emailFormService = new EmailFormService(wsClient)
 
   val emailForm: Form[EmailForm] = Form(
@@ -88,7 +88,6 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
       case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
     }
   }
-
 
   def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = Action { implicit request =>
     val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -14,6 +14,7 @@ import play.api.data.validation.Constraints.emailAddress
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc._
+import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -60,7 +61,7 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging {
   }
 }
 
-class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
+class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck, val csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
   val emailFormService = new EmailFormService(wsClient)
 
   val emailForm: Form[EmailForm] = Form(
@@ -77,23 +78,26 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
     Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
   }
 
-  def renderForm(emailType: String, listId: Int): Action[AnyContent] = Action { implicit request =>
+  def renderForm(emailType: String, listId: Int): Action[AnyContent] = csrfAddToken {
+    Action { implicit request =>
+      val identityName = EmailNewsletter(listId)
+        .orElse(EmailNewsletter.fromV1ListId(listId))
+        .map(_.identityName)
 
-    val identityName = EmailNewsletter(listId)
-                        .orElse(EmailNewsletter.fromV1ListId(listId))
-                        .map(_.identityName)
-
-    identityName match {
-      case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-      case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      identityName match {
+        case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      }
     }
   }
 
-  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = Action { implicit request =>
-    val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
-    id match {
-      case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-      case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = csrfAddToken {
+    Action { implicit request =>
+      val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
+      id match {
+        case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+      }
     }
   }
 
@@ -107,35 +111,36 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
 
   }
 
-  def submit(): Action[AnyContent] = Action.async { implicit request =>
-    AllEmailSubmission.increment()
+  def submit(): Action[AnyContent] = csrfCheck {
+    Action.async { implicit request =>
+      AllEmailSubmission.increment()
 
-    def respond(result: SubscriptionResult): Result = {
-      render {
-        case Accepts.Html() => result match {
-          case Subscribed   => SeeOther(LinkTo("/email/success"))
-          case InvalidEmail => SeeOther(LinkTo("/email/invalid"))
-          case OtherError   => SeeOther(LinkTo("/email/error"))
+      def respond(result: SubscriptionResult): Result = {
+        render {
+          case Accepts.Html() => result match {
+            case Subscribed   => SeeOther(LinkTo("/email/success"))
+            case InvalidEmail => SeeOther(LinkTo("/email/invalid"))
+            case OtherError   => SeeOther(LinkTo("/email/error"))
+          }
+
+          case Accepts.Json() => Cors(NoCache(result match {
+            case Subscribed   => Created("Subscribed")
+            case InvalidEmail => BadRequest("Invalid email")
+            case OtherError   => InternalServerError("Internal error")
+          }))
+          case _ =>
+            NotAccepted.increment()
+            NotAcceptable
         }
-
-        case Accepts.Json() => Cors(NoCache(result match {
-          case Subscribed   => Created("Subscribed")
-          case InvalidEmail => BadRequest("Invalid email")
-          case OtherError   => InternalServerError("Internal error")
-        }))
-        case _ =>
-          NotAccepted.increment()
-          NotAcceptable
       }
-    }
 
-    emailForm.bindFromRequest.fold(
-      formWithErrors => {
-        log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-        EmailFormError.increment()
-        Future.successful(respond(InvalidEmail))},
+      emailForm.bindFromRequest.fold(
+        formWithErrors => {
+          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+          EmailFormError.increment()
+          Future.successful(respond(InvalidEmail))},
 
-      form => emailFormService.submit(form).map(_.status match {
+        form => emailFormService.submit(form).map(_.status match {
           case 200 | 201 =>
             EmailSubmission.increment()
             respond(Subscribed)
@@ -153,6 +158,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
             APINetworkError.increment()
             respond(OtherError)
         })
+    }
   }
 
   def options(): Action[AnyContent] = Action { implicit request =>

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -42,6 +42,7 @@
 
 @form = {
     <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass", data-email-list-name="@listName">
+        @helper.CSRF.formField
         <div class="email-sub__form-wrapper">
             <div class="email-sub__inline-label js-email-sub__inline-label">
                 @if(componentClass == "plaintone") {


### PR DESCRIPTION
## What does this change?

Adds CSRF protection to email newsletter widgets

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
