### PR TITLE
Temporarily disable onward video container

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -15,7 +15,7 @@ import { MostPopular } from 'common/modules/onward/popular';
 import { related } from 'common/modules/onward/related';
 import { TonalComponent } from 'common/modules/onward/tonal';
 import { loadShareCounts } from 'common/modules/social/share-count';
-import { onwardVideo } from 'common/modules/video/onward-container';
+// import { onwardVideo } from 'common/modules/video/onward-container';
 import { moreInSeriesContainerInit } from 'common/modules/video/more-in-series-container';
 
 const initMoreInSection = (): void => {
@@ -95,6 +95,10 @@ const initRelated = () => {
     }
 };
 
+/**
+ * TODO: reinstate this when styling is correct
+ * https://trello.com/c/dq7QQQZ1
+
 const initOnwardVideoContainer = (): void => {
     if (
         config.get('page.contentType') !== 'Audio' &&
@@ -114,6 +118,7 @@ const initOnwardVideoContainer = (): void => {
         onwardVideo(el, mediaType);
     });
 };
+ */
 
 const initOnwardContent = () => {
     insertOrProximity('.js-onward', () => {
@@ -132,7 +137,9 @@ const initOnwardContent = () => {
                 });
         }
     });
-    initOnwardVideoContainer();
+    // TODO: reinstate this when styling is correct
+    // https://trello.com/c/dq7QQQZ1
+    // initOnwardVideoContainer();
 };
 
 const initDiscussion = () => {


### PR DESCRIPTION
## What does this change?

Onward video containers have not appeared on video or audio pages for ages, but nobody seemed to notice. However, we fixed the bug that was preventing their appearance (#19875) and now we're left with an ugly-looking pre-Garnett container 👎 

This change temporarily hides this container until we fix the styling.

See https://trello.com/c/dq7QQQZ1

## Screenshots

![picture_41](https://user-images.githubusercontent.com/5931528/41725401-8d3e1c10-7567-11e8-8bef-316e46d889a3.png)

## What is the value of this and can you measure success?

Hides a clearly broken container until we have time to fix it properly

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
