### PR TITLE
Change Email UX

### DIFF
--- a/identity/app/controllers/editprofile/EditProfileFormHandling.scala
+++ b/identity/app/controllers/editprofile/EditProfileFormHandling.scala
@@ -90,7 +90,7 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
                   profileFormsView(page, boundProfileForms.withErrors(idapiErrors), userDO)
 
                 case Right(updatedUser) =>
-                  val userChangedEmail: Option[String] = if (formData.toUserUpdateDTO(userDO).primaryEmailAddress.getOrElse(userDO.primaryEmailAddress) == userDO.primaryEmailAddress) None else formData.toUserUpdateDTO(userDO).primaryEmailAddress
+                  val userChangedEmail: Option[String] = formData.toUserUpdateDTO(userDO).primaryEmailAddress
                   profileFormsView(page, boundProfileForms.bindForms(updatedUser), updatedUser, changedEmail = userChangedEmail)
               }
           } // end of success

--- a/identity/app/controllers/editprofile/EditProfileFormHandling.scala
+++ b/identity/app/controllers/editprofile/EditProfileFormHandling.scala
@@ -89,7 +89,9 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
                   logger.error(s"Failed to process ${page.id} form submission for user ${userDO.getId}: $idapiErrors")
                   profileFormsView(page, boundProfileForms.withErrors(idapiErrors), userDO)
 
-                case Right(updatedUser) => profileFormsView(page, boundProfileForms.bindForms(updatedUser), updatedUser)
+                case Right(updatedUser) =>
+                  val userChangedEmail: Option[String] = if (formData.toUserUpdateDTO(userDO).primaryEmailAddress.getOrElse(userDO.primaryEmailAddress) == userDO.primaryEmailAddress) None else formData.toUserUpdateDTO(userDO).primaryEmailAddress
+                  profileFormsView(page, boundProfileForms.bindForms(updatedUser), updatedUser, changedEmail = userChangedEmail)
               }
           } // end of success
         ) // end fold
@@ -101,7 +103,8 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
     forms: ProfileForms,
     user: User,
     consentsUpdated: Boolean = false,
-    consentHint: Option[String] = None)
+    consentHint: Option[String] = None,
+    changedEmail: Option[String] = None)
     (implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
     val emailFilledForm: Future[Form[EmailPrefsData]] =
@@ -122,7 +125,8 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
             newsletterService.getEmailSubscriptions(emailFilledForm),
             EmailNewsletters.all,
             consentsUpdated,
-            consentHint
+            consentHint,
+            changedEmail
           )
         )(page, request, context)
       ))

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -45,14 +45,14 @@
                 @inputField(Input(accountDetailsForm("primaryEmailAddress"), ('_label, "Email address"),
                     Symbol("data-test-id") -> "email-address"))
 
-                <li class="form-field form-field--email-change">
-                    @if(changedEmail.isDefined) {
+                @changedEmail.map { email =>
+                    <li class="form-field form-field--email-change">
                         @fragments.inlineSvg("envelope", "icon")
                         <p class="form__note">
-                            To verify your new email address <b>@changedEmail.get</b> please check your inbox - the confirmation email is on its way. In the meantime you should keep using your old credentials to sign in.<br />
+                            To verify your new email address <b>@email</b> please check your inbox - the confirmation email is on its way. In the meantime you should keep using your old credentials to sign in.<br />
                         </p>
-                    }
-                </li>
+                    </li>
+                }
 
                 <li class="form-field form-field--email-validation">
                     @if(!user.statusFields.userEmailValidated.getOrElse(false)){

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -10,7 +10,8 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     idRequest: services.IdentityRequest,
     user: com.gu.identity.model.User,
-    accountDetailsForm: Form[_root_.form.AccountFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+    accountDetailsForm: Form[_root_.form.AccountFormData],
+    changedEmail: Option[String]= None)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @buildIdentityUrl(endpoint: String) = {
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
@@ -43,6 +44,15 @@
 
                 @inputField(Input(accountDetailsForm("primaryEmailAddress"), ('_label, "Email address"),
                     Symbol("data-test-id") -> "email-address"))
+
+                <li class="form-field form-field--email-change">
+                    @if(changedEmail.isDefined) {
+                        @fragments.inlineSvg("envelope", "icon")
+                        <p class="form__note">
+                            We have sent an email confirmation link to : <b>@changedEmail.get</b> .<br />
+                        </p>
+                    }
+                </li>
 
                 <li class="form-field form-field--email-validation">
                     @if(!user.statusFields.userEmailValidated.getOrElse(false)){

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -49,7 +49,7 @@
                     @if(changedEmail.isDefined) {
                         @fragments.inlineSvg("envelope", "icon")
                         <p class="form__note">
-                            We have sent an email confirmation link to : <b>@changedEmail.get</b> .<br />
+                            To verify your new email address <b>@changedEmail.get</b> please check your inbox - the confirmation email is on its way. In the meantime you should keep using your old credentials to sign in.<br />
                         </p>
                     }
                 </li>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -97,7 +97,7 @@
                     <div class="tabs__content">
                         @content(1, "/public/edit")(profile.publicProfileForm(idUrlBuilder, idRequest, user, forms.publicForm))
 
-                        @content(2, "/account/edit")(profile.accountDetailsForm(idUrlBuilder, idRequest, user, forms.accountForm, changedEmail = changedEmail))
+                        @content(2, "/account/edit")(profile.accountDetailsForm(idUrlBuilder, idRequest, user, forms.accountForm, changedEmail))
 
                         @content(3, "/membership/edit")(profile.membershipDetailsForm(idUrlBuilder, idRequest, user))
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -18,7 +18,8 @@
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
     consentsUpdated: Boolean,
-    consentHint: Option[String]
+    consentHint: Option[String],
+    changedEmail: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @*
@@ -96,7 +97,7 @@
                     <div class="tabs__content">
                         @content(1, "/public/edit")(profile.publicProfileForm(idUrlBuilder, idRequest, user, forms.publicForm))
 
-                        @content(2, "/account/edit")(profile.accountDetailsForm(idUrlBuilder, idRequest, user, forms.accountForm))
+                        @content(2, "/account/edit")(profile.accountDetailsForm(idUrlBuilder, idRequest, user, forms.accountForm, changedEmail = changedEmail))
 
                         @content(3, "/membership/edit")(profile.membershipDetailsForm(idUrlBuilder, idRequest, user))
 

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -275,6 +275,30 @@ $identity-header-height: 48px;
     }
 }
 
+/* Email Change
+   ========================================================================== */
+
+.form-field.form-field--email-change {
+    position: relative;
+    padding-left: 24px;
+
+    .inline-icon {
+        background-color: $neutral-3;
+        border-radius: 1000px;
+        fill: $neutral-1;
+        height: 30px;
+        left: 0;
+        position: absolute;
+        width: 30px;
+
+        svg {
+            height: 30 / 2 + px;
+            margin-top: 30 / 4 + px;
+            margin-left: 30 / 4 + px;
+            width: 30 / 2 + px;
+        }
+    }
+}
 
 /* Public Profile Page
    ========================================================================== */
@@ -301,6 +325,8 @@ $identity-header-height: 48px;
         }
     }
 }
