### PR TITLE
 Add sens key-value to appNexusPageTargeting

### DIFF
--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -51,7 +51,7 @@ fi
 function install_ssh_certificate() {
 	KEY_NAME="${1}.key"
 	CRT_NAME="${1}.crt"
-	echo "Downloading SSL certsificate $CRT_NAME from $S3_BUCKET"
+	echo "Downloading SSL certificate $CRT_NAME from $S3_BUCKET"
 	aws ${PROFILE} s3 cp "${S3_BUCKET}${KEY_NAME}" ${DIR} 1>/dev/null
 	echo "Downloading SSL key $KEY_NAME from $S3_BUCKET"
 	aws ${PROFILE} s3 cp "${S3_BUCKET}${CRT_NAME}" ${DIR} 1>/dev/null

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -130,6 +130,7 @@ const formatAppNexusTargeting = (obj: Object): string =>
 
 const buildAppNexusTargeting = once((pageTargeting: Object): string =>
     formatAppNexusTargeting({
+        sens: pageTargeting.sens,
         pt1: pageTargeting.url,
         pt2: pageTargeting.edition,
         pt3: pageTargeting.ct,


### PR DESCRIPTION
## What does this change?

New key-value `sens` being passed into `config.page.appNexusPageTargeting`

BEFORE:

> "pt1=/media/2012/dec/05/newspaper-editors-sign-up-leveson,pt2=uk,pt3=article,pt4=ng,pt5=uk/uk,pt5=pressandpublishing,pt5=leveson-inquiry,pt5=newspapers,pt5=national-newspapers,pt5=media,pt5=pcc,pt6=0,pt7=desktop,pt8=undefined,pt9=|jfmo9hw8c3gkpgtzuisb|dan-sabbagh|news|"

AFTER:

> "sens=f,pt1=/media/2012/dec/05/newspaper-editors-sign-up-leveson,pt2=uk,pt3=article,pt4=ng,pt5=uk/uk,pt5=pressandpublishing,pt5=leveson-inquiry,pt5=newspapers,pt5=national-newspapers,pt5=media,pt5=pcc,pt6=0,pt7=desktop,pt8=undefined,pt9=|jfmo5v7tim8bq1fjtfnd|dan-sabbagh|news|"

Bonus spelling correction that I encountered while hunting errors.

## What is the value of this and can you measure success?

Commercial business as usual 🤘 

## Does this affect other platforms - Amp, Apps, etc?

Nope.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope.

## Tested in CODE?

Nope. However tested locally and gives expected results.
