### PR TITLE
Bump the message character limit when sharing to Twitter

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -41,8 +41,8 @@ const $selectionSharing = $.create(selectionSharing);
 let $twitterAction;
 let $emailAction;
 
-// 140 - t.co length - 3 chars for quotes and url spacing
-const twitterMessageLimit = 114;
+// 280 - t.co length - 5 chars for quotes, url spacing and ellipsis
+const twitterMessageLimit = 252;
 
 const validAncestors = [
     'js-article__body',


### PR DESCRIPTION
## What does this change?

Bumps the magic number controlling how many characters can be posted to Twitter.

Take the magic number... add 140.... hey presto! New magic number? However, Twitter now uses a **weighted counting scheme**, which is much more difficult to take into account when deciding our new magic number 😅 

> The remaining count does not make sense to support in this library under the new weighted counting scheme, as this can differ based on the end user’s language of choice

https://developer.twitter.com/en/docs/basics/counting-characters.html

Due to changes in how Twitter handles URLs and unicode normalisation 252 is our new, working magic number! ✨

![shia labeouf gif-source](https://user-images.githubusercontent.com/8607683/38381249-185aca56-38fe-11e8-8a44-f203786732cf.gif)

## What is the value of this and can you measure success?

Sadly the specific tweet requesting this is lost to the sands of time... However, the user made a good point - we should increase the character limit when sharing to Twitter! This will make it easier for users to quote an article into tweets and will match a users expectations around character limits.

There is a bit of uncertainty about exactly how many characters we should truncate due to the new way that Twitter weights characters, as Twitter themselves state:

>  If you use anything beyond the most basic letters, numbers, and punctuation the situation gets more confusing. 

252 seems to work everywhere I have tested. In the rare case it does overshoot due to special characters, I hypothesis that users would rather delete a few characters themselves than still be constrained to 114. 👼 

## Does this affect other platforms - Amp, Apps, etc?

Twitter

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

## Screenshots

BEFORE:

<img width="824" alt="picture 4" src="https://user-images.githubusercontent.com/8607683/38381048-85980cce-38fd-11e8-8d24-904f104e6f82.png">

AFTER:

<img width="835" alt="picture 5" src="https://user-images.githubusercontent.com/8607683/38382374-a96b399c-3901-11e8-8a6e-dc4d6133d50c.png">

## Tested in CODE?

Nope - however tested extensively in DEV to ensure I am arbitrarily picking a sensible magic number
