### PR TITLE
Removed share modal from lightbox

### DIFF
--- a/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
+++ b/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
@@ -9,7 +9,7 @@
            href="https://www.facebook.com/dialog/share?app_id=180444840287&href=@{page.encodedUrl}&redirect_uri=@{page.encodedUrl}&quote=@{page.facebookText}"
            target="_blank"
            title="facebook">
-            <span class='inline-icon__fallback button share-modal__item share-modal__item--facebook'>Share on Facebook</span>
+            <span class='inline-icon__fallback button'>Share on Facebook</span>
             @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon centered-icon social-icon social-icon--facebook"))
         </a>
     </li>
@@ -19,7 +19,7 @@
            href="https://twitter.com/intent/tweet?text=@{URLEncoder.encode(page.twitterText, "utf-8")}&url=@{page.encodedUrl}"
            target="_blank"
            title="twitter">
-            <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Twitter</span>
+            <span class='inline-icon__fallback button'>Share on Twitter</span>
             @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon centered-icon social-icon social-icon--twitter"))
         </a>
     </li>
@@ -29,7 +29,7 @@
            href="mailto:?subject=@{page.emailSubjectText}&body=@{page.emailBodyText}"
            target="_blank"
            title="email">
-            <span class='inline-icon__fallback button share-modal__item share-modal__item--email'>Share via email</span>
+            <span class='inline-icon__fallback button'>Share via email</span>
             @fragments.inlineSvg("share-email", "icon", List("rounded-icon centered-icon social-icon social-icon--email"))
         </a>
     </li>
@@ -39,7 +39,7 @@
            href="https://www.pinterest.com/pin/find/?url=@{page.encodedUrl}"
            target="_blank"
            title="pinterest">
-            <span class='inline-icon__fallback button share-modal__item share-modal__item--pinterest'>Share on Pinterest</span>
+            <span class='inline-icon__fallback button'>Share on Pinterest</span>
             @fragments.inlineSvg("share-pinterest", "icon", List("rounded-icon centered-icon social-icon social-icon--pinterest"))
         </a>
     </li>

--- a/common/app/views/fragments/share/blockLevelSharing.scala.html
+++ b/common/app/views/fragments/share/blockLevelSharing.scala.html
@@ -1,7 +1,7 @@
 @import model.DotcomContentType
 @(id: String, shareItems: Seq[model.ShareLink], contentType: DotcomContentType, isNewGallery: Boolean = false, amp: Boolean = false)
 
-<div class="block-share block-share--@contentType.name.toLowerCase @if(!isNewGallery) { hide-on-mobile }" data-link-name="block share">
+<div class="block-share block-share--@contentType.name.toLowerCase" data-link-name="block share">
     @shareItems.map { item: model.ShareLink =>
         <a class="rounded-icon block-share__item block-share__item--@item.css js-blockshare-link" href="@item.href" target="_blank" data-link-name="social @item.css">
             @fragments.inlineSvg("share-" + item.css, "icon")
@@ -9,29 +9,3 @@
         </a>
     }
 </div>
-
-@if(contentType != DotcomContentType.Article && !isNewGallery && !amp) {
-    <div class="block-share--@contentType.name.toLowerCase-mobile" data-open-overlay-on-click="share-modal-@id" data-link-name="open mobile block share">
-        <button class="block-share__item--mobile button button--small @if(contentType == model.DotcomContentType.Gallery){button--tone-media-variant} else {button--tertiary} mobile-only">
-            Share
-        </button>
-    </div>
-
-    <div id="share-modal-@id" class="overlay overlay--@contentType.name.toLowerCase share-modal js-share-modal">
-        <div class="share-modal__content" data-link-name="mobile block share">
-            <div class="share-modal__title">Share this post</div>
-            @shareItems.map { item: model.ShareLink =>
-                <a class="share-modal__link" href="@item.href" target="_blank" data-link-name="social @item.css">
-                    <div class="share-modal__item button button--xlarge button--tertiary share-modal__item--@item.css">
-                        @fragments.inlineSvg("share-" + item.css, "icon")
-                        @item.text
-                    </div>
-                </a>
-            }
-            <button class="share-modal__close js-overlay-close" data-link-name="close">
-                <i class="i i-close-icon-dark-small"></i>
-                <span class="u-h">close</span>
-            </button>
-        </div>
-    </div>
-}

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -22,7 +22,7 @@
         href="@item.href"
         target="_blank"
         title="@item.text">
