### PR TITLE
Removing css which is breaking comment meta on mobile

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -853,6 +853,7 @@ $quote-mark: 35px;
 
     .content__head {
         overflow: hidden;
+
         @include mq(phablet) {
             overflow: visible;
         }
@@ -862,6 +863,7 @@ $quote-mark: 35px;
         background-image: none;
         padding-top: 0;
         margin-bottom: 0;
+
         @include mq(leftCol) {
             @include multiline(8, $garnett-neutral-4, 8);
             padding-top: $gs-baseline * 3;
@@ -873,8 +875,6 @@ $quote-mark: 35px;
     .meta__twitter,
     .meta__email,
     .content__dateline {
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
         @include mq(mobileLandscape) {
             padding-left: $gs-gutter;
             padding-right: $gs-gutter;
@@ -887,7 +887,7 @@ $quote-mark: 35px;
 
     .meta__twitter,
     .meta__email {
-        display: block;
+        //display: block;
         padding-top: 8px;
         // magic number used to align date stamp with Twitter handle
         margin-top: -3px;


### PR DESCRIPTION
## What does this change?
Fixing: https://trello.com/c/wgWX8UQK/191-twitter-handle-styles-problem-opinion and duplicate: https://trello.com/c/qXR5Nu1k/207-twitter-handle-appearing-over-text-on-mobile

## What is the value of this and can you measure success?
Fixing a 🐛 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
*Before:*
![image](https://user-images.githubusercontent.com/8774970/39748148-42f4ea9a-52a7-11e8-922c-de928d40ea40.png)

*After:*
![image](https://user-images.githubusercontent.com/8774970/39748170-58545c7c-52a7-11e8-9774-ed287b640a19.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
