### PR TITLE
Bump atom-renderer to 0.14.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "yarn": "1.7.0"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.14.4",
+    "@guardian/atom-renderer": "0.14.6",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "classnames": "~2.2.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.14.4"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.14.6"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,9 +62,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@guardian/atom-renderer@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.14.4.tgz#241d1a8ac69988bc40f920af5fa5c1eb3c201d7a"
+"@guardian/atom-renderer@0.14.6":
+  version "0.14.6"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.14.6.tgz#b43a6f3459330888ab9e43d992251a6c21c47912"
   dependencies:
     autoprefixer "^8.2.0"
     css-loader "^0.28.7"


### PR DESCRIPTION
This fixes a styling issue on the commons vote atom - see https://github.com/guardian/atom-renderer/pull/46

Confirmed the bullet points are removed in CODE:
![picture 7](https://user-images.githubusercontent.com/1513454/41086489-1df3140e-6a32-11e8-98a2-17fef82b6bef.png)
