### PR TITLE
Track clicks less in /complete-consents

### DIFF
--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -47,7 +47,7 @@
             </form>
         }
         <aside class="identity-forms-message__body">
-            <a class="manage-account__button manage-account__button--secondary" data-link-name="complete-consents : cta-bottom : @LinkTo(returnUrl)" href="@LinkTo(returnUrl)">
+            <a class="manage-account__button manage-account__button--secondary" data-link-name="complete-consents : cta-bottom" href="@LinkTo(returnUrl)">
                 Go to the theguardian.com
                 @fragments.inlineSvg("arrow-right", "icon")
             </a>


### PR DESCRIPTION
## What does this change?
#19465 introduced event tracking in `/complete-consents` that's pretty reasonable except for sending over the returnUrl, that was made for the purposes of identifying a bug in that page. The bug has been identified (crossing fingers!) so after it's confirmed we fixed it we don't have to track that anymore!

## What is the value of this and can you measure success?
We don't need this data for anything else