### PR TITLE
'Headline-only' endpoint for emails

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -97,6 +97,9 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
     (editionalisedPath != path) && request.getQueryString("page").isEmpty
   }
 
+  private[this] def shouldOnlyReturnHeadline(request: RequestHeader): Boolean =
+    request.getQueryString("format").contains("email-headline")
+
   def redirectTo(path: String)(implicit request: RequestHeader): Future[Result] = successful {
     val params = request.rawQueryStringOption.map(q => s"?$q").getOrElse("")
     Cached(CacheTime.Facia)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
@@ -111,27 +114,25 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader) = {
     val futureResult = frontJsonFapi.getLite(path).flatMap {
       case Some(faciaPage) =>
-        successful(
+        successful(Cached(CacheTime.Facia)(
           if (request.isRss) {
             val body = TrailsToRss.fromPressedPage(faciaPage)
-            Cached(CacheTime.Facia) {
-              RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)
-            }
+            RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)
           }
           else if (request.isJson)
-            Cached(CacheTime.Facia)(JsonFront(faciaPage))
+            JsonFront(faciaPage)
           else if (request.isEmail || ConfigAgent.isEmailFront(path)) {
-            val htmlResponse = FrontEmailHtmlPage.html(faciaPage)
-            Cached(CacheTime.Facia) {
+            if (shouldOnlyReturnHeadline(request)) {
+                RevalidatableResult.Ok(faciaPage.collections.head.curated.head.header.headline)
+            } else {
+              val htmlResponse = FrontEmailHtmlPage.html(faciaPage)
               RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse)
             }
           }
           else {
-            Cached(CacheTime.Facia) {
-                RevalidatableResult.Ok(FrontHtmlPage.html(faciaPage))
-            }
+            RevalidatableResult.Ok(FrontHtmlPage.html(faciaPage))
           }
-        )
+        ))
       case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))}
 
     futureResult.failed.foreach { t: Throwable => log.error(s"Failed rendering $path with $t", t)}

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -123,7 +123,11 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
             JsonFront(faciaPage)
           else if (request.isEmail || ConfigAgent.isEmailFront(path)) {
             if (shouldOnlyReturnHeadline(request)) {
-                RevalidatableResult.Ok(faciaPage.collections.head.curated.head.header.headline)
+              val headline = for {
+                topCollection <- faciaPage.collections.headOption
+                topCurated <- topCollection.curated.headOption
+              } yield topCurated.header.headline
+                RevalidatableResult.Ok(headline.getOrElse("Error: Could not extract headline from front"))
             } else {
               val htmlResponse = FrontEmailHtmlPage.html(faciaPage)
               RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse)


### PR DESCRIPTION
## What does this change?
This modifies the facia email endpoint so that if the ?format=email-headline parameter is given then only the headline will be returned. 

## What is the value of this and can you measure success?
Better email titles in exact target!

### Tested

- [x] Locally
- [x] On CODE (optional)
