### PR TITLE
Close 'More', 'Edition Picker' and 'Account' menus with ESC key press

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -208,23 +208,6 @@ const toggleMenu = (): void => {
     fastdom.write(update);
 };
 
-const initiateUserAccountDropdown = (): void => {
-    fastdom
-        .read(() => ({
-            menu: document.querySelector('.js-user-account-dropdown-menu'),
-            trigger: document.querySelector('.js-user-account-trigger'),
-        }))
-        .then((userAccountDropdownEls: MenuAndTriggerEls) => {
-            const button = userAccountDropdownEls.trigger;
-
-            if (button && button instanceof HTMLButtonElement) {
-                button.addEventListener('click', () =>
-                    toggleDropdown(userAccountDropdownEls)
-                );
-            }
-        });
-};
-
 const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     const openClass = 'dropdown-menu--open';
 
@@ -265,6 +248,23 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     });
 };
 
+const initiateUserAccountDropdown = (): void => {
+    fastdom
+        .read(() => ({
+            menu: document.querySelector('.js-user-account-dropdown-menu'),
+            trigger: document.querySelector('.js-user-account-trigger'),
+        }))
+        .then((userAccountDropdownEls: MenuAndTriggerEls) => {
+            const button = userAccountDropdownEls.trigger;
+
+            if (button && button instanceof HTMLButtonElement) {
+                button.addEventListener('click', () =>
+                    toggleDropdown(userAccountDropdownEls)
+                );
+            }
+        });
+};
+
 const toggleEditionPicker = (): void => {
     const menu: ?HTMLElement = document.querySelector(
         '.js-edition-dropdown-menu'
@@ -287,13 +287,9 @@ const toggleEditionPicker = (): void => {
 const MENU_TOGGLE_CLASS = 'main-menu-toggle';
 const EDITION_PICKER_TOGGLE_CLASS = 'edition-picker-toggle';
 
-const buttons = {
-    [MENU_TOGGLE_CLASS]: {
-        clickHandler: toggleMenu
-    },
-    [EDITION_PICKER_TOGGLE_CLASS]: {
-        clickHandler: toggleEditionPicker
-    },
+const buttonClickHandlers = {
+    [MENU_TOGGLE_CLASS]: toggleMenu,
+    [EDITION_PICKER_TOGGLE_CLASS]: toggleEditionPicker,
 };
 
 const enhanceCheckbox = (checkbox: HTMLElement): void => {
@@ -307,17 +303,13 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
         );
 
         const enhance = () => {
-            const btnOpts = buttons[checkboxId];
-
-            if (!btnOpts) {
-                return;
-            }
-
             button.setAttribute('id', checkboxId);
 
-            const eventHandler = btnOpts.clickHandler;
+            const clickHandler = buttonClickHandlers[checkboxId];
 
-            button.addEventListener('click', eventHandler);
+            if (clickHandler) {
+                button.addEventListener('click', clickHandler);
+            }
 
             button.setAttribute('aria-expanded', 'false');
 

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -295,12 +295,12 @@ const buttonClickHandlers = {
 const ESC_KEY_ID = 27;
 
 const menuKeyHandlers = {
-    [MENU_TOGGLE_CLASS]: event => {
+    [MENU_TOGGLE_CLASS]: (event: Event): void => {
         if (event.keyCode === ESC_KEY_ID) {
             toggleMenu();
         }
     },
-    [EDITION_PICKER_TOGGLE_CLASS]: event => {
+    [EDITION_PICKER_TOGGLE_CLASS]: (event: Event): void => {
         if (event.keyCode === ESC_KEY_ID) {
             toggleEditionPicker();
         }

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -208,6 +208,23 @@ const toggleMenu = (): void => {
     fastdom.write(update);
 };
 
+const initiateUserAccountDropdown = (): void => {
+    fastdom
+        .read(() => ({
+            menu: document.querySelector('.js-user-account-dropdown-menu'),
+            trigger: document.querySelector('.js-user-account-trigger'),
+        }))
+        .then((userAccountDropdownEls: MenuAndTriggerEls) => {
+            const button = userAccountDropdownEls.trigger;
+
+            if (button && button instanceof HTMLButtonElement) {
+                button.addEventListener('click', () =>
+                    toggleDropdown(userAccountDropdownEls)
+                );
+            }
+        });
+};
+
 const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     const openClass = 'dropdown-menu--open';
 
@@ -248,23 +265,6 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     });
 };
 
-const initiateUserAccountDropdown = (): void => {
-    fastdom
-        .read(() => ({
-            menu: document.querySelector('.js-user-account-dropdown-menu'),
-            trigger: document.querySelector('.js-user-account-trigger'),
-        }))
-        .then((userAccountDropdownEls: MenuAndTriggerEls) => {
-            const button = userAccountDropdownEls.trigger;
-
-            if (button && button instanceof HTMLButtonElement) {
-                button.addEventListener('click', () =>
-                    toggleDropdown(userAccountDropdownEls)
-                );
-            }
-        });
-};
-
 const toggleEditionPicker = (): void => {
     const menu: ?HTMLElement = document.querySelector(
         '.js-edition-dropdown-menu'
@@ -289,18 +289,10 @@ const EDITION_PICKER_TOGGLE_CLASS = 'edition-picker-toggle';
 
 const buttons = {
     [MENU_TOGGLE_CLASS]: {
-        innerHTML: `<span class="hide-until-desktop pillar-link pillar-link--dropdown pillar-link--sections">
-                        <span class="u-h">Show </span>More</span>
-                    </span>
-                    <span class=" hide-from-desktop veggie-burger">
-                        <span class="veggie-burger__icon"></span>
-                    </span>`,
-        clickHandler: toggleMenu,
+        clickHandler: toggleMenu
     },
     [EDITION_PICKER_TOGGLE_CLASS]: {
-        innerHTML: displayName =>
-            `<span class="u-h">current edition: </span>${displayName}`,
-        clickHandler: toggleEditionPicker,
+        clickHandler: toggleEditionPicker
     },
 };
 
@@ -350,15 +342,7 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
                     button.setAttribute('tabindex', labelTabIndex);
                 }
 
-                if (checkboxId === EDITION_PICKER_TOGGLE_CLASS) {
-                    const displayName = label.getAttribute('data-display-name');
-
-                    if (displayName) {
-                        button.innerHTML = btnOpts.innerHTML(displayName);
-                    }
-                } else {
-                    button.innerHTML = btnOpts.innerHTML;
-                }
+                button.innerHTML = label.innerHTML;
 
                 label.remove();
             }

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -292,16 +292,14 @@ const buttonClickHandlers = {
     [EDITION_PICKER_TOGGLE_CLASS]: toggleEditionPicker,
 };
 
-const ESC_KEY_ID = 27;
-
 const menuKeyHandlers = {
-    [MENU_TOGGLE_CLASS]: (event: Event): void => {
-        if (event.keyCode === ESC_KEY_ID) {
+    [MENU_TOGGLE_CLASS]: (event: KeyboardEvent): void => {
+        if (event.key === 'Escape') {
             toggleMenu();
         }
     },
-    [EDITION_PICKER_TOGGLE_CLASS]: (event: Event): void => {
-        if (event.keyCode === ESC_KEY_ID) {
+    [EDITION_PICKER_TOGGLE_CLASS]: (event: KeyboardEvent): void => {
+        if (event.key === 'Escape') {
             toggleEditionPicker();
         }
     },

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -292,6 +292,21 @@ const buttonClickHandlers = {
     [EDITION_PICKER_TOGGLE_CLASS]: toggleEditionPicker,
 };
 
+const ESC_KEY_ID = 27;
+
+const menuKeyHandlers = {
+    [MENU_TOGGLE_CLASS]: event => {
+        if (event.keyCode === ESC_KEY_ID) {
+            toggleMenu();
+        }
+    },
+    [EDITION_PICKER_TOGGLE_CLASS]: event => {
+        if (event.keyCode === ESC_KEY_ID) {
+            toggleEditionPicker();
+        }
+    },
+};
+
 const enhanceCheckbox = (checkbox: HTMLElement): void => {
     fastdom.read(() => {
         const button = document.createElement('button');
@@ -319,6 +334,13 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
 
             if (checkboxControls) {
                 button.setAttribute('aria-controls', checkboxControls);
+
+                const menu = document.getElementById(checkboxControls);
+                const keyHandler = menuKeyHandlers[checkboxId];
+
+                if (menu && keyHandler) {
+                    menu.addEventListener('keyup', keyHandler);
+                }
             }
 
             if (label) {

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -250,7 +250,6 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
 
             menu.setAttribute('aria-hidden', hiddenAttr);
             menu.classList.toggle(openClass, !isOpen);
-
             if (!isOpen) {
                 const menuId = menu.getAttribute('id');
                 const triggerToggle = clickSpec => {
@@ -307,33 +306,42 @@ const toggleEditionPicker = (): void => {
     }
 };
 
-const MENU_TOGGLE_CLASS = 'main-menu-toggle';
-const EDITION_PICKER_TOGGLE_CLASS = 'edition-picker-toggle';
+const MENU_TOGGLE_ID = 'main-menu-toggle';
+const EDITION_PICKER_TOGGLE_ID = 'edition-picker-toggle';
 
 const buttonClickHandlers = {
-    [MENU_TOGGLE_CLASS]: toggleMenu,
-    [EDITION_PICKER_TOGGLE_CLASS]: toggleEditionPicker,
+    [MENU_TOGGLE_ID]: toggleMenu,
+    [EDITION_PICKER_TOGGLE_ID]: toggleEditionPicker,
+};
+
+const returnFocusToButton = (btnId: string): void => {
+    fastdom.read(() => document.getElementById(btnId)).then(btn => {
+        if (btn) {
+            btn.focus();
+            /**
+             * As we're closing the menu with the ESC key we no longer need the
+             * clickstream listener that toggles the menu on a click outside the menu
+             * so let's unregister it here
+             * */
+            const menuId = btn.getAttribute('aria-controls');
+            if (menuId) {
+                removeClickstreamListener(menuId);
+            }
+        }
+    });
 };
 
 const menuKeyHandlers = {
-    [MENU_TOGGLE_CLASS]: (event: KeyboardEvent): void => {
+    [MENU_TOGGLE_ID]: (event: KeyboardEvent): void => {
         if (event.key === 'Escape') {
             toggleMenu();
-            /**
-             * As we're closing the menu with the ESC key we no longer need the
-             * clickstream listener that toggles the menu on a click outside the menu
-             * */
-            removeClickstreamListener(MENU_TOGGLE_CLASS);
+            returnFocusToButton(MENU_TOGGLE_ID);
         }
     },
-    [EDITION_PICKER_TOGGLE_CLASS]: (event: KeyboardEvent): void => {
+    [EDITION_PICKER_TOGGLE_ID]: (event: KeyboardEvent): void => {
         if (event.key === 'Escape') {
             toggleEditionPicker();
-            /**
-             * As we're closing the menu with the ESC key we no longer need the
-             * clickstream listener that toggles the menu on a click outside the menu
-             * */
-            removeClickstreamListener(EDITION_PICKER_TOGGLE_CLASS);
+            returnFocusToButton(EDITION_PICKER_TOGGLE_ID);
         }
     },
 };

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -272,6 +272,23 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     });
 };
 
+const returnFocusToButton = (btnId: string): void => {
+    fastdom.read(() => document.getElementById(btnId)).then(btn => {
+        if (btn) {
+            btn.focus();
+            /**
+             * As we're closing the menu with the ESC key we no longer need the
+             * clickstream listener that toggles the menu on a click outside the menu
+             * so let's unregister it here
+             * */
+            const menuId = btn.getAttribute('aria-controls');
+            if (menuId) {
+                removeClickstreamListener(menuId);
+            }
+        }
+    });
+};
+
 const initiateUserAccountDropdown = (): void => {
     fastdom
         .read(() => ({
@@ -322,23 +339,6 @@ const toggleEditionPicker = (): void => {
 const buttonClickHandlers = {
     [MENU_TOGGLE_ID]: toggleMenu,
     [EDITION_PICKER_TOGGLE_ID]: toggleEditionPicker,
-};
-
-const returnFocusToButton = (btnId: string): void => {
-    fastdom.read(() => document.getElementById(btnId)).then(btn => {
-        if (btn) {
-            btn.focus();
-            /**
-             * As we're closing the menu with the ESC key we no longer need the
-             * clickstream listener that toggles the menu on a click outside the menu
-             * so let's unregister it here
-             * */
-            const menuId = btn.getAttribute('aria-controls');
-            if (menuId) {
-                removeClickstreamListener(menuId);
-            }
-        }
-    });
 };
 
 const menuKeyHandlers = {

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -85,7 +85,10 @@ const removeClickstreamListener = (menuId: string): void => {
     delete clickstreamListeners[menuId];
 };
 
-const registerClickstreamListener = (menuId: string, clickHandler: () => void) => {
+const registerClickstreamListener = (
+    menuId: string,
+    clickHandler: () => void
+) => {
     removeClickstreamListener(menuId);
     mediator.on('module:clickstream:click', clickHandler);
     clickstreamListeners[menuId] = clickHandler;

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -16,7 +16,11 @@ type MenuAndTriggerEls = {
 };
 
 const enhanced = {};
+const clickstreamListeners = {};
 const SEARCH_STORAGE_KEY = 'gu.recent.search';
+const MY_ACCOUNT_ID = 'my-account-toggle';
+const MENU_TOGGLE_ID = 'main-menu-toggle';
+const EDITION_PICKER_TOGGLE_ID = 'edition-picker-toggle';
 
 const getMenu = (): ?HTMLElement =>
     document.getElementsByClassName('js-main-menu')[0];
@@ -76,8 +80,6 @@ const toggleMenuSection = (section: HTMLElement): void => {
         closeMenuSection(section);
     }
 };
-
-const clickstreamListeners = {};
 
 const removeClickstreamListener = (menuId: string): void => {
     const clickHandler = clickstreamListeners[menuId];
@@ -284,6 +286,17 @@ const initiateUserAccountDropdown = (): void => {
                     toggleDropdown(userAccountDropdownEls)
                 );
             }
+
+            const { menu } = userAccountDropdownEls;
+
+            if (menu) {
+                menu.addEventListener('keyup', (event: KeyboardEvent): void => {
+                    if (event.key === 'Escape') {
+                        toggleDropdown(userAccountDropdownEls);
+                        returnFocusToButton(MY_ACCOUNT_ID);
+                    }
+                });
+            }
         });
 };
 
@@ -305,9 +318,6 @@ const toggleEditionPicker = (): void => {
         toggleDropdown(editionPickerDropdownEls);
     }
 };
-
-const MENU_TOGGLE_ID = 'main-menu-toggle';
-const EDITION_PICKER_TOGGLE_ID = 'edition-picker-toggle';
 
 const buttonClickHandlers = {
     [MENU_TOGGLE_ID]: toggleMenu,

--- a/static/src/stylesheets/layout/nav/_main-menu-toggle.scss
+++ b/static/src/stylesheets/layout/nav/_main-menu-toggle.scss
@@ -2,46 +2,4 @@
     border: 0;
     padding: 0;
     background: none;
-
-    @include mq(desktop) {
-        span {    
-            &::after {
-                content: '';
-                border: 2px solid currentColor;
-                border-left: transparent;
-                border-top: transparent;
-                display: inline-block;
-                height: 6px;
-                margin-left: 6px;
-                transform: translateY(-3px) rotate(45deg);
-                transition: transform 250ms ease-out;
-                vertical-align: middle;
-                width: 6px;
-            }
-        }
-
-        &:hover {
-            span {
-                &::after {
-                    transform: translateY(0) rotate(45deg);
-                }
-            }
-        }
-
-        .new-header--open & {
-            span {
-                &::after {
-                    transform: translateY(1px) rotate(-135deg);
-                }
-            }
-
-            &:hover {
-                span {
-                    &::after {
-                        transform: translateY(-2px) rotate(-135deg);
-                    }
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
## What does this change?

Accessibility fix.

Currently If a user opens the  'More' or 'Edition Picker' menus and tabs into them there's no way of closing the menus with their keyboard.

This PR fixes that by adding the ability to close the menus using the `ESC` key, which is recommended behaviour. This functionality is enabled by adding a `keyup` event listener to the menu.

I've also simplified the logic from https://github.com/guardian/frontend/pull/19631, as I found I could reuse the `innerHTML` from the `label`'s  replaced by `button`s. Doing this meant I could remove the `HTML` in `new-header.js` and also remove redundant styles from `_main-menu-toggle.scss`.

## What is the value of this and can you measure success?

You can now close the 'More' and 'Edition Picker' menus with your keyboard

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

~No~ Yes