### PR TITLE
 Make Spacefinder play nice with the after-article and match report pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -100,7 +100,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
         bodySelector: '.js-article__body',
         slotSelector: ' > p',
         minAbove: 1000,
-        minBelow: 700,
+        minBelow: 800,
         selectors: {
             ' .ad-slot': adSlotClassSelectorSizes,
         },

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -1,6 +1,6 @@
 // @flow
 
-// total_hours_spent_maintaining_this = 70
+// total_hours_spent_maintaining_this = 72
 
 import qwery from 'qwery';
 import bean from 'bean';

--- a/static/src/stylesheets/module/content-garnett/_article.scss
+++ b/static/src/stylesheets/module/content-garnett/_article.scss
@@ -19,5 +19,4 @@
     display: block;
     content: ' ';
     margin-top: $gs-baseline*2;
-    clear: both;
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -671,6 +671,7 @@ $quote-mark: 35px;
 }
 
 // *************** Article overides *************
+.content--type-matchreport:not(.content--liveblog),
 .content--type-article:not(.content--liveblog) {
     .block-time.published-time {
         position: relative;

--- a/static/src/stylesheets/module/football/_article-embeds.scss
+++ b/static/src/stylesheets/module/football/_article-embeds.scss
@@ -6,9 +6,7 @@
         margin-bottom: $gs-baseline;
 
         @include mq(mobileLandscape) {
-            margin-left: $gs-gutter;
             margin-top: 0;
-            float: right;
             width: 100%;
         }
 

--- a/static/src/stylesheets/module/football/_stats.scss
+++ b/static/src/stylesheets/module/football/_stats.scss
@@ -286,6 +286,7 @@
 
 .after-article {
     .match-stats__container {
+        clear: left;
         position: relative;
         padding: 9px 0;
         background-color: mix($sport-garnett-main-1, #ffffff, 15%);


### PR DESCRIPTION
## What does this change?

#### 👉Bump the `minbelow` on the spacefinder rules
To accomadate the part of the submeta that exists in the padding.

#### 👉Delete the `float: right` on football tables
It used to be possible for tables to be part width and appear next to a paragraph and to do this we used to float them right (https://github.com/guardian/frontend/pull/3697). However, currently these tables all have a width of 100% therefore the `margin-left` and `float` are no longer doing anything useful.

#### 👉Remove the `clear: both` from the `after-article` and submeta
Now that football tables are not floating right, they no longer have collision issues with the match stats (https://github.com/guardian/frontend/pull/19462), therefore using `clear: both` should be unnecessary! 🎉 

This also solves an issue where floating items added by Spacefinder were pushing down the `after-article` and submeta:

![spacefinder-issue](https://user-images.githubusercontent.com/8607683/38863721-6e17ab04-4230-11e8-915f-1992dc89fccd.png)

#### 👉Bonus fix to timestamps on legacy match reports
Layout issue where `block-time.published-time` were seen overlaying the paragraph while testing the above changes:

<img width="738" alt="picture 9" src="https://user-images.githubusercontent.com/8607683/38865097-b92883e4-4234-11e8-9353-e54d9d50cc48.png">


## What is the value of this and can you measure success?

Spacefinder will correctly calculate the hight of the `js-article-body` and the secondary column. Items placed by spacefinder that offset into the secondary column do not have collision issues with the various components added to the `after-article` section (epic, match stats, etc).

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

###### after-article and DMPU before (right) and after (left) :

<img width="1640" alt="picture 17" src="https://user-images.githubusercontent.com/8607683/38866415-b580dc6a-4238-11e8-9ab7-c9987f71701c.png">

https://www.theguardian.com/football/2017/nov/01/tottenham-real-madrid-champions-league-match-report

###### No visual change to current liveblog match reports:

<img width="1669" alt="picture 14" src="https://user-images.githubusercontent.com/8607683/38864230-f2da4a58-4231-11e8-9b33-981254b45bbe.png">

https://www.theguardian.com/football/live/2017/nov/01/tottenham-hotspur-v-real-madrid-champions-league-live

###### No visual change to current match reports:

<img width="1668" alt="picture 15" src="https://user-images.githubusercontent.com/8607683/38864248-0244acc2-4232-11e8-92a6-30c271ee0b29.png">

https://www.theguardian.com/football/2018/apr/16/pep-guardiola-make-manchester-city-better-premier-league-title-champions-league

###### Legacy match reports before (right) and after (left) with fixed timestamps:

<img width="1655" alt="picture 16" src="https://user-images.githubusercontent.com/8607683/38864253-0a3c833c-4232-11e8-8232-cf75d1725373.png">

https://www.theguardian.com/football/2014/mar/25/manchester-united-manchester-city-live 

## Tested in CODE?

Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
