### PR TITLE
Fix styling for world cup table snaps

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -136,9 +136,13 @@ class LeagueTableController(
         "football",
         s"${table.competition.fullName} table"
       )
+
+      // For world cup group snaps we are not going to link as we just want to show the full table
+      val isWorldCup = table.competition.id == "700"
+
       val groupTable = Table(table.competition, Seq(group), hasGroups = true)
       val htmlResponse = () => football.views.html.tablesList.tablesPage(TablesPage(page, Seq(groupTable), table.competition.url, filters, Some(table.competition)))
-      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, multiGroup = false)
+      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, multiGroup = false, linkToCompetition = !isWorldCup)
       renderFormat(htmlResponse, jsonResponse, page)
     }
     response.getOrElse {

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -67,6 +67,9 @@
 
         @heading.map{ h=>
             <caption class="table__caption table__caption--top">
+                @group.round.name.map{ groupName =>
+                    <div class="football-matches__group-name">@groupName</div>
+                }
                 <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
             </caption>
         }

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -1,6 +1,12 @@
 @import model.{Competition, Group}
 
-@(competition: Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(
+  competition: Competition,
+  group: Group,
+  highlightTeamId: Option[String] = None,
+  multiGroup: Boolean = false,
+  linkToCompetition: Boolean = true
+)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @if(!multiGroup) {
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">
@@ -10,7 +16,7 @@
     @tableView(competition, group,
         highlightTeamId = highlightTeamId,
         heading = Some(competition.fullName),
-        linkToCompetition = true
+        linkToCompetition = linkToCompetition
     )
 </div>
 }else{

--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -9,7 +9,8 @@
     // Generic
     &.facia-snap-embed {
         height: $slice-innerHeight;
-        margin: 0 $gs-gutter/2;
+        margin: 0;
+        padding: 0 $gs-gutter/2;
         position: relative;
         background: #ffffff;
     }
@@ -59,10 +60,9 @@
         z-index: 2;
         position: absolute;
         margin: 0;
-        padding: 10px 0;
+        padding: 0;
 
         .full-table-link {
-            margin-left: $gs-gutter/2;
             display: inline-block;
         }
 
@@ -256,4 +256,9 @@ $footballBadgeSizeDesktop: 120px;
     background: $neutral-8;
     width: 100%;
     padding: $gs-baseline/1.5;
+}
+
+.football-matches__group-name {
+    float: right;
+    padding: .5em;
 }

--- a/static/src/stylesheets/module/football/_tables.scss
+++ b/static/src/stylesheets/module/football/_tables.scss
@@ -127,6 +127,7 @@
 
 .c-football-table {
     @include table-football--medium;
+    width: 100%;
 }
 
 .football__group {
@@ -142,4 +143,10 @@
         top: 2px;
         float: right;
     }
+}
+
+.table__caption--bottom {
+    padding: 0;
+    margin: 0;
+    line-height: 1;
 }


### PR DESCRIPTION
Fixes styling of football snaps to use for world cup.

Before:
![screen shot 2018-06-13 at 13 30 43](https://user-images.githubusercontent.com/858402/41357162-726962b4-6f1d-11e8-93dc-c0e848b00f71.png)

After:
![screen shot 2018-06-13 at 14 59 24](https://user-images.githubusercontent.com/858402/41357144-64708c46-6f1d-11e8-8a62-adc7f3b45295.png)
