### PR TITLE
fix the googlecard height

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -239,7 +239,7 @@
     }
 }
 
-.ad-slot--container-inline:not(.ad-slot--fluid) {
+.ad-slot--container-inline:not(.ad-slot--fluid):not(.ad-slot--gc) {
     .ad-slot__content {
         margin: 0 auto;
     }


### PR DESCRIPTION
## What does this change?
fixes the height of the google card and removes the empty space of the ad label
## What is the value of this and can you measure success?
serves the Google Native card without an ad label
## Does this affect other platforms - Amp, Apps, etc?
no
## Tested in CODE?
no
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
