### PR TITLE
Add utm tags to identity redirects

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -28,7 +28,7 @@ class AuthenticatedActions(
     val returnUrl = identityUrlBuilder.buildUrl(request.uri)
 
     val params = List("returnUrl" -> returnUrl) ++
-      List("INTCMP", "email") //only forward these if they exist in original query string
+      List("INTCMP", "email", "CMP", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content") //only forward these if they exist in original query string
         .flatMap(name => request.getQueryString(name).map(value => name -> value))
 
     val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, params)


### PR DESCRIPTION
## What does this change?
Keep utm tags across redirects in identity. This was already being done albeit in a more limited fashion.

Needed for #19546