### PR TITLE
Fix container overflow on mobile

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -459,7 +459,10 @@ $header-image-size-desktop: 100px;
         background: url('https://uploads.guim.co.uk/2018/05/17/himandher.png') no-repeat;
         background-size: 170px 150px;
         background-position: left bottom;
-        overflow: visible;
+        
+        @include mq(tablet) {
+            overflow: visible;
+        }
 
         @include mq($until: leftCol) {
             background-size: 85px 75px;


### PR DESCRIPTION
Zef emailed this as a non-urgent 24/7 request.

Before: 
<img width="455" alt="screen shot 2018-05-19 at 16 34 36" src="https://user-images.githubusercontent.com/1064734/40270302-585f7c90-5b82-11e8-88c3-6770956bf8ba.png">

After:
<img width="505" alt="screen shot 2018-05-19 at 16 34 41" src="https://user-images.githubusercontent.com/1064734/40270309-71cfd404-5b82-11e8-8e78-80947b1c279e.png">

