### PR TITLE
Pretty up the new cookie consent banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,6 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { Message } from 'common/modules/ui/message';
+import checkIcon from 'svgs/icon/arrow-right.svg';
 import {
     getAdConsentState,
     setAdConsentState,
@@ -16,6 +17,7 @@ const lifeTimeViewsKey: string = 'first-pv-consent.lifetime-views';
 const lifetimeDisplayEventKey: string = 'first-pv-consent : viewed-times :';
 
 type Template = {
+    heading: string,
     consentText: string,
     agreeButton: string,
     choicesButton: string,
@@ -27,6 +29,7 @@ type BindableClassNames = {
 };
 
 const template: Template = {
+    heading: `Your privacy`,
     consentText: `Do you agree to the use of cookies on our website and the sharing of data with our partners to see ads that are more relevant to you? You can learn more in our updated privacy policy and cookie policy, effective 25 May 2018.`,
     agreeButton: 'I agree',
     choicesButton: 'Show me more options',
@@ -38,6 +41,9 @@ const bindableClassNames: BindableClassNames = {
 };
 
 const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
+    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__head">${
+        tpl.heading
+    }</div>
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__intro">${
         tpl.consentText
     }</div>
@@ -49,7 +55,7 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
 }</a>
         <button data-link-name="first-pv-consent : agree" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
             classes.agree
-        }">${tpl.agreeButton}</button>
+        }">${checkIcon.markup}<span>${tpl.agreeButton}</span></button>
     </div>
 `;
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -41,13 +41,13 @@ const bindableClassNames: BindableClassNames = {
 };
 
 const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
-    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__head">${
+    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--head">${
         tpl.heading
     }</div>
-    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__intro">${
+    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">${
         tpl.consentText
     }</div>
-    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__actions">
+    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--actions">
         <button 
             data-link-name="first-pv-consent : agree" 
             class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
@@ -57,7 +57,7 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
         <a 
             href="${tpl.linkToPreferences}" 
             data-link-name="first-pv-consent : to-prefs" 
-            class="site-message--first-pv-consent__button site-message--first-pv-consent__button--link"
+            class="site-message--first-pv-consent__link"
         >${tpl.choicesButton}</a>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,5 +1,6 @@
 // @flow
 import config from 'lib/config';
+import { getCookie } from 'lib/cookies';
 import { Message } from 'common/modules/ui/message';
 import checkIcon from 'svgs/icon/tick.svg';
 import {
@@ -31,17 +32,21 @@ type BindableClassNames = {
 type Links = {
     privacy: string,
     cookies: string,
-}
+};
 
-const links :Links= {
+const links: Links = {
     privacy: 'https://www.theguardian.com/help/privacy-policy',
     cookies: 'https://www.theguardian.com/info/cookies',
-}
+};
 
 const template: Template = {
     heading: `Your privacy`,
     consentText: `We use cookies to improve your experience on our site and to show you relevant advertising. 
-To find out more, read our updated <a data-link-name="first-pv-consent : to-privacy" href="${links.privacy}">privacy policy</a> and <a data-link-name="first-pv-consent : to-cookies" href="${links.cookies}">cookie policy</a>.`,
+To find out more, read our updated <a data-link-name="first-pv-consent : to-privacy" href="${
+        links.privacy
+    }">privacy policy</a> and <a data-link-name="first-pv-consent : to-cookies" href="${
+        links.cookies
+    }">cookie policy</a>.`,
     agreeButton: 'OK',
     choicesButton: 'More information',
     linkToPreferences: `${config.get('page.idUrl')}/adverts/manage`,
@@ -73,6 +78,9 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
     </div>
 `;
 
+const isInEEA = (): boolean =>
+    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
+
 const onAgree = (msg: Message): void => {
     allAdConsents.forEach(_ => {
         setAdConsentState(_, true);
@@ -84,7 +92,7 @@ const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);
 
 const canShow = (): Promise<boolean> =>
-    Promise.resolve([hasUnsetAdChoices()].every(_ => _ === true));
+    Promise.resolve([hasUnsetAdChoices(), isInEEA()].every(_ => _ === true));
 
 const trackInteraction = (interaction: string): void => {
     ophan.record({

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -19,7 +19,7 @@ const lifetimeDisplayEventKey: string = 'first-pv-consent : viewed-times :';
 
 type Template = {
     heading: string,
-    consentText: string,
+    consentText: string[],
     agreeButton: string,
     choicesButton: string,
     linkToPreferences: string,
@@ -41,12 +41,14 @@ const links: Links = {
 
 const template: Template = {
     heading: `Your privacy`,
-    consentText: `We use cookies to improve your experience on our site and to show you relevant advertising. 
-To find out more, read our updated <a data-link-name="first-pv-consent : to-privacy" href="${
-        links.privacy
-    }">privacy policy</a> and <a data-link-name="first-pv-consent : to-cookies" href="${
-        links.cookies
-    }">cookie policy</a>.`,
+    consentText: [
+        `We use cookies to improve your experience on our site and to show you relevant advertising.`,
+        `To find out more, read our updated <a data-link-name="first-pv-consent : to-privacy" href="${
+            links.privacy
+        }">privacy policy</a> and <a data-link-name="first-pv-consent : to-cookies" href="${
+            links.cookies
+        }">cookie policy</a>.`,
+    ],
     agreeButton: 'OK',
     choicesButton: 'More information',
     linkToPreferences: `${config.get('page.idUrl')}/adverts/manage`,
