### PR TITLE
Refactor article controller

### DIFF
--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -44,7 +44,7 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
       .showFields("all")
     ).map { response =>
       val gallery = response.content.map(Content(_))
-      val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, StoryPackages(g, response), index, isTrail) }
+      val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, StoryPackages(g, response.packages), index, isTrail) }
 
       ModelOrResult(model, response)
 

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -59,7 +59,7 @@ class InteractiveController(contentApiClient: ContentApiClient, wsClient: WSClie
 
     val result = response map { response =>
       val interactive = response.content map {Interactive.make}
-      val page = interactive.map(i => InteractivePage(i, StoryPackages(i, response)))
+      val page = interactive.map(i => InteractivePage(i, StoryPackages(i, response.packages)))
 
       ModelOrResult(page, response)
     }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -42,7 +42,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
 
     val result = response map { response =>
       val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
-      val model = mediaOption map { media => MediaPage(media, StoryPackages(media, response)) }
+      val model = mediaOption map { media => MediaPage(media, StoryPackages(media, response.packages)) }
 
       ModelOrResult(model, response)
     }

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -20,7 +20,7 @@ trait ImageQuery extends ConciergeRepository {
     ) map { response: ItemResponse =>
         val mainContent = response.content.filter(_.isImageContent).map(Content(_))
         mainContent.map {
-          case content: ImageContent => Left(ImageContentPage(content, StoryPackages(content, response)))
+          case content: ImageContent => Left(ImageContentPage(content, StoryPackages(content, response.packages)))
           case _ => Right(NotFound)
         }.getOrElse(Right(NotFound))
       }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,40 +1,174 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
+import com.gu.contentapi.client.model.v1.{ItemResponse, Package, Content => ApiContent}
 import common._
-import conf.switches.Switches
-import contentapi.ContentApiClient
-import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
-import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model._
-import LiveBlogHelpers._
 import conf.Configuration
+import conf.switches.Switches.InlineEmailStyles
+import contentapi.ContentApiClient
+import controllers.ArticleController._
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import model.LiveBlogHelpers._
+import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
+import model._
 import model.liveblog._
 import org.joda.time.DateTime
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage, LiveBlogHtmlPage, MinuteHtmlPage}
+import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Json, _}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.twirl.api.Html
-import views.support._
 
 import scala.concurrent.duration._
-import scala.concurrent.Future
-
+import scala.concurrent.{ExecutionContext, Future}
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController
-    with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
+class ArticleController(
+  contentApiClient: ContentApiClient,
+  val controllerComponents: ControllerComponents,
+  ws: WSClient
+)(implicit context: ApplicationContext)
+  extends BaseController
+    with RendersItemResponse
+    with Logging
+    with ImplicitControllerExecutionContext {
 
-  private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
-  override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
-  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Some(Canonical))(render(path, _))
+  override def canRender(i: ItemResponse): Boolean = i.content.exists(ArticleController.isSupported)
+  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = render(path, Some(Canonical))(buildResponse)
 
