### PR TITLE
Make email newsletters buttons same colour

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -13,11 +13,7 @@
     </div>
     <div class="newsletter-card__wrapper">
         @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-            <div class="newsletter-card
-            @if(emailListing.tone.isDefined) {  newsletter-card--tone-@emailListing.tone
-            } else { newsletter-card--tone-news }"
-                data-component="newsletter-card @emailListing.name">
-
+            <div class="newsletter-card" data-component="newsletter-card @emailListing.name">
                 <div class="newsletter-card__content js-newsletter-content">
 
                     <div class="newsletter-card__name">@emailListing.name
@@ -93,7 +89,7 @@
         "Lifestyle"      -> lifestyleEmails,
         "Comment"        -> commentEmails,
         "Work"           -> workEmails,
-        "From the Papers" -> fromThePapersEmails
+        "From the papers" -> fromThePapersEmails
     ).map { case (theme, newsletters) =>
         <div class="newsletters-category" name="@theme">
             @emailListCategoryList(theme, newsletters)

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -37,7 +37,7 @@
         "lifestyle",
         "comment",
         "work",
-        "From the Papers"
+        "From the papers"
     ).zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.156"
+  val identityLibVersion = "3.157-SNAPSHOT"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.157-SNAPSHOT"
+  val identityLibVersion = "3.157"
   val awsVersion = "1.11.240"
   val capiVersion = "12.0"
   val faciaVersion = "2.6.0"

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -224,8 +224,10 @@
 }
 
 // TONE SPECIFIC MODS
-@mixin newsletter-card--tone($border, $cta: $garnett-neutral-1) {
-    border-top-color: $border;
+@mixin newsletter-card--tone() {
+    $cta: $garnett-neutral-1;
+
+    border-top-color: $neutral-3;
 
     .newsletter-card__signup {
         .newsletter-card__lozenge {
@@ -234,8 +236,8 @@
 
             &:hover,
             &:focus {
-                border-color: darken($cta, 10%);
-                background-color: darken($cta, 10%);
+                border-color: lighten($cta, 30%);
+                background-color: lighten($cta, 30%);
             }
         }
     }
@@ -258,32 +260,32 @@
 
 // TONE SPECIFIC MODS - FEATURE
 .newsletter-card--tone-feature {
-    @include newsletter-card--tone($features-support-3, $features-support-1)
+    @include newsletter-card--tone()
 }
 
 // TONE SPECIFIC MODS - COMMENT
 .newsletter-card--tone-comment {
-    @include newsletter-card--tone($comment-support-4, $comment-support-4)
+    @include newsletter-card--tone()
 }
 
 // TONE SPECIFIC MODS - MEDIA
 .newsletter-card--tone-media {
-    @include newsletter-card--tone($multimedia-main-2)
+    @include newsletter-card--tone()
 }
 
 // GARNETT TONES
 .newsletter-card--tone-news {
-    @include newsletter-card--tone($news-garnett-main-1)
+    @include newsletter-card--tone()
 }
 .newsletter-card--tone-opinion {
-    @include newsletter-card--tone($opinion-garnett-main-1)
+    @include newsletter-card--tone()
 }
 .newsletter-card--tone-sport {
-    @include newsletter-card--tone($sport-garnett-main-1)
+    @include newsletter-card--tone()
 }
 .newsletter-card--tone-lifestyle {
-    @include newsletter-card--tone($lifestyle-garnett-main-1)
+    @include newsletter-card--tone()
 }
 .newsletter-card--tone-culture {
-    @include newsletter-card--tone($culture-garnett-main-1)
+    @include newsletter-card--tone()
 }

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -38,7 +38,7 @@
 
 .newsletter-card {
     margin-bottom: $gs-baseline;
-    border-top: 1px solid $news-accent;
+    border-top: 1px solid $neutral-3;
     border-bottom: 1px solid $neutral-3;
     background-color: $comment-support-2;
     padding: $gs-baseline / 2 $gs-gutter / 2 $gs-baseline;
@@ -120,22 +120,37 @@
     }
 
     .newsletter-card__lozenge--preview {
-        color: $news-main-1;
+        border-color: $garnett-neutral-1;
+        color: $garnett-neutral-1;
         background-color: transparent;
         float: right;
 
         &:hover,
         &:focus,
         &:active {
-            background-color: darken($comment-support-2, 10%);
+            border-color: $garnett-neutral-1;
+            background-color: rgba(0, 0, 0, .1)
         }
     }
 
     .inline-arrow-right {
-        fill: $news-main-1;
+        fill: $garnett-neutral-1;
         position: absolute;
         height: $gs-baseline;
         line-height: $gs-baseline;
+    }
+}
+
+.newsletter-card__signup {
+    .newsletter-card__lozenge {
+        border-color: $garnett-neutral-1;
+        background-color: $garnett-neutral-1;
+
+        &:hover,
+        &:focus {
+            border-color: lighten($garnett-neutral-1, 30%);
+            background-color: lighten($garnett-neutral-1, 30%);
+        }
     }
 }
 
@@ -221,71 +236,4 @@
     @include mq(wide) {
         width: gs-span(3);
     }
-}
-
-// TONE SPECIFIC MODS
-@mixin newsletter-card--tone() {
-    $cta: $garnett-neutral-1;
-
-    border-top-color: $neutral-3;
-
-    .newsletter-card__signup {
-        .newsletter-card__lozenge {
-            border-color: $cta;
-            background-color: $cta;
-
-            &:hover,
-            &:focus {
-                border-color: lighten($cta, 30%);
-                background-color: lighten($cta, 30%);
-            }
-        }
-    }
-
-    .newsletter-card__lozenge--preview {
-        border-color: $cta;
-        color: $cta;
-
-        &:hover,
-        &:focus,
-        &:active {
-            border-color: $cta;
-        }
-
-        .inline-arrow-right {
-            fill: $cta;
-        }
-    }
-}
-
-// TONE SPECIFIC MODS - FEATURE
-.newsletter-card--tone-feature {
-    @include newsletter-card--tone()
-}
-
-// TONE SPECIFIC MODS - COMMENT
-.newsletter-card--tone-comment {
-    @include newsletter-card--tone()
-}
-
-// TONE SPECIFIC MODS - MEDIA
-.newsletter-card--tone-media {
-    @include newsletter-card--tone()
-}
-
-// GARNETT TONES
-.newsletter-card--tone-news {
-    @include newsletter-card--tone()
-}
-.newsletter-card--tone-opinion {
-    @include newsletter-card--tone()
-}
-.newsletter-card--tone-sport {
-    @include newsletter-card--tone()
-}
-.newsletter-card--tone-lifestyle {
-    @include newsletter-card--tone()
-}
-.newsletter-card--tone-culture {
-    @include newsletter-card--tone()
 }

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -39,7 +39,6 @@
 .newsletter-card {
     margin-bottom: $gs-baseline;
     border-top: 1px solid $neutral-3;
-    border-bottom: 1px solid $neutral-3;
     background-color: $comment-support-2;
     padding: $gs-baseline / 2 $gs-gutter / 2 $gs-baseline;
     box-sizing: border-box;


### PR DESCRIPTION
## What does this change?

Makes all the buttons at https://www.theguardian.com/email-newsletters the same colour.

Related PR: https://github.com/guardian/identity/pull/1191

## Screenshots

![image](https://user-images.githubusercontent.com/13835317/40544684-172419b8-6021-11e8-99da-70e8de6d4a49.png)

@katyabeer
