### PR TITLE
Football fixes

### DIFF
--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -5,7 +5,7 @@ import model.Cached.RevalidatableResult
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import common.{ImplicitControllerExecutionContext, Logging}
 import model.{ApplicationContext, Cached}
-import football.model.CompetitionStage
+import football.model.{CompetitionStage, KnockoutSpider}
 
 class WallchartController(
   competitionsService: CompetitionsService,
@@ -21,7 +21,8 @@ class WallchartController(
         "football",
         s"${competition.fullName} wallchart"
       )
-      val competitionStages = new CompetitionStage(competitionsService.competitions).stagesFromCompetition(competition)
+      val competitionStages = new CompetitionStage(competitionsService.competitions)
+        .stagesFromCompetition(competition, KnockoutSpider.orderings)
 
       Cached(60) {
         if(embed) RevalidatableResult.Ok(football.views.html.wallchart.embed(page, competition, competitionStages))

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -29,17 +29,23 @@ class CompetitionStage(competitions: Seq[Competition]) {
 
       if (stageLeagueEntries.isEmpty) {
         if (rounds.size > 1) {
-          orderings.get(competition.id).map { matchDates =>
-            // for knockout tournaments PA delete and re-issue ghost/placeholder matches when the actual teams become available
-            // this would create duplicate matches since our addMatches code is purely additive, so we must de-dupe matches based on KO time
-            val dedupedMatches = stageMatches.groupBy(_.date).flatMap { case (_, dateMatches) =>
-              dateMatches.sortWith { case (match1, match2) =>
-                Try(match1.id.toInt > match2.id.toInt)
-                  .getOrElse(match1.id > match2.id)
-              }.headOption
-            }
-            KnockoutSpider(competitions, dedupedMatches.toList, rounds, matchDates)
-          }.orElse(Some(KnockoutList(competitions, stageMatches, rounds)))
+          orderings.get(competition.id) match {
+            case Some(matchDates) if orderingsApplyToTheseMatches(matchDates, stageMatches) =>
+              // for knockout tournaments PA delete and re-issue ghost/placeholder matches when the actual teams become available
+              // this would create duplicate matches since our addMatches code is purely additive, so we must de-dupe matches based on KO time
+              val dedupedMatches = stageMatches.groupBy(_.date).flatMap { case (_, dateMatches) =>
+                dateMatches.sortWith { case (match1, match2) =>
+                  Try(match1.id.toInt > match2.id.toInt)
+                    .getOrElse(match1.id > match2.id)
+                }.headOption
+              }
+              Some(KnockoutSpider(competitions, dedupedMatches.toList, rounds, matchDates))
+            case _ =>
+              // if there are no orderings, or the provided orderings do not apply to the
+              // matches in this round then we cannot show a spider, fall back to list
+              // NOTE: check the timezone on your orderings (we use UK time for all football stuff)
+              Some(KnockoutList(competitions, stageMatches, rounds))
+          }
         } else None  // or just a collection of matches (e.g. international friendlies)
       } else {
         if (rounds.size > 1) {
@@ -52,6 +58,14 @@ class CompetitionStage(competitions: Seq[Competition]) {
         } else None
       }
     }
+  }
+
+  private def orderingsApplyToTheseMatches(matchDates: List[DateTime], matches: List[FootballMatch]): Boolean = {
+    KnockoutSpider
+      .makeMatchIntervals(matchDates)
+      .exists(interval => matches
+        .exists(fMatch => interval.contains(fMatch.date))
+      )
   }
 }
 
@@ -79,8 +93,21 @@ case class KnockoutSpider(competitions: Seq[Competition], matches: List[Football
   override def roundMatches(round: Round): List[FootballMatch] =
     super.roundMatches(round).sortWith(lt)
 
-  private val matchIntervals = matchDates.map(dateTime => new Interval(dateTime.minusHours(1), dateTime.plusHours(1)))
+  private val matchIntervals = KnockoutSpider.makeMatchIntervals(matchDates)
   private def lt(match1: FootballMatch, match2: FootballMatch): Boolean = {
     matchIntervals.indexWhere(_.contains(match1.date)) < matchIntervals.indexWhere(_.contains(match2.date))
+  }
+}
+object KnockoutSpider {
+  // Pay attention to the timezone for the orderings
+  // If the dates of the matches don't line up with the ordering dates, the ordering will be ignored.
+  val orderings: Map[String, List[DateTime]] = Map(
+    
+  )
+
+  // adds a little flex around the match dates in case they aren't listed at exactly the right time
+  // (especially for ghost/placeholder matches in tournaments)
+  def makeMatchIntervals(matchDates: List[DateTime]): List[Interval] = {
+    matchDates.map(dateTime => new Interval(dateTime.minusHours(1), dateTime.plusHours(1)))
   }
 }

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -9,27 +9,25 @@
             <li class="football-group">
                 <div class="football-group__container table--hide-from-importance-3">
                     @round.name.map{ name =>
-                        @fragments.dropdown(name, isActive = row.isFirst){
-                            <div class="football-group__table">
-                                @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
-                                    heading = round.name,
-                                    headingLink = groupTag(competition.id, round),
-                                    striped = true,
-                                    withCrests = true
-                                )
-                            </div>
+                        <div class="football-group__table">
+                            @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
+                                heading = round.name,
+                                headingLink = groupTag(competition.id, round),
+                                striped = true,
+                                withCrests = true
+                            )
+                        </div>
 
-                            <div class="football-group__matches">
-                                @matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                                    @competitionMatches.map { case (competition, matches) =>
-                                        @football.views.html.matchList.matchesList(matches, competition, date,
-                                            linkToCompetition = false,
-                                            heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
-                                        )
-                                    }
+                        <div class="football-group__matches">
+                            @matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                                @competitionMatches.map { case (competition, matches) =>
+                                    @football.views.html.matchList.matchesList(matches, competition, date,
+                                        linkToCompetition = false,
+                                        heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
+                                    )
                                 }
-                            </div>
-                        }
+                            }
+                        </div>
                     }
                 </div>
             </li>

