### PR TITLE
Use Imgix for site map images

### DIFF
--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -5,7 +5,9 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import model.Content
 import org.joda.time.{DateTime, DateTimeZone}
-import implicits.Dates.{ DateTime2ToCommonDateFormats, jodaToJavaInstant}
+import implicits.Dates.{DateTime2ToCommonDateFormats, jodaToJavaInstant}
+import views.support.Item1200
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.{Elem, NodeSeq}
 
@@ -87,7 +89,8 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
           case _ => None
         }).mkString(", ")
 
-        val imageUrl: String = item.elements.mainPicture.flatMap(_.images.largestEditorialCrop.flatMap(_.url))
+        val imageUrl = item.elements.mainPicture
+          .flatMap(element => Item1200.bestSrcFor(element.images))
           .getOrElse(Configuration.images.fallbackLogo)
 
         Url(


### PR DESCRIPTION
This is to ensure we don't kill our bandwidth by serving unoptimised master images.

*Note, the list of consumers for site map is unclear so it's hard to judge if the chosen image size/options are sensible.*

~~But it should fix our bandwidth woes for now.~~ This is far from clear as we're not confident of the source of the issue.