### PR TITLE
Use Prebid analytics stream name from parameter store

### DIFF
--- a/commercial/app/controllers/PrebidAnalyticsController.scala
+++ b/commercial/app/controllers/PrebidAnalyticsController.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.kinesisfirehose.model.{PutRecordRequest, Record}
 import com.amazonaws.services.kinesisfirehose.{AmazonKinesisFirehoseAsync, AmazonKinesisFirehoseAsyncClientBuilder}
 import common.Logging
 import conf.Configuration.aws.{mandatoryCredentials, region}
+import conf.Configuration.commercial.prebidAnalyticsStream
 import conf.Configuration.environment.isProd
 import conf.switches.Switches.prebidAnalytics
 import model.Cached.WithoutRevalidationResult
@@ -30,13 +31,11 @@ class PrebidAnalyticsController(val controllerComponents: ControllerComponents) 
       .build()
   }
 
-  private val deliveryStream = "CommercialPrebidAnalyticsStream"
-
   private val newLine = "\n".getBytes
 
   private def streamAnalytics(json: JsValue) = {
     val record  = new Record().withData(ByteBuffer.wrap(toBytes(json) ++ newLine))
-    val request = new PutRecordRequest().withDeliveryStreamName(deliveryStream).withRecord(record)
+    val request = new PutRecordRequest().withDeliveryStreamName(prebidAnalyticsStream).withRecord(record)
     val result  = firehose.putRecordFuture(request)
     result.failed foreach {
       case NonFatal(e) => log.error(s"Failed to put '$json'", e)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -450,6 +450,8 @@ class GuardianConfiguration extends Logging {
     lazy val gLabsTeam = configuration.getStringProperty("email.gLabsTeam")
 
     lazy val expiredPaidContentUrl = s"${site.host}/info/2015/feb/06/paid-content-removal-policy"
+
+    lazy val prebidAnalyticsStream = configuration.getMandatoryStringProperty("commercial.prebid.analytics.stream")
   }
 
   object interactive {


### PR DESCRIPTION
We're now storing the name of the analytics stream in parameter store, because it's stage-dependent.