### PR TITLE
Terms and Con-sistency

### DIFF
--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -18,7 +18,7 @@
             <div class="fieldset__heading">
                 <h2 class="form__heading">Use your social account</h2>
                 <div class="form__note">
-                    By proceeding, you agree to the Guardian's <a class="u-underline" href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of service">Terms of Service</a> and <a class="u-underline" href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy policy">Privacy Policy</a>.
+                    By proceeding, you agree to the Guardian's <a class="u-underline" href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of service">Terms &amp; Conditions</a> and <a class="u-underline" href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy policy">Privacy Policy</a>.
                 </div>
             </div>
             <div class="fieldset__fields">


### PR DESCRIPTION
@walaura 

## What does this change?

Bring consistency between the naming of Terms & Conditions between sign in and .com
Address https://trello.com/c/1Sh7tkJN

