### PR TITLE
Extend leeway for reauthentication server time discrepancies

### DIFF
--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -4,8 +4,9 @@ import idapiclient.{Auth, ScGuRp, ScGuU}
 import com.gu.identity.model.User
 import conf.FrontendIdentityCookieDecoder
 import play.api.mvc.{Cookie, RequestHeader, Results}
+
 import scala.language.implicitConversions
-import org.joda.time.Minutes
+import org.joda.time.Hours
 
 object AuthenticatedUser {
   implicit def authUserToUser(authUser: AuthenticatedUser): User = authUser.user
@@ -50,6 +51,6 @@ class AuthenticationService(
       cookieDecoder.userHasRecentScGuLaCookie(
         user,
         scGuLa.value,
-        Minutes.minutes(20).toStandardDuration))
+        Hours.hours(1).toStandardDuration))
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.135"
+  val identityLibVersion = "3.136"
   val awsVersion = "1.11.240"
   val capiVersion = "11.51"
   val faciaVersion = "2.5.4"


### PR DESCRIPTION
## What does this change?
Due to server timing issues there is a leeway built into the check from the identity library for "recent authentication".  We have extended this leeway because 1 minute wasn't enough.

I've also extended the length of "recent authentication" to be 1 hour anyway.  I don't think this impacts security, but certainly will avoid many reauth prompts for users.  As this is currently based on when they signed in and not when they were last active I think 20 minutes was too short.

## What is the value of this and can you measure success?
Less reauthentication looping (hopefully none!)
Less reauthentications more generally

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
