### PR TITLE
Fix weather autocomplete

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -243,9 +243,8 @@ export class SearchTool {
         this.$input.val(inputValue);
     }
 
-    renderList(results: Array<City>, numOfResults: number): void {
+    renderList(results: Array<City>, resultsToShow: number): void {
         const docFragment = document.createDocumentFragment();
-        const resultsToShow = results.length - numOfResults;
 
         results.slice(0, resultsToShow).forEach((item, index) => {
             const li = document.createElement('li');


### PR DESCRIPTION
Currently, autocomplete won't work once there are fewer than 5 results for weather. This is a problem as some places don't appear at all.

E.g. 'Porthmadog' is below the 5th item when 'porth' is searched, but when the 'm' is added there are now only 2 results, so none are shown.

**I am sure the existing code has some intent, so am a bit concerned about breaking stuff here - will ask as I certainly don't understand it currently.**
