### PR TITLE
[My account] nav dropdown tweaks

### DIFF
--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -41,11 +41,6 @@ object DropdownMenus {
       label = "Emails & marketing"
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/password/change"),
-      linkName = Some("change password"),
-      label = "Change password"
-    ),
-    DropdownMenuItem(
       href =Some(s"${Configuration.id.url}/signout"),
       linkName = Some("sign out"),
       label = "Sign out"

--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -21,27 +21,27 @@ object DropdownMenus {
       parentClassList = List("u-h","js-show-comment-activity")
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/public/edit"),
+      href = Some(s"${Configuration.id.url}/public/edit"),
       linkName = Some("edit profile"),
       label = "Public profile",
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/account/edit"),
+      href = Some(s"${Configuration.id.url}/account/edit"),
       linkName = Some("account details"),
       label = "Account details",
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/digitalpack/edit"),
+      href = Some(s"${Configuration.id.url}/digitalpack/edit"),
       linkName = Some("subscriptions"),
       label = "Digital Pack",
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/email-prefs"),
+      href = Some(s"${Configuration.id.url}/email-prefs"),
       linkName = Some("email prefs"),
       label = "Emails & marketing"
     ),
     DropdownMenuItem(
-      href =Some(s"${Configuration.id.url}/signout"),
+      href = Some(s"${Configuration.id.url}/signout"),
       linkName = Some("sign out"),
       label = "Sign out"
     )

--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -16,19 +16,29 @@ object DropdownMenus {
   val accountDropdownMenu: List[DropdownMenuItem] = List(
     DropdownMenuItem(
       linkName = Some("comment activity"),
-      label = "Comment activity",
+      label = "Comments & Replies",
       classList = List("js-add-comment-activity-link"),
       parentClassList = List("u-h","js-show-comment-activity")
     ),
     DropdownMenuItem(
       href =Some(s"${Configuration.id.url}/public/edit"),
       linkName = Some("edit profile"),
-      label = "Edit profile",
+      label = "Public profile",
+    ),
+    DropdownMenuItem(
+      href =Some(s"${Configuration.id.url}/account/edit"),
+      linkName = Some("account details"),
+      label = "Account details",
+    ),
+    DropdownMenuItem(
+      href =Some(s"${Configuration.id.url}/digitalpack/edit"),
+      linkName = Some("subscriptions"),
+      label = "Digital Pack",
     ),
     DropdownMenuItem(
       href =Some(s"${Configuration.id.url}/email-prefs"),
       linkName = Some("email prefs"),
-      label = "Email preferences"
+      label = "Emails & marketing"
     ),
     DropdownMenuItem(
       href =Some(s"${Configuration.id.url}/password/change"),

--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -16,7 +16,7 @@ object DropdownMenus {
   val accountDropdownMenu: List[DropdownMenuItem] = List(
     DropdownMenuItem(
       linkName = Some("comment activity"),
-      label = "Comments & Replies",
+      label = "Comments & replies",
       classList = List("js-add-comment-activity-link"),
       parentClassList = List("u-h","js-show-comment-activity")
     ),

--- a/identity/app/views/layout/identityHeader.scala.html
+++ b/identity/app/views/layout/identityHeader.scala.html
@@ -4,7 +4,7 @@
 @(hideNavigation: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 <header class="identity-header" data-component="identity-nav">
-    <div class="gs-container identity-header__container">
+    <div class="identity-wrapper identity-wrapper--wide monocolumn-wrapper identity-header__container">
 
         @if(!hideNavigation) {
             <div class="identity-header__links">
@@ -17,7 +17,7 @@
                         aria-controls="my-account-dropdown"
                         data-link-name="identity-nav : menu : toggle"
                         >
-                            <span>My account</span>
+                            <span class="identity-header__nav-name js_identity-header__nav-name">My account</span>
                         </span>
                     </label>
                     <input type="checkbox" value="open" id="identity-header-account-menu-fallback" class="identity-header__nav-fallback u-h" title="Open Menu" />

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -31,7 +31,7 @@
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
-            <h2 class="form__heading">Login & security</h2>
+            <h2 class="form__heading">Email & password</h2>
         </div>
 
         <div class="fieldset__fields">

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -45,10 +45,7 @@
                     Symbol("data-test-id") -> "email-address"))
 
                 <li class="form-field form-field--email-validation">
-                    @if(user.statusFields.userEmailValidated.getOrElse(false)){
-                        @fragments.inlineSvg("status-ok", "icon")
-                        <p class="form__note">Your email address has been validated.</p>
-                    }else{
+                    @if(!user.statusFields.userEmailValidated.getOrElse(false)){
                         @fragments.inlineSvg("status-alert", "icon")
                         <p class="form__note">
                             Please confirm your email address to post comments.<br />

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -12,6 +12,10 @@
     user: com.gu.identity.model.User,
     accountDetailsForm: Form[_root_.form.AccountFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
+@buildIdentityUrl(endpoint: String) = {
+    @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
+}
+
 <fieldset class="fieldset">
     <div class="form__note">These details will only be visible to you and the Guardian.</div>
 </fieldset>
@@ -27,7 +31,7 @@
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
-            <h2 class="form__heading">Email</h2>
+            <h2 class="form__heading">Login & security</h2>
         </div>
 
         <div class="fieldset__fields">
@@ -51,6 +55,12 @@
                             <a class="u-underline js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
                         </p>
                     }
+                </li>
+                <li class="form-field form-field--password">
+                    <div class="label" for="address_line1">Password</div>
+                    <div class="input">
+                        <a href="@buildIdentityUrl("password/change")" class="u-underline" data-link-name="identity : password : change">Change your password</a>
+                    </div>
                 </li>
             </ul>
         </div>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -75,7 +75,7 @@
         <div class="identity-wrapper identity-wrapper--wide monocolumn-wrapper">
                 <h1 class="identity-title" data-test-id="edit-profile-header">Edit your profile</h1>
                 <ol class="tabs__container tabs__container--multiple js-tabs js-account-profile-tabs" id="js-account-profile-tabs" role="tablist" data-is-bound="true">
-                    @tab(1, "Public", "/public/edit", None, redirect = redirectDecision)
+                    @tab(1, "Public profile", "/public/edit", None, redirect = redirectDecision)
 
                     @tab(2, "Account details", "/account/edit", Some("edit-account-details"), optionalClass="qa-account-details-tab", redirect = redirectDecision)
 

--- a/static/src/javascripts/projects/common/modules/identity/header.js
+++ b/static/src/javascripts/projects/common/modules/identity/header.js
@@ -1,16 +1,19 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import loadEnhancers from './modules/loadEnhancers';
 import { getUserFromCookie } from 'common/modules/identity/api';
+import loadEnhancers from './modules/loadEnhancers';
 
 const ERR_UNDEFINED_MENU = 'Undefined menu';
 
 const nameAccountMenu = (menuEl: HTMLElement): Promise<void> => {
     const user = getUserFromCookie();
     if (user && user.displayName) {
-        menuEl.innerText = user.displayName;
+        return fastdom.write(() => {
+            menuEl.innerText = user.displayName;
+        });
     }
+    return Promise.resolve();
 };
 
 const showAccountMenu = (

--- a/static/src/javascripts/projects/common/modules/identity/header.js
+++ b/static/src/javascripts/projects/common/modules/identity/header.js
@@ -2,8 +2,16 @@
 
 import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
+import { getUserFromCookie } from 'common/modules/identity/api';
 
 const ERR_UNDEFINED_MENU = 'Undefined menu';
+
+const nameAccountMenu = (menuEl: HTMLElement): Promise<void> => {
+    const user = getUserFromCookie();
+    if (user && user.displayName) {
+        menuEl.innerText = user.displayName;
+    }
+};
 
 const showAccountMenu = (
     buttonEl: HTMLElement,
@@ -52,7 +60,10 @@ const bindNavToggle = (buttonEl: HTMLElement): void => {
 };
 
 const initHeader = (): void => {
-    const loaders = [['.js_identity-header__nav-toggle', bindNavToggle]];
+    const loaders = [
+        ['.js_identity-header__nav-toggle', bindNavToggle],
+        ['.js_identity-header__nav-name', nameAccountMenu],
+    ];
     loadEnhancers(loaders);
 };
 

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -41,18 +41,22 @@ $gutter: 5px;
         display: block;
     }
 
-    .gs-container {
+    .identity-header__nav-name {
+        max-width: gs-span(2);
+        vertical-align: middle;
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .identity-header__container {
         display: flex;
         box-sizing: border-box;
         flex-direction: row-reverse;
         justify-content: space-between;
         align-items: flex-start;
-        padding-left: $gs-gutter / 2;
-        padding-right: $gs-gutter / 2;
-        @include mq(mobileLandscape) {
-            padding-left: $gs-gutter;
-            padding-right: $gs-gutter;
-        }
+        padding: 0;
     }
 }
 
@@ -82,9 +86,6 @@ html body .identity-header__logo {
 
     .inline-the-guardian-roundel {
         display: block;
-        @include mq(wide) {
-            margin-right: gs-span(2);
-        }
     }
     .inline-the-guardian-logo {
         display: none;

--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -69,7 +69,7 @@ $gutter: 5px;
 
 .identity-header__links {
     float: left;
-    height: $slim-nav-height - $gutter;
+    height: $slim-nav-height - ($gutter/2);
     display: flex;
     align-items: center;
 }


### PR DESCRIPTION
## What does this change?
Updates the nav dropdown to better match the tabs in MMA as per [this card](https://trello.com/c/JSIIQX0p/700-account-profile-revisit-the-dropdown-menu-to-reflect-the-changes-to-the-tabs)

- Rename 'Public' tab to 'Public profile'
- In Account details rename 'Email' to 'Login & security' or 'Email & login'
- Move 'Change password' to the 'Account details tab'
- Put the user name in the utility nav but not the icon
- Change the drop down items as per above visual

## Screenshots
![screen shot 2018-06-05 at 2 09 47 pm](https://user-images.githubusercontent.com/11539094/40979212-073a0710-68cd-11e8-8b1b-7b3d9e078dcc.png)
![screen shot 2018-06-05 at 2 33 40 pm](https://user-images.githubusercontent.com/11539094/40979340-75af9566-68cd-11e8-93b8-3f8a8ddee249.png)


## What is the value of this and can you measure success?
More consistent UX

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
