### PR TITLE
BUG FIX: Fix js error

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -17,7 +17,6 @@ export const getCampaign = () => {
             formFields,
             formId,
         } = campaignToShow.fields;
-
         return {
             title: callout,
             description,

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -17,6 +17,7 @@ export const getCampaign = () => {
             formFields,
             formId,
         } = campaignToShow.fields;
+
         return {
             title: callout,
             description,

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -5,8 +5,9 @@ import campaignForm from 'raw-loader!journalism/views/campaignForm.html';
 import { getCampaign } from 'journalism/modules/get-campaign';
 import { submitForm } from 'journalism/modules/submit-form';
 
-const renderCampaign = (anchorNode: HTMLElement): void => {
-    const campaign = template(campaignForm, { data: getCampaign() });
+const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
+    const campaign = template(campaignForm, { data: calloutData });
+
     const campaignDiv = `<figure class="element element-campaign">${
         campaign
     }</figure>`;
@@ -23,9 +24,13 @@ const renderCampaign = (anchorNode: HTMLElement): void => {
         });
 };
 
+
 export const initCampaign = () => {
+    const calloutData = getCampaign();
+    const isCalloutPresent = calloutData !== undefined;
+
     const fourthParagraph = document.querySelector(
         '.content__article-body p:nth-of-type(4)'
     );
-    if (fourthParagraph) renderCampaign(fourthParagraph);
+    if (isCalloutPresent && fourthParagraph) renderCampaign(fourthParagraph, calloutData);
 };

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -7,7 +7,6 @@ import { submitForm } from 'journalism/modules/submit-form';
 
 const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
     const campaign = template(campaignForm, { data: calloutData });
-
     const campaignDiv = `<figure class="element element-campaign">${
         campaign
     }</figure>`;
@@ -17,20 +16,21 @@ const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
             anchorNode.insertAdjacentHTML('afterend', campaignDiv);
         })
         .then(() => {
-            const cForm = anchorNode.querySelector('.campaign form');
+            const cForm = document.querySelector(
+                '.element-campaign .campaign .campaign--snippet__body'
+            );
             if (cForm) {
                 cForm.addEventListener('submit', submitForm);
             }
         });
 };
 
-
 export const initCampaign = () => {
     const calloutData = getCampaign();
-    const isCalloutPresent = calloutData !== undefined;
 
     const fourthParagraph = document.querySelector(
         '.content__article-body p:nth-of-type(4)'
     );
-    if (isCalloutPresent && fourthParagraph) renderCampaign(fourthParagraph, calloutData);
+    if (calloutData && fourthParagraph)
+        renderCampaign(fourthParagraph, calloutData);
 };

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
@@ -1,8 +1,12 @@
 // @flow
 
 import { initCampaign } from 'journalism/modules/render-campaign';
+import { getCampaign } from 'journalism/modules/get-campaign';
 
+// hack to stop flow complaining about 'mockImplementation'
+const mock = (mockFn: any) => mockFn;
 jest.mock('journalism/modules/get-campaign');
+mock(getCampaign).mockImplementation(() => ({ title: 'A great campaign' }));
 
 describe('Create a campaign element and insert into an article', () => {
     beforeEach(() => {


### PR DESCRIPTION
This fixes 2 bugs introduced by: https://github.com/guardian/frontend/pull/19437

**1. JS Error when no campaigns were present to a page**
Even if no campaigns were available the render went ahead anyway and threw a js error when no data was found
I've added a check to see if any campaigns are present. If they are not, the process stops. 

**2. Js Error in form submission**
The selector being used to add the form submit event listener to the form was broken. This fixes it, while making it more specific so it doesn't get tangled up. 

