### PR TITLE
Final fixes for privacy consents

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
+++ b/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
@@ -15,6 +15,10 @@ const upAlertViewCount = (): void => {
     userPrefs.set(alertViewCount, getAlertViewCount() + 1);
 };
 
+const resetAlertViewCount = (): void => {
+    userPrefs.set(alertViewCount, 0);
+};
+
 const onConsentSet = (consent: AdConsent, status: ?boolean): void => {
     ophan.record({
         component: `privacy-prefs`,
@@ -24,6 +28,7 @@ const onConsentSet = (consent: AdConsent, status: ?boolean): void => {
         component: `privacy-prefs`,
         value: `set-with-alert-views : ${getAlertViewCount()} : ${consent.cookie.toLowerCase()}`,
     });
+    resetAlertViewCount();
 };
 
 const trackConsentCookies = (
@@ -36,6 +41,12 @@ const trackConsentCookies = (
                 consentWithState.state
             )} : ${consentWithState.consent.cookie.toLowerCase()}`,
         });
+        if (typeof consentWithState.state !== 'boolean') {
+            ophan.record({
+                component: `privacy-prefs`,
+                value: `pv : null-with-alert-views : ${getAlertViewCount()} : ${consentWithState.consent.cookie.toLowerCase()}`,
+            });
+        }
     });
 };
 

--- a/static/src/stylesheets/module/identity/_ad-prefs.scss
+++ b/static/src/stylesheets/module/identity/_ad-prefs.scss
@@ -83,6 +83,7 @@
     padding-bottom: $gs-gutter / 2;
 
     > .manage-account__button {
+        opacity: .9999; /*this fixes the button on uc browser somehow*/
         &[disabled] {
             pointer-events: none;
             opacity: .5;


### PR DESCRIPTION
## What does this change?

- Adds a bit more tracking (banner impressions for null consents)
- Resets the banner impressions counter when a permission is set
- Fixes the save button disappearing in UC browser. UC Browser itself is not a compatibility risk (it's not used in EEA countries) BUT I'm worried the same drawing bug might manifest in some fringe chrome version or something.