### PR TITLE
theme YouTube player based on pillar

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -92,7 +92,7 @@
                                             }
 
                                             @video.mediaAtom.map { mediaAtom =>
-                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None)
+                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None, pillar = media.metadata.pillar)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -12,7 +12,7 @@ object InteractiveBodyCleaner {
   def apply(interactive: Interactive)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val html = interactive.fields.body
     val cleaners = List(
-      AtomsCleaner(interactive.content.atoms, shouldFence = false)
+      AtomsCleaner(interactive.content.atoms, shouldFence = false, pillar = interactive.metadata.pillar)
     ) ++ (if (interactive.content.isImmersive) List(InteractiveSrcdocCleaner) else Nil)
 
     withJsoup(html)(cleaners: _*)

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -31,7 +31,7 @@ object MainCleaner {
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
         MainFigCaptionCleaner,
-        AtomsCleaner(atoms = article.content.atoms, amp = amp, mediaWrapper = Some(MediaWrapper.MainMedia))
+        AtomsCleaner(atoms = article.content.atoms, amp = amp, mediaWrapper = Some(MediaWrapper.MainMedia), pillar = article.metadata.pillar)
       )
   }
 }
@@ -46,7 +46,7 @@ object BodyCleaner {
 
     List(
       InBodyElementCleaner,
-      AtomsCleaner(atoms = article.content.atoms, shouldFence = true, amp = amp),
+      AtomsCleaner(atoms = article.content.atoms, shouldFence = true, amp = amp, pillar = article.metadata.pillar),
       InBodyLinkCleaner("in body link", amp),
       BlockNumberCleaner,
       new TweetCleaner(article.content, amp),

--- a/commercial/app/views/CommercialBodyCleaner.scala
+++ b/commercial/app/views/CommercialBodyCleaner.scala
@@ -10,7 +10,7 @@ object CommercialBodyCleaner {
   def apply(article: HostedArticlePage, html: String)(implicit request: RequestHeader, context: ApplicationContext): Html = {
 
     val cleaners = List(
-      AtomsCleaner(atoms = article.content.atoms)
+      AtomsCleaner(atoms = article.content.atoms, pillar = article.metadata.pillar)
     )
 
     withJsoup(html)(cleaners :_*)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -426,13 +426,13 @@ case class MediaAtomPage(
   override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "media"
-  override val body = views.html.fragments.atoms.media(atom, displayCaption = false, mediaWrapper = Some(MediaWrapper.EmbedPage))
   override val javascriptModule = "youtube-embed"
   override val metadata = MetaData.make(
     id = atom.id,
     webTitle = atom.title,
     section = None
   )
+  override val body = views.html.fragments.atoms.media(atom, displayCaption = false, mediaWrapper = Some(MediaWrapper.EmbedPage), pillar = metadata.pillar)
 }
 
 case class StoryQuestionsAtomPage(

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,14 +1,15 @@
 @import model.content.MediaWrapper
 @import com.gu.contentatom.renderer.{ArticleAtomRenderer, ArticleConfiguration}
 @import conf.switches.Switches.AtomRendererSwitch
-@(model: _root_.model.content.Atom, config: ArticleConfiguration, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@import model.Pillar.RichPillar
+@(model: _root_.model.content.Atom, config: ArticleConfiguration, shouldFence: Boolean, amp: Boolean, pillar: RichPillar, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom, CommonsDivisionAtom}
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
-        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
+        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper, pillar = pillar)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case storyquestions: StoryQuestionsAtom if !amp => Html(ArticleAtomRenderer.getHTML(storyquestions.atom, config))
         case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp, inApp = false)

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,14 +1,24 @@
 @import model.content.MediaAssetPlatform
 @import model.content.MediaWrapper
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, displayEndSlate: Boolean = false, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
+@import model.Pillar.RichPillar
+@(
+    media: _root_.model.content.MediaAtom,
+    amp: Boolean = false,
+    displayCaption: Boolean,
+    displayEndSlate: Boolean = false,
+    mediaWrapper: Option[MediaWrapper],
+    pillar: RichPillar
+)(implicit request: RequestHeader)
 
 @{
     media match {
-            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
-                if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
-                else views.html.fragments.atoms.youtube(media, displayCaption, displayDuration = true, displayEndSlate, mediaWrapper = mediaWrapper)
-            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
-            case _ =>
-        }
+        case posterOnly if media.assets.isEmpty && media.posterImage.isDefined =>
+            views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
+        case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
+            if (amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
+            else views.html.fragments.atoms.youtube(media, displayCaption, displayDuration = true, displayEndSlate, mediaWrapper = mediaWrapper, pillar = pillar)
+        case genericAsset if media.assets.nonEmpty =>
+            views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
+        case _ =>
+    }
 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -11,8 +11,23 @@
 @import conf.switches.Switches.YouTubePosterOverride
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
+@import model.Pillar.RichPillar
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
+@import play.api.libs.json.Json
+
+@import views.support.GetYoutubePlayerColour
+@(
+    media: model.content.MediaAtom,
+    displayCaption: Boolean,
+    displayDuration: Boolean = true,
+    displayEndSlate: Boolean = true,
+    playable: Boolean = true,
+    pillar: RichPillar,
+    posterImageOverride: Option[ImageMedia] = None,
+    cardStyle: Option[CardStyle] = None,
+    mediaWrapper: Option[MediaWrapper] = None,
+    faciaHeaderProperties: Option[VideoFaciaProperties] = None
+)(implicit request: RequestHeader)
 
 @videoJsError() = @{
     <div class="vjs-error-display vjs-modal-dialog">
@@ -46,7 +61,8 @@
                 "enablejsapi" -> 1,
                 "rel" -> 0,
                 "showinfo" -> 0,
-                "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None),
+                "embed_config" -> Json.obj("primaryThemeColor" -> GetYoutubePlayerColour.forPillar(pillar))
                 )).toString
                 }") { embedUri: String  =>
                 <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -41,7 +41,18 @@
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
                         @youTubeAtom.map { youTubeAtom =>
-                            @youtube(media = youTubeAtom, displayCaption = false, mediaWrapper = Some(VideoContainer), displayEndSlate = false, displayDuration = false, faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None), showByline = item.properties.showByline, item.properties.byline)))
+                            @youtube(
+                                media = youTubeAtom,
+                                displayCaption = false,
+                                mediaWrapper = Some(VideoContainer),
+                                displayEndSlate = false,
+                                displayDuration = false,
+                                pillar = item.maybePillar,
+                                faciaHeaderProperties = Some(VideoFaciaProperties(
+                                    header = FaciaCardHeader.fromTrail(item, None),
+                                    showByline = item.properties.showByline,
+                                    item.properties.byline))
+                            )
                         }
                     }
 

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -139,7 +139,8 @@ data-test-id="facia-card"
                         displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate,
                         playable = item.cardTypes.showYouTubeMediaAtomPlayer,
                         posterImageOverride = media.posterImageOverride,
