### PR TITLE
Guardian today email front changes

### DIFF
--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -31,8 +31,6 @@ case class PressedCollection(
   hasMore: Boolean
 ) {
 
-  def withDisplayName(displayName: String): PressedCollection = copy(displayName = displayName)
-
   lazy val isEmpty: Boolean = curated.isEmpty && backfill.isEmpty && treats.isEmpty
 
   lazy val adFree = {
@@ -41,10 +39,6 @@ case class PressedCollection(
       backfill = backfill.filterNot(_.isPaidFor),
       treats = treats.filterNot(_.isPaidFor)
     )
-  }
-
-  def merge(target: PressedCollection, visible: Int): PressedCollection = {
-    copy(backfill = backfill ++ target.curated ++ target.backfill).full(visible)
   }
 
   def totalSize: Int = curated.size + backfill.size

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -3,6 +3,7 @@
 @import fragments.email._
 @import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
+@import model.PressedPage
 
 
 <table class="ft">
@@ -15,7 +16,16 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    <a href="%%unsub_center_url%%">Unsubscribe</a>
+                                    @page match {
+                                        case _: PressedPage => {
+                                            <a href="%%unsub_center_url%%">Unsubscribe</a>
+                                        }
+                                        case _ => {
+                                            <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                            <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
+                                        }
+                                    }
+
                                 </td>
                             </tr>
                             <tr>

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -90,9 +90,9 @@ object EmailFrontPath {
   }
 }
 
-case class EmailExtraCollections(canonical: PressedCollectionVisibility,
-                                 special: Option[PressedCollectionVisibility],
-                                 breaking: Option[PressedCollectionVisibility])
+case class EmailExtraCollections(canonical: Option[PressedCollectionVisibility],
+                                 special: List[PressedCollectionVisibility],
+                                 breaking: List[PressedCollectionVisibility])
 
 trait EmailFrontPress extends Logging {
 
@@ -103,7 +103,7 @@ trait EmailFrontPress extends Logging {
   def getFrontSeoAndProperties(path: String)(implicit executionContext: ExecutionContext): Future[(SeoData, FrontProperties)]
 
   private def mergeExtraEmailCollections(pressedCollections: List[PressedCollectionVisibility], emailCollections: EmailExtraCollections): List[PressedCollectionVisibility] = {
-    emailCollections.breaking.toList ::: List(emailCollections.canonical) ::: emailCollections.special.toList ::: pressedCollections
+    emailCollections.breaking :: emailCollections.canonical.toList ::: emailCollections.special ::: pressedCollections
   }
 
   def pressEmailFront(emailFrontPath: EmailFrontPath)(implicit executionContext: ExecutionContext): Response[PressedPageVersions] = {
@@ -168,36 +168,21 @@ trait EmailFrontPress extends Logging {
       } yield collectionId
     }
 
-    def renameMetaCollection(metaCollection: PressedCollectionVisibility, replacementName: String, visible: Int) = {
-      if (pressedCollections.map(_.pressedCollection.displayName).contains(metaCollection.pressedCollection.displayName))
-        metaCollection.withDisplayName(replacementName).withVisible(visible)
-      else
-        metaCollection.withVisible(visible)
+    def findMetaContainersWithLimit(metadata: Metadata, limit: Int): Response[List[PressedCollectionVisibility]] = {
+      Response
+        .traverse(findCollectionIds(metadata).map(generateCollectionJsonFromFapiClient))
+        .map(_.map(_.withVisible(limit)))
     }
 
-    def mergeCollections(first: PressedCollectionVisibility, tail: List[PressedCollectionVisibility], replacementName: String, visible: Int): PressedCollectionVisibility = {
-      tail.foldLeft(first)(_.mergeAndResize(_, visible)).withDisplayName(replacementName)
-    }
-
-    def pressedCollectionFromMetaTag(meta: Metadata, replacementName: String, visible: Int): Response[Option[PressedCollectionVisibility]] = {
-      val collections: Response[List[PressedCollectionVisibility]] = Response.traverse(findCollectionIds(meta).map(generateCollectionJsonFromFapiClient))
-      collections.map {
-        case first :: second :: tail => Some(renameMetaCollection(mergeCollections(first, second :: tail, replacementName, visible), replacementName, visible))
-        case head :: Nil => Some(renameMetaCollection(head, replacementName, visible))
-        case Nil => None
-      }
-    }
-
-    val canonicalPressedF = pressedCollectionFromMetaTag(Canonical, "Headlines", 6)
-    val breakingPressedF = pressedCollectionFromMetaTag(Breaking, "Breaking news", 5)
-    val specialPressedF = pressedCollectionFromMetaTag(Special, "Special report", 1)
+    val canonicalPressedF = findMetaContainersWithLimit(Canonical, 6)
+    val breakingPressedF = findMetaContainersWithLimit(Breaking, 5)
+    val specialPressedF = findMetaContainersWithLimit(Special, 1)
 
     for {
-      canonicalPressedO <- canonicalPressedF
-      canonicalPressed = canonicalPressedO.getOrElse(throw new RuntimeException(s"Unable to find Canonical headline on ${frontPath.edition}"))
+      canonicalPressed <- canonicalPressedF
       breakingPressed <- breakingPressedF
       specialPressed <- specialPressedF
-    } yield EmailExtraCollections(canonicalPressed, specialPressed, breakingPressed)
+    } yield EmailExtraCollections(canonicalPressed.headOption, specialPressed, breakingPressed)
 
   }
 

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -103,7 +103,7 @@ trait EmailFrontPress extends Logging {
   def getFrontSeoAndProperties(path: String)(implicit executionContext: ExecutionContext): Future[(SeoData, FrontProperties)]
 
   private def mergeExtraEmailCollections(pressedCollections: List[PressedCollectionVisibility], emailCollections: EmailExtraCollections): List[PressedCollectionVisibility] = {
-    emailCollections.breaking :: emailCollections.canonical.toList ::: emailCollections.special ::: pressedCollections
+    emailCollections.breaking ::: emailCollections.canonical.toList ::: emailCollections.special ::: pressedCollections
   }
 
   def pressEmailFront(emailFrontPath: EmailFrontPath)(implicit executionContext: ExecutionContext): Response[PressedPageVersions] = {

--- a/facia-press/app/frontpress/PressedCollectionVisibility.scala
+++ b/facia-press/app/frontpress/PressedCollectionVisibility.scala
@@ -10,7 +10,6 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
   import PressedCollectionVisibility._
 
   def withVisible(visible: Int): PressedCollectionVisibility = copy(visible = visible)
-  def withDisplayName(displayName: String): PressedCollectionVisibility = copy(pressedCollection = pressedCollection.withDisplayName(displayName))
 
   lazy val affectsDuplicates: Boolean = Container.affectsDuplicates(pressedCollection.collectionType)
   lazy val affectedByDuplicates: Boolean = Container.affectedByDuplicates(pressedCollection.collectionType)
@@ -51,10 +50,6 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
         val againstContainsContent = against.contains(content.header.url)
         againstContainsContent && content.participatesInDeduplication
       }
-  }
-
-  def mergeAndResize(target: PressedCollectionVisibility, size: Int) = {
-    withVisible(size).copy(pressedCollection = pressedCollection.merge(target.pressedCollection, size))
   }
 
 }


### PR DESCRIPTION
## What does this change?

- Do not rename guardian today fronts meta email containers 
- Show multiple breaking and special containers (do not merge them)
- Show trouble viewing link for article emails

## What is the value of this and can you measure success?

Pressed email fronts meet editorial specifications

### Tested

- [x] Locally
