### PR TITLE
Restored line to hide blockshare items at mobile

### DIFF
--- a/common/app/views/fragments/share/blockLevelSharing.scala.html
+++ b/common/app/views/fragments/share/blockLevelSharing.scala.html
@@ -1,7 +1,7 @@
 @import model.DotcomContentType
 @(id: String, shareItems: Seq[model.ShareLink], contentType: DotcomContentType, isNewGallery: Boolean = false, amp: Boolean = false)
 
-<div class="block-share block-share--@contentType.name.toLowerCase" data-link-name="block share">
+<div class="block-share block-share--@contentType.name.toLowerCase @if(!isNewGallery) { hide-on-mobile }" data-link-name="block share">
     @shareItems.map { item: model.ShareLink =>
         <a class="rounded-icon block-share__item block-share__item--@item.css js-blockshare-link" href="@item.href" target="_blank" data-link-name="social @item.css">
             @fragments.inlineSvg("share-" + item.css, "icon")


### PR DESCRIPTION
Restored a line I deleted to prevent this happening:
<img width="387" alt="screen shot 2018-04-24 at 11 05 32" src="https://user-images.githubusercontent.com/14570016/39180681-751f55e4-47af-11e8-8b09-d52404b1173a.png">
