### PR TITLE
Extend spacefinder-simplify and take possession of the switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -80,9 +80,9 @@ trait ABTestSwitches {
     ABTests,
     "ab-spacefinder-simplify",
     "Alters the rules for inserting ads on desktop breakpoints.",
-    owners = Seq(Owner.withGithub("JonNorman")),
+    owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 6),
+    sellByDate = new LocalDate(2018, 4, 17),
     exposeClientSide = true
   )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -30,7 +30,7 @@ object CommercialClientLogging extends Experiment(
 object CommercialBaseline extends Experiment(
   name = "commercial-baseline",
   description = "Users in this experiment will experience the commercial javascript stack as of 2018-01-01.",
-  owners = Seq(Owner.withGithub("JonNorman"), Owner.withGithub("shtukas")),
+  owners = Seq(Owner.withGithub("katebee"), Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2018, 4, 11),
   participationGroup = Perc2B
 )
@@ -38,7 +38,7 @@ object CommercialBaseline extends Experiment(
 object CommercialAdRefresh extends Experiment(
   name = "commercial-ad-refresh",
   description = "Users in this experiment will have their ad slots refreshed after 30 seconds",
-  owners = Seq(Owner.withGithub("JonNorman")),
+  owners = Seq(Owner.withGithub("katebee")),
   sellByDate = new LocalDate(2018, 4, 26),
   participationGroup = Perc20A
 )

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
@@ -3,7 +3,7 @@
 export const spacefinderSimplify: ABTest = {
     id: 'SpacefinderSimplify',
     start: '2018-03-05',
-    expiry: '2018-04-05',
+    expiry: '2018-04-17',
     author: 'Jon Norman',
     description:
         'This test alters the rules for inserting ads on desktop breakpoints.',


### PR DESCRIPTION
## What does this change?

- Extend an expiring switch
- Take over the switches and make them mine!

## What is the value of this and can you measure success?

Expiring switch does not break the build

Commercial tests and switches are kept in the immediate family 🦄 

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

## Screenshots

N/A

## Tested in CODE?

Nope
