### PR TITLE
Move video carousel iframe before overlay

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -40,6 +40,21 @@
 }
 
         @for(asset <- activeAsset if playable && !expired) {
+            @defining(s"https://www.youtube.com/embed${
+                asset.id
+                    .addParams(List(
+                    "enablejsapi" -> 1,
+                    "rel" -> 0,
+                    "showinfo" -> 0,
+                    "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                )).toString
+            }") { embedUri: String  =>
+                <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"
+                src="@embedUri" frameborder="0"
+                allowfullscreen="">
+                </iframe>
+            }
+
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 <div class="video-overlay">
                     <div class="video-overlay__headline">
@@ -57,21 +72,6 @@
                     </div>
                     <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
                 }
-            }
-
-            @defining(s"https://www.youtube.com/embed${
-                asset.id
-                    .addParams(List(
-                    "enablejsapi" -> 1,
-                    "rel" -> 0,
-                    "showinfo" -> 0,
-                    "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
-                )).toString
-            }") { embedUri: String  =>
-                <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"
-                src="@embedUri" frameborder="0"
-                allowfullscreen="">
-                </iframe>
             }
         }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>


### PR DESCRIPTION
## What does this change?

The video carousel overlay does not disappear when the video starts playing

![eep](https://user-images.githubusercontent.com/5931528/40436108-29cb7926-5eaa-11e8-99fb-e2f34e62635c.gif)

This bug was introduced in #19651

This change moves the iframe back before the overlay to preserve [this awkward selector](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/atoms/_youtube.scss#L86-L88). Reintroduces a small accessibility issue around the order elements appear in the tab order.

## What is the value of this and can you measure success?

Removes overlay from playing videos

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
