### PR TITLE
Display blank space when using non-existent emails

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -85,7 +85,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
 
       identityName match {
         case Some(listName) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _ => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+        case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
       }
     }
   }
@@ -95,7 +95,7 @@ class EmailSignupController(wsClient: WSClient, val controllerComponents: Contro
       val id = EmailNewsletter.fromIdentityName(listName).map(_.listIdV1)
       id match {
         case Some(listId) => Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragment(emailLandingPage, emailType, listName)))
-        case _            => Cached(15.minute)(WithoutRevalidationResult(NotFound))
+        case _            => Cached(15.minute)(WithoutRevalidationResult(NoContent))
       }
     }
   }


### PR DESCRIPTION
## What does this change?
Currently when using an old or incorrect email newsletter embed, we display an error page in the small iframe.  Instead this PR will just show blank space, which is an improvement at least.

This is a second attempt, this one has been tested in CODE though.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
