### PR TITLE
Press ad free fronts

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -72,7 +72,15 @@ case object LiteType extends PressedPageType {
   override def suffix = ".lite"
 }
 
-case class PressedPageVersions(lite: PressedPage, full: PressedPage)
+case object FullAdFreeType extends PressedPageType {
+  override def suffix = ".adfree"
+}
+
+case object LiteAdFreeType extends PressedPageType {
+  override def suffix = ".lite.adfree"
+}
+
+case class PressedPageVersions(lite: PressedPage, full: PressedPage, liteAdFree: PressedPage, fullAdFree: PressedPage)
 
 object PressedPageVersions {
   def fromPressedCollections(id: String,
@@ -81,12 +89,14 @@ object PressedPageVersions {
                              pressedCollections: List[PressedCollectionVersions]): PressedPageVersions = {
     PressedPageVersions(
       PressedPage(id, seoData, frontProperties, pressedCollections.map(_.lite)),
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full))
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full)),
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.liteAdFree)),
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullAdFree))
     )
   }
 }
 
-case class PressedCollectionVersions(lite: PressedCollection, full: PressedCollection)
+case class PressedCollectionVersions(lite: PressedCollection, full: PressedCollection, liteAdFree: PressedCollection, fullAdFree: PressedCollection)
 
 case class PressedPage (
   id: String,

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -80,6 +80,11 @@ case object LiteAdFreeType extends PressedPageType {
   override def suffix = ".lite.adfree"
 }
 
+case class PressedCollectionVersions(lite: PressedCollection,
+                                     full: PressedCollection,
+                                     liteAdFree: PressedCollection,
+                                     fullAdFree: PressedCollection)
+
 case class PressedPageVersions(lite: PressedPage, full: PressedPage, liteAdFree: PressedPage, fullAdFree: PressedPage)
 
 object PressedPageVersions {
@@ -88,21 +93,21 @@ object PressedPageVersions {
                              frontProperties: FrontProperties,
                              pressedCollections: List[PressedCollectionVersions]): PressedPageVersions = {
     PressedPageVersions(
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.lite)),
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full)),
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.liteAdFree)),
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullAdFree))
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.lite)).filterEmpty,
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full)).filterEmpty,
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.liteAdFree)).filterEmpty,
+      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullAdFree)).filterEmpty
     )
   }
 }
