### PR TITLE
Add liveblog to validate-a11y task

### DIFF
--- a/tools/__tasks__/validate/a11y/config.js
+++ b/tools/__tasks__/validate/a11y/config.js
@@ -11,6 +11,9 @@ module.exports = {
         // Issue: https://github.com/pa11y/pa11y/issues/335
         htmlcs: 'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js',
     },
-    paths: ['politics/2013/oct/31/universal'],
+    paths: [
+        'politics/2013/oct/31/universal',
+        'sport/live/2018/may/05/kentucky-derby-2018-mendelssohn-live',
+    ],
     logLevel: 1, // 1: error, 2: warning, 3: notice
 };

--- a/tools/__tasks__/validate/a11y/config.js
+++ b/tools/__tasks__/validate/a11y/config.js
@@ -14,6 +14,7 @@ module.exports = {
     paths: [
         'politics/2013/oct/31/universal',
         'sport/live/2018/may/05/kentucky-derby-2018-mendelssohn-live',
+        'world/2017/aug/24/the-school-beneath-the-wave-the-unimaginable-tragedy-of-japans-tsunami',
     ],
     logLevel: 1, // 1: error, 2: warning, 3: notice
 };


### PR DESCRIPTION
## What does this change?

Adds a liveblog and second article sample to the validate-a11y task

## What is the value of this and can you measure success?

More programmatic a11y coverage

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
