### PR TITLE
Fix issues experienced during frontend setup

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -29,6 +29,9 @@ Follow [this link](https://www.google.co.uk) and enter the relevant search strin
 3. Submit a PR
 4. You may need to `pip install awscli` and add `/Library/Frameworks/Python.framework/Versions/Current/bin` to your `$PATH` to run the commands Janus gives you.
 
+**Note:** To install `awscli` on MacOS El Capitan and later, you will need to run `pip install awscli --upgrade --ignore-installed six`
+due to the [System Integrity Protocol](https://github.com/pypa/pip/issues/3165)
+
 # Local dev server setup
 
 **Hello there!** 👋 After completing this setup guide, we would greatly appreciate it if you could complete our [Frontend Setup 

--- a/docs/01-start-here/04-troubleshooting.md
+++ b/docs/01-start-here/04-troubleshooting.md
@@ -16,7 +16,7 @@ npm WARN locking Error: EACCES, open '/Users/jduffell/.npm/_locks/karma-requirej
 Sometimes when you install npm, it ends up owned by root (but in your home
 directory).
 
-Check that you own your own .npm directory `ls -ld ~/.npm`
+Check that you own your own `.npm` directory: `ls -ld ~/.npm`
 
 If it is owned by root, then take ownership of it
 `sudo chown -R $(whoami) ~/.npm`
@@ -24,7 +24,7 @@ If it is owned by root, then take ownership of it
 ### { Error: ENOENT: no such file or directory, scandir '../frontend/node_modules/node-sass/vendor'
 Run `make reinstall` to resolve.
 
-### Accidentally ran `npm install` ot `yarn install`
+### Accidentally ran `npm install` or `yarn install`
 Run `make reinstall` to resolve.
 
 ### Global install permissions errors

--- a/setup.sh
+++ b/setup.sh
@@ -87,9 +87,9 @@ install_node() {
         sudo apt-get install -y curl
       fi
 
-      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.2/install.sh | bash
-    elif mac && installed brew; then
-      brew install nvm
+      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+    elif mac; then
+      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     fi
 
     nvm install

--- a/setup.sh
+++ b/setup.sh
@@ -86,12 +86,9 @@ install_node() {
       if ! installed curl; then
         sudo apt-get install -y curl
       fi
-
-      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
-    elif mac; then
-      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     fi
 
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     nvm install
     EXTRA_STEPS+=("Add https://git.io/vKTnK to your .bash_profile")
   else


### PR DESCRIPTION
## What does this change?

- Installing nvm using Homebrew is [not supported](https://github.com/creationix/nvm) and considered harmful. We should install by curling the installation script and piping to Bash
- Updates the Linux installation of nvm to use the latest version
- Updates documentation to cover issue installing `awscli` using pip on MacOS

## What is the value of this and can you measure success?

Less painful setup that doesn't break developer's computers.
