### PR TITLE
implement adrefresh blocking parameter

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -54,6 +54,7 @@ class DevParametersHttpRequestHandler(
   val commercialParams = Seq(
     "ad-unit", // allows overriding of the ad unit
     "adtest", // used to set ad-test cookie from admin domain
+    "adrefresh", // force adrefresh to be off with adrefresh=false in the URL
     "google_console", // two params for dfp console
     "googfc",
     "k", // keywords in commercial component requests

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -13,7 +13,7 @@ import { buildPageTargeting } from 'common/modules/commercial/build-page-targeti
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { onSlotRender } from 'commercial/modules/dfp/on-slot-render';
 import { onSlotLoad } from 'commercial/modules/dfp/on-slot-load';
-import { onSlotViewable } from 'commercial/modules/dfp/on-slot-viewable';
+import { onSlotViewableFunction } from 'commercial/modules/dfp/on-slot-viewable';
 import { onSlotVisibilityChanged } from 'commercial/modules/dfp/on-slot-visibility-changed';
 import { fillAdvertSlots } from 'commercial/modules/dfp/fill-advert-slots';
 import { refreshOnResize } from 'commercial/modules/dfp/refresh-on-resize';
@@ -56,9 +56,7 @@ const setDfpListeners = (): void => {
     pubads.addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
     pubads.addEventListener('slotOnload', raven.wrap(onSlotLoad));
 
-    if (config.get('tests.commercialAdRefreshVariant')) {
-        pubads.addEventListener('impressionViewable', onSlotViewable);
-    }
+    pubads.addEventListener('impressionViewable', onSlotViewableFunction());
 
     pubads.addEventListener('slotVisibilityChanged', onSlotVisibilityChanged);
     if (session.isAvailable()) {

--- a/static/src/javascripts/projects/commercial/types.js
+++ b/static/src/javascripts/projects/commercial/types.js
@@ -86,6 +86,8 @@ export type ImpressionViewableEvent = {
     slot: Slot,
 };
 
+export type ImpressionViewableEventCallback = ImpressionViewableEvent => void;
+
 export type SlotVisibilityChangedEvent = {
     inViewPercentage: number,
     serviceName: string,


### PR DESCRIPTION
This implements https://trello.com/c/rl2KLcwu/73-ability-to-opt-out-or-disable-the-ad-refresh and refactors the adrefresh activation a little bit, so it's at a less confusing place.