### PR TITLE
Bump identity client lib to get new optout titles

### DIFF
--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -1,10 +1,18 @@
 @import com.gu.identity.model.Consent
+@import com.gu.identity.model.ConsentWording
 @import _root_.form.IdFormHelpers.nonInputFields
 @import views.support.fragment.Switch._
 
 @* Product consent switch/checkbox *@
 
-@(consentField: Field, highlighted: Boolean = false, skin: Option[String] = None, boldTitle: Boolean = true)(messages: play.api.i18n.Messages)
+@(
+    consentField: Field,
+    highlighted: Boolean = false,
+    skin: Option[String] = None,
+    boldTitle: Boolean = true,
+    titleProvider: ConsentWording => String = w => w.wording,
+    descriptionProvider: ConsentWording => Option[String] = w => w.description
+)(messages: play.api.i18n.Messages)
 
 @getConsentText(consentField: Field) = @{
     Consent.wording(
@@ -19,9 +27,9 @@
 }
 
 @fragments.form.switch(
-    title = getConsentText(consentField).wording,
+    title = titleProvider(getConsentText(consentField)),
     subheading = None,
-    description = getConsentText(consentField).description,
+    description = descriptionProvider(getConsentText(consentField)),
     behaviour = ConsentSwitch,
     field = consentField("consented"),
     extraFields = consentHiddenFormFields,

--- a/identity/app/views/profile/nonElectronicOptOut.scala.html
+++ b/identity/app/views/profile/nonElectronicOptOut.scala.html
@@ -19,7 +19,12 @@
             @helper.repeatWithIndex(privacyForm("consents"), min=1){ (consentField, index) =>
                 @if(isOptOutChannel(consentField, user)) {
                     <li>
-                        @fragments.consentSwitch(consentField, boldTitle = false)(messages)
+                        @fragments.consentSwitch(
+                            consentField,
+                            boldTitle = false,
+                            titleProvider = wording => wording.description.getOrElse(""),
+                            descriptionProvider = _ => None
+                        )(messages)
                     </li>
                 }
             }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.140"
+  val identityLibVersion = "3.141"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.139"
+  val identityLibVersion = "3.140"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"


### PR DESCRIPTION
## What does this change?

- `phone_optout` and `post_optout` now have titles (for use by the consent mailer), so when we render those consents we should just render the description (as if it was the title). 

## What is the value of this and can you measure success?

- We will use the latest library for identity-model. 
 

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No, is identical to previous. 

## Tested in CODE?

No, locally. 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
