### PR TITLE
Jdr interactive fixes

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -1,6 +1,10 @@
 .content--interactive {
     padding: 0;
 
+    .content__head {
+        display: block;
+    }
+
     .content__headline {
         padding-bottom: $gs-baseline/2;
     }
@@ -30,6 +34,13 @@
     }
 
     .content__standfirst {
+        font-size: 18px;
+        @include mq(tablet) {
+            font-size: 20px;
+        }
+        @include mq(leftCol) {
+            font-size: 22px;
+        }
         @include mq($until: desktop) {
             margin-left: 0;
         }
@@ -60,6 +71,11 @@
         top: 0;
     }
 
+    .meta__extras {
+        border-bottom: 0;
+        border-top: 1px solid $garnett-neutral-4;
+    }
+
     .block-share__item,
     .inline-close,
     .social-icon,
@@ -74,10 +90,9 @@
         }
     }
 
-    .content__section-label,
-    .content__series-label {
-        @include mq(desktop) {
-            float: left;
+    .content__labels {
+        @include mq($until: tablet) {
+            margin-left: 0;
         }
     }
 
@@ -114,7 +129,10 @@
         padding-top: $gs-baseline/2;
     }
     .byline {
-        display: none;
+        max-width: gs-span(4) - $gs-gutter;
+        @include mq(leftCol) {
+            max-width: gs-span(6);
+        }
     }
     .content__meta-footer .byline {
         @include mq(desktop) {
@@ -132,18 +150,9 @@
     .meta__twitter {
         display: none;
     }
-    .content__dateline {
-        display: none;
-    }
-    .content__head .content__dateline {
-        display: block;
-        margin-bottom: ($gs-baseline/3) * 2;
 
-        @include mq(leftCol) {
-            min-height: 0;
-            border-top: 0;
-            margin-bottom: 0;
-        }
+    .content__head .content__dateline {
+        display: none;
     }
 
     // Ensure margins don't overlay full-page take over interactives

--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -29,19 +29,49 @@
         }
     }
 
-    .meta__extras {
-        border-top: 1px dotted $neutral-5;
-        display: flex;
-        justify-content: space-between;
+    .content__standfirst {
+        @include mq($until: desktop) {
+            margin-left: 0;
+        }
     }
 
-    .meta__social,
+    .byline {
+        padding-bottom: 0;
+    }
+
+    .byline,
+    .content__dateline {
+        min-height: 0;
+    }
+
+    .content__dateline,
+    .meta__numbers,
+    .meta__social {
+        border-top: 0;
+    }
+
+    .meta__social {
+        border-bottom: 1px solid $garnett-neutral-4;
+    }
+
     .meta__numbers {
-        border: 0 none;
+        position: absolute;
+        right: 0;
+        top: 0;
     }
 
-    .meta__number {
-        text-align: right;
+    .block-share__item,
+    .inline-close,
+    .social-icon,
+    .social-icon.social-icon--more {
+        background-color: transparent;
+        border: 1px solid $neutral-4;
+        &:focus,
+        &:hover {
+            svg {
+                fill: $garnett-neutral-5;
+            }
+        }
     }
 
     .content__section-label,

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -317,7 +317,7 @@
 }
 
 .content--interactive,
-.pillar-news:not(.paid-content) {
+.content--pillar-news:not(.paid-content) {
     @include colorPalatte($news-garnett-main-1, $news-garnett-feature, $news-garnett-media-main-1);
 }
 // #? There is a lot of :not(.paid-content) to avoid having to override

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -316,7 +316,8 @@
     }
 }
 
-.content--pillar-news:not(.paid-content) {
+.content--interactive,
+.pillar-news:not(.paid-content) {
     @include colorPalatte($news-garnett-main-1, $news-garnett-feature, $news-garnett-media-main-1);
 }
 // #? There is a lot of :not(.paid-content) to avoid having to override


### PR DESCRIPTION
## What does this change?
Tidy for the meta on interactives, brings in pillar colours etc and replicates layout from regular templates.

I haven't aligned the meta to the left col for large breakpoints as it would clash with some of the interactive content such as graph info

Before:
<img width="1413" alt="screen shot 2018-04-04 at 11 02 25" src="https://user-images.githubusercontent.com/8453924/38301753-6c82efc0-37f8-11e8-97c3-eafacd7e8c03.png">

After:
<img width="1419" alt="screen shot 2018-04-04 at 11 02 37" src="https://user-images.githubusercontent.com/8453924/38301758-711f5fc8-37f8-11e8-9ba3-1973d7e0a5af.png">

Before:
<img width="321" alt="screen shot 2018-04-04 at 11 03 00" src="https://user-images.githubusercontent.com/8453924/38301768-7ae24cbe-37f8-11e8-8fdb-aa7df6640216.png">

After:
<img width="321" alt="screen shot 2018-04-04 at 11 03 16" src="https://user-images.githubusercontent.com/8453924/38301774-7fd0e816-37f8-11e8-8892-53956d87d2d8.png">



