### PR TITLE
Add Oriel to applications and facia lifecycles

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -5,6 +5,7 @@ import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
 import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
+import common.commercial.OrielCacheLifecycle
 import conf.CachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient, SectionsLookUp, SectionsLookUpLifecycle}
@@ -62,7 +63,8 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     wire[SiteMapLifecycle],
     wire[CachedHealthCheckLifeCycle],
     wire[DiscussionExternalAssetsLifecycle],
-    wire[SkimLinksCacheLifeCycle]
+    wire[SkimLinksCacheLifeCycle],
+    wire[OrielCacheLifecycle]
   )
 
   lazy val router: Router = wire[Routes]

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -3,6 +3,7 @@ import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
+import common.commercial.OrielCacheLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
 import concurrent.BlockingOperations
 import conf.switches.SwitchboardLifecycle
@@ -49,7 +50,8 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     wire[SurgingContentAgentLifecycle],
     wire[IndexListingsLifecycle],
     wire[SwitchboardLifecycle],
-    wire[CachedHealthCheckLifeCycle]
+    wire[CachedHealthCheckLifeCycle],
+    wire[OrielCacheLifecycle]
   )
 
   lazy val router: Router = wire[Routes]


### PR DESCRIPTION
## What does this change?

This adds the Oriel lifecycle to applications and facia in order to serve the Oriel script on tag and front pages. Currently it is serving on article only.