### PR TITLE
Add returnUrl to password (re)set flow

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -76,12 +76,12 @@ class ChangePasswordController(
     }
   }
 
-  def renderPasswordConfirmation: Action[AnyContent] = Action{ implicit request =>
+  def renderPasswordConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     NoCache(Ok(
       IdentityHtmlPage.html(
-        views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)
+        views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl)
       )(page, request, context)
     ))
   }
@@ -112,7 +112,7 @@ class ChangePasswordController(
             )
           } else {
             val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
-            NoCache(SeeOther(routes.ChangePasswordController.renderPasswordConfirmation().url))
+            NoCache(SeeOther(routes.ChangePasswordController.renderPasswordConfirmation(None).url))
           }
         }
     }

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.nio.file.Paths
+
 import common.ImplicitControllerExecutionContext
 import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.data.{Form, Forms}
@@ -36,31 +38,27 @@ class ResetPasswordController(
     )
   )
 
-  private val requestPasswordResetFormWithConstraints = Form(
-    Forms.single(
-      "email-address" -> of[String].verifying(Constraints.nonEmpty)
-    )
-  )
-
   private val passwordResetForm = Form(
     Forms.tuple (
       "password" -> Forms.text,
       "password-confirm" ->  Forms.text,
-      "email-address" -> Forms.text
+      "email-address" -> Forms.text,
+      "returnUrl" -> Forms.optional(text)
     )
   )
 
-  private def passwordResetFormWithConstraints(implicit messagesProvider: MessagesProvider): Form[(String, String, String)] = Form(
+  private def passwordResetFormWithConstraints(implicit messagesProvider: MessagesProvider): Form[(String, String, String, Option[String])] = Form(
     Forms.tuple (
       "password" ->  idPassword
         .verifying(Constraints.nonEmpty),
       "password-confirm" ->  idPassword
         .verifying(Constraints.nonEmpty),
-      "email-address" -> of[String].verifying(Constraints.nonEmpty)
+      "email-address" -> of[String].verifying(Constraints.nonEmpty),
+      "returnUrl" -> Forms.optional(text)
     ) verifying(Messages("error.passwordsMustMatch"), { f => f._1 == f._2 }  )
   )
 
-  private def clearPasswords(form: Form[(String, String, String)]): Form[(String, String, String)] = form.copy(
+  private def clearPasswords(form: Form[(String, String, String, Option[String])]): Form[(String, String, String, Option[String])] = form.copy(
     data = form.data + ("password" -> "", "password-confirm" -> "")
   )
 
@@ -72,31 +70,31 @@ class ResetPasswordController(
     )(page, request, context))
   }
 
