### PR TITLE
Add an 'edit my account' link to comment history

### DIFF
--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -12,7 +12,7 @@
             <div class="identity-title identity-title--public-profile">
                 <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
                 <div class="user-profile__rows">
-                    <h1 class="user-profile__name">@user.publicFields.displayName</h1>
+                    <h1 class="user-profile__name" data-userid="@user.id">@user.publicFields.displayName</h1>
                     @user.dates.accountCreatedDate.map { accountCreatedDate =>
                         <p class="user-profile__last-seen">
                             Registered on @accountCreatedDate.toString("d MMM yyyy")

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -11,13 +11,14 @@
         <div class="user-profile u-cf">
             <div class="identity-title identity-title--public-profile">
                 <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
-                <h1 class="user-profile__name">@user.publicFields.displayName</h1>
-                @user.dates.accountCreatedDate.map { accountCreatedDate =>
-                    <p class="user-profile__last-seen">
-                        @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
-                        Registered on @accountCreatedDate.toString("d MMM yyyy")
-                    </p>
-                }
+                <div class="user-profile__rows">
+                    <h1 class="user-profile__name">@user.publicFields.displayName</h1>
+                    @user.dates.accountCreatedDate.map { accountCreatedDate =>
+                        <p class="user-profile__last-seen">
+                            Registered on @accountCreatedDate.toString("d MMM yyyy")
+                        </p>
+                    }
+                </div>
             </div>
             @user.publicFields.aboutMe.map{ aboutMe =>
                 <div class="user-profile__about">

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -14,6 +14,7 @@ import { enhanceConsentJourney } from 'common/modules/identity/consent-journey';
 import { setupLoadingAnimation } from 'common/modules/identity/delete-account';
 import { initHeader } from 'common/modules/identity/header';
 import { initUserAvatars } from 'common/modules/discussion/user-avatars';
+import { initUserEditLink } from 'common/modules/discussion/user-edit-link';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { enhanceAdPrefs } from 'common/modules/identity/ad-prefs';
 
@@ -53,6 +54,7 @@ const initProfile = (): void => {
         ['password-toggle', passwordToggle],
         ['init-validation-email', initValidationEmail],
         ['init-user-avatars', initUserAvatars],
+        ['init-user-edit-link', initUserEditLink],
         ['init-tabs', initTabs],
         ['init-account-profile', initAccountProfile],
         ['setup-loading-animation', setupLoadingAnimation],

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -12,6 +12,7 @@ const addEditLink = (containerEl: HTMLElement): void => {
     if (parentNode && myUserId === pageUserId) {
         const linkEl = document.createElement('a');
         linkEl.innerText = 'Edit your public profile';
+        linkEl.dataset.linkName = 'comments : edit profile';
         linkEl.href = `${config.get('page.idUrl')}/public/edit`;
         linkEl.classList.add('u-underline');
 

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -1,0 +1,38 @@
+// @flow
+
+import config from 'lib/config';
+import fastdom from 'lib/fastdom-promise';
+
+const addEditLink = (containerEl: HTMLElement): void => {
+
+    const myUserId: string = config.get('user.id');
+    const pageUserId: string = containerEl.dataset.userid;
+
+    const parentNode: ?Element = containerEl.parentElement;
+
+    if(parentNode && myUserId === pageUserId) {
+
+        const linkEl = document.createElement('a');
+        linkEl.innerText = 'Edit your public profile';
+        linkEl.href = `${config.get('page.idUrl')}/public/edit`;
+        linkEl.classList.add('u-underline');
+
+        const holderEl = document.createElement('p');
+        holderEl.appendChild(linkEl);
+        holderEl.classList.add('user-profile__edit-link');
+
+        fastdom.write(()=>{
+            containerEl.insertAdjacentElement('afterend', holderEl);
+        })
+    }
+
+};
+
+const initUserEditLink = (): Promise<void> =>
+    fastdom
+        .read(() => [...document.getElementsByClassName('user-profile__name')])
+        .then(names => {
+            names.forEach(addEditLink);
+        });
+
+export { initUserEditLink };

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -4,14 +4,12 @@ import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 
 const addEditLink = (containerEl: HTMLElement): void => {
-
     const myUserId: string = config.get('user.id');
     const pageUserId: string = containerEl.dataset.userid;
 
     const parentNode: ?Element = containerEl.parentElement;
 
-    if(parentNode && myUserId === pageUserId) {
-
+    if (parentNode && myUserId === pageUserId) {
         const linkEl = document.createElement('a');
         linkEl.innerText = 'Edit your public profile';
         linkEl.href = `${config.get('page.idUrl')}/public/edit`;
@@ -21,11 +19,10 @@ const addEditLink = (containerEl: HTMLElement): void => {
         holderEl.appendChild(linkEl);
         holderEl.classList.add('user-profile__edit-link');
 
-        fastdom.write(()=>{
+        fastdom.write(() => {
             containerEl.insertAdjacentElement('afterend', holderEl);
-        })
+        });
     }
-
 };
 
 const initUserEditLink = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -4,12 +4,12 @@ import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 
 const addEditLink = (containerEl: HTMLElement): void => {
-    const myUserId: string = config.get('user.id');
+    const myUserId: ?string = config.get('user.id');
     const pageUserId: string = containerEl.dataset.userid;
 
     const parentNode: ?Element = containerEl.parentElement;
 
-    if (parentNode && myUserId === pageUserId) {
+    if (parentNode && myUserId && myUserId === pageUserId) {
         const linkEl = document.createElement('a');
         linkEl.innerText = 'Edit your public profile';
         linkEl.dataset.linkName = 'comments : edit profile';

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -80,6 +80,7 @@ $identity-header-height: 48px;
 
 .identity-title--public-profile {
     display: flex;
+    align-items: center;
     @include mq(desktop) {
         float: left;
         white-space: nowrap;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -210,7 +210,7 @@ $identity-header-height: 48px;
     float: left;
     height: 60px;
     width: 60px;
-    margin-right: $gs-gutter;
+    margin-right: $gs-gutter/2;
 }
 
 .user-profile {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -79,6 +79,7 @@ $identity-header-height: 48px;
 }
 
 .identity-title--public-profile {
+    display: flex;
     @include mq(desktop) {
         float: left;
         white-space: nowrap;
@@ -208,7 +209,7 @@ $identity-header-height: 48px;
     float: left;
     height: 60px;
     width: 60px;
-    margin-right: $gs-gutter/2;
+    margin-right: $gs-gutter;
 }
 
 .user-profile {
@@ -241,11 +242,13 @@ $identity-header-height: 48px;
     }
 }
 .user-profile__last-seen,
-.user-profile__web-page {
+.user-profile__web-page,
+.user-profile__edit-link {
     @include fs-textSans(1);
     display: block;
     color: $neutral-2-contrasted;
     font-weight: normal;
+    margin: 0;
 }
 .user-profile__web-page {
     @include ellipsis();


### PR DESCRIPTION
## What does this change?
Very minor upgrade

## Screenshots
![screen shot 2018-06-11 at 2 59 12 pm](https://user-images.githubusercontent.com/11539094/41236507-3887777e-6d89-11e8-9b6a-b20df25be23b.png)

## What is the value of this and can you measure success?
Promotes visibility of 'edit profile' from comment history which is the top destination

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally