### PR TITLE
Be explicit about module coordination in the bootstrap

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -13,7 +13,6 @@ import {
     registerCompleteEvents,
     trackABTests,
 } from 'common/modules/experiments/ab-ophan';
-import { init as initCommon } from 'bootstraps/enhanced/common';
 import { initSport } from 'bootstraps/enhanced/sport';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { init as geolocationInit } from 'lib/geolocation';
@@ -84,282 +83,287 @@ const bootEnhanced = (): void => {
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
     ]);
 
-    bootstrapContext('common', initCommon);
-
-    // geolocation
-    catchErrorsWithContext([['geolocation', geolocationInit]]);
-
-    // Front
-    if (config.page.isFront) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'facia',
-                    require('bootstraps/enhanced/facia').init
-                );
-            },
-            'facia'
-        );
-    }
-
-    if (config.page.contentType === 'Article' && !config.page.isMinuteArticle) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'article',
-                    require('bootstraps/enhanced/article').init
-                );
-                bootstrapContext(
-                    'article : lightbox',
-                    require('common/modules/gallery/lightbox').init
-                );
-            },
-            'article'
-        );
-    }
-
-    if (config.page.contentType === 'Crossword') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'crosswords',
-                    require('bootstraps/enhanced/crosswords').init
-                );
-            },
-            'crosswords'
-        );
-    }
-
-    if (config.page.contentType === 'LiveBlog') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'liveBlog',
-                    require('bootstraps/enhanced/liveblog').init
-                );
-                bootstrapContext(
-                    'liveBlog : lightbox',
-                    require('common/modules/gallery/lightbox').init
-                );
-            },
-            'live-blog'
-        );
-    }
-
-    if (config.page.isMinuteArticle) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'articleMinute',
-                    require('bootstraps/enhanced/article-minute').init
-                );
-                bootstrapContext(
-                    'article : lightbox',
-                    require('common/modules/gallery/lightbox').init
-                );
-            },
-            'article-minute'
-        );
-    }
-
-    if (config.isMedia || config.page.contentType === 'Interactive') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'media : trail',
-                    require('bootstraps/enhanced/trail').initTrails
-                );
-            },
-            'trail'
-        );
-    }
-
-    fastdom
-        .read(() =>
-            qwery(
-                `${config.switches.enhancedVideoPlayer ? 'video, ' : ''} audio`
-            )
-        )
-        .then(els => {
-            if (els.length) {
+    import(/* webpackMode: "eager" */'bootstraps/enhanced/common')
+        .then(({ init }) => {
+            bootstrapContext('common', init);
+        })
+        .then(() => {
+            // geolocation
+            catchErrorsWithContext([['geolocation', geolocationInit]]);
+        
+            // Front
+            if (config.page.isFront) {
                 require.ensure(
                     [],
                     require => {
                         bootstrapContext(
-                            'media-player',
-                            require('bootstraps/enhanced/media-player')
-                                .initMediaPlayer
+                            'facia',
+                            require('bootstraps/enhanced/facia').init
                         );
                     },
-                    'media-player'
+                    'facia'
                 );
             }
+        
+            if (config.page.contentType === 'Article' && !config.page.isMinuteArticle) {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'article',
+                            require('bootstraps/enhanced/article').init
+                        );
+                        bootstrapContext(
+                            'article : lightbox',
+                            require('common/modules/gallery/lightbox').init
+                        );
+                    },
+                    'article'
+                );
+            }
+        
+            if (config.page.contentType === 'Crossword') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'crosswords',
+                            require('bootstraps/enhanced/crosswords').init
+                        );
+                    },
+                    'crosswords'
+                );
+            }
+        
+            if (config.page.contentType === 'LiveBlog') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'liveBlog',
+                            require('bootstraps/enhanced/liveblog').init
+                        );
+                        bootstrapContext(
+                            'liveBlog : lightbox',
+                            require('common/modules/gallery/lightbox').init
+                        );
+                    },
+                    'live-blog'
+                );
+            }
+        
+            if (config.page.isMinuteArticle) {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'articleMinute',
+                            require('bootstraps/enhanced/article-minute').init
+                        );
+                        bootstrapContext(
+                            'article : lightbox',
+                            require('common/modules/gallery/lightbox').init
+                        );
+                    },
+                    'article-minute'
+                );
+            }
+        
+            if (config.isMedia || config.page.contentType === 'Interactive') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'media : trail',
+                            require('bootstraps/enhanced/trail').initTrails
+                        );
+                    },
+                    'trail'
+                );
+            }
+        
+            fastdom
+                .read(() =>
+                    qwery(
+                        `${config.switches.enhancedVideoPlayer ? 'video, ' : ''} audio`
+                    )
+                )
+                .then(els => {
+                    if (els.length) {
+                        require.ensure(
+                            [],
+                            require => {
+                                bootstrapContext(
+                                    'media-player',
+                                    require('bootstraps/enhanced/media-player')
+                                        .initMediaPlayer
+                                );
+                            },
+                            'media-player'
+                        );
+                    }
+                });
+        
+            if (config.page.contentType === 'Gallery') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'gallery',
+                            require('bootstraps/enhanced/gallery').init
+                        );
+                        bootstrapContext(
+                            'gallery : lightbox',
+                            require('common/modules/gallery/lightbox').init
+                        );
+                    },
+                    'gallery'
+                );
+            }
+        
+            if (config.page.contentType === 'ImageContent') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'image-content : lightbox',
+                            require('common/modules/gallery/lightbox').init
+                        );
+                        bootstrapContext(
+                            'image-content : trail',
+                            require('bootstraps/enhanced/trail').initTrails
+                        );
+                    },
+                    'image-content'
+                );
+            }
+        
+            if (config.page.section === 'football') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'football',
+                            require('bootstraps/enhanced/football').init
+                        );
+                    },
+                    'football'
+                );
+            }
+        
+            if (config.page.section === 'sport') {
+                // Leaving this here for now as it's a tiny bootstrap.
+                bootstrapContext('sport', initSport);
+            }
+    
+            if (config.page.section === 'identity') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'profile',
+                            require('bootstraps/enhanced/profile').initProfile
+                        );
+                    },
+                    'profile'
+                );
+            }
+        
+            if (config.page.isPreferencesPage) {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'preferences',
+                            require('bootstraps/enhanced/preferences').init
+                        );
+                    },
+                    'preferences'
+                );
+            }
+        
+            if (config.page.section === 'newsletter-signup-page') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'newsletters',
+                            require('bootstraps/enhanced/newsletters').init
+                        );
+                    },
+                    'newsletters'
+                );
+            }
+        
+            // use a #force-sw hash fragment to force service worker registration for local dev
+            if (
+                (window.location.protocol === 'https:' &&
+                    config.page.section !== 'identity') ||
+                window.location.hash.indexOf('force-sw') > -1
+            ) {
+                const navigator = window.navigator;
+                if (navigator && navigator.serviceWorker) {
+                    navigator.serviceWorker.register('/service-worker.js');
+                }
+            }
+        
+            if (config.page.pageId === 'help/accessibility-help') {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'accessibility',
+                            require('bootstraps/enhanced/accessibility').init
+                        );
+                    },
+                    'accessibility'
+                );
+            }
+            
+            fastdom.read(() => {
+                if ($('.youtube-media-atom').length > 0) {
+                    require.ensure(
+                        [],
+                        require => {
+                            bootstrapContext(
+                                'youtube',
+                                require('bootstraps/enhanced/youtube').init
+                            );
+                        },
+                        'youtube'
+                    );
+                }
+            });
+        
+            if (window.location.hash.includes('experiments')) {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'experiments',
+                            require('common/modules/experiments').showExperiments
+                        );
+                    },
+                    'experiments'
+                );
+            }
+            
+            // Mark the end of synchronous execution.
+            markTime('App End');
+            catchErrorsWithContext([
+                [
+                    'ga-user-timing-enhanced-end',
+                    () => {
+                        trackPerformance(
+                            'Javascript Load',
+                            'enhancedEnd',
+                            'Enhanced end parse time'
+                        );
+                    },
+                ],
+            ]);
         });
 
