### PR TITLE
include hreflang alternate for current edition in page head

### DIFF
--- a/applications/test/SectionTemplateTest.scala
+++ b/applications/test/SectionTemplateTest.scala
@@ -17,9 +17,10 @@ import scala.collection.JavaConverters._
   it should "add alternate pages to editionalised sections for /uk/culture" in goTo("/uk/culture") { browser =>
 
     val alternateLinks = getAlternateLinks(browser)
-    alternateLinks.size should be (2)
+    alternateLinks.size should be (3)
     alternateLinks.exists(link => toPath(link.attribute("href")) == "/us/culture" && link.attribute("hreflang") == "en-US") should be (true)
     alternateLinks.exists(link => toPath(link.attribute("href")) == "/au/culture" && link.attribute("hreflang") == "en-AU") should be (true)
+    alternateLinks.exists(link => toPath(link.attribute("href")) == "/uk/culture" && link.attribute("hreflang") == "en-GB") should be (true)
 
   }
 
@@ -31,14 +32,6 @@ import scala.collection.JavaConverters._
         val href: Option[String] = Option(element.attribute("href"))
         href.isDefined && !href.exists(_.contains("ios-app"))
       })
-  }
-
-  it should "add alternate pages to editionalised sections for /au/culture" in goTo("/au/culture") { browser =>
-
-    val alternateLinks = getAlternateLinks(browser)
-    alternateLinks.size should be (2)
-    alternateLinks.exists(link => toPath(link.attribute("href")) == "/us/culture" && link.attribute("hreflang") == "en-US") should be (true)
-    alternateLinks.exists(link => toPath(link.attribute("href")) == "/uk/culture" && link.attribute("hreflang") == "en-GB") should be (true)
   }
 
   it should "not add alternate pages to non editionalised sections" in goTo("/books") { browser =>

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -84,10 +84,6 @@ object Edition {
 
   def others(edition: Edition): Seq[Edition] = all.filterNot(_ == edition)
 
-  def othersById(id: String): Seq[Edition] = byId(id).map(others(_)).getOrElse(Nil)
-  def othersByHomepage(path: String): Seq[Edition] = all.find(_.homePagePath == path)
-    .map(_.id).map(othersById).getOrElse(Nil)
-
   def byId(id: String): Option[Edition] = all.find(_.id.equalsIgnoreCase(id))
 
   implicit val editionWrites: Writes[Edition] = new Writes[Edition] {
@@ -103,18 +99,18 @@ object Edition {
 
   private lazy val EditionalisedId = s"^/($editionRegex)(/[\\w\\d-]+)$$".r
 
-
-  def otherPagesFor(request: RequestHeader): Seq[EditionLink] = {
+  def allPagesFor(request: RequestHeader): Seq[EditionLink] = {
     val path = request.path
     path match {
       case EditionalisedId(editionId, section) if Edition.defaultEdition.isEditionalised(section.drop(1)) =>
-        val links = Edition.othersById(editionId).map(EditionLink(_, section))
+        val links = Edition.all.map(EditionLink(_, section))
         links.filter(link => link.edition.isEditionalised(link.path.drop(1)))
       case EditionalisedFront(_) =>
-        Edition.othersByHomepage(path).map(EditionLink(_, "/"))
+        all.map(EditionLink(_, "/"))
       case _ => Nil
     }
   }
+
 }
 
 object Editionalise {

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -59,7 +59,7 @@
     ONLY for EDITONALISED sections
     https://support.google.com/webmasters/answer/189077
 *@
-@Edition.otherPagesFor(request).map{ link =>
+@Edition.allPagesFor(request).map{ link =>
     <link rel="alternate" href="@LinkTo(link.path, link.edition)" hreflang="@link.edition.locale.toLanguageTag" />
 }
 


### PR DESCRIPTION
## What does this change?

As requested by: Peter Martin

> Basically: each page needs a rel="alternate" pointing to itself, with the appropriate lang. So /uk needs this...
> 
> ```<link rel="alternate" href="https://www.theguardian.com/uk" hreflang="en-GB"/>```
> 
> ...in ADDITION to the existing ones:
> 
> ```<link rel="alternate" href="https://www.theguardian.com/us" hreflang="en-US"/>```
> ```<link rel="alternate" href="https://www.theguardian.com/au" hreflang="en-AU"/>```
> ```<link rel="alternate" href="https://www.theguardian.com/international" hreflang="en"/>```
> ```<link rel="canonical" href="https://www.theguardian.com/uk"/>```
> 
> It seems that we currently leave out the "alternate" one for the current edition - which not the > correct thing to do.

This PR prevents leaving out the self-referencing alternate link hreflang

## What is the value of this and can you measure success?

Google search better

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
