### PR TITLE
Pure json onward responses

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -8,14 +8,14 @@ import model._
 import model.pressed.PressedContent
 import play.api.libs.json._
 import play.api.mvc._
-import views.support.{ContentOldAgeDescriber, ImgSrc}
+import views.support.{ContentOldAgeDescriber, ImgSrc, RemoveOuterParaHtml}
 import views.support.FaciaToMicroFormat2Helpers._
 
 import scala.concurrent.Future
 
 case class MostPopularItem(
   url: String,
-  webTitle: String,
+  linkText: String,
   showByline: Boolean,
   byline: Option[String],
   image: Option[String],
@@ -139,7 +139,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
     trails.take(10).map(content =>
       MostPopularItem(
         url = LinkTo(content.header.url),
-        webTitle = content.properties.webTitle,
+        linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.properties.webTitle)).body,
         showByline = content.properties.showByline,
         byline = content.properties.byline,
         image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -6,10 +6,12 @@ import contentapi.ContentApiClient
 import feed.MostReadAgent
 import model.Cached.RevalidatableResult
 import model._
+import models.{OnwardCollection, OnwardCollectionResponse}
 import play.api.libs.json._
 import play.api.mvc._
 import services._
 import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
+import models.OnwardCollection._
 
 import scala.concurrent.duration._
 
@@ -43,7 +45,14 @@ class RelatedController(
   private def renderRelated(trails: Seq[RelatedContentItem], containerTitle: String)(implicit request: RequestHeader): Result = Cached(30.minutes) {
     val relatedTrails = trails take 8
 
-    if (request.isJson) {
+    if (request.isGuui) {
+      val data = OnwardCollectionResponse(
+        heading = containerTitle,
+        trails = trailsToItems(trails.map(_.faciaContent))
+      )
+
+      JsonComponent(data)
+    } else if (request.isJson) {
       val html = views.html.fragments.containers.facia_cards.container(
         onwardContainer(containerTitle, relatedTrails.map(_.faciaContent)),
         FrontProperties.empty

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -1,0 +1,57 @@
+package models
+
+import common.LinkTo
+import model.pressed.PressedContent
+import play.api.mvc.RequestHeader
+import views.support.{ContentOldAgeDescriber, ImgSrc, RemoveOuterParaHtml}
+import play.api.libs.json._
+import implicits.FaciaContentFrontendHelpers._
+
+case class OnwardItem(
+  url: String,
+  linkText: String,
+  showByline: Boolean,
+  byline: Option[String],
+  image: Option[String],
+  ageWarning: Option[String],
+  isLiveBlog: Boolean
+)
+
+case class MostPopularGeoResponse(
+  country: Option[String],
+  heading: String,
+  trails: Seq[OnwardItem]
+)
+
+case class OnwardCollectionResponse(
+  heading: String,
+  trails: Seq[OnwardItem]
+)
+
+object OnwardCollection {
+
+  implicit val itemWrites = Json.writes[OnwardItem]
+  implicit val popularGeoWrites = Json.writes[MostPopularGeoResponse]
+  implicit val collectionWrites = Json.writes[OnwardCollectionResponse]
+
+  def trailsToItems(trails: Seq[PressedContent])(implicit request: RequestHeader): Seq[OnwardItem] = {
+    def ageWarning(content: PressedContent): Option[String] = {
+      content.properties.maybeContent
+        .filter(c => c.tags.tags.exists(_.id == "tone/news"))
+        .map(ContentOldAgeDescriber.apply)
+        .filterNot(_ == "")
+    }
+
+    trails.take(10).map(content =>
+      OnwardItem(
+        url = LinkTo(content.header.url),
+        linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.properties.webTitle)).body,
+        showByline = content.properties.showByline,
+        byline = content.properties.byline,
+        image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
+        ageWarning = ageWarning(content),
+        isLiveBlog = false
+      )
+    )
+  }
+}


### PR DESCRIPTION
This adds support for pure json responses for most onward components (most-read/related content) when a `guui` query parameter is provided (required for Guui).

I've tried to keep the model lightweight, based on what it looks like the existing templates use. I couldn't see an appropriate existing model to use here, but it may well exist! So shout if there is one. Thanks :)

I've also not attempted to implement this for everything onward offers, as would rather see how this works out first and avoid premature redundant effort.

Currently, responses are like:

```
{
  "heading": "related stories",
  "trails": [
    {
      "url": "/society/2018/feb/06/vaping-is-safe-way-to-quit-smoking-says-health-body",
      "linkText": "E-cigarettes should be on sale in hospital shops, health body says",
      "showByline": false,
      "byline": "Sarah Boseley Health editor",
      "image": "//i.guim.co.uk/img/media/0342386e0b76d086813c5cd4484290e3752354cb/0_50_3500_2099/master/3500.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=f033ba34887becf33463c04833443ba9",
      "ageWarning": "2 months",
      "isLiveBlog": false
    },
    {
      "url": "/society/2018/jan/09/nhs-hospital-bans-sugar-from-its-meals-to-tackle-staff-obesity",
      "linkText": "NHS hospital bans sugar from its meals to tackle staff obesity",
      "showByline": false,
      "byline": "Sarah Marsh",
      "image": "//i.guim.co.uk/img/media/87930079e115d20ac044346899c3aea901970c72/0_73_5673_3405/master/5673.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=841c754b48c625509cfcbba2b5c7de42",
      "ageWarning": "3 months",
      "isLiveBlog": false
    },
    {
      "url": "/science/2017/nov/30/evolution-row-ends-as-scientists-declare-sponges-to-be-sister-of-all-animals",
      "linkText": "Evolution row ends as scientists declare sponges to be sister of all other animals",
      "showByline": false,
      "byline": "Nicola Davis",
      "image": "//i.guim.co.uk/img/media/0938d6b9581523ca7e8b9dd1ff1aa2f6914dd640/0_332_5175_3105/master/5175.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=77906ca13834c6c3198a00f33f83a3a7",
      "ageWarning": "4 months",
      "isLiveBlog": false
    },
    {
      "url": "/science/2017/nov/13/evidence-of-worlds-earliest-winemaking-uncovered-by-archaeologists",
      "linkText": "Evidence of world's earliest winemaking uncovered by archaeologists",
      "showByline": false,
      "byline": "Ashifa Kassam  and Nicola Davis",
      "image": "//i.guim.co.uk/img/media/3cea8c49d30fc77d22d5fd9f564265d65099b379/0_108_3500_2100/master/3500.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=ce7df70a2f1518f5d0b74344c076b890",
      "ageWarning": "5 months",
      "isLiveBlog": false
    },
    {
      "url": "/science/2017/sep/01/europe-unveils-worlds-most-powerful-x-ray-laser",
      "linkText": "Europe unveils world's most powerful X-ray laser",
      "showByline": false,
      "byline": "Hannah Devlin Science correspondent",
      "image": "//i.guim.co.uk/img/media/938bec9b68b09d0ca08e95f46520dbeeaf60830f/190_59_4903_2942/master/4903.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=0b34ed7796974c960ef8cd64c0f44eae",
      "ageWarning": "7 months",
      "isLiveBlog": false
    },
    {
      "url": "/society/2017/apr/07/uk-eats-almost-four-times-more-packaged-food-than-fresh",
      "linkText": "UK eats almost four times more packaged food than fresh",
      "showByline": false,
      "byline": "Sarah Boseley Health editor",
      "image": "//i.guim.co.uk/img/media/824955227d1b9261c163bb05fa908020e2d5dd12/193_387_4907_2945/master/4907.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=4e620dd45e857a301de4682065e3c8db",
      "ageWarning": "1 year",
      "isLiveBlog": false
    },
    {
      "url": "/science/2017/mar/28/worlds-largest-dinosaur-footprints-discovered-in-western-australia",
      "linkText": "World's largest dinosaur footprints discovered in Western Australia",
      "showByline": false,
      "byline": "Hannah Devlin and agencies",
      "image": "//i.guim.co.uk/img/media/f55a79570bf0dc99cd65c64222d2e0a5de1e3210/0_75_2346_1408/master/2346.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=1bd2c37861b509f03e967a904baa6fda",
      "ageWarning": "1 year",
      "isLiveBlog": false
    },
    {
      "url": "/science/2016/apr/14/worlds-largest-medical-imaging-study-will-scan-100000-britons",
      "linkText": "World's largest medical imaging study will scan 100,000 Britons",
      "showByline": false,
      "byline": "Ian Sample Science editor",
      "image": "//i.guim.co.uk/img/media/d524a937062d9d9fc344a316b5242ad9037312b1/0_0_5064_3040/5064.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=ac85e7b139be7c7f8f3618f79f07fbbe",
      "ageWarning": "1 year",
      "isLiveBlog": false
    },
    {
      "url": "/science/2013/may/03/britain-hottest-nuclear-physics-project-fair",
      "linkText": "Britain signs up to world's hottest nuclear physics project",
      "showByline": false,
      "byline": "Ian Sample, science correspondent",
      "image": "//i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2013/5/2/1367517856558/Artists-impression-of-the-010.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=2b683155b10f1665c8996346efeac451",
      "ageWarning": "4 years",
      "isLiveBlog": false
    },
    {
      "url": "/world/2010/mar/23/india-chilli-bhut-jolokia-terrorism",
      "linkText": "India deploys world's hottest chilli to fight terrorism",
      "showByline": false,
      "byline": "Stephen Bates",
      "image": "//i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2010/3/23/1269345445876/bhut-jolokia-001.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=fb29b85778b9c95d41c025f733df33c9",
      "ageWarning": "8 years",
      "isLiveBlog": false
    }
  ]
}
```
