### PR TITLE
Use article headline rather than front headline in emails

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -125,7 +125,7 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
             if (shouldOnlyReturnHeadline(request)) {
               val webTitle = for {
                 topCollection <- faciaPage.collections.headOption
-                topCurated <- topCollection.curated.headOption
+                topCurated <- topCollection.curatedPlusBackfillDeduplicated.headOption
               } yield topCurated.properties.webTitle
               webTitle.map(RevalidatableResult.Ok(_)).getOrElse(WithoutRevalidationResult(NotFound("Could not extract headline from front")))
             } else {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -126,8 +126,8 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
               val webTitle = for {
                 topCollection <- faciaPage.collections.headOption
                 topCurated <- topCollection.curatedPlusBackfillDeduplicated.headOption
-              } yield topCurated.properties.webTitle
-              webTitle.map(RevalidatableResult.Ok(_)).getOrElse(WithoutRevalidationResult(NotFound("Could not extract headline from front")))
+              } yield RevalidatableResult.Ok(topCurated.properties.webTitle)
+              webTitle.getOrElse(WithoutRevalidationResult(NotFound("Could not extract headline from front")))
             } else {
               val htmlResponse = FrontEmailHtmlPage.html(faciaPage)
               RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -2,11 +2,11 @@ package controllers
 
 import common._
 import controllers.front._
-import layout.{CollectionEssentials, FaciaCard, FaciaContainer, Front, ContentCard, FaciaCardAndIndex}
+import layout.{CollectionEssentials, ContentCard, FaciaCard, FaciaCardAndIndex, FaciaContainer, Front}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import model.facia.PressedCollection
-import model.pressed.CollectionConfig
+import model.pressed.{CollectionConfig, PressedContent}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html
@@ -123,11 +123,11 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
             JsonFront(faciaPage)
           else if (request.isEmail || ConfigAgent.isEmailFront(path)) {
             if (shouldOnlyReturnHeadline(request)) {
-              val headline = for {
+              val webTitle = for {
                 topCollection <- faciaPage.collections.headOption
                 topCurated <- topCollection.curated.headOption
-              } yield topCurated.header.headline
-                RevalidatableResult.Ok(headline.getOrElse("Error: Could not extract headline from front"))
+              } yield topCurated.properties.webTitle
+              webTitle.map(RevalidatableResult.Ok(_)).getOrElse(WithoutRevalidationResult(NotFound("Could not extract headline from front")))
             } else {
               val htmlResponse = FrontEmailHtmlPage.html(faciaPage)
               RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse)


### PR DESCRIPTION
## What does this change?
Modifies the `?format=email-headline` endpoint so that it returns the webTitle of the first curated piece of content in a front - previously it was using the 'fronts header headline' - i.e. in [this](https://m.code.dev-theguardian.com/email/uk/daily) piece it would be 'bolt comfortably wins....' as opposed to 'Usain Bolt comfortably...' which is the [full headline](https://m.code.dev-theguardian.com/sport/2015/may/26/usain-bolt-200m-golden-spike-ostrava)

Theresa Malone requested this change.

This change modifies the endpoint so that if it fails to find a title, it returns a not found response rather than a 200 with an error message - see [here](https://github.com/guardian/frontend/pull/19793/commits/2b52676840c964f9e533723ca67c1dff17a7e1c5).

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
