### PR TITLE
Unsub from all

### DIFF
--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -51,7 +51,7 @@ trait EmailsTab
 
   def deleteAllSubscriptionsAndMarketingConsents(): Action[AnyContent] =
     csrfCheck {
-      consentAuthWithIdapiUserAction.async { implicit request =>
+      recentFullAuthWithIdapiUserAction.async { implicit request =>
         identityApiClient.unsubscribeFromAllEmailsAndOptoutMarketingConsents(request.user.auth).map {
           case Right(_) => NoContent
           case Left(errors) =>

--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -49,6 +49,18 @@ trait EmailsTab
       }
     }
 
+  def deleteAllSubscriptionsAndMarketingConsents(): Action[AnyContent] =
+    csrfCheck {
+      consentAuthWithIdapiUserAction.async { implicit request =>
+        identityApiClient.unsubscribeFromAllEmailsAndOptoutMarketingConsents(request.user.auth).map {
+          case Right(_) => NoContent
+          case Left(errors) =>
+            logger.error(s"Failed to unsubscribe User ${request.user.id} from all")
+            InternalServerError(Json.toJson(errors))
+        }
+      }
+    }
+
   /** POST /privacy/edit-ajax */
   def saveConsentPreferencesAjax: Action[AnyContent] =
     csrfCheck {

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -166,6 +166,8 @@ class IdApiClient(
   def deleteTelephone(auth: Auth): Future[Response[Unit]] =
     delete("user/me/telephoneNumber", Some(auth)) map extractUnit
 
+  def unsubscribeFromAllEmailsAndOptoutMarketingConsents(auth: Auth): Future[Response[Unit]] =
+    post("remove/consent/all", Some(auth)).map(extractUnit)
 
   // THIRD PARTY SIGN-IN
   def addUserToGroup(groupCode: String, auth: Auth): Future[Response[Unit]] = {

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -40,7 +40,7 @@
                 <li>
                     <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
                         <span class="email-unsubscribe-all__label js-unsubscribe--basic manage-account__button-flexwrap">
-                            Unsubscribe from all newsletters
+                            Unsubscribe from all newsletters and marketing emails
                             @fragments.inlineSvg("cross", "icon")
                         </span>
                         <span class="email-unsubscribe-all__label js-unsubscribe--confirm hide" aria-hidden>

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -27,7 +27,7 @@
                 }
                 <li>
                     <p>
-                        <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">Change your email address</a>  (via Account & Privacy tab)
+                        <a href="@buildIdentityUrl("account/edit")" class="u-underline" data-link-name="identity : email : update">Change your email address</a>
                     </p>
                 </li>
                 <li>

--- a/identity/app/views/profile/otherChannels.scala.html
+++ b/identity/app/views/profile/otherChannels.scala.html
@@ -9,7 +9,7 @@
         <h2 class="form__heading">Other ways we may contact you about our products and services</h2>
         <p class="form__note">From time to time, we’d love to be able to update you about our products and services via telephone and post.</p>
     </div>
-    <div class="fieldset__fields">
+    <div class="fieldset__fields fieldset__fields--opt-out">
         @views.html.profile.nonElectronicContact(idUrlBuilder, idRequest, privacyForm, user)(request, messages)
     </div>
 </fieldset>
@@ -17,7 +17,7 @@
     <div class="fieldset__heading">
         <h2 class="form__heading">Using your data for marketing analysis</h2>
     </div>
-    <div class="fieldset__fields">
+    <div class="fieldset__fields fieldset__fields--opt-out">
         @views.html.profile.profilingConsent(idUrlBuilder, idRequest, privacyForm, user)(request, messages)
     </div>
 </fieldset>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -52,7 +52,7 @@
                 <p class="form__note">From time to time, we'd love to be able to send you information about our products, services and events.</p>
             </div>
 
-            <div class="fieldset__fields">
+            <div class="fieldset__fields fieldset__fields--opt-in">
 
                 <div class="manage-account__switches manage-account__switches--single-column">
                     <ul>

--- a/identity/app/views/profile/smsConsent.scala.html
+++ b/identity/app/views/profile/smsConsent.scala.html
@@ -11,7 +11,7 @@
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 <form method="post" action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" novalidate>
     @views.html.helper.CSRF.formField
-    <div class="manage-account__switches manage-account__switches--single-column js-manage-account__check-allCheckbox__ignore">
+    <div class="manage-account__switches manage-account__switches--single-column js-manage-account__check-allCheckbox__ignore fieldset__fields--opt-in">
         <ul>
         @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
             @if(isSmsChannel(consentField, user)) {

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -61,6 +61,8 @@ POST        /privacy/edit-ajax                      controllers.editprofile.Edit
 GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.editprofile.EditProfileController.saveEmailPreferencesAjax
 
+DELETE      /user/email-subscriptions               controllers.editprofile.EditProfileController.deleteAllSubscriptionsAndMarketingConsents()
+
 
 ########################################################################################################################
 # PUBLIC EDIT PROFILE

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -5,7 +5,7 @@ import debounce from 'debounce-promise';
 import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
 
-import { push as pushError } from './modules/show-errors';
+import {push as pushError} from './modules/show-errors';
 import {
     addSpinner,
     removeSpinner,
@@ -13,8 +13,8 @@ import {
     getInfo as getCheckboxInfo,
     bindAnalyticsEventsOnce as bindCheckboxAnalyticsEventsOnce,
 } from './modules/switch';
-import { addUpdatingState, removeUpdatingState } from './modules/button';
-import { getCsrfTokenFromElement } from './modules/fetchFormFields';
+import {addUpdatingState, removeUpdatingState} from './modules/button';
+import {getCsrfTokenFromElement} from './modules/fetchFormFields';
 
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
 const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
@@ -149,6 +149,17 @@ const confirmUnsubscriptionFromAll = (
             })
         );
 
+const unsubscribeFromAll = (csrfToken: string) => {
+    return reqwest({
+        url: `/user/email-subscriptions`,
+        method: 'DELETE',
+        withCredentials: true,
+        headers: {
+            'Csrf-Token': csrfToken
+        }
+    });
+};
+
 const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     buttonEl.addEventListener('click', () => {
         if (buttonEl.classList.contains('js-confirm-unsubscribe')) {
@@ -174,8 +185,8 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
                     )[0]
                 ),
             ])
-                .then(([newsletterIds, csrfToken]) =>
-                    submitNewsletterAction(csrfToken, 'remove', newsletterIds)
+                .then(([_, csrfToken]) =>
+                    unsubscribeFromAll(csrfToken)
                 )
                 .catch((err: Error) => {
                     pushError(err, 'reload').then(() => {
@@ -294,7 +305,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                                 `.${checkAllCheckboxClassName}`
                             ) === null &&
                             $checkbox.closest(`.${checkAllIgnoreClassName}`) ===
-                                null
+                            null
                     );
                 })
             );
@@ -332,7 +343,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                     })
                     .then(() => {
                         wrappedCheckboxEl.dispatchEvent(
-                            new Event('change', { bubbles: true })
+                            new Event('change', {bubbles: true})
                         );
                     });
             });

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -5,7 +5,7 @@ import debounce from 'debounce-promise';
 import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
 