-            <span class='@if(item.css.matches("facebook|twitter|email")) {inline-icon__fallback button share-modal__item share-modal__item--@item.css} else { u-h }'>@item.userMessage</span>
+            <span class='@if(item.css.matches("facebook|twitter|email")) {inline-icon__fallback button} else { u-h }'>@item.userMessage</span>
             @fragments.inlineSvg("share-" + item.css, "icon", List("rounded-icon", "centered-icon", "social-icon", "social-icon--" + item.css) ++ iconModifier)
         </a>
     </li>

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -16,7 +16,6 @@ import buttonTpl from 'raw-loader!common/views/content/button.html';
 import endslateTpl from 'raw-loader!common/views/content/endslate.html';
 import loaderTpl from 'raw-loader!common/views/content/loader.html';
 import shareButtonTpl from 'raw-loader!common/views/content/share-button.html';
-import shareButtonMobileTpl from 'raw-loader!common/views/content/share-button-mobile.html';
 import throttle from 'lodash/functions/throttle';
 import { loadCssPromise } from 'lib/load-css-promise';
 
@@ -213,9 +212,6 @@ class GalleryLightbox {
             blockShortUrl,
             shareButtons: shareItems
                 .map(s => template(shareButtonTpl, s))
-                .join(''),
-            shareButtonsMobile: shareItems
-                .map(s => template(shareButtonMobileTpl, s))
                 .join(''),
         });
     }

--- a/static/src/javascripts/projects/common/views/content/block-sharing.html
+++ b/static/src/javascripts/projects/common/views/content/block-sharing.html
@@ -8,20 +8,7 @@
             </div>
         <div class="<%=articleType%>-lightbox__img-caption"><%=caption%></div>
         <div class="<%=articleType%>-lightbox__img-credit"><%=credit%></div>
-        <div class="block-share block-share--<%=articleType%> hide-on-mobile" data-link-name="block share">
+        <div class="block-share block-share--<%=articleType%>" data-link-name="block share">
             <%=shareButtons%>
         </div>
-        <div class="block-share--<%=articleType%>-mobile" data-open-overlay-on-click="share-modal-<%=index%>" data-link-name="open mobile block share">
-            <button class="block-share__item--mobile button button--small button--tone-media-variant mobile-only">
-                Share
-            </button>
-        </div>
-    </div>
-    <div id="share-modal-<%=index%>" class="overlay share-modal overlay--<%=articleType%> js-share-modal">
-        <div class="share-modal__content" data-link-name="mobile block share">
-            <div class="share-modal__title">Share this post</div>
-            <%=shareButtonsMobile%>
-            <button class="share-modal__close js-overlay-close" data-link-name="close"><i class="i i-close-icon-dark-small"></i><span class="u-h">close</span></button>
-        </div>
-    </div>
 </li>

--- a/static/src/javascripts/projects/common/views/content/share-button-mobile.html
+++ b/static/src/javascripts/projects/common/views/content/share-button-mobile.html
@@ -1,6 +1,0 @@
-<a class="share-modal__link" href="<%=url%>" target="_blank" data-link-name="social <%=css%>">
-    <div class="share-modal__item button button--xlarge share-modal__item--<%=css%>">
-        <%= icon %>
-        <%=text%>
-    </div>
-</a>

--- a/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
@@ -99,132 +99,11 @@
     }
 }
 
