### PR TITLE
Add abtest to detect the deprecated TLS header

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,9 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     CommercialAdRefresh,
     OrielParticipation,
-    LotameParticipation
+    LotameParticipation,
+    LineHeightFontSize,
+    OldTLSSupportDeprecation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -45,4 +47,21 @@ object LotameParticipation extends Experiment(
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1D
+)
+
+object LineHeightFontSize extends Experiment(
+  name = "line-height-font-size",
+  description = "User in this experiment will have an increased article body line height and font size",
+  owners = Seq(Owner.withGithub("frankie297")),
+  sellByDate = new LocalDate(2018, 5, 17),
+  participationGroup = Perc1B
+)
+
+object OldTLSSupportDeprecation extends Experiment(
+  name = "old-tls-support-deprecation",
+  description = "This will turn on a deprecation notice to any user who is accessing our site using TLS v1.0 or v1.1",
+  owners = Seq(Owner.withGithub("natalialkb")),
+  sellByDate = new LocalDate(2018, 6, 13),
+  // Custom group based on header set in Fastly
+  participationGroup = TLSSupport
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialAdRefresh,
     OrielParticipation,
     LotameParticipation,
-    LineHeightFontSize,
     OldTLSSupportDeprecation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -47,14 +46,6 @@ object LotameParticipation extends Experiment(
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 6, 28),
   participationGroup = Perc1D
-)
-
-object LineHeightFontSize extends Experiment(
-  name = "line-height-font-size",
-  description = "User in this experiment will have an increased article body line height and font size",
-  owners = Seq(Owner.withGithub("frankie297")),
-  sellByDate = new LocalDate(2018, 5, 17),
-  participationGroup = Perc1B
 )
 
 object OldTLSSupportDeprecation extends Experiment(

--- a/common/app/experiments/ParticipationGroups.scala
+++ b/common/app/experiments/ParticipationGroups.scala
@@ -29,7 +29,7 @@ object ParticipationGroups extends enumeratum.Enum[ParticipationGroup] {
   case object Perc10A extends ParticipationGroup("X-GU-Experiment-10perc-A")
   case object Perc20A extends ParticipationGroup("X-GU-Experiment-20perc-A")
   case object Perc50 extends ParticipationGroup("X-GU-Experiment-50perc")
-
+  case object TLSSupport extends ParticipationGroup("X-GU-old-tls-traffic")
   override val values: immutable.IndexedSeq[ParticipationGroup] = findValues
 
 }


### PR DESCRIPTION
## What does this change?

This adds an abtest used to detect the presence of the X-GU-old-tls-traffic header sent from Fastly for browsers using a de-supported tls version. This will be used to conditionally switch on a banner for those users warning them that their browser won't be supported.

Client code (in the twirl template) should use something that looks like this

```
    ActiveExperiments.groupFor(experiments.OldTLSSupportDeprecation) match {
      case Excluded => println("Your TLS version was fine")
      case _ => println("OLD TLD HEADER DETECTED")
    }
```

You have to use the 'groupFor' rather than 'isParticipating' function to work around the fact that there is no distinction between variant and control for this header.

--




## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
