### PR TITLE
Engagement Banner Highlight Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 6, 5),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-engagement-banner-highlight",
+    "Hihglight a line in the banner",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 6, 5),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -59,12 +59,13 @@ const supporterCost = (location: string): string => {
             : euro + amount;
     }
 
-    return `${extendedCurrencySymbol[countryGroup]}
-            ${initialContribution}`;
+    return `${extendedCurrencySymbol[countryGroup]}${initialContribution}`;
 };
 
-const supporterEngagementCtaCopyJustOne = (location: string): string =>
-    `Support The Guardian from as little as ${supporterCost(location)}.`;
+const supporterEngagementCtaCopyControl = (location: string): string =>
+    `<span class="banner-cta-text"> Support The Guardian from as little as ${supporterCost(
+        location
+    )}.</span>`;
 
 export const engagementBannerParams = (
     location: string
@@ -74,6 +75,6 @@ export const engagementBannerParams = (
         linkUrl: supportContributeURL,
         products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
         messageText: engagementBannerCopy(),
-        ctaText: supporterEngagementCtaCopyJustOne(location),
+        ctaText: supporterEngagementCtaCopyControl(location),
         pageviewId: config.get('ophan.pageViewId', 'not_found'),
     });

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -6,9 +6,8 @@ export const acquisitionsBannerControlTemplate = (
         <div class="site-message__message site-message__message--membership">
             <div class="membership__message-text-long">
                 <span class = "membership__message-text">
-                    ${params.messageText} <strong>${
-        params.ctaText
-    }</strong></span>
+                    ${params.messageText}${params.ctaText}
+                </span>
             </div>
             <span class="membership__paypal-container">
                 <img class="membership__paypal-logo" src="${

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-highlight.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-engagement-banner-highlight.js
@@ -1,0 +1,37 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+
+const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName = 'AcquisitionsEngagementBannerHighlight';
+
+export const AcquisitionsEngagementBannerHighlight: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-05-25',
+    expiry: '2018-06-06',
+    author: 'Jonathan Rankin',
+    description:
+        'Tests a CTA message that aims to push people towards recurring contributions',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'All US transaction web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome: 'Increase in overall AV, and AV from recurring',
+    componentType,
+    showForSensitive: true,
+    canRun: () => true,
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'highlight',
+            options: {
+                engagementBannerParams: {
+                    bannerModifierClass: 'highlight-test',
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,5 +1,6 @@
 // @flow
+import { AcquisitionsEngagementBannerHighlight } from 'common/modules/experiments/tests/acquisitions-engagement-banner-highlight';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsEngagementBannerHighlight];

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -1030,3 +1030,22 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     width: 100%;
     height: 100%;
 }
+
+
+.banner-cta-text {
+    font-weight: bold;
+}
+
+
+//Test specific CSS
+.highlight-test {
+    .banner-cta-text {
+        font-weight: normal;
+        background-color: #000000;
+        color: #ffffff;
+        margin-left: 3px;
+        padding-left: 2px;
+        padding-right: 5px;
+        padding-bottom: 3px;
+    }
+}


### PR DESCRIPTION
## What does this change?
Tests a highlighted line to the banner.

Also a few tiny tweaks to the banner css, at the request of @ionamckendrick 

Control
![contorl](https://user-images.githubusercontent.com/2844554/40552187-e5b5f4b2-6036-11e8-98e2-b99916c5e5fc.png)

Variant
![var](https://user-images.githubusercontent.com/2844554/40552189-e63f235e-6036-11e8-86c3-fb62fa6e2ac4.png)
