### PR TITLE
Fix greedy CSS rule

### DIFF
--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -96,14 +96,14 @@
     align-items: center;
     border: 0;
     margin: 0;
+
+    svg:not(:root) {
+        overflow: hidden;
+    }
 }
 
 .content--pillar-news .campaign--snippet__handle:focus {
     background-color: $news-garnett-main-1;
-}
-
-svg:not(:root) {
-    overflow: hidden;
 }
 
 .speech-bubble {


### PR DESCRIPTION
Fixes a side-effect where a CSS rules applies to all SVGs in the page instead of just the one it is meant for.