### PR TITLE
fix webpack js reload

### DIFF
--- a/dev/watch.js
+++ b/dev/watch.js
@@ -47,7 +47,7 @@ webpackBundler.watch(
         const info = stats.toJson();
         // send editing errors to console and browser
         if (stats.hasErrors()) {
-            console.log(info.errors);
+            console.log(chalk.red(info.errors));
             return browserSync.sockets.emit('fullscreen:message', {
                 title: 'Webpack Error:',
                 body: info.errors,

--- a/dev/watch.js
+++ b/dev/watch.js
@@ -46,7 +46,7 @@ webpackBundler.watch(
 
         const info = stats.toJson();
         // send editing errors to console and browser
-        if (stats.hasErrors() || stats.hasWarnings()) {
+        if (stats.hasErrors()) {
             console.log(info.errors);
             return browserSync.sockets.emit('fullscreen:message', {
                 title: 'Webpack Error:',

--- a/dev/watch.js
+++ b/dev/watch.js
@@ -44,14 +44,19 @@ webpackBundler.watch(
             return browserSync.init(bsConfig);
         }
 
+        const info = stats.toJson();
         // send editing errors to console and browser
         if (stats.hasErrors() || stats.hasWarnings()) {
-            console.log(chalk.red(stats.toString('errors-only')));
+            console.log(info.errors);
             return browserSync.sockets.emit('fullscreen:message', {
                 title: 'Webpack Error:',
-                body: stats.toString('errors-only'),
+                body: info.errors,
                 timeout: 100000,
             });
+        }
+
+        if (stats.hasWarnings()) {
+            console.warn(chalk.yellow(info.warnings));
         }
 
         // announce the changes

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -6,6 +6,7 @@ const config = require('./webpack.config.js');
 
 module.exports = webpackMerge.smart(config, {
     devtool: 'inline-source-map',
+    mode: 'development',
     output: {
         filename: `graun.[name].js`,
         chunkFilename: `graun.[name].js`,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,6 +10,7 @@ const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const config = require('./webpack.config.js');
 
 module.exports = webpackMerge.smart(config, {
+    mode: 'production',
     output: {
         filename: `[chunkhash]/graun.[name].js`,
         chunkFilename: `[chunkhash]/graun.[name].js`,


### PR DESCRIPTION
## What does this change?

- sets `mode` in webpack configs
- updates error handling in watch task to handle webpack 4 errors
- adds warning logging in dev mode

## What is the value of this and can you measure success?

webpack was compiling JS in `production` mode when running `make watch`, because the mode flags were missing. this meant it was minifying it, and so it appeared the reload was failing. i _think_ it was just taking a _loooong_ time.

this should speed up JS compilation in dev again, and get reload working.

errors were also not being logged, because the API for getting them out of the watch `stats` object changed in v4, this fixes that too.