### PR TITLE
Bump up prebid analytics from 0.01 to 0.1% of PVs

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -53,8 +53,8 @@ class PrebidService {
             priceGranularity,
         });
 
-        // gather analytics from 0.01% of pageviews
-        const inSample = getRandomIntInclusive(1, 10000) === 1;
+        // gather analytics from 0.1% (1/1000) of pageviews
+        const inSample = getRandomIntInclusive(1, 1000) === 1;
         if (
             config.switches.prebidAnalytics &&
             (inSample || config.page.isDev)


### PR DESCRIPTION
This implements https://trello.com/c/lsmXbAiV/37-data-lake-has-prebid-analytics-from-01-of-page-views