### PR TITLE
update stay with us copy in feedback form for email stopping

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -29,7 +29,7 @@
                                             <label for="feedback-category">Please choose a service below </label>
                                             <select name="category" id="feedback-category" class="feedback__select">
                                                 <option value="nothing">Please choose a category first...</option>
-                                                <option value="feedback-form-stay-with-us">Stay With Us campaign issues/questions</option>
+                                                <option value="feedback-form-stay-with-us">I have stopped receiving emails from you</option>
                                                 <option value="feedback-form-account">Guardian account help</option>
                                                 <option value="feedback-form-website">Website help and issues</option>
                                                 <option value="feedback-form-jobs">Jobs account/alerts help</option>

--- a/onward/app/views/fragments/feedbackForms.scala.html
+++ b/onward/app/views/fragments/feedbackForms.scala.html
@@ -1,7 +1,8 @@
 @()(implicit request: RequestHeader)
 
 <div id="feedback-form-stay-with-us" class="feedback__blurb">
-    <p>This option is for questions related to the <a href="https://www.theguardian.com/staywithus">Stay with us</a> campaign. If you have received an email or on-site request to update your preferences you can see the frequently asked questions about this campaign by clicking <a href="https://www.theguardian.com/staywithus">this link</a>.</p>
+    <p>If you have recently stopped receiving communications or email newsletters from us, please click <a href="https://www.theguardian.com/info/ng-interactive/2018/feb/21/stay-with-us">here</a> to re-enable your email permissions.</p>
+    <p>If you are still having issues, contact our user support team using the form below.</p>
     <p>If you are getting in contact for another reason please select another option from the dropdown menu above.</p>
 </div>
 


### PR DESCRIPTION
## What does this change?

Small html change to update the wording on the user help contact form. Stay with us campaign has moved into stopping emails territory, so this makes it clearer what users should do

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Tested in CODE?
Only locally
