### PR TITLE
Remove isSocial from Discussion Profile model

### DIFF
--- a/discussion/app/discussion/model/Profile.scala
+++ b/discussion/app/discussion/model/Profile.scala
@@ -37,14 +37,13 @@ object Profile {
   }
 }
 
-case class PrivateProfileFields(canPostComment: Boolean, isPremoderated: Boolean, isSocial: Boolean)
+case class PrivateProfileFields(canPostComment: Boolean, isPremoderated: Boolean)
 
 object PrivateProfileFields{
   def apply(json: JsObject): PrivateProfileFields = {
     PrivateProfileFields(
       canPostComment = (json \\ "canPostComment") exists { _.as[Boolean] },
-      isPremoderated = (json \\ "isPremoderated") exists { _.as[Boolean] },
-      isSocial = (json \\ "isSocial") exists { _.as[Boolean] }
+      isPremoderated = (json \\ "isPremoderated") exists { _.as[Boolean] }
     )
   }
 }

--- a/discussion/test/ProfileTest.scala
+++ b/discussion/test/ProfileTest.scala
@@ -33,8 +33,7 @@ import discussion.model.Profile
                     |  "privateFields":
                     |  {
                     |    "canPostComment": true,
-                    |    "isPremoderated": false,
-                    |    "isSocial": true
+                    |    "isPremoderated": false
                     |  }
                     |}}""".stripMargin
     val json = Json.parse(jsonStr)
@@ -48,7 +47,6 @@ import discussion.model.Profile
     val fields = privateFields.get
     fields.canPostComment should be(true)
     fields.isPremoderated should be(false)
-    fields.isSocial should be(true)
   }
 
 }


### PR DESCRIPTION
It is unused, and this allows us to remove it from DAPI, which we want to do to simplify the model there.

**TODO test in CODE.**