-  def renderResetPassword(token: String): Action[AnyContent] = Action{ implicit request =>
+  def renderResetPassword(token: String, returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val boundForm = passwordResetForm.bindFromFlash.getOrElse(passwordResetForm)
     NoCache(Ok(
       IdentityHtmlPage.html(
-        views.html.password.resetPassword(page, idRequest, idUrlBuilder, boundForm, token)
+        views.html.password.resetPassword(page, idRequest, idUrlBuilder, boundForm, token, returnUrl.getOrElse(""))
       )(page, request, context)
     ))
   }
 
-  def resetPassword(token : String): Action[AnyContent] = Action.async { implicit request =>
+  def resetPassword(token : String, returnUrl: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     val boundForm = passwordResetFormWithConstraints.bindFromRequest
 
-    def onError(formWithErrors: Form[(String, String, String)]): Future[Result] = {
+    def onError(formWithErrors: Form[(String, String, String, Option[String])]): Future[Result] = {
       logger.info("form errors in reset password attempt")
       Future.successful {
         NoCache(
-          SeeOther(routes.ResetPasswordController.renderResetPassword(token).url)
+          SeeOther(routes.ResetPasswordController.renderResetPassword(token, returnUrl).url)
             .flashing(clearPasswords(formWithErrors).toFlash)
         )
       }
     }
 
-    def onSuccess(form: (String, String, String)): Future[Result] = form match {
-      case (password, password_confirm, email_address) =>
+    def onSuccess(form: (String, String, String, Option[String])): Future[Result] = form match {
+      case (password, password_confirm, email_address, returnUrl) =>
 
         val authResponse = api.resetPassword(token,password)
         signInService.getCookies(authResponse, true) map {
@@ -117,7 +115,7 @@ class ResetPasswordController(
 
           case Right(responseCookies) =>
             logger.trace("Logging user in")
-            SeeOther(routes.ResetPasswordController.renderPasswordResetConfirmation.url)
+            SeeOther(routes.ResetPasswordController.renderPasswordResetConfirmation(returnUrl).url)
               .withCookies(responseCookies:_*)
         }
     }
@@ -125,15 +123,15 @@ class ResetPasswordController(
     boundForm.fold[Future[Result]](onError, onSuccess)
   }
 
-  def renderPasswordResetConfirmation: Action[AnyContent] = Action{ implicit request =>
+  def renderPasswordResetConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     Ok(IdentityHtmlPage.html(
-      views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)
+      views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl)
     )(page, request, context))
   }
 
-  def processUpdatePasswordToken( token : String): Action[AnyContent] = Action.async { implicit request =>
+  def processUpdatePasswordToken(token : String, returnUrl: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     val idRequest = idRequestParser(request)
     api.userForToken(token) map {
       case Left(errors) =>
@@ -141,8 +139,8 @@ class ResetPasswordController(
         val idRequest = idRequestParser(request)
         NoCache(SeeOther(idUrlBuilder.buildUrl("/reset/resend", idRequest)))
       case Right(user) =>
-        val filledForm = passwordResetForm.fill("","", user.primaryEmailAddress)
-        NoCache(SeeOther(routes.ResetPasswordController.renderResetPassword(token).url).flashing(filledForm.toFlash))
+        val filledForm = passwordResetForm.fill("","", user.primaryEmailAddress, returnUrl)
+        NoCache(SeeOther(routes.ResetPasswordController.renderResetPassword(token, returnUrl).url).flashing(filledForm.toFlash))
    }
   }
 }

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -3,7 +3,8 @@
 @import services.{IdentityRequest, IdentityUrlBuilder}
 @import views.html.fragments.registrationFooter
 
-@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
+
 
 <div class="identity-wrapper monocolumn-wrapper">
 
@@ -12,7 +13,11 @@
     @if(!userIsLoggedIn){
         <p><a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.</p>
     }else{
-        <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
+        @returnUrl.map { url =>
+            <p><a class="u-underline" href="@url" data-link-name="Continue">Continue</a></p>
+        }.getOrElse {
+            <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
+        }
     }
 
     @registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String)], token : String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String, Option[String])], token : String, returnUrl: String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField
@@ -9,7 +9,7 @@
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Please enter your new password for @emailAddress</h1>
 
-        <form class="form" novalidate action="@idUrlBuilder.buildUrl("/reset-password", idRequest)/@token"  method="post">
+        <form class="form" novalidate action="@idUrlBuilder.buildUrl(s"/reset-password/$token", idRequest)"  method="post">
             <input type="hidden" value="@emailAddress" name="email-address" />
 
             @if(resetPasswordForm.globalError.isDefined) {
@@ -19,6 +19,7 @@
             <fieldset class="fieldset">
                 <div class="fieldset__fields">
                     <ul class="u-unstyled">
+                        <input type="hidden" name="returnUrl" value="@(returnUrl)">
 
                         @inputField(Password(resetPasswordForm("password"), '_label -> "New Password", '_help -> "Between 6 and 72 characters", 'autofocus -> true, 'class -> "js-register-password js-password-strength",
                         (Symbol("data-test-id"), "reset-new-password")))

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -16,6 +16,8 @@
     </appender>
 
     <logger name="exactTarget" level="DEBUG" />
+    <logger name="org.apache.http.wire" level="WARN" />
+    <logger name="org.apache.http.headers" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -8,13 +8,13 @@ GET         /google1ec7a89a27d60d47.html            controllers.Assets.at(path =
 GET         /reauthenticate                         controllers.ReauthenticationController.renderForm(returnUrl : Option[String])
 POST        /reauthenticate                         controllers.ReauthenticationController.processForm
 
-GET         /c/:resetToken                          controllers.ResetPasswordController.processUpdatePasswordToken( resetToken : String)
-POST        /reset-password/:resetToken             controllers.ResetPasswordController.resetPassword( resetToken : String )
-GET         /reset-password/:resetToken             controllers.ResetPasswordController.renderResetPassword( resetToken : String )
-GET         /password/confirm                       controllers.ChangePasswordController.renderPasswordConfirmation
+GET         /c/:resetToken                          controllers.ResetPasswordController.processUpdatePasswordToken( resetToken : String, returnUrl: Option[String])
+POST        /reset-password/:resetToken             controllers.ResetPasswordController.resetPassword( resetToken : String, returnUrl: Option[String])
+GET         /reset-password/:resetToken             controllers.ResetPasswordController.renderResetPassword( resetToken : String, returnUrl: Option[String] )
+GET         /password/confirm                       controllers.ChangePasswordController.renderPasswordConfirmation(returnUrl: Option[String])
 GET         /password/change                        controllers.ChangePasswordController.displayForm
 POST        /password/change                        controllers.ChangePasswordController.submitForm
-GET         /password/reset-confirmation            controllers.ResetPasswordController.renderPasswordResetConfirmation
+GET         /password/reset-confirmation            controllers.ResetPasswordController.renderPasswordResetConfirmation(returnUrl: Option[String])
 GET         /password/email-sent                    controllers.ResetPasswordController.renderEmailSentConfirmation
 GET         /user/id/:id                            controllers.PublicProfileController.renderProfileFromId(id: String, activityType = "discussions")
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -1,14 +1,17 @@
 package controllers
 
+import java.net.URLEncoder
+
 import org.scalatest.path
 import org.scalatest.Matchers
 import org.scalatest.mockito.MockitoSugar
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Mockito._
-import idapiclient.{IdApiClient, TrackingData, Response}
+import idapiclient.{IdApiClient, Response, TrackingData}
 import test.{Fake, WithTestApplicationContext, WithTestExecutionContext, WithTestIdConfig}
 import play.api.test._
 import play.api.test.Helpers._
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import com.gu.identity.model.User
@@ -73,9 +76,10 @@ class ResetPasswordControllerTest
        }
 
       "should propagate the returnUrl from the request" in Fake {
-        val result = resetPasswordController.processUpdatePasswordToken("1234", Some("https://profile.thegulocal.com/public/edit"))(fakeRequest)
+        val returnUrl = "https://profile.thegulocal.com/public/edit"
+        val result = resetPasswordController.processUpdatePasswordToken("1234", Some(returnUrl))(fakeRequest)
         status(result) should equal(SEE_OTHER)
-        header("Location", result).head should be ("/reset-password/1234?returnUrl=https://profile.thegulocal.com/public/edit")
+        header("Location", result).head should be (s"/reset-password/1234?returnUrl=${URLEncoder.encode(returnUrl, "UTF-8")}")
       }
     }
 


### PR DESCRIPTION
## What does this change?

- Passes a returnUrl for password (re)set emails

Related PRs:

https://github.com/guardian/identity-frontend/pull/426
https://github.com/guardian/identity/pull/1246

## Screenshots

N/A

## What is the value of this and can you measure success?

Forgetful users, or soft account holders may continue their contribution odyssey from some url, after resetting or setting their password. 


### Does this affect other platforms?

No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
