### PR TITLE
Add context to comment count for screen readers

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -15,7 +15,7 @@ import { ScrollDepth } from 'common/modules/analytics/scrollDepth';
 import { requestUserSegmentsFromId } from 'common/modules/commercial/user-ad-targeting';
 import { initDonotUseAdblock } from 'common/modules/commercial/donot-use-adblock';
 import { refresh as refreshUserFeatures } from 'common/modules/commercial/user-features';
-import CommentCount from 'common/modules/discussion/comment-count';
+import { initCommentCount } from 'common/modules/discussion/comment-count';
 import { init as initCookieRefresh } from 'common/modules/identity/cookierefresh';
 import { initNavigation } from 'common/modules/navigation/navigation';
 import { Profile } from 'common/modules/navigation/profile';
@@ -178,7 +178,7 @@ const startRegister = (): void => {
 
 const initDiscussion = (): void => {
     if (config.switches.enableDiscussionSwitch) {
-        CommentCount.init();
+        initCommentCount();
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -19,7 +19,7 @@ const getTemplate = (
     if (type === 'content') {
         return `<a href="${
             url
-        }" data-link-name="Comment count" class="commentcount2 tone-colour">
+        }" data-link-name="Comment count" class="commentcount2 tone-colour" aria-label="${count} comments">
                     <h3 class="commentcount2__heading">${
                         icon
                     } <span class ="commentcount2__text u-h">Comments</span></h3>
@@ -29,19 +29,9 @@ const getTemplate = (
                 </a>`;
     }
 
-    if (type === 'contentImmersive') {
-        return `<a href="${
-            url
-        }" data-link-name="Comment count" class="commentcount2 tone-colour">
-                    ${icon}<span class="commentcount__value">${
-            count
-        }</span> Comments
-                </a>`;
-    }
-
     return `<a class="fc-trail__count fc-trail__count--commentcount" href="${
         url
-    }" data-link-name="Comment count">${icon} ${count}</a>`;
+    }" data-link-name="Comment count" aria-label="${count} comments">${icon} ${count}</a>`;
 };
 
 const getElementsIndexedById = (context: HTMLElement): Promise<any> =>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -19,7 +19,9 @@ const getTemplate = (
     if (type === 'content') {
         return `<a href="${
             url
-        }" data-link-name="Comment count" class="commentcount2 tone-colour" aria-label="${count} comments">
+        }" data-link-name="Comment count" class="commentcount2 tone-colour" aria-label="${
+            count
+        } comments">
                     <h3 class="commentcount2__heading">${
                         icon
                     } <span class ="commentcount2__text u-h">Comments</span></h3>
@@ -31,7 +33,9 @@ const getTemplate = (
 
     return `<a class="fc-trail__count fc-trail__count--commentcount" href="${
         url
-    }" data-link-name="Comment count" aria-label="${count} comments">${icon} ${count}</a>`;
+    }" data-link-name="Comment count" aria-label="${count} comments">${icon} ${
+        count
+    }</a>`;
 };
 
 const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
@@ -133,12 +137,8 @@ const getCommentCounts = (context?: HTMLElement): Promise<void> => {
     return Promise.resolve();
 };
 
-const init = (): Promise<void> => {
+export const initCommentCount = (): Promise<void> => {
     mediator.on('modules:related:loaded', getCommentCounts);
 
     return getCommentCounts();
-};
-
-export default {
-    init,
 };

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -30,7 +30,6 @@ describe('Comment Count', () => {
                 <div class="trail" data-discussion-id="/p/3gh4n"><a href="/article/3">1</a></div>
                 <div class="trail" data-discussion-id="/p/3ghv5"><a href="/article/4">4</a></div>
                 <div class="trail" data-commentcount-format="content" data-discussion-id="/p/3ghNp"><a href="/article/3">1</a></div>
-                <div class="trail" data-commentcount-format="contentImmersive" data-discussion-id="/p/3ghNp"><a href="/article/4">4</a></div>
             </div>`;
         }
 
@@ -88,16 +87,5 @@ describe('Comment Count', () => {
             expect(contentCommentCounts.length).toBe(1);
 
             expect(contentCommentCounts[0].innerHTML).toBe('400');
-        }));
-
-    test('should append "content immersive" format comment counts to DOM', () =>
-        commentCount.init().then(() => {
-            const contentImmersiveCommentCounts = document.getElementsByClassName(
-                'commentcount__value'
-            );
-
-            expect(contentImmersiveCommentCounts.length).toBe(1);
-
-            expect(contentImmersiveCommentCounts[0].innerHTML).toBe('400');
         }));
 });

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -67,7 +67,7 @@ describe('Comment Count', () => {
                 document.querySelectorAll(
                     '.fc-trail__count--commentcount, .commentcount2'
                 ).length
-            ).toBe(6);
+            ).toBe(5);
         }));
 
     test('should append "default" format comment counts to DOM', () =>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import fetchJson from 'lib/fetch-json';
-import commentCount from './comment-count';
+import { initCommentCount } from './comment-count';
 
 jest.mock('lib/fastdom-promise');
 
@@ -62,7 +62,7 @@ describe('Comment Count', () => {
     });
 
     test('should append comment counts to DOM for open discussions only', () =>
-        commentCount.init().then(() => {
+        initCommentCount().then(() => {
             expect(
                 document.querySelectorAll(
                     '.fc-trail__count--commentcount, .commentcount2'
@@ -71,7 +71,7 @@ describe('Comment Count', () => {
         }));
 
     test('should append "default" format comment counts to DOM', () =>
-        commentCount.init().then(() => {
+        initCommentCount().then(() => {
             expect(
                 document.getElementsByClassName('fc-trail__count--commentcount')
                     .length
@@ -79,7 +79,7 @@ describe('Comment Count', () => {
         }));
 
     test('should append "content" format comment counts to DOM', () =>
-        commentCount.init().then(() => {
+        initCommentCount().then(() => {
             const contentCommentCounts = document.getElementsByClassName(
                 'commentcount2__value'
             );


### PR DESCRIPTION
## What does this change?

Currently when the comment count is highlighted on fronts or articles, only the number of comments are read by screen readers. This number is devoid of context; it is not clear that the number represents the comment count.

This change adds an `aria-label` which reads the number followed by "comments", providing much needed context.

In addition:

- removes code and test for the `contentImmersive` comment count format (which is no longer used)
- refactors comment-count to use named export instead of default export

## What is the value of this and can you measure success?

Makes site more accessible. Fixes #18897 

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
