### PR TITLE
Fix bug where trying to turn link into Youtube player

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -265,7 +265,7 @@ const checkElemForVideo = (elem: ?HTMLElement): void => {
     if (!elem) return;
 
     fastdom.read(() => {
-        $('.youtube-media-atom', elem).each((el, index) => {
+        $('.youtube-media-atom:not(.no-player)', elem).each((el, index) => {
             const playerDiv = el.querySelector('div');
 
             if (!playerDiv) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
@@ -26,4 +26,18 @@ describe('youtube', () => {
             );
         }
     });
+
+    it('does not try to replace link to a video page with a player', () => {
+        const atomId = 'atomA';
+        const div = `<div data-media-atom-id="${atomId}" class="no-player u-responsive-ratio youtube-media-atom"><div class="vjs-big-play-button youtube-media-atom__overlay"><div class="youtube-media-atom__play-button vjs-control-text">Play Video</div></div></div>`;
+        if (document.body) {
+            document.body.innerHTML = div;
+        }
+
+        checkElemsForVideos();
+
+        if (document.body) {
+            expect(document.body.innerHTML).toBe(div);
+        }
+    });
 });


### PR DESCRIPTION
This fixes a bug introduced by #19851 where code was trying to turn links into video players as well as placeholder divs.
This was leading to a bug in console on fronts:
```
www-widgetapi.js:101 Uncaught (in promise) Error: YouTube player element ID required.
at new Y (www-widgetapi.js:101)
at youtube-player.js:91
at youtube-player.js:136
```

But it wasn't stopping any videos from playing.  So only ill-effect was message in console.
