### PR TITLE
Ad-free audio content done server-side

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -2,12 +2,12 @@
 
 @import common.LinkTo
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}
-@import views.support.Commercial.isPaidContent
+@import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
-    @defining(isPaidContent(page)) { isPaidContent =>
+    @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
         <div class="l-side-margins @if(!isPaidContent) {l-side-margins--media}">
 
             <article id="article" class="@RenderClasses(
@@ -48,7 +48,8 @@
                                                     audioElement,
                                                     audio.trail.headline,
                                                     autoPlay = false
-                                                )
+                                                ),
+                                                isAdFree
                                             )
                                         }
                                         </figure>

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -566,7 +566,7 @@ object Audio {
     Audio(contentOverrides)
   }
 
-  def acastUrl(player: AudioPlayer, url: String): String = if (player.audio.tags.isPodcast) "https://flex.acast.com/" + url.replace("https://", "") else url
+  def acastUrl(player: AudioPlayer, url: String, isAdFree: Boolean): String = if (player.audio.tags.isPodcast && !isAdFree) "https://flex.acast.com/" + url.replace("https://", "") else url
 }
 
 final case class Audio (override val content: Content) extends ContentType {

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -1,4 +1,4 @@
-@(player: model.AudioPlayer)
+@(player: model.AudioPlayer, isAdFree: Boolean)
 
 @trackingCode(target: String) = {@if(player.audio.tags.isPodcast){podcast:}@target:@player.title}
 
@@ -8,7 +8,7 @@
         data-auto-play="@player.autoPlay" preload="none">
 
         @player.audioElement.audio.encodings.map { encoding =>
-            <source src="@model.Audio.acastUrl(player, encoding.url)" type="@encoding.format" />
+            <source src="@model.Audio.acastUrl(player, encoding.url, isAdFree)" type="@encoding.format" />
         }
     </audio>
     @player.audio match {
@@ -24,7 +24,7 @@
                 @audio.downloadUrl.map { downloadUrl =>
                     <li class="podcast-meta__item podcast-meta__item--download">
                         <a class="podcast-meta__item__link pseudo-icon pseudo-icon--download--white"
-                           href="@model.Audio.acastUrl(player, downloadUrl)"
+                           href="@model.Audio.acastUrl(player, downloadUrl, isAdFree)"
                            data-link-name="@trackingCode("download")">Download MP3</a>
                     </li>
                 }


### PR DESCRIPTION
## What does this change?
If we receive a request for a podcast from an ad-free user, we don't want to use the acast prefix for the URLs.

I initially thought we'd have to add some new VCL to split the cache for this (hence the referenced PR) but the cache key is already extended by the ad-free header, so I've closed that PR again.
 
## What is the value of this and can you measure success?
We inhibit acast-injected ads from podcasts for ad-free users.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
N/A

## Tested in CODE?
Yes

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
