### PR TITLE
Expand reach of the "Missing Something?" alert

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -41,7 +41,7 @@ const targets: LinkTargets = {
 };
 
 const template: Template = {
-    image: config.get('images.identity.opt-in-new-vertical'),
+    image: config.get('images.identity.missing'),
     title: `We’re changing how we communicate with you. Let us know which emails you wish to continue receiving, otherwise you will stop hearing from us.`,
     cta: `Continue`,
     remindMeLater: shouldDisplayForMoreUsers()

--- a/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/opt-in-engagement-banner.js
@@ -11,7 +11,7 @@ import userPrefs from 'common/modules/user-prefs';
 import type { LinkTargets, Template } from './opt-in-eb-template';
 import { makeTemplateHtml } from './opt-in-eb-template';
 
-const messageCode: string = 'gdpr-opt-in-jan-18';
+const messageCode: string = 'gdpr-opt-in-may-04';
 const messageHidAtPref: string = `${messageCode}-hid-at`;
 const messageMoreShownAtPref: string = `${messageCode}-more-shown-at`;
 const messageWasDismissedPref: string = `${messageCode}-was-dismissed`;
@@ -23,6 +23,7 @@ const messageUserUsesNewslettersCookie: string = `gu-${
 const messageCloseBtn = 'js-gdpr-oi-close';
 const remindMeLaterInterval = 24 * 60 * 60 * 1000;
 const lastShownAtInterval = 24 * 60 * 60 * 1000;
+
 const ERR_EXPECTED_NO_BANNER = 'ERR_EXPECTED_NO_BANNER';
 
 const shouldDisplayForMoreUsers = (): boolean =>
@@ -89,7 +90,6 @@ const getDisplayConditions = (): boolean[] => {
     if (shouldDisplayForMoreUsers()) {
         return [
             ...basics,
-            shouldDisplayOnceADay(),
             shouldDisplayBasedOnVisitedPageCount(),
             shouldDisplayIfNotAlreadyDismissed(),
         ];


### PR DESCRIPTION
## What does this change?
Makes the opt-in alert appear again for all users who closed it before plus it will now show up on every pageview > 5 until its explicitly dismissed

![screen shot 2018-05-04 at 11 08 39 am](https://user-images.githubusercontent.com/11539094/39622938-d30ae3ba-4f8b-11e8-9a5a-e9f5475be5e8.png)

The diff looks a bit scary as this PR also aligns the alert with the changes needed for #19591