@@ -60,9 +62,9 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--head">${
         tpl.heading
     }</div>
-    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">${
-        tpl.consentText
-    }</div>
+    <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">${tpl.consentText
+        .map(_ => `<p>${_}</p>`)
+        .join('')}</div>
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--actions">
         <button 
             data-link-name="first-pv-consent : agree" 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -28,11 +28,22 @@ type BindableClassNames = {
     agree: string,
 };
 
+type Links = {
+    privacy: string,
+    cookies: string,
+}
+
+const links :Links= {
+    privacy: 'https://www.theguardian.com/help/privacy-policy',
+    cookies: 'https://www.theguardian.com/info/cookies',
+}
+
 const template: Template = {
     heading: `Your privacy`,
-    consentText: `Do you agree to the use of cookies on our website and the sharing of data with our partners to see ads that are more relevant to you? You can learn more in our updated privacy policy and cookie policy, effective 25 May 2018.`,
-    agreeButton: 'I agree',
-    choicesButton: 'Show me more options',
+    consentText: `We use cookies to improve your experience on our site and to show you relevant advertising. 
+To find out more, read our updated <a data-link-name="first-pv-consent : to-privacy" href="${links.privacy}">privacy policy</a> and <a data-link-name="first-pv-consent : to-cookies" href="${links.cookies}">cookie policy</a>.`,
+    agreeButton: 'OK',
+    choicesButton: 'More information',
     linkToPreferences: `${config.get('page.idUrl')}/adverts/manage`,
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -81,7 +81,12 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
 `;
 
 const isInEEA = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
+    [
+        (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU',
+        ['NO', 'IS', 'LI'].includes(
+            (getCookie('GU_country') || 'OTHER').toUpperCase()
+        ),
+    ].some(_ => _ === true);
 
 const onAgree = (msg: Message): void => {
     allAdConsents.forEach(_ => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { Message } from 'common/modules/ui/message';
-import checkIcon from 'svgs/icon/arrow-right.svg';
+import checkIcon from 'svgs/icon/tick.svg';
 import {
     getAdConsentState,
     setAdConsentState,
@@ -48,14 +48,17 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
         tpl.consentText
     }</div>
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__actions">
-        <a href="${
-            tpl.linkToPreferences
-        }" data-link-name="first-pv-consent : to-prefs" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--link">${
-    tpl.choicesButton
-}</a>
-        <button data-link-name="first-pv-consent : agree" class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
-            classes.agree
-        }">${checkIcon.markup}<span>${tpl.agreeButton}</span></button>
+        <button 
+            data-link-name="first-pv-consent : agree" 
+            class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
+                classes.agree
+            }"
+        >${checkIcon.markup}<span>${tpl.agreeButton}</span></button>
+        <a 
+            href="${tpl.linkToPreferences}" 
+            data-link-name="first-pv-consent : to-prefs" 
+            class="site-message--first-pv-consent__button site-message--first-pv-consent__button--link"
+        >${tpl.choicesButton}</a>
     </div>
 `;
 

--- a/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
@@ -60,8 +60,17 @@ $underline: hsla(0, 100%, 100%, .5);
             align-items: center;
         }
     }
+    .site-message--first-pv-consent__head {
+        @include fs-header(4);
+        font-size: 24px;
+        position: relative;
+        padding-bottom: $gs-baseline/3;
+        line-height: get-line-height(header, 2);    
+        width: gs-span(4);
+        flex: 0 0 auto;
+    }
     .site-message--first-pv-consent__intro {
-        flex: 1 1 auto;
+        flex: 1 1 0;
         a {
             @extend %link;
             color: currentColor;
@@ -69,6 +78,7 @@ $underline: hsla(0, 100%, 100%, .5);
     }
     .site-message--first-pv-consent__actions {
         flex: 0 0 auto;
+        margin-right: gs-span(1);
     }
 }
 
