### PR TITLE
Remove paid-for content from async-loaded Facia cards for ad-free users

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -79,7 +79,9 @@ const dedupShowMore = ($container: bonzo, html: string): bonzo => {
         const articleClass = $article.attr('class');
         if (
             $article.attr(ARTICLE_ID_ATTRIBUTE) in seenArticles ||
-            (isAdFreeUser() && articleClass && articleClass.contains('paid-content'))
+            (isAdFreeUser() &&
+                articleClass &&
+                articleClass.contains('paid-content'))
         ) {
             $article.remove();
         }

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -10,6 +10,7 @@ import reportError from 'lib/report-error';
 import timeout from 'lib/timeout';
 import userPrefs from 'common/modules/user-prefs';
 import groupBy from 'lodash/collections/groupBy';
+import { isAdFreeUser } from 'common/modules/commercial/user-features';
 
 const HIDDEN_CLASS_NAME = 'fc-show-more--hidden';
 const VISIBLE_CLASS_NAME = 'fc-show-more--visible';
@@ -75,7 +76,11 @@ const dedupShowMore = ($container: bonzo, html: string): bonzo => {
 
     $(ITEM_SELECTOR, $html).each(article => {
         const $article = bonzo(article);
-        if ($article.attr(ARTICLE_ID_ATTRIBUTE) in seenArticles) {
+        const articleClass = $article.attr('class');
+        if (
+            $article.attr(ARTICLE_ID_ATTRIBUTE) in seenArticles ||
+            (isAdFreeUser() && articleClass && articleClass.contains('paid-content'))
+        ) {
             $article.remove();
         }
     });


### PR DESCRIPTION
## What does this change?
Facia removes paid-for cards on the server side during the initial page request, but subsequent top-up requests for content (e.g. when a **More _SectionName_** button is pressed) aren't currently identifiable as ad-free. We'll remove those items client-side until we can make the top-up requests respond to the ad-free state on the server side.

## Screenshots
**Before** (note the Ebay content)
![paidcontentinshowmore facia before](https://user-images.githubusercontent.com/690395/41728952-f7dafed2-756f-11e8-8a68-dfb66677d796.gif)

**After**
![paidcontentinshowmore facia after](https://user-images.githubusercontent.com/690395/41728984-08da5e26-7570-11e8-9aab-cfd36cd37d55.gif)

## What is the value of this and can you measure success?
We should not show paid-for content to ad-free users on fronts. Note that it's ok to serve the actual articles to ad-free users if they request them (e.g. from search)

Also, this will only be required until we move the filtering of this content server-side. Whitespace is left behind currently and while that's not ideal, it's still better than serving paid-for content.

One other thing to note: not many people use the Show more buttons on fronts anyway.

### Does this affect other platforms?
No, web only.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
Yes. It removes paid content _cards_ from _fronts_ for ad-free users.

### Tested
- [x] Locally
- [x] On CODE

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
