### PR TITLE
Badged articles: fix a big gap in liveblogs

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -27,7 +27,7 @@
     .content__header {
         @include mq($from: leftCol) {
             // Prevents badged labels area overlapping meta
-            min-height: gs-height(5);
+            min-height: gs-height(3.5);
         }
     }
 


### PR DESCRIPTION
## What does this change?

This PR reduces a blank gap in the header of sports liveblogs, immediately below the headline.

## Screenshots

**Before**
<img width=727 src=https://user-images.githubusercontent.com/4561/41408153-a174e176-6fc9-11e8-85fc-1debc129ad8f.png>


**After**
<img width=727 src=https://user-images.githubusercontent.com/4561/41408155-a3c49822-6fc9-11e8-81dc-8ea5d6475b2b.png>

### Tested

I have tested this on comment articles, to check that it doesn't break #19849, but will check with Zef again before merging