### PR TITLE
Use a valid value for align-items

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -118,7 +118,7 @@
     margin-top: $gs-baseline * 2;
 
     // Horizontal alignment
-    align-items: left;
+    align-items: flex-start;
 
     @include mq($from: mobileLandscape) {
         flex-direction: row;
@@ -171,7 +171,7 @@ a[href].contributions__contribute.contributions__contribute--epic {
     color: $garnett-neutral-1;
 
     svg path {
-        fill: $garnett-neutral-1; 
+        fill: $garnett-neutral-1;
     }
 
     &:hover {


### PR DESCRIPTION
## What does this change?

Fixes the CSS glitch spotted and fixed by @gustavpursche in #19817. I realised that the underlying problem was that we were using an invalid value for `align-items` on the parent (`left` and `right` aren't allowed, `flex-start` and `flex-end` are). This removes the need to set `align-self` on individual children.

## Screenshots

**Before**

<img width="426" alt="screen shot 2018-06-11 at 08 59 51" src="https://user-images.githubusercontent.com/2244375/41216740-d36b8e8a-6d55-11e8-9679-befe64b9d375.png">

**After**

<img width="416" alt="screen shot 2018-06-11 at 08 58 09" src="https://user-images.githubusercontent.com/2244375/41216746-d7c01dca-6d55-11e8-8cf5-0ceffce1a576.png">