### PR TITLE
Disable movement if user has declared they don’t want it

### DIFF
--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -107,3 +107,11 @@ input[type='button'],
 input[type='submit'] {
     touch-action: manipulation;
 }
+
+// don't animate anything if people have said they don't want it
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
## What does this change?

disables animations/transitions if device reports `prefers-reduced-motion`

been meaning to do this for ages and https://twitter.com/justmarkup/status/974581638637142016 prompted me

## What is the value of this and can you measure success?

if people don't want movement, we should respect it