### PR TITLE
Immersive card

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -78,8 +78,7 @@ final case class Content(
   lazy val isGallery = metadata.contentType.contains(DotcomContentType.Gallery)
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
-  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
-  lazy val isSplash = fields.displayHint.contains("splash")
+  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay || fields.displayHint.contains("splash")
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 
@@ -240,7 +239,6 @@ final case class Content(
     ("showRelatedContent", JsBoolean(if (tags.isTheMinuteArticle) { false } else showInRelated && !legallySensitive)),
     ("productionOffice", JsString(productionOffice.getOrElse(""))),
     ("isImmersive", JsBoolean(isImmersive)),
-    ("isSplash", JsBoolean(isSplash)),
     ("isColumn", JsBoolean(isColumn)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
@@ -450,7 +448,6 @@ object Article {
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
       ("isImmersive", JsBoolean(content.isImmersive)),
-      ("isSplash", JsBoolean(content.isSplash)),
       ("isHosted", JsBoolean(false)),
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
@@ -518,7 +515,6 @@ final case class Article (
   val isLiveBlog: Boolean = content.tags.isLiveBlog && content.fields.blocks.nonEmpty
   val isTheMinute: Boolean = content.tags.isTheMinuteArticle
   val isImmersive: Boolean = content.isImmersive
-  val isSplash: Boolean = content.isSplash
   val isPhotoEssay: Boolean = content.isPhotoEssay
   val isColumn: Boolean = content.isColumn
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().asScala.headOption

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -78,7 +78,7 @@ final case class Content(
   lazy val isGallery = metadata.contentType.contains(DotcomContentType.Gallery)
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
-  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay || fields.displayHint.contains("splash")
+  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -79,6 +79,7 @@ final case class Content(
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
   lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
+  lazy val isSplash = fields.displayHint.contains("splash")
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 
@@ -239,6 +240,7 @@ final case class Content(
     ("showRelatedContent", JsBoolean(if (tags.isTheMinuteArticle) { false } else showInRelated && !legallySensitive)),
     ("productionOffice", JsString(productionOffice.getOrElse(""))),
     ("isImmersive", JsBoolean(isImmersive)),
+    ("isSplash", JsBoolean(isSplash)),
     ("isColumn", JsBoolean(isColumn)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
@@ -448,6 +450,7 @@ object Article {
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
       ("isImmersive", JsBoolean(content.isImmersive)),
+      ("isSplash", JsBoolean(content.isSplash)),
       ("isHosted", JsBoolean(false)),
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
@@ -515,6 +518,7 @@ final case class Article (
   val isLiveBlog: Boolean = content.tags.isLiveBlog && content.fields.blocks.nonEmpty
   val isTheMinute: Boolean = content.tags.isTheMinuteArticle
   val isImmersive: Boolean = content.isImmersive
+  val isSplash: Boolean = content.isSplash
   val isPhotoEssay: Boolean = content.isPhotoEssay
   val isColumn: Boolean = content.isColumn
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().asScala.headOption

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -125,12 +125,10 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--half-tablet.fc-item--type-immersive.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--standard-mobile,
-    &.fc-item--three-quarters-tablet.fc-item--type-immersive.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-immersive  {
-        background-color: transparent;
-
+    &.fc-item--half-tablet.fc-item--type-splash.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-splash.fc-item--standard-mobile,
+    &.fc-item--three-quarters-tablet.fc-item--type-splash.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-splash  {
         .fc-item__content {
             background-color: map-get($palette, kicker);
         }
@@ -147,7 +145,7 @@ $pillars: (
     &.fc-item--gallery .fc-item__kicker,
     &.fc-item--video .fc-item__kicker,
     &.video-playlist__item .fc-item__kicker,
-    &.fc-item--type-immersive .fc-item__byline
+    &.fc-item--type-splash .fc-item__byline
     {
         color: map-get($palette, invertedKicker);
     }
@@ -157,12 +155,12 @@ $pillars: (
         fill: map-get($palette, invertedKicker);
     }
 
-    &.fc-item--type-immersive .fc-item__headline .inline-garnett-quote {
+    &.fc-item--type-splash .fc-item__headline .inline-garnett-quote {
         fill: map-get($palette, liveColour);
     }
 
-    &.fc-item--list-media-mobile.fc-item--type-immersive .fc-item__kicker,
-    &.fc-item--list-mobile.fc-item--type-immersive .fc-item__kicker
+    &.fc-item--list-media-mobile.fc-item--type-splash .fc-item__kicker,
+    &.fc-item--list-mobile.fc-item--type-splash .fc-item__kicker
     {
         color: map-get($palette, kicker);
         @include mq($from: tablet) {
@@ -170,23 +168,23 @@ $pillars: (
         }
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__kicker,
-    &.fc-item--list-media-tablet.fc-item--type-immersive .fc-item__kicker,
-    &.fc-item--list-tablet.fc-item--type-immersive .fc-item__kicker
+    &.fc-item--standard-tablet.fc-item--type-splash .fc-item__kicker,
+    &.fc-item--list-media-tablet.fc-item--type-splash .fc-item__kicker,
+    &.fc-item--list-tablet.fc-item--type-splash .fc-item__kicker
     {
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive:not(.fc-item--pillar-special-report) .fc-item__standfirst {
+    &.fc-item--standard-tablet.fc-item--type-splash:not(.fc-item--pillar-special-report) .fc-item__standfirst {
         color: $garnett-neutral-1;
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive .inline-icon,
-    &.fc-item--standard-tablet.fc-item--type-immersive .fc-item__meta,
-    &.fc-item--list-media-tablet.fc-item--type-immersive .inline-icon,
-    &.fc-item--list-media-tablet.fc-item--type-immersive .fc-item__meta,
-    &.fc-item--list-tablet.fc-item--type-immersive .inline-icon,
-    &.fc-item--list-tablet.fc-item--type-immersive .fc-item__meta
+    &.fc-item--standard-tablet.fc-item--type-splash .inline-icon,
+    &.fc-item--standard-tablet.fc-item--type-splash .fc-item__meta,
+    &.fc-item--list-media-tablet.fc-item--type-splash .inline-icon,
+    &.fc-item--list-media-tablet.fc-item--type-splash .fc-item__meta,
+    &.fc-item--list-tablet.fc-item--type-splash .inline-icon,
+    &.fc-item--list-tablet.fc-item--type-splash .fc-item__meta
     {
         fill: $garnett-neutral-6;
         color: $garnett-neutral-6;

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -10,7 +10,8 @@ $pillars: (
         headlineIcon: $news-garnett-main-1,
         metaText: $garnett-neutral-2,
         cutoutBackground: $news-garnett-main-1,
-        invertedKicker: $news-garnett-media-main-1
+        invertedKicker: $news-garnett-media-main-1,
+        liveColour: $live-garnett-main-2
     ),
     opinion: (
         cardBackground: $garnett-neutral-3,
@@ -23,7 +24,8 @@ $pillars: (
         headlineIcon: $opinion-garnett-main-1,
         metaText: $garnett-neutral-2,
         cutoutBackground: $opinion-garnett-main-1,
-        invertedKicker: $opinion-garnett-media-main-1
+        invertedKicker: $opinion-garnett-media-main-1,
+        liveColour: #ffffff
     ),
     sport: (
         cardBackground: $garnett-neutral-3,
@@ -36,7 +38,8 @@ $pillars: (
         headlineIcon: $sport-garnett-main-1,
         metaText: $garnett-neutral-2,
         cutoutBackground: $sport-garnett-feature,
-        invertedKicker: $sport-garnett-media-main-1
+        invertedKicker: $sport-garnett-media-main-1,
+        liveColour: $live-garnett-sport2
     ),
     arts: (
         cardBackground: $garnett-neutral-3,
@@ -49,7 +52,8 @@ $pillars: (
         headlineIcon: $culture-garnett-main-1,
         metaText: $garnett-neutral-2,
         cutoutBackground: $culture-garnett-main-1,
-        invertedKicker: $culture-garnett-media-main-1
+        invertedKicker: $culture-garnett-media-main-1,
+        liveColour: $live-garnett-culture2
     ),
     lifestyle: (
         cardBackground: $garnett-neutral-3,
@@ -62,7 +66,8 @@ $pillars: (
         headlineIcon: $lifestyle-garnett-main-1,
         metaText: $garnett-neutral-2,
         cutoutBackground: $lifestyle-garnett-feature,
-        invertedKicker: $lifestyle-garnett-media-main-1
+        invertedKicker: $lifestyle-garnett-media-main-1,
+        liveColour: $live-garnett-lifestyle2
     ),
     special-report: (
         cardBackground: $story-package-garnett,
@@ -75,7 +80,8 @@ $pillars: (
         headlineIcon: $story-package-garnett,
         metaText: $garnett-neutral-2,
         cutoutBackground: $news-garnett-highlight,
-        invertedKicker: $news-garnett-highlight
+        invertedKicker: $news-garnett-highlight,
+        liveColour: #ffffff
     )
 );
 
@@ -123,7 +129,6 @@ $pillars: (
     &.fc-item--third-tablet.fc-item--type-immersive.fc-item--standard-mobile,
     &.fc-item--three-quarters-tablet.fc-item--type-immersive.fc-item--standard-mobile,
     &.fc-item--third-tablet.fc-item--type-immersive  {
-        border-bottom: 1px solid map-get($palette, kicker);
         background-color: transparent;
 
         .fc-item__content {
@@ -148,9 +153,12 @@ $pillars: (
     }
 
 
-    &.fc-item--type-media .fc-item__headline .inline-garnett-quote,
-    &.fc-item--type-immersive .fc-item__headline .inline-garnett-quote {
+    &.fc-item--type-media .fc-item__headline .inline-garnett-quote {
         fill: map-get($palette, invertedKicker);
+    }
+
+    &.fc-item--type-immersive .fc-item__headline .inline-garnett-quote {
+        fill: map-get($palette, liveColour);
     }
 
     &.fc-item--list-media-mobile.fc-item--type-immersive .fc-item__kicker,

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -125,10 +125,10 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--half-tablet.fc-item--type-splash.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-splash.fc-item--standard-mobile,
-    &.fc-item--three-quarters-tablet.fc-item--type-splash.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-splash  {
+    &.fc-item--half-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
+    &.fc-item--three-quarters-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--has-boosted-title  {
         .fc-item__content {
             background-color: map-get($palette, kicker);
         }
@@ -145,7 +145,7 @@ $pillars: (
     &.fc-item--gallery .fc-item__kicker,
     &.fc-item--video .fc-item__kicker,
     &.video-playlist__item .fc-item__kicker,
-    &.fc-item--type-splash .fc-item__byline
+    &.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__byline
     {
         color: map-get($palette, invertedKicker);
     }
@@ -155,12 +155,12 @@ $pillars: (
         fill: map-get($palette, invertedKicker);
     }
 
-    &.fc-item--type-splash .fc-item__headline .inline-garnett-quote {
+    &.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__headline .inline-garnett-quote {
         fill: map-get($palette, liveColour);
     }
 
-    &.fc-item--list-media-mobile.fc-item--type-splash .fc-item__kicker,
-    &.fc-item--list-mobile.fc-item--type-splash .fc-item__kicker
+    &.fc-item--list-media-mobile.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
+    &.fc-item--list-mobile.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker
     {
         color: map-get($palette, kicker);
         @include mq($from: tablet) {
@@ -168,23 +168,23 @@ $pillars: (
         }
     }
 
-    &.fc-item--standard-tablet.fc-item--type-splash .fc-item__kicker,
-    &.fc-item--list-media-tablet.fc-item--type-splash .fc-item__kicker,
-    &.fc-item--list-tablet.fc-item--type-splash .fc-item__kicker
+    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
+    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
+    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker
     {
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--standard-tablet.fc-item--type-splash:not(.fc-item--pillar-special-report) .fc-item__standfirst {
+    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report) .fc-item__standfirst {
         color: $garnett-neutral-1;
     }
 
-    &.fc-item--standard-tablet.fc-item--type-splash .inline-icon,
-    &.fc-item--standard-tablet.fc-item--type-splash .fc-item__meta,
-    &.fc-item--list-media-tablet.fc-item--type-splash .inline-icon,
-    &.fc-item--list-media-tablet.fc-item--type-splash .fc-item__meta,
-    &.fc-item--list-tablet.fc-item--type-splash .inline-icon,
-    &.fc-item--list-tablet.fc-item--type-splash .fc-item__meta
+    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
+    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta,
+    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
+    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta,
+    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
+    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta
     {
         fill: $garnett-neutral-6;
         color: $garnett-neutral-6;

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -159,6 +159,10 @@ $pillars: (
         fill: map-get($palette, liveColour);
     }
 
+    &.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__byline {
+        color: map-get($palette, liveColour);
+    }
+
     &.fc-item--list-media-mobile.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
     &.fc-item--list-mobile.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker
     {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -119,12 +119,29 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
+    &.fc-item--half-tablet.fc-item--type-immersive.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--standard-mobile,
+    &.fc-item--three-quarters-tablet.fc-item--type-immersive.fc-item--standard-mobile,
+    &.fc-item--third-tablet.fc-item--type-immersive  {
+        border-bottom: 1px solid map-get($palette, kicker);
+        background-color: transparent;
+
+        .fc-item__content {
+            background-color: map-get($palette, kicker);
+        }
+
+        &:hover {
+            .fc-item__content {
+                background-color: darken(map-get($palette, kicker), 5%);
+            }
+        }
+    }
+
     //this is to make the colour lighter for the media cards
     &.fc-item--audio .fc-item__kicker,
     &.fc-item--gallery .fc-item__kicker,
     &.fc-item--video .fc-item__kicker,
     &.video-playlist__item .fc-item__kicker,
-    &.fc-item--type-immersive .fc-item__kicker,
     &.fc-item--type-immersive .fc-item__byline
     {
         color: map-get($palette, invertedKicker);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -52,10 +52,6 @@
 @mixin immersiveBottom() {
     @include immersiveCommon();
 
-    .fc-item__container {
-        // margin-bottom: 26px;
-    }
-
     .fc-item__content {
         margin: 0 30px 0 0;
     }
@@ -88,12 +84,8 @@
 @mixin immersiveLeft() {
     @include immersiveCommon();
 
-    .fc-item__container {
-        margin-bottom: 36px;
-    }
-
     .fc-item__content {
-        margin: 0 auto -36px 0;
+        margin: 0 auto 0 0;
         min-width: gs-span(5) - ($gs-gutter * 2);
 
         @include mq(desktop) {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -9,11 +9,11 @@
     }
 
     .fc-item__container {
-        // overflow: hidden;
+        overflow: hidden;
         position: relative;
     }
 
-    // Temporary css fix
+    // TODO: remove this temporary css fix
     .fc-item__standfirst,
     .fc-sublinks {
         display: none !important;
@@ -56,10 +56,18 @@
         margin: 0 30px 0 0;
     }
 
+    &.fc-item--third-tablet  {
+        @include mq($from: tablet) {
+            .fc-item__content {
+                max-width: gs-span(3);
+            }
+        }
+    }
+
     &.fc-item--half-tablet  {
         @include mq($from: tablet) {
             .fc-item__content {
-                max-width: 220px;
+                max-width: gs-span(4);
             }
         }
     }
@@ -101,11 +109,6 @@
 @mixin immersiveRight() {
     @include immersiveCommon();
 
-    .fc-item__content {
-        border-right: 20px solid green;
-    }
-
-
     .u-responsive-ratio {
         padding-bottom: 45%;
     }
@@ -140,15 +143,12 @@
         }
 
         .fc-item__meta {
-            position: absolute;
-            right: -180px;
-            bottom: 0;
-            // margin-left: auto;
-            // color: #ffffff;
+            margin-left: auto;
+            color: #ffffff;
         }
 
         .inline-icon {
-            // fill: #ffffff;
+            fill: #ffffff;
         }
 
         &.fc-item--standard-mobile {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -53,11 +53,11 @@
     @include immersiveCommon();
 
     .fc-item__container {
-        margin-bottom: 26px;
+        // margin-bottom: 26px;
     }
 
     .fc-item__content {
-        margin: 0 30px -26px 0;
+        margin: 0 30px 0 0;
     }
 
     &.fc-item--half-tablet  {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -1,14 +1,22 @@
 @mixin immersiveCommon() {
     .fc-item__kicker {
+        color: $news-garnett-highlight;
         display: block;
     }
 
-    .fc-item__container {
-        overflow: hidden;
+    .fc-item__headline {
+        color: #ffffff;
     }
 
-    .fc-item__content {
-        background-color: $immersive-garnett-main-1;
+    .fc-item__container {
+        // overflow: hidden;
+        position: relative;
+    }
+
+    // Temporary css fix
+    .fc-item__standfirst,
+    .fc-sublinks {
+        display: none !important;
     }
 
     //Todo better way to get this immersive card type to set the height when sublinks. This is fixed height enough to fit two lines of sublink
@@ -20,12 +28,7 @@
     }
 
     .fc-item__content {
-        position: absolute;
-        left: 0;
-
-        @include mq($from: tablet) {
-            position: relative;
-        }
+        position: relative;
     }
 
     .fc-item__headline {
@@ -40,37 +43,29 @@
         }
     }
 
-    .fc-slice--h-q-q & .fc-item__standfirst,
-    &.fc-item--three-quarters-tablet .fc-item__standfirst,
-    &.fc-item--three-quarters-tall-tablet .fc-item__standfirst {
-        display: block;
-        @include mq($from: tablet) {
-            margin-top: $gs-baseline * 2;
-        }
-    }
-
-    .fc-sublink__title {
-        color: #ffffff;
-    }
-
     // ensures image is positioned relative to fc-item__container
     .u-responsive-ratio {
         position: static;
     }
-
-    .fc-item__footer--horizontal {
-        position: absolute;
-        bottom: 0;
-    }
-
 }
 
 @mixin immersiveBottom() {
     @include immersiveCommon();
 
+    .fc-item__container {
+        margin-bottom: 26px;
+    }
+
     .fc-item__content {
-        bottom: 0;
-        right: 0;
+        margin: 0 30px -26px 0;
+    }
+
+    &.fc-item--half-tablet  {
+        @include mq($from: tablet) {
+            .fc-item__content {
+                max-width: 220px;
+            }
+        }
     }
 
     &.fc-item--three-quarters-tall-tablet {
@@ -84,20 +79,7 @@
     &.fc-item--standard-mobile {
         @include mq($from: mobile, $until: tablet) {
             .u-responsive-ratio {
-                padding-bottom: 100%;
-            }
-        }
-    }
-
-    &.fc-item--has-sublinks-1 {
-        .fc-item__footer--horizontal {
-            display: none;
-        }
-        .fc-item__footer--vertical {
-            display: block;
-
-            .fc-sublinks {
-                margin-left: 0;
+                padding-bottom: 60%;
             }
         }
     }
@@ -106,11 +88,18 @@
 @mixin immersiveLeft() {
     @include immersiveCommon();
 
-    .fc-item__content {
-        bottom: 0;
-        top: 0;
+    .fc-item__container {
+        margin-bottom: 36px;
     }
 
+    .fc-item__content {
+        margin: 0 auto -36px 0;
+        min-width: gs-span(5) - ($gs-gutter * 2);
+
+        @include mq(desktop) {
+            min-width: gs-span(6);
+        }
+    }
 
     .u-responsive-ratio {
         padding-bottom: 45%;
@@ -121,10 +110,7 @@
     @include immersiveCommon();
 
     .fc-item__content {
-        left: auto;
-        right: 0;
-        bottom: 0;
-        top: 0;
+        border-right: 20px solid green;
     }
 
 
@@ -161,17 +147,16 @@
             content: '/';
         }
 
-        .fc-item__standfirst {
-            color: #ffffff;
-        }
-
         .fc-item__meta {
-            margin-left: auto;
-            color: #ffffff;
+            position: absolute;
+            right: -180px;
+            bottom: 0;
+            // margin-left: auto;
+            // color: #ffffff;
         }
 
         .inline-icon {
-            fill: #ffffff;
+            // fill: #ffffff;
         }
 
         &.fc-item--standard-mobile {
@@ -189,36 +174,17 @@
             }
         }
 
-        @mixin immersiveSublinks() {
-            &[class*='fc-item--has-sublinks'] {
-                .fc-item__footer--horizontal {
-                    display: none;
-                }
-                .fc-sublinks,
-                .fc-sublink,
-                .fc-item__footer--vertical {
-                    display: block;
-                }
-                .fc-sublinks,
-                .fc-sublink {
-                    margin-left: 0;
-                }
-            }
-        }
-
         &.fc-item--full-media-75-tablet,
         &.fc-item--full-media-50-tablet,
         &.fc-item--three-quarters-tablet {
             @include mq($from: tablet) {
                 @include immersiveLeft();
-                @include immersiveSublinks();
             }
         }
 
         &.fc-item--three-quarters-right-tablet {
             @include mq($from: tablet) {
                 @include immersiveRight();
-                @include immersiveSublinks();
             }
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -13,7 +13,6 @@
         position: relative;
     }
 
-    // TODO: remove this temporary css fix
     .fc-item__standfirst,
     .fc-sublinks {
         display: none;
@@ -73,7 +72,7 @@
     }
 
     &.fc-item--standard-mobile {
-        @include mq($from: mobile, $until: tablet) {
+        @include mq($until: tablet) {
             .u-responsive-ratio {
                 padding-bottom: 60%;
             }
@@ -144,7 +143,7 @@
         }
 
         &.fc-item--standard-mobile {
-            @include mq($from: mobile, $until: tablet) {
+            @include mq($until: tablet) {
                 @include immersiveBottom();
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -16,15 +16,7 @@
     // TODO: remove this temporary css fix
     .fc-item__standfirst,
     .fc-sublinks {
-        display: none !important;
-    }
-
-    //Todo better way to get this immersive card type to set the height when sublinks. This is fixed height enough to fit two lines of sublink
-    &.fc-item--has-sublinks-3 .fc-item__content,
-    &.fc-item--has-sublinks-2 .fc-item__content {
-        @include mq($from: tablet) {
-            padding-bottom: $gs-gutter * 3.6;
-        }
+        display: none;
     }
 
     .fc-item__content {
@@ -114,7 +106,7 @@
     }
 }
 
-.fc-item--type-immersive {
+.fc-item--type-splash {
 
     // ?# It is very easy to opt out as the below, but
     // it increases the cyclomatic complexity of all selectors.

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -106,7 +106,7 @@
     }
 }
 
-.fc-item--type-splash {
+.fc-item--type-immersive.fc-item--has-boosted-title {
 
     // ?# It is very easy to opt out as the below, but
     // it increases the cyclomatic complexity of all selectors.


### PR DESCRIPTION
Immersive cards can look problematic a lot of the time, especially with sublinks and standfirsts contributing to the image being hidden.

This is a tweaked design that only contains a kicker and headline. By default immersive cards display as default articles. The immersive design can be turned on by switching on 'large headline' in the fronts tool.


![screen shot 2018-05-11 at 09 57 05](https://user-images.githubusercontent.com/14570016/39916260-db6ce9ba-5501-11e8-8166-5be2db895fd7.png)


# Before
<img width="1301" alt="screen shot 2018-05-11 at 09 45 52" src="https://user-images.githubusercontent.com/14570016/39916231-d046556c-5501-11e8-8234-34c7b6a32a1c.png">

# After
<img width="1302" alt="screen shot 2018-05-11 at 09 45 27" src="https://user-images.githubusercontent.com/14570016/39915794-c20a9888-5500-11e8-908e-104e29d0a9e7.png">

# Before
<img width="1296" alt="screen shot 2018-05-11 at 09 36 43" src="https://user-images.githubusercontent.com/14570016/39915804-c96a17b6-5500-11e8-90ff-62446af1bd40.png">

# After
<img width="1301" alt="screen shot 2018-05-11 at 09 36 49" src="https://user-images.githubusercontent.com/14570016/39915805-c9843a1a-5500-11e8-8584-a414974c5e29.png">