-import {push as pushError} from './modules/show-errors';
+import { push as pushError } from './modules/show-errors';
 import {
     addSpinner,
     removeSpinner,
@@ -13,8 +13,8 @@ import {
     getInfo as getCheckboxInfo,
     bindAnalyticsEventsOnce as bindCheckboxAnalyticsEventsOnce,
 } from './modules/switch';
-import {addUpdatingState, removeUpdatingState} from './modules/button';
-import {getCsrfTokenFromElement} from './modules/fetchFormFields';
+import { addUpdatingState, removeUpdatingState } from './modules/button';
+import { getCsrfTokenFromElement } from './modules/fetchFormFields';
 
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
 const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
@@ -149,45 +149,38 @@ const confirmUnsubscriptionFromAll = (
             })
         );
 
-const unsubscribeFromAll = (csrfToken: string) => {
-    return reqwest({
+const unsubscribeFromAll = (csrfToken: string) =>
+    reqwest({
         url: `/user/email-subscriptions`,
         method: 'DELETE',
         withCredentials: true,
         headers: {
-            'Csrf-Token': csrfToken
-        }
+            'Csrf-Token': csrfToken,
+        },
     });
-};
 
 const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     buttonEl.addEventListener('click', () => {
-        if (buttonEl.classList.contains('js-confirm-unsubscribe')) {
+        if (!buttonEl.classList.contains('js-confirm-unsubscribe')) {
+            confirmUnsubscriptionFromAll(buttonEl);
+        } else {
             addUpdatingState(buttonEl);
             resetUnsubscribeFromAll(buttonEl);
-
-            return Promise.all([
-                fastdom
-                    .read(() => [
-                        ...document.querySelectorAll(
-                            `.${newsletterCheckboxClassName} input:checked`
-                        ),
-                    ])
-                    .then(checkboxes => {
-                        checkboxes.forEach(inputEl => {
-                            inputEl.checked = false;
-                        });
-                        return checkboxes.map(inputEl => inputEl.name);
-                    }),
-                getCsrfTokenFromElement(
-                    document.getElementsByClassName(
-                        newsletterCheckboxClassName
-                    )[0]
-                ),
-            ])
-                .then(([_, csrfToken]) =>
-                    unsubscribeFromAll(csrfToken)
-                )
+            fastdom
+                .read(() => [
+                    ...document.querySelectorAll(
+                        `.${newsletterCheckboxClassName} input:checked`
+                    ),
+                ])
+                .then(checkboxes => {
+                    checkboxes.forEach(inputEl => {
+                        inputEl.checked = false;
+                    });
+                });
+            return getCsrfTokenFromElement(
+                document.getElementsByClassName(newsletterCheckboxClassName)[0]
+            )
+                .then(csrfToken => unsubscribeFromAll(csrfToken))
                 .catch((err: Error) => {
                     pushError(err, 'reload').then(() => {
                         window.scrollTo(0, 0);
@@ -197,7 +190,6 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
                     removeUpdatingState(buttonEl);
                 });
         }
-        confirmUnsubscriptionFromAll(buttonEl);
     });
 };
 
@@ -305,7 +297,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                                 `.${checkAllCheckboxClassName}`
                             ) === null &&
                             $checkbox.closest(`.${checkAllIgnoreClassName}`) ===
-                            null
+                                null
                     );
                 })
             );
