### PR TITLE
Show TLS deprecation banner if user is in variant

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -55,7 +55,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -50,7 +50,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -46,7 +46,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         galleryTop(),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -49,7 +49,7 @@ object IndexHtml {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -55,7 +55,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = bodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -42,7 +42,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -52,7 +52,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -53,7 +53,7 @@ object StoryHtmlPage {
         blockthrough() when BlockthroughSwitch.isSwitchedOn
       ),
       bodyTag(classes = bodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         survey() when SurveySwitch.isSwitchedOn,

--- a/common/app/experiments/ExperimentsDefinition.scala
+++ b/common/app/experiments/ExperimentsDefinition.scala
@@ -47,8 +47,4 @@ trait ExperimentsDefinition {
       Excluded
     }
   }
-
-  def isIncluded(experiment: Experiment)(implicit request: RequestHeader): Boolean = {
-    isParticipating(experiment) || isControl(experiment)
-  }
 }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -55,7 +55,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         inlineJSBlocking()
       ),
       bodyTag(classes = defaultBodyClasses)(
-        tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+        tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -43,7 +43,7 @@ object IdentityHtmlPage {
       ),
       bodyTag(classes = defaultBodyClasses())(
         views.html.layout.identityFlexWrap(page.isFlow)(
-          tlsWarning() when ActiveExperiments.isIncluded(OldTLSSupportDeprecation),
+          tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
           skipToMainContent(),
           views.html.layout.identityHeader(hideNavigation=page.isFlow) when !page.usesGuardianHeader,
           header() when page.usesGuardianHeader


### PR DESCRIPTION
## What does this change?

Currently the TLS deprecation warning banner is being displayed to all users. This change ensures only users with older browsers, that don't support TLS v1.2, see the banner

## What is the value of this and can you measure success?

Don't bother people with modern browsers.

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
