### PR TITLE
Add Xaxis to Prebid auctions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash-node": "^2.4.1",
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.9",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#b2652ad",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#5423870",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bidder-config.js
@@ -200,7 +200,7 @@ const improveDigitalBidder: PrebidBidder = {
 };
 
 const xaxisBidder: PrebidBidder = {
-    name: 'appnexus',
+    name: 'xhb',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidXaxisParams => ({
         placementId: getXaxisPlacementId(sizes),
     }),

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -93,9 +93,6 @@ class PrebidService {
         }
 
         if (config.switches.prebidXaxis) {
-            // Using AppNexus adapter for Xaxis bids but need to know they are actually Xaxis bids in DFP
-            window.pbjs.aliasBidder('appnexus', 'xhb');
-
             window.pbjs.bidderSettings.xhb = {
                 // for First Look deals
                 alwaysUseBid: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,9 +7464,9 @@ postcss@^6.0.21:
     source-map "^0.6.1"
     supports-color "^5.3.0"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#b2652ad":
-  version "1.8.0"
-  resolved "https://github.com/guardian/Prebid.js.git#b2652ad297ccb49c17529eff44b641ca6fc7381a"
+"prebid.js@https://github.com/guardian/Prebid.js.git#5423870":
+  version "1.9.0"
+  resolved "https://github.com/guardian/Prebid.js.git#5423870dae14d7630096314729dadc93e4de971a"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
Xaxis was previously included as an alias of the AppNexus adapter.
Now its name has been added to the list of aliases inside the adapter, so we no longer need to refer to it as an alias here.  Instead we can use its name directly.
Then the targeting values going through to DFP will be in the correct form, eg `hb_bidder_xhb`.