@@ -343,7 +335,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                     })
                     .then(() => {
                         wrappedCheckboxEl.dispatchEvent(
-                            new Event('change', {bubbles: true})
+                            new Event('change', { bubbles: true })
                         );
                     });
             });

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -21,6 +21,9 @@ const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
 const checkAllCheckboxClassName = 'js-manage-account__check-allCheckbox';
 const checkAllIgnoreClassName = 'js-manage-account__check-allCheckbox__ignore';
 
+const optOutClassName = 'fieldset__fields--opt-out';
+const optInClassName = 'fieldset__fields--opt-in';
+
 const requestDebounceTimeout = 150;
 
 const LC_CHECK_ALL = 'Select all';
@@ -159,6 +162,20 @@ const unsubscribeFromAll = (csrfToken: string): Promise<void> =>
         },
     });
 
+const toggleInputsWithSelector = (className: string, checked: boolean) => {
+    return fastdom
+        .read(() => [...document.querySelectorAll(`.${className} input[type="checkbox"]`)])
+        .then((boxes) => boxes.forEach((b) => b.checked = checked));
+};
+
+const checkAllOptOuts = (): Promise<void> => {
+    return toggleInputsWithSelector(optOutClassName, true);
+};
+
+const uncheckAllOptIns = (): Promise<void> => {
+    return toggleInputsWithSelector(optInClassName, false);
+};
+
 const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     buttonEl.addEventListener('click', () => {
         if (!buttonEl.classList.contains('js-confirm-unsubscribe')) {
@@ -181,6 +198,7 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
                 document.getElementsByClassName(newsletterCheckboxClassName)[0]
             )
                 .then(csrfToken => unsubscribeFromAll(csrfToken))
+                .then(() => Promise.all([checkAllOptOuts(), uncheckAllOptIns()]))
                 .catch((err: Error) => {
                     pushError(err, 'reload').then(() => {
                         window.scrollTo(0, 0);

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -149,7 +149,7 @@ const confirmUnsubscriptionFromAll = (
             })
         );
 
-const unsubscribeFromAll = (csrfToken: string) =>
+const unsubscribeFromAll = (csrfToken: string): Promise<void> =>
     reqwest({
         url: `/user/email-subscriptions`,
         method: 'DELETE',

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -162,19 +162,24 @@ const unsubscribeFromAll = (csrfToken: string): Promise<void> =>
         },
     });
 
-const toggleInputsWithSelector = (className: string, checked: boolean) => {
-    return fastdom
-        .read(() => [...document.querySelectorAll(`.${className} input[type="checkbox"]`)])
-        .then((boxes) => boxes.forEach((b) => b.checked = checked));
-};
+const toggleInputsWithSelector = (className: string, checked: boolean) =>
+    fastdom
+        .read(() => [
+            ...document.querySelectorAll(
+                `.${className} input[type="checkbox"]`
+            ),
+        ])
+        .then(boxes =>
+            boxes.forEach(b => {
+                b.checked = checked;
+            })
+        );
 
-const checkAllOptOuts = (): Promise<void> => {
-    return toggleInputsWithSelector(optOutClassName, true);
-};
+const checkAllOptOuts = (): Promise<void> =>
+    toggleInputsWithSelector(optOutClassName, true);
 
-const uncheckAllOptIns = (): Promise<void> => {
-    return toggleInputsWithSelector(optInClassName, false);
-};
+const uncheckAllOptIns = (): Promise<void> =>
+    toggleInputsWithSelector(optInClassName, false);
 
 const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     buttonEl.addEventListener('click', () => {
@@ -198,7 +203,9 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
                 document.getElementsByClassName(newsletterCheckboxClassName)[0]
             )
                 .then(csrfToken => unsubscribeFromAll(csrfToken))
-                .then(() => Promise.all([checkAllOptOuts(), uncheckAllOptIns()]))
+                .then(() =>
+                    Promise.all([checkAllOptOuts(), uncheckAllOptIns()])
+                )
                 .catch((err: Error) => {
                     pushError(err, 'reload').then(() => {
                         window.scrollTo(0, 0);


### PR DESCRIPTION
## What does this change?

- The unsubscribe from all button will now perform consent setting / unsetting work, via IDAPI. 

## What is the value of this and can you measure success?

- Consistent behaviour/messaging of *all*. 

## Does this affect other platforms - Amp, Apps, etc?
 
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No

## Tested in CODE?

Soon
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
