### PR TITLE
World cup container

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -466,11 +466,11 @@ $header-image-size-desktop: 100px;
 
         .fc-item__content {
             &:before {
-                background-image: url("https://uploads.guim.co.uk/2018/06/11/byline-mask.png");
+                background-image: url('https://uploads.guim.co.uk/2018/06/11/byline-mask.png');
                 background-repeat: no-repeat;
                 background-size: contain;
                 background-position: right;
-                content: "";
+                content: '';
                 position: absolute;
                 bottom: 9px;
                 right: 10px;

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -448,6 +448,58 @@ $header-image-size-desktop: 100px;
     transition: opacity .25s linear; // Used to fade-in new updates
 }
 
+[data-component='world-cup-2018'] {
+    .fc-item--has-cutout.fc-item--type-comment {
+        .fc-item__avatar {
+            background-color: transparent !important;
+            overflow: visible;
+
+            img {
+                filter: grayscale(100%);
+                position: relative;
+            }
+        }
+
+        .u-faux-block-link__overlay {
+            z-index: 1;
+        }
+
+        .fc-item__content {
+            &:before {
+                background-image: url("https://uploads.guim.co.uk/2018/06/11/byline-mask.png");
+                background-repeat: no-repeat;
+                background-size: contain;
+                background-position: right;
+                content: "";
+                position: absolute;
+                bottom: 9px;
+                right: 10px;
+                z-index: 1;
+                height: 90px;
+                width: 200px;
+            }
+        }
+
+        &.fc-item--standard-tablet .fc-item__content:before {
+            @include mq(tablet) {
+                height: 114px;
+                bottom: $gs-baseline / 2;
+            }
+
+            @include mq(desktop) {
+                height: 138px;
+            }
+        }
+
+        &.fc-item--list-media-tablet .fc-item__content:before {
+            @include mq(tablet) {
+                height: 76px;
+                bottom: 5px;
+            }
+        }
+    }
+}
+
 .fc-container__toggle {
     @include fs-textSans(3);
     background-color: transparent;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -146,7 +146,6 @@
 
         .fc-item__headline {
             color: $sport-garnett-main-1;
-            font-weight: 400;
         }
 
         .fc-item__title--quoted .fc-item__headline {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -105,7 +105,136 @@
     }
 }
 
-.fc-item--type-immersive.fc-item--has-boosted-title {
+[data-component='world-cup-2018'] {
+    background: url("https://uploads.guim.co.uk/2018/06/11/worldcup_bg_01.png");
+    background-repeat: no-repeat;
+    background-position: top left;
+    background-size: 1600px;
+
+    @include mq(desktop) {
+        background-position: top;
+        background-size: 1600px;
+    }
+
+    .fc-container__header__title {
+        .fc-container__title__text {
+            display: none;
+        }
+
+        a:before {
+            content: '';
+            background: url("https://uploads.guim.co.uk/2018/06/08/worldCupLogo_01.svg");
+            background-repeat: no-repeat;
+            background-size: contain;
+            display: block;
+            height: 70px;
+            width: 200px;
+
+            @include mq(desktop) {
+                width: auto;
+            }
+        }
+    }
+
+    // All cards but certain types
+    .fc-item:not(.fc-item--type-live):not(.fc-item--type-media) {
+        background-color: #ffffff !important;
+
+        &:hover {
+            background-color: $garnett-neutral-3 !important;
+        }
+
+        .fc-item__headline {
+            color: $sport-garnett-main-1;
+            font-weight: 400;
+        }
+
+        .fc-item__title--quoted .fc-item__headline {
+            color: $sport-garnett-feature;
+        }
+
+        .fc-item__kicker {
+            color: $sport-garnett-feature;
+        }
+    }
+
+    .fc-slice__item + .fc-slice__item:before {
+        content: none;
+    }
+
+    // All cards
+    .fc-item {
+        .fc-item__container:before {
+            background-color: $sport-garnett-main-1;
+        }
+
+        .fc-item__kicker {
+            &:after {
+                content: none;
+            }
+        }
+
+        .fc-sublink__title:before {
+            border-color: $sport-garnett-main-1;
+        }
+
+        @include mq(tablet) {
+            border-left: 1px solid $sport-garnett-main-1;
+
+            .fc-item__container:before {
+                height: 3px;
+            }
+
+            .fc-sublink__title:before {
+                left: -5px;
+            }
+        }
+    }
+
+    // Comment cards
+    .fc-item--type-comment {
+        // Forces blue colour scheme on all comment cards
+        .fc-item__meta {
+            background: none;
+        }
+
+        .fc-item__headline {
+            color: $sport-garnett-feature;
+        }
+
+        .inline-garnett-quote {
+            fill: $sport-garnett-main-1;
+        }
+
+        .fc-item__byline {
+            color: $sport-garnett-main-1;
+        }
+    }
+}
+
+[data-component='world-cup-2018'] .fc-item--has-boosted-title.fc-item--standard-mobile {
+    .fc-item__content {
+        background-color: $sport-garnett-feature !important;
+
+        .fc-item__headline {
+            font-weight: 800;
+        }
+
+        .fc-item__byline,
+        .fc-item__kicker {
+            color: $live-garnett-sport2 !important;
+        }
+    }
+
+    &:hover {
+        .fc-item__content {
+            background-color: darken($sport-garnett-feature, 5%) !important;
+        }
+    }
+}
+
+.fc-item--type-immersive.fc-item--has-boosted-title,
+[data-component='world-cup-2018'] .fc-item--has-boosted-title  {
 
     // ?# It is very easy to opt out as the below, but
     // it increases the cyclomatic complexity of all selectors.

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-immersive.scss
@@ -106,7 +106,7 @@
 }
 
 [data-component='world-cup-2018'] {
-    background: url("https://uploads.guim.co.uk/2018/06/11/worldcup_bg_01.png");
+    background: url('https://uploads.guim.co.uk/2018/06/11/worldcup_bg_01.png');
     background-repeat: no-repeat;
     background-position: top left;
     background-size: 1600px;
@@ -123,7 +123,7 @@
 
         a:before {
             content: '';
-            background: url("https://uploads.guim.co.uk/2018/06/08/worldCupLogo_01.svg");
+            background: url('https://uploads.guim.co.uk/2018/06/08/worldCupLogo_01.svg');
             background-repeat: no-repeat;
             background-size: contain;
             display: block;


### PR DESCRIPTION
TEMPORARY: Container specific styling to any container called "World Cup 2018". Any card within that container that's given "Boosted headline" will inherit the immersive card styling.

Just like we did with the royal wedding container. 

<img width="1680" alt="screen shot 2018-06-11 at 14 49 25" src="https://user-images.githubusercontent.com/14570016/41235440-bd54359e-6d86-11e8-9d4c-cabed7c47b1b.png">