-                        cardStyle = Some(item.cardStyle))
+                        cardStyle = Some(item.cardStyle),
+                        pillar = item.pillar)
                     </div>
                 </div>
             }

--- a/common/app/views/support/GetYoutubePlayerColour.scala
+++ b/common/app/views/support/GetYoutubePlayerColour.scala
@@ -1,0 +1,19 @@
+package views.support
+
+import model.Pillar.RichPillar
+
+object GetYoutubePlayerColour {
+  def forPillar(pillar: RichPillar): String = {
+    // Change the colour of the control bar in the YouTube player
+    // Text is always white; don't theme `special-report` as the contrast isn't high enough
+    pillar.nameOrDefault.toLowerCase match {
+      case "news"           => "#c70000"
+      case "opinion"        => "#e05e00"
+      case "sport"          => "#0084c6"
+      case "culture"        => "#a1845c"
+      case "lifestyle"      => "#bb3b80"
+      // case "special-report" => "#ffe500"
+      case _                => "#c70000"
+    }
+  }
+}

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -16,6 +16,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.HtmlFormat
 import services.SkimLinksCache
 import conf.Configuration.affiliatelinks._
+import model.Pillar.RichPillar
 import views.html.fragments.affiliateLinksDisclaimer
 
 import scala.collection.JavaConverters._
@@ -665,7 +666,7 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, mediaWrapper: Option[MediaWrapper] = None)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, mediaWrapper: Option[MediaWrapper] = None, pillar: RichPillar)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -691,7 +692,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
           atomContainer.attr("data-atom-id", atomId)
           atomContainer.attr("data-atom-type", atomType)
 
-          val html = views.html.fragments.atoms.atom(atomData, Atoms.articleConfig, shouldFence, amp, mediaWrapper).toString()
+          val html = views.html.fragments.atoms.atom(atomData, Atoms.articleConfig, shouldFence, amp, mediaWrapper = mediaWrapper, pillar = pillar).toString()
           bodyElement.remove()
           atomContainer.append(html)
         }

