### PR TITLE
Support in columns for special-report tone

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-column.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-column.scss
@@ -155,6 +155,12 @@
         }
     }
 
+    &.content--pillar-special-report {
+        .content__series-label__link {
+            color: $news-garnett-highlight;
+        }
+    }
+
     // Opinion specific styling
     &.content--type-comment {
         .content__headline-column-wrapper {

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -1,4 +1,4 @@
-.content--pillar-special-report:not(.content--type-immersive):not(.content--media) {
+.content--pillar-special-report:not(.content--type-immersive):not(.content--media):not(.content--type-column) {
     background-color: #eff1f2;
 
     .content__headline--byline .tone-colour {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -206,6 +206,7 @@
 }
 
 .content__series-label {
+    display: inline;
     font-family: $f-serif-headline;
     font-size: 16px;
     line-height: 19px;


### PR DESCRIPTION
Column template wasn't fully working with special report tone. There's more to be done to column template...

# Before
<img width="1680" alt="screen shot 2018-04-16 at 15 26 53" src="https://user-images.githubusercontent.com/14570016/38814945-a8ee48a6-418a-11e8-95f2-5fa9303d7a45.png">

# After
<img width="1680" alt="screen shot 2018-04-16 at 15 06 46" src="https://user-images.githubusercontent.com/14570016/38814943-a8c00ee6-418a-11e8-8b3b-1b9ca253a82f.png">
