### PR TITLE
Style content--type-recipe properly

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -12,6 +12,7 @@ $quote-mark: 35px;
 .content--type-article,
 .content--type-comment,
 .content--type-feature,
+.content--type-recipe,
 .content--type-guardianview,
 .content--type-immersive:not(.content--minute-article),
 .content--type-interview,


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/frontend/pull/19526 introduced some new content types - see [Alex's change](https://github.com/guardian/content-api-scala-client/commit/6366a7e7a04cf8f255937f35dc1d1a4f88c29449). This results in recipes, which have the `tone/recipe` tag getting the `Recipe` designType, which results in the [articleBodyGarnett](https://github.com/guardian/frontend/blob/master/article/app/views/fragments/articleBodyGarnett.scala.html) template adding the content--type-recipe class to the content, which appears not to have any styling associated with it at the moment.

## What is the value of this and can you measure success?
Fixes purple share buttons identified by Zef, and some other non-garnett styling


## Screenshots

## Tested in CODE?
Yes!
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
