### PR TITLE
Video carousel keyboard and screen reader improvements

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -55,7 +55,7 @@
                             @media.formattedDuration
                         </span>
                     </div>
-                    <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1"></a>
+                    <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
                 }
             }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -40,20 +40,6 @@
 }
 
         @for(asset <- activeAsset if playable && !expired) {
-            @defining(s"https://www.youtube.com/embed${
-                asset.id
-                .addParams(List(
-                "enablejsapi" -> 1,
-                "rel" -> 0,
-                "showinfo" -> 0,
-                "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
-                )).toString
-                }") { embedUri: String  =>
-                <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"
-                        src="@embedUri" frameborder="0"
-                        allowfullscreen="">
-                </iframe>
-                }
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 <div class="video-overlay">
                     <div class="video-overlay__headline">
@@ -65,13 +51,28 @@
                         }
 
                     </div>
-                    <span class="video-overlay__duration">
-                    @media.formattedDuration
-                    </span>
-                </div>
-                <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1"></a>
+                        <span class="video-overlay__duration">
+                            @media.formattedDuration
+                        </span>
+                    </div>
+                    <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1"></a>
+                }
             }
-          }
+
+            @defining(s"https://www.youtube.com/embed${
+                asset.id
+                    .addParams(List(
+                    "enablejsapi" -> 1,
+                    "rel" -> 0,
+                    "showinfo" -> 0,
+                    "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                )).toString
+            }") { embedUri: String  =>
+                <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"
+                src="@embedUri" frameborder="0"
+                allowfullscreen="">
+                </iframe>
+            }
         }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
             @if(!bestPosterImage.isDefined && expired) {

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -21,11 +21,14 @@
 <div class="video-playlist video-playlist--start js-video-playlist"
      data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)"
      data-component="video-playlist">
-    <div class="video-playlist__control video-playlist__control--prev js-video-playlist-prev" data-link-name="video-container-prev">
+    <div
+        class="video-playlist__control video-playlist__control--prev js-video-playlist-prev"
+        data-link-name="video-container-prev"
+        role="button"
+        tabindex="0"
+        aria-label="show previous video"
+    >
         @fragments.inlineSvg("chevron-left", "icon", Seq("video-playlist__icon"))
-    </div>
-    <div class="video-playlist__control video-playlist__control--next js-video-playlist-next" data-link-name="video-container-next">
-        @fragments.inlineSvg("chevron-right", "icon", Seq("video-playlist__icon"))
     </div>
 
     <ul class="u-unstyled video-playlist__inner js-video-playlist-inner">
@@ -79,4 +82,14 @@
         }
       }
     </ul>
+
+    <div
+        class="video-playlist__control video-playlist__control--next js-video-playlist-next"
+        data-link-name="video-container-next"
+        role="button"
+        tabindex="0"
+        aria-label="show next video"
+    >
+        @fragments.inlineSvg("chevron-right", "icon", Seq("video-playlist__icon"))
+    </div>
 </div>

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -21,15 +21,16 @@
 <div class="video-playlist video-playlist--start js-video-playlist"
      data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)"
      data-component="video-playlist">
-    <div
+    <a
         class="video-playlist__control video-playlist__control--prev js-video-playlist-prev"
         data-link-name="video-container-prev"
         role="button"
-        tabindex="0"
+        tabindex="-1"
+        aria-hidden="true"
         aria-label="show previous video"
     >
         @fragments.inlineSvg("chevron-left", "icon", Seq("video-playlist__icon"))
-    </div>
+    </a>
 
     <ul class="u-unstyled video-playlist__inner js-video-playlist-inner">
         <li class="video-playlist__item video-title video-title--leftcol fc-container__header__title">
@@ -83,7 +84,7 @@
       }
     </ul>
 
-    <div
+    <a
         class="video-playlist__control video-playlist__control--next js-video-playlist-next"
         data-link-name="video-container-next"
         role="button"
@@ -91,5 +92,5 @@
         aria-label="show next video"
     >
         @fragments.inlineSvg("chevron-right", "icon", Seq("video-playlist__icon"))
