### PR TITLE
Revert "Clean headers"

### DIFF
--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -54,7 +54,7 @@ import scala.collection.JavaConverters._
   it should "not cache 404s" in {
     val result = articleController.renderArticle("oops")(TestRequest())
     status(result) should be(404)
-    header("Cache-Control", result).head should be ("private, no-store")
+    header("Cache-Control", result).head should be ("no-cache")
   }
 
   it should "redirect for short urls" in {

--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -40,7 +40,8 @@ import test.{ConfiguredTestSuite, TestRequest}
   it should "not cache" in {
     val result = changeEditionController.render("us")(TestRequest())
 
-    header("Cache-Control", result) should be (Some("private, no-store"))
+    header("Cache-Control", result) should be (Some("no-cache"))
+    header("Pragma", result) should be (Some("no-cache"))
   }
 
   it should "not redirect to unknown editions" in {


### PR DESCRIPTION
Reverts guardian/frontend#19724

For some reason this looks like it breaks CSRF handling for Identity. Possibly cookies more broadly although I'll investigate once this is merged.