### PR TITLE
fix consent order, market at bottom

### DIFF
--- a/identity/app/utils/ConsentOrder.scala
+++ b/identity/app/utils/ConsentOrder.scala
@@ -15,7 +15,8 @@ object ConsentOrder {
       "offers",
       "post_optout",
       "phone_optout",
-      "sms"
+      "sms",
+      "market_research_optout"
     )
 
   /**


### PR DESCRIPTION
## What does this change?
- Market research needs to be defined in the order of the consents so it is displayed in the correct place. 

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/14179210/40236127-6687020e-5aa4-11e8-9cc6-5ac962ba1170.png)

After: 
![image](https://user-images.githubusercontent.com/14179210/40236115-5f11e336-5aa4-11e8-9fcf-b48f668b520f.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
