### PR TITLE
Smaller banner for /consents/swu

### DIFF
--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -92,12 +92,11 @@
     $multiline-height: 4px * 3 + 1px; /*height of multiline (4px) times the number of lines (3)*/
     background-color: #53bbd6;
     border-bottom: 1px solid $garnett-neutral-4;
-    background-position: center;
     background-repeat: no-repeat;
     overflow: visible;
     margin-bottom: $multiline-height;
     position: relative;
-    padding: $gs-row-height 0;
+    padding: ($gs-row-height/2) 0;
     box-shadow: 0 ($slim-nav-height * -2) 0 0 #53bbd6;
 
     .identity-consent-hero--gdpr-oi-campaign__bubble-holder {
@@ -121,7 +120,7 @@
 
     img {
         display: block;
-        margin: auto;
+        margin: 0 auto 10px;
         height: $gs-row-height * 3;
         @include mq(tablet) {
             height: $gs-row-height * 4;

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -98,6 +98,7 @@
     margin-bottom: $multiline-height;
     position: relative;
     padding: $gs-row-height 0;
+    box-shadow: 0 ($slim-nav-height * -2) 0 0 #53bbd6;
 
     .identity-consent-hero--gdpr-oi-campaign__bubble-holder {
         position: absolute;

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -7,7 +7,7 @@ $gutter: 5px;
     background-color: $nav-background-colour;
     padding: ($gutter/2) 0 0;
     color: $nav-primary-colour;
-    height: $slim-nav-height;
+    height: $slim-nav-height + 1px;
     overflow: visible;
     position: relative;
     z-index: $zindex-main-menu;
@@ -20,7 +20,7 @@ $gutter: 5px;
         right: 0;
         height: 1px;
         display: block;
-        z-index: 10;
+        z-index: 0;
         background: #000000;
         opacity: .14;
     }
@@ -78,7 +78,7 @@ $gutter: 5px;
 html body .identity-header__logo {
     float: right;
     order: -99;
-    z-index: 11;
+    z-index: 1;
 
     .inline-the-guardian-roundel {
         display: block;

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -7,17 +7,30 @@ $gutter: 5px;
     background-color: $nav-background-colour;
     padding: ($gutter/2) 0 0;
     color: $nav-primary-colour;
-    z-index: 999;
-    border-bottom: 1px solid $rule;
     height: $slim-nav-height;
     overflow: visible;
+    position: relative;
+    z-index: $zindex-main-menu;
+
+    &:before {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 1px;
+        display: block;
+        z-index: 10;
+        background: #000000;
+        opacity: .14;
+    }
 
     .identity-dropdown {
         position: absolute;
         display: none;
         left: 0;
         top: get-line-height(textSans, 3)*1.25;
-        z-index: 999;
+        z-index: $zindex-main-menu + 1;
         li {
             display: block;
         }
@@ -65,6 +78,7 @@ $gutter: 5px;
 html body .identity-header__logo {
     float: right;
     order: -99;
+    z-index: 11;
 
     .inline-the-guardian-roundel {
         display: block;


### PR DESCRIPTION
## What does this change?
I made the banner bleed into the header (to match [id-front/376](https://github.com/guardian/identity-frontend/pull/376)) and now it doesn't need as much padding! win-win

## What is the value of this and can you measure success?
It looks a bit nicer, more like the rest of the campaign, plus the alignment was a bit of a mess before

## Screenshots
![screen shot 2018-04-25 at 3 56 44 pm](https://user-images.githubusercontent.com/11539094/39254338-ca879788-48a1-11e8-836e-36915a9c7061.png)
![screen shot 2018-04-25 at 3 56 32 pm](https://user-images.githubusercontent.com/11539094/39254335-c8da7ffe-48a1-11e8-9312-50e0307e3a30.png)