### PR TITLE
Always show an ad in comments container when a user is signed in

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -5,9 +5,9 @@ import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { isUserLoggedIn } from 'common/modules/identity/api';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import type bonzo from 'bonzo';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 
 export const initCommentAdverts = (): ?boolean => {
     const $adSlotContainer: bonzo = $('.js-discussion__ad-slot');
@@ -33,11 +33,6 @@ export const initCommentAdverts = (): ?boolean => {
             .then((adSlot: HTMLElement) => addSlot(adSlot, false));
     };
 
-    if (isUserLoggedIn() && mainColHeight >= 300) {
-        insertCommentAd($commentMainColumn);
-    }
-
-
     if (!commercialFeatures.commentAdverts || !$adSlotContainer.length) {
         return false;
     }
@@ -52,7 +47,10 @@ export const initCommentAdverts = (): ?boolean => {
             fastdom
                 .read(() => $commentMainColumn.dim().height)
                 .then((mainColHeight: number) => {
-                    if (mainColHeight >= 800) {
+                    if (
+                        mainColHeight >= 800 ||
+                        (isUserLoggedIn() && mainColHeight >= 300)
+                    ) {
                         insertCommentAd($commentMainColumn);
                     } else {
                         mediator.once(

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -5,6 +5,7 @@ import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import type bonzo from 'bonzo';
 

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -32,6 +32,11 @@ export const initCommentAdverts = (): ?boolean => {
             .then((adSlot: HTMLElement) => addSlot(adSlot, false));
     };
 
+    if (isUserLoggedIn() && mainColHeight >= 300) {
+        insertCommentAd($commentMainColumn);
+    }
+
+
     if (!commercialFeatures.commentAdverts || !$adSlotContainer.length) {
         return false;
     }


### PR DESCRIPTION
## What does this change?
When a user is signed in and the container is 300px high, then show an MPU

## What is the value of this and can you measure success?
Allows more ad impressions for when a user is signed in
### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
