### PR TITLE
Add custom subnav for world cup 2018 front

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -68,7 +68,16 @@ object NavLinks {
   /* SPORT */
 
   // TODO remove after world cup
-  val worldCup2018 = NavLink("World Cup 2018", "/football/world-cup-2018")
+  val worldCup2018 = NavLink(
+    title = "World Cup 2018",
+    url = "/football/world-cup-2018",
+    children = List(
+      NavLink("Fixtures and standings", "/football/world-cup-2018/overview"),
+      NavLink("Player-by-player guide", "/football/ng-interactive/2018/jun/05/world-cup-2018-complete-guide-players-ratings-goals-caps"),
+      NavLink("Experts' Network", "/football/series/world-cup-2018-guardian-experts-network"),
+      NavLink("All-time XIs", "/football/series/world-cup-all-time-xis"),
+    )
+  )
 
   val football = NavLink("Football", "/football",
     children = List(
@@ -594,6 +603,7 @@ object NavLinks {
     "football/competitions",
     "football/results",
     "football/fixtures",
+    "football/world-cup-2018", // TODO remove after world cup
     "education",
     "crosswords/crossword-blog",
     "crosswords/series/crossword-editor-update",


### PR DESCRIPTION
(This is a bit hacky/custom so we'll remove after the tournament is finished.)

## What does this change?

Adds a custom subnav for the world cup front to increase discovery of the contained links.

## Screenshots

<img width="782" alt="screen shot 2018-06-06 at 12 39 24" src="https://user-images.githubusercontent.com/858402/41036135-f58485b2-6986-11e8-847f-5f080da25fbf.png">

## What is the value of this and can you measure success?

Traffic to the linked pages should go up!