### PR TITLE
Add csrf field to email-newsletters

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -6,24 +6,28 @@ import model.Cached.RevalidatableResult
 import pages.NewsletterHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import play.filters.csrf.CSRFAddToken
 import staticpages.StaticPages
 
 import scala.concurrent.duration._
 
 class SignupPageController(
   wsClient: WSClient,
-  val controllerComponents: ControllerComponents
+  val controllerComponents: ControllerComponents,
+  csrfAddToken: CSRFAddToken
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext {
 
   val defaultCacheDuration: Duration = 15.minutes
 
-  def renderNewslettersPage(): Action[AnyContent] = Action { implicit request =>
+  def renderNewslettersPage(): Action[AnyContent] = csrfAddToken {
+    Action { implicit request =>
       Cached(defaultCacheDuration)(
         RevalidatableResult.Ok(
           NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path))
         )
       )
-   }
+    }
+  }
 
 }

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -45,6 +45,7 @@
                     </div>
 
                     <form action="@LinkTo("/email")" method="post" target="magicframe" class="newsletter-card__signup">
+                        @helper.CSRF.formField
                         <input class="newsletter-card__text-input u-h"
                           type="text"
                           name="name"


### PR DESCRIPTION
## What does this change?

Adds a csrf input to `/email-newsletters`

## What is the value of this and can you measure success?

CSRF attempts can be detected and stopped.  

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
