### PR TITLE
Set flag when a banner has been picked

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
@@ -39,6 +39,7 @@ const init = (banners: Array<Banner>): Promise<void> => {
     return new Promise(resolve => {
         const TIME_LIMIT = 2000;
         const messageStates = userPrefs.get('messages');
+        let bannerPicked = false;
 
         banners.forEach((banner, index) => {
             const pushToResults = (result: boolean): void => {
@@ -46,9 +47,11 @@ const init = (banners: Array<Banner>): Promise<void> => {
 
                 const successfulBannerIndex = getSuccessfulBannerIndex();
 
-                if (successfulBannerIndex !== -1) {
+                if (!bannerPicked && successfulBannerIndex !== -1) {
                     const successfulBanner = banners[successfulBannerIndex];
                     successfulBanner.show();
+
+                    bannerPicked = true;
 
                     const trackingObj = {
                         component: 'banner-picker',

--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.spec.js
@@ -160,6 +160,7 @@ describe('bannerPicker', () => {
                     expect(fakeOphan.record).toHaveBeenCalledWith(trackingObj);
                     banners.forEach((banner, index) => {
                         if (index === test.successfulIndex) {
+                            expect(banner.show).toHaveBeenCalledTimes(1);
                             expect(banner.show).toHaveBeenCalled();
                         } else {
                             expect(banner.show).not.toHaveBeenCalled();


### PR DESCRIPTION
## What does this change?

Sets a flag when a banner has been picked in `bannerPicker`, so any subsequent `banner.canShow`s that resolve don't cause `banner.show` of the winning banner to be called more than once .

## What is the value of this and can you measure success?

Fixes bug causing inaccurate tracking

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

No

## Tested in CODE?

No