### PR TITLE
Extend commercial ad refresh switch by 4 weeks

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -28,7 +28,7 @@ object CommercialAdRefresh extends Experiment(
   name = "commercial-ad-refresh",
   description = "Users in this experiment will have their ad slots refreshed after 30 seconds",
   owners = Seq(Owner.withGithub("katebee")),
-  sellByDate = new LocalDate(2018, 5, 3),
+  sellByDate = new LocalDate(2018, 5, 31),
   participationGroup = Perc50
 )
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -239,7 +239,7 @@
     }
 }
 
-.ad-slot--container-inline:not(.ad-slot--fluid) {
+.ad-slot--container-inline:not(.ad-slot--fluid):not(.ad-slot--gc) {
     .ad-slot__content {
         margin: 0 auto;
     }


### PR DESCRIPTION
## What does this change?
Extends the end date of the commercial ad refresh test
## What is the value of this and can you measure success?
doesn't break the build and extends the testing period

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
