### PR TITLE
Extend test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Point the subscribe link in the header to a subscriptions-only version of the support site",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 5),
+    sellByDate = new LocalDate(2018, 4, 19),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Extend again because deciding how to move forward with this one is actually non-trivial - some product decisions pending

(Test has been switched off for a little while)