### PR TITLE
Prevent message banners from blocking the footer

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -55,7 +55,6 @@ object ContentHtmlPage extends HtmlPage[Page] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -50,7 +50,6 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -59,6 +58,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -46,7 +46,6 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -54,6 +53,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
         breakingNewsDiv(),
         galleryBody(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -49,7 +49,6 @@ object IndexHtml {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -58,6 +57,7 @@ object IndexHtml {
         breakingNewsDiv(),
         bodyContent,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -55,7 +55,6 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         breakingNewsDiv(),
         interactiveBody(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -42,7 +42,6 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -50,6 +49,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         breakingNewsDiv(),
         newsletterContent(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -52,7 +52,6 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -61,6 +60,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -53,7 +53,6 @@ object StoryHtmlPage {
         blockthrough() when BlockthroughSwitch.isSwitchedOn
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object StoryHtmlPage {
         content,
         twentyFourSevenTraining(),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -55,7 +55,6 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         breakingNewsDiv(),
         cleanedFrontBody(),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -159,7 +159,6 @@ const showBanner = (params: EngagementBannerParams): void => {
         ? params.template(templateParams)
         : acquisitionsBannerControlTemplate(templateParams);
     const messageShown = new Message(messageCode, {
-        pinOnHide: false,
         siteMessageLinkName: 'membership message',
         siteMessageCloseBtn: 'hide',
         siteMessageComponentName: params.campaignCode,

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -55,7 +55,6 @@ class Message {
     }
 
     show(message: string): boolean {
-
         // don't let messages unknowingly overwrite each other
         if (
             !this.$siteMessageContainer.hasClass('is-hidden') &&
@@ -174,8 +173,8 @@ class Message {
 
     hide(): void {
         $('#header').removeClass('js-site-message');
-        $('.js-site-message').addClass('is-hidden');
-        $('.js-site-message-overlay').addClass('is-hidden');
+        this.$siteMessageContainer.addClass('is-hidden');
+        this.$siteMessageOverlay.addClass('is-hidden');
     }
 
     remember(): void {

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -22,7 +22,6 @@ class Message {
     blocking: boolean;
     trackDisplay: boolean;
     type: string;
-    pinOnHide: boolean;
     siteMessageComponentName: string;
     siteMessageLinkName: string;
     siteMessageCloseBtn: string;
@@ -34,7 +33,6 @@ class Message {
     $siteMessage: Object;
     $siteMessageContainer: Object;
     $siteMessageOverlay: Object;
-    $footerMessage: Object;
 
     constructor(id: string, options?: Object) {
         const opts = options || {};
@@ -44,7 +42,6 @@ class Message {
         this.blocking = opts.blocking || false;
         this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
-        this.pinOnHide = opts.pinOnHide || false;
         this.siteMessageComponentName = opts.siteMessageComponentName || '';
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';
@@ -53,15 +50,11 @@ class Message {
         this.cssModifierClass = opts.cssModifierClass || '';
         this.customJs = opts.customJs || noop;
         this.customOpts = opts.customOpts || {};
-        this.$footerMessage = $('.js-footer-message');
         this.$siteMessageContainer = $('.js-site-message');
         this.$siteMessageOverlay = $('.js-site-message-overlay');
     }
 
     show(message: string): boolean {
-        if (this.pinOnHide) {
-            $('.js-footer-site-message-copy').html(message);
-        }
 
         // don't let messages unknowingly overwrite each other
         if (
@@ -69,9 +62,6 @@ class Message {
             !this.important
         ) {
             // if we're not showing a banner message, display it in the footer
-            if (this.pinOnHide) {
-                this.$footerMessage.removeClass('is-hidden');
-            }
             return false;
         }
 
@@ -186,9 +176,6 @@ class Message {
         $('#header').removeClass('js-site-message');
         $('.js-site-message').addClass('is-hidden');
         $('.js-site-message-overlay').addClass('is-hidden');
-        if (this.pinOnHide) {
-            this.$footerMessage.removeClass('is-hidden');
-        }
     }
 
     remember(): void {

--- a/static/src/javascripts/projects/common/modules/ui/message.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.spec.js
@@ -18,9 +18,6 @@ describe('Message', () => {
                     <div class="js-site-message-copy">...</div>
                     <button class="site-message__close"></button>
                 </div>
-                <div class="site-message--footer is-hidden js-footer-message">
-                    <div class="site-message__copy js-footer-site-message-copy u-cf"></div>
-                </div>'
             `;
         }
     });
@@ -32,16 +29,6 @@ describe('Message', () => {
     it('Show a message', () => {
         new Message('foo').show('hello world');
         expect($('.js-site-message-copy').text()).toEqual('hello world');
-        expect($('.js-footer-site-message-copy').text()).not.toEqual(
-            'hello world'
-        );
-        expect($('.js-site-message').hasClass('is-hidden')).toEqual(false);
-    });
-
-    it('Show a pinnable message', () => {
-        new Message('foo', { pinOnHide: true }).show('hello world');
-        expect($('.js-site-message-copy').text()).toEqual('hello world');
-        expect($('.js-footer-site-message-copy').text()).toEqual('hello world');
         expect($('.js-site-message').hasClass('is-hidden')).toEqual(false);
     });
 
@@ -50,15 +37,6 @@ describe('Message', () => {
         m.show('hello world');
         m.hide();
         expect($('.js-site-message').hasClass('is-hidden')).toEqual(true);
-        expect($('.js-footer-message').hasClass('is-hidden')).toEqual(true);
-    });
-
-    it('Hide a pinnable message', () => {
-        const m = new Message('foo', { pinOnHide: true });
-        m.show('hello world');
-        m.hide();
-        expect($('.js-site-message').hasClass('is-hidden')).toEqual(true);
-        expect($('.js-footer-message').hasClass('is-hidden')).toEqual(false);
     });
 
     it('Remember the user has acknowledged the message', () => {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -23,6 +23,7 @@
 
 .site-message--banner {
     position: fixed;
+    position: sticky;
     bottom: 0;
     width: 100%;
     z-index: $zindex-popover;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -576,7 +576,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         position: absolute;
         right: 0;
         top: 0;
-        height: 100%;
+        height: 95%;
         @include mq($from: mobile) {
             padding-right: 10px;
         }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -23,7 +23,9 @@
 
 .site-message--banner {
     position: fixed;
-    position: sticky;
+    @supports (position: sticky) {
+        position: sticky;
+    }
     bottom: 0;
     width: 100%;
     z-index: $zindex-popover;


### PR DESCRIPTION
## What does this change?
The sticky message banners are blocking the footer links. This poses a bit of a compliance problem in relation to the new cookie banner.

Anyway thanks to some `position: sticky` magic we can fix that with a oneliner for most modern browsers.

The actual fix is a oneliner **however** for this to work I had to move the banner's initialisation HTML itself to the footer. In doing so I came across older code (`pinOnHide`) that looked for `. site-message--footer`. We have no such element in guardian.com nowadays. I did a cleanup of that because it wasn't being used and as it stands today it was just going to fail silently anyway.

## What is the value of this and can you measure success?
clicks! on! the! (footer) links!

## Screenies
![screen shot 2018-05-30 at 2 50 03 pm](https://user-images.githubusercontent.com/11539094/40725498-8122aa84-641b-11e8-97c5-5d258e2fa928.png)
