### PR TITLE
minor bugfixes to the sign in engagement alert

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -48,7 +48,7 @@ const links: LinkTargets = {
     register: `${config.get(
         'page.idUrl'
     )}/register?cmp=sign-in-eb&utm_campaign=sign-in-eb`,
-    why: '#',
+    why: 'https://www.theguardian.com/info/2018/may/08/why-sign-in-to-the-guardian',
 };
 
 /* A "session" here is defined as views separated < 30 minutes away from each other */
@@ -89,6 +89,12 @@ const tpl: Template = {
     features,
     links,
 };
+
+/* Is not paid content */
+const isNotPaidContent = ():boolean =>
+    (config.get(
+        'page.isPaidContent'
+    ) || false) === false
 
 /* Must have visited 4 articles */
 const hasReadOver4Articles = (): boolean =>
@@ -161,6 +167,7 @@ const canShow = (): Promise<boolean> => {
         ? [true]
         : [
               isNotSignedIn(),
+              isNotPaidContent(),
               hasSeenBannerOnceInLastTwoDays(),
               isSecondSessionPageview(),
               hasSeenBannerLessThanFourTimesTotal(),

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -9,7 +9,7 @@ import userPrefs from 'common/modules/user-prefs';
 import mediator from 'lib/mediator';
 import { signInEngagementBannerDisplay } from 'common/modules/experiments/tests/sign-in-engagement-banner-display';
 import { getVariant, isInVariant } from 'common/modules/experiments/utils';
-import { trackNonClickInteraction } from 'common/modules/analytics/interaction-tracking';
+import { trackNonClickInteraction } from 'common/modules/analytics/google';
 
 import iconComment from 'svgs/icon/comment-16.svg';
 import iconEmail from 'svgs/icon/mail.svg';
@@ -197,7 +197,9 @@ const show = (): void => {
                 `.${bindableClassNames.closeBtn}`
             );
             ophan.record({
-                clickLinkNames: ['sign-in-eb : display'],
+                component: 'sign-in-eb',
+                action: 'sign-in-eb : show',
+                value: 'sign-in-eb : show',
             });
             trackNonClickInteraction('sign-in-eb : display');
             if (!closeButtonEl) {

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -28,18 +28,18 @@ import {
 const messageCode: string = 'sign-in-30-april';
 const signedInCookie: string = 'GU_U';
 
-const forceDisplayHash = 'sign-in-eb-display=true';
-const lastSeenAtKey = 'sign-in-eb.last-seen-at';
-const lifeTimeViewsKey = 'sign-in-eb.lifetime-views';
-const lifeTimeClosesKey = 'sign-in-eb.lifetime-closes';
-const sessionStartedAtKey = 'sign-in-eb.session-started-at';
-const sessionVisitsKey = 'sign-in-eb.session-visits';
+const forceDisplayHash: string = 'sign-in-eb-display=true';
+const lastSeenAtKey: string = 'sign-in-eb.last-seen-at';
+const lifeTimeViewsKey: string = 'sign-in-eb.lifetime-views';
+const lifeTimeClosesKey: string = 'sign-in-eb.lifetime-closes';
+const sessionStartedAtKey: string = 'sign-in-eb.session-started-at';
+const sessionVisitsKey: string = 'sign-in-eb.session-visits';
 
-const ERR_MALFORMED_HTML = 'ERR_MALFORMED_HTML';
+const ERR_MALFORMED_HTML: string = 'ERR_MALFORMED_HTML';
 
-const halfHourInMs = 30 * 60 * 1000;
-const dayInMs = 24 * 60 * 60 * 1000;
-const monthInMs = 30 * dayInMs;
+const halfHourInMs: number = 30 * 60 * 1000;
+const dayInMs: number = 24 * 60 * 60 * 1000;
+const monthInMs: number = 30 * dayInMs;
 
 const links: LinkTargets = {
     signIn: `${config.get(
@@ -153,7 +153,7 @@ const bannerDoesNotCollide = (): Promise<boolean> =>
         });
     });
 
-const hide = (msg: Message) => {
+const hide = (msg: Message): void => {
     userPrefs.set(
         lifeTimeClosesKey,
         (userPrefs.get(lifeTimeClosesKey) || 0) + 1

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -4,10 +4,12 @@ import { Message } from 'common/modules/ui/message';
 import { getCookie } from 'lib/cookies';
 import { local } from 'lib/storage';
 import config from 'lib/config';
+import ophan from 'ophan/ng';
 import userPrefs from 'common/modules/user-prefs';
 import mediator from 'lib/mediator';
 import { signInEngagementBannerDisplay } from 'common/modules/experiments/tests/sign-in-engagement-banner-display';
 import { getVariant, isInVariant } from 'common/modules/experiments/utils';
+import {trackNonClickInteraction} from "common/modules/analytics/interaction-tracking";
 
 import iconComment from 'svgs/icon/comment-16.svg';
 import iconEmail from 'svgs/icon/mail.svg';
@@ -188,6 +190,10 @@ const show = (): void => {
             const closeButtonEl: ?HTMLElement = document.querySelector(
                 `.${bindableClassNames.closeBtn}`
             );
+            ophan.record({
+                clickLinkNames: ['sign-in-eb : display']
+            });
+            trackNonClickInteraction('sign-in-eb : display');
             if (!closeButtonEl) {
                 hide(msg);
                 throw new Error(ERR_MALFORMED_HTML);

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -116,13 +116,13 @@ const hasSeenBannerOnceInLastTwoDays = (): boolean =>
 const isSecondSessionPageview = (): boolean =>
     (userPrefs.get(sessionVisitsKey) || 0) >= 2;
 
-/* Must have visited between 1 month & 24 hours ago */
+/* Must have first visited over 24 hours ago */
 const isRecurringVisitor = (): boolean => {
     const ga: ?string = getCookie('_ga');
     if (!ga) return false;
     const date: number = parseInt(ga.split('.').pop(), 10) * 1000;
     if (!date || Number.isNaN(date)) return false;
-    return Date.now() - date > dayInMs && Date.now() - date < monthInMs;
+    return Date.now() - date > dayInMs;
 };
 
 /* Test must be running & user must be in variant */

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.js
@@ -9,7 +9,7 @@ import userPrefs from 'common/modules/user-prefs';
 import mediator from 'lib/mediator';
 import { signInEngagementBannerDisplay } from 'common/modules/experiments/tests/sign-in-engagement-banner-display';
 import { getVariant, isInVariant } from 'common/modules/experiments/utils';
-import {trackNonClickInteraction} from "common/modules/analytics/interaction-tracking";
+import { trackNonClickInteraction } from 'common/modules/analytics/interaction-tracking';
 
 import iconComment from 'svgs/icon/comment-16.svg';
 import iconEmail from 'svgs/icon/mail.svg';
@@ -48,7 +48,8 @@ const links: LinkTargets = {
     register: `${config.get(
         'page.idUrl'
     )}/register?cmp=sign-in-eb&utm_campaign=sign-in-eb`,
-    why: 'https://www.theguardian.com/info/2018/may/08/why-sign-in-to-the-guardian',
+    why:
+        'https://www.theguardian.com/info/2018/may/08/why-sign-in-to-the-guardian',
 };
 
 /* A "session" here is defined as views separated < 30 minutes away from each other */
@@ -91,10 +92,8 @@ const tpl: Template = {
 };
 
 /* Is not paid content */
-const isNotPaidContent = ():boolean =>
-    (config.get(
-        'page.isPaidContent'
-    ) || false) === false
+const isNotPaidContent = (): boolean =>
+    (config.get('page.isPaidContent') || false) === false;
 
 /* Must have visited 4 articles */
 const hasReadOver4Articles = (): boolean =>
@@ -198,7 +197,7 @@ const show = (): void => {
                 `.${bindableClassNames.closeBtn}`
             );
             ophan.record({
-                clickLinkNames: ['sign-in-eb : display']
+                clickLinkNames: ['sign-in-eb : display'],
             });
             trackNonClickInteraction('sign-in-eb : display');
             if (!closeButtonEl) {

--- a/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/global/sign-in-engagement-banner.spec.js
@@ -16,7 +16,6 @@ const userPrefs: any = userPrefs_;
 const Message: any = Message_;
 
 const validGaCookie = 'GA1.2.xx.1524903850';
-const oldGaCookie = 'GA1.2.xx.1515096983';
 const newGaCookie = 'GA1.2.xx.1525096983';
 
 const timestampToday = 1525096983756;
@@ -33,6 +32,9 @@ jest.spyOn(Date, 'now').mockImplementation(() => timestampToday);
 jest.useFakeTimers();
 
 jest.mock('lib/mediator');
+jest.mock('ophan/ng', () => ({
+    record: jest.fn(),
+}));
 jest.mock('lib/storage', () => ({
     local: {
         get: jest.fn(() => 10),
@@ -197,20 +199,7 @@ describe('Sign in engagement banner', () => {
                 expect(showable).toBe(false);
             });
         });
-        it('should not show if the cookie is too old', () => {
-            getCookie.mockImplementation(name => {
-                if (name === '_ga') {
-                    return oldGaCookie;
-                }
-                return null;
-            });
-            const canShowPr = canShow();
-            jest.runAllTimers();
-            return canShowPr.then(showable => {
-                expect(showable).toBe(false);
-            });
-        });
-        it('should show if the cookie is between 1 month & 1 day', () => {
+        it('should show if the cookie is old enough', () => {
             getCookie.mockImplementation(name => {
                 if (name === '_ga') {
                     return validGaCookie;


### PR DESCRIPTION
## What does this change?
- Track visitors who first visited > 24hrs ago, but remove month check
- Track display impressions (ophan+ga)
- Set the link for "Why sign in?"
- Do not show on Guardian Labs pages

## Screenshots
No changes here
![screen shot 2018-05-04 at 12 47 23 pm](https://user-images.githubusercontent.com/11539094/39767893-b3f399fc-52df-11e8-86fe-6fec0e56d79b.png)

