### PR TITLE
Fix opt in alert image link

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
@@ -19,7 +19,7 @@ const makeTemplateHtml = (template: Template, targets: LinkTargets): string => `
         <div class="site-message__message identity-gdpr-oi-alert">
             <a class="identity-gdpr-oi-alert__logo" target="_blank" href="${
                 targets.landing
-            }" data-link-name="gdpr-oi-campaign : alert : to-consents : img">
+            }" data-link-name="gdpr-oi-campaign : alert : to-landing-img">
                 <img src="${template.image}" alt="Stay with us" />
             </a>
             <div class="identity-gdpr-oi-alert__body">

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-eb-template.js
@@ -12,14 +12,13 @@ type Template = {
 
 type LinkTargets = {
     landing: string,
-    journey: string,
 };
 
 const makeTemplateHtml = (template: Template, targets: LinkTargets): string => `
     <div id="site-message__message">
         <div class="site-message__message identity-gdpr-oi-alert">
             <a class="identity-gdpr-oi-alert__logo" target="_blank" href="${
-                targets.journey
+                targets.landing
             }" data-link-name="gdpr-oi-campaign : alert : to-consents : img">
                 <img src="${template.image}" alt="Stay with us" />
             </a>

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -39,9 +39,6 @@ type ApiUser = {
 const targets: LinkTargets = {
     landing:
         'https://www.theguardian.com/info/ng-interactive/2018/feb/21/stay-with-us?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert',
-    journey: `${config.get(
-        'page.idUrl'
-    )}/email-prefs?CMP=gdpr-oi-campaign-alert&utm_campaign=gdpr-oi-campaign-alert&clientId=opt-in`,
 };
 
 const template: Template = {


### PR DESCRIPTION
## What does this change?
The surprisingly popular clickable logo in the alert was still linking to the consents journey. This PR changes it to point to the landing page instead, mirroring the behaviour of the main CTA.