### PR TITLE
Open up adverts manager & move it to /privacy-settings

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -18,7 +18,7 @@ trait IdentitySwitches {
   val IdentityAdConsentsSwitch = Switch(
     SwitchGroup.Identity,
     "id-ad-consents",
-    "If switched on, allows access to /adverts/manage and replaces the cookie banner.",
+    "If switched on, replaces the cookie banner.",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 6, 25), // GDPR goes into effect + 1 month

--- a/identity/app/controllers/AdvertsManager.scala
+++ b/identity/app/controllers/AdvertsManager.scala
@@ -29,18 +29,15 @@ class AdvertsManager(
 
   def renderAdvertsManager(returnUrl: Option[String]): Action[AnyContent] = Action { implicit request =>
 
-    if(IdentityAdConsentsSwitch.isSwitchedOff) {
-      NotFound(views.html.errors._404())
-    } else {
-      val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
-      val verifiedReturnUrl = verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl)
+    val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
+    val verifiedReturnUrl = verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl)
 
-      NoCache(Ok(
-        IdentityHtmlPage.html(
-          content = views.html.advertsManager(verifiedReturnUrl,idUrlBuilder)
-        )(page, request, context)
-      ))
-    }
+    NoCache(Ok(
+      IdentityHtmlPage.html(
+        content = views.html.advertsManager(verifiedReturnUrl,idUrlBuilder)
+      )(page, request, context)
+    ))
+
   }
 
 }

--- a/identity/app/views/advertsManager.scala.html
+++ b/identity/app/views/advertsManager.scala.html
@@ -31,29 +31,13 @@
 
     <fieldset class="fieldset">
         <div class="fieldset__heading">
-            <h2 class="form__heading">More controls</h2>
+            <h2 class="form__heading"></h2>
         </div>
 
         <div class="fieldset__fields email-subscription__options">
             <p class="identity-title-explainer">
-                You can use the following links to control your ad personalisation across the web - not just The Guardian.
+                Your choices may not take effect until May 25, 2018.
             </p>
-            <ul class="u-unstyled">
-                <li>
-                    <p>
-                        <a href="https://adssettings.google.com/" class="u-underline" data-link-name="adverts-manager : out : google">
-                            Adjust your Google ads across the web
-                        </a>
-                    </p>
-                </li>
-                <li>
-                    <p>
-                        <a href="http://www.youronlinechoices.com" class="u-underline" data-link-name="adverts-manager : out : IAB">
-                            Visit AdChoices
-                        </a>
-                    </p>
-                </li>
-            </ul>
         </div>
 
     </fieldset>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -65,7 +65,7 @@ POST        /email-prefs                            controllers.editprofile.Edit
 ########################################################################################################################
 # PUBLIC EDIT PROFILE
 ########################################################################################################################
-GET         /adverts/manage                         controllers.AdvertsManager.renderAdvertsManager(returnUrl : Option[String])
+GET         /privacy-settings                       controllers.AdvertsManager.renderAdvertsManager(returnUrl : Option[String])
 
 ########################################################################################################################
 # Consents journey


### PR DESCRIPTION
## What does this change?
Removes the switch check for the existing adverts manager & moves it to `https://profile.theguardian.com/privacy-settings`.

The switch also controls the new cookie banner and while this page is not meant to go live yet it might go live before the banner. it's been decided that leaving it visible but unlinked while the wording is in flux is a reasonable risk.

Just in case anybody ends up here I've added some copy explaining the settings will not be honoured until the 25th.

## What else is going on with this page?
There's a related PR that implements the final UX: #19683 and there will, at some point, be a last and final PR that puts in the final wording and ties everything together.

## Screenshots
![screen shot 2018-05-21 at 11 48 28 am](https://user-images.githubusercontent.com/11539094/40304098-47004300-5ced-11e8-97c4-c146c4180bbb.png)
