### PR TITLE
Discussion on audio pages

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -131,6 +131,21 @@ const bootEnhanced = (): void => {
                 );
             }
 
+            if (
+                config.get('page.contentType') === 'Audio'
+            ) {
+                require.ensure(
+                    [],
+                    require => {
+                        bootstrapContext(
+                            'media : trail',
+                            require('bootstraps/enhanced/trail').initTrails
+                        );
+                    },
+                    'trail'
+                );
+            }
+
             if (config.get('page.contentType') === 'Crossword') {
                 require.ensure(
                     [],

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -131,9 +131,7 @@ const bootEnhanced = (): void => {
                 );
             }
 
-            if (
-                config.get('page.contentType') === 'Audio'
-            ) {
+            if (config.get('page.contentType') === 'Audio') {
                 require.ensure(
                     [],
                     require => {


### PR DESCRIPTION
## What does this change?

Bugfix for comments and most viewed not displaying on Audio pages
See https://trello.com/c/GCL55Qxq/263-comments-not-working-on-football-weekly

trail.js, containing most viewed and comments JavaScript is not required by audio pages. This PR adds the dependency.

Awaiting on product decision before release

## What is the value of this and can you measure success?

Users can view comments and most viewed on audio pages

### Tested

- [ ] On CODE (optional)

