### PR TITLE
Switch to show the gdpr opt-in alert to more users

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -25,4 +25,14 @@ trait IdentitySwitches {
     exposeClientSide = true
   )
 
+  val IdentityShowOptInEngagementBannerMore = Switch(
+    SwitchGroup.Identity,
+    "id-show-opt-in-engagement-banner-more",
+    "If switched on, all users will see UI to opt in to GDPR-compliant marketing",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 6, 25), // GDPR goes into effect + 1 month
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -4,14 +4,12 @@ import conf.switches.{Owner, SwitchGroup}
 import experiments.ParticipationGroups._
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
-import conf.switches.Switches.IdentityShowOptInEngagementBanner
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     CommercialClientLogging,
     CommercialAdRefresh,
     OrielParticipation,
-    GdprOptinAlert,
     LotameParticipation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -40,16 +38,6 @@ object OrielParticipation extends Experiment(
   sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1C
 )
-
-object GdprOptinAlert extends Experiment(
-  name = "gdpr-optin-alert",
-  description = "Audience who will see the Stay with us alert",
-  owners = Seq(Owner.withGithub("walaura")),
-  sellByDate = new LocalDate(2018, 6, 25), // GDPR goes into effect + 1 month
-  participationGroup = Perc0E
-) {
-  override def isParticipating[A](implicit request: RequestHeader, canCheck: CanCheckExperiment): Boolean = super.isParticipating || IdentityShowOptInEngagementBanner.isSwitchedOn
-}
 
 object LotameParticipation extends Experiment(
   name = "lotame-participation",

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
@@ -28,7 +28,7 @@ const makeTemplateHtml = (template: Template, targets: LinkTargets): string => `
                     ${template.title}
                 </div>
                 <div class="identity-gdpr-oi-alert__cta-space">
-                    <a data-link-name="gdpr-oi-campaign : alert : remind-me-later" class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
+                    <a href="#" data-link-name="gdpr-oi-campaign : alert : remind-me-later" class="identity-gdpr-oi-alert__cta identity-gdpr-oi-alert__cta--sub ${
                         template.messageCloseBtn
                     }">
                         ${template.remindMeLater}

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -59,7 +59,7 @@ const shouldDisplayBasedOnLocalHasVisitedConsentsFlag = (): boolean =>
     getCookie(HAS_VISITED_CONSENTS_COOKIE_KEY) !== 'true';
 
 const shouldDisplayBasedOnExperimentFlag = (): boolean =>
-    config.get('tests.gdprOptinAlertVariant') === 'variant';
+    config.get('switches.idShowOptInEngagementBanner');
 
 const shouldDisplayBasedOnMedium = (): boolean => userVisitedViaNewsletter();
 

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -49,7 +49,9 @@ const template: Template = {
         targets.landing
     }">Find out more</a> or click Continue.`,
     cta: `Continue`,
-    remindMeLater: shouldDisplayForMoreUsers() ? `Dismiss` : `Remind me later`,
+    remindMeLater: shouldDisplayForMoreUsers()
+        ? `No, thanks`
+        : `Remind me later`,
     messageCloseBtn,
 };
 

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1050,7 +1050,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 }
 
 .identity-gdpr-oi-alert__body {
-    margin: $gs-gutter / 4 $gs-gutter $gs-gutter / 1.25 $gs-gutter;
+    margin: $gs-gutter / 4 $gs-gutter $gs-gutter / 1.25 $gs-gutter * 2;
     max-width: gs-span(6);
     .identity-gdpr-oi-alert__cta-space {
         margin-left: -.1em;
@@ -1058,6 +1058,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     }
     @include mq($until: tablet) {
         flex: 1 1 0;
+        margin-left: $gs-gutter;
+    }
+    @include mq($until: mobile) {
+        margin-left: $gs-gutter / 2;
         .identity-gdpr-oi-alert__cta-space {
             margin-left: $gs-gutter * -.9;
         }
@@ -1079,13 +1083,11 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     margin-top: $gs-gutter / 4;
     overflow: hidden;
     position: relative;
-    width: 70px;
+    width: 30%;
+    max-width: 140px;
     min-height: 100px;
     > img {
         width: 100%;
-    }
-    @include mq(tablet) {
-        width: 140px;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Adds a switch that will make the gdpr opt in alert behave differently:

- ​B​e showable on any pageview (previously it was only shown when referred by an editorial or marketing email);
- ​N​ever show if another banner is trying to show
- ​N​ever show to signed-in users who have already re-permissioned
- ​P​er browser never show...
  - more than once per day
  - If it has ever been dismissed
  - If there has ever been a visit to the re-permissioning page (eg from a magic link) since 5 march  

It also now points it to `/email-prefs` which will capture existing users and new users 9who'll get redirected to the proper journey)

it also looks a bit better across all breakpoints (no brand hanges just the logo/text proportion is more balanced)

## What is the value of this and can you measure success?
Acquire more marketing consents

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2018-04-23 at 12 45 54 pm](https://user-images.githubusercontent.com/11539094/39124894-010049e4-46f5-11e8-84d1-ef33999b641f.png)

## Tested in CODE?
yes! 😋