### PR TITLE
Profiling optout to email-prefs page

### DIFF
--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -23,8 +23,7 @@ class AccountDetailsMapping
       "address"                   -> idAddress,
       "billingAddress"            -> optional(idAddress),
       "telephoneNumber"           -> optional(telephoneNumberMapping),
-      "deleteTelephoneNumber"     -> default(boolean, false),
-      "allowThirdPartyProfiling"  -> boolean
+      "deleteTelephoneNumber"     -> default(boolean, false)
     )(AccountFormData.apply)(AccountFormData.unapply _)
 
   protected def toUserFormData(user: User) = AccountFormData(user)
@@ -46,8 +45,7 @@ class AccountDetailsMapping
     ("privateFields.billingAddress4", "billingAddress.line4"),
     ("privateFields.billingPostcode", "billingAddress.postcode"),
     ("privateFields.billingCountry", "billingAddress.country"),
-    ("privateFields.telephoneNumber", "telephoneNumber"),
-    ("statusFields.allowThirdPartyProfiling", "allowThirdPartyProfiling")
+    ("privateFields.telephoneNumber", "telephoneNumber")
   )
 }
 
@@ -60,8 +58,7 @@ case class AccountFormData(
   address: AddressFormData,
   billingAddress: Option[AddressFormData],
   telephoneNumber: Option[TelephoneNumberFormData],
-  deleteTelephone: Boolean = false,
-  allowThirdPartyProfiling: Boolean = true
+  deleteTelephone: Boolean = false
 ) extends UserFormData {
 
   def toUserUpdateDTO(currentUser: User): UserUpdateDTO = UserUpdateDTO(
@@ -85,8 +82,6 @@ case class AccountFormData(
       billingCountry = billingAddress.flatMap(x => toUpdate(x.country, currentUser.privateFields.billingCountry)),
       telephoneNumber = telephoneNumber.flatMap(_.telephoneNumber)
     )),
-    statusFields = Some(currentUser.statusFields.copy(allowThirdPartyProfiling = Some(allowThirdPartyProfiling))),
-    consents = Some(List(Consent(id = Consent.ProfilingOptout.id, consented = !allowThirdPartyProfiling)))
   )
 }
 
@@ -119,7 +114,6 @@ object AccountFormData {
           billingPostcode.getOrElse(""),
           billingCountry.getOrElse("")))
     },
-    telephoneNumber = user.privateFields.telephoneNumber.map(TelephoneNumberFormData(_)),
-    allowThirdPartyProfiling = user.statusFields.allowThirdPartyProfiling.getOrElse(true)
+    telephoneNumber = user.privateFields.telephoneNumber.map(TelephoneNumberFormData(_))
   )
 }

