### PR TITLE
Membership engagement banner update

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -240,12 +240,6 @@ const startPinterest = (): void => {
     }
 };
 
-// const membershipEngagementBanner = (): void => {
-//     if (config.switches.membershipEngagementBanner) {
-//         membershipEngagementBannerInit();
-//     }
-// };
-
 const initialiseEmail = (): void => {
     // Initalise email embedded in page
     initEmail();

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -40,7 +40,7 @@ import { smartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { Toggles } from 'common/modules/ui/toggles';
 import { initPinterest } from 'common/modules/social/pinterest';
-import { membershipEngagementBannerInit } from 'common/modules/commercial/membership-engagement-banner';
+import membershipEngagementBanner from 'common/modules/commercial/membership-engagement-banner';
 import { signInEngagementBanner } from 'common/modules/identity/global/sign-in-engagement-banner';
 import { initEmail } from 'common/modules/email/email';
 import { init as initEmailArticle } from 'common/modules/email/email-article';
@@ -240,11 +240,11 @@ const startPinterest = (): void => {
     }
 };
 
-const membershipEngagementBanner = (): void => {
-    if (config.switches.membershipEngagementBanner) {
-        membershipEngagementBannerInit();
-    }
-};
+// const membershipEngagementBanner = (): void => {
+//     if (config.switches.membershipEngagementBanner) {
+//         membershipEngagementBannerInit();
+//     }
+// };
 
 const initialiseEmail = (): void => {
     // Initalise email embedded in page
@@ -285,6 +285,7 @@ const initialiseBanner = (): void => {
         optInEngagementBanner,
         signInEngagementBanner,
         membershipBanner,
+        membershipEngagementBanner,
     ];
     initBannerPicker(bannerList);
 };
@@ -319,7 +320,6 @@ const init = (): void => {
         ['c-media-listeners', mediaListener],
         ['c-accessibility-prefs', initAccessibilityPreferences],
         ['c-pinterest', startPinterest],
-        ['c-show-membership-engagement-banner', membershipEngagementBanner],
         ['c-email', initialiseEmail],
         ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -40,7 +40,7 @@ import { smartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { Toggles } from 'common/modules/ui/toggles';
 import { initPinterest } from 'common/modules/social/pinterest';
-import membershipEngagementBanner from 'common/modules/commercial/membership-engagement-banner';
+import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { signInEngagementBanner } from 'common/modules/identity/global/sign-in-engagement-banner';
 import { initEmail } from 'common/modules/email/email';
 import { init as initEmailArticle } from 'common/modules/email/email-article';
@@ -276,10 +276,10 @@ const initialiseBanner = (): void => {
         cookiesBanner,
         breakingNews,
         smartAppBanner,
+        membershipEngagementBanner,
         optInEngagementBanner,
         signInEngagementBanner,
         membershipBanner,
-        membershipEngagementBanner,
     ];
     initBannerPicker(bannerList);
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -122,10 +122,6 @@ const messageModifierClass = (
 };
 
 const showBanner = (params: EngagementBannerParams): void => {
-    if (isBlocked()) {
-        return;
-    }
-
     const test = getUserTest();
     const variant = getUserVariant(test);
     const paypalAndCreditCardImage =
@@ -198,23 +194,30 @@ const showBanner = (params: EngagementBannerParams): void => {
     }
 };
 
-const membershipEngagementBannerInit = (): Promise<void> => {
-    const bannerParams = deriveBannerParams(getGeoLocation());
-    if (bannerParams && getVisitCount() >= bannerParams.minArticles) {
-        return canDisplayMembershipEngagementBanner().then(canShow => {
-            if (canShow) {
-                mediator.on(
-                    'modules:onwards:breaking-news:ready',
-                    breakingShown => {
-                        if (!breakingShown) {
-                            showBanner(bannerParams);
-                        }
-                    }
-                );
-            }
-        });
+let bannerParams;
+
+const show = () => {
+    if (bannerParams) {
+        showBanner(bannerParams);
     }
-    return Promise.resolve(undefined);
 };
 
-export { membershipEngagementBannerInit };
+const canShow = (): Promise<boolean> => {
+    if (!config.get('switches.membershipEngagementBanner') || isBlocked()) {
+        return Promise.resolve(false);
+    }
+
+    bannerParams = deriveBannerParams(getGeoLocation());
+
+    if (bannerParams && getVisitCount() >= bannerParams.minArticles) {
+        return canDisplayMembershipEngagementBanner();
+    }
+
+    return Promise.resolve(false);
+};
+
+export default {
+    id: 'membershipEngagementBanner',
+    show,
+    canShow,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -197,7 +197,7 @@ const showBanner = (params: EngagementBannerParams): void => {
 
 let bannerParams;
 
-const show = () => {
+const show = (): void => {
     if (bannerParams) {
         showBanner(bannerParams);
     }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -12,6 +12,7 @@ import { engagementBannerParams } from 'common/modules/commercial/membership-eng
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
 import { getSync as getGeoLocation } from 'lib/geolocation';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import type { Banner } from 'common/modules/ui/bannerPicker';
 
 import {
     submitComponentEvent,
@@ -216,8 +217,10 @@ const canShow = (): Promise<boolean> => {
     return Promise.resolve(false);
 };
 
-export default {
+const membershipEngagementBanner: Banner = {
     id: 'membershipEngagementBanner',
     show,
     canShow,
 };
+
+export { membershipEngagementBanner };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -3,7 +3,7 @@ import fakeMediator from 'lib/mediator';
 import fakeConfig from 'lib/config';
 import fakeOphan from 'ophan/ng';
 import { engagementBannerParams as engagementBannerParams_ } from 'common/modules/commercial/membership-engagement-banner-parameters';
-import { membershipEngagementBannerInit } from 'common/modules/commercial/membership-engagement-banner';
+import membershipEngagementBanner from 'common/modules/commercial/membership-engagement-banner';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const engagementBannerParams: any = engagementBannerParams_;
@@ -25,7 +25,6 @@ jest.mock('lib/geolocation', () => ({
 jest.mock('common/views/svgs', () => ({
     inlineSvg: jest.fn(() => ''),
 }));
-
 jest.mock('common/modules/experiments/acquisition-test-selector', () => ({
     getTest: jest.fn(() => ({
         campaignId: 'fake-campaign-id',
@@ -43,7 +42,6 @@ jest.mock('common/modules/experiments/acquisition-test-selector', () => ({
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     })),
 }));
-
 jest.mock(
     'common/modules/experiments/tests/membership-engagement-banner-tests',
     () => ({
@@ -73,7 +71,6 @@ jest.mock(
         ],
     })
 );
-
 jest.mock(
     'common/modules/commercial/membership-engagement-banner-parameters',
     () => ({
@@ -105,7 +102,7 @@ jest.mock('ophan/ng', () => ({
     record: jest.fn(),
 }));
 jest.mock('lib/config', () => ({
-    get: jest.fn(() => ''),
+    get: jest.fn(() => true),
 }));
 jest.mock('lib/detect', () => ({
     adblockInUse: Promise.resolve(false),
@@ -119,11 +116,22 @@ const fakeVariantFor: any = require('common/modules/experiments/segment-util')
     .variantFor;
 const fakeConstructQuery: any = require('lib/url').constructQuery;
 const fakeInlineSvg: any = require('common/views/svgs').inlineSvg;
+const fakeIsBlocked: any = require('common/modules/commercial/membership-engagement-banner-block')
+    .isBlocked;
+const fakeGet: any = require('lib/storage').local.get;
+const fakeShouldShowReaderRevenue: any = require('common/modules/commercial/contributions-utilities')
+    .shouldShowReaderRevenue;
 
 beforeEach(() => {
     FakeMessage.mockReset();
     FakeMessage.prototype.show = jest.fn(() => true);
+    fakeIsBlocked.mockClear();
+    fakeVariantFor.mockClear();
+    fakeGet.mockClear();
+    fakeShouldShowReaderRevenue.mockClear();
+    fakeConfig.get.mockClear();
 });
+
 afterEach(() => {
     FakeMessage.prototype.show.mockRestore();
     fakeMediator.removeAllListeners();
@@ -131,16 +139,51 @@ afterEach(() => {
 });
 
 describe('Membership engagement banner', () => {
-    describe('If breaking news banner has show', () => {
-        it('should not show the membership engagement banner', () =>
-            membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', true);
-                expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
+    describe('canShow returns false', () => {
+        it('should return false if membershipEngagementBanner switch off', () => {
+            fakeConfig.get.mockImplementationOnce(() => false);
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
+            });
+        });
+
+        it('should return false if the engagement banner is blocked', () => {
+            fakeIsBlocked.mockReturnValueOnce(true);
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
+            });
+        });
+
+        it('should return false user variant is blocked for test', () => {
+            fakeVariantFor.mockImplementationOnce(() => ({
+                blockEngagementBanner: true,
             }));
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
+            });
+        });
+
+        it('should return false user visit count less than minArticles for banner', () => {
+            fakeGet.mockReturnValueOnce(0); // gu.alreadyVisited
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
+            });
+        });
+
+        it('should return false if shouldShowReaderRevenue false', () => {
+            fakeShouldShowReaderRevenue.mockReturnValueOnce(false);
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
+            });
+        });
     });
 
-    describe('If breaking news banner has not shown', () => {
-        let showBanner;
+    describe('canShow returns true', () => {
         let emitSpy;
 
         beforeEach(() => {
@@ -152,26 +195,38 @@ describe('Membership engagement banner', () => {
                 linkUrl: 'fake-link-url',
             }));
             emitSpy = jest.spyOn(fakeMediator, 'emit');
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
         });
+
         afterEach(() => {
             emitSpy.mockRestore();
         });
 
         it('should show the membership engagement banner', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1);
             }));
+
         it('should emit a display event', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(emitSpy).toHaveBeenCalledWith(
                     'membership-message:display'
                 );
             }));
+
         it('should record the component event in ophan with a/b test info', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(fakeOphan.record).toHaveBeenCalledWith({
                     componentEvent: {
                         component: {
@@ -193,16 +248,14 @@ describe('Membership engagement banner', () => {
     describe('If user already member', () => {
         it('should not show any messages even to engaged readers', () => {
             (shouldShowReaderRevenue: any).mockImplementationOnce(() => false);
-            membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-                expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
+
+            return membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(false);
             });
         });
     });
 
     describe('creates message with', () => {
-        let showBanner;
-
         beforeEach(() => {
             engagementBannerParams.mockImplementationOnce(() => ({
                 minArticles: 1,
@@ -217,19 +270,25 @@ describe('Membership engagement banner', () => {
                     engagementBannerParams: {},
                 },
             }));
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
         });
 
         it('correct campaign code', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(
                     FakeMessage.mock.calls[0][1].siteMessageComponentName
                 ).toBe('fake-campaign-id_fake-variant-id');
             }));
+
         it('correct CSS modifier class', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.mock.calls[0][1].cssModifierClass).toBe(
                     'fake-colour-class'
                 );
@@ -237,8 +296,6 @@ describe('Membership engagement banner', () => {
     });
 
     describe('renders message with', () => {
-        let showBanner;
-
         beforeEach(() => {
             engagementBannerParams.mockImplementationOnce(() => ({
                 minArticles: 1,
@@ -247,50 +304,78 @@ describe('Membership engagement banner', () => {
                 linkUrl: 'fake-link-url',
                 buttonCaption: 'fake-button-caption',
             }));
-            fakeConfig.get.mockImplementationOnce(
-                () => 'fake-paypal-and-credit-card-image'
-            );
+            fakeConfig.get
+                .mockImplementationOnce(() => true)
+                .mockImplementationOnce(
+                    () => 'fake-paypal-and-credit-card-image'
+                );
             fakeInlineSvg.mockImplementationOnce(() => 'fake-button-svg');
             fakeConstructQuery.mockImplementationOnce(
                 () => 'fake-query-parameters'
             );
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
         });
 
         it('message text', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-message-text/
                 );
             }));
+
         it('paypal and credit card image', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-paypal-and-credit-card-image/
                 );
             }));
+
         it('colour class', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-colour-class/
                 );
             }));
+
         it('link URL', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-link-url\?fake-query-parameters/
                 );
             }));
+
         it('button caption', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-button-caption/
                 );
             }));
+
         it('button SVG', () =>
-            showBanner.then(() => {
+            membershipEngagementBanner.canShow().then(canShow => {
+                expect(canShow).toBe(true);
+
+                membershipEngagementBanner.show();
+
                 expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
                     /fake-button-svg/
                 );

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -3,7 +3,7 @@ import fakeMediator from 'lib/mediator';
 import fakeConfig from 'lib/config';
 import fakeOphan from 'ophan/ng';
 import { engagementBannerParams as engagementBannerParams_ } from 'common/modules/commercial/membership-engagement-banner-parameters';
-import membershipEngagementBanner from 'common/modules/commercial/membership-engagement-banner';
+import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const engagementBannerParams: any = engagementBannerParams_;


### PR DESCRIPTION
## What does this change?

Updates `membership-engagement-banner.js` to be compatible with `bannerPicker.js`.

Summary of changes...
- Export an object from `membership-engagement-banner.js`, with 3 properties `id`, `show` and `canShow`.
- Move all conditional checks into `canShow`. This involved moving the `!config.get('switches.membershipEngagementBanner')` and `isBlocked()` check into `canShow` from `enhanced/common.js` and `showBanner()`.
- Update tests to use `show` and `canShow`.

## What is the value of this and can you measure success?

Updates `membership-engagement-banner.js` to be compatible with `bannerPicker.js`

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No
