### PR TITLE
Remove sign in link if user is signed in

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -52,7 +52,7 @@ const showMyAccountIfNecessary = (): void => {
             return fastdom
                 .write(() => {
                     signIns.forEach(signIn => {
-                        signIn.parentNode.removeNode(signIn);
+                        signIn.remove();
                     });
 
                     accountActionsLists.forEach(accountActions => {

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -52,7 +52,7 @@ const showMyAccountIfNecessary = (): void => {
             return fastdom
                 .write(() => {
                     signIns.forEach(signIn => {
-                        signIn.classList.add('u-h');
+                        signIn.parentNode.removeNode(signIn);
                     });
 
                     accountActionsLists.forEach(accountActions => {


### PR DESCRIPTION
## What does this change?

Currently, if the user is signed in, the "sign in" links in the desktop header and mobile header are hidden using the `u-h` class. This doesn't remove the links from the tab order, nor does it hide the links from screen readers.

So if the user is signed in, why not remove the nodes from the DOM entirely? It's not like we'll miss them 👋 

## What is the value of this and can you measure success?

Less confusing navigation for screen reader and keyboard users.

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
