### PR TITLE
Remove switch so that personalised ad status always considered

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -416,14 +416,4 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
-
-  val includePersonalisedAdsConsent: Switch = Switch(
-    group = Commercial,
-    name = "include-personalised-ads-consent",
-    description = "Include a flag with consent status in ad calls.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 5, 25),
-    exposeClientSide = true
-  )
 }

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -5,10 +5,7 @@ import model.Article
 import org.jsoup.nodes.{Document, Element}
 import views.support.{AmpAd, AmpAdDataSlot, HtmlCleaner}
 
-import conf.switches.Switches.includePersonalisedAdsConsent
-
 import scala.collection.JavaConverters._
-import scala.xml.{Attribute, Null}
 
 object AmpAdCleaner {
   val AD_LIMIT = 8
@@ -100,7 +97,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
       // data-block-on-consent should not have ANY value
       // according to https://www.ampproject.org/docs/reference/components/amp-consent
       // This is not compatible with proper XML, hence the stringware hack
-        
+
       // This cannot be activated until we designed a solution to either inject/synchronise consent from our storage
       // or gather it in AMP.
       // ( ampAd % Attribute(null, "data-block-on-consent", "PLEASEREMOVEME", Null) ).toString().replaceFirst("=\"PLEASEREMOVEME\"", "")

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -71,23 +71,21 @@ const setDfpListeners = (): void => {
 };
 
 const setPersonalisedAds = (): void => {
-    if (config.switches.includePersonalisedAdsConsent) {
-        const wantPersonalisedAds: ?boolean = getAdConsentState(
-            thirdPartyTrackingAdConsent
-        );
-        switch (wantPersonalisedAds) {
-            // personalised ads have been explicitly accepted
-            case true:
-                window.googletag.pubads().setRequestNonPersonalizedAds(0);
-                break;
-            // personalised ads have been explicitly rejected
-            case false:
-                window.googletag.pubads().setRequestNonPersonalizedAds(1);
-                break;
-            // no preference has been specified
-            default:
-                window.googletag.pubads();
-        }
+    const wantPersonalisedAds: ?boolean = getAdConsentState(
+        thirdPartyTrackingAdConsent
+    );
+    switch (wantPersonalisedAds) {
+        // personalised ads have been explicitly accepted
+        case true:
+            window.googletag.pubads().setRequestNonPersonalizedAds(0);
+            break;
+        // personalised ads have been explicitly rejected
+        case false:
+            window.googletag.pubads().setRequestNonPersonalizedAds(1);
+            break;
+        // no preference has been specified
+        default:
+            window.googletag.pubads();
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -60,9 +60,7 @@ const configureSegments = () => {
 };
 
 const onLoad = () => {
-    if (config.switches.includePersonalisedAdsConsent) {
-        configureSegments();
-    }
+    configureSegments();
 };
 
 const retrieve = (n: string): string => {


### PR DESCRIPTION
Switch was to work behind before GDPR day, but tomorrow it will become redundant!