### PR TITLE
Remove mention to 30 April in the opt in alert

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -43,7 +43,7 @@ const targets: LinkTargets = {
 
 const template: Template = {
     image: config.get('images.identity.opt-in-new-vertical'),
-    title: `We’re changing how we communicate with you. Let us know <strong>before 30 April</strong> which emails you wish to continue receiving, otherwise you will stop hearing from us.`,
+    title: `We’re changing how we communicate with you. Let us know which emails you wish to continue receiving, otherwise you will stop hearing from us.`,
     cta: `Continue`,
     remindMeLater: shouldDisplayForMoreUsers()
         ? `No, thanks`


### PR DESCRIPTION
Requested by mydata because, well, it's 30 April today and this is not really a very convincing argument for users to opt in anymore.

<img width="358" alt="screen shot 2018-04-30 at 6 27 41 pm" src="https://user-images.githubusercontent.com/11539094/39440865-36544564-4ca4-11e8-86d7-83589b7a90bf.png">
