### PR TITLE
[minor] Fix ad-prefs.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -118,7 +118,7 @@ class ConsentBoxes extends Component<
     onSubmit(event: SyntheticInputEvent<HTMLFormElement>): void {
         event.preventDefault();
         this.state.consentsWithState.forEach(consentWithState => {
-            if (consentWithState.state) {
+            if (typeof consentWithState.state === 'boolean') {
                 setAdConsentState(
                     consentWithState.consent,
                     consentWithState.state


### PR DESCRIPTION
## What does this change?
Turns out, if you do a lazy null check on a boolean you end with literally half of your code cases not actually working. Who would have thought!

Ah, types

## What is the value of this and can you measure success?
This bug would have prevented users from opting out of ads past the 25th so actually this is actually terrible in terms of raw value, now they'll be able to.