### PR TITLE
Better logic for colour on splash cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -197,12 +197,6 @@ $fc-item-gutter: $gs-gutter / 4;
 .fc-item__header {
     flex: 1 1 auto;
     font-weight: 400;
-
-    .fc-item--has-boosted-title & {
-        @include mq($from: tablet) {
-            font-weight: 900;
-        }
-    }
 }
 
 .fc-item__kicker {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -125,10 +125,7 @@ $pillars: (
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--half-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
-    &.fc-item--three-quarters-tablet.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile,
-    &.fc-item--third-tablet.fc-item--type-immersive.fc-item--has-boosted-title  {
+    &.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile {
         .fc-item__content {
             background-color: map-get($palette, kicker);
         }
@@ -172,23 +169,16 @@ $pillars: (
         }
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
-    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker,
-    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker
+    &.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__kicker
     {
         color: map-get($palette, kicker);
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report) .fc-item__standfirst {
+    &.fc-item--type-immersive.fc-item--has-boosted-title:not(.fc-item--pillar-special-report) .fc-item__standfirst {
         color: $garnett-neutral-1;
     }
 
-    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
-    &.fc-item--standard-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta,
-    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
-    &.fc-item--list-media-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta,
-    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon,
-    &.fc-item--list-tablet.fc-item--type-immersive.fc-item--has-boosted-title .fc-item__meta
+    &.fc-item--type-immersive.fc-item--has-boosted-title .inline-icon
     {
         fill: $garnett-neutral-6;
         color: $garnett-neutral-6;
@@ -342,6 +332,18 @@ $pillars: (
 
 .fc-item--pillar-special-report,
 .fc-item--pillar-special-report.fc-item--type-feature {
+    &.fc-item--type-immersive.fc-item--has-boosted-title.fc-item--standard-mobile {
+        .fc-item__content {
+            background-color: $story-package-garnett;
+        }
+
+        &:hover {
+            .fc-item__content {
+                background-color: darken($story-package-garnett, 5%);
+            }
+        }
+    }
+
     &.fc-item--type-comment {
         .fc-item__headline,
         .fc-item__standfirst {


### PR DESCRIPTION
Size specific rules were excluding certain immersive cards from having correct colouring. As we only apply splash to cards by choice now - we don't need these specific rules. Furthermore, special report splash cards were not showing correctly.

Here's how it was looking:
<img width="1117" alt="screen shot 2018-05-18 at 11 15 38" src="https://user-images.githubusercontent.com/14570016/40229713-03f3952e-5a8d-11e8-91e3-7212e8f65246.png">

<img width="483" alt="screen shot 2018-05-18 at 11 16 33" src="https://user-images.githubusercontent.com/14570016/40229714-040872d2-5a8d-11e8-94ef-e060258f432d.png">
