### PR TITLE
Parameterise table component heading

### DIFF
--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -89,7 +89,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
           maybeCompetitionAndGroup map { case CompetitionAndGroup(competition, group) =>
             HtmlAndClasses(
               3,
-              tablesComponent(competition, group, highlightTeamId = Some(teamId), false),
+              tablesComponent(competition, group, competition.fullName, highlightTeamId = Some(teamId), false),
               cssClasses
             )
           }

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -110,7 +110,7 @@ class LeagueTableController(
 
       val smallTableGroup = table.copy(groups = table.groups.map { group => group.copy(entries = group.entries.take(10)) }).groups(0)
       val htmlResponse = () => football.views.html.tablesList.tablesPage(TablesPage(page, Seq(table), table.competition.url, filters, Some(table.competition)))
-      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, smallTableGroup, multiGroup = table.multiGroup)
+      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, smallTableGroup, table.competition.fullName, multiGroup = table.multiGroup)
 
       renderFormat(htmlResponse, jsonResponse, page)
 
@@ -140,9 +140,13 @@ class LeagueTableController(
       // For world cup group snaps we are not going to link as we just want to show the full table
       val isWorldCup = table.competition.id == "700"
 
+      val heading = group.round.name
+        .map(name => s"${table.competition.fullName} - $name")
+        .getOrElse(table.competition.fullName)
+
       val groupTable = Table(table.competition, Seq(group), hasGroups = true)
       val htmlResponse = () => football.views.html.tablesList.tablesPage(TablesPage(page, Seq(groupTable), table.competition.url, filters, Some(table.competition)))
-      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, multiGroup = false, linkToCompetition = !isWorldCup)
+      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, heading, multiGroup = false, linkToCompetition = !isWorldCup)
       renderFormat(htmlResponse, jsonResponse, page)
     }
     response.getOrElse {

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -67,9 +67,6 @@
 
         @heading.map{ h=>
             <caption class="table__caption table__caption--top">
-                @group.round.name.map{ groupName =>
-                    <div class="football-matches__group-name">@groupName</div>
-                }
                 <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
             </caption>
         }

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -3,6 +3,7 @@
 @(
   competition: Competition,
   group: Group,
+  heading: String,
   highlightTeamId: Option[String] = None,
   multiGroup: Boolean = false,
   linkToCompetition: Boolean = true
@@ -13,9 +14,11 @@
 
     @football.views.html.fragments.componentStyles()
 
-    @tableView(competition, group,
+    @tableView(
+        competition,
+        group,
         highlightTeamId = highlightTeamId,
-        heading = Some(competition.fullName),
+        heading = Some(heading),
         linkToCompetition = linkToCompetition
     )
 </div>

--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -257,8 +257,3 @@ $footballBadgeSizeDesktop: 120px;
     width: 100%;
     padding: $gs-baseline/1.5;
 }
-
-.football-matches__group-name {
-    float: right;
-    padding: .5em;
-}


### PR DESCRIPTION
At the moment there is a bug on football tables where for some versions the heading duplicates:

![screen shot 2018-06-18 at 11 46 58](https://user-images.githubusercontent.com/858402/41532063-66beaeb4-72ed-11e8-9ce3-74af9b24cab8.png)

https://www.theguardian.com/football/world-cup-2018/overview

This was caused by a separate change (https://github.com/guardian/frontend/pull/19848) which added group names to snap headings but in a somewhat hackier way.

For this PR I've fixed both by simply making the component heading customisable and passing different values depending on context.