### PR TITLE
Remove negative margins from epic highlighted line

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -51,8 +51,6 @@
 .contributions__highlight {
     background-color: $news-garnett-highlight;
     padding: 4px 2px;
-    margin-left: -2px;
-    margin-right: -2px;
 }
 
 .contributions__hidden {


### PR DESCRIPTION
## What does this change?
For some reason, the `contributions__highlight` class, which adds a yellow highlight to text on contributions asks, had negative margins either side, which didn't look great, especially in the live blog. This PR removes them. 

## Screenshots
Liveblog:

| Before | After |
| ------| ------ |
|![withmargin](https://user-images.githubusercontent.com/2844554/41772570-061ed008-7611-11e8-9f0a-1236a48cb2a3.png) | ![marginremove](https://user-images.githubusercontent.com/2844554/41772574-0d53b8de-7611-11e8-891a-4c3095d27bb1.png) |


Article epic:

| Before | After |
| ------| ------ |
|<img width="637" alt="epicwithmar" src="https://user-images.githubusercontent.com/2844554/41772598-21930e58-7611-11e8-9122-7f36b20f031b.png">| <img width="630" alt="epicwithout" src="https://user-images.githubusercontent.com/2844554/41772605-29256fd0-7611-11e8-8d1e-820e7fd5840b.png">|


@guardian/contributions 



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
