### PR TITLE
Epic borders and thank you test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 6, 5),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-border-thankyou",
+    "Try 2 variants - one adding a border to the epic and one with copy thanking our readers",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 6, 5),
+    exposeClientSide = true
+  )
 }

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -29,7 +29,9 @@
                 "adblock-coins-us": "@Static("images/membership/adblock-coins-us.png")"
             },
             "acquisitions": {
-                "paypal-and-credit-card": "@Static("images/acquisitions/paypal-and-credit-card.png")"
+                "paypal-and-credit-card": "@Static("images/acquisitions/paypal-and-credit-card.png")",
+                "info-logo": "@Static("images/acquisitions/info-logo.svg")"
+
             },
             "identity": {
                 "missing": "@Static("images/identity/missing.svg")"

--- a/static/public/images/acquisitions/info-logo.svg
+++ b/static/public/images/acquisitions/info-logo.svg
@@ -1,0 +1,12 @@
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Epic-border-i-2" transform="translate(-63.000000, -94.000000)">
+            <g id="Group" transform="translate(63.000000, 94.000000)">
+                <circle id="Oval" fill="#FFE500" cx="10" cy="10" r="10"></circle>
+                <text id="i" font-family="GHGuardianHeadline-MediumItalic, GH Guardian Headline" font-size="18" font-style="italic" font-weight="500" fill="#121212">
+                    <tspan x="7" y="16">i</tspan>
+                </text>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -41,6 +41,9 @@ const controlP1Highlight =
 const dropAdsFallingP1 =
     '&hellip; we have a small favour to ask. Unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. More people are reading the Guardian than ever but our independent, investigative journalism takes a lot of time, money and hard work to produce. So you can see why we need to ask for your help. We do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 
+const thankyouP2FirstSentence =
+    'Thank you to the many people who have already supported us financially &ndash; your contribution is what makes stories like you’ve just read possible. We increasingly need our readers to fund our work so that we can continue holding power to account and producing fearless journalism.</br></br>';
+
 /*
  Exported instances of AcquisitionsEpicTemplateCopy
  */
@@ -66,6 +69,12 @@ export const dropAdsFallingCopy = {
     heading: controlHeading,
     p1: dropAdsFallingP1,
     p2: controlP2(controlP2FirstSentence),
+};
+
+export const thankyou = {
+    heading: controlHeading,
+    p1: controlP1,
+    p2: controlP2(thankyouP2FirstSentence),
 };
 
 export const liveblogCopy = (

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-border.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-border.js
@@ -1,0 +1,42 @@
+// @flow
+import config from 'lib/config';
+
+export const acquisitionsEpicBorderTemplate = ({
+    copy: { heading = '', p1, p2 },
+    componentName,
+    buttonTemplate,
+    testimonialBlock = '',
+}: {
+    copy: AcquisitionsEpicTemplateCopy,
+    componentName: string,
+    buttonTemplate: string,
+    testimonialBlock?: string,
+}) => {
+    const infoLogo = `<img class="contributions__info-logo" src="${config.get(
+        'images.acquisitions.info-logo',
+        ''
+    )}" alt="Info">`;
+
+    return `
+        <div class="contributions__epic contributions__epic_border" data-component="${
+            componentName
+        }">
+        <div>
+            <div>
+                <h2 class="contributions__title contributions__title--epic">
+                    ${infoLogo}${heading}
+                </h2>
+                <p class="contributions__paragraph contributions__paragraph--epic">
+                    ${p1}
+                </p>
+                ${testimonialBlock}
+                <p class="contributions__paragraph contributions__paragraph--epic">
+                    ${p2}
+                </p>
+            </div>
+    
+            ${buttonTemplate}
+        </div>
+    </div>
+    `;
+};

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,6 +14,7 @@ import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAlwaysAskAprilStory } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-april-story';
 import { AcquisitionsEpicDoubleHighlightDropAdsFalling } from 'common/modules/experiments/tests/acquisitions-epic-double-highlight-drop-ads-falling';
+import { AcquisitionsEpicBorderThankyou } from 'common/modules/experiments/tests/acquisitions-epic-border-thankyou';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -41,6 +42,7 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicAlwaysAskAprilStory,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
+    AcquisitionsEpicBorderThankyou,
     AcquisitionsEpicDoubleHighlightDropAdsFalling,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-border-thankyou.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-border-thankyou.js
@@ -1,0 +1,54 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { control, thankyou } from 'common/modules/commercial/acquisitions-copy';
+import { acquisitionsEpicBorderTemplate } from 'common/modules/commercial/templates/acquisitions-epic-border';
+
+const abTestName = 'AcquisitionsEpicBorderThankyou';
+
+export const AcquisitionsEpicBorderThankyou: EpicABTest = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-05-23',
+    expiry: '2018-06-05',
+
+    author: 'Jonathan Rankin',
+    description:
+        'Try 2 variants - one adding a border to the epic and one with copy thanking our readers',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Both variants beat the control',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    variants: [
+        {
+            id: 'control',
+            products: [],
+        },
+        {
+            id: 'border',
+            products: [],
+            options: {
+                template(variant) {
+                    return acquisitionsEpicBorderTemplate({
+                        copy: control,
+                        componentName: variant.options.componentName,
+                        buttonTemplate: variant.options.buttonTemplate({
+                            supportUrl: variant.options.supportURL,
+                        }),
+                        testimonialBlock: variant.options.testimonialBlock,
+                    });
+                },
+            },
+        },
+        {
+            id: 'thankyou',
+            products: [],
+            options: {
+                copy: thankyou,
+            },
+        },
+    ],
+});

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -132,6 +132,11 @@
     height: 25px;
 }
 
+.contributions__info-logo {
+    vertical-align: sub;
+    padding-right: 10px;
+}
+
 .contributions__contribute {
     background-color: $news-main-1;
     color: #ffffff;
@@ -254,4 +259,11 @@ a[href].contributions__contribute.contributions__contribute--epic {
     border: 0;
     width: 100%;
     max-width: 620px;
+}
+
+.contributions__epic_border {
+    border-top: 8px solid #121212;
+    border-left: 1px solid #121212;
+    padding-left: 10px;
+    padding-right: 10px;
 }


### PR DESCRIPTION
## What does this change?

New epic test, testing a) adding a border and an info logo to the epic and b) the impact of thanking our readers in the epic copy.


| Control | ![control](https://user-images.githubusercontent.com/2844554/40240757-36c7c0be-5ab1-11e8-8b98-24a6cab2c149.png)|
|---------|--------|
| Borders - mobile | ![high](https://user-images.githubusercontent.com/2844554/40421700-b12f5188-5e84-11e8-8e0b-5f40282158ee.png) |
| Borders - desktop | ![high](https://user-images.githubusercontent.com/2844554/40421733-c6227e8a-5e84-11e8-8848-c28f6671e59c.png) |
|   Thankyou message      |  ![image](https://user-images.githubusercontent.com/2844554/40422587-c2e58aca-5e87-11e8-9059-ced485befa82.png)   |





@guardian/contributions 