### PR TITLE
Make video play button expand on focus

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -69,7 +69,7 @@
                     @media.formattedDuration
                     </span>
                 </div>
-                <a href="@f.header.url.get(request)" class="video-container-overlay-link"></a>
+                <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1"></a>
             }
           }
         }

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -45,13 +45,15 @@ document.addEventListener('focusout', () => {
 });
 
 document.addEventListener('focusin', () => {
-    fastdom.read(() => $('.vjs-big-play-button')).then(($playButton: bonzo) => {
-        fastdom.write(() => {
-            if ($playButton) {
-                $playButton.removeClass('youtube-play-btn-focussed');
-            }
+    fastdom
+        .read(() => $('.vjs-big-play-button'))
+        .then(($playButton: ?bonzo) => {
+            fastdom.write(() => {
+                if ($playButton) {
+                    $playButton.removeClass('youtube-play-btn-focussed');
+                }
+            });
         });
-    });
 });
 
 // retrieves actual id of atom without appended index

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -26,26 +26,26 @@ declare class YoutubePlayerEvent {
 const players = {};
 const iframes = [];
 
-document.addEventListener('focusout', function () {
+document.addEventListener('focusout', () => {
     iframes.forEach(iframe => {
-        fastdom.read(() => {
-            if (document.activeElement === iframe) {
-                return $('.vjs-big-play-button', iframe.parentElement)
-            }
-        }).then(($playButton: ?bonzo) => {
-            fastdom.write(() => {
-                if ($playButton) {
-                    $playButton.addClass('youtube-play-btn-focussed');
+        fastdom
+            .read(() => {
+                if (document.activeElement === iframe) {
+                    return $('.vjs-big-play-button', iframe.parentElement);
                 }
+            })
+            .then(($playButton: ?bonzo) => {
+                fastdom.write(() => {
+                    if ($playButton) {
+                        $playButton.addClass('youtube-play-btn-focussed');
+                    }
+                });
             });
-        });
     });
 });
 
-document.addEventListener('focusin', function () {
-    fastdom.read(() => {
-        return $('.vjs-big-play-button');
-    }).then(($playButton: bonzo) => {
+document.addEventListener('focusin', () => {
+    fastdom.read(() => $('.vjs-big-play-button')).then(($playButton: bonzo) => {
         fastdom.write(() => {
             if ($playButton) {
                 $playButton.removeClass('youtube-play-btn-focussed');
@@ -238,7 +238,7 @@ const onPlayerReady = (
         players[atomId].overlay = overlay;
 
         if (
-            !!config.page.section &&
+            !!config.get('page.section') &&
             isBreakpoint({
                 min: 'desktop',
             })

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -98,9 +98,9 @@ $ima-controls-height: 70px;
         padding-bottom: $vjs-control-height;
     }
 
-    &:hover .vjs-control-text {
+    &:hover .vjs-control-text,
+    &.youtube-play-btn-focussed .vjs-control-text {
         transform: scale(1.15);
-
     }
 
     .gu-media--audio &,


### PR DESCRIPTION
## What does this change?

Currently there is no indication to keyboard users that the video play button is in focus. This is because really, it isn't! The YouTube play button is actually in focus, but this is hidden behind our overlay, resulting in a usability issue.

This change checks for `focusout` events (fired when a user presses the tab key to change focus). When the active element is inside an iframe, we check whether the iframe is in the list of known YouTube video iframes. If it is, it finds the closest video overlay and adds a class that makes the button expand.

Whenever the user tabs out of an element, we remove the class from every element that has it.

This works because we know that before the video starts playing, the only element a user can tab to in a YouTube iframe is the play button (we initially hide all other controls).

This change also takes the overlay out of the tab order. The overlay is in place only for mobile devices, since we don't want to roll videos on mobile in the carousel or on facia cards.

## What is the value of this and can you measure success?

Makes it clearer to keyboard users that the play button is in focus, addressing an accessibility concern.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

I don't think so?

## Screenshots

![may-10-2018 15-02-14](https://user-images.githubusercontent.com/5931528/39873555-2c6b8af0-5463-11e8-89b2-c22265f21037.gif)

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
