### PR TITLE
Rename edit your profile

### DIFF
--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -73,7 +73,7 @@
 
     <div class="identity-wrapper-header">
         <div class="identity-wrapper monocolumn-wrapper">
-                <h1 class="identity-title" data-test-id="edit-profile-header">Your settings</h1>
+                <h1 class="identity-title" data-test-id="edit-profile-header">Your account</h1>
                 <ol class="tabs__container tabs__container--multiple js-tabs js-account-profile-tabs" id="js-account-profile-tabs" role="tablist" data-is-bound="true">
                     @tab(1, "Public", "/public/edit", None, redirect = redirectDecision)
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -73,7 +73,7 @@
 
     <div class="identity-wrapper-header">
         <div class="identity-wrapper monocolumn-wrapper">
-                <h1 class="identity-title" data-test-id="edit-profile-header">Edit your profile</h1>
+                <h1 class="identity-title" data-test-id="edit-profile-header">Your settings</h1>
                 <ol class="tabs__container tabs__container--multiple js-tabs js-account-profile-tabs" id="js-account-profile-tabs" role="tablist" data-is-bound="true">
                     @tab(1, "Public", "/public/edit", None, redirect = redirectDecision)
 


### PR DESCRIPTION
## What does this change?
Renames "Edit Your Profile" to "Your settings".  Could also be changed to "Your account" TBD.

## What is the value of this and can you measure success?
Clearer labelling of a section that contains more than just a "profile"

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
