### PR TITLE
Tightened line height on series tags at mobile

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -206,13 +206,16 @@
 }
 
 .content__series-label {
-    display: inline;
     font-family: $f-serif-headline;
     font-size: 16px;
     line-height: 19px;
 
     @include mq($until: tablet) {
         font-weight: 800;
+    }
+
+    @include mq(tablet) {
+        display: inline;
     }
 
     @include mq(leftCol) {


### PR DESCRIPTION
Display inline was preventing line-height from being usable:

# Before
<img width="360" alt="screen shot 2018-04-05 at 15 30 19" src="https://user-images.githubusercontent.com/14570016/38372301-65e139da-38e6-11e8-9706-866c949f1974.png">

# After
<img width="360" alt="screen shot 2018-04-05 at 15 30 37" src="https://user-images.githubusercontent.com/14570016/38372302-6618dd22-38e6-11e8-8320-2e1b844b56d1.png">
