### PR TITLE
Add a timestamp to GU_TK

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -20,9 +20,11 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
 };
 
 const getAdConsentState = (provider: AdConsent): ?boolean => {
-    const cookie = getCookie(provider.cookie).split(',')[0];
-    if (cookie === '1') return true;
-    if (cookie === '0') return false;
+    const cookieRaw = getCookie(provider.cookie);
+    if (!cookieRaw) return null;
+    const cookieParsed = cookieRaw.split(',')[0];
+    if (cookieParsed === '1') return true;
+    if (cookieParsed === '0') return false;
     return null;
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -15,11 +15,12 @@ const thirdPartyTrackingAdConsent: AdConsent = {
 const allAdConsents: AdConsent[] = [thirdPartyTrackingAdConsent];
 
 const setAdConsentState = (provider: AdConsent, state: boolean): void => {
-    addCookie(provider.cookie, state ? '1' : '0', 365 * 6, true);
+    const cookie = [state ? '1' : '0', Date.now()].join(',');
+    addCookie(provider.cookie, cookie, 30 * 18, true);
 };
 
 const getAdConsentState = (provider: AdConsent): ?boolean => {
-    const cookie = getCookie(provider.cookie);
+    const cookie = getCookie(provider.cookie).split(',')[0];
     if (cookie === '1') return true;
     if (cookie === '0') return false;
     return null;

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
@@ -40,12 +40,12 @@ describe('setAdConsentState', () => {
     it('should set a full proper cookie', () => {
         setAdConsentState(testConsent, true);
         expect(addCookie.mock.calls[0][0]).toBe('GU_AD_CONSENT_TEST');
-        expect(addCookie.mock.calls[0][1]).toBe('1');
-        expect(addCookie.mock.calls[0][2]).toBe(365 * 6);
+        expect(addCookie.mock.calls[0][1]).toMatch('1,');
+        expect(addCookie.mock.calls[0][2]).toBe(30 * 18);
         expect(addCookie.mock.calls[0][3]).toBe(true);
     });
     it('should set a false cookie', () => {
         setAdConsentState(testConsent, false);
-        expect(addCookie.mock.calls[0][1]).toBe('0');
+        expect(addCookie.mock.calls[0][1]).toMatch('0,');
     });
 });


### PR DESCRIPTION
## What does this change?
Adds a second parameter to GU_TK containing the last time the consent was updated, will be used in the future to ask users to re-consent before the cookie expires