### PR TITLE
Update jobs deletion text to be the truth

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -68,8 +68,7 @@
 
                 <h4><a class="u-underline" href="https://jobs.theguardian.com/article/faq">Guardian Jobs</a></h4>
                 <p class="identity-section__text">
-                    Deleting your account does not delete your Jobs account. If you would like to delete your Jobs account,
-                    please <a class="u-underline" href="https://jobs.theguardian.com/deletemyaccount">click here.</a>
+                    Deleting your account will remove submitted applications, your profile information, CV, and job alerts.
                 </p>
 
                 <h4><a class="u-underline" href="https://witness.theguardian.com/faq">Guardian Witness</a></h4>


### PR DESCRIPTION
## What does this change?
Updates the explainer text for jobs accounts on the account deletion page.  It is more truthy now that we automatically delete the jobs account.

## What is the value of this and can you measure success?
Tell users how it is.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