-
-case class PressedCollectionVersions(lite: PressedCollection, full: PressedCollection, liteAdFree: PressedCollection, fullAdFree: PressedCollection)
 
 case class PressedPage (
   id: String,
   seoData: SeoData,
   frontProperties: FrontProperties,
   collections: List[PressedCollection]) extends StandalonePage {
+
+  lazy val filterEmpty: PressedPage = copy(collections = collections.filterNot(_.isEmpty))
 
   override val metadata: MetaData = PressedPage.makeMetadata(id, seoData, frontProperties, collections)
   val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId == id)

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -31,6 +31,26 @@ case class PressedCollection(
   hasMore: Boolean
 ) {
 
+  lazy val adFree = {
+    copy(
+      curated = curated.filterNot(_.isPaidFor),
+      backfill = backfill.filterNot(_.isPaidFor),
+      treats = treats.filterNot(_.isPaidFor)
+    )
+  }
+
+  def lite(visible: Int): PressedCollection = {
+    val liteCurated = curated.take(visible)
+    val liteBackfill = backfill.take(visible - liteCurated.length)
+    val hasMore = curatedPlusBackfillDeduplicated.length > visible
+    copy(curated = liteCurated, backfill = liteBackfill, hasMore = hasMore)
+  }
+
+  def full(visible: Int): PressedCollection = {
+    val hasMore = curatedPlusBackfillDeduplicated.length > visible
+    copy(hasMore = hasMore)
+  }
+
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)
 
   lazy val curatedPlusBackfillDeduplicated = (curated ++ backfill).distinctBy { c =>

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -31,6 +31,8 @@ case class PressedCollection(
   hasMore: Boolean
 ) {
 
+  lazy val isEmpty: Boolean = curated.isEmpty && backfill.isEmpty && treats.isEmpty
+
   lazy val adFree = {
     copy(
       curated = curated.filterNot(_.isPaidFor),

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -253,7 +253,9 @@ final case class PressedProperties(
   href: Option[String],
   webUrl: Option[String],
   editionBrandings: Option[Seq[EditionBranding]]
-)
+) {
+  lazy val isPaidFor: Boolean = editionBrandings.exists(_.exists(branding => branding.branding.exists(_.isPaid) && branding.edition == Edition.defaultEdition))
+}
 
 object PressedCardHeader {
   def make(content: fapi.FaciaContent): PressedCardHeader = {
@@ -367,6 +369,8 @@ sealed trait PressedContent {
   def display: PressedDisplaySettings
   def maybePillar: Option[Pillar] = Pillar(properties.maybeContent)
   lazy val participatesInDeduplication: Boolean = properties.embedType.isEmpty
+
+  def isPaidFor: Boolean = properties.isPaidFor
 
   def branding(edition: Edition): Option[Branding] =
     for {

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -121,6 +121,8 @@ trait FapiFrontPress extends Logging {
       .map { pressedFronts: PressedPageVersions =>
         putPressedPage(path, pressedFronts.full, FullType)
         putPressedPage(path, pressedFronts.lite, LiteType)
+        putPressedPage(path, pressedFronts.fullAdFree, FullAdFreeType)
+        putPressedPage(path, pressedFronts.liteAdFree, LiteAdFreeType)
       }.fold(
         e => {
           StatusNotification.notifyFailedJob(path, isLive = isLiveContent, e)
@@ -159,6 +161,8 @@ trait FapiFrontPress extends Logging {
     val metric: SamplerMetric = pressedType match {
       case FullType => FaciaPressMetrics.FrontPressContentSize
       case LiteType => FaciaPressMetrics.FrontPressContentSizeLite
+      case LiteAdFreeType => FaciaPressMetrics.FrontPressContentSizeLite
+      case FullAdFreeType => FaciaPressMetrics.FrontPressContentSize
     }
 
     metric.recordSample(json.getBytes.length, new DateTime())

--- a/facia-press/app/frontpress/PressedCollectionVisibility.scala
+++ b/facia-press/app/frontpress/PressedCollectionVisibility.scala
@@ -24,12 +24,12 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
   }
 
   lazy val pressedCollectionVersions: PressedCollectionVersions = {
-    val liteCurated = pressedCollection.curated.take(visible)
-    val liteBackfill = pressedCollection.backfill.take(visible - liteCurated.length)
-    val hasMore = pressedCollection.curatedPlusBackfillDeduplicated.length > visible
-    val liteCollection = pressedCollection.copy(curated = liteCurated, backfill = liteBackfill, hasMore = hasMore)
-    val fullCollection = pressedCollection.copy(hasMore = hasMore)
-    PressedCollectionVersions(liteCollection, fullCollection)
+    PressedCollectionVersions(
+      pressedCollection.lite(visible),
+      pressedCollection.full(visible),
+      pressedCollection.adFree.lite(visible),
+      pressedCollection.adFree.full(visible)
+    )
   }
 
   def deduplicate(against: Seq[HeaderUrl]): PressedCollectionVisibility = {

--- a/facia-press/test/frontpress/PressedCollectionVisibilityTest.scala
+++ b/facia-press/test/frontpress/PressedCollectionVisibilityTest.scala
@@ -43,7 +43,7 @@ class PressedCollectionVisibilityTest extends FlatSpec with Matchers with FaciaT
     val collectionVisibility: PressedCollectionVisibility = PressedCollectionVisibility(pressedCollection.copy(hasMore = false), 3)
     val liteCollection = pressedCollection.copy(curated = pressedCollection.curated.take(3), hasMore = true)
     val fullCollection = pressedCollection.copy(hasMore = true)
-    collectionVisibility.pressedCollectionVersions shouldBe PressedCollectionVersions(liteCollection, fullCollection)
+    collectionVisibility.pressedCollectionVersions shouldBe PressedCollectionVersions(liteCollection, fullCollection, liteCollection, fullCollection)
   }
 
   it should "identify web collections" in new PressedCollectionVisibilityScope {


### PR DESCRIPTION
## What does this change?

facia-press presses ad free fronts

## What is the value of this and can you measure success?

Facia will be able to serve ad free fronts (next PR)
This PR needs to go live, and all fronts pressed before releasing the changes to facia

### Tested

- Code

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
