### PR TITLE
Prevent message banners from blocking the footer: Round 2

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -55,7 +55,6 @@ object ContentHtmlPage extends HtmlPage[Page] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -50,7 +50,6 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -59,6 +58,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -46,7 +46,6 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -54,6 +53,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
         breakingNewsDiv(),
         galleryBody(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -49,7 +49,6 @@ object IndexHtml {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -58,6 +57,7 @@ object IndexHtml {
         breakingNewsDiv(),
         bodyContent,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -55,7 +55,6 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         breakingNewsDiv(),
         interactiveBody(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -42,7 +42,6 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -50,6 +49,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         breakingNewsDiv(),
         newsletterContent(page),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -52,7 +52,6 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -61,6 +60,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         breakingNewsDiv(),
         content,
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -53,7 +53,6 @@ object StoryHtmlPage {
         blockthrough() when BlockthroughSwitch.isSwitchedOn
       ),
       bodyTag(classes = bodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object StoryHtmlPage {
         content,
         twentyFourSevenTraining(),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -55,7 +55,6 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        message(),
         tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
@@ -64,6 +63,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         breakingNewsDiv(),
         cleanedFrontBody(),
         footer(),
+        message(),
         inlineJSNonBlocking(),
         analytics.base()
       ),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -159,7 +159,6 @@ const showBanner = (params: EngagementBannerParams): void => {
         ? params.template(templateParams)
         : acquisitionsBannerControlTemplate(templateParams);
     const messageShown = new Message(messageCode, {
-        pinOnHide: false,
         siteMessageLinkName: 'membership message',
         siteMessageCloseBtn: 'hide',
         siteMessageComponentName: params.campaignCode,

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -45,7 +45,7 @@ class Message {
         this.blocking = opts.blocking || false;
         this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
-        this.position = opts.position || 'top';
+        this.position = opts.position || 'bottom';
         this.siteMessageComponentName = opts.siteMessageComponentName || '';
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -70,8 +70,13 @@ class Message {
 
         // Move the message to the top if needed
         if(this.position === 'top'){
-          document.body.insertBefore(this.$siteMessageContainer[0],document.body.childNodes[0]);
-          this.$siteMessageContainer.addClass('site-message--on-top');
+            const bodyEl: ?HTMLElement = document.body;
+            if(!bodyEl) throw new Error('Missing <body>');
+            const bodyElFirstChild: ?Node = bodyEl.childNodes[0];
+            if(!bodyElFirstChild) throw new Error('<body> is empty');
+            
+            bodyEl.insertBefore(this.$siteMessageContainer[0],bodyElFirstChild);
+            this.$siteMessageContainer.addClass('site-message--on-top');
         }
 
         $('.js-site-message-copy').html(message);

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -69,13 +69,16 @@ class Message {
         }
 
         // Move the message to the top if needed
-        if(this.position === 'top'){
+        if (this.position === 'top') {
             const bodyEl: ?HTMLElement = document.body;
-            if(!bodyEl) throw new Error('Missing <body>');
+            if (!bodyEl) throw new Error('Missing <body>');
             const bodyElFirstChild: ?Node = bodyEl.childNodes[0];
-            if(!bodyElFirstChild) throw new Error('<body> is empty');
-            
-            bodyEl.insertBefore(this.$siteMessageContainer[0],bodyElFirstChild);
+            if (!bodyElFirstChild) throw new Error('<body> is empty');
+
+            bodyEl.insertBefore(
+                this.$siteMessageContainer[0],
+                bodyElFirstChild
+            );
             this.$siteMessageContainer.addClass('site-message--on-top');
         }
 
@@ -234,5 +237,5 @@ class Message {
     }
 }
 
-export type {MessagePosition}
+export type { MessagePosition };
 export { Message };

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -8,6 +8,8 @@ import { isBreakpoint } from 'lib/detect';
 import { begin } from 'common/modules/analytics/register';
 import uniq from 'lodash/arrays/uniq';
 
+type MessagePosition = 'top' | 'bottom';
+
 /**
  * Message provides a common means of flash messaging a user in the UI.
  *
@@ -22,6 +24,7 @@ class Message {
     blocking: boolean;
     trackDisplay: boolean;
     type: string;
+    position: MessagePosition;
     siteMessageComponentName: string;
     siteMessageLinkName: string;
     siteMessageCloseBtn: string;
@@ -42,6 +45,7 @@ class Message {
         this.blocking = opts.blocking || false;
         this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
+        this.position = opts.position || 'top';
         this.siteMessageComponentName = opts.siteMessageComponentName || '';
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';
@@ -62,6 +66,11 @@ class Message {
         ) {
             // if we're not showing a banner message, display it in the footer
             return false;
+        }
+
+        // Move the message to the top if needed
+        if(this.position === 'top'){
+          document.body.insertBefore(this.$siteMessageContainer[0],document.body.childNodes[0])
         }
 
         $('.js-site-message-copy').html(message);
@@ -219,4 +228,5 @@ class Message {
     }
 }
 
+export type {MessagePosition}
 export { Message };

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -70,7 +70,8 @@ class Message {
 
         // Move the message to the top if needed
         if(this.position === 'top'){
-          document.body.insertBefore(this.$siteMessageContainer[0],document.body.childNodes[0])
+          document.body.insertBefore(this.$siteMessageContainer[0],document.body.childNodes[0]);
+          this.$siteMessageContainer.addClass('site-message--on-top');
         }
 
         $('.js-site-message-copy').html(message);

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -22,7 +22,6 @@ class Message {
     blocking: boolean;
     trackDisplay: boolean;
     type: string;
-    pinOnHide: boolean;
     siteMessageComponentName: string;
     siteMessageLinkName: string;
     siteMessageCloseBtn: string;
@@ -34,7 +33,6 @@ class Message {
     $siteMessage: Object;
     $siteMessageContainer: Object;
     $siteMessageOverlay: Object;
-    $footerMessage: Object;
 
     constructor(id: string, options?: Object) {
         const opts = options || {};
@@ -44,7 +42,6 @@ class Message {
         this.blocking = opts.blocking || false;
         this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
-        this.pinOnHide = opts.pinOnHide || false;
         this.siteMessageComponentName = opts.siteMessageComponentName || '';
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';
@@ -53,25 +50,17 @@ class Message {
         this.cssModifierClass = opts.cssModifierClass || '';
         this.customJs = opts.customJs || noop;
         this.customOpts = opts.customOpts || {};
-        this.$footerMessage = $('.js-footer-message');
         this.$siteMessageContainer = $('.js-site-message');
         this.$siteMessageOverlay = $('.js-site-message-overlay');
     }
 
     show(message: string): boolean {
-        if (this.pinOnHide) {
-            $('.js-footer-site-message-copy').html(message);
-        }
-
         // don't let messages unknowingly overwrite each other
         if (
             !this.$siteMessageContainer.hasClass('is-hidden') &&
             !this.important
         ) {
             // if we're not showing a banner message, display it in the footer
-            if (this.pinOnHide) {
-                this.$footerMessage.removeClass('is-hidden');
-            }
             return false;
         }
 
@@ -185,12 +174,9 @@ class Message {
 
     hide(): void {
         $('#header').removeClass('js-site-message');
-        $('.js-site-message').addClass('is-hidden');
-        $('.js-site-message-overlay').addClass('is-hidden');
+        this.$siteMessageContainer.addClass('is-hidden');
+        this.$siteMessageOverlay.addClass('is-hidden');
         $('body, html').removeClass('is-scroll-blocked');
-        if (this.pinOnHide) {
-            this.$footerMessage.removeClass('is-hidden');
-        }
     }
 
     remember(): void {

--- a/static/src/javascripts/projects/common/modules/ui/message.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.spec.js
@@ -18,9 +18,6 @@ describe('Message', () => {
                     <div class="js-site-message-copy">...</div>
                     <button class="site-message__close"></button>
                 </div>
-                <div class="site-message--footer is-hidden js-footer-message">
-                    <div class="site-message__copy js-footer-site-message-copy u-cf"></div>
-                </div>'
             `;
         }
     });
@@ -32,16 +29,6 @@ describe('Message', () => {
     it('Show a message', () => {
         new Message('foo').show('hello world');
         expect($('.js-site-message-copy').text()).toEqual('hello world');
-        expect($('.js-footer-site-message-copy').text()).not.toEqual(
-            'hello world'
-        );
-        expect($('.js-site-message').hasClass('is-hidden')).toEqual(false);
-    });
-
-    it('Show a pinnable message', () => {
-        new Message('foo', { pinOnHide: true }).show('hello world');
-        expect($('.js-site-message-copy').text()).toEqual('hello world');
-        expect($('.js-footer-site-message-copy').text()).toEqual('hello world');
         expect($('.js-site-message').hasClass('is-hidden')).toEqual(false);
     });
 
@@ -50,15 +37,6 @@ describe('Message', () => {
         m.show('hello world');
         m.hide();
         expect($('.js-site-message').hasClass('is-hidden')).toEqual(true);
-        expect($('.js-footer-message').hasClass('is-hidden')).toEqual(true);
-    });
-
-    it('Hide a pinnable message', () => {
-        const m = new Message('foo', { pinOnHide: true });
-        m.show('hello world');
-        m.hide();
-        expect($('.js-site-message').hasClass('is-hidden')).toEqual(true);
-        expect($('.js-footer-message').hasClass('is-hidden')).toEqual(false);
     });
 
     it('Remember the user has acknowledged the message', () => {

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -70,7 +70,7 @@ const canShow = (): Promise<boolean> =>
 
 const show = (): void => {
     loadCssPromise.then(() => {
-        const msg = new Message(messageCode);
+        const msg = new Message(messageCode,{position:'top'});
         const fullTemplate = tmp + (getBreakpoint() === 'mobile' ? '' : tablet);
 
         msg.show(template(fullTemplate, DATA[messageCode.toUpperCase()]));

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -70,7 +70,7 @@ const canShow = (): Promise<boolean> =>
 
 const show = (): void => {
     loadCssPromise.then(() => {
-        const msg = new Message(messageCode,{position:'top'});
+        const msg = new Message(messageCode, { position: 'top' });
         const fullTemplate = tmp + (getBreakpoint() === 'mobile' ? '' : tablet);
 
         msg.show(template(fullTemplate, DATA[messageCode.toUpperCase()]));

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -29,6 +29,10 @@
     bottom: 0;
     width: 100%;
     z-index: $zindex-popover;
+    &.site-message--on-top {
+        bottom: auto;
+        top: 0;
+    }
 }
 
 .site-message--alt {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -23,6 +23,9 @@
 
 .site-message--banner {
     position: fixed;
+    @supports (position: sticky) {
+        position: sticky;
+    }
     bottom: 0;
     width: 100%;
     z-index: $zindex-popover;
@@ -575,7 +578,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         position: absolute;
         right: 0;
         top: 0;
-        height: 100%;
+        height: 95%;
         @include mq($from: mobile) {
             padding-right: 10px;
         }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -22,16 +22,24 @@
 }
 
 .site-message--banner {
-    position: fixed;
-    @supports (position: sticky) {
-        position: sticky;
-    }
-    bottom: 0;
     width: 100%;
     z-index: $zindex-popover;
+    position: fixed;
+    bottom: 0;
+    @supports (position: sticky) {
+        position: sticky;
+        bottom: -1px;
+        /*chrome calculates sticky in dip
+        instead of real px and that can
+        sometimes leave a 1px gap in some
+        screen sizes*/
+    }
     &.site-message--on-top {
         bottom: auto;
         top: 0;
+        @supports (position: sticky) {
+            top: -1px;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/release-messages/_sign-in.scss
+++ b/static/src/stylesheets/module/release-messages/_sign-in.scss
@@ -28,6 +28,7 @@ $sign-in-eb-vertical-mq: 36em;
     align-content: center;
     align-items: center;
     overflow-y: auto;
+    position: fixed;
     -webkit-overflow-scrolling: touch;
     .gs-container {
         margin: auto;


### PR DESCRIPTION
_#19762 broke the sign in engagement banner :( .This is the same PR with more safeguards in place_

## What does this change?
The sticky message banners are blocking the footer links. This poses a bit of a compliance problem in relation to the new cookie banner.

Anyway thanks to some `position: sticky` magic we can fix that with a oneliner for most modern browsers.

The actual fix is a oneliner. **however**, for this to work I had to move the banner's initialisation HTML itself to the footer. In doing so I came across older code (`pinOnHide`) that looked for `. site-message--footer`. We have no such element in guardian.com nowadays. I did a cleanup of that because it wasn't being used and as it stands today it was just going to fail silently anyway.

## What has changed since the last PR?
- The sign in engagement banner enforces its container being fixed
- There's a new position argument that can be `top` or `bottom` for the smart app banner and other potential top-aligned banners. This directly affects the DOM position of the element.
- In the future, 'modal' banners like the sign in alert could use a third position, 'floating' or something instead of the CSS hacks in place to support the existing thing

## Screenies
![screen shot 2018-05-31 at 10 09 06 am](https://user-images.githubusercontent.com/11539094/40774574-e46b70f6-64bd-11e8-946b-a337f33cf427.png)
![screen shot 2018-05-31 at 10 09 33 am](https://user-images.githubusercontent.com/11539094/40774576-e49d32c6-64bd-11e8-8e96-a69bf54fbf34.png)
![screen shot 2018-05-31 at 10 10 01 am](https://user-images.githubusercontent.com/11539094/40774579-e4b99204-64bd-11e8-864a-d318cac55db5.png)
![screen shot 2018-05-31 at 10 12 41 am](https://user-images.githubusercontent.com/11539094/40774580-e4d59210-64bd-11e8-859e-adc354be02a0.png)
![screen shot 2018-05-31 at 10 28 30 am](https://user-images.githubusercontent.com/11539094/40774581-e4f1072a-64bd-11e8-93c0-ff52d6a8f9fb.png)
