### PR TITLE
Add more metadata to Hosted pages, and reduce shared image sizes

### DIFF
--- a/common/app/common/commercial/hosted/ContentUtils.scala
+++ b/common/app/common/commercial/hosted/ContentUtils.scala
@@ -2,8 +2,9 @@ package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.ElementType.Image
 import com.gu.contentapi.client.model.v1.{Asset, Content, Element}
+import conf.Configuration
 import model.{ImageMedia, Element => ModelElement}
-import views.support.{ImgSrc, Item300}
+import views.support.{Item300, Item700, Item1200}
 
 object ContentUtils {
 
@@ -34,4 +35,10 @@ object ContentUtils {
 
   def thumbnailUrl(item: Content): String =
     Item300.bestSrcFor(imageMedia(item)) getOrElse ""
+
+  def imageForSocialShare(content: Content): String = {
+    findLargestMainImageAsset(content)
+      .flatMap(_.file)
+      .getOrElse(Configuration.images.fallbackLogo)
+  }
 }

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -2,11 +2,10 @@ package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common.Logging
-import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, thumbnailUrl}
+import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, imageForSocialShare, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Content, MetaData}
-import views.support.{ImgSrc, Item700, Item1200}
-import conf.Configuration
+import views.support.{ImgSrc, Item1200, Item700}
 
 case class HostedArticlePage(
   override val id: String,
@@ -38,9 +37,10 @@ object HostedArticlePage extends Logging {
     } yield {
 
       val mainImageAsset = findLargestMainImageAsset(content)
-      val mainImage = mainImageAsset.flatMap(_.file).getOrElse(Configuration.images.fallbackLogo)
 
-      val openGraphImages: Seq[String] = Seq(ImgSrc(mainImage, Item1200))
+      val openGraphImages: Seq[String] = Seq(ImgSrc(imageForSocialShare(content), Item1200))
+      val twitterImage: String = ImgSrc(imageForSocialShare(content), Item700)
+
 
       HostedArticlePage(
         id = content.id,
@@ -59,7 +59,7 @@ object HostedArticlePage extends Logging {
           .copy(
             openGraphImages = openGraphImages,
             twitterPropertiesOverrides = Map(
-              "twitter:image" -> ImgSrc(mainImage, Item700)
+              "twitter:image" -> twitterImage
             )
           ),
         content = Content.make(content)

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -5,6 +5,8 @@ import common.Logging
 import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Content, MetaData}
+import views.support.{ImgSrc, Item700, Item1200}
+import conf.Configuration
 
 case class HostedArticlePage(
   override val id: String,
@@ -36,6 +38,9 @@ object HostedArticlePage extends Logging {
     } yield {
 
       val mainImageAsset = findLargestMainImageAsset(content)
+      val mainImage = mainImageAsset.flatMap(_.file).getOrElse(Configuration.images.fallbackLogo)
+
+      val openGraphImages: Seq[String] = Seq(ImgSrc(mainImage, Item1200))
 
       HostedArticlePage(
         id = content.id,
@@ -50,7 +55,13 @@ object HostedArticlePage extends Logging {
         thumbnailUrl = thumbnailUrl(content),
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
-        metadata = HostedMetadata.fromContent(content).copy(openGraphImages = mainImageAsset.flatMap(_.file).toList),
+        metadata = HostedMetadata.fromContent(content)
+          .copy(
+            openGraphImages = openGraphImages,
+            twitterPropertiesOverrides = Map(
+              "twitter:image" -> ImgSrc(mainImage, Item700)
+            )
+          ),
         content = Content.make(content)
       )
     }

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -5,6 +5,8 @@ import common.Logging
 import common.commercial.hosted.ContentUtils._
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.MetaData
+import views.support.{ImgSrc, Item700, Item1200}
+import conf.Configuration
 
 case class HostedGalleryPage(
   override val id: String,
@@ -56,6 +58,12 @@ object HostedGalleryPage extends Logging {
         }
       }
 
+      val mainImage = findLargestMainImageAsset(content)
+        .flatMap(_.file)
+        .getOrElse(Configuration.images.fallbackLogo)
+
+      val openGraphImages: Seq[String] = Seq(ImgSrc(mainImage, Item1200))
+
       HostedGalleryPage(
         id = content.id,
         campaign = HostedCampaign.fromContent(content),
@@ -67,9 +75,14 @@ object HostedGalleryPage extends Logging {
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
         thumbnailUrl = thumbnailUrl(content),
-        metadata = HostedMetadata
-          .fromContent(content)
-          .copy(openGraphImages = findLargestMainImageAsset(content).flatMap(_.file).toList)
+        metadata = HostedMetadata.fromContent(content)
+          .copy(
+            schemaType = Some("https://schema.org/ImageGallery"),
+            openGraphImages = openGraphImages,
+            twitterPropertiesOverrides = Map(
+              "twitter:image" -> ImgSrc(mainImage, Item700)
+            )
+        )
       )
     }
 

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -5,8 +5,7 @@ import common.Logging
 import common.commercial.hosted.ContentUtils._
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.MetaData
-import views.support.{ImgSrc, Item700, Item1200}
-import conf.Configuration
+import views.support.{ImgSrc, Item1200, Item700}
 
 case class HostedGalleryPage(
   override val id: String,
@@ -58,11 +57,11 @@ object HostedGalleryPage extends Logging {
         }
       }
 
-      val mainImage = findLargestMainImageAsset(content)
-        .flatMap(_.file)
-        .getOrElse(Configuration.images.fallbackLogo)
+      val openGraphImages: Seq[String] = galleryImages.map { img =>
+        ImgSrc(img.url, Item1200)
+      }
 
-      val openGraphImages: Seq[String] = Seq(ImgSrc(mainImage, Item1200))
+      val twitterImage: String = ImgSrc(imageForSocialShare(content), Item700)
 
       HostedGalleryPage(
         id = content.id,
@@ -80,7 +79,7 @@ object HostedGalleryPage extends Logging {
             schemaType = Some("https://schema.org/ImageGallery"),
             openGraphImages = openGraphImages,
             twitterPropertiesOverrides = Map(
-              "twitter:image" -> ImgSrc(mainImage, Item700)
+              "twitter:image" -> twitterImage
             )
         )
       )

--- a/common/app/common/commercial/hosted/HostedMetadata.scala
+++ b/common/app/common/commercial/hosted/HostedMetadata.scala
@@ -41,6 +41,7 @@ object HostedMetadata {
       opengraphPropertiesOverrides = Map(
         "og:url" -> s"${site.host}/${item.id}",
         "og:title" -> item.webTitle,
+        "og:type" -> "article",
         "og:description" -> s"ADVERTISER CONTENT FROM ${owner.toUpperCase} HOSTED BY THE GUARDIAN | $description",
         "fb:app_id" -> "180444840287"
       )

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -43,7 +43,11 @@ object HostedVideoPage extends Logging {
 
       // using capi trail text instead of standfirst because we don't want the markup
       val standfirst = content.fields.flatMap(_.trailText).getOrElse("")
-      val mainImage = video.posterUrl.getOrElse(Configuration.images.fallbackLogo)
+
+      val mainImage: String = video.posterUrl.orElse(
+        findLargestMainImageAsset(content)
+        .flatMap(_.file))
+        .getOrElse(Configuration.images.fallbackLogo)
 
       HostedVideoPage(
         id = content.id,
@@ -64,7 +68,7 @@ object HostedVideoPage extends Logging {
         metadata = HostedMetadata.fromContent(content)
           .copy(
             schemaType = Some("https://schema.org/VideoObject"),
-            openGraphImages = video.posterUrl.toList,
+            openGraphImages = Seq(ImgSrc(mainImage, Item1200)),
             twitterPropertiesOverrides = Map(
               "twitter:image" -> ImgSrc(mainImage, Item700)
             )

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -3,9 +3,11 @@ package common.commercial.hosted
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.AtomData
 import common.Logging
-import common.commercial.hosted.ContentUtils.thumbnailUrl
+import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Encoding, EncodingOrdering, MetaData}
+import views.support.{ImgSrc, Item700, Item1200}
+import conf.Configuration
 
 case class HostedVideoPage(
   override val id: String,
@@ -41,6 +43,7 @@ object HostedVideoPage extends Logging {
 
       // using capi trail text instead of standfirst because we don't want the markup
       val standfirst = content.fields.flatMap(_.trailText).getOrElse("")
+      val mainImage = video.posterUrl.getOrElse(Configuration.images.fallbackLogo)
 
       HostedVideoPage(
         id = content.id,
@@ -58,7 +61,14 @@ object HostedVideoPage extends Logging {
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
         thumbnailUrl = thumbnailUrl(content),
-        metadata = HostedMetadata.fromContent(content).copy(openGraphImages = video.posterUrl.toList)
+        metadata = HostedMetadata.fromContent(content)
+          .copy(
+            schemaType = Some("https://schema.org/VideoObject"),
+            openGraphImages = video.posterUrl.toList,
+            twitterPropertiesOverrides = Map(
+              "twitter:image" -> ImgSrc(mainImage, Item700)
+            )
+          )
       )
     }
 

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -3,11 +3,10 @@ package common.commercial.hosted
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.AtomData
 import common.Logging
-import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, thumbnailUrl}
+import common.commercial.hosted.ContentUtils.{imageForSocialShare, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Encoding, EncodingOrdering, MetaData}
-import views.support.{ImgSrc, Item700, Item1200}
-import conf.Configuration
+import views.support.{ImgSrc, Item1200, Item700}
 
 case class HostedVideoPage(
   override val id: String,
@@ -44,10 +43,7 @@ object HostedVideoPage extends Logging {
       // using capi trail text instead of standfirst because we don't want the markup
       val standfirst = content.fields.flatMap(_.trailText).getOrElse("")
 
-      val mainImage: String = video.posterUrl.orElse(
-        findLargestMainImageAsset(content)
-        .flatMap(_.file))
-        .getOrElse(Configuration.images.fallbackLogo)
+      val mainImage: String = video.posterUrl getOrElse imageForSocialShare(content)
 
       HostedVideoPage(
         id = content.id,


### PR DESCRIPTION
## What does this change?

Custom crawler content rises again - this PR is all about page METADATA

**We currently have a [bug occurring off-platform](https://trello.com/c/zB128HwO/86-hosted-galleries-twitter-shares-missing-main-image) that this PR aims to fix...**

Background: Hosted pages are using the raw images for the `og:image` and these images are rather large! Facebook does a good job of compressing these when it scrapes, yet twitter tends to be fussier and requires twitter images to be under 1MB in size. 

Hosted content is currently missing some meta-tags that are present on the rest of the site. Twitter uses Open Graph tags as fallbacks when Twitter Card meta-tags are missing or not usable.

The suspected issue appears to be that we are setting raw images to the `og:image` meta-tag of Hosted content. Facebook has a stated size restriction of 8MB on images; the debugger will give you a warning is an image is larger, yet the their cache seems to accept it anyway. However, Twitter actually enforces this image size restriction; images must be less than 1MB in size for Twitter Cards ([docs](https://dev.twitter.com/cards/overview)) and our raw images often exceed this.

#### 👉Switch from offering FB the raw image, to using `Item1200`

This will bring Hosted into line with the rest of the site

#### 👉HostedGalleries now get all images added as `og:image` rather than just one

<img width="1038" alt="picture 40" src="https://user-images.githubusercontent.com/8607683/39972002-37563e4a-56fe-11e8-8673-0537fbc49d74.png">

#### 👉All Hosted pages now have an actual meta prop for `twitter:image` 

This metadata was absent from hosted pages, so is being added in. Also, the image being linked to by the  `twitter:image` is a reduced size of the raw main image, to ensure that the file will be cached by Twitter.

<img width="1167" alt="picture 41" src="https://user-images.githubusercontent.com/8607683/39972152-b7e61f38-5700-11e8-9c95-e150d693075a.png">


#### 👉All Hosted pages now specify an `og:type` of `article` 

...As per all other content on the site

> This object represents an article on a website. It is the preferred type for blog posts and news stories.

#### 👉Missing Schema types added in for Hosted content

Mostly for completion sake, and to bring parity with other content on the site:

https://schema.org/ImageGallery
https://schema.org/VideoObject

## What is the value of this and can you measure success?

- FB shares of Hosted content continue to work as expected, with a slightly reduced image size
- Twitter shares start using a image
- More options of which image to use when sharing Hosted Galleries to Facebook
- Hosted videos should use a reduced size of the video poster, however now also have fallback options if the video poster is missing


##### To validate the TwitterCard and OpenGraph metadata, these tools may be helpful:
👉https://cards-dev.twitter.com/validator
👉https://developers.facebook.com/tools/debug/

## Does this affect other platforms - Amp, Apps, etc?

**Yes - intended off-platform impact! However, this change is scoped to Hosted content only** 

Example content pages:
https://www.theguardian.com/advertiser-content/best-of-all-its-in-hong-kong/hong-kongs-great-outdoors

https://www.theguardian.com/advertiser-content/universal-pictures-darkest-hour/universal-pictures-darkest

Facebook shares, including from AMP articles should be affected, along with anywhere else that scrapes info from OpenGraph metatags, or falls back to them (looking at you Google Search and Twitter!)

<img width="1437" alt="picture 39" src="https://user-images.githubusercontent.com/8607683/39971940-f4fc914e-56fc-11e8-9878-0e0a4e4d344b.png">

**N.B. regarding Facebook testing....**

Objects in the user timeline have their image 'locked' therefore it will not be updated, even after changing the `og:image` and forcing a cache refresh. So to test that this does not break FB shares you will need to post an article you have not posted before....

## Tested in CODE?

Nope - testing in PROD 😈🤘

Unfortunately the FB and Twitter scrapers and cache are black boxes that interact with PROD in a specific way. 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
