### PR TITLE
Make effect of personalised ad consent clearer

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -72,12 +72,22 @@ const setDfpListeners = (): void => {
 
 const setPersonalisedAds = (): void => {
     if (config.switches.includePersonalisedAdsConsent) {
-        // everything except an explicit non-consent gives personalised ads
-        const personalised =
-            getAdConsentState(thirdPartyTrackingAdConsent) !== false;
-        window.googletag
-            .pubads()
-            .setRequestNonPersonalizedAds(personalised ? 0 : 1);
+        const wantPersonalisedAds: ?boolean = getAdConsentState(
+            thirdPartyTrackingAdConsent
+        );
+        switch (wantPersonalisedAds) {
+            // personalised ads have been explicitly accepted
+            case true:
+                window.googletag.pubads().setRequestNonPersonalizedAds(0);
+                break;
+            // personalised ads have been explicitly rejected
+            case false:
+                window.googletag.pubads().setRequestNonPersonalizedAds(1);
+                break;
+            // no preference has been specified
+            default:
+                window.googletag.pubads();
+        }
     }
 };
 


### PR DESCRIPTION
Previously,  there was no distinction between explicitly denying consent and not specifying a decision.
Now the two cases are distinguished.