### PR TITLE
retry press non training fronts on failure

### DIFF
--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -40,6 +40,9 @@ object SQSQueues {
 
     def sendMessageFuture(request: SendMessageRequest): Future[SendMessageResult] =
       asFuture[SendMessageRequest, SendMessageResult](client.sendMessageAsync(request, _))
+
+    def changeMessageVisibilityFuture(request: ChangeMessageVisibilityRequest): Future[ChangeMessageVisibilityResult] =
+      asFuture[ChangeMessageVisibilityRequest, ChangeMessageVisibilityResult](client.changeMessageVisibilityAsync(request, _))
   }
 }
 
@@ -53,6 +56,10 @@ class MessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implicit executi
 
   protected def sendMessage(sendRequest: SendMessageRequest): Future[SendMessageResult] = {
     client.sendMessageFuture(sendRequest)
+  }
+
+  def retryMessageAfter(handle: ReceiptHandle, timeoutSeconds: Int): Future[ChangeMessageVisibilityResult] = {
+    client.changeMessageVisibilityFuture(new ChangeMessageVisibilityRequest(queueUrl, handle.get, timeoutSeconds))
   }
 
   protected def receiveMessages(receiveRequest: ReceiveMessageRequest): Future[mutable.Buffer[AWSMessage]] = {

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -1,16 +1,25 @@
 package frontpress
 
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.gu.facia.api.models.TrainingPriority
 import common.FaciaPressMetrics.FrontPressCronSuccess
 import common.{JsonMessageQueue, SNSNotification}
 import conf.switches.Switches.FrontPressJobSwitch
 import conf.Configuration
+import services.ConfigAgent
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorker: ToolPressQueueWorker)(implicit executionContext: ExecutionContext) extends JsonQueueWorker[SNSNotification] {
-  lazy val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
   override val deleteOnFailure: Boolean = true
+
+  def retryPress(message: common.Message[SNSNotification]): Boolean = {
+    ConfigAgent.getFrontPriorityFromConfig(message.get.Message) match {
+      case Some(TrainingPriority) => false
+      case Some(_) => true
+      case _ => false
+    }
+  }
 
   override val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -13,11 +13,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorker: ToolPressQueueWorker)(implicit executionContext: ExecutionContext) extends JsonQueueWorker[SNSNotification] {
   override val deleteOnFailure: Boolean = true
 
-  def retryPress(message: common.Message[SNSNotification]): Boolean = {
+  def shouldRetryPress(message: common.Message[SNSNotification]): Boolean = {
     ConfigAgent.getFrontPriorityFromConfig(message.get.Message) match {
       case Some(TrainingPriority) => false
       case Some(_) => true
-      case _ => false
+      case None => false
     }
   }
 

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -94,7 +94,7 @@ abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionC
 
           case Failure(error) =>
             if (retryPress(message)) {
-              log.warn(s"Retrying $message", error)
+              log.warn(s"JsonQueueWorker getAndProcess retrying $message", error)
               queue.retryMessageAfter(message.handle, 5)
             } else if (deleteOnFailure) {
               queue.delete(receipt).failed.foreach {

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -19,7 +19,7 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
     throw new RuntimeException("Required property 'frontpress.sqs.tool_queue_url' not set")
   }
 
-  override def retryPress(message: Message[PressJob]): Boolean = false
+  override def shouldRetryPress(message: Message[PressJob]): Boolean = false
 
   override def process(message: Message[PressJob]): Future[Unit] = {
     val PressJob(FrontPath(path), pressType, creationTime, forceConfigUpdate) = message.get

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -19,6 +19,8 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
     throw new RuntimeException("Required property 'frontpress.sqs.tool_queue_url' not set")
   }
 
+  override def retryPress(message: Message[PressJob]): Boolean = false
+
   override def process(message: Message[PressJob]): Future[Unit] = {
     val PressJob(FrontPath(path), pressType, creationTime, forceConfigUpdate) = message.get
 


### PR DESCRIPTION
## What does this change?

Retry press non training fronts on failure. 

## What is the value of this and can you measure success?

When we do press all, we want to be sure that all fronts are pressed successfully. Failed attempts will go into a deadletter queue.

### Tested

- [x] On CODE (optional)