+  def renderLiveBlogJson(
+    path: String,
+    lastUpdate: Option[String],
+    rendered: Option[Boolean],
+    isLivePage: Option[Boolean]
+  ): Action[AnyContent] = {
 
-  private def renderNewerUpdates(page: PageWithStoryPackage, lastUpdateBlockId: SinceBlockId, isLivePage: Option[Boolean])(implicit request: RequestHeader): Result = {
+    Action.async { implicit request =>
+      val range = lastUpdate.map(ParseBlockId.fromBlockId) match {
+        case Some(ParsedBlockId(id)) => Some(SinceBlockId(id))
+        case Some(InvalidFormat) => None
+        case None => Some(Canonical)
+      }
+
+      range match {
+        case Some(r) =>
+          render(path, range) { page =>
+            r match {
+              case since: SinceBlockId => renderLiveBlogUpdates(page, since, isLivePage)
+              case render if rendered.contains(true) => buildResponse(page)
+              case block => blockText(page, 6)
+
+            }
+          }
+        case None =>
+          // indicates invalid block ID
+          Future.successful(Cached(10)(WithoutRevalidationResult(NotFound)))
+      }
+    }
+  }
+
+  def renderLiveBlog(path: String, page: Option[String], format: Option[String]): Action[AnyContent] = {
+    Action.async { implicit request =>
+      val range = page.map(ParseBlockId.fromPageParam) match {
+        case Some(ParsedBlockId(id)) => Some(PageWithBlock(id))
+        case Some(InvalidFormat) => None
+        case None => Some(Canonical)
+      }
+
+      range match {
+        case _ if request.isEmail =>
+          render(path, None)(buildResponse)
+        case Some(r) =>
+          render(path, range)(buildResponse)
+        case None =>
+          // indicates invalid block ID
+          Future.successful(Cached(10)(WithoutRevalidationResult(NotFound)))
+      }
+    }
+  }
+
+  def renderArticle(path: String): Action[AnyContent] = {
+    Action.async { implicit request =>
+      val range = if (request.isEmail || request.isGuuiJson) {
+        Some(ArticleBlocks)
+      } else None
+
+      if (request.isGuui) {
+        renderAsync(path, range)(renderFromGuui(path, _))
+      } else {
+        render(path, range)(buildResponse)
+      }
+    }
+  }
+
+  def renderJson(path: String): Action[AnyContent] = renderArticle(path)
+
+  private[this] def render(
+    path: String,
+    range: Option[BlockRange]
+  )(transform: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
+
+    renderAsync(path, range)(page => Future.successful(transform(page)))
+  }
+
+  def renderAsync(
+    path: String,
+    range: Option[BlockRange]
+  )(transform: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
+
+    val item = getFromCAPI(contentApiClient, path, range)
+
+    // need to access errors and item
+    val result = for {
+      item <- item
+      apiContent <- getOrNotFound(item)
+      _ <- checkValidContentType(apiContent)
+      _ <- checkRedirects(request, item)
+      page <- toPage(Content(apiContent), item.packages, range, request.isEmail)
+      result <- handleInternaErrors(transform(page), item)
+    } yield result
+
+    // handle internal errors
+    val handled = for {
+      item <- item
+      handled <- handleInternaErrors(result, item)
+    } yield handled
+
+    handled recover convertApiExceptionsWithoutEither
+  }
+
+  private[this] def toPage(
+    content: ContentType,
+    packages: Option[Seq[Package]],
+    range: Option[BlockRange],
+    isEmail: Boolean
+  ): Future[PageWithStoryPackage] = {
+
+    content match {
+      case minute: Article if minute.isTheMinute =>
+        Future.successful(MinutePage(minute, StoryPackages(minute, packages)))
+      // Enable an email format for 'Minute' content (which are actually composed as a LiveBlog), without changing the non-email display of the page
+      case liveBlog: Article if liveBlog.isLiveBlog && isEmail =>
+        Future.successful(MinutePage(liveBlog, StoryPackages(liveBlog, packages)))
+      case liveBlog: Article if liveBlog.isLiveBlog =>
+        for {
+          r <- range.map(Future.successful).getOrElse(Future.failed(MissingRange))
+          m <- createLiveBlogModel(liveBlog, packages, r).map(Future.successful).getOrElse(Future.failed(ContentNotFound))
+        } yield m
+      case article: Article =>
+        Future.successful(ArticlePage(article, StoryPackages(article, packages)))
+    }
+  }
+
+  private[this] def renderLiveBlogUpdates(
+    page: PageWithStoryPackage,
+    lastUpdateBlockId: SinceBlockId,
+    isLivePage: Option[Boolean]
+  )(implicit request: RequestHeader): Result = {
+
     val newBlocks = page.article.fields.blocks.toSeq.flatMap {
       _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
     }.takeWhile { block =>
@@ -62,7 +196,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     publishedDateTime: Option[DateTime],
     lastUpdatedDateTime: Option[DateTime],
     body: String
-    )
+  )
 
   implicit val blockWrites = (
     (__ \ "id").write[String] ~
@@ -72,167 +206,123 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       (__ \ "body").write[String]
     )(unlift(TextBlock.unapply))
 
-  private def blockText(page: PageWithStoryPackage, number: Int)(implicit request: RequestHeader): Result = page match {
+  private[this] def blockText(page: PageWithStoryPackage, number: Int)(implicit request: RequestHeader): Result = page match {
     case LiveBlogPage(liveBlog, _, _) =>
       val blocks =
         liveBlog.blocks.toSeq.flatMap { blocks =>
-        blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq.flatMap { bodyBlocks: Seq[BodyBlock] =>
-          bodyBlocks.collect {
-            case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
-              TextBlock(id, title, publishedAt, updatedAt, summary)
+          blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq.flatMap { bodyBlocks: Seq[BodyBlock] =>
+            bodyBlocks.collect {
+              case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
+                TextBlock(id, title, publishedAt, updatedAt, summary)
+            }
           }
-        }
-      }.take(number)
+        }.take(number)
       Cached(page)(JsonComponent("blocks" -> Json.toJson(blocks)))
     case _ => Cached(600)(WithoutRevalidationResult(NotFound("Can only return block text for a live blog")))
 
   }
 
-  private def noAMP(renderPage: => Result)(implicit  request: RequestHeader): Result = {
-    if (request.isAmp) NotFound
-    else renderPage
-  }
+  private[this] def buildResponse(page: PageWithStoryPackage)(implicit request: RequestHeader): Result = {
+    def asHtml(page: Page, html: Html)(implicit request: RequestHeader): Result = Cached(page)(RevalidatableResult.Ok(html))
+    def asEmail(page: Page, html: Html)(implicit request: RequestHeader): Result = {
+      Cached(page)(RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html))
+    }
+    def asJson(page: Page, html: Html)(implicit request: RequestHeader): Result = Cached(page)(JsonComponent(page, html))
 
-  private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader) = page match {
-    case blog: LiveBlogPage =>
-      val htmlResponse = () => {
-        if (request.isAmp) views.html.liveBlogAMP(blog)
-        else LiveBlogHtmlPage.html(blog)
-      }
-      val jsonResponse = () => views.html.liveblog.liveBlogBody(blog)
-      renderFormat(htmlResponse, jsonResponse, blog, Switches.all)
+    val isAmp = request.isAmp
+    val isJson = request.isJson
+    val isEmail = request.isEmail
+    val notFound = Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
 
-    case minute: MinutePage =>
-      noAMP {
-        val htmlResponse = () => {
-          if (request.isEmail) ArticleEmailHtmlPage.html(minute)
-          else MinuteHtmlPage.html(minute)
-        }
+    page match {
+      case ampArticle: ArticlePage if isAmp => asHtml(page, views.html.articleAMP(ampArticle))
+      case emailArticle: ArticlePage if isEmail => asEmail(page, ArticleEmailHtmlPage.html(emailArticle))
+      case jsonArticle: ArticlePage if isJson => asJson(page, views.html.fragments.articleBody(jsonArticle))
+      case article: ArticlePage => asHtml(page, ArticleHtmlPage.html(article))
 
-        val jsonResponse = () => views.html.fragments.minuteBody(minute)
-        renderFormat(htmlResponse, jsonResponse, minute, Switches.all)
-      }
+      case ampBlog: LiveBlogPage if isAmp => asHtml(page, views.html.liveBlogAMP(ampBlog))
+      case emailBlog: LiveBlogPage if isEmail => notFound
+      case jsonBlog: LiveBlogPage if isJson => asJson(page, views.html.liveblog.liveBlogBody(jsonBlog))
+      case blog: LiveBlogPage => asHtml(page, LiveBlogHtmlPage.html(blog))
 
-    case article: ArticlePage =>
-      val htmlResponse = () => {
-        if (request.isEmail) ArticleEmailHtmlPage.html(article)
-        else if (request.isAmp) views.html.articleAMP(article)
-        else ArticleHtmlPage.html(article)
-      }
-
-      val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      renderFormat(htmlResponse, jsonResponse, article)
-  }
-
-  def renderLiveBlog(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
-    if (format.contains("email"))
-      renderArticle(path)
-    else
-      Action.async { implicit request =>
-
-        def renderWithRange(range: BlockRange) =
-          mapModel(path, range = Some(range)) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
-            render(path, _)
-          }
-
-        page.map(ParseBlockId.fromPageParam) match {
-          case Some(ParsedBlockId(id)) => renderWithRange(PageWithBlock(id)) // we know the id of a block
-          case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-          case None => renderWithRange(Canonical) // no page param
-        }
-      }
-
-  def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
-    Action.async { implicit request =>
-
-      def renderWithRange(range: BlockRange) =
-        mapModel(path, Some(range)) { model =>
-          range match {
-            case SinceBlockId(lastBlockId) => renderNewerUpdates(model, SinceBlockId(lastBlockId), isLivePage)
-            case _ => render(path, model)
-          }
-        }
-
-      lastUpdate.map(ParseBlockId.fromBlockId) match {
-        case Some(ParsedBlockId(id)) => renderWithRange(SinceBlockId(id))
-        case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-        case None => if (rendered.contains(false)) mapModel(path, Some(Canonical)) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
-      }
+      case ampMinute: MinutePage if isAmp => notFound
+      case emailMinute: MinutePage if isEmail => asEmail(page, ArticleEmailHtmlPage.html(emailMinute))
+      case jsonMinute: MinutePage if isJson => asJson(page, ArticleEmailHtmlPage.html(jsonMinute))
+      case minute: MinutePage => asHtml(page, MinuteHtmlPage.html(minute))
     }
   }
 
-  def renderJson(path: String): Action[AnyContent] = {
-    Action.async { implicit request =>
-      mapModel(path, if (request.isGuuiJson) Some(ArticleBlocks) else None) {
-        render(path, _)
-      }
+  def renderFromGuui(path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = {
+    def remoteRenderArticle(payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
+      .withRequestTimeout(2000.millis)
+      .addHttpHeaders("Content-Type" -> "application/json")
+      .post(payload)
+      .map((response) =>
+        response.body
+      )
+
+    model match {
+      case article : ArticlePage =>
+        val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+        val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+        val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+        remoteRenderArticle(jsonPayload).map(s => {
+          Cached(article){ RevalidatableResult.Ok(Html(s)) }
+        })
+      case _ => throw new Exception("Remote render not supported for this content type")
+    }
+  }
+}
+
+object ArticleController {
+
+  object ContentNotFound extends Exception
+  object InvalidContentType extends Exception
+  object MissingRange extends Exception
+  case class Redirect(result: Result) extends Exception
+
+  def handleInternaErrors(
+    result: Future[Result],
+    item: ItemResponse
+  )(implicit request: RequestHeader,
+    ec: ExecutionContext,
+    ap: ApplicationContext,
+    log: Logger
+  ): Future[Result] = {
+    val notFound = Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
+
+    result recover {
+      case ContentNotFound | InvalidContentType => ContentRedirect.internal(request, item).getOrElse(notFound)
+      case MissingRange => notFound
+      case Redirect(result) => result
     }
   }
 
-  def remoteRenderArticle(payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
-    .withRequestTimeout(2000.millis)
-    .addHttpHeaders("Content-Type" -> "application/json")
-    .post(payload)
-    .map((response) =>
-      response.body
-    )
-
-  def remoteRender(path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
-
-    case article : ArticlePage =>
-      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
-
-      remoteRenderArticle(jsonPayload).map(s => {
-        Cached(article){ RevalidatableResult.Ok(Html(s)) }
-      })
-
-    case _ => throw new Exception("Remote render not supported for this content type")
-
-  }
-
-  // for the GUUI demo. Same as mapModel except the render method should return a  Future[Result] instead of Result
-  def mapModelGUUI(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
-
-    lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range)(itemResp)).recover(convertApiExceptions).flatMap {
-      case Left(model) => render(model)
-      case Right(other) => Future.successful(RenderOtherStatus(other))
-    }
-
-  }
-
-  def renderArticle(path: String): Action[AnyContent] = {
-    Action.async { implicit request =>
-
-      if(request.isGuui){
-        mapModelGUUI(path, Some(ArticleBlocks)){
-          remoteRender(path, _)
-        }
-      } else {
-        mapModel(path, range = if (request.isEmail) Some(ArticleBlocks) else None) {
-          render(path, _)
-        }
-      }
-
+  def checkRedirects(request: RequestHeader, item: ItemResponse)(implicit ec: ExecutionContext): Future[Unit] = {
+    ContentRedirect.canonical(request, item) match {
+      case Some(r) => Future.failed(Redirect(r))
+      case None => Future.successful(())
     }
   }
 
-  // range: None means the url didn't include /live/, Some(...) means it did.  Canonical just means no url parameter
-  // if we switch to using blocks instead of body for articles, then it no longer needs to be Optional
-  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
-    lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
-      case Left(model) => render(model)
-      case Right(other) => RenderOtherStatus(other)
+  def checkValidContentType(content: ApiContent)(implicit ec: ExecutionContext): Future[Unit] = {
+    if (content.isArticle || content.isLiveBlog || content.isSudoku) Future.successful(())
+    else Future.failed(InvalidContentType)
+  }
+
+  def getOrNotFound(item: ItemResponse)(implicit ec: ExecutionContext): Future[ApiContent] = {
+    item.content match {
+      case Some(content) => Future.successful(content)
+      case None => Future.failed(ContentNotFound)
     }
   }
 
-  private def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
+  def isSupported(c: ApiContent): Boolean = c.isArticle || c.isLiveBlog || c.isSudoku
+
+  def getFromCAPI(client: ContentApiClient, path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
     val edition = Edition(request)
 
-    val capiItem = contentApiClient.item(path, edition)
+    val capiItem = client.item(path, edition)
       .showTags("all")
       .showFields("all")
       .showReferences("all")
@@ -242,38 +332,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
       capiItem.showBlocks(blocksParam)
     }.getOrElse(capiItem)
-    contentApiClient.getResponse(capiItemWithBlocks)
 
+    client.getResponse(capiItemWithBlocks)
   }
-
-  /**
-   * convert a response into something we can render, and return it
-   * optionally, throw a response if we know it's not right to send the content
-    *
-    * @param response
-   * @return Either[PageWithStoryPackage, Result]
-   */
-  def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
-    val supportedContent = response.content.filter(isSupported).map(Content(_))
-    val supportedContentResult = ModelOrResult(supportedContent, response)
-    val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {
-      case minute: Article if minute.isTheMinute =>
-        Left(MinutePage(minute, StoryPackages(minute, response)))
-        // Enable an email format for 'Minute' content (which are actually composed as a LiveBlog), without changing the non-email display of the page
-      case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
-        Left(MinutePage(liveBlog, StoryPackages(liveBlog, response)))
-      case liveBlog: Article if liveBlog.isLiveBlog =>
-        range.map {
-          createLiveBlogModel(liveBlog, response, _)
-        }.getOrElse(Right(NotFound))
-      case article: Article =>
-        Left(ArticlePage(article, StoryPackages(article, response)))
-    }
-
-    content
-  }
-
-
 }
-
-

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.model.v1.ItemResponse
+import com.gu.contentapi.client.model.v1.Package
 import common.`package`._
 import model.liveblog.BodyBlock
 import model.ParseBlockId.ParsedBlockId
@@ -43,7 +44,7 @@ object LiveBlogHelpers {
 
   }
 
-  def createLiveBlogModel(liveBlog: Article, response: ItemResponse, range: BlockRange): Either[LiveBlogPage, Status] = {
+  def createLiveBlogModel(liveBlog: Article, packages: Option[Seq[Package]], range: BlockRange): Option[LiveBlogPage] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -74,9 +75,7 @@ object LiveBlogHelpers {
         content = liveBlog.content.copy(
           metadata = liveBlog.content.metadata.copy(
             cacheTime = cacheTime)))
-      Left(LiveBlogPage(liveBlogCache, pageModel, StoryPackages(liveBlog, response)))
-
-    }.getOrElse(Right(NotFound))
-
+      LiveBlogPage(liveBlogCache, pageModel, StoryPackages(liveBlog, packages))
+    }
   }
 }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, ItemResponse}
