### PR TITLE
enforce valid email on /consents as well as email-prefs

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -147,7 +147,7 @@ class AuthenticatedActions(
 
       def filter[A](request: AuthRequest[A]) = {
         redirectService.toConsentsRedirect(request.user, request).map { redirect =>
-          if (redirect.isAllowedFrom(""))
+          if (redirect.isAllowedFrom("/consents"))
             Some(sendUserToUserRedirectDecision(request, redirect))
           else
             None

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -147,7 +147,7 @@ class AuthenticatedActions(
 
       def filter[A](request: AuthRequest[A]) = {
         redirectService.toConsentsRedirect(request.user, request).map { redirect =>
-          if (redirect.isAllowedFrom("/consents"))
+          if (redirect.isAllowedFrom(request.path))
             Some(sendUserToUserRedirectDecision(request, redirect))
           else
             None

--- a/identity/app/services/ProfileRedirectService.scala
+++ b/identity/app/services/ProfileRedirectService.scala
@@ -23,7 +23,7 @@ sealed abstract class ProfileRedirect(val url: String) {
 }
 
 case object RedirectToEmailValidationFromEmailPrefsOrConsentJourney extends ProfileRedirect("/verify-email") {
-  override def isAllowedFrom(url: String): Boolean = (url contains "email-prefs") || (url contains "consents")
+  override def isAllowedFrom(url: String): Boolean = (url startsWith "/email-prefs") || (url startsWith "/consents")
 }
 
 case object RedirectToConsentsFromEmailPrefs extends ProfileRedirect("/consents/staywithus") {

--- a/identity/app/services/ProfileRedirectService.scala
+++ b/identity/app/services/ProfileRedirectService.scala
@@ -22,8 +22,8 @@ sealed abstract class ProfileRedirect(val url: String) {
   def isAllowedFrom(url: String): Boolean
 }
 
-case object RedirectToEmailValidationFromEmailPrefs extends ProfileRedirect("/verify-email") {
-  override def isAllowedFrom(url: String): Boolean = url contains "email-prefs"
+case object RedirectToEmailValidationFromEmailPrefsOrConsentJourney extends ProfileRedirect("/verify-email") {
+  override def isAllowedFrom(url: String): Boolean = (url contains "email-prefs") || (url contains "consents")
 }
 
 case object RedirectToConsentsFromEmailPrefs extends ProfileRedirect("/consents/staywithus") {
@@ -53,7 +53,7 @@ class ProfileRedirectService(
   def toConsentsRedirect[A](user: User, request: RequestHeader): Future[ProfileRedirect] = {
     user.statusFields.isUserEmailValidated match {
       case true => Future.successful(NoRedirect)
-      case false => Future.successful(RedirectToEmailValidationFromEmailPrefs)
+      case false => Future.successful(RedirectToEmailValidationFromEmailPrefsOrConsentJourney)
     }
   }
 
@@ -64,7 +64,7 @@ class ProfileRedirectService(
 
     (userEmailValidated, userHasRepermissioned) match {
       case (false, _) =>
-        Future.successful(RedirectToEmailValidationFromEmailPrefs)
+        Future.successful(RedirectToEmailValidationFromEmailPrefsOrConsentJourney)
 
       case (true, false) =>
         Future.successful(RedirectToConsentsFromEmailPrefs)

--- a/identity/test/services/ProfileRedirectServiceTest.scala
+++ b/identity/test/services/ProfileRedirectServiceTest.scala
@@ -73,7 +73,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
     "redirect to email validation if user has not validated their email" in new TestFixture {
       val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, request)
 
-      whenReady(result)( _ shouldBe RedirectToEmailValidationFromEmailPrefs)
+      whenReady(result)( _ shouldBe RedirectToEmailValidationFromEmailPrefsOrConsentJourney)
     }
 
      "don't redirect from account details page even without validated email" in new TestFixture {

--- a/identity/test/services/ProfileRedirectServiceTest.scala
+++ b/identity/test/services/ProfileRedirectServiceTest.scala
@@ -46,8 +46,10 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
     val userWithoutValidEmail = new User(statusFields = new StatusFields(userEmailValidated = Some(false)))
     val profileRedirectService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponents)
 
-    val originalUrl = "https://profile.thegulocal.com/email-prefs"
-    val request = Request(FakeRequest("GET", originalUrl), AnyContent())
+    val originalEmailPreflUrl = "https://profile.thegulocal.com/email-prefs"
+    val originalConsentUrl = "https://profile.thegulocal.com/consents/staywithus"
+    val emailPrefRequest = Request(FakeRequest("GET", originalEmailPreflUrl), AnyContent())
+    val consentJourneyRequest = Request(FakeRequest("GET", originalConsentUrl), AnyContent())
 
   }
 
@@ -57,7 +59,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
 
         when(newsletterService.getV1EmailSubscriptions(emailForm)) thenReturn List.empty
 
-        val result: Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithValidEmailAndHasRepermed, request)
+        val result: Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithValidEmailAndHasRepermed, emailPrefRequest)
 
         whenReady(result)(_ shouldBe NoRedirect)
       }
@@ -65,15 +67,40 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
     "redirect to newsletter consents when user still has v1 subscriptions" in new TestFixture {
       when(newsletterService.getV1EmailSubscriptions(emailForm)) thenReturn List("somethingHere")
 
-      val result: Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithValidEmailAndHasRepermed, request)
+      val result: Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithValidEmailAndHasRepermed, emailPrefRequest)
 
       whenReady(result)(_ shouldBe RedirectToNewsletterConsentsFromEmailPrefs)
     }
 
     "redirect to email validation if user has not validated their email" in new TestFixture {
-      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, request)
+      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, emailPrefRequest)
 
       whenReady(result)( _ shouldBe RedirectToEmailValidationFromEmailPrefsOrConsentJourney)
+    }
+
+    "redirect to email validation from consent journey if user has not validated their email" in new TestFixture {
+      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, consentJourneyRequest)
+
+      whenReady(result)( res =>
+      res.isAllowedFrom("/consents/staywithus") shouldBe true)
+    }
+
+    "redirect to email validation from email-prefs" in new TestFixture {
+      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, emailPrefRequest)
+
+      whenReady(result)( res =>
+        res.isAllowedFrom("/email-prefs") shouldBe true)
+    }
+
+    "don't redirect to email validation from /public/edit" in new TestFixture {
+
+      val accountEditUrl = "https://profile.thegulocal.com/public/edit"
+      val fakeRequest = Request(FakeRequest("GET", accountEditUrl), AnyContent())
+
+      val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, emailPrefRequest)
+
+      whenReady(result)( res =>
+        res.isAllowedFrom("/public/edit") shouldBe false)
     }
 
      "don't redirect from account details page even without validated email" in new TestFixture {
@@ -84,7 +111,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
        val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, fakeRequest)
 
        whenReady(result){ res =>
-         res.isAllowedFrom(accountDetailsUrl) shouldBe false
+         res.isAllowedFrom("/account/edit") shouldBe false
        }
      }
 
@@ -95,7 +122,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
       val result : Future[ProfileRedirect] = profileRedirectService.toProfileRedirect(userWithoutValidEmail, fakeRequest)
 
       whenReady(result){ res =>
-        res.isAllowedFrom(membershipEditUrl) shouldBe false
+        res.isAllowedFrom("/membership/edit") shouldBe false
       }
     }
   }


### PR DESCRIPTION
## What does this change?
- Enforce email validation on consent journey as well as /email-prefs

## What is the value of this and can you measure success?
- Don't take consents from invalid emails 

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
