### PR TITLE
Remove LineHeightFontSize test and change the CSS to match the variant

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,8 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     CommercialAdRefresh,
     OrielParticipation,
-    LotameParticipation,
-    LineHeightFontSize
+    LotameParticipation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -46,12 +45,4 @@ object LotameParticipation extends Experiment(
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1D
-)
-
-object LineHeightFontSize extends Experiment(
-  name = "line-height-font-size",
-  description = "User in this experiment will have an increased article body line height and font size",
-  owners = Seq(Owner.withGithub("frankie297")),
-  sellByDate = new LocalDate(2018, 5, 17),
-  participationGroup = Perc1B
 )

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: RequestHeader)
 @import conf.switches.Switches._
 
 /**

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -1,6 +1,5 @@
-@()(implicit request: RequestHeader)
+@()
 @import conf.switches.Switches._
-@import experiments.{ ActiveExperiments, LineHeightFontSize }
 
 /**
  * Choose how the browser should render the page before any painting begins.
@@ -121,10 +120,6 @@
         docClass = docClass.replace(/\bis-not-modern\b/g, 'is-modern');
     }
 
-    @if(ActiveExperiments.isParticipating(LineHeightFontSize)) {
-      docClass += ' commercial-line-height';
-    }
-
     @if(FontKerningSwitch.isSwitchedOn) {
         if (window.location.hash !== '#no-kern') {docClass += ' should-kern'}
     } else {
@@ -155,7 +150,7 @@
 
     // % used for padding-bottom isn't supported on Grid items in FireFox <53
     // unless explicit width is set on the element with padding-bottom.
-    // .force-percentage-padding ensures width is explicitly set so padding-bottom 
+    // .force-percentage-padding ensures width is explicitly set so padding-bottom
     // works on responsive-ratio media.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
     if(forcePercentagePadding()) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -488,11 +488,11 @@
 
 .ad-slot--offset-right {
     @include mq(desktop) {
-        margin-right: -20em;
+        margin-right: -320px;
     }
 
     @include mq(wide) {
-        margin-right: -25em;
+        margin-right: -400px;
     }
 }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -260,7 +260,8 @@ $quote-mark: 35px;
     }
 
     .content__article-body {
-        line-height: 1.4;
+        font-size: 17px;
+        line-height: 24px;
 
         @include mq(tablet) {
             margin-left: 0;
@@ -345,7 +346,8 @@ $quote-mark: 35px;
     .content__standfirst {
         @include fs-bodyCopy(2);
         font-weight: 700;
-        line-height: 20px;
+        font-size: 17px;
+        line-height: 22px;
         border-top: 0;
         color: $garnett-neutral-1;
         padding-top: 2px;
@@ -358,25 +360,6 @@ $quote-mark: 35px;
         @include mq(tablet) {
             max-width: gs-span(7);
             margin-left: 0;
-        }
-    }
-
-    // overrides for those in the LineHeightFontSize server-side test
-    .commercial-line-height & {
-        .content__standfirst {
-            font-size: 17px;
-            line-height: 22px;
-        }
-
-        .content__article-body {
-            font-size: 17px;
-            line-height: 24px;
-        }
-
-        // negative margin on these is currently based on inital
-        // font-size so we need to set this for the test duration.
-        .ad-slot--offset-right {
-            font-size: 16px;
         }
     }
 


### PR DESCRIPTION
## What does this change?
Removes the server side test for Line Height and Font Size and changes the CSS to match the variant of the test. See original PR: #19583
## What is the value of this and can you measure success?
The test has finished and we can use the CSS of the variant
## Screenshots
In removing the test the margin on the right needs to change too see also #19611 

Before (wide breakpoint)![picture 298](https://user-images.githubusercontent.com/19835654/39934241-1a5ca40e-553d-11e8-9753-93e21fb712d6.png)
After (wide breakpoint)
![picture 296](https://user-images.githubusercontent.com/19835654/39934262-2fd02e82-553d-11e8-8f04-63ea6b7cb760.png)

Before (desktop breakpoint)
![picture 298](https://user-images.githubusercontent.com/19835654/39934272-379754ec-553d-11e8-939c-f058ee2dac92.png)
After (desktop breakpoint)
![picture 297](https://user-images.githubusercontent.com/19835654/39934288-4227188e-553d-11e8-8f70-df9705c82039.png)



## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
