### PR TITLE
FIX: Show latest campaign added, not first one

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -6,11 +6,11 @@ export const getCampaign = () => {
     const isCallout = campaign => campaign.fields._type === 'callout';
     const allCampaigns = config.get('page.campaigns');
 
-    // targeting should become better once the campaigns tool works
+    // take the last added campaign as campaign to show
     const allCallouts = allCampaigns.filter(isCallout);
-    const campaignToShow = allCallouts.shift();
+    const campaignToShow = allCallouts[allCallouts.length - 1];
 
-    if (campaignToShow !== undefined) {
+    if (campaignToShow) {
         const {
             callout,
             description,

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.spec.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.spec.js
@@ -101,13 +101,13 @@ describe('Finding the callouts to display ', () => {
     });
 
     // change this when new targeting rules come in
-    it('if there are two or more callout campaigns, it shows the first one', () => {
+    it('if there are two or more callout campaigns, it shows the last one', () => {
         config.page.campaigns = twoCampaigns;
         const callout2 = {
-            title: 'Has this happened to you?',
-            description: 'Tell us your story and upload a file',
+            title: 'Do you have a supermarket near you?',
+            description: 'How far away is it?',
             formFields: [],
-            formId: 2994970,
+            formId: 3028078,
         };
         expect(getCampaign()).toEqual(callout2);
     });


### PR DESCRIPTION
When two or more campaigns are available, we want the interface to pick the last one added. This is at the end of the array. 

This also tightens up the check on `campaignToShow`. 
