### PR TITLE
Upgrade babel loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babel-jest": "^22.2.0",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.4",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,9 +782,9 @@ babel-jest@^22.2.2:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.2.0"
 
-babel-loader@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
+babel-loader@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.4.tgz#e3463938bd4e6d55d1c174c5485d406a188ed015"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"


### PR DESCRIPTION
## What does this change?

The currently installed version of `babel-loader` does not (officially) support Webpack 4. This doesn't appear to cause an issue, but `yarn` gives us the following warning:

 > warning " > babel-loader@7.1.2" has incorrect peer dependency "webpack@2 || 3".

Upgrading `babel-loader` fixes this dependency issue and the associated warning.

## What is the value of this and can you measure success?

Fewer warnings

