### PR TITLE
Remove innacurate final payment copy

### DIFF
--- a/identity/app/views/profile/membershipForm/cancelled.scala.html
+++ b/identity/app/views/profile/membershipForm/cancelled.scala.html
@@ -6,10 +6,6 @@
         membership section won't be available in your profile.
     </p>
     <p>
-        <span class="js-mem-current-period-start-container is-hidden">
-            Your final subscription payment was taken on
-            <strong><span class="js-mem-current-period-start"></span></strong>.
-        </span>
         Please note, you won't be able to amend your package again until this change has been processed.
     </p>
 </div>


### PR DESCRIPTION
## What does this change?
The copy for the post cancellation page shows an innacurate final payment date, so is being removed.
## Screenshots
![image](https://user-images.githubusercontent.com/2670496/41474602-4f6769e4-70b4-11e8-8a92-a0c231ff01eb.png)

## What is the value of this and can you measure success?
Bugfix.
## Checklist

### Does this affect other platforms?

Supporter Experience/profile only.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.
 
### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- ❌ [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
	- This is not keyboard navigable, so probably isn't going to be much good in a screen reader.
-  ❌ [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/) 
	- Profile tabs are not keyboard navigable.
-  ❌ [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
	- The black on yellow passes, but the greys in the footer are pushing it at 1:4.6.

None of these are a result of this change.

### Tested


- [X] On CODE 
<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
