### PR TITLE
Fix epic styling

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-testimonial-block.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-testimonial-block.js
@@ -4,8 +4,8 @@ import quoteSvg from 'svgs/icon/garnett-quote.svg';
 export const acquisitionsTestimonialBlockTemplate = (
     params: AcquisitionsEpicTestimonialCopy
 ) =>
-    `<div class="epic__testimonial-container epic__testimonial-container--subtle">
-        <div class="epic__testimonial-quote epic__testimonial-quote--subtle">
+    `<div class="epic__testimonial-container">
+        <div class="epic__testimonial-quote">
             ${quoteSvg.markup}
         </div>
         <blockquote class="epic__testimonial-text">

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -19,19 +19,19 @@
     }
 
     .epic__testimonial-text {
-        margin: 0;
-        padding: 0 (3 * $gs-gutter);
-
         @include fs-textSans(5);
         font-style: italic;
+
+        margin: 0;
+        padding: 0 (3 * $gs-gutter);
     }
 
     .epic__testimonial-name {
-        display: block;
-        margin-top: 5px;
-
         @include fs-textSans(3);
         font-style: normal;
+
+        display: block;
+        margin-top: 5px;
     }
 }
 
@@ -42,4 +42,3 @@
     // for instance .from-content-api cite
     @include testimonial-styles;
 }
-

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,77 +1,45 @@
-// CSS used for the Epic testimonials test
+@mixin testimonial-styles {
+    .epic__testimonial-container {
+        margin: $gs-baseline 0;
+        position: relative;
+    }
 
-// Common classes
+    .epic__testimonial-quote {
+        position: absolute;
+        left: $gs-gutter / 2;
+        top: 0;
 
-.epic__testimonial-container {
-    margin-top: $gs-gutter;
-    margin-bottom: $gs-gutter;
-}
+        span.inline-garnett-quote {
+            svg {
+                width: $gs-gutter;
+                height: $gs-gutter;
+                fill: $neutral-3;
+            }
+        }
+    }
 
-.epic__testimonial-quote {
-    position: relative;
-}
+    .epic__testimonial-text {
+        margin: 0;
+        padding: 0 (3 * $gs-gutter);
 
-.epic__testimonial-quote span {
-    position: absolute;
-}
+        @include fs-textSans(5);
+        font-style: italic;
+    }
 
-.epic__testimonial-container .epic__testimonial-quote .inline-garnett-quote svg {
-    fill: $multimedia-main-2;
-    width: $gs-gutter;
-    height: $gs-gutter;
-    padding-left: 10px;
-}
+    .epic__testimonial-name {
+        display: block;
+        margin-top: 5px;
 
-.epic__testimonial-text {
-    margin-bottom: 0;
-    font-family: $f-sans-serif-text;
-    font-style: italic;
-    padding-left: 2 * $gs-gutter;
-}
-
-.epic__testimonial-name {
-    display: block;
-    margin-top: 5px;
-    font-family: $f-sans-serif-text;
-    font-style: normal;
-}
-
-
-// Variant 1 - control
-
-// Variant 2 - prominent
-
-// Variant 3 - subtle
-
-.epic__testimonial-container--subtle .epic__testimonial-quote--subtle .inline-garnett-quote svg {
-    fill: $neutral-3;
-}
-
-
-
-// Remaining classes taken from previous pull request
-
-.contributions__epic--subtle {
-    // Unset border top as it will be set for the inline header element
-    border-top: 0;
-    background-color: #ffffff;
-    margin-top: $gs-baseline * 4;
-    margin-bottom: $gs-baseline * 4;
-}
-
-.contributions__title--epic--subtle {
-    @include fs-header(3);
-    display: inline;
-    border-top: 1px solid $multimedia-main-2;
-    padding-top: $gs-baseline / 3;
-}
-
-.contributions__paragraph--subtle {
-    margin-top: 0;
-}
-
-.contributions__epic--testimonial-usa {
-    .inline-quote svg {
-        fill: #ffbb00;
+        @include fs-textSans(3);
+        font-style: normal;
     }
 }
+
+@include testimonial-styles;
+
+.from-content-api {
+    // needed to override nested selectors from _from-content-api.scss,
+    // for instance .from-content-api cite
+    @include testimonial-styles;
+}
+


### PR DESCRIPTION
## What does this change?
Fixes some long-standing styling issues with the testimonial within the epic, caused by nested `.from-content-api` rules in [this file](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/external/_from-content-api.scss) (e.g. [this one](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/external/_from-content-api.scss#L255-L275)).

Specifically:
- Quote overlaps text in immersive articles
- Citation name isn't text sans
- Differing text sizes in immersive & normal articles

Also does some refactoring and cleanup of cruft from old tests

## Screenshots
### Before - in normal article
![picture 217](https://user-images.githubusercontent.com/5122968/41658392-1c0dec0c-748e-11e8-9de7-4b3197ae975c.png)

### Before - in immersive article
![picture 218](https://user-images.githubusercontent.com/5122968/41658410-28f59e6a-748e-11e8-82f6-48ff4c5ac7b1.png)

### After - in normal article
![picture 219](https://user-images.githubusercontent.com/5122968/41658418-2d162618-748e-11e8-8db1-3b3a86a2375c.png)

### After - in immersive article
![picture 220](https://user-images.githubusercontent.com/5122968/41658424-3208f088-748e-11e8-85b6-9b328ac79c75.png)
