### PR TITLE
Newsletters Page: display current user's email address

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -2,6 +2,7 @@
 
 @import services.EmailPrefsData
 
+@import com.gu.identity.model.User
 @(
     page: model.Page,
     emailPrefsForm: Form[EmailPrefsData],

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -1,6 +1,8 @@
+@import com.gu.identity.model.User
 @(
     idRequest: services.IdentityRequest,
-    idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+    idUrlBuilder: services.IdentityUrlBuilder,
+    user: User)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @buildIdentityUrl(endpoint: String) = {
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
@@ -15,17 +17,23 @@
 
         <div class="fieldset__fields email-subscription__options">
             <ul class="u-unstyled">
+                @if(user.primaryEmailAddress != null && user.primaryEmailAddress.nonEmpty) {
+                    <li>
+                        <p>
+                            You are receiving newsletters, notifications and all other emails to
+                            <b>@user.primaryEmailAddress</b><b>.</b>
+                        </p>
+                    </li>
+                }
                 <li>
                     <p>
-                        <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">
-                            Update your email address
-                        </a>
+                        <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">Change your email address</a>  (via Account & Privacy tab)
                     </p>
                 </li>
                 <li>
                     <p>
                         <a href="https://jobs.theguardian.com/your-jobs/?ActiveSection=JbeList" class="u-underline" data-link-name="identity : jobs : alert-settings">
-                            Edit your Job Alert settings
+                            Manage your Jobs alerts
                         </a>
                     </p>
                 </li>

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -21,7 +21,7 @@
                     <li>
                         <p>
                             You are receiving newsletters, notifications and all other emails to
-                            <b>@user.primaryEmailAddress</b><b>.</b>
+                            <strong>@user.primaryEmailAddress</strong>.
                         </p>
                     </li>
                 }

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -103,7 +103,7 @@
 @smsConsent
 
 @* EMAIL SETTINGS *@
-@views.html.profile.emailSettings(idRequest, idUrlBuilder)
+@views.html.profile.emailSettings(idRequest, idUrlBuilder, user)
 
 @* CHANNELS *@
 <hr class="manage-account-divider" />


### PR DESCRIPTION
## What does this change?

UX Improvements from Katya: 
- Displays the current user's email address on `/email-prefs`
- Wording on the two links in that section (see screenshot)

## What is the value of this and can you measure success?

- UX is improved

## Does this affect other platforms - Amp, Apps, etc?

NO

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

NO

## Screenshots

![screen shot 2018-05-29 at 13 20 33](https://user-images.githubusercontent.com/3636251/40658523-732b5d00-6343-11e8-8b55-c7916d226691.png)



<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
