### PR TITLE
login users from password reset

### DIFF
--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -4,8 +4,8 @@ import common.ImplicitControllerExecutionContext
 import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.data.{Form, Forms}
 import play.api.mvc._
-import idapiclient.IdApiClient
-import services.{AuthenticationService, IdRequestParser, IdentityUrlBuilder}
+import idapiclient.{EmailPassword, IdApiClient}
+import services._
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.data.validation._
 import play.api.data.Forms._
@@ -22,6 +22,7 @@ class ResetPasswordController(
   idRequestParser: IdRequestParser,
   idUrlBuilder: IdentityUrlBuilder,
   authenticationService: AuthenticationService,
+  signInService : PlaySigninService,
   val controllerComponents: ControllerComponents,
   val httpConfiguration: HttpConfiguration
 )(implicit context: ApplicationContext)
@@ -111,10 +112,10 @@ class ResetPasswordController(
                   .flashing(formWithError.toFlash)
               )
             }
-
-          case Right(ok) =>
-            val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
+          case Right(cookieResponse) =>
+            logger.trace("Logging user in from reset password")
             NoCache(SeeOther(routes.ResetPasswordController.renderPasswordResetConfirmation.url))
+              .withCookies(signInService.getCookies(cookieResponse, true):_*)
         }
     }
 

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -119,11 +119,11 @@ class IdApiClient(
     response map extractUser
   }
 
-  def resetPassword( token : String, newPassword : String ): Future[Response[Unit]] = {
+  def resetPassword( token : String, newPassword : String ): Future[Response[CookiesResponse]] = {
     val apiPath = urlJoin("pwd-reset", "reset-pwd-for-user")
     val postBody = write(TokenPassword(token, newPassword))
     val response = httpClient.POST(apiUrl(apiPath), Some(postBody), clientAuth.parameters, clientAuth.headers)
-    response map extractUnit
+    response map extract(jsonField("cookies"))
   }
 
   def sendPasswordResetEmail(emailAddress : String, trackingParameters: TrackingData): Future[Response[Unit]] = {

--- a/identity/app/services/PlaySigninService.scala
+++ b/identity/app/services/PlaySigninService.scala
@@ -24,4 +24,13 @@ class PlaySigninService(conf: IdentityConfiguration) extends SafeLogging {
       }
     }
   }
+
+  def getCookies(apiCookies: CookiesResponse, rememberMe: Boolean)(implicit executionContext: ExecutionContext): List[Cookie] = {
+    val maxAge = if (rememberMe) Some(Seconds.secondsBetween(DateTime.now, apiCookies.expiresAt).getSeconds) else None
+    apiCookies.values.map { cookie =>
+      val secureHttpOnly = cookie.key.startsWith("SC_")
+      val cookieMaxAgeOpt = maxAge.filterNot(_ => cookie.isSessionCookie)
+      Cookie(cookie.key, cookie.value, cookieMaxAgeOpt, "/", Some(conf.domain), secureHttpOnly, secureHttpOnly)
+    }
+  }
 }

--- a/identity/app/services/PlaySigninService.scala
+++ b/identity/app/services/PlaySigninService.scala
@@ -24,13 +24,4 @@ class PlaySigninService(conf: IdentityConfiguration) extends SafeLogging {
       }
     }
   }
-
-  def getCookies(apiCookies: CookiesResponse, rememberMe: Boolean)(implicit executionContext: ExecutionContext): List[Cookie] = {
-    val maxAge = if (rememberMe) Some(Seconds.secondsBetween(DateTime.now, apiCookies.expiresAt).getSeconds) else None
-    apiCookies.values.map { cookie =>
-      val secureHttpOnly = cookie.key.startsWith("SC_")
-      val cookieMaxAgeOpt = maxAge.filterNot(_ => cookie.isSessionCookie)
-      Cookie(cookie.key, cookie.value, cookieMaxAgeOpt, "/", Some(conf.domain), secureHttpOnly, secureHttpOnly)
-    }
-  }
 }

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -5,9 +5,7 @@ import org.scalatest.Matchers
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Mockito._
-import idapiclient.{IdApiClient, Response, TrackingData}
-import test.{Fake, WithTestApplicationContext, WithTestExecutionContext}
-import idapiclient.{IdApiClient, TrackingData}
+import idapiclient.{IdApiClient, TrackingData, Response}
 import test.{Fake, WithTestApplicationContext, WithTestExecutionContext, WithTestIdConfig}
 import play.api.test._
 import play.api.test.Helpers._

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.Matchers
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Mockito._
+import idapiclient.{IdApiClient, Response, TrackingData}
+import test.{Fake, WithTestApplicationContext, WithTestExecutionContext}
 import idapiclient.{IdApiClient, TrackingData}
 import test.{Fake, WithTestApplicationContext, WithTestExecutionContext, WithTestIdConfig}
 import play.api.test._
@@ -52,6 +54,7 @@ class ResetPasswordControllerTest
   val userNotFound = List(Error("Not found", "Resource not found", 404))
   val tokenExpired = List(Error("Token expired", "The password reset token is longer valid"))
   val accesssDenied = List(Error("Access Denied", "Access Denied"))
+  val cookieList = List(mock[Cookie])
 
   val user = mock[User]
   when(user.primaryEmailAddress).thenReturn("someone@test.com")
@@ -87,19 +90,22 @@ class ResetPasswordControllerTest
     val fakeRequest = FakeRequest(POST, "/reset_password" ).withFormUrlEncodedBody("password" -> "newpassword", "password-confirm" -> "newpassword", "email-address" -> "test@somewhere.com")
     "when the token provided is valid" - {
       when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Right(cookieList)))
+
       "should call the api the password with the provided new password and token" in Fake {
          resetPasswordController.resetPassword("1234")(fakeRequest)
          verify(api).resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"))
       }
       "should return password confirmation view in" in Fake {
-        when(signInService.getCookies(MockitoMatchers.any[CookiesResponse], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(List(cookie))
-         val result = resetPasswordController.resetPassword("1234")(fakeRequest)
+        val result = resetPasswordController.resetPassword("1234")(fakeRequest)
          status(result) should be (SEE_OTHER)
         header("Location", result).head should be ("/password/reset-confirmation")
       }
     }
 
     "when the reset token has expired" - {
+      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(tokenExpired)))
 
       when(api.resetPassword("1234","newpassword")).thenReturn(Future.successful(Left(tokenExpired)))
       "should redirect to request request new password with a token expired" in Fake {
@@ -110,6 +116,8 @@ class ResetPasswordControllerTest
     }
 
     "when the reset token is not valid" - {
+      when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(accesssDenied)))
+
       when(api.resetPassword("1234", "newpassword")).thenReturn(Future.successful(Left(accesssDenied)))
       "should redirect to request new password with a problem resetting your password" in Fake {
         val result = resetPasswordController.resetPassword("1234")(fakeRequest)


### PR DESCRIPTION
## What does this change?
- Logs users in after reseting password 
- Doesn't require users to sign in again after resetting password
Identity PR : https://github.com/guardian/identity/pull/1098


## What is the value of this and can you measure success?
- Less friction in login

## Does this affect other platforms - Amp, Apps, etc?
- no
## Tested in CODE?
- no
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
