### PR TITLE
Send credentials for GET /useremails/{userId}

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -157,6 +157,7 @@ export const getUserEmailSignUps = (): Promise<any> => {
             url: (idApiRoot || '') + endpoint,
             type: 'jsonp',
             crossOrigin: true,
+            withCredentials: true,
         });
 
         return request;


### PR DESCRIPTION
## What does this change?

`GET /useremails/{userId}` will soon [require authentication](https://github.com/guardian/identity/pull/1210). Include credentials from the browser when attempting to call the endpoint. 

## Screenshots

N/A

## What is the value of this and can you measure success?

Subscription data is no longer publicly accessible. 

## Checklist

### Does this affect other platforms?

No

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
