### PR TITLE
Enable nielsen analytics for all amp articles

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -1,6 +1,5 @@
 @import common.commercial.hosted.HostedArticlePage
 @import play.api.Mode
-@import model.Nielsen
 @(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.hosted.HostedAmp.ampify
 @import views.html.hosted._
@@ -32,7 +31,6 @@
             <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
         </amp-analytics>
 
-        @if(Nielsen.isTestingPath(request.path)) {
         <amp-analytics type="nielsen">
             <script type="application/json">
                 {
@@ -46,7 +44,6 @@
                 }
             </script>
         </amp-analytics>
-        }
 
         <div class="main-body">
             <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">

--- a/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
@@ -4,7 +4,6 @@
 @import com.gu.contentapi.client.model.v1.Asset
 @import com.gu.contentapi.client.model.v1.AssetType
 @import play.api.Mode
-@import model.Nielsen
 @(page: HostedGalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
 @import conf.Configuration
@@ -44,7 +43,6 @@
             <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
         </amp-analytics>
 
-        @if(Nielsen.isTestingPath(request.path)) {
         <amp-analytics type="nielsen">
             <script type="application/json">
                 {
@@ -58,7 +56,7 @@
                 }
             </script>
         </amp-analytics>
-        }
+
         <div class="main-body hosted-gallery-page__main-body">
 
             @guardianHostedHeader(if(page.fontColour.isDark) "hosted-gallery-page hosted-page--bright" else "hosted-gallery-page", page, isAMP = true)

--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -4,7 +4,6 @@
 @import conf.Configuration.environment
 @import conf.Configuration.site.host
 @import play.api.Mode
-@import model.Nielsen
 @(page: HostedVideoPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!doctype html>
@@ -36,7 +35,6 @@
         <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
     </amp-analytics>
 
-    @if(Nielsen.isTestingPath(request.path)) {
     <amp-analytics type="nielsen">
         <script type="application/json">
             {
@@ -50,7 +48,6 @@
             }
         </script>
     </amp-analytics>
-    }
 
     <div class="main-body">
       @guardianHostedHeader(if(page.fontColour.isDark) "hosted-video-page hosted-page--bright" else "hosted-video-page", page, isAMP = true)

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -65,7 +65,6 @@ object SectionId {
 }
 
 object Nielsen {
-
   private sealed trait Apid
   private case object Guardian extends Apid
   private case object Books extends Apid

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -66,13 +66,6 @@ object SectionId {
 
 object Nielsen {
 
-  private val testingPaths = Set(
-    "2017/dec/15/good-night-stories-for-rebel-girls-jk-rowling",
-    "2015/may/26/fc-united-manchester-benfica-united-fans",
-    "2016/apr/29/revitalised-and-calmed-by-an-english-wood-in-spring"
-  )
-  def isTestingPath(path: String): Boolean = testingPaths.exists(path.contains(_))
-
   private sealed trait Apid
   private case object Guardian extends Apid
   private case object Books extends Apid

--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -1,7 +1,6 @@
 @import play.api.Mode
 @import model.Tag
 @import play.api.libs.json.Json
-@import model.Nielsen
 @(content: model.Content, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.Configuration
@@ -35,7 +34,6 @@ are used to generate the confidence graphs on the frontend dashboard.
 </amp-analytics>
 
 
-@if(Nielsen.isTestingPath(request.path)) {
 <amp-analytics type="nielsen">
     <script type="application/json">
         {
@@ -49,4 +47,3 @@ are used to generate the confidence graphs on the frontend dashboard.
         }
     </script>
 </amp-analytics>
-}


### PR DESCRIPTION
## What does this change?

Enable nielsen analytics for all amp articles
see:
https://trello.com/c/FagOKxZ0/136-add-neilsen-analytics-to-amp-for-australia

`Due to monthly reporting in DCR being released at the end of this month, we will only start including the AMP audience from the first day of the following month after the implementation is live - 1st July in this case.`

## What is the value of this and can you measure success?

 nielsen analytics for all amp articles

### Tested

- [x] Locally

