### PR TITLE
Remove extraneous `overflow:hidden` from footer.scss

### DIFF
--- a/static/src/stylesheets/layout/footer/_footer.scss
+++ b/static/src/stylesheets/layout/footer/_footer.scss
@@ -19,7 +19,3 @@
         color: $neutral-3;
     }
 }
-
-.footer__primary {
-    overflow: hidden;
-}


### PR DESCRIPTION
## What does this change?
`footer.scss` was cutting off the `back to top` link circle in pages without a double footer. I investigated this with @SiAdcock and this property dates back to 2015 and with the current layout, it is unnecessary. (My guess is it could have been a one-line clearfix at some point?)

So, the site looks nicer and we get three lines of code out of the codebase. Win-win!

## Screenshots
![screen shot 2018-05-23 at 10 38 00 am](https://user-images.githubusercontent.com/11539094/40416682-c907b372-5e75-11e8-99a0-0190bb87ca3f.png)
![screen shot 2018-05-23 at 10 39 05 am](https://user-images.githubusercontent.com/11539094/40416687-cab46d78-5e75-11e8-9a15-eb07ae1e5890.png)
