### PR TITLE
Stop showing reader revenue messaging to logged in digital subscribers

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -11,13 +11,15 @@ const PAYING_MEMBER_COOKIE = 'gu_paying_member';
 const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
+const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
 
 const userHasData = (): boolean => {
     const cookie =
         getCookie(USER_FEATURES_EXPIRY_COOKIE) ||
         getCookie(PAYING_MEMBER_COOKIE) ||
         getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||
-        getCookie(AD_FREE_USER_COOKIE);
+        getCookie(AD_FREE_USER_COOKIE) ||
+        getCookie(DIGITAL_SUBSCRIBER_COOKIE);
     return !!cookie;
 };
 
@@ -43,6 +45,10 @@ const persistResponse = (JsonResponse: () => void) => {
         RECURRING_CONTRIBUTOR_COOKIE,
         JsonResponse.contentAccess.recurringContributor
     );
+    addCookie(
+        DIGITAL_SUBSCRIBER_COOKIE,
+        JsonResponse.contentAccess.digitalPack
+    );
 
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
@@ -64,6 +70,7 @@ const deleteOldData = (): void => {
     removeCookie(RECURRING_CONTRIBUTOR_COOKIE);
     removeCookie(AD_FREE_USER_COOKIE);
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
+    removeCookie(DIGITAL_SUBSCRIBER_COOKIE);
 };
 
 const requestNewData = (): Promise<void> =>
@@ -136,6 +143,10 @@ const isRecurringContributor = (): boolean =>
     // If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
     isUserLoggedIn() && getCookie(RECURRING_CONTRIBUTOR_COOKIE) !== 'false';
 
+const isDigitalSubscriber = (): boolean =>
+    // If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
+    isUserLoggedIn() && getCookie(DIGITAL_SUBSCRIBER_COOKIE) !== 'false';
+
 /*
     Whenever the checks are updated, please make sure to update
     applyRenderConditions.scala.js too, where the global CSS class, indicating
@@ -153,6 +164,7 @@ export {
     isContributor,
     isRecentContributor,
     isRecurringContributor,
+    isDigitalSubscriber,
     shouldSeeReaderRevenue,
     refresh,
     deleteOldData,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -144,7 +144,7 @@ const isRecurringContributor = (): boolean =>
     isUserLoggedIn() && getCookie(RECURRING_CONTRIBUTOR_COOKIE) !== 'false';
 
 const isDigitalSubscriber = (): boolean =>
-    // If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
+    // If the user is logged in, but has no cookie yet, play it safe and assume they're a digital subscriber
     isUserLoggedIn() && getCookie(DIGITAL_SUBSCRIBER_COOKIE) !== 'false';
 
 /*
@@ -153,7 +153,10 @@ const isDigitalSubscriber = (): boolean =>
     the user should not see the revenue messages, is added to the body
 */
 const shouldSeeReaderRevenue = (): boolean =>
-    !isPayingMember() && !isRecentContributor() && !isRecurringContributor();
+    !isPayingMember() &&
+    !isRecentContributor() &&
+    !isRecurringContributor() &&
+    !isDigitalSubscriber();
 
 const isAdFreeUser = (): boolean => adFreeDataIsPresent() && !adFreeDataIsOld();
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -286,17 +286,17 @@ describe('The isDigitalSubscriber getter', () => {
             isUserLoggedIn.mockReturnValue(true);
         });
 
-        it('Is true when the user has a `true` recurring contributor cookie', () => {
+        it('Is true when the user has a `true` digital subscriber cookie', () => {
             addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
             expect(isDigitalSubscriber()).toBe(true);
         });
 
-        it('Is false when the user has a `false` recurring contributor cookie', () => {
+        it('Is false when the user has a `false` digital subscriber cookie', () => {
             addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'false');
             expect(isDigitalSubscriber()).toBe(false);
         });
 
-        it('Is true when the user has no recurring contributor cookie', () => {
+        it('Is true when the user has no digital subscriber cookie', () => {
             // If we don't know, we err on the side of caution, rather than annoy paying users
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
             expect(isDigitalSubscriber()).toBe(true);


### PR DESCRIPTION
## What does this change?
This PR updates the criteria so that if a the user is a logged in digital subscriber, they won't see reader revenue messaging (epics, banners).  

This also adds a gu_digital_subscriber cookie.

## Screenshots

## What is the value of this and can you measure success?
Digital subscribers are already supporting us, and so we'll stop targeting them with messaging to support us. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (please specify) Reduces the amount we will link to support frontend to contribute/subscribe.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

n/a
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @guardian/reader-revenue  

Note: following this PR, we will remove the gu_digital_subscriber cookie here: https://github.com/guardian/identity-frontend/pull/423