### PR TITLE
Make bot bait field mandatory

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -33,16 +33,19 @@ case class EmailForm(
   listName: Option[String],
   referrer: Option[String],
   campaignCode: Option[String],
-  name: Option[String]) {
+  name: String) {
 
   // `name` is a hidden (via css) form input
   // if it was set to something this form was likely filled by a bot
   // https://stackoverflow.com/a/34623588/2823715
-  def isLikelyBotSubmission: Boolean = name.map(_.trim) match {
-    case Some("") | Some(null) | Some("undefined") | None | Some("null") => false
-    case _ => true
-  }
-
+  def isLikelyBotSubmission: Boolean =
+    if (name == null)
+      false
+    else
+      name match {
+        case "" | "undefined" | "null" => false
+        case _ => true
+      }
 }
 
 class EmailFormService(wsClient: WSClient) extends LazyLogging {
@@ -70,7 +73,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
       "listName" -> optional[String](of[String]),
       "referrer" -> optional[String](of[String]),
       "campaignCode" -> optional[String](of[String]),
-      "name" -> optional(text)
+      "name" -> text
     )(EmailForm.apply)(EmailForm.unapply)
   )
 

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -115,7 +115,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
 
   }
 
-  def submit(): Action[AnyContent] = csrfCheck { Action.async { implicit request =>
+  def submit(): Action[AnyContent] = Action.async { implicit request =>
     AllEmailSubmission.increment()
 
     def respond(result: SubscriptionResult): Result = {
@@ -161,7 +161,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
           APINetworkError.increment()
           respond(OtherError)
       })
-  }}
+  }
 
   def options(): Action[AnyContent] = Action { implicit request =>
     TinyResponse.noContent(Some("GET, POST, OPTIONS"))

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -38,14 +38,10 @@ case class EmailForm(
   // `name` is a hidden (via css) form input
   // if it was set to something this form was likely filled by a bot
   // https://stackoverflow.com/a/34623588/2823715
-  def isLikelyBotSubmission: Boolean =
-    if (name == null)
-      false
-    else
-      name match {
-        case "" | "undefined" | "null" => false
-        case _ => true
-      }
+  def isLikelyBotSubmission: Boolean = name match {
+    case "" | "undefined" | "null" => false
+    case _ => true
+  }
 }
 
 class EmailFormService(wsClient: WSClient) extends LazyLogging {

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -112,7 +112,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
 
   }
 
-  def submit(): Action[AnyContent] = Action.async { implicit request =>
+  def submit(): Action[AnyContent] = csrfCheck { Action.async { implicit request =>
     AllEmailSubmission.increment()
 
     def respond(result: SubscriptionResult): Result = {
@@ -158,7 +158,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
           APINetworkError.increment()
           respond(OtherError)
       })
-  }
+  }}
 
   def options(): Action[AnyContent] = Action { implicit request =>
     TinyResponse.noContent(Some("GET, POST, OPTIONS"))


### PR DESCRIPTION
## What does this change?

Adds a CSRF check to `POST /email`

## What is the value of this and can you measure success?

Will detect and block CSRF attempts

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

Soon

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
