### PR TITLE
Replicate VideoJS events in post-videojs world

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/video-player.js
@@ -2,6 +2,7 @@
 
 import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
+import bean from 'bean';
 import raven from 'lib/raven';
 import {
     buildGoogleAnalyticsEvent,
@@ -76,13 +77,21 @@ const bindTrackingEvents = (el: HTMLMediaElement): void => {
         }
 
         // don't fire events every time video is paused then restarted
-        el.removeEventListener('play', playHandler);
+        bean.off(el, 'play', playHandler);
     };
 
-    el.addEventListener('play', playHandler);
-    el.addEventListener('ended', () => {
+    bean.on(el, 'play', playHandler);
+    bean.on(el, 'ended', () => {
         // track re-plays
-        el.addEventListener('play', playHandler);
+        bean.on(el, 'play', playHandler);
+    });
+    bean.on(el, 'play pause', () => {
+        // synthetic click on data-component="main video"
+        const figure: HTMLElement = (el.parentNode &&
+            el.parentNode.parentNode &&
+            el.parentNode.parentNode.parentNode: any);
+
+        figure.click();
     });
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/video-player.js
@@ -56,7 +56,7 @@ const bindTrackingEvents = (el: HTMLMediaElement): void => {
             const eventObject = {
                 video: {
                     id: mediaId,
-                    eventType: 'play',
+                    eventType: 'video:content:play',
                 },
             };
 


### PR DESCRIPTION
## What does this change?

When the video is played, we are currently recording an Ophan event that looks like this:

```
viewId:
ji4ijbv5do61yosff161
video:
{"id":"gu-video-57874596e4b08239dbab739c","eventType":"play"}
 ```

This change updates the event to look like this:

I have also simulated a click on the video's parent element (`data-component="main video"`) since when clicking the play / pause controls, the click event does not propagate.

```
viewId:
ji4ijbv5do61yosff161
video:
{"id":"gu-video-57874596e4b08239dbab739c","eventType":"video:content:play"}
 ```

## What is the value of this and can you measure success?

Parity with existing VideoJS events

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
