### PR TITLE
UX: Unsubscribe from all Modal

### DIFF
--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -11,7 +11,7 @@
 @confirmModal = {
     <section class="identity-forms-message">
         <h1>Are you sure?</h1>
-        <p>You've chosen not to receive any editorial or marketing newsletters from the Guardian.</p>
+        <p>You've chosen not to receive any editorial or marketing newsletters from The Guardian.</p>
 
         <p><strong>Are you sure you want to unsubscribe from these emails?</strong></p>
 

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -8,6 +8,21 @@
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
 }
 
+@confirmModal = {
+    <section class="identity-forms-message">
+        <h1>Are you sure?</h1>
+        <p>You've chosen not to receive any editorial or marketing newsletters from the Guardian.</p>
+
+        <p><strong>Are you sure you want to unsubscribe from these emails?</strong></p>
+
+        <footer class="identity-forms-message__options">
+            <button class="js-identity-modal__closer manage-account__button manage-account__button--main manage-account__button--center js-confirm-unsubscribe-all">Yes, unsubscribe me</button>
+            <button class="manage-account__button manage-account__button--secondary manage-account__button--center js-identity-modal__closer">Cancel</button>
+        </footer>
+
+    </section>
+}
+
 <div class="email-subscription__fieldset">
 
     <fieldset class="fieldset">
@@ -39,16 +54,16 @@
                 </li>
                 <li>
                     <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
-                        <span class="email-unsubscribe-all__label js-unsubscribe--basic manage-account__button-flexwrap">
+                        <span class="email-unsubscribe-all__label manage-account__button-flexwrap">
                             Unsubscribe from all newsletters and marketing emails
                             @fragments.inlineSvg("cross", "icon")
-                        </span>
-                        <span class="email-unsubscribe-all__label js-unsubscribe--confirm hide" aria-hidden>
-                            Are you sure?
                         </span>
                     </button>
                 </li>
             </ul>
+
+            @fragments.modal("confirm-unsubscribe-all", confirmModal)
+
         </div>
 
     </fieldset>

--- a/identity/app/views/profile/emailSettings.scala.html
+++ b/identity/app/views/profile/emailSettings.scala.html
@@ -54,10 +54,8 @@
                 </li>
                 <li>
                     <button type="button" class="manage-account__button--mini manage-account__button--icon manage-account__button email-unsubscribe js-unsubscribe" data-link-name="identity : email : unsubscribe-all">
-                        <span class="email-unsubscribe-all__label manage-account__button-flexwrap">
-                            Unsubscribe from all newsletters and marketing emails
-                            @fragments.inlineSvg("cross", "icon")
-                        </span>
+                        Unsubscribe from all newsletters and marketing emails
+                        @fragments.inlineSvg("cross", "icon")
                     </button>
                 </li>
             </ul>

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -15,7 +15,7 @@ import {
 } from './modules/switch';
 import { addUpdatingState, removeUpdatingState } from './modules/button';
 import { getCsrfTokenFromElement } from './modules/fetchFormFields';
-import { getContents, show as showModal } from './modules/modal';
+import { show as showModal } from './modules/modal';
 
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
 const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
@@ -129,30 +129,6 @@ const resetUnsubscribeFromAll = (buttonEl: HTMLButtonElement): Promise<void> =>
             })
         );
 
-const confirmUnsubscriptionFromAll = (
-    buttonEl: HTMLButtonElement
-): Promise<void> =>
-    fastdom
-        .read(() => [
-            [
-                ...document.getElementsByClassName(
-                    'email-unsubscribe-all__label'
-                ),
-            ],
-        ])
-        .then(([unsubAllLabelEls]) =>
-            fastdom.write(() => {
-                /* TODO:simplify this once classList.remove() is fixed */
-                [
-                    'email-unsubscribe--confirm',
-                    'js-confirm-unsubscribe',
-                ].forEach(classname => buttonEl.classList.add(classname));
-                unsubAllLabelEls.forEach(unsubAllLabelEl =>
-                    unsubAllLabelEl.classList.toggle('hide')
-                );
-            })
-        );
-
 const unsubscribeFromAll = (csrfToken: string): Promise<void> =>
     reqwest({
         url: `/user/email-subscriptions`,
@@ -201,9 +177,7 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
             document.getElementsByClassName(newsletterCheckboxClassName)[0]
         )
             .then(csrfToken => unsubscribeFromAll(csrfToken))
-            .then(() =>
-                Promise.all([checkAllOptOuts(), uncheckAllOptIns()])
-            )
+            .then(() => Promise.all([checkAllOptOuts(), uncheckAllOptIns()]))
             .catch((err: Error) => {
                 pushError(err, 'reload').then(() => {
                     window.scrollTo(0, 0);
@@ -215,11 +189,12 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     });
 };
 
-const bindUnsubscribeFromAllModalConfirmation = (buttonEl: HTMLButtonElement) => {
+const bindUnsubscribeFromAllModalConfirmation = (
+    buttonEl: HTMLButtonElement
+) => {
     buttonEl.addEventListener('click', () => {
-            showModal('confirm-unsubscribe-all');
-        }
-    );
+        showModal('confirm-unsubscribe-all');
+    });
 };
 
 const updateNewsletterSwitch = (labelEl: HTMLElement): Promise<void> =>

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -438,38 +438,8 @@ $identity-header-height: 48px;
         }
     }
 
-    &.is-updating-subscriptions {
-        display: inherit;
-        margin-top: 0;
-        font-size: 0;
-        background-color: $garnett-neutral-4;
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: 40px;
-    }
-
     .email-subscription--subscribed & {
         @extend %manage-account__button--light;
-    }
-
-    &.email-unsubscribe {
-        float: none;
-        margin-top: $gs-baseline;
-        &.is-updating {
-            svg {
-                display: none;
-            }
-        }
-    }
-
-    &.email-unsubscribe--confirm,
-    &.email-unsubscribe--confirm:hover,
-    &.email-unsubscribe--confirm:focus {
-        color: $error!important;
-        background: #ffffff!important;
-        font-weight: bold!important;
-        border: 1px solid $error!important;
-        box-shadow: inset 0 0 0 01px $error;
     }
 
     .email-subscription__fieldset & {
@@ -492,14 +462,6 @@ $identity-header-height: 48px;
     .label-like {
         @include fs-bodyCopy(1, true);
         margin-top: $gs-gutter;
-    }
-}
-
-.email-unsubscribe-all__label {
-    display: inline;
-
-    &.hide {
-        display: none!important;
     }
 }
 


### PR DESCRIPTION
## What does this change?

- When unsubscribing from all via `/email-prefs` instead of requiring two clicks on a single button for confirmation,  display a modal after the first click that requires you to confirm your request. 

## What is the value of this and can you measure success?

- Users will get value for money out of this button: two pages for the price of one!
- We can display some text in the modal to further discourage users from unsubscribing from emails. 

## Does this affect other platforms - Amp, Apps, etc?

No


## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

Mobile: 

![screen shot 2018-05-30 at 13 58 36](https://user-images.githubusercontent.com/3636251/40722167-7c4cc2e0-6413-11e8-98c3-0a2ea4c5111f.png)

Desktop: 

![screen shot 2018-05-30 at 14 06 22](https://user-images.githubusercontent.com/3636251/40722173-82dd3b1c-6413-11e8-9793-a7513ecea819.png)


## Tested in CODE?

Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
