### PR TITLE
Programmatic Render Tier Chooser

### DIFF
--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -10,15 +10,15 @@ case object LocalRender extends RenderType
 
 object RenderingTierPicker {
 
-  private def isUnSupportedType(page: PageWithStoryPackage): Boolean = {
+  private def isSupportedType(page: PageWithStoryPackage): Boolean = {
     page match {
-      case a:ArticlePage => false
-      case _ => true
+      case a:ArticlePage => true
+      case _ => false
     }
   }
 
-  private def hasUnsupportedElements(page: PageWithStoryPackage): Boolean = {
-    page.article.blocks.get.body.exists((block: BodyBlock) => {
+  private def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
+    ! page.article.blocks.get.body.exists((block: BodyBlock) => {
 
       val hasUnsupportedElements: Boolean = block.elements.flatMap {
         case b: TextBlockElement => None
@@ -31,16 +31,16 @@ object RenderingTierPicker {
     })
   }
 
-  private def canHaveAds(page: PageWithStoryPackage): Boolean = {
-    ! page.metadata.sensitive
+  private def isAdFree(page: PageWithStoryPackage): Boolean = {
+    page.metadata.sensitive
   }
 
   def getRenderTierFor(page: PageWithStoryPackage): RenderType = {
 
-    if(hasUnsupportedElements(page) || canHaveAds(page) || isUnSupportedType(page)){
-      LocalRender
-    } else {
+    if(hasOnlySupportedElements(page) && isAdFree(page) && isSupportedType(page)){
       RemoteRender
+    } else {
+      LocalRender
     }
 
   }

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -50,11 +50,11 @@ object RenderingTierPicker {
 
     // todo: clean up
 
-    val canRemotelyRender = hasBlocks(page) &&
+    val canRemotelyRender = isSupportedType(page) &&
+      hasBlocks(page) &&
       hasOnlySupportedElements(page) &&
       discussionDisabled(page) &&
-      isAdFree(page) &&
-      isSupportedType(page)
+      isAdFree(page)
 
     if(canRemotelyRender){
       RemoteRender

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -1,0 +1,48 @@
+package services
+
+import controllers.ArticlePage
+import model.PageWithStoryPackage
+import model.liveblog.{BodyBlock, ImageBlockElement, TextBlockElement}
+
+sealed trait RenderType
+case object RemoteRender extends RenderType
+case object LocalRender extends RenderType
+
+object RenderingTierPicker {
+
+  private def isUnSupportedType(page: PageWithStoryPackage): Boolean = {
+    page match {
+      case a:ArticlePage => false
+      case _ => true
+    }
+  }
+
+  private def hasUnsupportedElements(page: PageWithStoryPackage): Boolean = {
+    page.article.blocks.get.body.exists((block: BodyBlock) => {
+
+      val hasUnsupportedElements: Boolean = block.elements.flatMap {
+        case b: TextBlockElement => None
+        case b: ImageBlockElement => None
+        case b => Some(b)
+      }.nonEmpty
+
+      hasUnsupportedElements
+
+    })
+  }
+
+  private def canHaveAds(page: PageWithStoryPackage): Boolean = {
+    ! page.metadata.sensitive
+  }
+
+  def getRenderTierFor(page: PageWithStoryPackage): RenderType = {
+
+    if(hasUnsupportedElements(page) || canHaveAds(page) || isUnSupportedType(page)){
+      LocalRender
+    } else {
+      RemoteRender
+    }
+
+  }
+
+}

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -10,7 +10,7 @@ case object LocalRender extends RenderType
 
 object RenderingTierPicker {
 
-  private def discussionDisabled(page: PageWithStoryPackage): Boolean = {
+  private def isDiscussionDisabled(page: PageWithStoryPackage): Boolean = {
     (! page.article.content.trail.isCommentable) && page.article.content.trail.isClosedForComments
   }
 
@@ -53,7 +53,7 @@ object RenderingTierPicker {
     val canRemotelyRender = isSupportedType(page) &&
       hasBlocks(page) &&
       hasOnlySupportedElements(page) &&
-      discussionDisabled(page) &&
+      isDiscussionDisabled(page) &&
       isAdFree(page)
 
     if(canRemotelyRender){

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -10,6 +10,17 @@ case object LocalRender extends RenderType
 
 object RenderingTierPicker {
 
+  private def discussionDisabled(page: PageWithStoryPackage): Boolean = {
+    (! page.article.content.trail.isCommentable) && page.article.content.trail.isClosedForComments
+  }
+
+  private def hasBlocks(page: PageWithStoryPackage): Boolean = {
+    page.article.blocks match {
+      case Some(b) => b.body.nonEmpty
+      case None => false
+    }
+  }
+
   private def isSupportedType(page: PageWithStoryPackage): Boolean = {
     page match {
       case a:ArticlePage => true
@@ -37,7 +48,15 @@ object RenderingTierPicker {
 
   def getRenderTierFor(page: PageWithStoryPackage): RenderType = {
 
-    if(hasOnlySupportedElements(page) && isAdFree(page) && isSupportedType(page)){
+    // todo: clean up
+
+    val canRemotelyRender = hasBlocks(page) &&
+      hasOnlySupportedElements(page) &&
+      discussionDisabled(page) &&
+      isAdFree(page) &&
+      isSupportedType(page)
+
+    if(canRemotelyRender){
       RemoteRender
     } else {
       LocalRender

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -1,5 +1,6 @@
 package services
 
+import common.Logging
 import controllers.ArticlePage
 import model.PageWithStoryPackage
 import model.liveblog.{BodyBlock, ImageBlockElement, TextBlockElement}
@@ -47,8 +48,6 @@ object RenderingTierPicker {
   }
 
   def getRenderTierFor(page: PageWithStoryPackage): RenderType = {
-
-    // todo: clean up
 
     val canRemotelyRender = isSupportedType(page) &&
       hasBlocks(page) &&


### PR DESCRIPTION
## What does this change?

Introduces a utility that checks whether a given page can be rendered using the new rendering tier or not. This will get logged out when you hit an article so we can see the results in Kibana

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
