### PR TITLE
Extend commercial-ad-refresh switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -28,7 +28,7 @@ object CommercialAdRefresh extends Experiment(
   name = "commercial-ad-refresh",
   description = "Users in this experiment will have their ad slots refreshed after 30 seconds",
   owners = Seq(Owner.withGithub("katebee")),
-  sellByDate = new LocalDate(2018, 5, 31),
+  sellByDate = new LocalDate(2018, 9, 27),
   participationGroup = Perc50
 )
 


### PR DESCRIPTION
## What does this change?

Extends the commercial-ad-refresh switch far into the future

## What is the value of this and can you measure success?

Experiment can continue running, and we can stop worrying about the switch expiring again

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Tested in CODE?

N/A