### PR TITLE
Don't send Krux segments to DFP if opted out of personalised ads

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -71,8 +71,12 @@ const retrieve = (n: string): string => {
     return local.getRaw(k) || getCookie(`${k}=([^;]*)`) || '';
 };
 
-export const getKruxSegments = (): Array<string> =>
-    retrieve('segs') ? retrieve('segs').split(',') : [];
+export const getKruxSegments = (): Array<string> => {
+    const wantPersonalisedAds: boolean =
+        getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    const segments: string = wantPersonalisedAds ? retrieve('segs') : '';
+    return segments ? segments.split(',') : [];
+};
 
 export const krux: ThirdPartyTag = {
     shouldRun: config.switches.krux,


### PR DESCRIPTION
This shouldn't be necessary, but it appears to be necessary at the moment.