### PR TITLE
Exclude SMS checkbox from select all

### DIFF
--- a/identity/app/views/profile/smsConsent.scala.html
+++ b/identity/app/views/profile/smsConsent.scala.html
@@ -10,7 +10,7 @@
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 <form method="post" action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" novalidate>
     @views.html.helper.CSRF.formField
-    <div class="manage-account__switches manage-account__switches--single-column">
+    <div class="manage-account__switches manage-account__switches--single-column js-manage-account__check-allCheckbox__ignore">
         <ul>
         @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
             @if(isSmsChannel(consentField, user)) {


### PR DESCRIPTION
## What does this change?

Does not select the SMS checkbox when clicking Select All

## What is the value of this and can you measure success?

???

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

Soon

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
