### PR TITLE
Smart App banner update

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -16,6 +16,7 @@ import config from 'lib/config';
  * Persist close state
  */
 const COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER';
+
 const DATA = {
     IOS: {
         LOGO: 'https://assets.guim.co.uk/images/apps/ios-logo.png',
@@ -34,26 +35,37 @@ const DATA = {
         STORE: 'in Google Play',
     },
 };
+
 const cookieVal = getCookie(COOKIE_IMPRESSION_KEY);
+
 const impressions =
     cookieVal && !Number.isNaN(cookieVal) ? parseInt(cookieVal, 10) : 0;
+
 const tmp =
     '<img src="<%=LOGO%>" class="app__logo" alt="Guardian App logo" /><div class="app__cta"><h4 class="app__heading">The Guardian app</h4>' +
     '<p class="app__copy">Instant alerts. Offline reading.<br/>Tailored to you.</p>' +
     '<p class="app__copy"><strong>FREE</strong> – <%=STORE%></p></div><a href="<%=LINK%>" class="app__link">View</a>';
+
 const tablet =
     '<img src="<%=SCREENSHOTS%>" class="app__screenshots" alt="screenshots" />';
 
 const isDevice = (): boolean => isIOS() || isAndroid();
 
-const canShow = (): boolean => impressions < 4;
+const validImpressionCount = (): boolean => impressions < 4;
 
 const canUseSmartBanner = (): boolean =>
-    config.switches.smartAppBanner &&
+    config.get('switches.smartAppBanner') &&
     getUserAgent.browser === 'Safari' &&
     isIOS();
 
-const showMessage = (): void => {
+const canShow = (): Promise<boolean> =>
+    new Promise(resolve => {
+        const result =
+            !canUseSmartBanner() && isDevice() && validImpressionCount();
+        resolve(result);
+    });
+
+const show = (): void => {
     loadCssPromise.then(() => {
         const platform = isIOS() ? 'ios' : 'android';
         const msg = new Message(platform);
@@ -74,17 +86,11 @@ const showMessage = (): void => {
 };
 
 const init = (): void => {
-    if (!canUseSmartBanner() && isDevice() && canShow()) {
-        showMessage();
-    }
+    canShow().then(result => {
+        if (result) {
+            show();
+        }
+    });
 };
 
-const isMessageShown = (): boolean =>
-    $('.site-message--android').css('display') === 'block' ||
-    $('.site-message--ios').css('display') === 'block';
-
-const getMessageHeight = (): number =>
-    $('.site-message--android').dim().height ||
-    $('.site-message--ios').dim().height;
-
-export { init, isMessageShown, getMessageHeight };
+export { init };

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -93,8 +93,10 @@ const init = (): void => {
     });
 };
 
+// TODO: remove once bannerPicker is in use
 export { init };
 
+// To be used by bannerPicker
 export default {
     id: 'smartAppBanner',
     show,

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -94,3 +94,9 @@ const init = (): void => {
 };
 
 export { init };
+
+export default {
+    id: 'smartAppBanner',
+    show,
+    canShow,
+};


### PR DESCRIPTION
## What does this change?

In preparation for the `bannerPicker` from https://github.com/guardian/frontend/pull/19591 I've updated the interface exposed by the smart app banner.

The smart app banner will continue to work as expected on `master` with the interface from this PR by using the named export. Once the `bannerPicker` is ready we'll use the `default` export and remove the named export in https://github.com/guardian/frontend/pull/19591.

We'll be raising a similar PR for each of the remaining banners in preparation for the `bannerPicker`.

We decided to do this rather than refactor all the banners in https://github.com/guardian/frontend/pull/19591 in order to reduce the noise in that PR and the need to keep the banner's in that branch in sync with changes on `master`.

## What is the value of this and can you measure success?

Easier integration with bannerPicker

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Tested in CODE?

Yes