### PR TITLE
Update football page headings.

### DIFF
--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -65,6 +65,16 @@ trait MatchesList extends Football with RichList with implicits.Collections {
     val nextMatchDate = matchDates.takeWhile(dateComesFirstInList(_, date)).lastOption
     nextMatchDate.map(s"$baseUrl/" + _.toString("yyyy/MMM/dd"))
   }
+
+  def getPageTitle: String = {
+    pageType match {
+      case "live" => "Live football scores"
+      case "matches" => "Football scores"
+      case "fixtures" => "Football fixtures"
+      case "results" => "Football results"
+      case _ => pageType
+    }
+  }
 }
 
 trait Fixtures extends MatchesList {

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -15,7 +15,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <h2 class="hide-on-mobile-if-localnav content__inline-section page-type--football">
-                    @matchesList.pageType
+                    @matchesList.getPageTitle
                     </h2>
 
                     <div class="page-sponsor--football">

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -10,7 +10,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <@if(!page.singleCompetition){h1}else{h2} class="hide-on-mobile-if-localnav content__inline-section page-heading--football">
-                        Football Tables
+                        Football tables
                     </@if(!page.singleCompetition){h1}else{h2}>
 
                     @football.views.html.fragments.leagueSelector(page.filters, "tables", page.comp)

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -10,7 +10,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <@if(!page.singleCompetition){h1}else{h2} class="hide-on-mobile-if-localnav content__inline-section page-heading--football">
-                        tables
+                        Football Tables
                     </@if(!page.singleCompetition){h1}else{h2}>
 
                     @football.views.html.fragments.leagueSelector(page.filters, "tables", page.comp)

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -40,7 +40,7 @@ import org.scalatest._
 
         Then("The <h1> Should be tables")
         val h2 = $("h2")
-        $("h1").texts should contain("tables")
+        $("h1").texts should contain("Football tables")
         h2.texts should contain("Premier League")
         h2.texts should contain("Champions League")
       }


### PR DESCRIPTION
This is basically a cleanup job - these pages e.g. theguardian.com/football/live - look a bit sad at the moment. This gives them capitalised names. I renamed more than just what Peter Martin asked for since they all looked a bit broken (I think capitalising is the norm in Garnett land?):

https://trello.com/c/Xd5dJoQB/225-change-headings-on-fronts-and-tag-pages