### PR TITLE
improve twitter share

### DIFF
--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -105,6 +105,9 @@ object ShareLinks {
       mediaPath.map(path => "picture" -> path)
     ).flatten.toMap
 
+    // add a hairspace to prevent Twitter recognising this text as a URL and thus not rendering the article url
+    lazy val twitterText = title.replace("Leave.EU", "Leave. EU").encodeURIComponent
+
     val fullLink = platform match {
       case GooglePlus => s"https://plus.google.com/share?url=$encodedHref&amp;hl=en-GB&amp;wwc=1"
       case WhatsApp => s"""whatsapp://send?text=${("\"" + title + "\" " + href).encodeURIComponent}"""
@@ -113,7 +116,7 @@ object ShareLinks {
       case Email => s"mailto:?subject=${title.encodeURIComponent}&body=$encodedHref"
       case LinkedIn => s"http://www.linkedin.com/shareArticle?mini=true&title=${title.urlEncoded}&url=$encodedHref"
       case Facebook => s"https://www.facebook.com/dialog/share".appendQueryParams(facebookParams)
-      case Twitter => s"https://twitter.com/intent/tweet?text=${title.encodeURIComponent}&url=$encodedHref"
+      case Twitter => s"https://twitter.com/intent/tweet?text=$twitterText&url=$encodedHref"
       case Messenger => s"fb-messenger://share?link=$encodedHref&app_id=180444840287"
     }
 


### PR DESCRIPTION
## What does this change?
add a hairspace to prevent Twitter from recognising this text as a URL and this not rendering the article url when the social share button is used

## What is the value of this and can you measure success?
A Tweet of [this article](https://www.theguardian.com/politics/2018/may/11/what-did-leaveeu-do-wrong-and-could-its-breaches-stop-brexit), via the social share button, includes a link to the article, rather than leave.eu.

## Does this affect other platforms - Amp, Apps, etc?
no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
no

## Screenshots

## Tested in CODE?
no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
