### PR TITLE
Fix some bugs with the LineHeight test

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -1,6 +1,6 @@
 @()(implicit request: RequestHeader)
 @import conf.switches.Switches._
-@import experiments.LineHeightFontSize
+@import experiments.{ ActiveExperiments, LineHeightFontSize }
 
 /**
  * Choose how the browser should render the page before any painting begins.
@@ -121,7 +121,7 @@
         docClass = docClass.replace(/\bis-not-modern\b/g, 'is-modern');
     }
 
-    @if(LineHeightFontSize.canRun) {
+    @if(ActiveExperiments.isParticipating(LineHeightFontSize)) {
       docClass += ' commercial-line-height';
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -372,6 +372,12 @@ $quote-mark: 35px;
             font-size: 17px;
             line-height: 24px;
         }
+
+        // negative margin on these is currently based on inital
+        // font-size so we need to set this for the test duration.
+        .ad-slot--offset-right {
+            font-size: 16px;
+        }
     }
 
     .media-primary {


### PR DESCRIPTION
## What does this change?

- Stops applying the font-size change to `ad-slot--offset-right` since this throws out the negative margin calc.

- Swap `canRun` for `isParticipating` since these actually do very different things and the latter is what we want 🙈 

## What is the value of this and can you measure success?

Bugs squashed: Right hand side MPUs (in article) offset too far right

![image](https://user-images.githubusercontent.com/8607683/39576564-7668097c-4ed6-11e8-8655-097787fe66b6.png)

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

#### AFTER (left) and BEFORE (right)
<img width="1663" alt="picture 30" src="https://user-images.githubusercontent.com/8607683/39576361-c8383598-4ed5-11e8-83fa-dabedfddcaeb.png">

## Tested in CODE?

YEP
