### PR TITLE
Betterer meta

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -39,15 +39,6 @@ category: Common
 ```
 */
 
-.meta__social {
-    min-height: 45px; // Height of social + padding + 1px border to ensure layout is kept when opening overlay
-}
-
-.social:not(.social--bottom) {
-    overflow-y: hidden;
-    height: 32px;
-}
-
 .social__item {
     float: left;
     min-width: 32px;
@@ -70,22 +61,6 @@ category: Common
 .social__action {
     display: inline-block;
 }
-
-.social__saveforlater {
-    display: none;
-}
-
-.content--article,
-.content--liveblog,
-.content--gallery,
-.content--media,
-.content--image,
-.content--interactive {
-    .social--top {
-        padding-top: $gs-baseline / 2;
-        padding-bottom: $gs-baseline / 2;
-    }
- }
 
 /**
  * Social icons

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -158,64 +158,6 @@ category: Common
     padding: ($gs-baseline/3*2) ($gs-gutter/10) 0 ($gs-gutter/2);
 }
 
-.social--referred-only {
-    &.social--bottom .social__item {
-        display: none;
-    }
-
-    &.social--top .social__item--referred,
-    &.social--bottom .social__item--referred {
-        display: list-item;
-    }
-}
-
-.social__item--referred {
-    @include mq($until: desktop) {
-        margin-right: $gs-baseline / 3;
-    }
-
-    .social-icon:after {
-        @include fs-textSans(1);
-        margin-right: $gs-baseline;
-        margin-left: $gs-baseline * -1/2;
-
-        .svg & i {
-            width: none;
-        }
-    }
-
-    .social-icon:after {
-        @include fs-textSans(1);
-        margin-right: $gs-baseline;
-        margin-left: $gs-baseline * -1/2;
-
-        .svg & i {
-            width: none;
-        }
-    }
-
-    .svg & .social-icon i {
-        width: 32px;
-    }
-
-    &.social__item--facebook .social-icon:after {
-        content: 'Share on Facebook';
-    }
-
-    &.social__item--twitter .social-icon:after {
-        content: 'Share on Twitter';
-    }
-
-    &.social__item--facebook .social-icon:after,
-    &.social__item--twitter .social-icon:after {
-        @include mq(leftCol, $until: wide) {
-            & {
-                content: 'share';
-            }
-        }
-    }
-}
-
 // Pintrest is inappropriate in certain sections
 
 .social__item--pinterest {

--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -12,6 +12,14 @@
 }
 
 .meta__numbers {
+    @include mq($from: leftCol, $until: wide) {
+        .content:not(.content--liveblog):not(.content--gallery) .meta__extras:not(.meta__extras--crossword) & {
+            border-top: 1px solid $garnett-neutral-4;
+            margin-top: -1px;
+            flex-grow: 1;
+        }
+    }
+
     .commentcount2 {
         display: block;
     }

--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -13,7 +13,8 @@
 
 .meta__numbers {
     @include mq($from: leftCol, $until: wide) {
-        .content:not(.content--liveblog):not(.content--gallery) .meta__extras:not(.meta__extras--crossword) & {
+        // Excude templates that have a full width meta
+        .content:not(.content--liveblog):not(.content--gallery):not(.content--interactive) .meta__extras:not(.meta__extras--crossword) & {
             border-top: 1px solid $garnett-neutral-4;
             margin-top: -1px;
             flex-grow: 1;

--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -88,35 +88,14 @@
 
 .meta__number {
     display: block;
-    height: 100%;
-    text-align: left;
+    text-align: right;
     float: left;
     min-width: 15px; // Min width is the width of the icons
-
-    @include mq($until: leftCol) {
-        text-align: right;
-    }
-}
-
-.meta__extras--crossword {
-    border-top: 1px dotted $neutral-5;
-    display: flex;
-    justify-content: space-between;
-
-    .meta__social,
-    .meta__numbers {
-        border: 0 none;
-    }
-
-    .meta__number {
-        border-left: 1px solid $neutral-7;
-        padding-left: $gs-gutter / 2;
-        text-align: right;
-    }
+    padding-top: $gs-baseline / 2;
 }
 
 .meta__number:not(.u-h) + .meta__number {
-    border-left: 1px solid $neutral-7;
-    padding-left: $gs-gutter / 2;
-    margin-left: $gs-gutter / 2;
+    border-left: 1px solid $garnett-neutral-4;
+    padding-left: $gs-gutter / 4;
+    margin-left: $gs-gutter / 4;
 }

--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -103,7 +103,7 @@
     padding-top: $gs-baseline / 2;
 }
 
-.meta__number:not(.u-h) + .meta__number {
+.meta__number + .meta__number {
     border-left: 1px solid $garnett-neutral-4;
     padding-left: $gs-gutter / 4;
     margin-left: $gs-gutter / 4;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1152,7 +1152,7 @@
         .commentcount,
         .meta__numbers,
         .meta__social,
-        .meta__number:not(u-h)+.meta__number {
+        .meta__number + .meta__number {
             border-color: $neutral-3;
         }
         .byline {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -679,7 +679,6 @@
 }
 
 .meta__social {
-    box-sizing: border-box;
     padding-top: $gs-baseline / 2;
 }
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -534,22 +534,6 @@
     margin-left: $gs-gutter/4;
 }
 
-.meta__numbers {
-    padding-bottom: $gs-baseline / 2;
-    padding-top: $gs-baseline / 2;
-    position: absolute;
-    right: 0;
-    top: 0;
-
-    @include mq(leftCol) {
-        border-top: 1px dotted $neutral-5;
-        height: 36px;
-        padding-bottom: $gs-baseline / 4;
-        padding-top: $gs-baseline / 4;
-        position: static;
-    }
-}
-
 .byline {
     @include fs-bodyHeading(2);
     margin-bottom: 0;
@@ -681,15 +665,13 @@
 }
 
 .meta__extras {
+    border-top: 1px solid $garnett-neutral-4;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: $gs-baseline / 2;
     position: relative;
     clear: both;
-    min-height: 45px;
-    border-top: 1px dotted $neutral-5;
-    border-bottom: 1px dotted $neutral-5;
-
-    @include mq(leftCol) {
-        border: 0;
-    }
 
     .content__head--crossword & {
         clear: none;
@@ -697,44 +679,8 @@
 }
 
 .meta__social {
-    padding: 0;
     box-sizing: border-box;
-
-    @include mq(leftCol) {
-        border-top: 1px dotted $neutral-5;
-    }
-
-    .meta__extras--crossword & {
-        @include mq(leftCol) {
-            float: left;
-        }
-    }
-}
-
-.meta__social--sticky {
-    position: fixed;
-    bottom: $gs-baseline;
-    border: 0;
-    z-index: 4;
-    transform: translate3d(0, $gs-baseline * 4, 0);
-
-    @include mq(leftCol, $until: wide) {
-        margin-left: $gs-gutter * -8;
-        .social__item--gplus {
-            display: none;
-        }
-    }
-    @include mq(wide) {
-        margin-left: $gs-gutter * -12;
-    }
-}
-
-.meta__social--sticky--revealable {
-    transition: transform 100ms linear;
-}
-
-.meta__social--sticky--reveal {
-    transform: translate3d(0, 0, 0);
+    padding-top: $gs-baseline / 2;
 }
 
 .meta__twitter,
@@ -1296,19 +1242,5 @@
     }
     .fc-item__title svg {
         fill: $multimedia-main-2;
-    }
-    &.content--article,
-    &.tonal--tone-media {
-        .meta__numbers,
-        .meta__social {
-            @include multiline(1, $garnett-neutral-6, top);
-            border-top: 0;
-            padding-top: $gs-baseline / 2;
-        }
-        .meta__social {
-            @include mq($until: leftCol) {
-                border-bottom: 1px solid $garnett-neutral-6;
-            }
-        }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -9,8 +9,9 @@
     }
 
     .meta__extras {
-        display: flex;
-        justify-content: space-between;
+        border-top: 0;
+        margin-top: -2px;
+        padding: 0;
     }
 
     .tonal__standfirst {

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -218,23 +218,6 @@
         background-color: $garnett-neutral-7;
     }
 
-    // Reset the styles from _content.scss
-    .meta__numbers {
-        position: relative;
-        border: 0 none;
-        height: auto;
-        padding: $gs-baseline/2 0 0;
-    }
-
-    .meta__number {
-        text-align: right;
-    }
-
-    .meta__social {
-        background-image: none !important;
-        border-bottom: 0;
-    }
-
     .badge--alt {
         margin-top: 0;
         margin-bottom: $gs-baseline;

--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -84,27 +84,8 @@
         margin-left: 0;
         width: 100%;
 
-        .meta__number {
-            @include mq($until: mobile) {
-                position: relative;
-                top: $gs-baseline;
-            }
-        }
-
         @include mq(leftCol) {
             position: relative;
-        }
-
-        .commentcount {
-            top: $gs-baseline / 3;
-
-            @include mq(desktop) {
-                display: block;
-                position: static;
-                padding-top: $gs-baseline / 3;
-                margin-bottom: $gs-baseline;
-                border-top: 1px dotted $neutral-5;
-            }
         }
     }
     .content__meta-container--twitter,

--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -55,25 +55,8 @@
         min-height: 0;
     }
 
-    .content__dateline,
-    .meta__numbers,
-    .meta__social {
+    .content__dateline {
         border-top: 0;
-    }
-
-    .meta__social {
-        border-bottom: 1px solid $garnett-neutral-4;
-    }
-
-    .meta__numbers {
-        position: absolute;
-        right: 0;
-        top: 0;
-    }
-
-    .meta__extras {
-        border-bottom: 0;
-        border-top: 1px solid $garnett-neutral-4;
     }
 
     .block-share__item,

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1034,6 +1034,12 @@ $quote-mark: 35px;
         font-style: normal;
     }
 
+    .meta__extras,
+    .meta__number:not(.u-h) + .meta__number,
+    .meta__numbers {
+        border-color: $garnett-neutral-7;
+    }
+
     .tonal__standfirst {
         @include mq($until: tablet) {
             max-width: gs-span(8);

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -38,7 +38,7 @@ $quote-mark: 35px;
     .content__labels,
     .content__standfirst,
     .old-article-message,
-    .social--top,
+    .meta__extras,
     .meta__contact-wrap {
         padding-left: $gs-gutter/2;
         padding-right: $gs-gutter/2;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -822,25 +822,12 @@ $quote-mark: 35px;
         background-color: $opinion-garnett-background;
         padding-bottom: $gs-baseline/2;
 
-        .social--top {
-            background-color: $opinion-garnett-background;
-        }
-
         .rich-link {
             background-color: $garnett-neutral-5;
         }
 
         .rich-link.tone-media--item {
             background-color: $neutral-1;
-        }
-
-        .social__item {
-            @include mq(tablet) {
-                padding-bottom: 0;
-            }
-            @include mq(leftCol) {
-                padding-bottom: $gs-baseline/2;
-            }
         }
 
         .element-pullquote,

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -244,7 +244,7 @@ $quote-mark: 35px;
         }
     }
 
-    .meta__number:not(.u-h)+.meta__number {
+    .meta__number + .meta__number {
         border-color: $garnett-neutral-4;
     }
     // *************** Header and Body Styles ***************

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -229,13 +229,10 @@ $quote-mark: 35px;
 
     .meta__extras {
         order: 5;
-        border: 0;
     }
 
     .block-share__item,
-    .inline-close,
-    .social-icon,
-    .social-icon.social-icon--more {
+    .social-icon {
         background-color: transparent;
         border: 1px solid $neutral-4;
 
@@ -243,53 +240,6 @@ $quote-mark: 35px;
         &:hover {
             svg {
                 fill: $garnett-neutral-5;
-            }
-        }
-    }
-
-    .social-icon {
-        @include mq(leftCol) {
-            max-width: 29px;
-            min-width: 29px;
-            height: 29px;
-        }
-        @include mq(wide) {
-            min-width: 32px;
-            max-width: 100%;
-            width: auto;
-            height: 32px;
-        }
-    }
-
-    .social--top {
-        padding-top: 0!important;
-        //only way to override behaviour
-    }
-
-    .meta__numbers,
-    .meta__social {
-        @include multiline(1, $garnett-neutral-4, top);
-        border-top: 0;
-        padding-top: $gs-baseline / 2;
-    }
-
-    .meta__social {
-        @include mq($until: leftCol) {
-            border-bottom: 1px solid $garnett-neutral-4;
-        }
-    }
-
-    .meta__numbers {
-        margin-right: $gs-gutter/2;
-        @include mq(mobileLandscape) {
-            margin-right: $gs-gutter;
-        }
-        @include mq(phablet) {
-            margin-right: 0;
-        }
-        @include mq($until: leftCol) {
-            &:before {
-                content: none;
             }
         }
     }
@@ -1107,16 +1057,6 @@ $quote-mark: 35px;
 
     .content__meta-container {
         @include multiline(4, $garnett-neutral-7, top);
-    }
-
-    .meta__numbers,
-    .meta__social {
-        @include multiline(1, $garnett-neutral-7, top);
-    }
-
-    .meta__numbers {
-        background-image: none;
-        padding-top: 0;
     }
 
     .inline-icon,

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -66,15 +66,6 @@ $block-padding-left: gs-span(1) + $gs-gutter;
         min-height: gs-height(1)*1.5;
         position: static;
         width: 100%;
-
-        .meta__numbers {
-            @include clearfix;
-            border-bottom: 0;
-            height: 36px;
-            padding-bottom: $gs-baseline / 4;
-            padding-top: $gs-baseline / 4;
-            position: static;
-        }
     }
 
     .byline {

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -97,26 +97,3 @@
         text-align: right;
     }
 }
-
-.meta__extras--crossword {
-    border-top: 1px dotted $neutral-5;
-    display: flex;
-    justify-content: space-between;
-
-    .meta__social,
-    .meta__numbers {
-        border: 0 none;
-    }
-
-    .meta__number {
-        border-left: 1px solid $neutral-7;
-        padding-left: $gs-gutter / 2;
-        text-align: right;
-    }
-}
-
-.meta__number:not(.u-h) + .meta__number {
-    border-left: 1px solid $neutral-7;
-    padding-left: $gs-gutter / 2;
-    margin-left: $gs-gutter / 2;
-}

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -860,7 +860,7 @@
         .commentcount,
         .meta__numbers,
         .meta__social,
-        .meta__number:not(u-h) + .meta__number {
+        .meta__number + .meta__number {
             border-color: $neutral-3;
         }
 

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -77,7 +77,7 @@
     .meta__extras,
     .submeta,
     .submeta__keywords,
-    .meta__number:not(u-h) + .meta__number {
+    .meta__number + .meta__number {
         border-color: $media-mute;
     }
 

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -77,7 +77,7 @@
 
             .meta__extras,
             .gallery__meta-container:before,
-            .meta__number:not(.u-h)+.meta__number {
+            .meta__number + .meta__number {
                 border-color: rgba(255, 255, 255, .4);
             }
 

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -160,19 +160,6 @@
     margin: $gs-baseline 0;
 }
 
-.meta__extras--crossword {
-    .meta__numbers {
-        border-bottom: 0;
-        padding-bottom: 0;
-
-        @include mq(mobile, $until: tablet) {
-            border-top: 0;
-            margin-top: ($gs-baseline * -4) + 2px;
-            margin-right: $gs-gutter * 3;
-        }
-    }
-}
-
 .content__dateline-crossword {
     min-height: 0px;
     display: inline;


### PR DESCRIPTION
Further standardisation and neatening of the meta area... bit by bit. This PR pulls the info onto the same line across templates, for a more consistant visual appearance across the site. I haven't touched colour logic yet - this is just layout. In the process spotted some more legacy test stuff that I was able to to get rid of, so resulted in a lot of removed scss.

# Before
<img width="234" alt="screen shot 2018-04-24 at 10 33 10" src="https://user-images.githubusercontent.com/14570016/39179063-43c909d0-47ab-11e8-9c29-709cf299b21e.png">

# After
<img width="231" alt="screen shot 2018-04-24 at 10 33 39" src="https://user-images.githubusercontent.com/14570016/39179064-43e41644-47ab-11e8-985f-c0d8d0e4be47.png">

<img width="687" alt="screen shot 2018-04-24 at 10 36 45" src="https://user-images.githubusercontent.com/14570016/39179124-693f2a3c-47ab-11e8-8828-439e79d5fe77.png">

