### PR TITLE
Crosswords: Don't assume a clue is in focus

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/clues.js
@@ -72,7 +72,8 @@ class Clues extends Component<*, *> {
                 min: 'tablet',
                 max: 'leftCol',
             }) &&
-            (!prev.focussed || prev.focussed.id !== this.props.focussed.id)
+            (this.props.focussed &&
+                (!prev.focussed || prev.focussed.id !== this.props.focussed.id))
         ) {
             fastdom.read(() => {
                 this.scrollIntoView(this.props.focussed);


### PR DESCRIPTION
## What does this change?

We are making an assumption, when the `Clues` component updates, that a clue is in focus. This is not always the case, which is generating a lot of errors in Sentry.

This change adds a guard to fix this case.

## What is the value of this and can you measure success?

Fewer Sentry errors

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
