### PR TITLE
Fix gallery caption claner.

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -34,7 +34,9 @@ object GalleryCaptionCleaners {
     val cleaners = List(
       GalleryCaptionCleaner,
       AffiliateLinksCleaner(request.uri, page.gallery.content.metadata.sectionId, page.gallery.content.fields.showAffiliateLinks, "gallery", appendDisclaimer = rowNum == 1))
-    withJsoup(caption)(cleaners: _*)
+
+    val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(caption)) { case (html, cleaner) => cleaner.clean(html) }
+    Html(cleanedHtml.toString)
   }
 
 }


### PR DESCRIPTION
The [`withJsoup`](https://github.com/guardian/frontend/blob/master/common/app/views/support/package.scala#L91) function expects the passed html to have a body property, which a caption doesn't.