### PR TITLE
AB test for the cookie banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,6 +38,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-first-pv-consent-blocker",
+    "This test will make the cookie consent banner blocking",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019,5, 31),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-always-ask-if-tagged",
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,10 +3,12 @@ import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import { signInEngagementBannerDisplay } from './tests/sign-in-engagement-banner-display';
+import { firstPvConsentBlocker } from './tests/first-pv-consent-blocker';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     signInEngagementBannerDisplay,
+    firstPvConsentBlocker,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
@@ -6,7 +6,7 @@ export const firstPvConsentBlocker: ABTest = {
     expiry: '2019-05-31',
     author: 'Laura gonzalez',
     description: 'This test will make the cookie consent banner blocking.',
-    audience: 0.1,
+    audience: 0.004,
     audienceOffset: 0.7,
     successMeasure: 'More consents',
     audienceCriteria: 'All web traffic who can see the banner',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const firstPvConsentBlocker: ABTest = {
+    id: 'FirstPvConsentBlocker',
+    start: '2018-05-31',
+    expiry: '2019-05-31',
+    author: 'Laura gonzalez',
+    description: 'This test will make the cookie consent banner blocking.',
+    audience: 0.3,
+    audienceOffset: 0.7,
+    successMeasure: 'More consents',
+    audienceCriteria: 'All web traffic who can see the banner',
+    dataLinkNames: '"privacy-prefs" component',
+    idealOutcome:
+        'We increase the number of consents without getting an equal number of explicit nos or damaging the guardian brand.',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: () => {},
+        },
+        {
+            id: 'control',
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/first-pv-consent-blocker.js
@@ -6,7 +6,7 @@ export const firstPvConsentBlocker: ABTest = {
     expiry: '2019-05-31',
     author: 'Laura gonzalez',
     description: 'This test will make the cookie consent banner blocking.',
-    audience: 0.3,
+    audience: 0.1,
     audienceOffset: 0.7,
     successMeasure: 'More consents',
     audienceCriteria: 'All web traffic who can see the banner',

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -10,10 +10,7 @@ import {
 } from 'common/modules/commercial/ad-prefs.lib';
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
-import {
-    upAlertViewCount,
-    getAlertViewCount,
-} from 'common/modules/analytics/send-privacy-prefs';
+import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { firstPvConsentBlocker } from 'common/modules/experiments/tests/first-pv-consent-blocker';
@@ -38,7 +35,6 @@ type Links = {
 
 const displayEventKey: string = 'first-pv-consent : display';
 const messageCode: string = 'first-pv-consent';
-const blockMessageAfterPageViewNo: number = 4;
 
 const links: Links = {
     privacy: 'https://www.theguardian.com/help/privacy-policy',
@@ -96,9 +92,6 @@ const isNotInHelpOrInfoPage = (): boolean =>
 const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);
 
-const hasSeenTooManyPages = (): boolean =>
-    getAlertViewCount() > blockMessageAfterPageViewNo;
-
 const isInTestVariant = (): boolean => {
     const variant = getVariant(firstPvConsentBlocker, 'variant');
     if (!variant) return false;
@@ -125,9 +118,7 @@ const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
 const canBlockThePage = (): boolean =>
-    [isInTestVariant(), hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
-        _ => _ === true
-    );
+    [isInTestVariant(), isNotInHelpOrInfoPage()].every(_ => _ === true);
 
 const show = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -16,6 +16,8 @@ import {
 } from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import { firstPvConsentBlocker } from 'common/modules/experiments/tests/first-pv-consent-blocker';
+import { getVariant, isInVariant } from 'common/modules/experiments/utils';
 
 type Template = {
     heading: string,
@@ -97,6 +99,12 @@ const hasUnsetAdChoices = (): boolean =>
 const hasSeenTooManyPages = (): boolean =>
     getAlertViewCount() > blockMessageAfterPageViewNo;
 
+const isInTestVariant = (): boolean => {
+    const variant = getVariant(firstPvConsentBlocker, 'variant');
+    if (!variant) return false;
+    return isInVariant(firstPvConsentBlocker, variant);
+};
+
 const onAgree = (msg: Message): void => {
     allAdConsents.forEach(_ => {
         setAdConsentState(_, true);
@@ -116,9 +124,8 @@ const trackInteraction = (interaction: string): void => {
 const canShow = (): Promise<boolean> =>
     Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
 
-// TODO: enable the following checks, once page blocking behaviour has been approved by the business
 const canBlockThePage = (): boolean =>
-    [false, hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
+    [isInTestVariant(), hasSeenTooManyPages(), isNotInHelpOrInfoPage()].every(
         _ => _ === true
     );
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -51,6 +51,11 @@ jest.mock('common/modules/analytics/google', () => ({
     trackNonClickInteraction: jest.fn(),
 }));
 
+jest.mock('common/modules/experiments/utils', () => ({
+    getVariant: jest.fn(() => ({})),
+    isInVariant: jest.fn(() => true),
+}));
+
 jest.mock('common/modules/commercial/ad-prefs.lib', () => {
     const adConsentsState = [null, null];
     return {
@@ -82,39 +87,9 @@ describe('First PV consents banner', () => {
             test.bindableClassNames.agree
         );
     });
-
-    describe('should never block the page', () => {
-        it('should not block the page on the first pv', () => {
-            getAlertViewCount.mockImplementation(() => 1);
-            expect(test.canBlockThePage()).toBeFalsy();
-        });
-        it('should block the page after x pvs', () => {
-            getAlertViewCount.mockImplementation(() => 999999);
-            expect(test.canBlockThePage()).toBeFalsy();
-        });
+    
+    describe('When blocking the page', () => {
         it('should not block info or help pages', () => {
-            getAlertViewCount.mockImplementation(() => 999999);
-            config.get.mockImplementation(() => 'info');
-            expect(test.canBlockThePage()).toBeFalsy();
-            config.get.mockImplementation(() => 'help');
-            expect(test.canBlockThePage()).toBeFalsy();
-            config.get.mockImplementation(() => 'sport');
-            expect(test.canBlockThePage()).toBeFalsy();
-        });
-    });
-
-    // TODO: unskip these tests and delete the above test once the business approves blocking the page
-    describe.skip('When blocking the page', () => {
-        it('should not block the page on the first pv', () => {
-            getAlertViewCount.mockImplementation(() => 1);
-            expect(test.canBlockThePage()).toBeFalsy();
-        });
-        it('should not block the page after x pvs', () => {
-            getAlertViewCount.mockImplementation(() => 999999);
-            expect(test.canBlockThePage()).toBeTruthy();
-        });
-        it('should not block info or help pages', () => {
-            getAlertViewCount.mockImplementation(() => 999999);
             config.get.mockImplementation(() => 'info');
             expect(test.canBlockThePage()).toBeFalsy();
             config.get.mockImplementation(() => 'help');

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -13,7 +13,6 @@ const getCookie: any = require('lib/cookies').getCookie;
 const config: any = require('lib/config');
 const {
     upAlertViewCount,
-    getAlertViewCount,
 }: any = require('common/modules/analytics/send-privacy-prefs');
 
 const passingCookies = _ => {
@@ -87,7 +86,7 @@ describe('First PV consents banner', () => {
             test.bindableClassNames.agree
         );
     });
-    
+
     describe('When blocking the page', () => {
         it('should not block info or help pages', () => {
             config.get.mockImplementation(() => 'info');

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -26,19 +26,21 @@
     z-index: $zindex-popover;
     position: fixed;
     bottom: 0;
-    @supports (position: sticky) {
-        position: sticky;
-        bottom: -1px;
-        /*chrome calculates sticky in dip
-        instead of real px and that can
-        sometimes leave a 1px gap in some
-        screen sizes*/
-    }
     &.site-message--on-top {
         bottom: auto;
         top: 0;
-        @supports (position: sticky) {
-            top: -1px;
+    }
+    @supports (position: sticky) {
+        html:not(.is-scroll-blocked) & {
+            position: sticky;
+            bottom: -1px;
+            /*chrome calculates sticky in dip
+            instead of real px and that can
+            sometimes leave a 1px gap in some
+            screen sizes*/
+            &.site-message--on-top {
+                top: -1px;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?
Throws in an (inactive) AB test for making the cookie banner blocking.

## What is the value of this and can you measure success?
Requirements & logic are still pending discussion (@stephanfowler @katyabeer) But this is the groundwork to get an easy 1 click toggle to launch this when/if this is needed.

## Screenshots
![screen shot 2018-05-31 at 12 09 34 pm](https://user-images.githubusercontent.com/11539094/40779309-5d5b0c98-64cc-11e8-9251-5eb90a7a4241.png)

## Tested in CODE?
No. Will be tested before merging, as the requirements become clearer.