### PR TITLE
Bluer identity flow pages

### DIFF
--- a/static/src/stylesheets/module/identity/_header.scss
+++ b/static/src/stylesheets/module/identity/_header.scss
@@ -21,8 +21,7 @@ $gutter: 5px;
         height: 1px;
         display: block;
         z-index: 0;
-        background: #000000;
-        opacity: .14;
+        background: $rule;
     }
 
     .identity-dropdown {
@@ -57,13 +56,6 @@ $gutter: 5px;
         align-items: flex-start;
         padding-top: 0;
         padding-bottom: 0;
-    }
-}
-
-.identity-wrapper-page-flex.identity-wrapper-page-flex--flow {
-    .identity-header, .identity-header:after {
-        background-color: transparent;
-        border-color: $garnett-neutral-4;
     }
 }
 

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -153,7 +153,7 @@ $identity-header-height: 48px;
     }
 
     .social-signin__action--gplus {
-        background-color: #dd4b39;
+        background-color: #4285f4;
 
         @include mq(tablet) {
             margin-left: $gs-gutter/2;

--- a/static/src/stylesheets/module/identity/_wrapper.scss
+++ b/static/src/stylesheets/module/identity/_wrapper.scss
@@ -68,7 +68,7 @@
     min-height: 100vh;
     align-items: stretch;
     &.identity-wrapper-page-flex--flow {
-        background: $garnett-neutral-3;
+        background: $garnett-nav-background;
     }
     & > .identity-wrapper-page-flex__content {
         flex: 1 1 auto;


### PR DESCRIPTION
## What does this change?
Makes the identity flow pages (consents) match `identity-frontend` (was neutral grey, now is header grey) as some of the flows starting there end in these pages. 

Also changes the sign in with Google button in `/reauthenticate` to blue from red, to match the buttons in `identity-frontend`.

## Show me
![screen shot 2018-06-08 at 3 49 06 pm](https://user-images.githubusercontent.com/11539094/41164612-8224fc92-6b33-11e8-8f58-da7ff0b94b02.png)


## Laura the sign in with Google button looks horrible that's not even the right icon
I know but this will make it _less_ horrible during the weekend.