### PR TITLE
Remove comma from id cookie

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -49,7 +49,10 @@ import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
 import { init as initBannerPicker } from 'common/modules/ui/bannerPicker';
 import { breakingNews } from 'common/modules/onward/breaking-news';
 import { trackConsentCookies } from 'common/modules/analytics/send-privacy-prefs';
-import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.lib';
+import {
+    getAllAdConsentsWithState,
+    updateCookieString,
+} from 'common/modules/commercial/ad-prefs.lib';
 import ophan from 'ophan/ng';
 
 const initialiseTopNavItems = (): void => {
@@ -296,6 +299,7 @@ const init = (): void => {
     catchErrorsWithContext([
         // Analytics comes at the top. If you think your thing is more important then please think again...
         ['c-analytics', loadAnalytics],
+        ['c-update-cookie-string', updateCookieString],
         ['c-consent-cookie-tracking', initialiseConsentCookieTracking],
         ['c-identity', initIdentity],
         ['c-adverts', requestUserSegmentsFromId],

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -18,8 +18,8 @@ import type { CmpConfig } from 'commercial/modules/cmp/types';
 
 const readConsentCookie = (cookieName: string): boolean | null => {
     const cookieVal: ?string = getCookie(cookieName);
-    if (cookieVal && cookieVal.split(',')[0] === '1') return true;
-    if (cookieVal && cookieVal.split(',')[0] === '0') return false;
+    if (cookieVal && cookieVal.split('.')[0] === '1') return true;
+    if (cookieVal && cookieVal.split('.')[0] === '0') return false;
     return null;
 };
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -18,8 +18,10 @@ import type { CmpConfig } from 'commercial/modules/cmp/types';
 
 const readConsentCookie = (cookieName: string): boolean | null => {
     const cookieVal: ?string = getCookie(cookieName);
-    if (cookieVal && cookieVal.split('.')[0] === '1') return true;
-    if (cookieVal && cookieVal.split('.')[0] === '0') return false;
+    if (cookieVal && cookieVal.replace(',', '.').split('.')[0] === '1')
+        return true;
+    if (cookieVal && cookieVal.replace(',', '.').split('.')[0] === '0')
+        return false;
     return null;
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -21,7 +21,7 @@ const thirdPartyTrackingAdConsent: AdConsent = {
 const allAdConsents: AdConsent[] = [thirdPartyTrackingAdConsent];
 
 const setAdConsentState = (provider: AdConsent, state: boolean): void => {
-    const cookie = [state ? '1' : '0', Date.now()].join(',');
+    const cookie = [state ? '1' : '0', Date.now()].join('.');
     addCookie(provider.cookie, cookie, 30 * 18, true);
     onConsentSet(provider, state);
 };
@@ -29,7 +29,7 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
 const getAdConsentState = (provider: AdConsent): ?boolean => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
-    const cookieParsed = cookieRaw.split(',')[0];
+    const cookieParsed = cookieRaw.split('.')[0];
     if (cookieParsed === '1') return true;
     if (cookieParsed === '0') return false;
     return null;

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -13,6 +13,8 @@ type AdConsentWithState = {
     state: ?boolean,
 };
 
+const cookieExpiryDate = 30 * 18;
+
 const thirdPartyTrackingAdConsent: AdConsent = {
     label: 'Third party tracking',
     cookie: 'GU_TK',
@@ -20,16 +22,29 @@ const thirdPartyTrackingAdConsent: AdConsent = {
 
 const allAdConsents: AdConsent[] = [thirdPartyTrackingAdConsent];
 
+// TODO: remove this after a reasonable time passes
+const updateCookieString = () => {
+    const cookieRaw = getCookie(thirdPartyTrackingAdConsent.cookie);
+    if (cookieRaw) {
+        addCookie(
+            thirdPartyTrackingAdConsent.cookie,
+            cookieRaw.replace(',', '.'),
+            cookieExpiryDate,
+            true
+        );
+    }
+};
+
 const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     const cookie = [state ? '1' : '0', Date.now()].join('.');
-    addCookie(provider.cookie, cookie, 30 * 18, true);
+    addCookie(provider.cookie, cookie, cookieExpiryDate, true);
     onConsentSet(provider, state);
 };
 
 const getAdConsentState = (provider: AdConsent): ?boolean => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
-    const cookieParsed = cookieRaw.split('.')[0];
+    const cookieParsed = cookieRaw.replace(',', '.').split('.')[0];
     if (cookieParsed === '1') return true;
     if (cookieParsed === '0') return false;
     return null;
@@ -48,4 +63,5 @@ export {
     getAllAdConsentsWithState,
     allAdConsents,
     thirdPartyTrackingAdConsent,
+    updateCookieString,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
@@ -44,12 +44,12 @@ describe('setAdConsentState', () => {
     it('should set a full proper cookie', () => {
         setAdConsentState(testConsent, true);
         expect(addCookie.mock.calls[0][0]).toBe('GU_AD_CONSENT_TEST');
-        expect(addCookie.mock.calls[0][1]).toMatch('1,');
+        expect(addCookie.mock.calls[0][1]).toMatch('1.');
         expect(addCookie.mock.calls[0][2]).toBe(30 * 18);
         expect(addCookie.mock.calls[0][3]).toBe(true);
     });
     it('should set a false cookie', () => {
         setAdConsentState(testConsent, false);
-        expect(addCookie.mock.calls[0][1]).toMatch('0,');
+        expect(addCookie.mock.calls[0][1]).toMatch('0.');
     });
 });


### PR DESCRIPTION
## What does this change?
The `GU_TK` cookie having a comma was against the cookies standard and was preventing social sign-ins

This PR will change the new cookie format to using commas to split values and will try to retroactively convert existing cookies to use dot separators.