### PR TITLE
Excluded special-report from standfirst colour

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -152,7 +152,7 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__standfirst {
+    &.fc-item--standard-tablet.fc-item--type-immersive:not(.fc-item--pillar-special-report) .fc-item__standfirst {
         color: $garnett-neutral-1;
     }
 


### PR DESCRIPTION
Excluding special report prevents this from happening:

![unnamed](https://user-images.githubusercontent.com/14570016/39048973-5409f96a-4497-11e8-80ed-7a7e95b43894.png)
