### PR TITLE
Query media content types instead of isMedia property

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -179,7 +179,8 @@ const bootEnhanced = (): void => {
             }
 
             if (
-                config.get('isMedia') ||
+                config.get('page.contentType') === 'Audio' ||
+                config.get('page.contentType') === 'Video' ||
                 config.get('page.contentType') === 'Interactive'
             ) {
                 require.ensure(

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -28,7 +28,8 @@ const initMoreInSection = (): void => {
     } = config.get('page', {});
 
     if (
-        !config.get('isMedia') ||
+        (config.get('page.contentType') !== 'Audio' &&
+            config.get('page.contentType') !== 'Video') ||
         !showRelatedContent ||
         isPaidContent ||
         !section
@@ -95,7 +96,10 @@ const initRelated = () => {
 };
 
 const initOnwardVideoContainer = (): void => {
-    if (!config.get('isMedia')) {
+    if (
+        config.get('page.contentType') !== 'Audio' &&
+        config.get('page.contentType') !== 'Video'
+    ) {
         return;
     }
 

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -74,8 +74,6 @@ const dateFromSlug = (): ?string => {
     return s ? s[0] : null;
 };
 
-const isMedia: boolean = ['Video', 'Audio'].includes(config.page.contentType);
-
 export default Object.assign(
     {},
     {
@@ -87,7 +85,6 @@ export default Object.assign(
         referenceOfType,
         webPublicationDateAsUrlPart,
         dateFromSlug,
-        isMedia,
     },
     config
 );


### PR DESCRIPTION
This is to fix related content container not appearing on media pages.