### PR TITLE
Update new profiling opt out as well as old status field

### DIFF
--- a/identity/app/controllers/editprofile/EditProfileController.scala
+++ b/identity/app/controllers/editprofile/EditProfileController.scala
@@ -1,3 +1,6 @@
+
+
+
 package controllers.editprofile
 
 import actions.AuthenticatedActions

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -2,7 +2,7 @@ package form
 
 import model.Titles
 import play.api.data.Forms._
-import com.gu.identity.model.{PrivateFields, User, UserDates}
+import com.gu.identity.model.{Consent, PrivateFields, User, UserDates}
 import idapiclient.UserUpdateDTO
 import play.api.data.Mapping
 import play.api.i18n.MessagesProvider
@@ -85,7 +85,8 @@ case class AccountFormData(
       billingCountry = billingAddress.flatMap(x => toUpdate(x.country, currentUser.privateFields.billingCountry)),
       telephoneNumber = telephoneNumber.flatMap(_.telephoneNumber)
     )),
-    statusFields = Some(currentUser.statusFields.copy(allowThirdPartyProfiling = Some(allowThirdPartyProfiling)))
+    statusFields = Some(currentUser.statusFields.copy(allowThirdPartyProfiling = Some(allowThirdPartyProfiling))),
+    consents = Some(List(Consent(id = Consent.ProfilingOptout.id, consented = !allowThirdPartyProfiling)))
   )
 }
 

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -47,7 +47,7 @@ import scala.concurrent.Future
     val httpConfiguration = HttpConfiguration.createWithDefaults()
 
     val userId: String = "123"
-    val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
+    val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))
     val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
     val authenticatedUser = AuthenticatedUser(user, testAuth, true)
     val phoneNumbers = PhoneNumbers

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
     val httpConfiguration = HttpConfiguration.createWithDefaults()
 
     val userId: String = "123"
-    val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
+    val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))
     val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
     val authenticatedUser = AuthenticatedUser(user, testAuth, true)
     val phoneNumbers = PhoneNumbers

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -41,7 +41,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   when(api.resendEmailValidationEmail(any[Auth], any[TrackingData], any[Option[String]])) thenReturn Future.successful(Right({}))
 
   val userId: String = "123"
-  val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true), userEmailValidated = Some(true)))
+  val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))
   val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
   val authenticatedUser = AuthenticatedUser(user, testAuth, true)
   val phoneNumbers = PhoneNumbers

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -42,7 +42,7 @@ class FormstackControllerTest extends path.FreeSpec
   val newsletterService = spy(new NewsletterService(api, requestParser, idUrlBuilder))
 
   val userId = "123"
-  val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
+  val user = User("test@example.com", userId)
   val authenticatedActions = new AuthenticatedActions(authService, mock[IdApiClient], mock[IdentityUrlBuilder], controllerComponents, newsletterService, requestParser, profileRedirectService)
 
   when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, ScGuU("abc", GuUCookieData(user, 0, None))))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.142"
+  val identityLibVersion = "3.144"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.144"
+  val identityLibVersion = "3.150"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"


### PR DESCRIPTION
## What does this change?
- Bump the identity model version to get the profiling opt_out introduced in https://github.com/guardian/identity/pull/1163 
- Make the old opt-in checkbox update this opt-out consent but continue to update the old statusField 
- This will happen simultaneously until we create the new profiling "opt out" section in the email-prefs section client-side
## What is the value of this and can you measure success?
- GDPR
## Does this affect other platforms - Amp, Apps, etc?
No
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
