### PR TITLE
Extend Cambridge Analytica test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -122,7 +122,7 @@ trait ABTestSwitches {
     "turn on always ask for CA stories",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 18),
+    sellByDate = new LocalDate(2018, 6, 5),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-cambridge-analytica-always-ask-final.js
@@ -11,7 +11,7 @@ export const acquisitionsEpicCambridgeAnalyticaAlwaysAskFinal: EpicABTest = make
         campaignId: abTestName,
 
         start: '2018-03-20',
-        expiry: '2018-04-10',
+        expiry: '2018-06-05',
 
         author: 'Jonathan Rankin',
         description: 'Always ask on Cambridge analytica stories',


### PR DESCRIPTION
Stories are still being published in this series (e.g. https://www.theguardian.com/news/2018/apr/10/cambridge-analytica-and-facebook-face-class-action-lawsuit)