### PR TITLE
Inside the guardian - nav link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -460,6 +460,7 @@ object NavLinks {
     podcasts,
     pictures,
     newsletters,
+    insideTheGuardian,
     digitalNewspaperArchive,
     crosswords
   )
@@ -469,6 +470,7 @@ object NavLinks {
     podcasts,
     pictures,
     newsletters,
+    insideTheGuardian,
     digitalNewspaperArchive,
     crosswords
   )

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -141,6 +141,7 @@ object NavLinks {
       NavLink("Saturday review", "/theguardian/guardianreview")
     )
   )
+  val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/membership/series/inside-the-guardian")
   val observer = NavLink("The Observer", "/observer",
     children = List(
       NavLink("Comment", "/theobserver/news/comment"),
@@ -446,6 +447,7 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
+    insideTheGuardian,
     observer,
     digitalNewspaperArchive,
     NavLink("Professional networks", "/guardian-professional"),
@@ -477,6 +479,7 @@ object NavLinks {
     pictures,
     newsletters,
     todaysPaper,
+    insideTheGuardian,
     observer,
     digitalNewspaperArchive,
     crosswords


### PR DESCRIPTION
A new link added to all editions in the More section of the expanded nav:

<img width="478" alt="screen shot 2018-05-22 at 14 45 42" src="https://user-images.githubusercontent.com/14570016/40366370-dbe8ef8a-5dce-11e8-8a34-3cc1ab0d29bb.png">
