### PR TITLE
Remove CSRF check for email widget, send client IP to consent mailer

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import com.gu.identity.model.EmailNewsletter
+import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{ImplicitControllerExecutionContext, LinkTo, Logging}
 import conf.Configuration
+import http.RemoteAddress
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
-import com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
-import com.typesafe.scalalogging.LazyLogging
 import play.api.data.Forms._
 import play.api.data._
 import play.api.data.format.Formats._
@@ -14,11 +15,9 @@ import play.api.data.validation.Constraints.emailAddress
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc._
-import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
 
 object emailLandingPage extends StandalonePage {
   private val id = "email-landing-page"
@@ -44,9 +43,9 @@ case class EmailForm(
   }
 }
 
-class EmailFormService(wsClient: WSClient) extends LazyLogging {
+class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
 
-  def submit(form: EmailForm): Future[WSResponse] = if (form.isLikelyBotSubmission) {
+  def submit(form: EmailForm)(implicit request: Request[_]): Future[WSResponse] = if (form.isLikelyBotSubmission) {
     Future.failed(new IllegalAccessException("Form was likely submitted by a bot."))
   } else {
     val idAccessClientToken = Configuration.id.apiClientToken
@@ -56,11 +55,12 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging {
     wsClient
       .url(consentMailerUrl)
       .addHttpHeaders("X-GU-ID-Client-Access-Token" -> s"Bearer $idAccessClientToken")
+      .addHttpHeaders("X-Forwarded-For" -> clientIp(request).getOrElse("NA"))
       .post(consentMailerPayload)
   }
 }
 
-class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents, csrfCheck: CSRFCheck, csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
+class EmailSignupController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends BaseController with ImplicitControllerExecutionContext with Logging {
   val emailFormService = new EmailFormService(wsClient)
 
   val emailForm: Form[EmailForm] = Form(
@@ -77,28 +77,26 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
     Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
   }
 
-  def renderForm(emailType: String, listId: Int): Action[AnyContent] = csrfAddToken {
-    Action { implicit request =>
-      val identityName = EmailNewsletter(listId)
-        .orElse(EmailNewsletter.fromV1ListId(listId))
-        .map(_.identityName)
+  def renderForm(emailType: String, listId: Int): Action[AnyContent] = Action { implicit request =>
+    val identityName = EmailNewsletter(listId)
+      .orElse(EmailNewsletter.fromV1ListId(listId))
+      .map(_.identityName)
 
-      identityName match {
-        case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
-      }
+    identityName match {
+      case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+      case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
     }
   }
 
-  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = csrfAddToken {
-    Action { implicit request =>
-      val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
-      id match {
-        case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
-      }
+
+  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] = Action { implicit request =>
+    val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
+    id match {
+      case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
+      case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
     }
   }
+
 
 
   def subscriptionResult(result: String): Action[AnyContent] = Action { implicit request =>

--- a/common/app/http/RemoteAddress.scala
+++ b/common/app/http/RemoteAddress.scala
@@ -1,4 +1,4 @@
-package utils
+package http
 
 import play.api.mvc.RequestHeader
 

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -42,7 +42,6 @@
 
 @form = {
     <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass", data-email-list-name="@listName">
-        @helper.CSRF.formField
         <div class="email-sub__form-wrapper">
             <div class="email-sub__inline-label js-email-sub__inline-label">
                 @if(componentClass == "plaintone") {

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -2,9 +2,10 @@ package services
 
 import idapiclient.TrackingData
 import play.api.mvc.RequestHeader
-import utils.{ThirdPartyConditions, RemoteAddress}
+import utils.ThirdPartyConditions
 import jobs.TorExitNodeList
 import conf.switches.Switches
+import http.RemoteAddress
 
 class IdRequestParser(returnUrlVerifier: ReturnUrlVerifier) extends RemoteAddress {
   def apply(request: RequestHeader): IdentityRequest = {

--- a/identity/test/utils/RemoteAddressTest.scala
+++ b/identity/test/utils/RemoteAddressTest.scala
@@ -1,5 +1,6 @@
 package utils
 
+import http.RemoteAddress
 import org.scalatest.FunSuite
 import play.api.test.FakeRequest
 import play.api.test.Helpers._

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -57,11 +57,8 @@ const submitForm = (
     const listName = encodeURIComponent(
         $('input[name="listName"]', form).val()
     );
-    const csrfToken = encodeURIComponent(
-        $('input[name="csrfToken"]', form).val()
-    );
-    const formQueryString = `${inputs.email}=${email}&csrfToken=${
-        csrfToken
+    const formQueryString = `${inputs.email}=${
+        email
     }&listName=${listName}&${inputs.dummy}=${dummyEmail}`;
 
     return fetch(`${config.get('page.ajaxUrl')}/email`, {

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -57,10 +57,9 @@ const submitForm = (
     const listName = encodeURIComponent(
         $('input[name="listName"]', form).val()
     );
-    const formQueryString = `${inputs.email
-    }=${
-        email
-    }&listName=${listName}&${inputs.dummy}=${dummyEmail}`;
+    const formQueryString = `${inputs.email}=${email}&listName=${listName}&${
+        inputs.dummy
+    }=${dummyEmail}`;
 
     return fetch(`${config.get('page.ajaxUrl')}/email`, {
         method: 'POST',

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -57,7 +57,8 @@ const submitForm = (
     const listName = encodeURIComponent(
         $('input[name="listName"]', form).val()
     );
-    const formQueryString = `${inputs.email}=${
+    const formQueryString = `${inputs.email
+    }=${
         email
     }&listName=${listName}&${inputs.dummy}=${dummyEmail}`;
 

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -253,7 +253,6 @@ const submitForm = (
 
     return event => {
         const emailAddress = $(`.${classes.textInput}`, $form).val();
-        const csrfToken = $(`input[name=csrfToken]`, $form).val();
         const dummy = $(`.${classes.dummyInput}`, $form).val();
         const listName = $(`.${classes.listNameHiddenInput}`, $form);
 
@@ -266,9 +265,7 @@ const submitForm = (
                 emailAddress
             )}&name=${encodeURIComponent(dummy)}&campaignCode=${
                 formData.campaignCode
-            }&referrer=${formData.referrer}&csrfToken=${encodeURIComponent(
-                csrfToken
-            )}&listName=${listName.val()}`;
+            }&referrer=${formData.referrer}&listName=${listName.val()}`;
 
             analyticsInfo = `rtrt | email form inline | ${
                 analytics.formType


### PR DESCRIPTION
## What does this change?

adds csrf check to `POST /email`

## What is the value of this and can you measure success?

Prevent CSRF attempts 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
