### PR TITLE
Display commercial badge as a child of the meta container

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -10,7 +10,6 @@
 
     <div class="gs-container">
         <div class="content__main-column content__main-column--gallery">
-            @fragments.commercial.badge(gallery.item, gallery)
 
             @fragments.contentMeta(gallery.item, gallery)
 

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -88,7 +88,10 @@
 
 
     @if(
-        item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && (item.content.isImmersive || !isPaidContent(page)))
+        item.tags.isVideo ||
+        item.tags.isAudio ||
+        (item.tags.isArticle && (item.content.isImmersive || !isPaidContent(page))) ||
+        item.tags.isGallery
     ) {
         @fragments.commercial.badge(item, page)
     }


### PR DESCRIPTION
This fixes https://trello.com/c/hJvMbe72/124-logo-links-on-paid-galleries-work , where the meta div was preventing mouse events to reach the commercial badge.

This codes extends the 'badge as container child' logic to include galleries, and removes the gallery special.