### PR TITLE
Add timing code to articleController for remote vs local

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -58,7 +58,9 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
     ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric,
-    ContentApiMetrics.ContentApiRequestsMetric
+    ContentApiMetrics.ContentApiRequestsMetric,
+    RenderingMetrics.RemoteRenderingMetric,
+    RenderingMetrics.LocalRenderingMetric
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -59,8 +59,8 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric,
     ContentApiMetrics.ContentApiRequestsMetric,
-    RenderingMetrics.RemoteRenderingMetric,
-    RenderingMetrics.LocalRenderingMetric
+    ArticleRenderingMetrics.RemoteRenderingMetric,
+    ArticleRenderingMetrics.LocalRenderingMetric
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -196,7 +196,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   }
 
-  def timedPage[T](future: Future[T], metric: TimingMetric): Future[T] = {
+  def timedFuture[T](future: Future[T], metric: TimingMetric): Future[T] = {
       val start = currentTimeMillis
       future.onComplete(_ => metric.recordDuration(currentTimeMillis - start))
       future
@@ -217,20 +217,20 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
       if(request.isGuui){
 
-        timedPage(
+        timedFuture(
           mapModelGUUI(path, Some(ArticleBlocks)){
             remoteRender(path, _)
           },
-          RenderingMetrics.RemoteRenderingMetric
+          ArticleRenderingMetrics.RemoteRenderingMetric
         )
 
       } else {
 
-        timedPage(
+        timedFuture(
           mapModel(path, range = if (request.isEmail) Some(ArticleBlocks) else None) {
             render(path, _)
           },
-          RenderingMetrics.LocalRenderingMetric
+          ArticleRenderingMetrics.LocalRenderingMetric
         )
 
       }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -165,14 +165,14 @@ object ApplicationMetrics {
   def apply(metrics: FrontendMetric*): ApplicationMetrics = ApplicationMetrics(metrics.toList)
 }
 
-object RenderingMetrics {
+object ArticleRenderingMetrics {
   val RemoteRenderingMetric = TimingMetric(
-    "remote-rendering-time",
-    "Remote rendering time"
+    "remote-rendering-time-article",
+    "Remote rendering time for articles"
   )
   val LocalRenderingMetric = TimingMetric(
-    "local-rendering-time",
-    "Local rendering time"
+    "local-rendering-time-article",
+    "Local rendering time for articles"
   )
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -165,6 +165,17 @@ object ApplicationMetrics {
   def apply(metrics: FrontendMetric*): ApplicationMetrics = ApplicationMetrics(metrics.toList)
 }
 
+object RenderingMetrics {
+  val RemoteRenderingMetric = TimingMetric(
+    "remote-rendering-time",
+    "Remote rendering time"
+  )
+  val LocalRenderingMetric = TimingMetric(
+    "local-rendering-time",
+    "Local rendering time"
+  )
+}
+
 class CloudWatchMetricsLifecycle(
   appLifecycle: ApplicationLifecycle,
   appIdentity: ApplicationIdentity,


### PR DESCRIPTION
## What does this change?

This adds a new cloudwatch metric to the articleController that measures all inclusive render time (capi+render) for both the twirl and remote rendering calls. This is the same code that we used to measure the 404 page previously.

Note that metrics are batched up and sent to cloudwatch every 5 minutes, so adding this shouldn't slow down the critical path of the page load. 

This code will be removed after we have collected enough data.

@nicl @QuarpT @SiAdcock 

## What is the value of this and can you measure success?

I want to check the performance of these two since one is mysteriously faster than the other.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
