### PR TITLE
a11y spring cleaning

### DIFF
--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -1,5 +1,6 @@
 package pages
 
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -33,6 +34,7 @@ object IdentityHtmlPage {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -82,7 +82,7 @@
 }
 
 @marketingStepContent = {
-    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+    <form action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" method="post">
         @views.html.helper.CSRF.formField
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>

--- a/identity/app/views/layout/identityFlexWrap.scala.html
+++ b/identity/app/views/layout/identityFlexWrap.scala.html
@@ -7,7 +7,7 @@
     @for(f <- topFragments){
         @f
     }
-    <div class="identity-wrapper-page-flex__content">
+    <div class="identity-wrapper-page-flex__content" id="maincontent">
         @for(f <- contentFragments){
             @f
         }

--- a/identity/app/views/layout/identityFlexWrap.scala.html
+++ b/identity/app/views/layout/identityFlexWrap.scala.html
@@ -7,7 +7,7 @@
     @for(f <- topFragments){
         @f
     }
-    <div class="identity-wrapper-page-flex__content" id="maincontent">
+    <div class="identity-wrapper-page-flex__content" id="maincontent" role="main">
         @for(f <- contentFragments){
             @f
         }

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -13,7 +13,7 @@ passwordExists: Boolean
     <h1 class="identity-title">Change password</h1>
 
     @defining(idUrlBuilder.buildUrl("/password/change", idRequest, "passwordExists" -> passwordExists.toString)){ actionUrl =>
-    <form class="form js-register-form" novalidate action="@actionUrl" role="main" method="post">
+    <form class="form js-register-form" novalidate action="@actionUrl" role="form" method="post">
         @views.html.helper.CSRF.formField
 
         @if(passwordForm.hasGlobalErrors) {

--- a/identity/app/views/password/requestPasswordReset.scala.html
+++ b/identity/app/views/password/requestPasswordReset.scala.html
@@ -11,7 +11,7 @@
     <h1 class="identity-title">Forgotten or need to reset your password?</h1>
     <p>We'll email you a link to reset it.</p>
 
-    <form class="form js-reset-form" novalidate action="@idUrlBuilder.buildUrl("/reset", idRequest)" role="main" method="post">
+    <form class="form js-reset-form" novalidate action="@idUrlBuilder.buildUrl("/reset", idRequest)" role="form" method="post">
         @if(emailForm.globalError.isDefined) {
             <div class="form__error">@emailForm.globalErrors.map(_.message).mkString(", ")</div>
         }

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -16,7 +16,7 @@
     <div class="form__note">These details will only be visible to you and the Guardian.</div>
 </fieldset>
 
-<form class="form js-account-details-form" novalidate action="@idUrlBuilder.buildUrl("/account/edit", idRequest)" role="main" method="post">
+<form class="form js-account-details-form" novalidate action="@idUrlBuilder.buildUrl("/account/edit", idRequest)" role="form" method="post">
     <button type="submit" class="is-hidden"></button>
     @views.html.helper.CSRF.formField
 

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -88,7 +88,7 @@
                 </p>
             </div>
 
-            <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post" id="deleteForm">
+            <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" method="post" id="deleteForm">
                 @views.html.helper.CSRF.formField
 
                 <div class="identity-section">

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -15,7 +15,7 @@
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
 }
 
-<form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
+<form novalidate action="@buildIdentityUrl("email-prefs")" method="post" class="js-manage-account__ajaxForm">
     @views.html.helper.CSRF.formField
     @if(emailPrefsForm.globalError.isDefined) {
         <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -32,7 +32,7 @@
 }
 
 @marketingConsentForm = {
-    <form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+    <form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="form" method="post">
         @views.html.helper.CSRF.formField
 
         @* This displays both global and key-bound errors *@

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -35,16 +35,6 @@
     <form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="form" method="post">
         @views.html.helper.CSRF.formField
 
-        @* This displays both global and key-bound errors *@
-        @if(privacyForm.hasErrors) {
-            <div class="form__error">
-                Error processing the form. Your changes have not been saved:
-                <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
-            </div>
-        }
-
-        <div class="js-errorHolder manage-account__errors"></div>
-
         <fieldset class="fieldset fieldset--manage-account-noborder">
 
             <div class="fieldset__heading">
@@ -93,6 +83,16 @@
         <p>Your Email preferences have been updated.</p>
     </div>
 }
+
+@* This displays both global and key-bound errors *@
+@if(privacyForm.hasErrors) {
+    <div class="form__error">
+        Error processing the form. Your changes have not been saved:
+        <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
+    </div>
+}
+
+<div class="js-errorHolder manage-account__errors"></div>
 
 @* NEWSLETTERS *@
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -86,7 +86,7 @@
 
 @* This displays both global and key-bound errors *@
 @if(privacyForm.hasErrors) {
-    <div class="form__error">
+    <div class="form__error" role="alert">
         Error processing the form. Your changes have not been saved:
         <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
     </div>

--- a/identity/app/views/profile/publicProfileForm.scala.html
+++ b/identity/app/views/profile/publicProfileForm.scala.html
@@ -36,7 +36,7 @@
 }
 
 <fieldset class="fieldset">
-    <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
+    <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="form" method="post">
         @views.html.helper.CSRF.formField
 
         @if(publicProfileForm.globalError.isDefined) {

--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -9,7 +9,7 @@
     <h1 class="identity-title" data-test-id="reauthentication-header">Confirm your identity</h1>
     <p>Your privacy is important to us. Please re-enter your password to access your personal data.</p>
 
-    <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/reauthenticate", idRequest)" role="main" method="post">
+    <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/reauthenticate", idRequest)" role="form" method="post">
         @if(reauthenticationForm.globalError.isDefined) {
             <div class="form__error">@reauthenticationForm.globalErrors.map(_.message).mkString(", ")</div>
         }

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -22,6 +22,7 @@ const renderError = (error: IdentityRenderableError): Promise<void> =>
         .then((errorHolderEl: HTMLElement) =>
             fastdom.write(() => {
                 const errorEl = document.createElement('div');
+                errorEl.setAttribute('role', 'alert');
                 errorEl.innerHTML = `<p>${error.message}.${
                     error.times > 1 ? ` (${error.times} times)` : ``
                 }</p>`;

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -84,12 +84,12 @@ $checkbox-size: $gs-gutter / 1.25;
         .manage-account__switch-checkbox {
             border-color: $identity-main;
         }
-        input:checked + .manage-account__switch-checkbox {
+        input + .manage-account__switch-checkbox {
             box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px $identity-main;
         }
     }
 
-    input:focus:checked + .manage-account__switch-checkbox {
+    input:focus + .manage-account__switch-checkbox {
         box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px $garnett-neutral-7;
     }
 


### PR DESCRIPTION
## What does this change?
A couple of minor accessibility fixes on MMA:

- Put the "we are hiring easter egg" (consistent with dotcom)
- Normalize landmarks (right now they were inconsistently used)
- Put errors on top and make them aria alerts
- Fix "jump to main contents" link
- Restore css focus state on checkboxes

## What is the value of this and can you measure success?
Better accessibility. This is by no means all we can do a11y wise, more like covering the most flagrant bugs we had.