### PR TITLE
Track new cookie banner lifetime views

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -67,7 +67,7 @@ const hasUnsetAdChoices = (): boolean =>
 const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices()].every(_ => _ === true));
 
-const trackInteraction = (interaction: string) => {
+const trackInteraction = (interaction: string): void => {
     ophan.record({
         component: 'first-pv-consent',
         action: interaction,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -13,7 +13,6 @@ import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
 
 const lifeTimeViewsKey: string = 'first-pv-consent.lifetime-views';
-const displayEventKey: string = 'first-pv-consent : display';
 const lifetimeDisplayEventKey: string = 'first-pv-consent : viewed-times :';
 
 type Template = {
@@ -78,11 +77,9 @@ const trackInteraction = (interaction: string): void => {
 
 const show = (): void => {
     userPrefs.set(lifeTimeViewsKey, (userPrefs.get(lifeTimeViewsKey) || 0) + 1);
-
-    [
-        displayEventKey,
-        `${lifetimeDisplayEventKey} ${userPrefs.get(lifeTimeViewsKey)}`,
-    ].forEach(trackInteraction);
+    trackInteraction(
+        `${lifetimeDisplayEventKey} ${userPrefs.get(lifeTimeViewsKey)}`
+    );
 
     const msg = new Message('first-pv-consent', {
         important: true,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -13,8 +13,8 @@ import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
 
 const lifeTimeViewsKey: string = 'first-pv-consent.lifetime-views';
-const displayEventKey: string = 'sign-in-eb : display';
-const lifetimeDisplayEventKey: string = 'sign-in-eb : viewed-times :';
+const displayEventKey: string = 'first-pv-consent : display';
+const lifetimeDisplayEventKey: string = 'first-pv-consent : viewed-times :';
 
 type Template = {
     consentText: string,
@@ -45,10 +45,10 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__actions">
         <a href="${
             tpl.linkToPreferences
-        }" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--link">${
+        }" data-link-name="first-pv-consent : to-prefs" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--link">${
     tpl.choicesButton
 }</a>
-        <button class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
+        <button data-link-name="first-pv-consent : agree" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
             classes.agree
         }">${tpl.agreeButton}</button>
     </div>

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -16,8 +16,16 @@ beforeEach(() => {
     Message.prototype.hide = jest.fn(() => true);
 });
 
+jest.mock('ophan/ng', () => ({
+    record: jest.fn(),
+}));
+
 jest.mock('common/modules/ui/message', () => ({
     Message: jest.fn(),
+}));
+
+jest.mock('common/modules/analytics/google', () => ({
+    trackNonClickInteraction: jest.fn(),
 }));
 
 jest.mock('common/modules/commercial/ad-prefs.lib', () => {


### PR DESCRIPTION
## What does this change?
There's a fear that the new initial pageview consent banner might never be dismissed by users, preventing the rest of messages in the site (including the yellow engagement banner) from ever appearing. This PR adds a basic way of tracking to see how many times the banner does actually show per user.

## What is the value of this and can you measure success?
The goal here is to have the data to iterate on this banner until we are happy with the numbers, at which point we can call it a day and remove the event. While it doesn't add a lot of overhead it does feel a bit overzealous and somewhat ironic, considering this is in itself the banner where we are informing users we are tracking them.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
It will but there's no special treatment needed

## Screenshots
Not even I know how it's gonna look yet. 😩☝️. Picture the existing cookie banner but taller.