### PR TITLE
Delete unused lint overrides

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -30,17 +30,11 @@ module.exports = {
         // if we go more [p]react we should look at them.
         // not saying it's ok, but we don't reuse modules or
         // develop this stuff much. disabling for now.
-        'react/prefer-es6-class': 'off',
         'react/no-multi-comp': 'off',
         'react/no-find-dom-node': 'off',
         'react/jsx-no-bind': 'off',
-        'react/no-deprecated': 'off', // still on 0.13
-        'react/prop-types': 'off',
         'react/no-string-refs': 'off',
         'react/prefer-stateless-function': 'off',
-        'react/no-render-return-value': 'off',
-        'react/jsx-indent': [2, 4],
-        'react/jsx-indent-props': [2, 4],
         'react/jsx-filename-extension': 'off',
 
         // disallow naming variables 'guardian', because

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     plugins: ['flowtype', 'flow-header'],
     rules: {
         // require-specific overrides
-        'import/no-extraneous-dependencies': 'off', // necessary while we use aliases
         'import/extensions': 'off',
         'import/no-webpack-loader-syntax': 'off', // used for require plugins still
         'import/no-namespace': 2,


### PR DESCRIPTION
## What does this change?

We're overriding a bunch of lint rules because our old React code was bad. Now it's not _quite_ so bad, so we can reinstate these rules 🎉 

Since the Webpack migration, we are also free to disallow extraneous dependencies, so I've removed this override too.

## What is the value of this and can you measure success?

Killing all of these overrides is an important step towards upgrading React or migrating to Preact. Removing unused overrides helps us tell the wood from the trees.
