### PR TITLE
Prevented odd sizing in badged immersive series label

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -603,6 +603,7 @@
 
             @include mq($from: tablet) {
                 margin-left: -($gs-gutter / 2);
+                max-width: gs-span(4) + ($gs-gutter / 2);
                 padding: ($gs-baseline / 2) ($gs-gutter / 2);
             }
         }
@@ -614,6 +615,10 @@
             @include mq($from: tablet) {
                 margin-right: $gs-gutter / 2;
             }
+        }
+
+        .content__series-label {
+            display: inline;
         }
 
         .content__series-label__link {


### PR DESCRIPTION
# Before
<img width="874" alt="screen shot 2018-06-01 at 15 11 33" src="https://user-images.githubusercontent.com/14570016/40845267-1b121970-65ae-11e8-9e0b-3eba441e763d.png">

# After
<img width="834" alt="screen shot 2018-06-01 at 15 11 27" src="https://user-images.githubusercontent.com/14570016/40845268-1ce0631a-65ae-11e8-9deb-3a800b9b2e59.png">
