### PR TITLE
allow accented characters for crosswords

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -371,9 +371,14 @@ class Crossword extends Component<*, CrosswordState> {
     returnPosition: ?number;
 
     insertCharacter(character: string): void {
+        const characterUppercase = character.toUpperCase();
         const cell = this.state.cellInFocus;
-        if (/[A-Z]/.test(character) && character.length === 1 && cell) {
-            this.setCellValue(cell.x, cell.y, character);
+        if (
+            /[A-Za-zÀ-ÿ]/.test(characterUppercase) &&
+            characterUppercase.length === 1 &&
+            cell
+        ) {
+            this.setCellValue(cell.x, cell.y, characterUppercase);
             this.save();
             this.focusNext();
         }

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -51,7 +51,7 @@ class HiddenInput extends Component<*, *> {
     }
 
     handleChange(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.insertCharacter(event.target.value.toUpperCase());
+        this.props.crossword.insertCharacter(event.target.value);
         this.setState({
             value: '',
         });


### PR DESCRIPTION
## What does this change?

Bugfix for:
- Users cannot input accented characters into crosswords

https://trello.com/c/nMgEnPo8/265-diacritics-not-accepted-in-crosswords-solutions

The pr implements this solution
https://stackoverflow.com/a/26900132

### How is this useful?

Crosswords are completable

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
