### PR TITLE
Turn /consents/staywithus into a redirect

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -24,11 +24,6 @@ trait ConsentsJourney
   def displayConsentsJourneyThankYou: Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageThankYou, None)
 
-  /** previously GET /consents/staywithus, now unused - but may come back */
-  //TODO: remove this once confirmed branded version of journey not needed
-  def displayConsentsJourneyGdprCampaign: Action[AnyContent] =
-    displayConsentJourneyForm(ConsentJourneyPageGdprCampaign, None)
-
   /** GET /consents */
   def displayConsentsJourney(consentHint: Option[String] = None): Action[AnyContent] =
     displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint)
@@ -63,6 +58,13 @@ trait ConsentsJourney
         )
       }
     }
+
+  /** Handle redirects*/
+  def redirectToConsentsJourney: Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      routes.EditProfileController.displayConsentsJourney(None),
+      MOVED_PERMANENTLY)
+  }
 
   private def displayConsentJourneyForm(
     page: ConsentJourneyPage,

--- a/identity/app/controllers/editprofile/editprofile.scala
+++ b/identity/app/controllers/editprofile/editprofile.scala
@@ -15,6 +15,5 @@ package object editprofile {
       extends IdentityPage(id, "Consent", isFlow = true)
 
   object ConsentJourneyPageThankYou extends ConsentJourneyPage("/consents/thank-you", ThankYouConsentsJourney)
-  object ConsentJourneyPageGdprCampaign extends ConsentJourneyPage("/consents/staywithus", GdprCampaignConsentsJourney)
   object ConsentJourneyPageDefault extends ConsentJourneyPage("/consents", DefaultConsentsJourney)
 }

--- a/identity/app/services/ProfileRedirectService.scala
+++ b/identity/app/services/ProfileRedirectService.scala
@@ -26,11 +26,7 @@ case object RedirectToEmailValidationFromEmailPrefsOrConsentJourney extends Prof
   override def isAllowedFrom(url: String): Boolean = (url startsWith "/email-prefs") || (url startsWith "/consents")
 }
 
-case object RedirectToConsentsFromEmailPrefs extends ProfileRedirect("/consents/staywithus") {
-  override def isAllowedFrom(url: String): Boolean = url contains "email-prefs"
-}
-
-case object RedirectToNewsletterConsentsFromEmailPrefs extends ProfileRedirect("/consents/newsletters") {
+case object RedirectToConsentsFromEmailPrefs extends ProfileRedirect("/consents") {
   override def isAllowedFrom(url: String): Boolean = url contains "email-prefs"
 }
 

--- a/identity/app/utils/ConsentsJourneyType.scala
+++ b/identity/app/utils/ConsentsJourneyType.scala
@@ -5,7 +5,6 @@ object ConsentsJourneyType {
   sealed trait AnyConsentsJourney
 
   case object ThankYouConsentsJourney extends AnyConsentsJourney
-  case object GdprCampaignConsentsJourney extends AnyConsentsJourney
   case object DefaultConsentsJourney extends AnyConsentsJourney
 
 }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -111,22 +111,6 @@
     )
 }
 
-@introGdprCampaignStep= @{
-    ConsentStep(
-        name = "intro",
-        title = "Please select the emails you wish to continue receiving",
-        help = List(
-            ConsentStepHelpText(
-                s"Why are we asking you to re-subscribe? <strong><a class='u-underline' data-link-name='gdpr-oi-campaign : consents : to-landing' href='${LinkTo("https://www.theguardian.com/info/ng-interactive/2018/feb/21/stay-with-us")}'>Find out here</a></strong>"
-            ),
-            ConsentStepHelpText(
-                "You can change your preferences anytime by signing in, clicking My Account, then selecting Email Preferences."
-            )
-        ),
-        content = selectAllCheckboxContent
-    )
-}
-
 @introThankYouStep= @{
     ConsentStep(
         name = "intro",
@@ -212,12 +196,7 @@
                     ) ++ defaultJourney
 
                 }