+import com.gu.contentapi.client.model.v1.Package
 import model.pressed.PressedContent
 import services.FaciaContentConvert
 
@@ -21,10 +22,10 @@ case class RelatedContent (items: Seq[RelatedContentItem]) {
 }
 
 object StoryPackages {
-  def apply(parent: ContentType, response: ItemResponse): RelatedContent = {
+  def apply(parent: ContentType, packages: Option[Seq[Package]]): RelatedContent = {
 
-    val storyPackagesContent: Seq[ApiContent] = response.packages.map { packages =>
-      val allContentsPerPackage: Seq[Seq[ApiContent]] = packages.map(_.articles.map(_.content))
+    val storyPackagesContent: Seq[ApiContent] = packages.map { ps =>
+      val allContentsPerPackage: Seq[Seq[ApiContent]] = ps.map(_.articles.map(_.content))
       if(packages.size > 1) { //intermix packages only if more than one
         allContentsPerPackage
          .flatMap(_.zipWithIndex) // zip content with its position

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -93,17 +93,6 @@ case object R2VideoCleaner extends HtmlCleaner {
 
 }
 
-case class RecipeBodyImage(isRecipeArticle: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
-    if(isRecipeArticle) {
-      document.getElementsByClass("element-image").asScala foreach(_.remove())
-      document.getElementsByTag("aside").asScala.filter(_.hasClass("element-pullquote")) foreach( _.remove())
-      document.getElementsByClass("element-rich-link").asScala.foreach( _.remove())
-    }
-    document
-  }
-}
-
 case class PictureCleaner(article: Article, amp: Boolean)(implicit request: RequestHeader) extends HtmlCleaner with implicits.Numbers {
 
   def clean(body: Document): Document = {


### PR DESCRIPTION
**Requires testing on CODE**

This aims to improve the code in the article controller. See commit message (and code) for specifics. In particular, I have tried to separate out different concerns (e.g. redirect logic from model transformations).

Things outside this PR that will also simplify things, potentially for a later date:

* do not treat article service like a 404/lookup service (all the internal redirect logic). To be honest, I'm not even sure this is necessary as the router may already help here
* ensure downstream code is separate for different content types (HtmlCleaners I'm looking at you! 😬 )
* further work to reduce common and remove it