### PR TITLE
Reinstate video carousel images on mobile 

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -78,7 +78,7 @@
     }
 }
 
-.youtube-media-atom__iframe:not(.youtube__video-ready) ~ .youtube-media-atom__overlay,
+.youtube-media-atom:not(.no-player) .youtube-media-atom__iframe:not(.youtube__video-ready) ~ .youtube-media-atom__overlay,
 .youtube-media-atom__iframe.youtube__video-ended ~ .youtube-media-atom__overlay {
     @include hide;
 }


### PR DESCRIPTION
## What does this change?

Video carousel images are currently hidden on mobile due to a style rule being applied to [`.youtube-media-atom__overlay`](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/atoms/_youtube.scss#L81-L84) (the element that takes a background image of a still from the video).

A change was introduced in #19851 that moved the `youtube-media-atom__iframe` class to a container `<div>`. 

- Previously this class was applied directly to the video's `<iframe>`, and thus would only appear at wider viewports. 
- Now this class is applied to a `<div>` that is replaced by an `<iframe>` on wider viewports, but is not replaced on narrower viewports.

This change updates the selector that hides the image until the video is ready, making it apply only when a YouTube player exists. Since a YouTube player does not exist on narrower viewports, the image will not be hidden. 😰 

This issue is hard to replicate locally due to a race condition between the YouTube bootstrap and Facia's bootstrap that upgrades players in the video carousel.

## Screenshots

![screen shot 2018-06-18 at 12 08 02](https://user-images.githubusercontent.com/5931528/41550412-91edc0ce-7320-11e8-8a5d-688d8a519d85.png)

## What is the value of this and can you measure success?

Repairs the video carousel experience on mobile

