### PR TITLE
Fix spider img positioning

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -7,7 +7,7 @@
     <div class="football-match__container">
         <div class="football-match__team football-match__team--home @if(fm.homeTeam.isGhostTeam){football-match__team--ghost}">
             @if(!fm.homeTeam.isGhostTeam){
-                <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.homeTeam.id}.png" />
+                <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.homeTeam.id}.png" />
             }
             @fm.homeTeam.knockoutName
             @if(fm.hasStarted){
@@ -34,7 +34,7 @@
         </div>
         <div class="football-match__team football-match__team--away @if(fm.awayTeam.isGhostTeam){football-match__team--ghost}">
             @if(!fm.awayTeam.isGhostTeam){
-                <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.awayTeam.id}.png" />
+                <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.awayTeam.id}.png" />
             }
             @fm.awayTeam.knockoutName
             @if(fm.hasStarted){

--- a/static/src/stylesheets/module/football/_matches.scss
+++ b/static/src/stylesheets/module/football/_matches.scss
@@ -78,6 +78,12 @@
     .team-crest {
         float: left;
     }
+
+    .knockout--crest {
+        float: none;
+        vertical-align: middle;
+    }
+
 }
 
 .football-match__team--away {
@@ -91,6 +97,11 @@
 
     .team-crest {
         float: right;
+    }
+
+    .knockout--crest {
+        float: none;
+        vertical-align: middle;
     }
 }
 

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -384,6 +384,7 @@
         display: block;
     }
 }
+
 .football-knockout-chart--4-rounds,
 .football-knockout-chart--5-rounds {
     .football-round {


### PR DESCRIPTION
I have tested out the world cup spider diagram by running it with the data from the previous world cup in Brazil. The images are a bit out of whack for away teams and have bad vertical alignment for all teams. Both are fixed here.

Before:
![screen shot 2018-06-12 at 15 23 00](https://user-images.githubusercontent.com/858402/41297174-78fc9b90-6e56-11e8-9ccf-242701e3c96e.png)
![screen shot 2018-06-12 at 15 21 49](https://user-images.githubusercontent.com/858402/41297235-a046439a-6e56-11e8-8ede-0d985d96c5a0.png)


After:
![screen shot 2018-06-12 at 15 28 38](https://user-images.githubusercontent.com/858402/41297180-7fe16cec-6e56-11e8-825d-a013fc15819b.png)
![screen shot 2018-06-12 at 15 28 28](https://user-images.githubusercontent.com/858402/41297244-a4dda16e-6e56-11e8-991c-d2de5cf166eb.png)