-    if (config.page.contentType === 'Gallery') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'gallery',
-                    require('bootstraps/enhanced/gallery').init
-                );
-                bootstrapContext(
-                    'gallery : lightbox',
-                    require('common/modules/gallery/lightbox').init
-                );
-            },
-            'gallery'
-        );
-    }
-
-    if (config.page.contentType === 'ImageContent') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'image-content : lightbox',
-                    require('common/modules/gallery/lightbox').init
-                );
-                bootstrapContext(
-                    'image-content : trail',
-                    require('bootstraps/enhanced/trail').initTrails
-                );
-            },
-            'image-content'
-        );
-    }
-
-    if (config.page.section === 'football') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'football',
-                    require('bootstraps/enhanced/football').init
-                );
-            },
-            'football'
-        );
-    }
-
-    if (config.page.section === 'sport') {
-        // Leaving this here for now as it's a tiny bootstrap.
-        bootstrapContext('sport', initSport);
-    }
-
-    if (config.page.section === 'identity') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'profile',
-                    require('bootstraps/enhanced/profile').initProfile
-                );
-            },
-            'profile'
-        );
-    }
-
-    if (config.page.isPreferencesPage) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'preferences',
-                    require('bootstraps/enhanced/preferences').init
-                );
-            },
-            'preferences'
-        );
-    }
-
-    if (config.page.section === 'newsletter-signup-page') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'newsletters',
-                    require('bootstraps/enhanced/newsletters').init
-                );
-            },
-            'newsletters'
-        );
-    }
-
-    // use a #force-sw hash fragment to force service worker registration for local dev
-    if (
-        (window.location.protocol === 'https:' &&
-            config.page.section !== 'identity') ||
-        window.location.hash.indexOf('force-sw') > -1
-    ) {
-        const navigator = window.navigator;
-        if (navigator && navigator.serviceWorker) {
-            navigator.serviceWorker.register('/service-worker.js');
-        }
-    }
-
-    if (config.page.pageId === 'help/accessibility-help') {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'accessibility',
-                    require('bootstraps/enhanced/accessibility').init
-                );
-            },
-            'accessibility'
-        );
-    }
-
-    fastdom.read(() => {
-        if ($('.youtube-media-atom').length > 0) {
-            require.ensure(
-                [],
-                require => {
-                    bootstrapContext(
-                        'youtube',
-                        require('bootstraps/enhanced/youtube').init
-                    );
-                },
-                'youtube'
-            );
-        }
-    });
-
-    if (window.location.hash.includes('experiments')) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'experiments',
-                    require('common/modules/experiments').showExperiments
-                );
-            },
-            'experiments'
-        );
-    }
-
-    // Mark the end of synchronous execution.
-    markTime('App End');
-    catchErrorsWithContext([
-        [
-            'ga-user-timing-enhanced-end',
-            () => {
-                trackPerformance(
-                    'Javascript Load',
-                    'enhancedEnd',
-                    'Enhanced end parse time'
-                );
-            },
-        ],
-    ]);
 };
 
 export { bootEnhanced };

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -83,14 +83,14 @@ const bootEnhanced = (): void => {
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
     ]);
 
