### PR TITLE
Replace branded consent journey

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -24,7 +24,8 @@ trait ConsentsJourney
   def displayConsentsJourneyThankYou: Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageThankYou, None)
 
-  /** GET /consents/staywithus */
+  /** previously GET /consents/staywithus, now unused - but may come back */
+  //TODO: remove this once confirmed branded version of journey not needed
   def displayConsentsJourneyGdprCampaign: Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageGdprCampaign, None)
 

--- a/identity/app/utils/ConsentsJourneyType.scala
+++ b/identity/app/utils/ConsentsJourneyType.scala
@@ -4,7 +4,6 @@ object ConsentsJourneyType {
 
   sealed trait AnyConsentsJourney
 
-  case object NewsletterConsentsJourney extends AnyConsentsJourney
   case object ThankYouConsentsJourney extends AnyConsentsJourney
   case object GdprCampaignConsentsJourney extends AnyConsentsJourney
   case object DefaultConsentsJourney extends AnyConsentsJourney

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -133,7 +133,7 @@
 @introStep = @{
     ConsentStep(
         name = "intro",
-        title = "Please select the emails you wish to continue receiving",
+        title = "Please select the emails you wish to receive",
         help = List(
             ConsentStepHelpText(
                 "You can change your preferences anytime by signing in, clicking My Account, then selecting Email Preferences."

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -189,15 +189,6 @@
     " data-journey="@journey" data-component="identity-consent-journey-@journey">
         @renderBlocks(
             journey match {
-                case NewsletterConsentsJourney => {
-                    List(
-                        ConsentStep(
-                            name = "error",
-                            title = "Sorry",
-                            content = Html("<p class=\"form__error\">Something went wrong updating your newsletters.</p>")
-                        )
-                    )
-                }
                 case ThankYouConsentsJourney => {
                     List(
                         ConsentBanner(

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -71,7 +71,7 @@ GET         /adverts/manage                         controllers.AdvertsManager.r
 # Consents journey
 ########################################################################################################################
 GET         /consents/thank-you                     controllers.editprofile.EditProfileController.displayConsentsJourneyThankYou
-GET         /consents/staywithus                    controllers.editprofile.EditProfileController.displayConsentsJourneyGdprCampaign
+GET         /consents/staywithus                    controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 GET         /consents                               controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
 GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete


### PR DESCRIPTION
## What does this change?
The branded version of the consent journey is no longer needed for Friday (at least temporarily).  This PR just replaces it with the "regular" journey, leaving the functionality intact in case we get updated branding going forwards (all TBD).

Looks like there are some changes here that should have been in the last PR instead, but they don't affect functionality anyway - just dead code being removed.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
