### PR TITLE
Fix banners in hosted content pages

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -40,10 +40,8 @@
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", content.exists(_.tags.hasSuperStickyBanner)),
-            ("has-absolute-container", page match {
-                case page: commercial.hosted.HostedPage => true
-                case _ => false
-            }),
+            ("is-immersive", content.exists(_.content.isImmersive)),
+            ("is-hosted-content", page.metadata.isHosted),
             ("is-immersive-interactive", content.exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -40,7 +40,7 @@
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", content.exists(_.tags.hasSuperStickyBanner)),
-            ("is-immersive-hosted", page match {
+            ("has-absolute-container", page match {
                 case page: commercial.hosted.HostedPage => true
                 case _ => false
             }),

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -40,11 +40,12 @@
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", content.exists(_.tags.hasSuperStickyBanner)),
-            ("is-immersive", content.exists(_.content.isImmersive)),
+            ("is-immersive-hosted", page match {
+                case page: commercial.hosted.HostedPage => true
+                case _ => false
+            }),
             ("is-immersive-interactive", content.exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">
-
-        @fragments.message()
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
@@ -89,6 +90,8 @@
         }
 
         @fragments.footer()
+
+        @fragments.message()
 
         @fragments.inlineJSNonBlocking()
 

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -31,7 +31,7 @@
         top: 0;
     }
     @supports (position: sticky) {
-        html:not(.is-scroll-blocked) body:not(.has-absolute-container) & {
+        html:not(.is-scroll-blocked) body:not(.is-hosted-content) & {
             position: sticky;
             bottom: -1px;
             /*chrome calculates sticky in dip

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -31,7 +31,7 @@
         top: 0;
     }
     @supports (position: sticky) {
-        html:not(.is-scroll-blocked) & {
+        html:not(.is-scroll-blocked) body:not(.has-absolute-container) & {
             position: sticky;
             bottom: -1px;
             /*chrome calculates sticky in dip


### PR DESCRIPTION
## What does this change?
#19767 introduced a bug in hosted content pages where the banners would go on top instead of on the bottom. This was due to the hosted gallery page not containing any elements using a normal page flow but rather a fixed container at 100% height. 

I've put in a body class that states that and lets the banner be fixed instead of sticky

## Screenshots
![screen shot 2018-06-12 at 1 11 01 pm](https://user-images.githubusercontent.com/11539094/41289969-4ea6b6a4-6e43-11e8-8268-eb76e430b70b.png)
![screen shot 2018-06-12 at 1 10 42 pm](https://user-images.githubusercontent.com/11539094/41289974-509a761c-6e43-11e8-9068-19ae579f9732.png)

## What is the value of this and can you measure success?
Top aligned banners look off

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] Yes (please give details)

### Accessibility test checklist

n/a
### Tested
- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
