### PR TITLE
I Can't Believe This Banner Just Keeps Getting Bigger When Will It Stop

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
+++ b/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
@@ -44,4 +44,4 @@ const trackConsentCookies = (
     });
 };
 
-export { onConsentSet, trackConsentCookies, upAlertViewCount };
+export { onConsentSet, trackConsentCookies, upAlertViewCount, getAlertViewCount };

--- a/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
+++ b/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
@@ -44,4 +44,9 @@ const trackConsentCookies = (
     });
 };
 
-export { onConsentSet, trackConsentCookies, upAlertViewCount, getAlertViewCount };
+export {
+    onConsentSet,
+    trackConsentCookies,
+    upAlertViewCount,
+    getAlertViewCount,
+};

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -36,7 +36,7 @@ type Links = {
 
 const displayEventKey: string = 'first-pv-consent : display';
 const messageCode: string = 'first-pv-consent';
-const blockMessageAfterPageViewNo = 4;
+const blockMessageAfterPageViewNo: number = 4;
 
 const links: Links = {
     privacy: 'https://www.theguardian.com/help/privacy-policy',

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -116,8 +116,11 @@ const trackInteraction = (interaction: string): void => {
 const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
-const canBlockThePage = (): boolean =>
-    [hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(_ => _ === true);
+const canBlockThePage = (): boolean => {
+    // TODO: enable the following check, once page blocking behaviour has been approved by the business
+    // [hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(_ => _ === true);
+    return false;
+};
 
 const show = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -118,7 +118,7 @@ const canShow = (): Promise<boolean> =>
 
 const canBlockThePage = (): boolean => {
     // TODO: enable the following checks, once page blocking behaviour has been approved by the business
-    [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
+    return [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
         _ => _ === true
     );
 };

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -117,9 +117,10 @@ const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
 const canBlockThePage = (): boolean => {
-    // TODO: enable the following check, once page blocking behaviour has been approved by the business
-    // [hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(_ => _ === true);
-    return false;
+    // TODO: enable the following checks, once page blocking behaviour has been approved by the business
+    [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
+        _ => _ === true
+    );
 };
 
 const show = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -116,12 +116,11 @@ const trackInteraction = (interaction: string): void => {
 const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
-const canBlockThePage = (): boolean => {
-    // TODO: enable the following checks, once page blocking behaviour has been approved by the business
-    return [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
+// TODO: enable the following checks, once page blocking behaviour has been approved by the business
+const canBlockThePage = (): boolean =>
+    [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
         _ => _ === true
     );
-};
 
 const show = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -36,7 +36,7 @@ type Links = {
 
 const displayEventKey: string = 'first-pv-consent : display';
 const messageCode: string = 'first-pv-consent';
-const blockMessageAfterPageViewNo = 0;
+const blockMessageAfterPageViewNo = 4;
 
 const links: Links = {
     privacy: 'https://www.theguardian.com/help/privacy-policy',
@@ -146,6 +146,7 @@ const firstPvConsentBanner: Banner = {
 
 export const _ = {
     onAgree,
+    canBlockThePage,
     bindableClassNames,
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -10,7 +10,10 @@ import {
 } from 'common/modules/commercial/ad-prefs.lib';
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
-import { upAlertViewCount, getAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
+import {
+    upAlertViewCount,
+    getAlertViewCount,
+} from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
@@ -82,16 +85,17 @@ const makeHtml = (tpl: Template, classes: BindableClassNames): string => `
     </div>
 `;
 
-const isInEU  = (): boolean =>
+const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
 const isNotInHelpOrInfoPage = (): boolean =>
-    ['info','help'].every(_=>_!==config.get('page.section'));
+    ['info', 'help'].every(_ => _ !== config.get('page.section'));
 
 const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);
 
-const hasSeenTooManyPages = (): boolean => (getAlertViewCount() > blockMessageAfterPageViewNo)
+const hasSeenTooManyPages = (): boolean =>
+    getAlertViewCount() > blockMessageAfterPageViewNo;
 
 const onAgree = (msg: Message): void => {
     allAdConsents.forEach(_ => {
@@ -113,7 +117,7 @@ const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
 const canBlockThePage = (): boolean =>
-    [hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(_ => _ === true)
+    [hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(_ => _ === true);
 
 const show = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -83,7 +83,28 @@ describe('First PV consents banner', () => {
         );
     });
 
-    describe('When blocking the page', () => {
+    describe('should never block the page', () => {
+        it('should not block the page on the first pv', () => {
+            getAlertViewCount.mockImplementation(() => 1);
+            expect(test.canBlockThePage()).toBeFalsy();
+        });
+        it('should block the page after x pvs', () => {
+            getAlertViewCount.mockImplementation(() => 999999);
+            expect(test.canBlockThePage()).toBeFalsy();
+        });
+        it('should not block info or help pages', () => {
+            getAlertViewCount.mockImplementation(() => 999999);
+            config.get.mockImplementation(() => 'info');
+            expect(test.canBlockThePage()).toBeFalsy();
+            config.get.mockImplementation(() => 'help');
+            expect(test.canBlockThePage()).toBeFalsy();
+            config.get.mockImplementation(() => 'sport');
+            expect(test.canBlockThePage()).toBeFalsy();
+        });
+    });
+
+    // TODO: unskip these tests and delete the above test once the business approves blocking the page
+    describe.skip('When blocking the page', () => {
         it('should not block the page on the first pv', () => {
             getAlertViewCount.mockImplementation(() => 1);
             expect(test.canBlockThePage()).toBeFalsy();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -109,7 +109,7 @@ describe('First PV consents banner', () => {
             getAlertViewCount.mockImplementation(() => 1);
             expect(test.canBlockThePage()).toBeFalsy();
         });
-        it('should block the page after x pvs', () => {
+        it('should not block the page after x pvs', () => {
             getAlertViewCount.mockImplementation(() => 999999);
             expect(test.canBlockThePage()).toBeTruthy();
         });

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -79,6 +79,7 @@ class Message {
 
         // Add a blocking overlay if needed
         if (this.blocking) {
+            $('body, html').addClass('is-scroll-blocked');
             this.$siteMessageOverlay.removeClass('is-hidden');
             this.$siteMessageOverlay[0].addEventListener('click', () => {
                 this.$siteMessageContainer[0].focus();
@@ -186,6 +187,7 @@ class Message {
         $('#header').removeClass('js-site-message');
         $('.js-site-message').addClass('is-hidden');
         $('.js-site-message-overlay').addClass('is-hidden');
+        $('body, html').removeClass('is-scroll-blocked');
         if (this.pinOnHide) {
             this.$footerMessage.removeClass('is-hidden');
         }

--- a/static/src/stylesheets/base/_state.scss
+++ b/static/src/stylesheets/base/_state.scss
@@ -50,6 +50,10 @@
     }
 }
 
+.is-scroll-blocked {
+    overflow: hidden;
+}
+
 .is-updating-cursor {
     cursor: wait;
 }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -17,7 +17,7 @@
     right: 0;
     top: 0;
     background: $garnett-neutral-1;
-    opacity: .85;
+    opacity: .7;
     z-index: $zindex-popover - 1;
 }
 

--- a/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/release-messages/_first-pv-consent.scss
@@ -12,7 +12,7 @@ $btn-height: ($gs-baseline*3.5);
     }
 
     @include mq(leftCol) {
-        padding-bottom: $gs-baseline * 6;
+        padding-bottom: $gs-baseline * 4;
     }
 
     .site-message__media {
@@ -25,10 +25,10 @@ $btn-height: ($gs-baseline*3.5);
         display: block;
         margin: 0 $gs-gutter / 2;
         @include mq(leftCol) {
-            display: flex;
-            align-items: flex-start;
-            margin-left: $gs-gutter;
-            margin-right: $gs-gutter;
+            padding-left: gs-span(2) + $gs-gutter * 1.5;
+        }
+        @include mq(wide) {
+            padding-left: gs-span(3) + $gs-gutter * 1.5;
         }
     }
 }
@@ -71,33 +71,20 @@ $btn-height: ($gs-baseline*3.5);
 }
 
 .site-message--first-pv-consent__block {
-    &:not(:last-child) {
-        margin-right: $gs-gutter;
-    }
+    max-width: gs-span(8);
     &.site-message--first-pv-consent__block--head {
-        @include fs-header(4);
-        @include mq(desktop) {
-            width: gs-span(2);
+        @include fs-headlineGarnett(4);
+        @include mq(leftCol) {
+            @include fs-headlineGarnett(6, true);
         }
-        @include mq(wide) {
-            width: gs-span(3);
-        }
-        @include mq($until: wide) {
-            @include font-size(20px, 24px);
-        }
-        flex: 0 0 auto;
-        position: relative;
-        padding-bottom: $gs-baseline / 2;
-        line-height: get-line-height(header, 2);
+        font-weight: bold;
+        padding-bottom: $gs-baseline;
         color: $news-garnett-highlight;
     }
     &.site-message--first-pv-consent__block--intro {
         @include fs-bodyCopy(2);
         font-size: 17px;
         line-height: 24px;
-        flex: 1 1 0;
-        margin-top: 3px;
-        max-width: gs-span(8);
         a {
             color: currentColor;
         }
@@ -106,8 +93,7 @@ $btn-height: ($gs-baseline*3.5);
 
 .site-message--first-pv-consent__actions {
     @include fs-textSans(3);
-    flex: 0 0 auto;
-    margin-top: $gs-baseline;
+    margin-top: $gs-baseline * 2;
     .site-message--first-pv-consent__button {
         margin-right: $gs-baseline;
     }
@@ -115,8 +101,5 @@ $btn-height: ($gs-baseline*3.5);
     .site-message--first-pv-consent__link {
         display: inline-block;
         vertical-align: baseline;
-    }
-    @include mq($until: desktop) {
-        margin-top: $gs-baseline;
     }
 }


### PR DESCRIPTION
## What does this change?
Makes the cookie banner **BIGGER** (#19744 #19742)

There's a couple checks in place to make sure it can't cover the privacy policy or help pages

## What is the value of this and can you measure success?
We need more consents and more clicks overall.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

![screen shot 2018-05-30 at 1 43 04 pm](https://user-images.githubusercontent.com/11539094/40721802-7632f5ce-6412-11e8-97ab-edc52c0f9e6f.png)

## Picture of a cookie
![screen shot 2018-05-30 at 1 58 49 pm](https://user-images.githubusercontent.com/11539094/40722026-1c55ed8a-6413-11e8-9c77-fc2ce40a1322.png)
