### PR TITLE
Extend expiries of epic 'tests'

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 7, 19),
+    sellByDate = new LocalDate(2019, 1, 24),
     exposeClientSide = true
   )
 
@@ -22,7 +22,7 @@ trait ABTestSwitches {
     "This places the epic below those blocks on liveblogs which have been marked for displaying the epic in Composer",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 7, 19),
+    sellByDate = new LocalDate(2019, 1, 24),
     exposeClientSide = true
   )
 
@@ -32,7 +32,7 @@ trait ABTestSwitches {
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 7, 19),
+    sellByDate = new LocalDate(2019, 1, 24),
     exposeClientSide = true
   )
 
@@ -42,7 +42,7 @@ trait ABTestSwitches {
     "Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 9, 5),
+    sellByDate = new LocalDate(2019, 1, 24),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -6,7 +6,7 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeABTest({
     campaignId: 'epic_always_ask_if_tagged',
 
     start: '2017-05-23',
-    expiry: '2018-07-19',
+    expiry: '2019-01-24',
 
     author: 'Jonathan Rankin',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -137,7 +137,7 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     campaignSuffix: pageId.replace(/-/g, '_').replace(/\//g, '__'),
 
     start: '2017-04-01',
-    expiry: '2018-04-01',
+    expiry: '2019-01-24',
 
     author: 'Joseph Smith',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -13,7 +13,7 @@ export const acquisitionsEpicThankYou = makeABTest({
     componentType: 'ACQUISITIONS_THANK_YOU_EPIC',
 
     start: '2017-06-01',
-    expiry: '2018-09-05',
+    expiry: '2019-01-24',
 
     author: 'Guy Dawson',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -6,7 +6,7 @@ export const askFourEarning: EpicABTest = makeABTest({
     campaignId: 'kr1_epic_ask_four_earning',
 
     start: '2017-01-24',
-    expiry: '2018-07-19',
+    expiry: '2019-01-24',
 
     author: 'Jonathan Rankin',
     description:


### PR DESCRIPTION
@guardian/contributions 