### PR TITLE
Football admin improvements

### DIFF
--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -25,9 +25,9 @@ object PA extends Collections {
     ("625", "Bundesliga"),
     ("635", "Serie A"),
     ("650", "La Liga"),
-    ("700", "World Cup 2014"),
+    ("700", "World Cup"),
     ("721", "International friendlies"),
-    ("870", "Women's World Cup 2015")
+    ("870", "Women's World Cup")
   )
   def competitionName(season: Season): String = competitionNames.getOrElse(season.id, season.name)
 

--- a/admin/app/views/football/browse.scala.html
+++ b/admin/app/views/football/browse.scala.html
@@ -1,8 +1,14 @@
 @()(implicit context: model.ApplicationContext, request: RequestHeader)
 @views.html.football.main("PA API browser") {
     <div class="page-header">
-      <h1>PA API browser</h1>
-      <p>Copy queries from <a href="@{conf.AdminConfiguration.pa.apiExplorer}">the PA Football documentation</a> into the query box below.</p>
+        <h1>PA API browser</h1>
+        <p>Copy queries from <a href="@{conf.AdminConfiguration.pa.apiExplorer}">the PA Football documentation</a> into the query box below.</p>
+        <p>Example queries</p>
+        <ul>
+            <li>/competitions/competitions/:apiKey</li>
+            <li>/competitions/matchDay/:apiKey/:matchDay</li>
+            <li>/competition/stats/summary/:apiKey/:competitionId/:startDate/:endDate</li>
+        </ul>
     </div>
 
     <form action="/admin/football/browserRedirect" method="POST" class="browser-form">

--- a/admin/app/views/football/browse.scala.html
+++ b/admin/app/views/football/browse.scala.html
@@ -2,12 +2,15 @@
 @views.html.football.main("PA API browser") {
     <div class="page-header">
         <h1>PA API browser</h1>
-        <p>Copy queries from <a href="@{conf.AdminConfiguration.pa.apiExplorer}">the PA Football documentation</a> into the query box below.</p>
+        <p>
+            Copy queries from <a href="@{conf.AdminConfiguration.pa.apiExplorer}">the PA Football documentation</a> into the query box below.
+            (Use Football API v1.5)
+        </p>
         <p>Example queries</p>
         <ul>
-            <li>/competitions/competitions/:apiKey</li>
-            <li>/competitions/matchDay/:apiKey/:matchDay</li>
-            <li>/competition/stats/summary/:apiKey/:competitionId/:startDate/:endDate</li>
+            <li>/competitions/competitions/{apiKey}</li>
+            <li>/competitions/matchDay/{apiKey}/{matchDay}</li>
+            <li>/competition/stats/summary/{apiKey}/{competitionId}/{startDate}/{endDate}</li>
         </ul>
     </div>
 

--- a/admin/public/football/javascripts/browser.js
+++ b/admin/public/football/javascripts/browser.js
@@ -61,10 +61,16 @@ jQuery(function($){
                 label: "Premier league 2013/14",
                 value: "785"
             }],
-            competitionID: [{
-                label: "Premier league 2013/14",
-                value: "100"
-            }],
+            competitionID: [
+                {
+                    label: "Premier league",
+                    value: "100"
+                },
+                {
+                    label: "World Cup",
+                    value: "700"
+                }
+            ],
             type: [
                 {
                     label: "Strikers",
@@ -91,7 +97,10 @@ jQuery(function($){
         currentFields = {},
         createReplacements = function() {
             var r = /({.*?})/g,
-                query = dom.query.val(),
+                query = dom.query.val()
+                    // replace to convert new-style in PA docs `:key`
+                    // to old-style `{key}` supported by this tool
+                    .replace(/:([^\/]+)/g, "{$1}"),
                 fields = $.map(query.match(r), function(field){
                     return field.replace("{", "").replace("}", "");
                 }).filter(function(field){

--- a/admin/public/football/javascripts/browser.js
+++ b/admin/public/football/javascripts/browser.js
@@ -17,7 +17,11 @@ jQuery(function($){
             return dom;
         })(),
         hints = {
-            teamID: [
+            teamId: [
+                {
+                    label: "England",
+                    value: "497"
+                },
                 {
                     label: "Spurs",
                     value: "19"
@@ -39,7 +43,7 @@ jQuery(function($){
                     value: "31"
                 }
             ],
-            playerID: [
+            playerId: [
                 {
                     label: "Joe Hart",
                     value: "Joe_Hart"
@@ -49,19 +53,19 @@ jQuery(function($){
                     value: "237670"
                 }
             ],
-            matchID: [{
-                label: "Swansea v Spurs, 19/01/2014",
-                value: "3684146"
+            matchId: [{
+                label: "Stoke v Spurs, 07/04/2018",
+                value: "3998945"
             }],
-            managerID: [{
+            managerId: [{
                 label: "Andre Villas-Boas",
                 value: "468795"
             }],
-            seasonID: [{
-                label: "Premier league 2013/14",
-                value: "785"
+            seasonId: [{
+                label: "Premier league 17/18",
+                value: "4578"
             }],
-            competitionID: [
+            competitionId: [
                 {
                     label: "Premier league",
                     value: "100"

--- a/admin/public/football/javascripts/browser.js
+++ b/admin/public/football/javascripts/browser.js
@@ -106,8 +106,6 @@ jQuery(function($){
                 }).filter(function(field){
                     return field !== "apiKey";
                 });
-            // set input to converted value
-            dom.query.val(query);
             $.each(fields, function(_, field){
                 if (!currentFields.hasOwnProperty(field)) {
                     addReplacementField(field);
@@ -150,7 +148,7 @@ jQuery(function($){
         setTimeout(createReplacements, 10);
     });
     dom.form.on("submit", function() {
-        dom.query.val(dom.query.val().replace("{", "%7B").replace("}", "%7D"));
+        dom.query.val(dom.query.val().replace(/:([^\/]+)/g, "{$1}").replace("{", "%7B").replace("}", "%7D"));
     });
     dom.parameters.on("click", ".hint", function(e) {
         e.preventDefault();

--- a/admin/public/football/javascripts/browser.js
+++ b/admin/public/football/javascripts/browser.js
@@ -106,6 +106,8 @@ jQuery(function($){
                 }).filter(function(field){
                     return field !== "apiKey";
                 });
+            // set input to converted value
+            dom.query.val(query);
             $.each(fields, function(_, field){
                 if (!currentFields.hasOwnProperty(field)) {
                     addReplacementField(field);


### PR DESCRIPTION
## What does this change?

Improves the football admin

## What is the value of this and can you measure success?

The football admin includes tools for journalists, as well as the PA browser. This PR tweaks some broken things. In particular, the PA Browser is extremely useful for development, so this change will make it possible for developers (e.g. me) to fix other football problems ahead of the World Cup.

## Does this affect other platforms - Amp, Apps, etc?

N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

N/A

## Screenshots

![pa-browser-update](https://user-images.githubusercontent.com/29761/39182139-da0a1b52-47b3-11e8-8678-db0e4237cf64.png)


## Tested in CODE?

Nope. Hack day YOLO.
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