--- a/common/app/views/support/ImmersiveMainCleaner.scala
+++ b/common/app/views/support/ImmersiveMainCleaner.scala
@@ -5,12 +5,13 @@ import model.content.MediaWrapper
 import model.{ApplicationContext, Article}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
+import model.Pillar.RichPillar
 
 object ImmersiveMainCleaner {
   def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     implicit val edition = Edition(request)
     withJsoup(BulletCleaner(html))(
-      AtomsCleaner(article.content.atoms, shouldFence = true, amp, mediaWrapper = Some(MediaWrapper.ImmersiveMainMedia))
+      AtomsCleaner(article.content.atoms, shouldFence = true, amp, mediaWrapper = Some(MediaWrapper.ImmersiveMainMedia), pillar = RichPillar(article.metadata.pillar))
     )
   }
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -10,6 +10,7 @@ import test.{TestRequest, WithTestApplicationContext}
 import views.support.AtomsCleaner
 import conf.switches.Switches
 import model.{ImageAsset, ImageMedia}
+import model.Pillar.RichPillar
 
 import scala.collection.JavaConverters._
 
@@ -52,8 +53,10 @@ class AtomCleanerTest extends FlatSpec
     profiles = Nil,
     timelines = Nil,
     commonsdivisions = Nil
-  )
-)
+  ))
+
+  val pillar: RichPillar = RichPillar(None)
+
   def doc: Document = Jsoup.parse( s"""<figure class="element element-atom">
                                 <gu-atom data-atom-id="887fb7b4-b31d-4a38-9d1f-26df5878cf9c" data-atom-type="media">
                                 <div>
@@ -64,13 +67,13 @@ class AtomCleanerTest extends FlatSpec
 
 
  private def clean(document: Document, atom:Option[Atoms], amp: Boolean): Document = {
-    val cleaner = AtomsCleaner(youTubeAtom, amp = amp)(TestRequest(), testApplicationContext)
+    val cleaner = AtomsCleaner(youTubeAtom, amp = amp, pillar = pillar)(TestRequest(), testApplicationContext)
     cleaner.clean(document)
     document
   }
 
  private def renderAndGetId(atom: MediaAtom): String = {
-   val html = views.html.fragments.atoms.youtube(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+   val html = views.html.fragments.atoms.youtube(media = atom, displayCaption = false, mediaWrapper = None, pillar = pillar)(TestRequest())
    val doc = Jsoup.parse(html.toString())
 
    doc.getElementsByClass("youtube-media-atom__iframe").attr("id")
@@ -92,19 +95,19 @@ class AtomCleanerTest extends FlatSpec
   }
 
   "Youtube template" should "include endslate path" in {
-    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = false, mediaWrapper = None, pillar = pillar)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.select("div.youtube-media-atom").first().attr("data-end-slate") should be("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z")
   }
 
   "Youtube template" should "include main media caption" in {
-    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = true, mediaWrapper = Some(MediaWrapper.MainMedia))(TestRequest())
+    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = true, mediaWrapper = Some(MediaWrapper.MainMedia), pillar = pillar)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.select("figcaption").hasClass("caption--main") should be(true)
   }
 
   "Youtube template" should "include duration" in {
-    val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None, pillar = pillar)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").html() should be("0:36")
   }


### PR DESCRIPTION
## What does this change?
It is now possible to set the colour of the control bar in the YouTube player! Set the value based on the content pillar.

Note: we can't change the colour of the text yet (it is always white), therefore we can't use the special report yellow as the contrast isn't high enough (screenshot below).

I'm not especially keen on having hex colour codes in scala, improvements welcomed!

## What is the value of this and can you measure success?
#GarnettAllTheThings

## Does this affect other platforms - Amp, Apps, etc?
no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots
### News
![image](https://user-images.githubusercontent.com/836140/39204057-8fb6c894-47ee-11e8-9896-10f5c671861b.png)

### Sport
![image](https://user-images.githubusercontent.com/836140/39204165-f85e8f30-47ee-11e8-8565-e706997285a2.png)

### Lifestyle
![image](https://user-images.githubusercontent.com/836140/39204336-6dd316f0-47ef-11e8-8681-2f08fb9b6114.png)

### Special Report
(this is just to demonstrate the bad contrast)
![image](https://user-images.githubusercontent.com/836140/39204496-d53501dc-47ef-11e8-84be-e90226c30713.png)

## Tested in CODE?
Not yet.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