--- a/sport/test/football/model/CompetitionStageTest.scala
+++ b/sport/test/football/model/CompetitionStageTest.scala
@@ -211,14 +211,22 @@ import test._
         stages(0) should be (instanceOf[KnockoutList])
       }
 
+      "creates a knockout list if orderings are provided but do not apply to the provided matches" in {
+        val matchDates = tournament.matches.map(_.date.plusYears(1)).toList
+        val orderings = Map("1" -> matchDates)
+        val stages = competitionStage.stagesFromCompetition(tournament, orderings)
+        stages(0) should be (instanceOf[KnockoutList])
+      }
+
       "will de-dupe spider matches based on provided ordering" in {
         // for knockout tournaments PA will delete and then re-issue a ghost/placeholder match when the actual teams become available
         // e.g. final teams are known after semi finals are done
         // this would create duplicate matches since our addMatches code is purely additive, so we must de-dupe matches based on time
         val matches = futureKnockoutMatches(Stage("1"))
+        val dates = matches.map(_.date)
         val reissuedMatches = List(matches(0).copy(id="1235"), matches(1).copy(id="1236"), matches(2).copy(id="1237"), matches(3).copy(id="1238"))
         val comp = testCompetition(leagueTable = Nil, matches = futureKnockoutMatches(Stage("1")) ++ reissuedMatches)
-        val stages = competitionStage.stagesFromCompetition(comp, Map("1" -> Nil))
+        val stages = competitionStage.stagesFromCompetition(comp, Map("1" -> dates))
         val ko = stages(0).asInstanceOf[KnockoutSpider]
         ko should be (instanceOf[KnockoutSpider])
         val qfMatches = ko.roundMatches(quarterFinals)

--- a/static/src/stylesheets/module/football/_tables.scss
+++ b/static/src/stylesheets/module/football/_tables.scss
@@ -54,6 +54,23 @@
             @include u-h;
         }
     }
+
+    .football-match--result {
+        >td {
+            padding-left: .3rem;
+            padding-right: .3rem;
+            &:first-child {
+                padding-left: .5rem;
+            }
+            &:last-child {
+                padding-right: .5rem;
+            }
+        }
+
+        .team-crest {
+            margin-right: 0;
+        }
+    }
 }
 
 .team-crest {


### PR DESCRIPTION
## What does this change?

Minor fixes in preparation for adding the World Cup 2018.

Fixes a layout bug in group stages overview display.
Improves the logic that decides whether to display a KnockoutList / KnockoutSpider. It now falls back more gracefully.

## What is the value of this and can you measure success?

Adding the world cup will be possible, rather than it displaying broken HTML.

These changes are to fix problems uncovered while adding WC2018. I'll do that in a separate PR though, so that there's a historical log of "what to do for the next big tournament".

## Does this affect other platforms - Amp, Apps, etc?

N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

N/A

## Screenshots

### Fixed

![screenshot 5](https://user-images.githubusercontent.com/29761/39241200-f82d4350-487d-11e8-89d4-f1b9c0db041a.jpeg)

### PROD now :-/

![screenshot 6](https://user-images.githubusercontent.com/29761/39241214-04777342-487e-11e8-82bb-69d0ad4b531e.jpeg)

## Tested in CODE?

Nope. Happy to do that if someone wants to lend a hand, or I can hand this over to @nicl in our catchup today.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
