### PR TITLE
Redirect to get endpoint after POST

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -60,7 +60,7 @@ trait ConsentsJourney
 
               case Right(updatedUser) =>
                 logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
-                Future.successful(SeeOther(s"/complete-consents?returnUrl=${returnUrl}"))
+                Future.successful(SeeOther(s"${routes.EditProfileController.displayConsentComplete().url}?returnUrl=${returnUrl}"))
             }
           }
         )

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -60,7 +60,7 @@ trait ConsentsJourney
 
               case Right(updatedUser) =>
                 logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
-                SeeOther(s"${routes.EditProfileController.displayConsentComplete().url}?returnUrl=${returnUrl}")
+                Redirect(s"${routes.EditProfileController.displayConsentComplete().url}", Map("returnUrl" -> Seq(returnUrl)))
             }
           }
         )

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -60,8 +60,7 @@ trait ConsentsJourney
 
               case Right(updatedUser) =>
                 logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
-                val page = IdentityPage("/complete-consents", "Complete Consents", isFlow = true)
-                consentCompleteView(page, returnUrl)
+                Future.successful(SeeOther(s"/complete-consents?returnUrl=${returnUrl}"))
             }
           }
         )

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -53,14 +53,14 @@ trait ConsentsJourney
               request.user.id,
               UserUpdateDTO(consents = Some(newConsents), statusFields = Some(StatusFields(hasRepermissioned = Some(true)))),
               request.user.auth
-            ).flatMap {
+            ).map {
               case Left(idapiErrors) =>
                 logger.error(s"Failed to set hasRepermissioned flag for user ${request.user.id}: $idapiErrors")
-                Future.successful(InternalServerError(Json.toJson(idapiErrors)))
+                InternalServerError(Json.toJson(idapiErrors))
 
               case Right(updatedUser) =>
                 logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
-                Future.successful(SeeOther(s"${routes.EditProfileController.displayConsentComplete().url}?returnUrl=${returnUrl}"))
+                SeeOther(s"${routes.EditProfileController.displayConsentComplete().url}?returnUrl=${returnUrl}")
             }
           }
         )

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -137,7 +137,7 @@ import scala.concurrent.Future
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitRepermissionedFlag.apply(fakeRequest)
-        status(result) should be(200)
+        status(result) should be(303)
 
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))


### PR DESCRIPTION
## What does this change?
- On submitting consents from /consents (POSTing a form) we will redirect to a GET endpoint of /complete-consents
- Previously we would serve the /complete-consents via the consent submitting POST with the returnUrl on the button on the complete-consent page populated via the original form.

- This meant our check to blacklist any /consent returnUrl was not catching the pre-populated form as it checks the returnUrl in the request.

## What is the value of this and can you measure success?
- No more users redirected back to /consents from /complete-consents
## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

![screen shot 2018-04-04 at 11 28 27 am](https://user-images.githubusercontent.com/14179210/38303364-c8120c04-37fd-11e8-9305-2e8dd2a5caa3.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
