### PR TITLE
Add a 0% ab test for the sign in alert

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,6 +28,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-sign-in-engagement-banner-display",
+    "This test will show a sign in engagement banner to non signed in users",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 1, 24),
+    exposeClientSide = true
+  ),
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-always-ask-if-tagged",
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,7 +34,7 @@ trait ABTestSwitches {
     safeState = Off,
     sellByDate = new LocalDate(2019, 1, 24),
     exposeClientSide = true
-  ),
+  )
 
   Switch(
     ABTests,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,9 +3,11 @@ import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import { spacefinderSimplify } from 'common/modules/experiments/tests/spacefinder-simplify';
+import { signInEngagementBannerDisplay } from './tests/sign-in-engagement-banner-display';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
+    signInEngagementBannerDisplay,
     spacefinderSimplify,
 ].filter(Boolean);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
@@ -3,7 +3,7 @@
 export const signInEngagementBannerDisplay: ABTest = {
     id: 'SignInEngagementBannerDisplay',
     start: '2018-04-26',
-    expiry: '2018-05-26',
+    expiry: '2019-01-24',
     author: 'Laura gonzalez',
     description:
         'This test will show a sign in engagement banner to non signed in users.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const signInEngagementBannerDisplay: ABTest = {
+    id: 'SignInEngagementBannerDisplay',
+    start: '2018-04-26',
+    expiry: '2018-05-26',
+    author: 'Laura gonzalez',
+    description:
+        'This test will show a sign in engagement banner to non signed in users.',
+    audience: 0,
+    audienceOffset: 0.25,
+    successMeasure: 'More signed in users as % of visitors',
+    audienceCriteria: 'All web traffic',
+    dataLinkNames: 'All starting with "sign-in-eb :"',
+    idealOutcome:
+        'We increase the number of signed in users more than the banner puts people off visiting the site.',
+    variants: [
+        {
+            id: 'variant',
+            test: () => {},
+        },
+        {
+            id: 'control',
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-engagement-banner-display.js
@@ -14,6 +14,7 @@ export const signInEngagementBannerDisplay: ABTest = {
     dataLinkNames: 'All starting with "sign-in-eb :"',
     idealOutcome:
         'We increase the number of signed in users more than the banner puts people off visiting the site.',
+    canRun: () => true,
     variants: [
         {
             id: 'variant',


### PR DESCRIPTION
## What does this change?
Adds a new 0% AB test for the upcoming sign in alert, this will be bumped up (to 50%) in the future but my plan for this is to let stakeholders test the alert before it goes live, which they can do with `#ab-SignInEngagementBannerDisplay=variant`. 