### PR TITLE
Brand the sign-in opt-in journey

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -28,7 +28,7 @@ class AuthenticatedActions(
     val returnUrl = identityUrlBuilder.buildUrl(request.uri)
 
     val params = List("returnUrl" -> returnUrl) ++
-      List("INTCMP", "email", "CMP", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content") //only forward these if they exist in original query string
+      List("INTCMP", "email", "CMP", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content","clientId") //only forward these if they exist in original query string
         .flatMap(name => request.getQueryString(name).map(value => name -> value))
 
     val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, params)

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -41,7 +41,7 @@ const targets: LinkTargets = {
         'https://gu.com/staywithus?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert',
     journey: `${config.get(
         'page.idUrl'
-    )}/email-prefs?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert`,
+    )}/email-prefs?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert&clientId=opt-in`,
 };
 
 const template: Template = {


### PR DESCRIPTION
## What does this change?
Adds this massive teal banner to the top of sign-in pages for users coming via the opt-in alert, the goal being to provide some visual continuity. Worth giving it a shot.

![screen shot 2018-04-25 at 12 08 39 pm](https://user-images.githubusercontent.com/11539094/39259144-9a9654e0-48ad-11e8-8c62-17f5109bb5be.png)

![screen shot 2018-04-25 at 5 24 01 pm](https://user-images.githubusercontent.com/11539094/39259072-774b61d8-48ad-11e8-800f-e9f5598918fa.png)
