### PR TITLE
Send Prebid analytics by POST instead of PUT

### DIFF
--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -45,5 +45,4 @@ GET         /facebook-ia/remote.html                                        cont
 GET         /ads.txt                                                        commercial.controllers.AdsDotTextViewController.renderTextFile()
 
 # Prebid analytics
-PUT         /commercial/api/hb                                              commercial.controllers.PrebidAnalyticsController.insert()
-OPTIONS     /commercial/api/hb                                              commercial.controllers.PrebidAnalyticsController.getOptions
+POST        /commercial/api/hb                                              commercial.controllers.PrebidAnalyticsController.insert()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -275,8 +275,7 @@ GET            /advertiser-content/:campaignName/:pageName/autoplay.json        
 GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize
 GET            /ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderTextFile()
 GET            /commercial/prebid/revenue                                                                                        controllers.admin.commercial.TeamKPIController.renderPrebidDashboard()
-PUT            /commercial/api/hb                                                                                                commercial.controllers.PrebidAnalyticsController.insert()
-OPTIONS        /commercial/api/hb                                                                                                commercial.controllers.PrebidAnalyticsController.getOptions
+POST           /commercial/api/hb                                                                                                commercial.controllers.PrebidAnalyticsController.insert()
 
 # Commercial Admin
 GET         /commercial                                                                                                          controllers.admin.CommercialController.renderCommercialMenu()

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#400046e4c10231884a4e76420f8904251361517c",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#5d101d9",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7525,9 +7525,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#400046e4c10231884a4e76420f8904251361517c":
+"prebid.js@https://github.com/guardian/Prebid.js.git#5d101d9":
   version "1.12.0"
-  resolved "https://github.com/guardian/Prebid.js.git#400046e4c10231884a4e76420f8904251361517c"
+  resolved "https://github.com/guardian/Prebid.js.git#5d101d95ceee0c2a10feb5b90a340772edcbd6c4"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This is to avoid the preflight OPTIONS request.

The server-side work for https://github.com/guardian/Prebid.js/pull/34