### PR TITLE
Ad refresh 100 percent

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,7 +8,6 @@ import play.api.mvc.RequestHeader
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     CommercialClientLogging,
-    CommercialAdRefresh,
     OrielParticipation,
     LotameParticipation,
     OldTLSSupportDeprecation
@@ -22,14 +21,6 @@ object CommercialClientLogging extends Experiment(
   owners = Owner.group(SwitchGroup.Commercial),
   sellByDate = new LocalDate(2018, 6, 29),
   participationGroup = Perc1A
-)
-
-object CommercialAdRefresh extends Experiment(
-  name = "commercial-ad-refresh",
-  description = "Users in this experiment will have their ad slots refreshed after 30 seconds",
-  owners = Seq(Owner.withGithub("katebee")),
-  sellByDate = new LocalDate(2018, 9, 27),
-  participationGroup = Perc50
 )
 
 object OrielParticipation extends Experiment(

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -54,9 +54,7 @@ const setSlotAdRefresh = (event: ImpressionViewableEvent): void => {
 export const onSlotViewableFunction = (): ImpressionViewableEventCallback => {
     const queryParams = getUrlVars();
 
-    if (
-        queryParams.adrefresh !== 'false'
-    ) {
+    if (queryParams.adrefresh !== 'false') {
         return setSlotAdRefresh;
     }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -1,6 +1,5 @@
 // @flow
 
-import config from 'lib/config';
 import { getUrlVars } from 'lib/url';
 
 import type {
@@ -49,15 +48,14 @@ const setSlotAdRefresh = (event: ImpressionViewableEvent): void => {
 
   Returns a function to be used as a callback for GTP 'impressionViewable' event
 
-  Uses the global config and URL parameters.
+  Uses URL parameters.
 
  */
 export const onSlotViewableFunction = (): ImpressionViewableEventCallback => {
     const queryParams = getUrlVars();
 
     if (
-        queryParams.adrefresh !== 'false' &&
-        config.get('tests.commercialAdRefreshVariant')
+        queryParams.adrefresh !== 'false'
     ) {
         return setSlotAdRefresh;
     }


### PR DESCRIPTION
Wow! How did we get here. After a bit of mulling in the past about ever doing this, here we are!
Ad refresh at the Guardian. :clap:  Are you ready?

@guardian/commercial-dev @JonNorman @katebee

## What does this change?

This removes the `CommercialAdRefresh` experiment and it's usages in javascript via `config.get('tests.commercialAdRefreshVariant')`.

This means ad refresh will now run at 100% of the audience instead of 50%.

## What is the value of this and can you measure success?

A lot more impressions, measured via various sources; the datalake and DFP.

## Checklist
 - [x] Breathe in
 - [x] Breathe out
 - [x] I'm ready for this
 - [ ] Merge it

### Does this affect other platforms?

No