### PR TITLE
Revert "Return bad request for email form render errors"

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -85,7 +85,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
 
       identityName match {
         case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _ => Cached(15.minute)(WithoutRevalidationResult(BadRequest))
+        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
       }
     }
   }
@@ -95,7 +95,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
       val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
       id match {
         case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _            => Cached(15.minute)(WithoutRevalidationResult(BadRequest))
+        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
       }
     }
   }


### PR DESCRIPTION
Reverts guardian/frontend#19759 because it didn't have the desired effect.