### PR TITLE
Upgrade event emitter

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,7 +35,6 @@ module.name_mapper='^svgs' -> '<PROJECT_ROOT>/static/src/inline-svgs'
 # modules that go by different names in webpack
 module.name_mapper='^lodash\(.*\)$' -> 'lodash-node/compat\1'
 module.name_mapper='^raven' -> 'raven-js'
-module.name_mapper='^EventEmitter' -> 'wolfy87-eventemitter'
 module.name_mapper='^videojs' -> 'video.js'
 module.name_mapper='^ophan/ng' -> 'ophan-tracker-js'
 module.name_mapper='^ophan/embed' -> 'ophan-tracker-js/build/ophan.embed'

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "moduleNameMapper": {
       "^lodash/(.*)$": "lodash-node/compat/$1",
       "raven": "raven-js",
-      "EventEmitter": "wolfy87-eventemitter",
       "videojs": "video.js",
       "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.js",
       "^(.*)\\.html$": "<rootDir>/__mocks__/templateMock.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "videojs-persistvolume": "guardian/videojs-persistvolume#0.1.4",
     "videojs-playlist": "guardian/videojs-playlist#0.1.4",
     "webshot": "^0.18.0",
-    "wolfy87-eventemitter": "~4.2.6"
+    "wolfy87-eventemitter": "~5.2.4"
   },
   "devDependencies": {
     "amphtml-validator": "^1.0.21",

--- a/static/src/javascripts/lib/mediator.js
+++ b/static/src/javascripts/lib/mediator.js
@@ -1,5 +1,5 @@
 // @flow
 
-import EventEmitter from 'EventEmitter';
+import EventEmitter from 'wolfy87-eventemitter';
 
 export default new EventEmitter();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,6 @@ module.exports = {
             // #wp-rjs weird old aliasing from requirejs
             lodash: 'lodash-node/compat',
             raven: 'raven-js',
-            EventEmitter: 'wolfy87-eventemitter',
             videojs: 'video.js',
 
             svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9852,9 +9852,9 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-wolfy87-eventemitter@~4.2.6:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-4.2.11.tgz#f2b42aab226deab6f5352f4b449bd071d609ab33"
+wolfy87-eventemitter@~5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.4.tgz#5021d2952d3611cbcd195149711d9b595cd11d48"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
## What does this change?

- upgrades `wolfy-eventemitter` to 5.2.4. [Tags page](https://github.com/Olical/EventEmitter/tags) and [Changelog](https://github.com/Olical/EventEmitter/blob/master/CHANGES.md) are not very helpful but the [API](https://github.com/Olical/EventEmitter/blob/master/docs/api.md) doesn't appear to have changed
- removes some weird aliasing left over from the Bower days that we don't really need

## What is the value of this and can you measure success?

Less indirection, more up to date dependencies

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
