### PR TITLE
use headline field in most-popular

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,3 +207,24 @@ val main = root().aggregate(
     baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
   )
 )
+val badgeHash = inputKey[Unit]("Generate special badge salts and hashes")
+badgeHash := {
+  import java.math.BigInteger
+  import java.security.MessageDigest
+  import complete.DefaultParsers._
+  import java.util.UUID
+
+  val result = spaceDelimited("<arg>").parsed.headOption.map { tag =>
+    val salt = UUID.randomUUID.toString.replaceAll("-", "")
+    val saltedTag = salt + tag
+    val digest = MessageDigest.getInstance("MD5")
+    digest.update(saltedTag.getBytes(), 0, saltedTag.length)
+    val hash = new BigInteger(1, digest.digest()).toString(16)
+    s"salt=$salt\nhash=$hash"
+  }.getOrElse {
+    "error: expected tag parameter"
+  }
+
+  println(result)
+}
+

--- a/docs/01-start-here/07-faqs.md
+++ b/docs/01-start-here/07-faqs.md
@@ -28,7 +28,7 @@ Sometimes we want to create a badge for a story, but don't want the world to kno
 
 To link a badge to a secret tag:
 
-1. Run `sbt "badgeHash [your tag]`"
+1. Run `sbt "badgeHash [your tag]"`
 2. The output looks like
 ```
 salt=XXXXXXXXX

--- a/docs/01-start-here/07-faqs.md
+++ b/docs/01-start-here/07-faqs.md
@@ -28,15 +28,11 @@ Sometimes we want to create a badge for a story, but don't want the world to kno
 
 To link a badge to a secret tag:
 
-1. Install `pwgen`, a random string generator. Mac users can install this using Homebrew: `brew install pwgen`
-2. Generate a bunch of random strings: `pwgen -n -y 20`. Copy one of them to the clipboard. This will be the salt.
-3. From the command line, run `sbt`. Inside `sbt` run `console`
-4. From the console run: `import java.security.MessageDigest`
-5. From the console run: `import java.math.BigInteger`
-6. From the console run: `val input = "[salt from the clipboard]" + "your/secret/tag"`
-7. From the console run: `val digest = MessageDigest.getInstance("MD5")`
-8. From the console run: `digest.update(input.getBytes(), 0, input.length)`
-9. From the console run: `new BigInteger(1, digest.digest()).toString(16)`
-10. The result of the last step is your encrypted tag
-11. In the `Badges` object, add a new val: `val specialReport = SpecialBadge("[salt]", "[encrypted tag]", Static("path/to/Badge.svg"))`
-12. In CODE create an article with your new tag and ensure the badge is applied correctly
+1. Run `sbt "badgeHash [your tag]`"
+2. The output looks like
+```
+salt=XXXXXXXXX
+hash=XXXXXXXXX
+```
+3. In the `Badges` object, add a new val: `val specialReport = SpecialBadge("[salt]", "[hashed tag]", Static("path/to/Badge.svg"))`
+4. In CODE create an article with your new tag and ensure the badge is applied correctly

--- a/docs/01-start-here/07-faqs.md
+++ b/docs/01-start-here/07-faqs.md
@@ -34,5 +34,5 @@ To link a badge to a secret tag:
 salt=XXXXXXXXX
 hash=XXXXXXXXX
 ```
-3. In the `Badges` object, add a new val: `val specialReport = SpecialBadge("[salt]", "[hashed tag]", Static("path/to/Badge.svg"))`
+3. In the `model.Badges` object, add a new val: `val specialReport = SpecialBadge("[salt]", "[hashed tag]", Static("path/to/Badge.svg"))`
 4. In CODE create an article with your new tag and ensure the badge is applied correctly

--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -20,7 +20,7 @@
                             </div>
                         }
                         <div class="media__body">
-                            <h4 class="right-most-popular-item__headline">@trail.properties.linkText</h4>
+                            <h4 class="right-most-popular-item__headline">@trail.header.headline</h4>
                             @trail.properties.maybeContent.map { content =>
                                 @if(content.tags.tags.exists(_.id == "tone/news")) {
                                     @fragments.contentAgeNotice(ContentOldAgeDescriber(content))

--- a/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
@@ -25,7 +25,7 @@
                                 @if(trail.properties.isLiveBlog) {
                                     <span class="right-most-popular__kicker">Live</span>
                                 }
-                                @trail.properties.webTitle
+                                @trail.header.headline
                             </h4>
                             @if(trail.properties.showByline) {
                                 <span class="


### PR DESCRIPTION
https://trello.com/c/vlrHs33O/98-use-headline-field-in-most-popular

## What does this change?

Uses the headline field for right most popular list. Also add badgeHash sbt command for generating badge hashes

## What is the value of this and can you measure success?

Don't display author name in header as seen in trello ticket.
easier to generate badge hashes

## Tested in CODE?

locally
