### PR TITLE
Fix wc snaps

### DIFF
--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -69,21 +69,23 @@
         <div class="col-sm-6">
         </div>
     </div>
-    <div class="row">
-        <div class="col-sm-12">
-            <h2>Big match special</h2>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <form class="form-inline" role="form" action="/admin/football/fronts/matches/redirect" method="post">
-                @views.html.football.fragments.chooseLeague("competition", competitions)
-                @views.html.football.fragments.chooseTeam("team1", teams)
-                @views.html.football.fragments.chooseTeam("team2", teams)
-                <button type="submit" class="btn btn-success">Find matches</button>
-            </form>
-        </div>
-        <div class="col-sm-6">
-        </div>
-    </div>
+
+    {@ Disabling for now as broken - only provides countries in drop-down regardless of competition selected @}
+    <!--<div class="row">-->
+        <!--<div class="col-sm-12">-->
+            <!--<h2>Big match special</h2>-->
+        <!--</div>-->
+    <!--</div>-->
+    <!--<div class="row">-->
+        <!--<div class="col-sm-6">-->
+            <!--<form class="form-inline" role="form" action="/admin/football/fronts/matches/redirect" method="post">-->
+                <!--@views.html.football.fragments.chooseLeague("competition", competitions)-->
+                <!--@views.html.football.fragments.chooseTeam("team1", teams)-->
+                <!--@views.html.football.fragments.chooseTeam("team2", teams)-->
+                <!--<button type="submit" class="btn btn-success">Find matches</button>-->
+            <!--</form>-->
+        <!--</div>-->
+        <!--<div class="col-sm-6">-->
+        <!--</div>-->
+    <!--</div>-->
 }

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -70,7 +70,7 @@
         </div>
     </div>
 
-    {@ Disabling for now as broken - only provides countries in drop-down regardless of competition selected @}
+    @* Disabling for now as broken - only provides countries in drop-down regardless of competition selected *@
     <!--<div class="row">-->
         <!--<div class="col-sm-12">-->
             <!--<h2>Big match special</h2>-->

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -33,6 +33,7 @@ class LeagueTableController(
         "Scottish Championship",
         "Scottish League One",
         "Scottish League Two",
+        "World Cup 2018",
         "Euro 2016",
         "Euro 2016 qualifying",
         "Champions League qualifying",


### PR DESCRIPTION
Main change is to add world cup to ordered list of league tables so that it is included and relevant snaps can be created.

I've also disabled the big match special snap in admin temporarily as it's broken. I'm not sure if editorial use this so will check before fixing/removing.
