### PR TITLE
Fix broken audio and video ophan analytics

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -13,7 +13,11 @@
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },
         "tests": { @JavaScript(experiments.ActiveExperiments.getJavascriptConfig) },
-        "modules": { },
+        "modules": { 
+            "media": {
+                analyticsReady: false
+            }
+        },
         "images": {
             "commercial": {
                 "ab-icon": "@Static("images/commercial/ab-icon.png")",

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -15,7 +15,7 @@
         "tests": { @JavaScript(experiments.ActiveExperiments.getJavascriptConfig) },
         "modules": { 
             "media": {
-                analyticsReady: false
+                "analyticsReady": false
             }
         },
         "images": {

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -14,8 +14,8 @@
         },
         "tests": { @JavaScript(experiments.ActiveExperiments.getJavascriptConfig) },
         "modules": { 
-            "media": {
-                "analyticsReady": false
+            "tracking": {
+                "ready": null
             }
         },
         "images": {

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -5,6 +5,10 @@
 // eslint-disable-next-line guardian-frontend/global-config
 const config: Object = window.guardian.config;
 
+config.modules.media = {
+    analyticsReady: false
+};
+
 // allows you to safely get items from config using a query of
 // dot or bracket notation, with optional default fallback
 const get = (path: string = '', defaultValue: any): any => {

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -21,14 +21,13 @@ const get = (path: string = '', defaultValue: any): any => {
 };
 
 // let S = { l1, l2, ..., ln } be a non-empty ordered set of labels
-// let l1.l2.....ln be the string reprentation of S
-// set(S, x) is the function that takes any value x into the config
+// let s = l1.l2.....ln be the string reprentation of S
+// set(s, x) is the function that takes any value x into the config
 // object following the path described by S, making sure that path
 // actually leads somewhere.
 const set = (path: string, value: any): void => {
     const pathSegments = path.split('.');
     const last = pathSegments.pop();
-    // eslint should embrace mutation, a core feature of javascript, indeed the only one
     // eslint-disable-next-line no-return-assign
     pathSegments.reduce((c, x) => c[x] || (c[x] = {}), config)[last] = value;
 };

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -5,10 +5,6 @@
 // eslint-disable-next-line guardian-frontend/global-config
 const config: Object = window.guardian.config;
 
-config.modules.media = {
-    analyticsReady: false,
-};
-
 // allows you to safely get items from config using a query of
 // dot or bracket notation, with optional default fallback
 const get = (path: string = '', defaultValue: any): any => {

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -20,6 +20,19 @@ const get = (path: string = '', defaultValue: any): any => {
     return defaultValue;
 };
 
+// let S = { l1, l2, ..., ln } be a non-empty ordered set of labels
+// let l1.l2.....ln be the string reprentation of S
+// set(S, x) is the function that takes any value x into the config
+// object following the path described by S, making sure that path
+// actually leads somewhere.
+const set = (path: string, value: any): void => {
+    const pathSegments = path.split('.');
+    const last = pathSegments.pop();
+    // eslint should embrace mutation, a core feature of javascript, indeed the only one
+    // eslint-disable-next-line no-return-assign
+    pathSegments.reduce((c, x) => c[x] || (c[x] = {}), config)[last] = value;
+};
+
 const hasTone = (name: string): boolean =>
     (config.page.tones || '').includes(name);
 
@@ -63,6 +76,7 @@ export default Object.assign(
     {},
     {
         get,
+        set,
         hasTone,
         hasSeries,
         referencesOfType,

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -6,7 +6,7 @@
 const config: Object = window.guardian.config;
 
 config.modules.media = {
-    analyticsReady: false
+    analyticsReady: false,
 };
 
 // allows you to safely get items from config using a query of

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -28,8 +28,11 @@ const get = (path: string = '', defaultValue: any): any => {
 const set = (path: string, value: any): void => {
     const pathSegments = path.split('.');
     const last = pathSegments.pop();
-    // eslint-disable-next-line no-return-assign
-    pathSegments.reduce((c, x) => c[x] || (c[x] = {}), config)[last] = value;
+    pathSegments.reduce(
+        // eslint-disable-next-line no-return-assign
+        (obj, subpath) => obj[subpath] || (obj[subpath] = {}),
+        config
+    )[last] = value;
 };
 
 const hasTone = (name: string): boolean =>

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -69,7 +69,7 @@ describe('Config', () => {
         expect(config.get('page.qwert')).toBeUndefined();
     });
 
-    it('`get` should return default value for non-existing key with a default', () => {
+    it('`set` should return default value for non-existing key with a default', () => {
         expect(config.get('page.qwert', ['I am the default'])).toEqual([
             'I am the default',
         ]);

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -80,4 +80,9 @@ describe('Config', () => {
             false
         );
     });
+
+    it('`get` should safely set (or orverride) a value deep inside the config object', () => {
+        config.set('some.random.path', 'hello');
+        expect(config.get('some.random.path')).toEqual('hello');
+    });
 });

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -69,7 +69,7 @@ describe('Config', () => {
         expect(config.get('page.qwert')).toBeUndefined();
     });
 
-    it('`set` should return default value for non-existing key with a default', () => {
+    it('`get` should return default value for non-existing key with a default', () => {
         expect(config.get('page.qwert', ['I am the default'])).toEqual([
             'I am the default',
         ]);
@@ -81,7 +81,7 @@ describe('Config', () => {
         );
     });
 
-    it('`get` should safely set (or orverride) a value deep inside the config object', () => {
+    it('`set` should safely set (or orverride) a value deep inside the config object', () => {
         config.set('some.random.path', 'hello');
         expect(config.get('some.random.path')).toEqual('hello');
     });

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -1,20 +1,20 @@
 // @flow
-import mediator from 'lib/mediator';
+import config from 'lib/config';
 
-let analyticsReady = false;
-
-mediator.on('analytics:ready', () => {
-    analyticsReady = true;
+const analyticsReady = new Promise(resolve => {
+    const check = () => {
+        if (config.get('modules.media.analyticsReady')) {
+            resolve(true);
+            return;
+        } else {
+            setTimeout(check, 100);
+        }
+    };
+    check();
 });
 
 const deferToAnalytics = (afterAnalytics: () => void): void => {
-    if (analyticsReady) {
-        afterAnalytics();
-    } else {
-        mediator.on('analytics:ready', () => {
-            afterAnalytics();
-        });
-    }
+    analyticsReady.then(afterAnalytics);
 };
 
 export default deferToAnalytics;

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -5,7 +5,6 @@ const analyticsReady = new Promise(resolve => {
     const check = () => {
         if (config.get('modules.media.analyticsReady')) {
             resolve(true);
-            return;
         } else {
             setTimeout(check, 100);
         }

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -2,7 +2,9 @@
 import config from 'lib/config';
 
 const deferToAnalytics = (afterAnalytics: () => void): void => {
-    config.get('modules.tracking.ready').then(afterAnalytics);
+    try {
+        config.get('modules.tracking.ready').then(afterAnalytics);
+    } catch (e) {} // eslint-disable-line no-empty
 };
 
 export default deferToAnalytics;

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -1,19 +1,8 @@
 // @flow
 import config from 'lib/config';
 
-const analyticsReady = new Promise(resolve => {
-    const check = () => {
-        if (config.get('modules.media.analyticsReady')) {
-            resolve(true);
-        } else {
-            setTimeout(check, 100);
-        }
-    };
-    check();
-});
-
 const deferToAnalytics = (afterAnalytics: () => void): void => {
-    analyticsReady.then(afterAnalytics);
+    config.get('modules.tracking.ready').then(afterAnalytics);
 };
 
 export default deferToAnalytics;

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
@@ -1,4 +1,5 @@
 // @flow
+import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { session } from 'lib/storage';
 import {
@@ -96,7 +97,7 @@ const init = (options: Object = {}): void => {
         loc = options.location; // allow a fake location to be passed in for testing
     }
     addHandlers();
-    mediator.emit('analytics:ready');
+    config.modules.media.analyticsReady = true;
 };
 
 export default {

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
@@ -97,7 +97,7 @@ const init = (options: Object = {}): void => {
         loc = options.location; // allow a fake location to be passed in for testing
     }
     addHandlers();
-    config.modules.media.analyticsReady = true;
+    config.set('modules.tracking.ready', Promise.resolve());
 };
 
 export default {

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
@@ -12,13 +12,6 @@ import interactionTracking from './interaction-tracking';
 
 jest.mock('lib/mediator');
 jest.mock('lib/storage');
-jest.mock('lib/config', () => ({
-    modules: {
-        media: {
-            analyticsReady: false,
-        },
-    },
-}));
 
 jest.mock('common/modules/analytics/google', () => ({
     trackSamePageLinkClick: jest.fn(),

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
@@ -12,6 +12,13 @@ import interactionTracking from './interaction-tracking';
 
 jest.mock('lib/mediator');
 jest.mock('lib/storage');
+jest.mock('lib/config', () => ({
+    modules: {
+        media: {
+            analyticsReady: false,
+        },
+    },
+}));
 
 jest.mock('common/modules/analytics/google', () => ({
     trackSamePageLinkClick: jest.fn(),


### PR DESCRIPTION
## What is the context?

Since 29th December we have been tracking a regression of number of video events sent to `Ophan`.

![drop](https://user-images.githubusercontent.com/615085/40134682-0f76dbb6-593b-11e8-8328-f2ad7d418129.png)

We had not been able to reproduce the issue ourself. As the drop of events was more visible from google referrers, it let me think that it was coming from a change on google side. The theory was they were sending us more people to `AMP` rather our platform. This was an appealing theory at that time because:

- we were not tracking video events on `AMP` pages on Ophan
- youtube analytics were showing an increase of video views from AMP platform on the 30th
- Deployed changes on this project were not revealing anything suspicious that could explain the issue.
   
So [we added AMP tracking in ophan](https://github.com/guardian/ophan/pull/2705) and number of events increased significantly, but when comparing to google analytics we were still observing an average drop on `25%` 😞    

![image](https://user-images.githubusercontent.com/615085/40134855-892a5532-593b-11e8-9389-04f785252c04.png)

I missed that were not tracking either video events on AMP pages on Google analytics 😱 

At that time, we have been scratching our head on what could causing the issues, reviewing sentries errors log, trying to find a clue.

Up to yesterday afternoon when @stuartmutter shared with us the missing piece of this puzzle.
Since the same date, audio events on [our web platform are down to zero](https://docs.google.com/spreadsheets/d/1RLtsYpcOTwA1_F0S6ITx_RGAbkgx4oxdcuDc6EgRJDk/edit#gid=1512540775).

<img width="976" alt="screen shot 2018-05-16 at 19 27 15" src="https://user-images.githubusercontent.com/615085/40136264-4cb16b00-593f-11e8-938c-617d77d48756.png">

Being able to reproduce we quickly identified yesterday morning that ophan [tracker events are not initialised as expected](https://github.com/guardian/frontend/blob/a54a1980d50b0784c7e408557ee7b7b4202341b5/static/src/javascripts/bootstraps/enhanced/media-player.js#L194-L195), and that the reason was because `defer-to-analytics` is depending on `analytics:ready` event sent to the `mediator`, but that event is sent by `interaction-tracking` before `defer-to-analytics` has registered as a listener the `mediator`.

The most interesting thing of this issue is, I think, how we introduced the regression. [This commit](https://github.com/guardian/frontend/commit/51a48141db332d6719057fc5212deb5a498ddd4c) from @rich-nguyen has removed some commercial modules and change the loading mechanism to be dynamic, which by side effect change initialisation order of other modules. If you can spot this issue through a code review, hat off!

## What does this change?

Currently `defer-to-analytics` and `interaction-tracking` communicate state through a `bus event`, the `mediator`. This is fragile because it requires both of those modules to be initialised in the right order for events to not be missed, which is incredibly difficult to ensure, because other modules may depend on them.

With the associated change, written by @regiskuckaertz, the state is stored in `JS` config object which nicely remove the dependency on the module initialisation order.     

Another approach will be to use a `stream` rather than a `bus` with the ability for the stream consumer/listener to read events since the beginning of time rather at the time a consumer/listener register.   

## What is the value of this and can you measure success?

Repair tracking of media events in Ophan,

## Does this affect other platforms - Amp, Apps, etc?

No