### PR TITLE
Email fronts: show images in free text containers

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -125,6 +125,13 @@
     }
 }
 
+@freeTextWithImage(card: ContentCard) = {
+    @faciaCard(classesForCard(card)) {
+        @row(Seq("no-pad")){@imgFromCard(card)}
+        @row(Seq("free-text"))(Html(card.header.headline))
+    }
+}
+
 @freeText(text: String) = {
     @fullRow(Seq("free-text"))(Html(text))
 }
@@ -132,7 +139,12 @@
 @renderCard(card: ContentCard, cardStyle: EmailCardStyle, isBranded: Boolean) = {
     @cardStyle match {
         case EmailHidden => { }
-        case EmailFreeText => { @freeText(card.header.headline) }
+        case EmailFreeText if card.displayElement.isEmpty => {
+            @freeText(card.header.headline)
+        }
+        case EmailFreeText => {
+            @freeTextWithImage(card)
+        }
         case layoutStyle: EmailFaciaCard => {
             @card.cardStyle match {
                 case ExternalLink => {


### PR DESCRIPTION
## What does this change?

Currently, if an image is added to a free text container, the image does not appear. This change ensures free text containers with images appear with an image, as expected.

## What is the value of this and can you measure success?

Nicer email fronts

## Does this affect other platforms - Amp, Apps, etc?

No, just email fronts

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

**Before**

![screen shot 2018-05-21 at 17 58 50](https://user-images.githubusercontent.com/5931528/40319767-2f235c66-5d21-11e8-8214-0349f2b228b3.png)


**After**

![screen shot 2018-05-21 at 18 03 08](https://user-images.githubusercontent.com/5931528/40319782-3f7728e0-5d21-11e8-9512-1e23d714e97f.png)


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