@@ -86,4 +96,7 @@ $underline: hsla(0, 100%, 100%, .5);
 
 .site-message--first-pv-consent__block {
     margin: $gs-gutter / 2 0;
+    &:not(:last-child) {
+        margin-right: $gs-gutter*2;
+    }
 }

--- a/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
@@ -1,4 +1,5 @@
 $underline: hsla(0, 100%, 100%, .5);
+$btn-height: ($gs-baseline*3.5);
 
 %link {
     text-decoration: underline;
@@ -12,20 +13,47 @@ $underline: hsla(0, 100%, 100%, .5);
     }
 }
 
-$btn-height: ($gs-baseline*3.5);
+.site-message.site-message--first-pv-consent {
+    padding: ($gs-baseline / 2) 0 $gs-baseline;
+
+    .site-message__media {
+        display: none;
+    }
+    .site-message__inner {
+        padding: 0;
+    }
+    .site-message__copy {
+        display: block;
+        margin: 0 $gs-gutter / 2;
+        @include mq(mobileLandscape) {
+            margin-left: $gs-gutter;
+            margin-right: $gs-gutter;
+        }
+        @include mq(tablet) {
+            display: flex;
+            align-items: flex-start;
+        }
+    }
+}
+
 .site-message--first-pv-consent__button {
-    @include fs-textSans(3);
+    @include fs-textSans(5);
     @include circular;
     height: $btn-height;
-    background: transparent;
-    padding: 0 $gs-gutter 0 $gs-gutter+($btn-height*.5);
+    background: $news-garnett-highlight;
+    color: $garnett-neutral-1;
+    padding: 0 ($gs-gutter*1.25) 0 ($gs-gutter*1.25)+($btn-height*.5);
     display: block;
-    color: currentColor;
     align-items: flex-start;
     justify-content: space-between;
     cursor: pointer;
     position: relative;
-
+    border: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    &:hover {
+        background: darken($news-garnett-highlight, 1%);
+    }
     svg {
         position: absolute;
         top: 0;
@@ -39,46 +67,20 @@ $btn-height: ($gs-baseline*3.5);
             fill: $garnett-neutral-1;
         }
     }
-
-    &.site-message--first-pv-consent__button--link {
-        @extend %link;
-        padding-left: 0;
-        padding-right: 0;
-        height: auto;
-    }
-
-    &.site-message--first-pv-consent__button--main {
-        @include fs-textSans(5, true);
-        background: $news-garnett-highlight;
-        color: $garnett-neutral-1;
-        border: 0;
-        &:hover {
-            background: darken($news-garnett-highlight, 1%);
-        }
-    }
 }
 
+.site-message--first-pv-consent__link {
+    @extend %link;
+    display: block;
+}
 
