### PR TITLE
Remove newsletter repermission step

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -42,12 +42,6 @@
     </div>
 }
 
-@onlySubscribedToV1Newsletters = @{
-    EmailNewsletters.all.subscriptions.filter { newsletter =>
-        emailSubscriptions.contains(newsletter.listIdV1.toString)
-    }
-}
-
 @smsStepContent = {
     @views.html.profile.smsConsent(idUrlBuilder, idRequest, forms.privacyForm, user)(request, messages)
 }
@@ -104,39 +98,6 @@
     )
 }
 
-@emailRepermissionStepContent = {
-    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-        @views.html.helper.CSRF.formField
-        @fragments.form.hidden(emailPrefsForm("htmlPreference"))
-        <div class="manage-account__switches manage-account__switches--single-column">
-            <ul>
-            @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
-            <li>
-                @fragments.newsletterSwitch(
-                    emailPrefsForm,
-                    emailSubscriptions,
-                    newsletter = newsletter,
-                    unchecked = true,
-                    skin = skin
-                )(nonInputFields, messages, request)
-            </li>
-            }
-            </ul>
-        </div>
-    </form>
-}
-@emailRepermissionStep() = @{
-    ConsentStep(
-        name = "email",
-        title = "Email Newsletters",
-        help = List(
-            ConsentStepHelpText("The Guardian’s newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.")
-        ),
-        content = emailRepermissionStepContent,
-        show = onlySubscribedToV1Newsletters.nonEmpty
-    )
-}
-
 @introGdprCampaignStep= @{
     ConsentStep(
         name = "intro",
@@ -149,7 +110,7 @@
                 "You can change your preferences anytime by signing in, clicking My Account, then selecting Email Preferences."
             )
         ),
-        content = selectAllCheckboxContent,
+        content = selectAllCheckboxContent
     )
 }
 
@@ -184,7 +145,6 @@
 }
 
 @defaultJourney = @{List(
-    emailRepermissionStep,
     marketingConsentStep,
     smsStep,
     nonElectronicOptOutStep
@@ -230,20 +190,13 @@
         @renderBlocks(
             journey match {
                 case NewsletterConsentsJourney => {
-                    if(emailRepermissionStep.show) {
-                        List(
-                            introGdprCampaignStep,
-                            emailRepermissionStep
+                    List(
+                        ConsentStep(
+                            name = "error",
+                            title = "Sorry",
+                            content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
                         )
-                    } else {
-                        List(
-                            ConsentStep(
-                                name = "error",
-                                title = "Sorry",
-                                content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
-                            )
-                        )
-                    }
+                    )
                 }
                 case ThankYouConsentsJourney => {
                     List(

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -170,16 +170,6 @@ import scala.concurrent.Future
         contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
       }
 
-      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
-        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(anyString(), any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
-
-        val result = controller.displayConsentsJourney(None).apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
-      }
-
     }
 
 
@@ -195,16 +185,6 @@ import scala.concurrent.Future
         val result = controller.displayConsentsJourneyGdprCampaign.apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
         contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
-      }
-
-      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
-        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(anyString(), any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
-
-        val result = controller.displayConsentsJourneyGdprCampaign.apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
       }
 
     }
@@ -225,16 +205,6 @@ import scala.concurrent.Future
         contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
       }
 
-      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
-        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(anyString(), any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
-
-        val result = controller.displayConsentsJourneyThankYou().apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
-      }
-
     }
 
 
@@ -244,16 +214,6 @@ import scala.concurrent.Future
         val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
         contentAsString(result) should not include xml.Utility.escape(Supporter.latestWording.wording)
-      }
-
-      "prompt users with V1 emails to repermission" in new ConsentsJourneyFixture {
-        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listIdV1.toString))
-        when(api.userEmails(anyString(), any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
-
-        val result = controller.displayConsentsJourneyNewsletters().apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(EmailNewsletters.guardianTodayUk.name))
       }
 
     }


### PR DESCRIPTION
## What does this change?
Removes the newsletter step from consents journeys.  This causes a minor issue on the newsletter only journey.  In that (edge) case we will just display an error at the moment.  PR incoming that will fix that anyway.

## What is the value of this and can you measure success?
Stop showing people's old newsletters during repermissioning as we don't want to use this legacy data going forwards.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
