### PR TITLE
Show the 'stay with us' alert more

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
@@ -1,0 +1,45 @@
+// @flow
+
+import { inlineSvg } from 'common/views/svgs';
+
+type Template = {
+    image: string,
+    title: string,
+    cta: string,
+    remindMeLater: string,
+    messageCloseBtn: string,
+};
+
+type LinkTargets = {
+    landing: string,
+    journey: string,
+};
+
+const makeTemplateHtml = (template: Template, targets: LinkTargets): string => `
+    <div id="site-message__message">
+        <div class="site-message__message identity-gdpr-oi-alert">
+            <div class="identity-gdpr-oi-alert__logo">
+                <img src="${template.image}" alt="Stay with us" />
+            </div>
+            <div class="identity-gdpr-oi-alert__body">
+                <div class="identity-gdpr-oi-alert__text">
+                    ${template.title}
+                </div>
+                <div class="identity-gdpr-oi-alert__cta-space">
+                    <a data-link-name="gdpr-oi-campaign : alert : remind-me-later" class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
+                        template.messageCloseBtn
+                    }">
+                        ${template.remindMeLater}
+                    </a>
+                    <a class="identity-gdpr-oi-alert__cta" target="_blank" href="${
+                        targets.journey
+                    }" data-link-name="gdpr-oi-campaign : alert : to-consents">
+                        ${template.cta}
+                        ${inlineSvg('arrowWhiteRight')}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>`;
+
+export { Template, LinkTargets, makeTemplateHtml };

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
@@ -42,4 +42,5 @@ const makeTemplateHtml = (template: Template, targets: LinkTargets): string => `
         </div>
     </div>`;
 
-export { Template, LinkTargets, makeTemplateHtml };
+export type { Template, LinkTargets };
+export { makeTemplateHtml };

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -14,7 +14,7 @@ const messageCode: string = 'gdpr-opt-in-jan-18';
 const messageHidAtPref: string = `${messageCode}-hid-at`;
 const messageUserUsesNewslettersCookie: string = `gu-${
     messageCode
-}-via-newsletter`.toUpperCase();
+}-via-newsletter`.toUpperCase().replace(/\-/g, '_');
 const messageCloseBtn = 'js-gdpr-oi-close';
 const remindMeLaterInterval = 24 * 60 * 60 * 1000;
 

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -14,7 +14,9 @@ const messageCode: string = 'gdpr-opt-in-jan-18';
 const messageHidAtPref: string = `${messageCode}-hid-at`;
 const messageUserUsesNewslettersCookie: string = `gu-${
     messageCode
-}-via-newsletter`.toUpperCase().replace(/\-/g, '_');
+}-via-newsletter`
+    .toUpperCase()
+    .replace(/-/g, '_');
 const messageCloseBtn = 'js-gdpr-oi-close';
 const remindMeLaterInterval = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## What does this change?
- Adds a new condition for the swu alert where it'll pop for urls containing `utm_source=eml` too.
- Sets a cookie for all users coming in from newsletters. The goal of this is to eventually use this to display the alert passively on normal visits not coming from emails.
- Tidy up the code, separated the display logic and the template as the file was getting rather hefty

## Screenshots
![screen shot 2018-04-09 at 12 12 46 pm](https://user-images.githubusercontent.com/11539094/38496359-2c4e4ca0-3bf5-11e8-8220-395b3bd9595c.png)
