### PR TITLE
Fix display of timezone notice

### DIFF
--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -394,9 +394,11 @@
 .football-knockout-chart__timezone {
     @include fs-textSans(1);
     padding: $gs-baseline 0;
-    float: left;
     text-align: center;
     width: 100%;
+    position: absolute;
+    bottom: 0;
+    z-index: $zindex-ui;
 }
 
 .football-rounds--second-half {


### PR DESCRIPTION
I'm not sure why this broke in the last four years. Someone with better CSS foo might be able to come up with a more elegant solution.

Before:
![screen shot 2018-06-12 at 12 07 25](https://user-images.githubusercontent.com/858402/41286981-31462e6e-6e39-11e8-985f-5f478eeb01f7.png)

After:
![screen shot 2018-06-12 at 11 51 54](https://user-images.githubusercontent.com/858402/41286738-6eb4568c-6e38-11e8-90ac-8f350e84800c.png)
