### PR TITLE
Avoid inline adslots less than 600px above a fullwidth immersive image

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -88,6 +88,10 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minAbove: 35,
                 minBelow: 400,
             },
+            ' figure.element--immersive': {
+                minAbove: 0,
+                minBelow: 600,
+            },
         },
         filter: filterNearbyCandidates(adSizes.mpu.height),
     };
@@ -99,6 +103,10 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
         minBelow: 800,
         selectors: {
             ' .ad-slot': adSlotClassSelectorSizes,
+            ' figure.element--immersive': {
+                minAbove: 0,
+                minBelow: 600,
+            },
         },
         filter: filterNearbyCandidates(adSizes.halfPage.height),
     };


### PR DESCRIPTION
This fixes the issue described here: https://trello.com/c/WI80aoue

Additionally, a bit of renaming and a tiny bit more comments should make spacefinder a little bit easier to understand.