### PR TITLE
[/consents] Only show the confirm alert for non rp'd users

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -221,7 +221,12 @@
 }
 
 @displayJourney = {
-    <div class="identity-consent-journey @{skin.map(s => s"identity-consent-journey--$s" )} u-h" data-journey="@journey" data-component="identity-consent-journey-@journey">
+    <div class="
+        identity-consent-journey
+        @{if (!user.statusFields.hasRepermissioned.getOrElse(false)){"identity-consent-journey--with-alert"}}
+        @{skin.map(s => s"identity-consent-journey--$s" )}
+        u-h
+    " data-journey="@journey" data-component="identity-consent-journey-@journey">
         @renderBlocks(
             journey match {
                 case NewsletterConsentsJourney => {

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -121,6 +121,20 @@ import scala.concurrent.Future
         contentAsString(result) should include ("older than 13 years")
       }
 
+      "show an alert modal for non rp'd users" in new ConsentsJourneyFixture {
+        user.statusFields.setHasRepermissioned(false)
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should include ("identity-consent-journey--with-alert")
+      }
+
+      "not show an alert modal for rp'd users" in new ConsentsJourneyFixture {
+        user.statusFields.setHasRepermissioned(true)
+        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
+        status(result) should be(200)
+        contentAsString(result) should not include ("identity-consent-journey--with-alert")
+      }
+
       "set a repermission flag on submit" in new ConsentsJourneyFixture {
         user.statusFields.setHasRepermissioned(false)
 

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -173,7 +173,7 @@ const setLocalHasVisitedConsentsFlag = (): void => {
 const enhanceConsentJourney = (): void => {
     const loaders = [
         ['.identity-consent-journey', showJourney],
-        ['.identity-consent-journey', showJourneyAlert],
+        ['.identity-consent-journey--with-alert', showJourneyAlert],
         ['.identity-consent-journey', setLocalHasVisitedConsentsFlag],
         ['.js-identity-consent-journey-continue', submitJourneyAnyway],
         ['#identityConsentsLoadingError', hideLoading],


### PR DESCRIPTION
Shows the confirm dialog only for non-repermissioned users.

![screen shot 2018-04-19 at 12 10 27 pm](https://user-images.githubusercontent.com/11539094/38988310-a986dfac-43ca-11e8-9c24-564045f29429.png)
