### PR TITLE
Emails prefs page rejigery

### DIFF
--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -1,4 +1,4 @@
-@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false, isAnimated: Boolean = false)(content: Html)
+@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false, isAnimated: Boolean = false, totalEmails: Int = 0)(content: Html)
 
 @defining("dropdown-"+content.hashCode){ hash =>
 <div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active} @if(isAnimated){dropdown--animated}" data-dropdown-label="@if(isClientSideTemplate) {<%=name%>} else {@name}">
@@ -9,6 +9,7 @@
             aria-expanded="@{isActive.toString}">
         <span class="dropdown__label">@if(isClientSideTemplate) {<%=name%>} else {@name}</span>
         @fragments.inlineSvg("dropdown-mask", "icon", List("control", "modern-visible"))
+        <span class="dropdown__total">0 / @if(isClientSideTemplate) {<%=totalEmails%>} else {@totalEmails}</span>
     </button>
 
     <label class="dropdown__toggle-label"

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -11,7 +11,7 @@
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
-    @fragments.dropdown(theme.capitalize, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
+    @fragments.dropdown(theme.capitalize, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true, totalEmails =newsletters.length) {
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>
                 @newsletters.zipWithRowInfo.map { case (newsletter, row) =>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -32,4 +32,18 @@
     @List("news", "features", "sport", "culture", "lifestyle", "comment", "work").zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), (startsOpen == true && index == 0))
     }
+
+    <ul class="u-unstyled">
+        <li>
+            <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
+                <span class="email-unsubscribe-all__label js-unsubscribe--basic manage-account__button-flexwrap">
+                    Unsubscribe from all newsletters
+                    @fragments.inlineSvg("cross", "icon")
+                </span>
+                <span class="email-unsubscribe-all__label js-unsubscribe--confirm hide" aria-hidden>
+                    Are you sure?
+                </span>
+            </button>
+        </li>
+    </ul>
 </div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -52,8 +52,8 @@
                     @if(user.primaryEmailAddress != null | !user.primaryEmailAddress.isEmpty) {
                         <li>
                             <p>
-                                You are receiving newsletters, notifications and all other emails to: <br>
-                                <b>@user.primaryEmailAddress</b>
+                                You are receiving newsletters, notifications and all other emails to
+                                <b>@user.primaryEmailAddress</b><b>.</b>
                             </p>
                         </li>
                     }
@@ -75,17 +75,6 @@
                                 Edit your Job Alert settings
                             </a>
                         </p>
-                    </li>
-                    <li>
-                        <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
-                            <span class="email-unsubscribe-all__label js-unsubscribe--basic manage-account__button-flexwrap">
-                                Unsubscribe from all newsletters
-                                @fragments.inlineSvg("cross", "icon")
-                            </span>
-                            <span class="email-unsubscribe-all__label js-unsubscribe--confirm hide" aria-hidden>
-                                Are you sure?
-                            </span>
-                        </button>
                     </li>
                 </ul>
             </div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -66,7 +66,7 @@
                     </li>
                     <li>
                         <a href="#identity-modal--newsletterFormat" class="u-underline js-email-subscription__formatFieldsetToggle" data-link-name="identity : email : format">
-                            Change email format (HTML/txt)
+                            Change email format (HTML/text)
                         </a>
                     </li>
                     <li>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -34,7 +34,7 @@
                 The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
             </p>
         </div>
-        <div class="fieldset__fields">
+        <div class="fieldset__fields email-categories__categories">
             @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
         </div>
     </fieldset>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -11,7 +11,8 @@
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
     idRequest: services.IdentityRequest,
