### PR TITLE
Acquisitions Epic Double Highlight/Remove Ads Falling test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -85,4 +85,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 6, 5),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-double-highlight-drop-ads-falling",
+    "Try 2 variants - one adding a double highlight and one removing the ads falling line",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 6, 5),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -33,6 +33,14 @@ const ctaLinkSentence = (
         supportUrl
     }" target="_blank" class="u-underline">Make a contribution</a>`;
 
+// double highlight
+const controlP1Highlight =
+    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. <span class="contributions__highlight">And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can.</span> So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
+
+// drop ads falling
+const dropAdsFallingP1 =
+    '&hellip; we have a small favour to ask. Unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. More people are reading the Guardian than ever but our independent, investigative journalism takes a lot of time, money and hard work to produce. So you can see why we need to ask for your help. We do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
+
 /*
  Exported instances of AcquisitionsEpicTemplateCopy
  */
@@ -45,6 +53,18 @@ export const control: AcquisitionsEpicTemplateCopy = {
 export const regulars: AcquisitionsEpicTemplateCopy = {
     heading: controlHeadingRegulars,
     p1: controlP1Regulars,
+    p2: controlP2(controlP2FirstSentence),
+};
+
+export const doubleHighlightCopy = {
+    heading: controlHeading,
+    p1: controlP1Highlight,
+    p2: controlP2(controlP2FirstSentence),
+};
+
+export const dropAdsFallingCopy = {
+    heading: controlHeading,
+    p1: dropAdsFallingP1,
     p2: controlP2(controlP2FirstSentence),
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,6 +13,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAlwaysAskAprilStory } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-april-story';
+import { AcquisitionsEpicDoubleHighlightDropAdsFalling } from 'common/modules/experiments/tests/acquisitions-epic-double-highlight-drop-ads-falling';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -40,6 +41,7 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicAlwaysAskAprilStory,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
+    AcquisitionsEpicDoubleHighlightDropAdsFalling,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-double-highlight-drop-ads-falling.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-double-highlight-drop-ads-falling.js
@@ -1,0 +1,49 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import {
+    doubleHighlightCopy,
+    dropAdsFallingCopy,
+} from 'common/modules/commercial/acquisitions-copy';
+
+const abTestName = 'AcquisitionsEpicDoubleHighlightDropAdsFalling';
+
+export const AcquisitionsEpicDoubleHighlightDropAdsFalling: EpicABTest = makeABTest(
+    {
+        id: abTestName,
+        campaignId: abTestName,
+
+        start: '2018-05-18',
+        expiry: '2018-06-05',
+
+        author: 'Jonathan Rankin',
+        description:
+            'Try 2 variants - one adding a double highlight and one removing the ads falling line',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Both variants beat the control',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        variants: [
+            {
+                id: 'control',
+                products: [],
+            },
+            {
+                id: 'double_highlight',
+                products: [],
+                options: {
+                    copy: doubleHighlightCopy,
+                },
+            },
+            {
+                id: 'drop_ads_falling',
+                products: [],
+                options: {
+                    copy: dropAdsFallingCopy,
+                },
+            },
+        ],
+    }
+);


### PR DESCRIPTION
## What does this change?

New epic test, testing a) the impact of highlighting an extra sentence in the epic, and b) the impact of removing a line about ad revenues falling.

## What does this change?

New epic test, testing a) adding a border and an info logo to the epic and b) the impact of thanking our readers in the epic copy.


| Control | ![control](https://user-images.githubusercontent.com/2844554/40240757-36c7c0be-5ab1-11e8-8b98-24a6cab2c149.png)|
|---------|--------|
| Double highlight |![high](https://user-images.githubusercontent.com/2844554/40421946-8aa104c0-5e85-11e8-8939-37eeb0e4e4ba.png) |
| Ads falling |![screenshot at may 18 15-26-21](https://user-images.githubusercontent.com/2844554/40421968-9fbc5832-5e85-11e8-94fb-fd81ab32bb74.png)|

