### PR TITLE
Add the required keys for the comments MPU to Prebid

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -59,6 +59,8 @@ const getTrustXAdUnitId = (slotId: string): string => {
             return '2962';
         case 'dfp-ad--top-above-nav':
             return '2963';
+        case 'dfp-ad--comments':
+            return '3840';
         default:
             // for inline10 and onwards just use same IDs as inline9
             if (slotId.startsWith('dfp-ad--inline')) {
@@ -152,6 +154,7 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
 const getImproveSizeParam = (slotId: string): PrebidImproveSizeParam => {
     const key = stripTrailingNumbersAbove1(stripMobileSuffix(slotId));
     return key.endsWith('mostpop') ||
+        key.endsWith('comments') ||
         key.endsWith('inline1') ||
         (key.endsWith('inline') && !isDesktopArticle)
         ? { w: 300, h: 250 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -48,4 +48,9 @@ export const slots: PrebidSlot[] = [
         sizes: [[300, 250]],
         labelAny: ['mobile', 'tablet', 'desktop'],
     },
+    {
+        key: 'comments',
+        sizes: [[300, 250]],
+        labelAny: ['desktop'],
+    },
 ];

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -37,7 +37,8 @@ export type PrebidSlotKey =
     | 'right'
     | 'inline1'
     | 'inline'
-    | 'mostpop';
+    | 'mostpop'
+    | 'comments';
 
 export type PrebidSlotLabel =
     | 'mobile'


### PR DESCRIPTION
## What does this change?

Adds support for `comments` slot to Prebid.

## What is the value of this and can you measure success?

This will allow Prebid to run auctions on `comments` slot

https://trello.com/c/b13fFJiJ/26-allow-prebid-to-run-auctions-on-comments-slot

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

## Screenshots
<img width="1677" alt="picture 66" src="https://user-images.githubusercontent.com/8607683/40661239-1e5f567a-634b-11e8-9c1f-39947b9ecac8.png">

##### N.B. This screenshot was taken by hacking around with my local files to allow the comments MPU to appear when a user is not signed in.
