### PR TITLE
Cookies banner update

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,7 +31,7 @@ import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-pr
 import { initClickstream } from 'common/modules/ui/clickstream';
 import { init as initDropdowns } from 'common/modules/ui/dropdowns';
 import { fauxBlockLink } from 'common/modules/ui/faux-block-link';
-import { init as initCookiesBanner}  from 'common/modules/ui/cookiesBanner';
+import { init as initCookiesBanner } from 'common/modules/ui/cookiesBanner';
 import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import { init as initCustomSmartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,7 +31,7 @@ import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-pr
 import { initClickstream } from 'common/modules/ui/clickstream';
 import { init as initDropdowns } from 'common/modules/ui/dropdowns';
 import { fauxBlockLink } from 'common/modules/ui/faux-block-link';
-import cookiesBanner from 'common/modules/ui/cookiesBanner';
+import { init as initCookiesBanner}  from 'common/modules/ui/cookiesBanner';
 import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import { init as initCustomSmartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';
@@ -286,7 +286,7 @@ const init = (): void => {
     catchErrorsWithContext([
         // Analytics comes at the top. If you think your thing is more important then please think again...
         ['c-analytics', loadAnalytics],
-        ['c-cookies-banner', cookiesBanner.init],
+        ['c-cookies-banner', initCookiesBanner],
         ['c-identity', initIdentity],
         ['c-adverts', requestUserSegmentsFromId],
         ['c-discussion', initDiscussion],

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -53,8 +53,10 @@ const init = (): void => {
     });
 };
 
+// TODO: remove once bannerPicker is in use
 export { init };
 
+// To be used by bannerPicker
 export default {
     id: 'cookieBanner',
     show,

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -46,8 +46,6 @@ const show = (): void => {
 
 const init = (): void => {
     canShow().then(result => {
-        console.log('*** result ***', result);
-
         if (result) {
             show();
         }

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -14,8 +14,8 @@ import { Message } from 'common/modules/ui/message';
 
 const EU_COOKIE_MSG = 'GU_EU_MSG';
 
-const canShow = (): Promise<boolean> => {
-    return new Promise(resolve => {
+const canShow = (): Promise<boolean> =>
+    new Promise(resolve => {
         const geoContinentCookie = getCookie('GU_geo_continent');
 
         if (!geoContinentCookie || geoContinentCookie.toUpperCase() !== 'EU') {
@@ -30,7 +30,6 @@ const canShow = (): Promise<boolean> => {
             resolve(true);
         }
     });
-};
 
 const show = (): void => {
     const link = 'https://www.theguardian.com/info/cookies';
@@ -60,4 +59,4 @@ export default {
     id: 'cookieBanner',
     show,
     canShow,
-}
+};

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -14,22 +14,21 @@ import { Message } from 'common/modules/ui/message';
 
 const EU_COOKIE_MSG = 'GU_EU_MSG';
 
-const canShow = (): Promise<boolean> =>
-    new Promise(resolve => {
-        const geoContinentCookie = getCookie('GU_geo_continent');
+const canShow = (): Promise<boolean> => {
+    const geoContinentCookie = getCookie('GU_geo_continent');
 
-        if (!geoContinentCookie || geoContinentCookie.toUpperCase() !== 'EU') {
-            resolve(false);
-        }
+    if (!geoContinentCookie || geoContinentCookie.toUpperCase() !== 'EU') {
+        return Promise.resolve(false);
+    }
 
-        const euMessageCookie = getCookie(EU_COOKIE_MSG);
+    const euMessageCookie = getCookie(EU_COOKIE_MSG);
 
-        if (euMessageCookie && euMessageCookie === 'seen') {
-            resolve(false);
-        } else {
-            resolve(true);
-        }
-    });
+    if (euMessageCookie && euMessageCookie === 'seen') {
+        return Promise.resolve(false);
+    }
+
+    return Promise.resolve(true);
+};
 
 const show = (): void => {
     const link = 'https://www.theguardian.com/info/cookies';
@@ -47,6 +46,8 @@ const show = (): void => {
 
 const init = (): void => {
     canShow().then(result => {
+        console.log('*** result ***', result);
+
         if (result) {
             show();
         }


### PR DESCRIPTION
## What does this change?

In preparation for the `bannerPicker` from https://github.com/guardian/frontend/pull/19591 I've updated the interface exposed by the cookie banner.

The cookie banner will continue to work as expected on `master` with the interface from this PR by using the named export. Once the `bannerPicker` is ready we'll use the `default` export and remove the named export in https://github.com/guardian/frontend/pull/19591.

We'll be raising a similar PR for each of the remaining banners in preparation for the `bannerPicker`.

We decided to do this rather than refactor all the banners in https://github.com/guardian/frontend/pull/19591 in order to reduce the noise in that PR and the need to keep the banner's in that branch in sync with changes on `master`.

## What is the value of this and can you measure success?

Easier integration with bannerPicker

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Tested in CODE?

Yes