### PR TITLE
Include personalised ads status flag in ad calls

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -417,9 +417,9 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val personalisedAdsConsent: Switch = Switch(
+  val includePersonalisedAdsConsent: Switch = Switch(
     group = Commercial,
-    name = "personalised-ads-consent",
+    name = "include-personalised-ads-consent",
     description = "Include a flag with consent status in ad calls.",
     owners = group(Commercial),
     safeState = Off,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -416,4 +416,14 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
+
+  val personalisedAdsConsent: Switch = Switch(
+    group = Commercial,
+    name = "personalised-ads-consent",
+    description = "Include a flag with consent status in ad calls.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -423,7 +423,7 @@ trait CommercialSwitches {
     description = "Include a flag with consent status in ad calls.",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 6, 6),
+    sellByDate = new LocalDate(2018, 5, 25),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -68,9 +68,12 @@ const setDfpListeners = (): void => {
 };
 
 const setPersonalisedAds = (): void => {
-    if (config.switches.personalisedAdsConsent) {
-        const nonPersonalised = 1;
-        window.googletag.pubads().setRequestNonPersonalizedAds(nonPersonalised);
+    if (config.switches.includePersonalisedAdsConsent) {
+        // TODO: replace this hardcoded value with one from local storage
+        const personalised = false;
+        window.googletag
+            .pubads()
+            .setRequestNonPersonalizedAds(personalised ? 0 : 1);
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -67,6 +67,13 @@ const setDfpListeners = (): void => {
     }
 };
 
+const setPersonalisedAds = (): void => {
+    if (config.switches.personalisedAdsConsent) {
+        const nonPersonalised = 1;
+        window.googletag.pubads().setRequestNonPersonalizedAds(nonPersonalised);
+    }
+};
+
 const setPageTargeting = (): void => {
     const pubads = window.googletag.pubads();
     // because commercialFeatures may export itself as {} in the event of an exception during construction
@@ -111,6 +118,7 @@ export const init = (start: () => void, stop: () => void): Promise<void> => {
         // fulfilled), but don't assume fillAdvertSlots is complete when queueing subsequent work using cmd.push
         window.googletag.cmd.push(
             setDfpListeners,
+            setPersonalisedAds,
             setPageTargeting,
             setPublisherProvidedId,
             refreshOnResize,


### PR DESCRIPTION
This is the failsafe position: including a flag that will make all ads impersonal.

The next step is to set the status according to a parameter in local storage.
