### PR TITLE
Switch Oriel to the full 1%

### DIFF
--- a/common/app/views/fragments/commercial/orielAnalytics.scala.html
+++ b/common/app/views/fragments/commercial/orielAnalytics.scala.html
@@ -7,14 +7,14 @@
 @if(
     Configuration.environment.isProd &&
     OrielAnalyticsSwitch.isSwitchedOn &&
-    ActiveExperiments.isParticipating(OrielParticipation)
+    (ActiveExperiments.isParticipating(OrielParticipation) || ActiveExperiments.isControl(OrielParticipation))
 ) {
     <script async type="text/javascript" src="//f92j5.com/bilezg79cncj63usndtoa8igmvoritwjei5.js"></script>
 } else {
     @if(
         Configuration.environment.isCode &&
         OrielAnalyticsSwitch.isSwitchedOn &&
-        ActiveExperiments.isParticipating(OrielParticipation)
+        (ActiveExperiments.isParticipating(OrielParticipation) || ActiveExperiments.isControl(OrielParticipation))
     ) {
         <script async type="text/javascript" src="//f92j5.com/ejihwhhs1nv430sy6u4d51elu49.js"></script>
     }

--- a/common/app/views/fragments/page/head/orielScriptTag.scala.html
+++ b/common/app/views/fragments/page/head/orielScriptTag.scala.html
@@ -7,7 +7,7 @@
 
 
 @if(
-    (OrielAnalyticsSwitch.isSwitchedOff && ActiveExperiments.isParticipating(OrielParticipation)) ||
+    (OrielAnalyticsSwitch.isSwitchedOff && (ActiveExperiments.isParticipating(OrielParticipation) || ActiveExperiments.isControl(OrielParticipation))) ||
             (orielSonobiIntegration.isSwitchedOn && request.path == "/environment/2018/mar/11/labrador-switch-energy-suppliers")
 ) {
     @OrielCache.cache.get().getLoaderScript.map { loaderScript => <script>@HtmlFormat.raw(loaderScript)</script> }


### PR DESCRIPTION
## What does this change?

We only use the variant half of the test to drop both the Oriel analytics integration along with the full integration; this changes it so we use the full group. We don't really need a direct comparison to a control for this test.
