### PR TITLE
Use personalised ad consent status in video ads

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -2,6 +2,10 @@
 import fastdom from 'fastdom';
 
 import { loadScript } from 'lib/load-script';
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {
@@ -58,13 +62,21 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: HTMLElement) => {
     }
 };
 
-const setupPlayer = (videoId: string, onReady, onStateChange) =>
-    new window.YT.Player(videoId, {
+const setupPlayer = (videoId: string, onReady, onStateChange) => {
+    const wantPersonalisedAds: boolean =
+        getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    return new window.YT.Player(videoId, {
         events: {
             onReady,
             onStateChange,
         },
+        embedConfig: {
+            adsConfig: {
+                nonPersonalizedAd: !wantPersonalisedAds,
+            },
+        },
     });
+};
 
 const hasPlayerStarted = event => event.target.getCurrentTime() > 0;
 


### PR DESCRIPTION
I can't tell whether this change has any effect or not.
The best I can say is that pre-roll ads still work, and videos still work.
And the value of the `nonPersonalizedAd` parameter appears to be right.