### PR TITLE
Don't return article as a 404 for guui endpoint

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -5,7 +5,7 @@ import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
 import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
-import model.Cached.WithoutRevalidationResult
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import LiveBlogHelpers._
 import conf.Configuration
@@ -185,9 +185,11 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
       val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
       val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+
       remoteRenderArticle(jsonPayload).map(s => {
-        Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound(Html(s))))
+        Cached(article){ RevalidatableResult.Ok(Html(s)) }
       })
+
     case _ => throw new Exception("Remote render not supported for this content type")
 
   }


### PR DESCRIPTION
## What does this change?

Small oversight; we're returning a 404 status for the guui endpoint in all cases, should just be
the normal one

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
