### PR TITLE
Extend expiry of US gun campaign thank you epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -23,7 +23,7 @@ export const acquisitionsEpicUSGunCampaign = makeABTest({
     campaignId: 'epic_us_gun_campaign_2017',
 
     start: '2017-11-14',
-    expiry: '2018-01-04',
+    expiry: '2019-02-06',
 
     author: 'Guy Dawson',
     description:


### PR DESCRIPTION
This thank you epic isn't actually displaying because the test has expired