### PR TITLE
`blocking` parameter for Message.js

### DIFF
--- a/common/app/views/fragments/message.scala.html
+++ b/common/app/views/fragments/message.scala.html
@@ -1,6 +1,7 @@
 @()(implicit request: RequestHeader)
 
-<div class="site-message js-site-message is-hidden" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
+<div class="site-message-overlay js-site-message-overlay is-hidden" data-link-name="release message : overlay"></div>
+<div class="site-message js-site-message is-hidden" tabindex="-1" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
     <div class="gs-container">
         <div class="site-message__inner js-site-message-inner">
             <div class="site-message__media">

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -19,6 +19,7 @@ class Message {
     id: string;
     important: boolean;
     permanent: boolean;
+    blocking: boolean;
     trackDisplay: boolean;
     type: string;
     pinOnHide: boolean;
@@ -38,6 +39,7 @@ class Message {
         this.id = id;
         this.important = opts.important || false;
         this.permanent = opts.permanent || false;
+        this.blocking = opts.blocking || false;
         this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
         this.pinOnHide = opts.pinOnHide || false;
@@ -50,10 +52,12 @@ class Message {
         this.customJs = opts.customJs || noop;
         this.customOpts = opts.customOpts || {};
         this.$footerMessage = $('.js-footer-message');
+        this.$siteMessage = $('.js-site-message');
     }
 
     show(message: string): boolean {
         const siteMessage = $('.js-site-message');
+        const siteMessageOverlay = $('.js-site-message-overlay');
 
         if (this.pinOnHide) {
             $('.js-footer-site-message-copy').html(message);
@@ -71,6 +75,18 @@ class Message {
             return false;
         }
         $('.js-site-message-copy').html(message);
+
+        // Add a blocking overlay if needed
+        if (this.blocking) {
+            siteMessageOverlay.removeClass('is-hidden');
+            siteMessageOverlay[0].addEventListener('click', () => {
+                siteMessage[0].focus();
+            });
+            siteMessageOverlay[0].addEventListener('focus', () => {
+                siteMessage[0].focus();
+            });
+            this.trapFocus();
+        }
 
         // Add site modifier message
         if (this.cssModifierClass) {
@@ -143,9 +159,28 @@ class Message {
         );
     }
 
+    trapFocus(): void {
+        const messageEl = this.$siteMessage[0];
+        const [trapStartEl, trapEndEl] = new Array(2).fill(
+            document.createElement('div')
+        );
+
+        trapStartEl.tabIndex = -1;
+        trapEndEl.tabIndex = 0;
+
+        trapEndEl.addEventListener('focus', () => {
+            trapStartEl.focus();
+        });
+
+        messageEl.prepend(trapStartEl);
+        messageEl.append(trapEndEl);
+        messageEl.focus();
+    }
+
     hide(): void {
         $('#header').removeClass('js-site-message');
         $('.js-site-message').addClass('is-hidden');
+        $('.js-site-message-overlay').addClass('is-hidden');
         if (this.pinOnHide) {
             this.$footerMessage.removeClass('is-hidden');
         }

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -31,8 +31,10 @@ class Message {
     cssModifierClass: string;
     customJs: Object => void;
     customOpts: Object;
-    $footerMessage: Object;
     $siteMessage: Object;
+    $siteMessageContainer: Object;
+    $siteMessageOverlay: Object;
+    $footerMessage: Object;
 
     constructor(id: string, options?: Object) {
         const opts = options || {};
@@ -52,20 +54,19 @@ class Message {
         this.customJs = opts.customJs || noop;
         this.customOpts = opts.customOpts || {};
         this.$footerMessage = $('.js-footer-message');
-        this.$siteMessage = $('.js-site-message');
+        this.$siteMessageContainer = $('.js-site-message');
+        this.$siteMessageOverlay = $('.js-site-message-overlay');
     }
 
     show(message: string): boolean {
-        const siteMessage = $('.js-site-message');
-        const siteMessageOverlay = $('.js-site-message-overlay');
-
         if (this.pinOnHide) {
             $('.js-footer-site-message-copy').html(message);
         }
 
         // don't let messages unknowingly overwrite each other
         if (
-            (!siteMessage.hasClass('is-hidden') && !this.important) ||
+            (!this.$siteMessageContainer.hasClass('is-hidden') &&
+                !this.important) ||
             this.hasSeen()
         ) {
             // if we're not showing a banner message, display it in the footer
@@ -78,19 +79,21 @@ class Message {
 
         // Add a blocking overlay if needed
         if (this.blocking) {
-            siteMessageOverlay.removeClass('is-hidden');
-            siteMessageOverlay[0].addEventListener('click', () => {
-                siteMessage[0].focus();
+            this.$siteMessageOverlay.removeClass('is-hidden');
+            this.$siteMessageOverlay[0].addEventListener('click', () => {
+                this.$siteMessageContainer[0].focus();
             });
-            siteMessageOverlay[0].addEventListener('focus', () => {
-                siteMessage[0].focus();
+            this.$siteMessageOverlay[0].addEventListener('focus', () => {
+                this.$siteMessageContainer[0].focus();
             });
             this.trapFocus();
         }
 
         // Add site modifier message
         if (this.cssModifierClass) {
-            siteMessage.addClass(`site-message--${this.cssModifierClass}`);
+            this.$siteMessageContainer.addClass(
+                `site-message--${this.cssModifierClass}`
+            );
         }
 
         this.$siteMessage = $('.js-site-message__message');
@@ -103,13 +106,19 @@ class Message {
         );
 
         if (this.siteMessageComponentName) {
-            siteMessage.attr('data-component', this.siteMessageComponentName);
+            this.$siteMessageContainer.attr(
+                'data-component',
+                this.siteMessageComponentName
+            );
             if (this.trackDisplay) {
                 begin(this.siteMessageComponentName);
             }
         }
         if (this.siteMessageLinkName) {
-            siteMessage.attr('data-link-name', this.siteMessageLinkName);
+            this.$siteMessageContainer.attr(
+                'data-link-name',
+                this.siteMessageLinkName
+            );
         }
         if (this.siteMessageCloseBtn) {
             $('.site-message__close-btn', '.js-site-message').attr(
@@ -118,12 +127,12 @@ class Message {
             );
         }
 
-        siteMessage
+        this.$siteMessageContainer
             .addClass(`site-message--${this.type}`)
             .addClass(`site-message--${this.id}`);
-        siteMessage.removeClass('is-hidden');
+        this.$siteMessageContainer.removeClass('is-hidden');
         if (this.permanent) {
-            siteMessage.addClass('site-message--permanent');
+            this.$siteMessageContainer.addClass('site-message--permanent');
             $('.site-message__close').addClass('is-hidden');
         } else {
             bean.on(
@@ -160,19 +169,15 @@ class Message {
     }
 
     trapFocus(): void {
-        const messageEl = this.$siteMessage[0];
-        const [trapStartEl, trapEndEl] = new Array(2).fill(
-            document.createElement('div')
-        );
+        const messageEl = this.$siteMessageContainer[0];
+        const trapEndEl = document.createElement('div');
 
-        trapStartEl.tabIndex = -1;
         trapEndEl.tabIndex = 0;
 
         trapEndEl.addEventListener('focus', () => {
-            trapStartEl.focus();
+            messageEl.focus();
         });
 
-        messageEl.prepend(trapStartEl);
         messageEl.append(trapEndEl);
         messageEl.focus();
     }

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -292,9 +292,9 @@ $zindex-ads: 1010;     // Ads
 $zindex-content: 1015; // Modals and overlays inside content
 $zindex-sticky: 1020;  // Sticky header
 $zindex-modal: 1030;   // Search modal
-$zindex-popover: 1040; // Breaking news
 $zindex-overlay: 1050; // Overlays
 $zindex-notifications-permissions-warning: 1060; //Chrome Live Blog notifications
 $zindex-main-menu: 1070; // New header navigation dropdown
 $zindex-sticky-top-banner: 1080;  // Sticky header
-$zindex-lightbox: 1090; // Lightbox
+$zindex-popover: 1090; // Breaking news
+$zindex-lightbox: 1100; // Lightbox

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -3,10 +3,22 @@
     background: $garnett-neutral-1;
     display: block;
     color: #ffffff;
+    outline: none;
 
     @include mq(tablet) {
         @include fs-headline(2, true);
     }
+}
+
+.site-message-overlay {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: 0;
+    background: $garnett-neutral-8;
+    opacity: .75;
+    z-index: $zindex-popover - 1;
 }
 
 .site-message--banner {


### PR DESCRIPTION
## What does this change?
Pretty much what it says on the tin. Lets a message block the page until action is taken on it to hide it. This will be used in an upcoming sign-in experiment.

I added basic keyboard support. However, the page can scroll freely underneath, which is a bit of an oversight but can be added in a subsequent PR if needed (the specs for the sign-in experiment are still a bit up in the air)

All details are up for debate, let me know what you think!

## Screenshots

![screen shot 2018-04-25 at 11 44 26 am](https://user-images.githubusercontent.com/11539094/39241695-b76013b4-487f-11e8-8abe-cd5acbcedfb4.png)
(Terrifying mental picture I know)