-    </div>
+    </a>
 </div>

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -166,6 +166,7 @@ const update = (state: State, container: Element): Promise<number> => {
             activeEl.classList.remove('video-playlist__item--active');
             $('.youtube-media-atom__iframe', activeEl).hide();
             $('.video-overlay .fc-item__link', activeEl).attr('tabindex', '-1');
+            $('.video-overlay .fc-item__link', activeEl).attr('aria-hidden', 'true');
         }
 
         const newActive = container.querySelector(
@@ -178,6 +179,9 @@ const update = (state: State, container: Element): Promise<number> => {
             $('.video-overlay .fc-item__link', newActive).removeAttr(
                 'tabindex'
             );
+            $('.video-overlay .fc-item__link', newActive).removeAttr(
+                'aria-hidden'
+            );
         }
 
         container.classList.remove(
@@ -188,10 +192,14 @@ const update = (state: State, container: Element): Promise<number> => {
         if (state.atStart) {
             container.classList.add('video-playlist--start');
             $('.video-title__link', container).removeAttr('tabindex');
+            $('.video-title__link', container).removeAttr('aria-hidden');
             $('.treats__treat', container).removeAttr('tabindex');
+            $('.treats__treat', container).removeAttr('aria-hidden');
         } else {
             $('.video-title__link', container).attr('tabindex', '-1');
+            $('.video-title__link', container).attr('aria-hidden', 'true');
             $('.treats__treat', container).attr('tabindex', '-1');
+            $('.treats__treat', container).attr('aria-hidden', 'true');
         }
 
         if (state.atEnd) {
@@ -311,5 +319,6 @@ export const videoContainerInit = (container: Element) => {
     $('.video-playlist__item:not(.video-playlist__item--first)').each($el => {
         $('.youtube-media-atom__iframe', $el).hide();
         $('.video-overlay .fc-item__link', $el).attr('tabindex', '-1');
+        $('.video-overlay .fc-item__link', $el).attr('aria-hidden', 'true');
     });
 };

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -92,6 +92,9 @@ const reducers = {
                 ];
                 overlayLinks.forEach(el => {
                     el.classList.add('u-faux-block-link__overlay');
+                    // make visible to screen readers / keyboard users
+                    el.removeAttribute('tabindex');
+                    el.removeAttribute('aria-hidden');
                 });
 
                 const atomWrapper = [
@@ -166,7 +169,10 @@ const update = (state: State, container: Element): Promise<number> => {
             activeEl.classList.remove('video-playlist__item--active');
             $('.youtube-media-atom__iframe', activeEl).hide();
             $('.video-overlay .fc-item__link', activeEl).attr('tabindex', '-1');
-            $('.video-overlay .fc-item__link', activeEl).attr('aria-hidden', 'true');
+            $('.video-overlay .fc-item__link', activeEl).attr(
+                'aria-hidden',
+                'true'
+            );
         }
 
         const newActive = container.querySelector(

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -201,15 +201,24 @@ const update = (state: State, container: Element): Promise<number> => {
             $('.video-title__link', container).removeAttr('aria-hidden');
             $('.treats__treat', container).removeAttr('tabindex');
             $('.treats__treat', container).removeAttr('aria-hidden');
+            $('.js-video-playlist-prev', container).attr('aria-hidden', 'true');
+            $('.js-video-playlist-prev', container).attr('tabindex', '-1');
         } else {
             $('.video-title__link', container).attr('tabindex', '-1');
             $('.video-title__link', container).attr('aria-hidden', 'true');
             $('.treats__treat', container).attr('tabindex', '-1');
             $('.treats__treat', container).attr('aria-hidden', 'true');
+            $('.js-video-playlist-prev', container).removeAttr('aria-hidden');
+            $('.js-video-playlist-prev', container).attr('tabindex', '0');
         }
 
         if (state.atEnd) {
             container.classList.add('video-playlist--end');
+            $('.js-video-playlist-next', container).attr('aria-hidden', 'true');
+            $('.js-video-playlist-next', container).attr('tabindex', '-1');
+        } else {
+            $('.js-video-playlist-next', container).removeAttr('aria-hidden');
+            $('.js-video-playlist-next', container).attr('tabindex', '0');
         }
 
         // fetch the next image (for desktop)

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -175,7 +175,9 @@ const update = (state: State, container: Element): Promise<number> => {
         if (newActive != null) {
             newActive.classList.add('video-playlist__item--active');
             $('.youtube-media-atom__iframe', newActive).show();
-            $('.video-overlay .fc-item__link', newActive).removeAttr('tabindex');
+            $('.video-overlay .fc-item__link', newActive).removeAttr(
+                'tabindex'
+            );
         }
 
         container.classList.remove(
@@ -234,7 +236,7 @@ const setupDispatches = (
         });
     });
 
-    bean.on(container, 'keypress', '.js-video-playlist-next', (e) => {
+    bean.on(container, 'keypress', '.js-video-playlist-next', e => {
         e.preventDefault();
         if (e.key === ' ' || e.key === 'Enter') {
             dispatch({
@@ -249,7 +251,7 @@ const setupDispatches = (
         });
     });
 
-    bean.on(container, 'keypress', '.js-video-playlist-prev', (e) => {
+    bean.on(container, 'keypress', '.js-video-playlist-prev', e => {
         e.preventDefault();
         if (e.key === ' ' || e.key === 'Enter') {
             dispatch({
@@ -306,7 +308,7 @@ export const videoContainerInit = (container: Element) => {
         update(store.getState(), container);
     });
 
-    $('.video-playlist__item:not(.video-playlist__item--first)').each(($el) => {
+    $('.video-playlist__item:not(.video-playlist__item--first)').each($el => {
         $('.youtube-media-atom__iframe', $el).hide();
         $('.video-overlay .fc-item__link', $el).attr('tabindex', '-1');
     });

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -162,13 +162,23 @@ const update = (state: State, container: Element): Promise<number> => {
         const activeEl = container.querySelector(
             '.video-playlist__item--active'
         );
-        if (activeEl != null)
+
+        if (activeEl != null) {
             activeEl.classList.remove('video-playlist__item--active');
+            $('.youtube-media-atom__iframe', activeEl).hide();
+            $('.video-overlay .fc-item__link', activeEl).attr('tabindex', '-1');
+
+        }
+
         const newActive = container.querySelector(
             `.js-video-playlist-item-${state.position}`
         );
-        if (newActive != null)
+
+        if (newActive != null) {
             newActive.classList.add('video-playlist__item--active');
+            $('.youtube-media-atom__iframe', newActive).show();
+            $('.video-overlay .fc-item__link', newActive).removeAttr('tabindex');
+        }
 
         container.classList.remove(
             'video-playlist--end',
@@ -225,7 +235,6 @@ const setupDispatches = (
     });
 };
 
-// #? is this over-kill? should we use Redux?
 const reducer = (previousState: State, action: Action): State =>
     reducers[action.type]
         ? reducers[action.type](previousState)
@@ -271,5 +280,10 @@ export const videoContainerInit = (container: Element) => {
     setupDispatches(store.dispatch, container);
     store.subscribe(() => {
         update(store.getState(), container);
+    });
+
+    $('.video-playlist__item:not(.video-playlist__item--first)').each(($el) => {
+        $('.youtube-media-atom__iframe', $el).hide();
+        $('.video-overlay .fc-item__link', $el).attr('tabindex', '-1');
     });
 };

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -251,8 +251,8 @@ const setupDispatches = (
     });
 
     bean.on(container, 'keypress', '.js-video-playlist-next', e => {
-        e.preventDefault();
         if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
             dispatch({
                 type: 'NEXT',
             });
@@ -266,8 +266,8 @@ const setupDispatches = (
     });
 
     bean.on(container, 'keypress', '.js-video-playlist-prev', e => {
-        e.preventDefault();
         if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
             dispatch({
                 type: 'PREV',
             });

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -6,21 +6,20 @@ import { elementInView } from 'lib/element-inview';
 import { onVideoContainerNavigation } from 'common/modules/atoms/youtube';
 import { isBreakpoint } from 'lib/detect';
 
-type State = {
-    position: number,
-    length: number,
-    videoWidth: number,
-    container: Element,
-};
-
 type Action = {
     type: string,
 };
 
 type Position = {
     position: number,
-    atStart: boolean,
-    atEnd: boolean,
+    atStart?: boolean,
+    atEnd?: boolean,
+};
+
+type State = Position & {
+    length: number,
+    videoWidth: number,
+    container: Element,
 };
 
 const updateYouTubeVideo = (currentItem: ?Element): void => {
@@ -167,7 +166,6 @@ const update = (state: State, container: Element): Promise<number> => {
             activeEl.classList.remove('video-playlist__item--active');
             $('.youtube-media-atom__iframe', activeEl).hide();
             $('.video-overlay .fc-item__link', activeEl).attr('tabindex', '-1');
-
         }
 
         const newActive = container.querySelector(
@@ -184,10 +182,18 @@ const update = (state: State, container: Element): Promise<number> => {
             'video-playlist--end',
             'video-playlist--start'
         );
+
+        if (state.atStart) {
+            container.classList.add('video-playlist--start');
+            $('.video-title__link', container).removeAttr('tabindex');
+            $('.treats__treat', container).removeAttr('tabindex');
+        } else {
+            $('.video-title__link', container).attr('tabindex', '-1');
+            $('.treats__treat', container).attr('tabindex', '-1');
+        }
+
         if (state.atEnd) {
             container.classList.add('video-playlist--end');
-        } else if (state.atStart) {
-            container.classList.add('video-playlist--start');
         }
 
         // fetch the next image (for desktop)
@@ -228,10 +234,28 @@ const setupDispatches = (
         });
     });
 
+    bean.on(container, 'keypress', '.js-video-playlist-next', (e) => {
+        e.preventDefault();
+        if (e.key === ' ' || e.key === 'Enter') {
+            dispatch({
+                type: 'NEXT',
+            });
+        }
+    });
+
     bean.on(container, 'click', '.js-video-playlist-prev', () => {
         dispatch({
             type: 'PREV',
         });
+    });
+
+    bean.on(container, 'keypress', '.js-video-playlist-prev', (e) => {
+        e.preventDefault();
+        if (e.key === ' ' || e.key === 'Enter') {
+            dispatch({
+                type: 'PREV',
+            });
+        }
     });
 };
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -164,7 +164,8 @@ $video-width-desktop: 700px;
         z-index: 2;
         cursor: pointer;
 
-        &:hover .video-playlist__icon {
+        &:hover .video-playlist__icon,
+        &:focus .video-playlist__icon {
             background-color: $news-garnett-highlight;
 
             svg {

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -168,7 +168,8 @@ $video-width-desktop: 700px;
         z-index: 2;
         cursor: pointer;
 
-        &:hover .video-playlist__icon {
+        &:hover .video-playlist__icon,
+        &:focus .video-playlist__icon {
             background-color: $media-default;
 
             svg {


### PR DESCRIPTION
## What does this change?

- User can no longer use keyboard to tab to non-active slides. The next / previous buttons are now the only way to navigate through slides
- Overlay now appears before the video in the tab order, so a screen reader user will hear the title of the video first, then has the option to play the video inline
- Previous / next buttons are focussable, marked up as buttons and respond to Space and Enter keypresses

## What is the value of this and can you measure success?

Better consideration for keyboard and screen reader users.

## Screenshots

**Before**

![may-11-2018 15-00-22](https://user-images.githubusercontent.com/5931528/39928028-16abc0d0-552c-11e8-81f5-01c5dc7b23c5.gif)

**After**

![may-11-2018 15-16-41](https://user-images.githubusercontent.com/5931528/39928862-5d2ec550-552e-11e8-9c22-93218b241841.gif)


## Tested in CODE?

No

## Cross browser testing

- [x] Chrome with VoiceOver

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
