### PR TITLE
When calculating how old an article is, months should be 30 days long

### DIFF
--- a/common/app/views/support/ContentOldAgeDescriber.scala
+++ b/common/app/views/support/ContentOldAgeDescriber.scala
@@ -34,7 +34,7 @@ class ContentOldAgeDescriber {
       if (pubDate.isBefore(DateTime.now().minusDays(warnLimitDays))) {
         val ageMillis = DateTime.now().getMillis - pubDate.getMillis
         val years = TimeUnit.MILLISECONDS.toDays(ageMillis) / 365
-        val months = TimeUnit.MILLISECONDS.toDays(ageMillis) / 28
+        val months = TimeUnit.MILLISECONDS.toDays(ageMillis) / 30
         val weeks = TimeUnit.MILLISECONDS.toDays(ageMillis) / 7
         val days = TimeUnit.MILLISECONDS.toDays(ageMillis)
 

--- a/common/app/views/support/ContentOldAgeDescriber.scala
+++ b/common/app/views/support/ContentOldAgeDescriber.scala
@@ -34,7 +34,7 @@ class ContentOldAgeDescriber {
       if (pubDate.isBefore(DateTime.now().minusDays(warnLimitDays))) {
         val ageMillis = DateTime.now().getMillis - pubDate.getMillis
         val years = TimeUnit.MILLISECONDS.toDays(ageMillis) / 365
-        val months = TimeUnit.MILLISECONDS.toDays(ageMillis) / 30
+        val months = TimeUnit.MILLISECONDS.toDays(ageMillis) / 31
         val weeks = TimeUnit.MILLISECONDS.toDays(ageMillis) / 7
         val days = TimeUnit.MILLISECONDS.toDays(ageMillis)
 


### PR DESCRIPTION
Currently [this](https://www.theguardian.com/science/2017/jul/06/mars-covered-in-toxic-chemicals-that-can-wipe-out-living-organisms-tests-reveal) article is showing up as 12 months old when it is only 11 months! It is better to underestimate how old something is rather than overestimate (as we used the text 'at least') so I've made the month longer.