### PR TITLE
Delete legacy tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,8 +154,6 @@
   },
   "scripts": {
     "postinstall": "./tools/sync-githooks.js",
-    "amdtoes6": "amdtoes6 --beautify",
-    "lebab": "lebab --transform arrow,let,arg-rest,arg-spread,obj-method,obj-shorthand,no-strict,class,default-param --replace",
     "eslint-fix": "eslint --color --fix",
     "flow": "flow",
     "test": "jest"

--- a/tools/__tasks__/compile/javascript/clean.js
+++ b/tools/__tasks__/compile/javascript/clean.js
@@ -4,7 +4,7 @@ const rimraf = require('rimraf');
 const { target, hash } = require('../../config').paths;
 
 module.exports = {
-    description: 'Clear JS build artifacts',
+    description: 'Clear JS build artefacts',
     task: () => {
         rimraf.sync(path.resolve(target, 'javascripts'));
         rimraf.sync(path.resolve(hash, 'javascripts'));

--- a/tools/__tasks__/compile/javascript/clean.js
+++ b/tools/__tasks__/compile/javascript/clean.js
@@ -1,13 +1,12 @@
 const path = require('path');
 const rimraf = require('rimraf');
 
-const { target, hash, transpiled } = require('../../config').paths;
+const { target, hash } = require('../../config').paths;
 
 module.exports = {
-    description: 'Clear JS build artefacts',
+    description: 'Clear JS build artifacts',
     task: () => {
         rimraf.sync(path.resolve(target, 'javascripts'));
-        rimraf.sync(path.resolve(transpiled, 'javascripts'));
         rimraf.sync(path.resolve(hash, 'javascripts'));
     },
 };

--- a/tools/__tasks__/compile/javascript/copy.js
+++ b/tools/__tasks__/compile/javascript/copy.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const cpy = require('cpy');
 
-const { src, vendor, target, transpiled } = require('../../config').paths;
+const { vendor, target } = require('../../config').paths;
 
 module.exports = {
     description: 'Copy 3rd JS party libraries',
@@ -16,14 +16,5 @@ module.exports = {
                     nodir: true,
                 }
             ),
-
-            // copy all non-JS source files from the JS directory
-            // e.g. *.html templates etc
-            cpy(['**/*'], path.resolve(transpiled, 'javascripts'), {
-                cwd: path.resolve(src, 'javascripts'),
-                parents: true,
-                nodir: true,
-                ignore: '**/*.js',
-            }),
         ]),
 };

--- a/tools/__tasks__/compile/javascript/copy.js
+++ b/tools/__tasks__/compile/javascript/copy.js
@@ -8,14 +8,7 @@ module.exports = {
     task: () =>
         Promise.all([
             cpy(
-                [
-                    'formstack-interactive/**/*',
-                    'omniture/**/*',
-                    'prebid/**/*',
-                    'stripe/**/*',
-                    'react/**/*',
-                    'ophan/**/*',
-                ],
+                ['formstack-interactive/**/*'],
                 path.resolve(target, 'javascripts', 'vendor'),
                 {
                     cwd: path.resolve(vendor, 'javascripts'),

--- a/tools/__tasks__/config.js
+++ b/tools/__tasks__/config.js
@@ -3,7 +3,6 @@ const path = require('path');
 module.exports = {
     paths: {
         target: path.join(__dirname, '../', '../', 'static', 'target'),
-        transpiled: path.join(__dirname, '../', '../', 'static', 'transpiled'),
         hash: path.join(__dirname, '../', '../', 'static', 'hash'),
         src: path.join(__dirname, '../', '../', 'static', 'src'),
         public: path.join(__dirname, '../', '../', 'static', 'public'),

--- a/tools/__tasks__/validate/javascript-fix.js
+++ b/tools/__tasks__/validate/javascript-fix.js
@@ -10,14 +10,6 @@ module.exports = {
     description: 'Fix JS linting errors',
     task: [
         {
-            description: 'Fix static/tests/javascripts-legacy',
-            task: ctx =>
-                execa(
-                    'eslint',
-                    ['static/test/javascripts-legacy/**/*.js'].concat(config)
-                ).then(handleSuccess.bind(null, ctx)),
-        },
-        {
             description: 'Fix static/src',
             task: ctx =>
                 execa('eslint', ['static/src/**/*.js'].concat(config)).then(

--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -37,13 +37,8 @@ module.exports = {
                 onError: error,
             })),
         {
-            description: `Tests ${chalk.dim('legacy')}`,
-            task: `eslint static/test/javascripts-legacy ${config}`,
-            onError: error,
-        },
-        {
             description: 'Tools etc.',
-            task: `eslint --ignore-pattern /static/test/javascripts-legacy --ignore-pattern /static/src --ignore-pattern . ${
+            task: `eslint --ignore-pattern /static/src --ignore-pattern . ${
                 config
             }`,
             onError: error,


### PR DESCRIPTION
## What does this change?

When removing the legacy JS infrastructure #19286, a few tasks were missed. This change cleans up the last of them, and also removes some obsolete scripts from `package.json`

## What is the value of this and can you measure success?

Less redundant code