-    idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+    idUrlBuilder: services.IdentityUrlBuilder,
+    user: com.gu.identity.model.User)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @buildIdentityUrl(endpoint: String) = {
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
@@ -43,17 +44,30 @@
 
         <fieldset class="fieldset">
             <div class="fieldset__heading">
-                <h2 class="form__heading">Settings</h2>
+                <h2 class="form__heading">Email Settings</h2>
             </div>
 
             <div class="fieldset__fields email-subscription__options">
                 <ul class="u-unstyled">
+                    @if(user.primaryEmailAddress != null | !user.primaryEmailAddress.isEmpty) {
+                        <li>
+                            <p>
+                                You are receiving newsletters, notifications and all other emails to: <br>
+                                <b>@user.primaryEmailAddress</b>
+                            </p>
+                        </li>
+                    }
                     <li>
                         <p>
                             <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">
-                                Update your email address
+                                Change email address via Account & profile tab
                             </a>
                         </p>
+                    </li>
+                    <li>
+                        <a href="#identity-modal--newsletterFormat" class="u-underline js-email-subscription__formatFieldsetToggle" data-link-name="identity : email : format">
+                            Change email format (HTML/txt)
+                        </a>
                     </li>
                     <li>
                         <p>
@@ -61,11 +75,6 @@
                                 Edit your Job Alert settings
                             </a>
                         </p>
-                    </li>
-                    <li>
-                        <a href="#identity-modal--newsletterFormat" class="u-underline js-email-subscription__formatFieldsetToggle" data-link-name="identity : email : format">
-                            Change format
-                        </a>
                     </li>
                     <li>
                         <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -36,7 +36,7 @@
         <fieldset class="fieldset fieldset--manage-account-noborder">
 
             <div class="fieldset__heading">
-                <h2 class="form__heading">What can we tell you about?</h2>
+                <h2 class="form__heading">What else can we tell you about?</h2>
                 <p class="form__note">The Guardian would like to occasionally send you information about their products, services and events</p>
             </div>
 
@@ -83,12 +83,12 @@
     </div>
 }
 
-@* MARKETING CONSENT *@
-@marketingConsentForm
-
 @* NEWSLETTERS *@
-<hr class="manage-account-divider" />
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
+
+@* MARKETING CONSENT *@
+<hr class="manage-account-divider" />
+@marketingConsentForm
 
 @* CHANNELS *@
 <hr class="manage-account-divider" />

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -84,7 +84,7 @@
 }
 
 @* NEWSLETTERS *@
-@profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
+@profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder, user)
 
 @* MARKETING CONSENT *@
 <hr class="manage-account-divider" />

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -85,7 +85,7 @@
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", redirect = redirectDecision)
 
-                    @tab(6, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab", redirect = redirectDecision)
+                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", redirect = redirectDecision)
                 </ol>
         </div>
     </div>

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -359,6 +359,9 @@ $identity-header-height: 48px;
                 margin-left: 4px;
             }
         }
+        .dropdown__total {
+            float: right;
+        }
         .dropdown__content {
             padding-bottom: 2em;
         }

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -226,3 +226,12 @@ $checkbox-size: $gs-gutter / 1.25;
         margin-right: .25em;
     }
 }
+
+@include mq(desktop) {
+    .fieldset__fields {
+        &.email-categories__categories {
+            width: gs-span(8);
+            max-width: gs-span(8);
+        }
+    }
+}

--- a/static/src/stylesheets/module/identity/_wrapper.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.scss
@@ -36,7 +36,7 @@
     }
 
     @include mq(desktop) {
-        max-width: gs-span(10);
+        max-width: gs-span(12);
     }
 }
 

--- a/static/src/stylesheets/module/identity/_wrapper.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.scss
@@ -21,7 +21,7 @@
 .identity-wrapper {
     margin-left: auto;
     margin-right: auto;
-    max-width: gs-span(6);
+    max-width: gs-span(8);
     padding-bottom: $gs-gutter * 2;
     padding-top: $gs-gutter / 4;
 


### PR DESCRIPTION
## What does this change?
- Settings title -> Emails settings
- "Your currently receiving emails to this email address: XX " In settings tab
- Emails tab -> Emails & marketing
- Wider tabs in desktop view to accommodate longer wording of Emails & marketing

## What is the value of this and can you measure success?
- More clarity

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
![image](https://user-images.githubusercontent.com/14179210/39523943-3bc38d40-4e0f-11e8-9f87-464149ab4f0f.png)
----------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/14179210/39523951-42d7d078-4e0f-11e8-850d-257f0af4daf6.png)

## Tested in CODE?
No

@katyabeer
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
