### PR TITLE
Extend spacefinder-simplify test expiry into next week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Alters the rules for inserting ads on desktop breakpoints.",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 4, 24),
+    sellByDate = new LocalDate(2018, 4, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-simplify.js
@@ -4,7 +4,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 export const spacefinderSimplify: ABTest = {
     id: 'SpacefinderSimplify',
     start: '2018-04-10',
-    expiry: '2018-04-24',
+    expiry: '2018-04-30',
     author: 'Jon Norman',
     description:
         'This test alters the rules for inserting ads on desktop breakpoints.',


### PR DESCRIPTION
## What does this change?

extends the spacefinder test until next week (mostly so it does not break the build tomorrow while almost everyone is at hackday). If we have enough data to stop the test then we can always turn the switch off - this just gives us a bit of breathing space to delete the code.

## What is the value of this and can you measure success?

Working build

## Does this affect other platforms - Amp, Apps, etc?

Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
