### PR TITLE
Extend videojs switch until next quarter

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -161,7 +161,7 @@ trait FeatureSwitches {
     "If this is switched on then videos are enhanced using our JavaScript player",
     owners = Seq(Owner.withGithub("siadcock")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 5, 8),
+    sellByDate = new LocalDate(2018, 7, 19),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

We are currently investigating the removal of VideoJS. This change extends the switch until next quarter, by which time a decision should have been made and appropriate action taken.

## What is the value of this and can you measure success?

Less broken builds