-.site-message.site-message--first-pv-consent {
-    .site-message__media {
-        display: none;
+.site-message--first-pv-consent__block {
+    @include fs-textSans(3);
+
+    &:not(:last-child) {
+        margin-right: $gs-gutter;
     }
-    .site-message__inner {
-        padding: 0;
-    }
-    .site-message__copy {
-        margin: 0 $gs-gutter / 2;
-        display: block;
-        @include mq(mobileLandscape) {
-            margin-left: $gs-gutter;
-            margin-right: $gs-gutter;
-        }
-        @include mq(tablet) {
-            display: flex;
-            align-items: flex-start;
-        }
-    }
-    .site-message--first-pv-consent__head {
+    &.site-message--first-pv-consent__block--head {
         @include fs-header(4);
         @include mq(tablet) {
             width: gs-span(2);
@@ -89,26 +91,25 @@ $btn-height: ($gs-baseline*3.5);
         @include mq($until: wide) {
             @include font-size(20px, 24px);
         }
+        flex: 0 0 auto;
         position: relative;
         padding-bottom: $gs-baseline/3;
         line-height: get-line-height(header, 2);
-        flex: 0 0 auto;
     }
-    .site-message--first-pv-consent__intro {
-        @include fs-textSans(3);
+    &.site-message--first-pv-consent__block--intro {
         flex: 1 1 0;
-
         a {
             @extend %link;
             color: currentColor;
         }
     }
-    .site-message--first-pv-consent__actions {
+    &.site-message--first-pv-consent__block--actions {
         flex: 0 0 auto;
         @include mq($until: tablet) {
             display: flex;
             justify-content: space-between;
             align-items: center;
+            margin-top:$gs-baseline;
         }
         @include mq(tablet) {
             .site-message--first-pv-consent__button--main {
@@ -121,24 +122,5 @@ $btn-height: ($gs-baseline*3.5);
         @include mq(wide) {
             margin-right: gs-span(1) + $gs-gutter;
         }
-    }
-}
-
-.site-message--first-pv-consent__actions {
-    .site-message--first-pv-consent__button {
-        margin: 0 $gs-gutter / 4;
-        &:first-child {
-            margin-left: 0;
-        }
-        &:last-child {
-            margin-right: 0;
-        }
-    }
-}
-
-.site-message--first-pv-consent__block {
-    margin: $gs-gutter / 2 0;
-    &:not(:last-child) {
-        margin-right: $gs-gutter;
     }
 }

--- a/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
@@ -109,7 +109,7 @@ $btn-height: ($gs-baseline*3.5);
             display: flex;
             justify-content: space-between;
             align-items: center;
-            margin-top:$gs-baseline;
+            margin-top: $gs-baseline;
         }
         @include mq(tablet) {
             .site-message--first-pv-consent__button--main {

--- a/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
@@ -12,30 +12,48 @@ $underline: hsla(0, 100%, 100%, .5);
     }
 }
 
+$btn-height: ($gs-baseline*3.5);
 .site-message--first-pv-consent__button {
     @include fs-textSans(3);
     @include circular;
     height: $btn-height;
     background: transparent;
-    padding: 0 $gs-gutter;
-    display: inline-block;
-    display: inline-flex;
+    padding: 0 $gs-gutter 0 $gs-gutter+($btn-height*.5);
+    display: block;
     color: currentColor;
-    vertical-align: middle;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     cursor: pointer;
+    position: relative;
+
+    svg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        margin: auto;
+        width: $btn-height;
+        height: $btn-height;
+        transform: scale(.5);
+        g, path {
+            fill: $garnett-neutral-1;
+        }
+    }
 
     &.site-message--first-pv-consent__button--link {
         @extend %link;
         padding-left: 0;
         padding-right: 0;
+        height: auto;
     }
 
     &.site-message--first-pv-consent__button--main {
-        border: 1px solid $underline;
+        @include fs-textSans(5, true);
+        background: $news-garnett-highlight;
+        color: $garnett-neutral-1;
+        border: 0;
         &:hover {
-            border-color: currentColor;
+            background: darken($news-garnett-highlight, 1%);
         }
     }
 }
@@ -57,20 +75,29 @@ $underline: hsla(0, 100%, 100%, .5);
         }
         @include mq(tablet) {
             display: flex;
-            align-items: center;
+            align-items: flex-start;
         }
     }
     .site-message--first-pv-consent__head {
         @include fs-header(4);
-        font-size: 24px;
+        @include mq(tablet) {
+            width: gs-span(2);
+        }
+        @include mq(wide) {
+            width: gs-span(3);
+        }
+        @include mq($until: wide) {
+            @include font-size(20px, 24px);
+        }
         position: relative;
         padding-bottom: $gs-baseline/3;
-        line-height: get-line-height(header, 2);    
-        width: gs-span(4);
+        line-height: get-line-height(header, 2);
         flex: 0 0 auto;
     }
     .site-message--first-pv-consent__intro {
+        @include fs-textSans(3);
         flex: 1 1 0;
+
         a {
             @extend %link;
             color: currentColor;
@@ -78,7 +105,22 @@ $underline: hsla(0, 100%, 100%, .5);
     }
     .site-message--first-pv-consent__actions {
         flex: 0 0 auto;
-        margin-right: gs-span(1);
+        @include mq($until: tablet) {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        @include mq(tablet) {
+            .site-message--first-pv-consent__button--main {
+                margin-bottom: $gs-baseline / 2;
+            }
+        }
+        @include mq(desktop) {
+            width: gs-span(3);
+        }
+        @include mq(wide) {
+            margin-right: gs-span(1) + $gs-gutter;
+        }
     }
 }
 
@@ -97,6 +139,6 @@ $underline: hsla(0, 100%, 100%, .5);
 .site-message--first-pv-consent__block {
     margin: $gs-gutter / 2 0;
     &:not(:last-child) {
-        margin-right: $gs-gutter*2;
+        margin-right: $gs-gutter;
     }
 }


### PR DESCRIPTION
## What does this change?
Add the final copy and design (thanks zef!) to the new gdpr compliant cookie banner.

Also adds a new check to only display it for users located in the EU fastly region.

## Screenshots
![screen shot 2018-05-22 at 1 13 31 pm](https://user-images.githubusercontent.com/11539094/40361636-f1319bec-5dc1-11e8-88ce-89478e988d73.png)
