### PR TITLE
Robust-er ad consents

### DIFF
--- a/identity/app/views/advertsManager.scala.html
+++ b/identity/app/views/advertsManager.scala.html
@@ -19,8 +19,8 @@
 
         <div class="fieldset__fields">
             <p class="identity-title-explainer">Google uses personalisation to deliver better ads. Unticking this will not reduce the number of ads in The Guardian but it will make them less relevant to your interests</p>
-            <div class="js-manage-account__ad-prefs is-hidden">
-                <span>Loading</span>
+            <div class="js-manage-account__ad-prefs">
+                <span>Loading…</span>
             </div>
             <noscript>
                 Javascript is required to edit your advert preferences

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -7,8 +7,6 @@ type AdConsent = {
     cookie: string,
 };
 
-type AdConsentState = ?boolean;
-
 const thirdPartyTrackingAdConsent: AdConsent = {
     label: 'Third party tracking',
     cookie: 'GU_TK',
@@ -21,7 +19,7 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     addCookie(provider.cookie, cookie, 30 * 18, true);
 };
 
-const getAdConsentState = (provider: AdConsent): AdConsentState => {
+const getAdConsentState = (provider: AdConsent): ?boolean => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
     const cookieParsed = cookieRaw.split(',')[0];
@@ -30,7 +28,7 @@ const getAdConsentState = (provider: AdConsent): AdConsentState => {
     return null;
 };
 
-export type { AdConsent, AdConsentState };
+export type { AdConsent };
 export {
     setAdConsentState,
     getAdConsentState,

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -7,6 +7,8 @@ type AdConsent = {
     cookie: string,
 };
 
+type AdConsentState = ?boolean;
+
 const thirdPartyTrackingAdConsent: AdConsent = {
     label: 'Third party tracking',
     cookie: 'GU_TK',
@@ -19,7 +21,7 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     addCookie(provider.cookie, cookie, 30 * 18, true);
 };
 
-const getAdConsentState = (provider: AdConsent): ?boolean => {
+const getAdConsentState = (provider: AdConsent): AdConsentState => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
     const cookieParsed = cookieRaw.split(',')[0];
@@ -28,7 +30,7 @@ const getAdConsentState = (provider: AdConsent): ?boolean => {
     return null;
 };
 
-export type { AdConsent };
+export type { AdConsent, AdConsentState };
 export {
     setAdConsentState,
     getAdConsentState,

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -9,9 +9,10 @@ import {
     setAdConsentState,
     allAdConsents,
 } from 'common/modules/commercial/ad-prefs.lib';
-import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
-
-type AdConsentState = ?boolean;
+import type {
+    AdConsent,
+    AdConsentState,
+} from 'common/modules/commercial/ad-prefs.lib';
 
 type AdConsentWithState = {
     consent: AdConsent,
@@ -30,6 +31,12 @@ type ConsentBoxProps = {
     consent: AdConsent,
     state: AdConsentState,
     onUpdate: (state: AdConsentState) => void,
+};
+
+type AdPrefsWrapperProps = {
+    getAdConsentState: (consent: AdConsent) => AdConsentState,
+    setAdConsentState: (consent: AdConsent, state: boolean) => void,
+    allAdConsents: AdConsent[],
 };
 
 const rootSelector: string = '.js-manage-account__ad-prefs';
@@ -91,14 +98,10 @@ class ConsentBox extends Component<ConsentBoxProps, {}> {
 }
 
 class AdPrefsWrapper extends Component<
-    {
-        getAdConsentState: (consent: AdConsent) => AdConsentState,
-        setAdConsentState: (consent: AdConsent, state: AdConsentState) => void,
-        allAdConsents: AdConsent[],
-    },
+    AdPrefsWrapperProps,
     { consentsWithState: AdConsentWithState[], changesPending: boolean }
 > {
-    constructor(props: {}): void {
+    constructor(props: AdPrefsWrapperProps): void {
         super(props);
         this.state = {
             changesPending: false,

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -90,18 +90,24 @@ class ConsentBox extends Component<ConsentBoxProps, {}> {
     }
 }
 
-class ConsentBoxes extends Component<
-    {},
+class AdPrefsWrapper extends Component<
+    {
+        getAdConsentState: (consent: AdConsent) => AdConsentState,
+        setAdConsentState: (consent: AdConsent, state: AdConsentState) => void,
+        allAdConsents: AdConsent[],
+    },
     { consentsWithState: AdConsentWithState[], changesPending: boolean }
 > {
     constructor(props: {}): void {
         super(props);
         this.state = {
             changesPending: false,
-            consentsWithState: allAdConsents.map((consent: AdConsent) => ({
-                consent,
-                state: getAdConsentState(consent),
-            })),
+            consentsWithState: this.props.allAdConsents.map(
+                (consent: AdConsent) => ({
+                    consent,
+                    state: this.props.getAdConsentState(consent),
+                })
+            ),
         };
     }
 
@@ -119,7 +125,7 @@ class ConsentBoxes extends Component<
         event.preventDefault();
         this.state.consentsWithState.forEach(consentWithState => {
             if (typeof consentWithState.state === 'boolean') {
-                setAdConsentState(
+                this.props.setAdConsentState(
                     consentWithState.consent,
                     consentWithState.state
                 );
@@ -173,12 +179,18 @@ class ConsentBoxes extends Component<
 
 const enhanceAdPrefs = (): void => {
     fastdom
-        .read(() => document.querySelectorAll(rootSelector))
+        .read(() => [...document.querySelectorAll(rootSelector)])
         .then((wrapperEls: HTMLElement[]) => {
             wrapperEls.forEach(_ => {
                 fastdom.write(() => {
-                    _.classList.remove('is-hidden');
-                    render(<ConsentBoxes />, _);
+                    render(
+                        <AdPrefsWrapper
+                            allAdConsents={allAdConsents}
+                            getAdConsentState={getAdConsentState}
+                            setAdConsentState={setAdConsentState}
+                        />,
+                        _
+                    );
                 });
             });
         });

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -9,14 +9,11 @@ import {
     setAdConsentState,
     allAdConsents,
 } from 'common/modules/commercial/ad-prefs.lib';
-import type {
-    AdConsent,
-    AdConsentState,
-} from 'common/modules/commercial/ad-prefs.lib';
+import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 
 type AdConsentWithState = {
     consent: AdConsent,
-    state: AdConsentState,
+    state: ?boolean,
 };
 
 type ConsentRadioButtonProps = {
@@ -29,12 +26,12 @@ type ConsentRadioButtonProps = {
 
 type ConsentBoxProps = {
     consent: AdConsent,
-    state: AdConsentState,
-    onUpdate: (state: AdConsentState) => void,
+    state: ?boolean,
+    onUpdate: (state: ?boolean) => void,
 };
 
 type AdPrefsWrapperProps = {
-    getAdConsentState: (consent: AdConsent) => AdConsentState,
+    getAdConsentState: (consent: AdConsent) => ?boolean,
     setAdConsentState: (consent: AdConsent, state: boolean) => void,
     allAdConsents: AdConsent[],
 };
@@ -114,7 +111,7 @@ class AdPrefsWrapper extends Component<
         };
     }
 
-    onUpdate(consentId: number, state: AdConsentState): void {
+    onUpdate(consentId: number, state: ?boolean): void {
         const consentsWithState = [...this.state.consentsWithState];
         const changesPending = consentsWithState[consentId].state !== state;
         consentsWithState[consentId].state = state;
@@ -154,7 +151,7 @@ class AdPrefsWrapper extends Component<
                                 consent={consentWithState.consent}
                                 state={consentWithState.state}
                                 key={consentWithState.consent.cookie}
-                                onUpdate={(state: AdConsentState) => {
+                                onUpdate={(state: ?boolean) => {
                                     this.onUpdate(index, state);
                                 }}
                             />


### PR DESCRIPTION
## What does this change?
– Makes ad consents work in IE (oops!)
– Improves eventual testability of the react app by not depending on js globals but instead having the main app component take all imports itself

## What is the value of this and can you measure success?
Robust-er code