### PR TITLE
Clean headers

### DIFF
--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -54,7 +54,7 @@ import scala.collection.JavaConverters._
   it should "not cache 404s" in {
     val result = articleController.renderArticle("oops")(TestRequest())
     status(result) should be(404)
-    header("Cache-Control", result).head should be ("no-cache")
+    header("Cache-Control", result).head should be ("private, no-store")
   }
 
   it should "redirect for short urls" in {

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -107,8 +107,6 @@ object Cached extends implicits.Dates {
   */
   private def cacheHeaders(maxAge: Int, result: Result, maybeHash: Option[(Hash, Option[String])]) = {
     val now = DateTime.now
-    val expiresTime = if (LongCacheSwitch.isSwitchedOn) now + min(maxAge, 60).seconds else now + maxAge.seconds
-
     val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
     val surrogateCacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds"
 
@@ -138,28 +136,20 @@ object Cached extends implicits.Dates {
       // the cache headers that make their way through to the browser
       "Cache-Control" -> cacheControl,
 
-      "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString,
       "ETag" -> etagHeaderString)
   }
 }
 
-object PrivateCache {
-  def apply(result: Result): Result = result.withHeaders("Cache-Control" -> "private")
-}
-
 object NoCache {
-  def apply(result: Result): Result = result.withHeaders("Cache-Control" -> "no-cache", "Pragma" -> "no-cache")
+  def apply(result: Result): Result = result.withHeaders("Cache-Control" -> "private, no-store")
 }
 
 case class NoCache[A](action: Action[A])(implicit val executionContext: ExecutionContext) extends Action[A] {
 
   override def apply(request: Request[A]): Future[Result] = {
-    action(request) map { response =>
-      response.withHeaders(
-        ("Cache-Control", "no-cache, no-store, must-revalidate"),
-        ("Pragma", "no-cache"),
-        ("Expires", "0")
+    action(request) map { response => response.withHeaders(
+        ("Cache-Control", "private, no-store")
       )
     }
   }

--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -40,8 +40,7 @@ import test.{ConfiguredTestSuite, TestRequest}
   it should "not cache" in {
     val result = changeEditionController.render("us")(TestRequest())
 
-    header("Cache-Control", result) should be (Some("no-cache"))
-    header("Pragma", result) should be (Some("no-cache"))
+    header("Cache-Control", result) should be (Some("private, no-store"))
   }
 
   it should "not redirect to unknown editions" in {


### PR DESCRIPTION
Expires is unnecessary as we always set a max-age in Cache-Control when we set Expires.

No caching behaviour has also been simplified. I don't think we need no-cache and also pragma anymore - although willing to be corrected!

See also: https://github.com/guardian/fastly-edge-cache/pull/816.
