### PR TITLE
Allow tag combiner webTitles to be overridden (controversial?)

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -517,11 +517,11 @@ case class TagCombiner(
   pagination: Option[Pagination] = None
 ) extends StandalonePage {
 
-  val webTitleOverrides: Map[String, String] = Map(
+  private val webTitleOverrides: Map[String, String] = Map(
     "football/football+tone/minutebyminute" -> "Live football scores"
   )
 
-  val webTitle: String = webTitleOverrides.getOrElse(id, s"${leftTag.name} + ${rightTag.name}")
+  private val webTitle: String = webTitleOverrides.getOrElse(id, s"${leftTag.name} + ${rightTag.name}")
 
   override val metadata: MetaData = MetaData.make(
     id = id,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -517,10 +517,16 @@ case class TagCombiner(
   pagination: Option[Pagination] = None
 ) extends StandalonePage {
 
+  val webTitleOverrides: Map[String, String] = Map(
+    "football/football+tone/minutebyminute" -> "Live football scores"
+  )
+
+  val webTitle: String = webTitleOverrides.getOrElse(id, s"${leftTag.name} + ${rightTag.name}")
+
   override val metadata: MetaData = MetaData.make(
     id = id,
     section = leftTag.metadata.section,
-    webTitle = s"${leftTag.name} + ${rightTag.name}",
+    webTitle = webTitle,
     pagination = pagination,
     description = Some(DotcomContentType.TagIndex.toString),
     commercial = Some(


### PR DESCRIPTION
## What does this change?
This adds a hard coded map of 'overrides' for tag combiners. This follows a request from Peter Martin to rename "football/football+tone/minutebyminute" to "Live football scores"

It's a bit controversial as it adds random rename logic to our code base. However, I think this is maybe ok as it will be very clear to anyone coming to this code in future what's going on, and easy for them to remove the logic if they so choose.

## Screenshots
![screen shot 2018-06-13 at 10 25 28](https://user-images.githubusercontent.com/3606555/41342440-29c0736e-6ef4-11e8-9368-fb5228c8caee.png)

## What is the value of this and can you measure success?
SEO improvement

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
