### PR TITLE
Add end to end endpoint for guui rendering on article

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import java.lang.System._
-
 import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
 import conf.switches.Switches

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -171,7 +171,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     }
   }
 
-  def remoteRenderArticle(payload: String): Future[String] = ws.url(Configuration.moon.moonEndpoint)
+  def remoteRenderArticle(payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
     .withRequestTimeout(2000.millis)
     .addHttpHeaders("Content-Type" -> "application/json")
     .post(payload)

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -3,12 +3,14 @@ package controllers
 import com.softwaremill.macwire._
 import contentapi.ContentApiClient
 import model.ApplicationContext
+import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
 trait ArticleControllers {
   def contentApiClient: ContentApiClient
   def controllerComponents: ControllerComponents
+  def wsClient: WSClient
   implicit def appContext: ApplicationContext
   lazy val bookAgent: NewspaperBookTagAgent = wire[NewspaperBookTagAgent]
   lazy val bookSectionAgent: NewspaperBookSectionTagAgent = wire[NewspaperBookSectionTagAgent]

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -23,6 +23,9 @@ GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderArticle(path)
+GET     /*path/guui                 controllers.ArticleController.renderArticleGUUI(path)
+
 # temp route for live blogs so we can paginate without getting the blocks for all articles
+
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
-GET     /*path                      controllers.ArticleController.renderArticle(path)
+GET     /*path                         controllers.ArticleController.renderArticle(path)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -23,9 +23,6 @@ GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderArticle(path)
-GET     /*path/guui                 controllers.ArticleController.renderArticleGUUI(path)
-
 # temp route for live blogs so we can paginate without getting the blocks for all articles
-
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
-GET     /*path                         controllers.ArticleController.renderArticle(path)
+GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -16,13 +16,18 @@ import scala.collection.JavaConverters._
   with WithMaterializer
   with WithTestWsClient
   with WithTestApplicationContext
-  with WithTestContentApiClient {
+  with WithTestContentApiClient
+ {
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
   val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
   val sudokuUrl = "lifeandstyle/2013/sep/09/sudoku-2599-easy"
 
-  lazy val articleController = new ArticleController(testContentApiClient, play.api.test.Helpers.stubControllerComponents())
+  lazy val articleController = new ArticleController(
+    testContentApiClient,
+    play.api.test.Helpers.stubControllerComponents(),
+    wsClient
+  )
 
   "Article Controller" should "200 when content type is article" in {
     val result = articleController.renderArticle(articleUrl)(TestRequest(articleUrl))

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -17,7 +17,11 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
 
-  lazy val articleController = new ArticleController(testContentApiClient, play.api.test.Helpers.stubControllerComponents())
+  lazy val articleController = new ArticleController(
+    testContentApiClient,
+    play.api.test.Helpers.stubControllerComponents(),
+    wsClient
+  )
 
   it should "Include organisation metadata" in {
     val result = articleController.renderArticle(articleUrl)(TestRequest(articleUrl))

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -28,7 +28,7 @@ import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
   val bookAgent = mock[NewspaperBookTagAgent]
   val bookSectionAgent = mock[NewspaperBookSectionTagAgent]
   lazy val controllerComponents = play.api.test.Helpers.stubControllerComponents()
-  lazy val articleController = new ArticleController(testContentApiClient, controllerComponents)
+  lazy val articleController = new ArticleController(testContentApiClient, controllerComponents, wsClient)
   lazy val publicationController = new PublicationController(bookAgent, bookSectionAgent, articleController, controllerComponents)
 
   "Publication Controller" should "redirect to an /all page when an observer dated book url is requested" in {

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -40,11 +40,11 @@ object JsonComponent extends Results with implicits.Requests {
     resultFor(request, json)
   }
 
-  private def jsonFor(page: Page, items: (String, Any)*)(implicit request: RequestHeader, context: ApplicationContext): String = {
+  def jsonFor(page: Page, items: (String, Any)*)(implicit request: RequestHeader, context: ApplicationContext): String = {
     jsonFor(("config" -> Json.parse(templates.js.javaScriptConfig(page).body)) +: items: _*)
   }
 
-  private def jsonFor(items: (String, Any)*) = {
+  def jsonFor(items: (String, Any)*): String = {
     import play.api.libs.json.Writes._
     Json.stringify(toJson(
       (items.toMap + ("refreshStatus" -> AutoRefreshSwitch.isSwitchedOn)).map {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -144,6 +144,10 @@ class GuardianConfiguration extends Logging {
     lazy val feedpipeEndpoint = configuration.getMandatoryStringProperty("feedback.feedpipeEndpoint")
   }
 
+  object rendering {
+    lazy val renderingEndpoint = configuration.getMandatoryStringProperty("rendering.endpoint")
+  }
+
   object weather {
     lazy val apiKey = configuration.getStringProperty("weather.api.key")
   }

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -78,6 +78,7 @@ class DevParametersHttpRequestHandler(
     if (
       context.environment.mode != Prod &&
       !request.isJson &&
+      !request.isGuui &&
       !request.uri.startsWith("/oauth2callback") &&
       !request.uri.startsWith("/px.gif")  && // diagnostics box
       !request.uri.startsWith("/tech-feedback") &&

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -19,8 +19,10 @@ trait Requests {
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 
-    // parameter for moon/guui new rendering layer project.
-    lazy val isGuuiJson: Boolean = isJson && r.getQueryString("guui").isDefined
+    // parameters for moon/guui new rendering layer project.
+    lazy val isGuuiJson: Boolean = isJson && isGuui
+
+    lazy val isGuui: Boolean = r.getQueryString("guui").isDefined
 
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 


### PR DESCRIPTION
## What does this change?

If you add ?guui to the end of an article url, it will render the given article using the remote node app. This code is for the tech-time on the 27th of April, we'll refactor it into something more generic after that.

I didn't want to muck around with the return types and method signatures of the existing code, so I just wrote some new methods and added a conditional at the top-most renderArticle function, for easy removal.

I think the edge cache and router should pass the ?guui parameter through fine without any changes, since we handle the .json?guui endpoint and the regex for that is just on '?guui'

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