+
+
 
 
 /* Email subscriptions

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -280,12 +280,12 @@ $identity-header-height: 48px;
 
 .form-field.form-field--email-change {
     position: relative;
-    padding-left: 24px;
+    padding-left: $gs-gutter * 1.2;
 
     .inline-icon {
-        background-color: $neutral-3;
+        background-color: $garnett-neutral-2;
         border-radius: 1000px;
-        fill: $neutral-1;
+        fill: $garnett-neutral-7;
         height: 18px;
         left: 0;
         position: absolute;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -283,7 +283,7 @@ $identity-header-height: 48px;
     padding-left: $gs-gutter * 1.2;
 
     .inline-icon {
-        background-color: $garnett-neutral-2;
+        background-color: $garnett-neutral-4;
         border-radius: 1000px;
         fill: $garnett-neutral-7;
         height: 18px;
@@ -296,6 +296,8 @@ $identity-header-height: 48px;
             margin-top: 18 / 4 + px;
             margin-left: 18 / 4 + px;
             width: 18 / 2 + px;
+            transform: scale(1.2);
+            position: absolute;
         }
     }
 }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -286,16 +286,16 @@ $identity-header-height: 48px;
         background-color: $neutral-3;
         border-radius: 1000px;
         fill: $neutral-1;
-        height: 30px;
+        height: 18px;
         left: 0;
         position: absolute;
-        width: 30px;
+        width: 18px;
 
         svg {
-            height: 30 / 2 + px;
-            margin-top: 30 / 4 + px;
-            margin-left: 30 / 4 + px;
-            width: 30 / 2 + px;
+            height: 18 / 2 + px;
+            margin-top: 18 / 4 + px;
+            margin-left: 18 / 4 + px;
+            width: 18 / 2 + px;
         }
     }
 }
@@ -325,8 +325,6 @@ $identity-header-height: 48px;
         }
     }
 }
-
-
 
 
 /* Email subscriptions


### PR DESCRIPTION
Related PR's: 
- Idenitity : https://github.com/guardian/identity/pull/1241
- Identity-frontend : https://github.com/guardian/identity-frontend/pull/419

## What does this change?
- ~~TODO : Sort out the envelope SVG sizing~~ 
- Displays a message to a user when the email address is changed to check their emails for a link.

## Screenshots
![image](https://user-images.githubusercontent.com/14179210/41772755-cc885fe8-7611-11e8-88eb-ef598e16f059.png)




## What is the value of this and can you measure success?
- User flow that makes more sense

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
