### PR TITLE
Allow unicode addresses

### DIFF
--- a/identity/app/form/AddressMapping.scala
+++ b/identity/app/form/AddressMapping.scala
@@ -7,10 +7,13 @@ import play.api.i18n.{Messages, MessagesProvider}
 
 trait AddressMapping extends Mappings {
 
-  private val AddressLinePattern = """[^\w\s'#,./-]""".r
+  private val validAddressChars = Seq('\'','#',',','.','/','-')
+  private def isValidAddressChar(char: Char): Boolean =
+    char.isLetterOrDigit || char.isUnicodeIdentifierPart || char.isUnicodeIdentifierStart || char.isWhitespace || validAddressChars.contains(char)
+
   private def idAddressLine(implicit messagesProvider: MessagesProvider): Mapping[String] = textField verifying (
     Messages("error.address"),
-    { value => value.isEmpty || AddressLinePattern.findFirstIn(value).isEmpty }
+    { value => value.isEmpty || value.forall(isValidAddressChar)}
   )
 
   def idAddress(implicit messagesProvider: MessagesProvider): Mapping[AddressFormData] = mapping(


### PR DESCRIPTION
## What does this change?

Allows unicode characters to be used in Address Data, see user help case 64447

## What is the value of this and can you measure success?

Users can call their own address in their own language. 

## Does this affect other platforms - Amp, Apps, etc?

No 

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

OLD: 
![screen shot 2018-05-02 at 12 10 29](https://user-images.githubusercontent.com/3636251/39520252-d7e492c2-4e01-11e8-960d-e68f2a324e80.png)

NEW: 

![screen shot 2018-05-02 at 12 11 22](https://user-images.githubusercontent.com/3636251/39520281-f7574924-4e01-11e8-94ad-ca62cc8319c2.png)


Validation still rejects weirdness:

![screen shot 2018-05-02 at 12 07 54](https://user-images.githubusercontent.com/3636251/39520306-05a0d784-4e02-11e8-8b1a-a9c067b79d2e.png)


## Tested in CODE?

**Yes**

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
