### PR TITLE
Guardiantoday small changes

### DIFF
--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -15,8 +15,7 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    <a href="%%unsub_center_url%%">Unsubscribe</a> |
-                                    <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
+                                    <a href="%%unsub_center_url%%">Unsubscribe</a>
                                 </td>
                             </tr>
                             <tr>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -37,9 +37,8 @@
             @RemoveOuterParaHtml(card.header.headline)
         </a>
     }
-    @if(card.header.quoted) {
-        @card.bylineText.map { byline => @row(Seq("byline")){@byline} }
-    }
+
+    @card.bylineText.map { byline => @row(Seq("byline")){@byline} }
 
     @card.starRating.map { numberOfStars =>
         @row(Seq("review-stars")) {

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -82,7 +82,7 @@ $container-color: #ffffff;
     font-family: 'Guardian Egyptian Web Header', 'Guardian Egyptian Web Headline', Georgia, serif;
     font-size: 26px;
     color: #121212;
-    padding: 4px 0 0;
+    padding: 4px 12px 0;
 }
 
 // a


### PR DESCRIPTION
## What does this change?

completes the remaining email front changes requested in https://docs.google.com/document/d/1DEj2_fYrYw7lu_Ff-sxNswcfWyhMjuF9tdeszv3DDD8/edit#

- show byline regardless of quoted meta
- add padding to email container titles
- remove trouble viewing link (it doesn't work as intended and editorial is happy to remove it)

## What's the value of this?

Improve the Guardian today email experience

### Tested

- Locally
