### PR TITLE
Epic: fix stretched logo grid

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -129,6 +129,7 @@
 }
 
 .contributions__payment-logos {
+    align-self: flex-start;
     height: 25px;
 }
 


### PR DESCRIPTION
## What does this change?

Fixes a CSS glitch. Before the logo grid in the epic was stretched (latest Chrome). It could also be fixed by `object-fit: contain;` but then the logos would be centered horizontally, which is not intended (I guess).

## Screenshots

**Before**

<img width="426" alt="screen shot 2018-06-11 at 08 59 51" src="https://user-images.githubusercontent.com/2244375/41216740-d36b8e8a-6d55-11e8-9679-befe64b9d375.png">

**After**

<img width="416" alt="screen shot 2018-06-11 at 08 58 09" src="https://user-images.githubusercontent.com/2244375/41216746-d7c01dca-6d55-11e8-8cf5-0ceffce1a576.png">


## What is the value of this and can you measure success?

Biutiful.

## Checklist

### Accessibility test checklist

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)


❤️ 
