### PR TITLE
Extend commercial-ad-refresh switch by one week

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,7 +27,7 @@ object CommercialAdRefresh extends Experiment(
   name = "commercial-ad-refresh",
   description = "Users in this experiment will have their ad slots refreshed after 30 seconds",
   owners = Seq(Owner.withGithub("katebee")),
-  sellByDate = new LocalDate(2018, 4, 26),
+  sellByDate = new LocalDate(2018, 5, 3),
   participationGroup = Perc50
 )
 


### PR DESCRIPTION
## What does this change?

Temporarily extend `commercial-ad-refresh` by 1 week as it's expired so frontend builds will be failing.

@katebee please feel free to alter this with whatever date you like

## What is the value of this and can you measure success?

Working builds