### PR TITLE
Worldcup overview

### DIFF
--- a/sport/app/football/views/wallchart/wallchart.scala.html
+++ b/sport/app/football/views/wallchart/wallchart.scala.html
@@ -12,7 +12,7 @@
             <div class="facia-header__inner gs-container">
                 <div class="facia-header__column">
                     @fragments.inlineSvg("world_cup_badge", "badges", List("world__cup-svg", "world__cup-badge"))
-                    <h1 class="container__title"><span class="container__title__label">World Cup 2018</span></h1>
+                    <h1 class="container__title"><span class="container__title__label">World cup 2018 <span class="container__title__label-secondary">Groups, scores and fixtures</span></span></h1>
                 </div>
 
                 @next.map { nextMatch =>

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -204,7 +204,6 @@
         }
 
         @include mq($from: wide) {
-            margin-left: 70px;
             margin-left: 48px;
         }
     }

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -18,7 +18,7 @@
         flex-direction: column;
 
         @include mq($from: desktop) {
-            height: gs-span(1);
+            height: gs-span(1.2);
             flex-direction: row;
         }
     }
@@ -91,15 +91,42 @@
     }
 
     .container__title__label {
-        max-width: 150px;
+        max-width: 320px;
+        width: 300px;
         display: inline-block;
-        font-size: 30px;
-        line-height: 26px;
+        font-size: 20px;
+        line-height: 22px;
 
         @include mq($from: desktop) {
-            max-width: 110px;
+            max-width: 160px;
+            width: 160px;
             font-size: 20px;
             line-height: 22px;
+        }
+
+        @include mq($from: leftCol) {
+            max-width: 120px;
+            width: 120px;
+        }
+
+        @include mq($from: wide) {
+            max-width: 160px;
+            width: 160px;
+        }
+
+        .container__title__label-secondary {
+            display: block;
+            font-style: italic;
+            font-weight: 400;
+            width: 100%;
+
+            @include mq($from: leftCol) {
+                display: none;
+            }
+
+            @include mq($from: wide) {
+                display: block;
+            }
         }
     }
 
@@ -107,6 +134,7 @@
         margin-right: $gs-gutter / 2;
         margin-left: $gs-gutter / 2;
         float: left;
+        width: 30px;
 
         @include mq($from: desktop) {
             margin-left: $gs-gutter;
@@ -163,20 +191,21 @@
         height: 112px;
         overflow: hidden;
         display: inline-block;
-        margin-top: -52px;
+        margin-top: -36px;
     }
 
     .wc-player-image__offset {
         display: none;
 
         @include mq($from: leftCol) {
-            margin-left: 68px;
-            margin-right: -60px;
+            margin-left: 30px;
+            margin-right: -20px;
             display: inline-block;
         }
 
         @include mq($from: wide) {
-            margin-left: 124px;
+            margin-left: 70px;
+            margin-left: 48px;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
As per editorial request, the header title has been updated to say "World cup 2018
Groups, scores and fixtures". Accordingly, some of the spacing has had to be tweaked. 

![picture 151](https://user-images.githubusercontent.com/11950919/41408088-6eea0fa6-6fc9-11e8-98f2-6aa8dcbd6797.png)