-
-.share-modal__item--facebook {
-    background-color: $social-facebook;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-facebook, 15%);
-    }
-}
-
-.share-modal__item--twitter {
-    background-color: $social-twitter;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-twitter, 15%);
-    }
-}
-
-.share-modal__item--gplus {
-    background-color: $social-gplus;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-gplus, 15%);
-    }
-}
-
-.share-modal__item--pinterest {
-    background-color: $social-pinterest;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-pinterest, 15%);
-    }
-}
-
-.share-modal__item--email {
-    background-color: $social-email;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-email, 15%);
-    }
-}
-
 .block-share--liveblog-mobile {
     margin-left: $gs-gutter / 2;
     margin-top: $gs-baseline / 2;
     cursor: pointer;
     clear: both;
-}
-
-.share-modal {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-color: $neutral-8;
-}
-
-.share-modal__content {
-    @extend %absolute-center;
-    height: gs-height(8);
-}
-
-.share-modal__title {
-    @include fs-textSans(3);
-    color: $neutral-2;
-    text-align: center;
-    margin-bottom: $gs-baseline * 3;
-    font-weight: bold;
-}
-
-.share-modal__item {
-    width: gs-span(3);
-    margin: auto;
-    display: block;
-    text-align: center;
-    position: relative;
-    border: 0;
-
-    &.inline-icon__fallback {
-        width: 150px;
-        position: relative;
-    }
-
-    .inline-icon {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        margin: auto 0;
-        left: 5px;
-        svg {
-            width: 33px;
-            height: 33px;
-            vertical-align: middle;
-        }
-    }
-}
-
-.share-modal__close {
-    @include circular;
-    border: 1px solid $neutral-2;
-    width: 40px;
-    height: 40px;
-    padding: 0;
-    position: absolute;
-    left: 0;
-    right: 0;
-    margin: gs-height(1) + $gs-baseline auto 0;
-    background: transparent;
-    box-sizing: border-box;
-
-    .i {
-        @extend %absolute-center;
-        width: 85%;
-        height: 85%;
-        opacity: .6;
-    }
-}
-
-.share-modal__link + .share-modal__link {
-    display: block;
-    margin-top: $gs-baseline;
 }
 
 // Live blogs
@@ -279,16 +158,6 @@
     cursor: pointer;
     opacity: .8;
     margin-top: $gs-baseline / 2;
-}
-
-.overlay--gallery {
-    background-color: $neutral-1;
-    .share-modal__title {
-        color: #ffffff;
-    }
-    .share-modal__close .i {
-        @include icon(close-icon-white-small);
-    }
 }
 
 // Inline embeds


### PR DESCRIPTION
This is the first in a series of PRs waging war on our share buttons. The first victim is the share modal. This is just to improve the functionality, I will be looking at styling seperately.

Please let me know if there's something I've missed out, that could also be deleted (with regards to modal functionality).

## What does this change?
No more share modal. 

## What is the value of this and can you measure success?
It's currently broken, so users will get a consistent experience now, and actually be able to share images from lightboxes again.

## Does this affect other platforms - Amp, Apps, etc?
Nope.

## Screenshots
# Before
<img width="359" alt="screen shot 2018-04-19 at 10 59 56" src="https://user-images.githubusercontent.com/14570016/38985460-50559fc6-43c1-11e8-8c84-d7db59f60e40.png">

# This is what loads behind the lightbox
<img width="359" alt="screen shot 2018-04-19 at 11 00 05" src="https://user-images.githubusercontent.com/14570016/38985461-5067cb92-43c1-11e8-8643-50c48bf7d0d3.png">

# And now it will behave the same regardless of breakpoint
<img width="357" alt="screen shot 2018-04-19 at 11 00 34" src="https://user-images.githubusercontent.com/14570016/38985462-507b5568-43c1-11e8-8552-6394f07753dd.png">
