### PR TITLE
/theguardian shouldn't have lowercase container names

### DIFF
--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -23,7 +23,7 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with Logg
 
   val dateForFrontPagePattern = DateTimeFormat.forPattern("EEEE d MMMM y")
   private val hrefFormat = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
-  val FRONT_PAGE_DISPLAY_NAME = "front page"
+  val FRONT_PAGE_DISPLAY_NAME = "Front page"
   val pathToTag = Map("theguardian" -> "theguardian/mainsection", "theobserver" -> "theobserver/news")
 
   def fetchLatestGuardianNewspaper()(implicit executionContext: ExecutionContext): Future[List[FaciaContainer]] = {
@@ -77,7 +77,7 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with Logg
 
       val bookSectionContainers = orderedBookSections.map { list =>
         val content = list.content.map(c => FaciaContentConvert.contentToFaciaContent(c))
-        bookSectionContainer(Some(list.tag.id), Some(lowercaseDisplayName(list.tag.webTitle)), None, content, orderedBookSections.indexOf(list) + 1, Nil)
+        bookSectionContainer(Some(list.tag.id), Some(list.tag.webTitle), None, content, orderedBookSections.indexOf(list) + 1, Nil)
       }
 
       firstPageContainer :: bookSectionContainers
@@ -134,8 +134,6 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with Logg
   }
 
   private def getNewspaperPageNumber(content: ApiContent) = content.fields.flatMap(_.newspaperPageNumber)
-
-  def lowercaseDisplayName(s: String): String = if(s.equals("UK news") || s.equals("US news")) s else s.toLowerCase()
 
   def getPastSundayDateFor(date: DateTime): DateTime = {
     if(date.getDayOfWeek != DateTimeConstants.SUNDAY) {

--- a/applications/test/services/NewspaperQueryTest.scala
+++ b/applications/test/services/NewspaperQueryTest.scala
@@ -17,12 +17,6 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   lazy val newspaperQuery = new NewspaperQuery(testContentApiClient)
 
   "NewspapeQueryTest" - {
-    "lowercase display name except UK news and US news" in {
-      newspaperQuery.lowercaseDisplayName("International") should be("international")
-      newspaperQuery.lowercaseDisplayName("UK news") should be("UK news")
-      newspaperQuery.lowercaseDisplayName("US news") should be("US news")
-    }
-
     "use past Sunday date for a given day (required for /theobserver)" in {
       newspaperQuery.getPastSundayDateFor(new DateTime(2015, 11, 19, 0, 0).withZone(DateTimeZone.UTC)).toISODateTimeString should be("2015-11-15T00:00:00.000Z")
     }


### PR DESCRIPTION
## What does this change?
Since these container display names are controlled in our code, CP were unable to update these for Garnett. Now display names should not be all lowercase.

This is a fairly easy change to make so I decided to fix it rather than only raise ticket 💨.

https://trello.com/c/0xGNRZq1/210-container-names-lowercase-on-todays-paper-and-the-oberserver-pages

## What is the value of this and can you measure success?
Inline with our new styling rules (no longer all lowercase)

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/39830419-51fc6280-53b9-11e8-8f9b-f011614f3bd9.png)

After:
![image](https://user-images.githubusercontent.com/8774970/39830431-58ea7f32-53b9-11e8-8ce4-488f00a15850.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