-    import(/* webpackMode: "eager" */'bootstraps/enhanced/common')
+    import(/* webpackMode: "eager" */ 'bootstraps/enhanced/common')
         .then(({ init }) => {
             bootstrapContext('common', init);
         })
         .then(() => {
             // geolocation
             catchErrorsWithContext([['geolocation', geolocationInit]]);
-        
+
             // Front
             if (config.page.isFront) {
                 require.ensure(
@@ -104,8 +104,11 @@ const bootEnhanced = (): void => {
                     'facia'
                 );
             }
-        
-            if (config.page.contentType === 'Article' && !config.page.isMinuteArticle) {
+
+            if (
+                config.page.contentType === 'Article' &&
+                !config.page.isMinuteArticle
+            ) {
                 require.ensure(
                     [],
                     require => {
@@ -121,7 +124,7 @@ const bootEnhanced = (): void => {
                     'article'
                 );
             }
-        
+
             if (config.page.contentType === 'Crossword') {
                 require.ensure(
                     [],
@@ -134,7 +137,7 @@ const bootEnhanced = (): void => {
                     'crosswords'
                 );
             }
-        
+
             if (config.page.contentType === 'LiveBlog') {
                 require.ensure(
                     [],
@@ -151,7 +154,7 @@ const bootEnhanced = (): void => {
                     'live-blog'
                 );
             }
-        
+
             if (config.page.isMinuteArticle) {
                 require.ensure(
                     [],
@@ -168,7 +171,7 @@ const bootEnhanced = (): void => {
                     'article-minute'
                 );
             }
-        
+
             if (config.isMedia || config.page.contentType === 'Interactive') {
                 require.ensure(
                     [],
@@ -181,11 +184,13 @@ const bootEnhanced = (): void => {
                     'trail'
                 );
             }
-        
+
             fastdom
                 .read(() =>
                     qwery(
-                        `${config.switches.enhancedVideoPlayer ? 'video, ' : ''} audio`
+                        `${
+                            config.switches.enhancedVideoPlayer ? 'video, ' : ''
+                        } audio`
                     )
                 )
                 .then(els => {
@@ -203,7 +208,7 @@ const bootEnhanced = (): void => {
                         );
                     }
                 });
-        
+
             if (config.page.contentType === 'Gallery') {
                 require.ensure(
                     [],
@@ -220,7 +225,7 @@ const bootEnhanced = (): void => {
                     'gallery'
                 );
             }
-        
+
             if (config.page.contentType === 'ImageContent') {
                 require.ensure(
                     [],
@@ -237,7 +242,7 @@ const bootEnhanced = (): void => {
                     'image-content'
                 );
             }
-        
+
             if (config.page.section === 'football') {
                 require.ensure(
                     [],
@@ -250,12 +255,12 @@ const bootEnhanced = (): void => {
                     'football'
                 );
             }
-        
+
             if (config.page.section === 'sport') {
                 // Leaving this here for now as it's a tiny bootstrap.
                 bootstrapContext('sport', initSport);
             }
-    
+
             if (config.page.section === 'identity') {
                 require.ensure(
                     [],
@@ -268,7 +273,7 @@ const bootEnhanced = (): void => {
                     'profile'
                 );
             }
-        
+
             if (config.page.isPreferencesPage) {
                 require.ensure(
                     [],
@@ -281,7 +286,7 @@ const bootEnhanced = (): void => {
                     'preferences'
                 );
             }
-        
+
             if (config.page.section === 'newsletter-signup-page') {
                 require.ensure(
                     [],
@@ -294,7 +299,7 @@ const bootEnhanced = (): void => {
                     'newsletters'
                 );
             }
-        
+
             // use a #force-sw hash fragment to force service worker registration for local dev
             if (
                 (window.location.protocol === 'https:' &&
@@ -306,7 +311,7 @@ const bootEnhanced = (): void => {
                     navigator.serviceWorker.register('/service-worker.js');
                 }
             }
-        
+
             if (config.page.pageId === 'help/accessibility-help') {
                 require.ensure(
                     [],
@@ -319,7 +324,7 @@ const bootEnhanced = (): void => {
                     'accessibility'
                 );
             }
-            
+
             fastdom.read(() => {
                 if ($('.youtube-media-atom').length > 0) {
                     require.ensure(
@@ -334,20 +339,21 @@ const bootEnhanced = (): void => {
                     );
                 }
             });
-        
+
             if (window.location.hash.includes('experiments')) {
                 require.ensure(
                     [],
                     require => {
                         bootstrapContext(
                             'experiments',
-                            require('common/modules/experiments').showExperiments
+                            require('common/modules/experiments')
+                                .showExperiments
                         );
                     },
                     'experiments'
                 );
             }
-            
+
             // Mark the end of synchronous execution.
             markTime('App End');
             catchErrorsWithContext([
@@ -363,7 +369,6 @@ const bootEnhanced = (): void => {
                 ],
             ]);
         });
-
 };
 
 export { bootEnhanced };

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -83,6 +83,12 @@ const bootEnhanced = (): void => {
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
     ]);
 
+    /** common sets up many things that subsequent modules may need.
+     * here we make sure it runs first; it's a nice way to avoid
+     * race conditions caused by one of the modules below having
+     * a transitive dependency on a module that has already been
+     * loaded.
+     */
     import(/* webpackMode: "eager" */ 'bootstraps/enhanced/common')
         .then(({ init }) => {
             bootstrapContext('common', init);

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -28,11 +28,13 @@ const get = (path: string = '', defaultValue: any): any => {
 const set = (path: string, value: any): void => {
     const pathSegments = path.split('.');
     const last = pathSegments.pop();
-    pathSegments.reduce(
-        // eslint-disable-next-line no-return-assign
-        (obj, subpath) => typeof obj[subpath] === 'object' ? obj[subpath] : (obj[subpath] = {}),
-        config
-    )[last] = value;
+    pathSegments.reduce((obj, subpath) => {
+        if (typeof obj[subpath] === 'object') {
+            return obj[subpath];
+        }
+        obj[subpath] = {};
+        return obj[subpath];
+    }, config)[last] = value;
 };
 
 const hasTone = (name: string): boolean =>

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -30,7 +30,10 @@ const set = (path: string, value: any): void => {
     const last = pathSegments.pop();
     pathSegments.reduce(
         // eslint-disable-next-line no-return-assign
-        (obj, subpath) => typeof obj[subpath] === 'object' ? obj[subpath] : (obj[subpath] = {}),
+        (obj, subpath) =>
+            typeof obj[subpath] === 'object'
+                ? obj[subpath]
+                : (obj[subpath] = {}),
         config
     )[last] = value;
 };

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -30,7 +30,7 @@ const set = (path: string, value: any): void => {
     const last = pathSegments.pop();
     pathSegments.reduce(
         // eslint-disable-next-line no-return-assign
-        (obj, subpath) => obj[subpath] || (obj[subpath] = {}),
+        (obj, subpath) => typeof obj[subpath] === 'object' ? obj[subpath] : (obj[subpath] = {}),
         config
     )[last] = value;
 };

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -1,10 +1,7 @@
 // @flow
-import config from 'lib/config';
 
 const deferToAnalytics = (afterAnalytics: () => void): void => {
-    try {
-        config.get('modules.tracking.ready').then(afterAnalytics);
-    } catch (e) {} // eslint-disable-line no-empty
+    afterAnalytics();
 };
 
 export default deferToAnalytics;

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
@@ -1,5 +1,4 @@
 // @flow
-import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { session } from 'lib/storage';
 import {
@@ -97,7 +96,6 @@ const init = (options: Object = {}): void => {
         loc = options.location; // allow a fake location to be passed in for testing
     }
     addHandlers();
-    config.set('modules.tracking.ready', Promise.resolve());
 };
 
 export default {


### PR DESCRIPTION
A race condition was identified [recently](https://github.com/guardian/frontend/pull/19669) where two modules relied on events to sync their work, but [completely unrelated work](https://github.com/guardian/frontend/pull/18617) changed the network profile and as a result events were sent before anything was listening to them.

The previous fix was a bit hacky, this PR intends to improve on that. Promises are the only abstraction available to us for imposing order in asynchronous code, so we'll use that via the almighty `import` command provided by Webpack. The assumption is that the `common` module provides enhancements for all other modules, so it must run before all the others kick off.

The cautious reader will notice that solution is far from perfect, as `bootstrapContext` does not return a promise, so there is no way to ensure full execution of the `common` module and its dependencies. I leave that as a potential improvement for the future.

cc @mchv @sndrs 