### PR TITLE
Tab-able account menu

### DIFF
--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -12,27 +12,6 @@
         Sign in
     </a>
 
-    <ul class="dropdown-menu js-user-account-dropdown-menu"
-        id="my-account-dropdown"
-        aria-hidden="true">
-
-        @for((item) <- accountDropdownMenu) {
-            <li class="@{(List("dropdown-menu__item") ++ item.parentClassList).mkString(" ")}">
-                <a
-                    class="@{(List("dropdown-menu__title") ++ item.classList).mkString(" ")}"
-                    @if(item.href.isDefined) {
-                        href="@item.href"
-                    }
-                    @if(item.linkName.isDefined) {
-                        data-link-name="nav2 : topbar : @item.linkName"
-                    }
-                >
-                    @item.label
-                </a>
-            </li>
-        }
-    </ul>
-
     <button class="is-hidden dropdown-menu-fallback js-user-account-trigger"
         id="my-account-toggle"
         title="user account toggle"
@@ -46,4 +25,25 @@
 
         My account
     </label>
+
+    <ul class="dropdown-menu js-user-account-dropdown-menu"
+    id="my-account-dropdown"
+    aria-hidden="true">
+
+    @for((item) <- accountDropdownMenu) {
+        <li class="@{(List("dropdown-menu__item") ++ item.parentClassList).mkString(" ")}">
+            <a
+            class="@{(List("dropdown-menu__title") ++ item.classList).mkString(" ")}"
+                @if(item.href.isDefined) {
+                    href="@item.href"
+                }
+                @if(item.linkName.isDefined) {
+                    data-link-name="nav2 : topbar : @item.linkName"
+                    }
+            >
+            @item.label
+            </a>
+        </li>
+    }
+    </ul>
 </div>


### PR DESCRIPTION
## What does this change?

Currently, the list of Account menu options appears before the button / label, so the user has to counter-intuitively shift-tab up the menu, instead of tabbing down it!

This change moves the menu options so they appear after the button / label in the tab order.

## What is the value of this and can you measure success?

Moving the list of menu items after the button and label makes the tab order more intuitive

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
