### PR TITLE
Add Snyk badge, remove Gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://badges.gitter.im/guardian/frontend.svg)](https://gitter.im/guardian/frontend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Known Vulnerabilities](https://snyk.io/test/github/guardian/frontend/badge.svg)](https://snyk.io/test/github/guardian/frontend)
 
 ## We're hiring!
 Ever thought about joining us? 


### PR DESCRIPTION
## What does this change?

Currently, Snyk notifies us by email that there are vulnerabilities in our dependencies.

This change adds a Snyk vulnerabilities badge to our README to give us a secondary mechanism by which we are notified of vulnerabilities.

This change also removes the Gitter badge, which I think is effectively redundant? Let me know if we still use Gitter and I'll back out this change.

## What is the value of this and can you measure success?

Less chance of missing a security vulnerability
