### PR TITLE
Don't read adverts to screen readers.

### DIFF
--- a/article/app/views/fragments/articleAsideSlot.scala.html
+++ b/article/app/views/fragments/articleAsideSlot.scala.html
@@ -8,7 +8,7 @@
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn && shouldShowAds) {
-  <div class="ad-slot-container">
+  <div class="ad-slot-container" aria-hidden="true">
   @fragments.commercial.adSlot(
       "right",
       Seq("mpu-banner-ad"),

--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -23,6 +23,7 @@
     @sizeMapping.map { case(breakpoint, sizes) =>
         data-@breakpoint="@sizes.mkString("|")"
     }
+    aria-hidden="true"
     >@placeholderContent
 
 </div>

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -121,6 +121,7 @@ const createAdSlotElements = (
     adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
     adSlot.setAttribute('data-link-name', `ad slot ${name}`);
     adSlot.setAttribute('data-name', name);
+    adSlot.setAttribute('aria-hidden', 'true');
     Object.keys(attrs).forEach(attr => {
         adSlot.setAttribute(attr, attrs[attr]);
     });
@@ -136,6 +137,7 @@ const createAdSlotElements = (
         blockthroughAdSlot.className = 'bt-uid-tg';
         blockthroughAdSlot.setAttribute('uid', blockthroughUid);
         blockthroughAdSlot.setAttribute('style', 'display: none !important');
+        blockthroughAdSlot.setAttribute('aria-hidden', 'true');
 
         adSlots.push(blockthroughAdSlot);
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -8,6 +8,7 @@ const imHtml = `
     class="js-ad-slot ad-slot ad-slot--im"
     data-link-name="ad slot im"
     data-name="im"
+    aria-hidden="true"
     data-mobile="1,1|2,2|88,85|fluid"
     data-label="false"
     data-refresh="false"></div>
@@ -18,13 +19,14 @@ const inline1Html = `
     class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline1"
     data-link-name="ad slot inline1"
     data-name="inline1"
+    aria-hidden="true"
     data-mobile="1,1|2,2|300,250|fluid"
     data-desktop="1,1|2,2|300,250|620,1|620,350|fluid">
 </div>
 `;
 
 const inline1BlockthroughHtml = `
-<span class="bt-uid-tg" uid="5a98587091-157" style="display: none !important"></span>
+<span class="bt-uid-tg" uid="5a98587091-157" style="display: none !important" aria-hidden="true"></span>
 `;
 
 jest.mock('lib/config', () => ({ page: { edition: 'UK' } }));

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
@@ -12,7 +12,7 @@ const outbrainUrl = '//widgets.outbrain.com/outbrain.js';
 const outbrainTpl = ({ widgetCode }: { widgetCode: string }): string => `
     <div class="OUTBRAIN" data-widget-id="${
         widgetCode
-    }" data-ob-template="guardian"></div>
+    }" data-ob-template="guardian" aria-hidden="true"></div>
     `;
 
 const selectors = {


### PR DESCRIPTION
## What does this change?
Liberally sprinkles `aria-hidden="true"` on top of adverts and outbrain, as they present a poor experience to screen reader users. 

## What is the value of this and can you measure success?
This improves UX for screen reader users. 

## Does this affect other platforms - Amp, Apps, etc?
No. 

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots
My screen recorder tool doesn't work with voiceover. 

## Tested in CODE?
yup. (post hack day presentation)
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
