### PR TITLE
Added krux targeting to amp-ad

### DIFF
--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -5,6 +5,7 @@ import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValu
 import common.Edition
 import common.commercial.AdUnitMaker
 import common.commercial.EditionAdTargeting._
+import conf.switches.Switches.KruxSwitch
 import model.Article
 import play.api.libs.json._
 
@@ -30,4 +31,18 @@ case class AmpAdDataSlot(article: Article) {
     def setAmpPlatform(adUnit: String) = adUnit.stripSuffix("/ng") + "/amp"
     setAmpPlatform(AdUnitMaker.make(article.metadata.id, article.metadata.adUnitSuffix))
   }
+}
+
+case class AmpAdRtcConfig() {
+  def toJsonString: String =
+    Json.obj("urls" -> (
+               Json.arr() ++
+                 (
+                   if(KruxSwitch.isSwitchedOn)
+                     // See https://trello.com/c/zBlwvOWI
+                     Json.arr("https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid")
+                   else Json.arr()
+                 )
+             )
+    ).toString()
 }

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -3,7 +3,7 @@ package views.support.cleaner
 import common.Edition
 import model.Article
 import org.jsoup.nodes.{Document, Element}
-import views.support.{AmpAd, AmpAdDataSlot, HtmlCleaner}
+import views.support.{AmpAd, AmpAdDataSlot, AmpAdRtcConfig, HtmlCleaner}
 
 import scala.collection.JavaConverters._
 
@@ -87,11 +87,15 @@ object AmpAdCleaner {
 case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends HtmlCleaner {
 
   def adAfter(element: Element): Element = {
-    val ampAd = <amp-ad data-npa-on-unknown-consent="true"
-              width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
-              json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
-              data-slot={AmpAdDataSlot(article).toString()}>
-      </amp-ad>
+    val ampAd = <amp-ad
+                   data-npa-on-unknown-consent="true"
+                   width="300" height="250"
+                   type="doubleclick"
+                   data-loading-strategy="prefer-viewability-over-views"
+                   json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
+                   data-slot={AmpAdDataSlot(article).toString()}
+                   rtc-config={AmpAdRtcConfig().toJsonString}
+                ></amp-ad>
 
     val ampAdString = {
       // data-block-on-consent should not have ANY value


### PR DESCRIPTION
This implements https://trello.com/c/zBlwvOWI according to https://konsole.zendesk.com/hc/en-us/articles/360002278694