--- a/identity/app/utils/ConsentOrder.scala
+++ b/identity/app/utils/ConsentOrder.scala
@@ -16,7 +16,8 @@ object ConsentOrder {
       "post_optout",
       "phone_optout",
       "sms",
-      "market_research_optout"
+      "market_research_optout",
+      "profiling_optout"
     )
 
   /**

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -198,27 +198,6 @@
     }
 
     <fieldset class="fieldset">
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Profiling</h2>
-        </div>
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
-                @accountDetailsForm.error("statusFields.allowThirdPartyProfiling").map { error =>
-                    <div class="form__error">@error.message</div>
-                }
-
-                <label class="label">In addition to the data that you provide to us, we may also match profiling data from third parties with your registration details.</label>
-
-                @checkboxField(
-                    Checkbox(
-                        accountDetailsForm("allowThirdPartyProfiling"),
-                        ('_label, "Allow matching with third party data"), Symbol("data-test-id") -> "profiling")
-                )(nonInputFields, messages)
-            </ul>
-        </div>
-    </fieldset>
-
-    <fieldset class="fieldset">
         <div class="fieldset__heading"></div>
         <div class="fieldset__fields">
             <button type="submit" class="manage-account__button manage-account__button--icon" data-link-name="Create account" data-test-id="save-changes">

--- a/identity/app/views/profile/otherChannels.scala.html
+++ b/identity/app/views/profile/otherChannels.scala.html
@@ -24,3 +24,11 @@
         @views.html.profile.nonElectronicOptOut(idUrlBuilder, idRequest, privacyForm, user)(request, messages)
     </div>
 </fieldset>
+<fieldset class="fieldset">
+    <div class="fieldset__heading">
+        <h2 class="form__heading">Using your data for marketing analysis</h2>
+    </div>
+    <div class="fieldset__fields">
+        @views.html.profile.profilingConsent(idUrlBuilder, idRequest, privacyForm, user)(request, messages)
+    </div>
+</fieldset>

--- a/identity/app/views/profile/profilingConsent.scala.html
+++ b/identity/app/views/profile/profilingConsent.scala.html
@@ -1,0 +1,29 @@
+@import views.support.fragment.ConsentChannel._
+
+@(
+    idUrlBuilder: services.IdentityUrlBuilder,
+    idRequest: services.IdentityRequest,
+    privacyForm: Form[_root_.form.PrivacyFormData],
+    user: com.gu.identity.model.User,
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+<form method="post" action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" novalidate>
+    @views.html.helper.CSRF.formField
+    <div class="manage-account__switches manage-account__switches--single-column js-manage-account__check-allCheckbox__ignore">
+        <ul>
+        @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
+            @if(isProfilingChannel(consentField, user)) {
+                <p class="identity-title-explainer">From time to time we may use your personal data for marketing analysis. That includes looking at what products or services you have bought from us and what pages you have been viewing on
+                    guardian.com and other Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this to understand your interests and preferences so that we can make out marketing communication more relevant to you.</p>
+                <li>
+                @fragments.consentSwitch(
+                    consentField,
+                    boldTitle = false,
+                    titleProvider = wording => wording.description.getOrElse(""),
+                    descriptionProvider = _ => None
+                )(messages)
+                </li>
+            }
+        }
+        </ul>
+    </div>
+</form>

--- a/identity/app/views/profile/profilingConsent.scala.html
+++ b/identity/app/views/profile/profilingConsent.scala.html
@@ -13,7 +13,7 @@
         @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
             @if(isProfilingChannel(consentField, user)) {
                 <p class="identity-title-explainer">From time to time we may use your personal data for marketing analysis. That includes looking at what products or services you have bought from us and what pages you have been viewing on
-                    guardian.com and other Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this to understand your interests and preferences so that we can make out marketing communication more relevant to you.</p>
+                    theguardian.com and other Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this to understand your interests and preferences so that we can make our marketing communication more relevant to you.</p>
                 <li>
                 @fragments.consentSwitch(
                     consentField,

--- a/identity/app/views/profile/profilingConsent.scala.html
+++ b/identity/app/views/profile/profilingConsent.scala.html
@@ -12,8 +12,7 @@
         <ul>
         @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
             @if(isProfilingChannel(consentField, user)) {
-                <p class="identity-title-explainer">From time to time we may use your personal data for marketing analysis. That includes looking at what products or services you have bought from us and what pages you have been viewing on
-                    theguardian.com and other Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this to understand your interests and preferences so that we can make our marketing communication more relevant to you.</p>
+                <p class="identity-title-explainer">From time to time we may use your personal data for marketing analysis. That includes looking at what products or services you have bought from us and what pages you have been viewing on theguardian.com and other Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this to understand your interests and preferences so that we can make our marketing communication more relevant to you.</p>
                 <li>
                 @fragments.consentSwitch(
                     consentField,

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -51,6 +51,8 @@ object ConsentChannel {
   def isMarketResearch(consentField: Field, user: User) : Boolean =
     consentField("id").value.exists(_ == MarketResearchConsentChannel.id)
 
+  def isProfilingChannel(consentField:Field, user: User): Boolean =
+    consentField("id").value.exists(_ == ProfilingConsentChannel.id)
 
   def isChannel(consentField: Field): Boolean = {
     consentField("id").value.exists { id => channelsIds.contains(id) }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.152"
+  val identityLibVersion = "3.154"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"


### PR DESCRIPTION
## What does this change?
- Adds the profiling optout to the email prefs page
- Makes it an optout on the frontend 
- Removes profiling from the account details page
- Bumps the identity version to get the latest wording

## What is the value of this and can you measure success?
GDPR and that

## Screenshots
![image](https://user-images.githubusercontent.com/14179210/40436737-8c28d540-5eab-11e8-8f50-58f4d733e867.png)



## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