-                case GdprCampaignConsentsJourney => {
-                    List(
-                        introGdprCampaignStep
-                    ) ++ defaultJourney
-                }
-                case DefaultConsentsJourney => {
+                case _ => {
                     List(
                         introStep
                     ) ++ defaultJourney

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -54,7 +54,6 @@ GET         /membership/edit                        controllers.editprofile.Edit
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.displayRecurringContributionForm
 GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.displayDigitalPackForm
 
-GET         /privacy/edit                           controllers.editprofile.EditProfileController.displayPrivacyFormRedirect(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /privacy/edit                           controllers.editprofile.EditProfileController.saveConsentPreferences
 POST        /privacy/edit-ajax                      controllers.editprofile.EditProfileController.saveConsentPreferencesAjax
 
@@ -73,8 +72,13 @@ GET         /privacy-settings                       controllers.AdvertsManager.r
 # Consents journey
 ########################################################################################################################
 GET         /consents/thank-you                     controllers.editprofile.EditProfileController.displayConsentsJourneyThankYou
-GET         /consents/staywithus                    controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 GET         /consents                               controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
 GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete
 ########################################################################################################################
+
+########################################################################################################################
+# Old routes
+########################################################################################################################
+GET         /consents/staywithus                    controllers.editprofile.EditProfileController.redirectToConsentsJourney()
+GET         /privacy/edit                           controllers.editprofile.EditProfileController.displayPrivacyFormRedirect(consentsUpdated: Boolean ?= false, consentHint: Option[String])

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -173,17 +173,6 @@ import scala.concurrent.Future
     }
 
 
-    "using displayConsentsJourneyGdprCampaign" should {
-
-      "have consent checkboxes" in new ConsentsJourneyFixture {
-        val result = controller.displayConsentsJourneyGdprCampaign.apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (xml.Utility.escape(Supporter.latestWording.wording))
-      }
-
-    }
-
-
     "using displayConsentsJourneyThankYou" should {
 
       "thank you" in new ConsentsJourneyFixture {

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -109,10 +109,10 @@ class EmailVerificationControllerTest extends path.FreeSpec
       }
 
       "should redirect to original returnUrl if it was already a consent journey" in {
-        when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://profile.theguardian.com/consents/staywithus"))
+        when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(Some("https://profile.theguardian.com/consents"))
         val result = controller.verify(token)(testRequest)
         status(result) should be(SEE_OTHER)
-        redirectLocation(result).get should include("/consents/staywithus")
+        redirectLocation(result).get should include("/consents")
       }
     }
 

--- a/identity/test/services/ProfileRedirectServiceTest.scala
+++ b/identity/test/services/ProfileRedirectServiceTest.scala
@@ -47,7 +47,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
     val profileRedirectService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponents)
 
     val originalEmailPreflUrl = "https://profile.thegulocal.com/email-prefs"
-    val originalConsentUrl = "https://profile.thegulocal.com/consents/staywithus"
+    val originalConsentUrl = "https://profile.thegulocal.com/consents"
     val emailPrefRequest = Request(FakeRequest("GET", originalEmailPreflUrl), AnyContent())
     val consentJourneyRequest = Request(FakeRequest("GET", originalConsentUrl), AnyContent())
 
@@ -70,7 +70,7 @@ class ProfileRedirectServiceTest extends path.FreeSpec with MockitoSugar with Sc
 
     "redirect to email validation from consent journey if user has not validated their email" in new TestFixture {
       val result: ProfileRedirect = profileRedirectService.toProfileRedirect(userWithoutValidEmail, consentJourneyRequest)
-      result.isAllowedFrom("/consents/staywithus") shouldBe true
+      result.isAllowedFrom("/consents") shouldBe true
     }
 
     "redirect to email validation from email-prefs" in new TestFixture {


### PR DESCRIPTION
## What does this change?
Clean up everything to do with `consents/staywithus` (And a bit of `consents/newsletters`) and turn it into a normal HTTP redirect to `/consents`

## What is the value of this and can you measure success?
Less code

## Does this affect other platforms - Amp, Apps, etc?
No