### PR TITLE
Fix aria roles in mobile sidebar

### DIFF
--- a/common/app/views/fragments/nav/headerMenu.scala.html
+++ b/common/app/views/fragments/nav/headerMenu.scala.html
@@ -110,10 +110,11 @@
                 @UrlHelpers.readerRevenueLinks.map { item =>
                     <li class="menu-item hide-from-desktop"
                         data-edition="@{edition.id.toLowerCase}"
-                        role="menuitem">
+                        role="none">
 
                         <a class="menu-item__title @item.classList.mkString(" ")"
                            href="@item.url"
+                           role="menuitem"
                            data-link-name="nav2 : @item.title">
                             @item.title
                         </a>
@@ -133,9 +134,10 @@
 
                 @navMenu.brandExtensions.map { item =>
                     <li class="menu-item hide-from-desktop"
-                        role="menuitem">
+                        role="none">
                         <a class="menu-item__title"
                            href="@LinkTo { @item.url }"
+                           role="menuitem"
                            data-link-name="nav2 : @item.title">
                             @item.title
                         </a>

--- a/common/app/views/fragments/nav/headerMenu.scala.html
+++ b/common/app/views/fragments/nav/headerMenu.scala.html
@@ -8,11 +8,12 @@
 @sectionList(pillar: NavLink, edition: Edition) = {
     <li class="menu-item js-navigation-item"
         data-section-name="@pillar.title"
-        role="menuitem">
+        role="none">
 
         <button class="menu-item__title menu-item__title--@pillar.title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : secondary : @pillar.title"
                 aria-haspopup="true"
+                role="menuitem"
                 aria-expanded="true">
 
             <i class="menu-item__toggle"></i>
@@ -27,8 +28,9 @@
                 <li class="@RenderClasses(Map(
                             "menu-item--home hide-from-desktop" -> (sectionItem.iconName == "home")
                         ), "menu-item")"
-                    role="menuitem">
+                    role="none">
                     <a class="menu-item__title"
+                       role="menuitem"
                        href="@LinkTo { @sectionItem.url }"
                        data-link-name="nav2 : secondary : @{ if(sectionItem.longTitle.isEmpty) sectionItem.title else sectionItem.longTitle }">
                             @if(sectionItem.iconName.nonEmpty) {
@@ -145,9 +147,10 @@
                             "hide-from-desktop" -> (item.title == "The Guardian app"),
                             "menu-item--no-border" -> (item.title == "Video")
                         ), "menu-item")"
-                        role="menuitem">
+                        role="none">
 
                         <a class="menu-item__title"
+                            role="menuitem"
                             href="@LinkTo { @item.url }"
                             data-link-name="nav2 : @item.title">
                             @item.title
@@ -156,9 +159,10 @@
                 }
 
                 <li class="menu-item hide-from-desktop"
-                    role="menuitem">
+                    role="none">
                     <a class="menu-item__title"
                        href="https://www.facebook.com/theguardian"
+                       role="menuitem"
                        data-link-name="nav2 : facebook">
                         @fragments.inlineSvg("share-facebook", "icon", List("menu-item__icon"), isPresentation = true)
                         Facebook
@@ -166,9 +170,10 @@
                 </li>
 
                 <li class="menu-item hide-from-desktop"
-                    role="menuitem">
+                    role="none">
                     <a class="menu-item__title"
                        href="https://twitter.com/guardian"
+                       role="menuitem"
                        data-link-name="nav2 : twitter">
                         @fragments.inlineSvg("share-twitter", "icon", List("menu-item__icon"), isPresentation = true)
                         Twitter


### PR DESCRIPTION
## What does this change?
The links in the mobile nav were being read as 'menu item' in iOS voiceover as opposed to their actual contents. I've updated them to match the [W3C guidance on lists](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html)

## What is the value of this and can you measure success?
A11y!

### Does this affect other platforms?
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

I haven't actually checked voiceover on AMP pages but it's using a different menu altogether. crossing fingers it works.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)