### PR TITLE
Remove dot conversion from `gu_tk`

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -49,10 +49,7 @@ import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
 import { init as initBannerPicker } from 'common/modules/ui/bannerPicker';
 import { breakingNews } from 'common/modules/onward/breaking-news';
 import { trackConsentCookies } from 'common/modules/analytics/send-privacy-prefs';
-import {
-    getAllAdConsentsWithState,
-    updateCookieString,
-} from 'common/modules/commercial/ad-prefs.lib';
+import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.lib';
 import ophan from 'ophan/ng';
 
 const initialiseTopNavItems = (): void => {
@@ -299,7 +296,6 @@ const init = (): void => {
     catchErrorsWithContext([
         // Analytics comes at the top. If you think your thing is more important then please think again...
         ['c-analytics', loadAnalytics],
-        ['c-update-cookie-string', updateCookieString],
         ['c-consent-cookie-tracking', initialiseConsentCookieTracking],
         ['c-identity', initIdentity],
         ['c-adverts', requestUserSegmentsFromId],

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -18,10 +18,8 @@ import type { CmpConfig } from 'commercial/modules/cmp/types';
 
 const readConsentCookie = (cookieName: string): boolean | null => {
     const cookieVal: ?string = getCookie(cookieName);
-    if (cookieVal && cookieVal.replace(',', '.').split('.')[0] === '1')
-        return true;
-    if (cookieVal && cookieVal.replace(',', '.').split('.')[0] === '0')
-        return false;
+    if (cookieVal && cookieVal.split('.')[0] === '1') return true;
+    if (cookieVal && cookieVal.split('.')[0] === '0') return false;
     return null;
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -22,19 +22,6 @@ const thirdPartyTrackingAdConsent: AdConsent = {
 
 const allAdConsents: AdConsent[] = [thirdPartyTrackingAdConsent];
 
-// TODO: remove this after a reasonable time passes
-const updateCookieString = () => {
-    const cookieRaw = getCookie(thirdPartyTrackingAdConsent.cookie);
-    if (cookieRaw) {
-        addCookie(
-            thirdPartyTrackingAdConsent.cookie,
-            cookieRaw.replace(',', '.'),
-            cookieExpiryDate,
-            true
-        );
-    }
-};
-
 const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     const cookie = [state ? '1' : '0', Date.now()].join('.');
     addCookie(provider.cookie, cookie, cookieExpiryDate, true);
@@ -44,7 +31,7 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
 const getAdConsentState = (provider: AdConsent): ?boolean => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
-    const cookieParsed = cookieRaw.replace(',', '.').split('.')[0];
+    const cookieParsed = cookieRaw.split('.')[0];
     if (cookieParsed === '1') return true;
     if (cookieParsed === '0') return false;
     return null;
@@ -63,5 +50,4 @@ export {
     getAllAdConsentsWithState,
     allAdConsents,
     thirdPartyTrackingAdConsent,
-    updateCookieString,
 };


### PR DESCRIPTION
## What does this change?
Removes the cookie conversion code from #19745 and starts assuming all `GU_TK` cookies are dot-separated instead of either comma-separated or dot-separated After this gets merged, users who did not get their cookie converted in time will just get see the consent banner again.

I wanted to get this PR out already to not forget about it but I think it's worth it to leave the converter running for at least a full week (until this Friday). 

## What is the value of this and can you measure success?
Less code!
