### PR TITLE
Close "My Account" with ESC key

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -263,10 +263,10 @@ const initiateUserAccountDropdown = (): void => {
                 );
             }
 
-            const { menu } =  userAccountDropdownEls;
+            const { menu } = userAccountDropdownEls;
 
             if (menu) {
-                menu.addEventListener('keyup', (event: KeyboardEvent) => {
+                menu.addEventListener('keyup', (event: KeyboardEvent): void => {
                     if (event.key === 'Escape') {
                         toggleDropdown(userAccountDropdownEls);
                     }

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -262,6 +262,16 @@ const initiateUserAccountDropdown = (): void => {
                     toggleDropdown(userAccountDropdownEls)
                 );
             }
+
+            const { menu } =  userAccountDropdownEls;
+
+            if (menu) {
+                menu.addEventListener('keyup', (event: KeyboardEvent) => {
+                    if (event.key === 'Escape') {
+                        toggleDropdown(userAccountDropdownEls);
+                    }
+                });
+            }
         });
 };
 


### PR DESCRIPTION
## What does this change?

Accessibility fix.

Currently If a user opens the 'My Account' menu and tabs into it there's no way of closing the menu with their keyboard.

This PR fixes that by adding the ability to close the menu using the `ESC` key, which is recommended behaviour. This functionality is enabled by adding a `keyup` event listener to the menu.

## What is the value of this and can you measure success?

You can now close the 'More' and 'Edition Picker' menus with your keyboard

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

Yes