### PR TITLE
No string refs

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
         'react/no-multi-comp': 'off',
         'react/no-find-dom-node': 'off',
         'react/jsx-no-bind': 'off',
-        'react/no-string-refs': 'off',
         'react/prefer-stateless-function': 'off',
         'react/jsx-filename-extension': 'off',
 

--- a/static/src/javascripts/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/clues.js
@@ -47,7 +47,7 @@ class Clues extends Component<*, *> {
     }
 
     componentDidMount() {
-        this.$cluesNode = (findDOMNode(this.refs.clues): any);
+        this.$cluesNode = (findDOMNode(this.clues): any);
 
         const height =
             this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
@@ -84,7 +84,7 @@ class Clues extends Component<*, *> {
 
     scrollIntoView(clue: Object) {
         const buffer = 100;
-        const node: HTMLElement = (findDOMNode(this.refs[clue.id]): any);
+        const node: HTMLElement = (findDOMNode(this[clue.id]): any);
         const visible =
             node.offsetTop - buffer > this.$cluesNode.scrollTop &&
             node.offsetTop + buffer <
@@ -103,7 +103,9 @@ class Clues extends Component<*, *> {
                 .filter(clue => clue.entry.direction === direction)
                 .map(clue => (
                     <Clue
-                        ref={clue.entry.id}
+                        ref={clueRef => {
+                            this[clue.entry.id] = clueRef;
+                        }}
                         id={clue.entry.id}
                         key={clue.entry.id}
                         number={clue.entry.number}
@@ -122,7 +124,11 @@ class Clues extends Component<*, *> {
                 className={`crossword__clues--wrapper ${
                     this.state.showGradient ? '' : 'hide-gradient'
                 }`}>
-                <div className="crossword__clues" ref="clues">
+                <div
+                    className="crossword__clues"
+                    ref={clues => {
+                        this.clues = clues;
+                    }}>
                     <div className="crossword__clues--across">
                         <h3 className={headerClass}>Across</h3>
                         <ol className="crossword__clues-list">

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -69,9 +69,9 @@ class Crossword extends Component<*, CrosswordState> {
 
     componentDidMount(): void {
         // Sticky clue
-        const $stickyClueWrapper = $(findDOMNode(this.refs.stickyClueWrapper));
-        const $grid = $(findDOMNode(this.refs.grid));
-        const $game = $(findDOMNode(this.refs.game));
+        const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
+        const $grid = $(findDOMNode(this.grid));
+        const $game = $(findDOMNode(this.game));
 
         mediator.on(
             'window:resize',
@@ -317,7 +317,7 @@ class Crossword extends Component<*, CrosswordState> {
 
     setGridHeight(): void {
         if (!this.$gridWrapper) {
-            this.$gridWrapper = $(findDOMNode(this.refs.gridWrapper));
+            this.$gridWrapper = $(findDOMNode(this.gridWrapper));
         }
 
         if (
@@ -516,7 +516,7 @@ class Crossword extends Component<*, CrosswordState> {
 
     focusHiddenInput(x: number, y: number): void {
         const wrapper: HTMLElement = (findDOMNode(
-            this.refs.hiddenInputComponent.refs.wrapper
+            this.hiddenInputComponent.wrapper
         ): any);
         const left = gridSize(x);
         const top = gridSize(y);
@@ -527,7 +527,7 @@ class Crossword extends Component<*, CrosswordState> {
         wrapper.style.top = `${position.y}%`;
 
         const hiddenInputNode: HTMLElement = (findDOMNode(
-            this.refs.hiddenInputComponent.refs.input
+            this.hiddenInputComponent.input
         ): any);
 
         if (document.activeElement !== hiddenInputNode) {
@@ -748,7 +748,9 @@ class Crossword extends Component<*, CrosswordState> {
             separators: buildSeparatorMap(this.props.data.entries),
             crossword: this,
             focussedCell: this.state.cellInFocus,
-            ref: 'grid',
+            ref: grid => {
+                this.grid = grid;
+            },
         };
 
         return (
@@ -757,16 +759,21 @@ class Crossword extends Component<*, CrosswordState> {
                     this.props.data.crosswordType
                 } crossword__container--react`}
                 data-link-name="Crosswords">
-                <div className="crossword__container__game" ref="game">
+                <div
+                    className="crossword__container__game"
+                    ref={game => {
+                        this.game = game;
+                    }}>
                     <div
                         className="crossword__sticky-clue-wrapper"
-                        ref="stickyClueWrapper">
+                        ref={stickyClueWrapper => {
+                            this.stickyClueWrapper = stickyClueWrapper;
+                        }}>
                         <div
                             className={classNames({
                                 'crossword__sticky-clue': true,
                                 'is-hidden': !focused,
-                            })}
-                            ref="stickyClue">
+                            })}>
                             {focused && (
                                 <div className="crossword__sticky-clue__inner">
                                     <div className="crossword__sticky-clue__inner__inner">
@@ -784,12 +791,16 @@ class Crossword extends Component<*, CrosswordState> {
                     </div>
                     <div
                         className="crossword__container__grid-wrapper"
-                        ref="gridWrapper">
+                        ref={gridWrapper => {
+                            this.gridWrapper = gridWrapper;
+                        }}>
                         {Grid(gridProps)}
                         <HiddenInput
                             crossword={this}
                             value={this.hiddenInputValue()}
-                            ref="hiddenInputComponent"
+                            ref={hiddenInputComponent => {
+                                this.hiddenInputComponent = hiddenInputComponent;
+                            }}
                         />
                         {anagramHelper}
                     </div>

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -20,7 +20,7 @@ class HiddenInput extends Component<*, *> {
             })
         ) {
             fastdom.read(() => {
-                const offsets = bonzo(findDOMNode(this.refs.input)).offset();
+                const offsets = bonzo(findDOMNode(this.input)).offset();
                 const clueHeight = document.getElementsByClassName(
                     'crossword__sticky-clue'
                 )[0].offsetHeight;
@@ -59,7 +59,11 @@ class HiddenInput extends Component<*, *> {
 
     render() {
         return (
-            <div className="crossword__hidden-input-wrapper" ref="wrapper">
+            <div
+                className="crossword__hidden-input-wrapper"
+                ref={wrapper => {
+                    this.wrapper = wrapper;
+                }}>
                 <input
                     type="text"
                     className="crossword__hidden-input"
@@ -73,7 +77,9 @@ class HiddenInput extends Component<*, *> {
                     autoComplete="off"
                     spellCheck="false"
                     autoCorrect="off"
-                    ref="input"
+                    ref={input => {
+                        this.input = input;
+                    }}
                 />
             </div>
         );


### PR DESCRIPTION
## What does this change?

String refs are deprecated in React, and only work in our application because they are currently support by preact-compat. This PR replaces string refs with function refs, which are more efficient and are likely to have a longer shelf life.

## What is the value of this and can you measure success?

Long term support, one less lint override

### Tested

- [x] Locally
