### PR TITLE
Add pillar tracking to google analytics

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -4,8 +4,15 @@
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.{Commercial, GoogleAnalyticsAccount}
 @import conf.Configuration
+@import common.Edition
+@import navigation.NavMenu
 
 <script id='google_analytics'>
+
+@defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+    const pillar = '@{navMenu.currentPillar.map(_.title).getOrElse("")}';
+}
+
 
 (function() {
 
@@ -107,11 +114,13 @@
           ga('@{trackerName}.set', 'dimension42', '@brandingType.name');
         }
         ga('@{trackerName}.set', 'dimension43', getExperienceValue()); @* 'Experience' dimension, for short-lived experiment values. *@
+        ga('@{trackerName}.set', 'dimension50', pillar);
 
         if(document.location.hash === '#fbLogin') {
             ga('@{trackerName}.set', 'referrer', null);
             document.location.hash = '';
         }
+
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker(context).trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?

I added dimension 50 to the [dimensions spreadsheet](https://docs.google.com/spreadsheets/d/1MmWHNeeiQE_dzekImIP9Tv4beLx_8JzWx3rOtCp4PGg/edit?usp=sharing) and I've found some code to grab the pillar name out of the nav model. Not sure if I need to do anything more for this.

The original ticket asked for the pillar name and pillar ID, with potentially only the ID being needed. But it looks easier to implement the name than the ID since the name is already on the models we're working with. I might dig more around the code and see if there's a better way of grabbing the pillar ID.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
