### PR TITLE
Fix faux overlays for screen readers

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -255,6 +255,6 @@ data-test-id="facia-card"
             @meta(item)
         }
 
-        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(item.header.headline)</a>
+        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>
     </div>
 }

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -36,7 +36,8 @@
         class="u-faux-block-link__overlay js-headline-text"
         data-link-name="@omnitureId"
         data-component="@omnitureId"
-        tabindex="-1"></a>
+        tabindex="-1"
+        aria-hidden="true"></a>
     </div>
 </div>
 

--- a/common/app/views/fragments/richLinkDefault.scala.html
+++ b/common/app/views/fragments/richLinkDefault.scala.html
@@ -19,6 +19,6 @@
             Read more
         </div>
     </div>
-    <a class="rich-link__link u-faux-block-link__overlay" href="@href"></a>
+    <a class="rich-link__link u-faux-block-link__overlay" href="@href" aria-label="@title"></a>
     </div>
 </div>

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -89,6 +89,6 @@
                 }
             </div>
         </div>
-        <a class="rich-link__link u-faux-block-link__overlay" href="@content.metadata.webUrl"></a>
+        <a class="rich-link__link u-faux-block-link__overlay" href="@content.metadata.webUrl" aria-label="@content.trail.headline"></a>
     </div>
 </div>


### PR DESCRIPTION
## What does this change?

When screen reader users are navigating links on fronts, the faux overlay pattern means each link is read out twice. This change fixes the issue by hiding the overlay from screen readers.

This change also adds labels to rich links, so screen readers read the headline rather than the URL.

## What is the value of this and can you measure success?

More screen reader accessible

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

Improves accessibility for unbranded adverts too!

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
