### PR TITLE
Add Market research checkbox

### DIFF
--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -122,7 +122,7 @@ object PrivacyFormData extends SafeLogging {
     * Filter out any invalid consents that are still lingering in Mongo DB.
     *
     * For example, if consent id is renamed, then some users might still have the old consent.
-    *qq
+    *
     * @param userDO Identity User domain model from IDAPI defiend that might contain some old invalid consents
     * @return list of valid consents
     */

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -130,12 +130,7 @@ object PrivacyFormData extends SafeLogging {
     def consentExistsInModel(consent:Consent): Boolean =
       Try(Consent.wording(consent.id, consent.version)).isSuccess
 
-    def applyMissingDefaults(userDoConsents: List[Consent]): List[Consent] = {
-      val missingDefaultsConsentIds = defaultConsents.map(_.id).filterNot(userDoConsents.map(_.id).contains)
-      userDO.consents ++ defaultConsents.filter(c => missingDefaultsConsentIds.contains(c.id))
-    }
-
-    val newUserConsents = applyMissingDefaults(userDO.consents)
+    val newUserConsents = Consent.addNewDefaults(userDO.consents)
     val (validConsents, invalidConsents) = newUserConsents.partition(consentExistsInModel)
 
     invalidConsents.foreach(consent =>

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -131,8 +131,8 @@ object PrivacyFormData extends SafeLogging {
       Try(Consent.wording(consent.id, consent.version)).isSuccess
 
     def applyMissingDefaults(userDoConsents: List[Consent]): List[Consent] = {
-      val missingDefaults = defaultConsents.map(_.id).filterNot(userDoConsents.map(_.id).contains)
-      userDO.consents ++ defaultConsents.filter(c => missingDefaults.contains(c.id))
+      val missingDefaultsConsentIds = defaultConsents.map(_.id).filterNot(userDoConsents.map(_.id).contains)
+      userDO.consents ++ defaultConsents.filter(c => missingDefaultsConsentIds.contains(c.id))
     }
 
     val newUserConsents = applyMissingDefaults(userDO.consents)

--- a/identity/app/views/profile/nonElectronicOptOut.scala.html
+++ b/identity/app/views/profile/nonElectronicOptOut.scala.html
@@ -27,6 +27,19 @@
                         )(messages)
                     </li>
                 }
+                @if(isMarketResearch(consentField, user)) {
+                    <p class="form__heading">Market Research</p>
+                    <p class="identity-title-explainer">From time to time we may contact you for market research purposes inviting you to complete a survey, or take part in a group discussion. Normally, this invitation would be sent via email, but we may
+                        also contact you by phone.</p>
+                    <li>
+                    @fragments.consentSwitch(
+                        consentField,
+                        boldTitle = false,
+                        titleProvider = wording => wording.description.getOrElse(""),
+                        descriptionProvider = _ => None
+                    )(messages)
+                    </li>
+                }
             }
         </ul>
     </div>

--- a/identity/app/views/profile/nonElectronicOptOut.scala.html
+++ b/identity/app/views/profile/nonElectronicOptOut.scala.html
@@ -29,8 +29,7 @@
                 }
                 @if(isMarketResearch(consentField, user)) {
                     <p class="form__heading">Market Research</p>
-                    <p class="identity-title-explainer">From time to time we may contact you for market research purposes inviting you to complete a survey, or take part in a group discussion. Normally, this invitation would be sent via email, but we may
-                        also contact you by phone.</p>
+                    <p class="identity-title-explainer">From time to time we may contact you for market research purposes inviting you to complete a survey, or take part in a group discussion. Normally, this invitation would be sent via email, but we may also contact you by phone.</p>
                     <li>
                     @fragments.consentSwitch(
                         consentField,

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -8,11 +8,13 @@ object ConsentChannel {
   case object TextConsentChannel  extends ConsentChannelBehaviour("sms")
   case object PhoneOptOutConsentChannel extends ConsentChannelBehaviour("phone_optout")
   case object PostOptOutConsentChannel  extends ConsentChannelBehaviour("post_optout")
+  case object MarketResearchConsentChannel extends ConsentChannelBehaviour("market_research_optout")
 
   private val channelsIds = List(
     TextConsentChannel.id,
     PhoneOptOutConsentChannel.id,
-    PostOptOutConsentChannel.id
+    PostOptOutConsentChannel.id,
+    MarketResearchConsentChannel.id
   )
 
   def channelsProvidedBy(user: User): List[ConsentChannelBehaviour] = {
@@ -40,7 +42,7 @@ object ConsentChannel {
 
   def isOptOutChannel(consentField: Field, user: User): Boolean =
     consentField("id").value match {
-      case Some(PhoneOptOutConsentChannel.id) | Some(PostOptOutConsentChannel.id) => true
+      case Some(PhoneOptOutConsentChannel.id) | Some(PostOptOutConsentChannel.id) | Some(MarketResearchConsentChannel.id) => true
       case _ => false
     }
 

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -9,12 +9,14 @@ object ConsentChannel {
   case object PhoneOptOutConsentChannel extends ConsentChannelBehaviour("phone_optout")
   case object PostOptOutConsentChannel  extends ConsentChannelBehaviour("post_optout")
   case object MarketResearchConsentChannel extends ConsentChannelBehaviour("market_research_optout")
+  case object ProfilingConsentChannel extends ConsentChannelBehaviour("profiling_optout")
 
   private val channelsIds = List(
     TextConsentChannel.id,
     PhoneOptOutConsentChannel.id,
     PostOptOutConsentChannel.id,
-    MarketResearchConsentChannel.id
+    MarketResearchConsentChannel.id,
+    ProfilingConsentChannel.id
   )
 
   def channelsProvidedBy(user: User): List[ConsentChannelBehaviour] = {
@@ -40,11 +42,16 @@ object ConsentChannel {
   def isSmsChannel(consentField: Field, user: User): Boolean =
     consentField("id").value.exists(_ == TextConsentChannel.id)
 
-  def isOptOutChannel(consentField: Field, user: User): Boolean =
+  def isOptOutChannel(consentField: Field, user: User): Boolean = {
     consentField("id").value match {
-      case Some(PhoneOptOutConsentChannel.id) | Some(PostOptOutConsentChannel.id) | Some(MarketResearchConsentChannel.id) => true
+      case Some(PhoneOptOutConsentChannel.id) | Some(PostOptOutConsentChannel.id) => true
       case _ => false
     }
+  }
+
+  def isMarketResearch(consentField: Field, user: User) : Boolean =
+    consentField("id").value.exists(_ == MarketResearchConsentChannel.id)
+
 
   def isChannel(consentField: Field): Boolean = {
     consentField("id").value.exists { id => channelsIds.contains(id) }

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -42,12 +42,11 @@ object ConsentChannel {
   def isSmsChannel(consentField: Field, user: User): Boolean =
     consentField("id").value.exists(_ == TextConsentChannel.id)
 
-  def isOptOutChannel(consentField: Field, user: User): Boolean = {
+  def isOptOutChannel(consentField: Field, user: User): Boolean =
     consentField("id").value match {
       case Some(PhoneOptOutConsentChannel.id) | Some(PostOptOutConsentChannel.id) => true
       case _ => false
     }
-  }
 
   def isMarketResearch(consentField: Field, user: User) : Boolean =
     consentField("id").value.exists(_ == MarketResearchConsentChannel.id)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.151"
+  val identityLibVersion = "3.152"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"


### PR DESCRIPTION
## What does this change?
- Adds a market research opt-out checkbox to the email and consents pages
- Bumps the Identity library to get new wording for this consent deployed in https://github.com/guardian/identity/pull/1179

## Screenshots
![image](https://user-images.githubusercontent.com/14179210/40230519-b76691f4-5a8f-11e8-8378-eb10ef811d35.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
