### PR TITLE
Removed silly css

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -790,15 +790,6 @@
         &:before {
             display: none;
         }
-
-        .content__dateline {
-            display: block;
-            margin-left: auto;
-
-            @include mq($from: leftCol) {
-                margin: auto;
-            }
-        }
     }
     .drop-cap {
         height: 105px;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -395,18 +395,6 @@
         vertical-align: top;
         top: 3px;
     }
-
-    @include mq(tablet) {
-        padding-right: 0;
-    }
-
-    @include mq(leftCol) {
-        min-height: gs-height(1) + $gs-baseline;
-        padding-top: $gs-baseline/6;
-        padding-bottom: $gs-baseline;
-        margin-bottom: 0;
-        border-top: 1px dotted $neutral-5;
-    }
 }
 
 .content__dateline-wpd--modified {

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -21,8 +21,7 @@
     .gallery__meta-container {
         // TODO: remove the need for important by restructuring _types.scss
         background-image: none !important;
-        .byline,
-        .content__dateline {
+        .byline {
             background-image: none;
             border: 0;
             padding-top: 0;

--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -50,12 +50,12 @@
         padding-bottom: 0;
     }
 
-    .byline,
-    .content__dateline {
+    .byline {
         min-height: 0;
     }
 
-    .content__dateline {
+    .meta__numbers,
+    .meta__social {
         border-top: 0;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -102,8 +102,7 @@ $quote-mark: 35px;
         }
     }
 
-    .byline,
-    .content__dateline {
+    .byline {
         padding-top: 0;
         padding-bottom: $gs-baseline*1.5;
         @include mq($until: phablet) {
@@ -154,17 +153,6 @@ $quote-mark: 35px;
         border-top: 0;
         padding-top: 0;
         padding-bottom: $gs-baseline;
-    }
-
-    .content__dateline {
-        border: 0;
-        min-height: 0;
-        // magic numbers are correcting line heights so vertical alignment appears even
-        margin-bottom: -4px;
-        display: block;
-        padding-bottom: $gs-baseline;
-        padding-top: 2px;
-        margin-top: -$gs-baseline / 4;
     }
 
     .old-article-message {
@@ -878,21 +866,6 @@ $quote-mark: 35px;
         }
     }
 
-    .content__dateline {
-        // magic number used to align date stamp with standfirst baseline in opinion pieces per design
-        margin-top: 8px;
-
-        @include mq(leftCol) {
-            margin-top: -$gs-baseline/2;
-        }
-    }
-
-    .content__dateline:before {
-        @include mq($from: leftCol) {
-            @include multiline(1, $garnett-neutral-4);
-        }
-    }
-
     .meta__twitter,
     .meta__email {
         display: block;
@@ -1058,13 +1031,6 @@ $quote-mark: 35px;
     .meta__numbers .inline-share svg,
     .social-icon__svg {
         fill: $garnett-neutral-4;
-    }
-
-    .content__dateline {
-        @include mq(phablet) {
-            @include multiline(1, $garnett-neutral-7, top);
-            padding-top: $gs-baseline;
-        }
     }
 
     .byline span {


### PR DESCRIPTION
More scss barbarism in the meta area. Today's target --> content__dateline.

Everything looks and behaves the same. Just got rid of a lot of unnecessary lines of scss.