### PR TITLE
Update password reset confirmation page

### DIFF
--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -30,7 +30,7 @@ class ResetPasswordController(
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging with Mappings with implicits.Forms {
 
-  private val page = IdentityPage("/reset-password", "Reset Password")
+  private val page = IdentityPage("/reset-password", "Reset Password", isFlow = true)
 
   private val requestPasswordResetForm = Form(
     Forms.single(

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -8,17 +8,37 @@
 
 <div class="identity-wrapper monocolumn-wrapper">
 
-    <h1 class="identity-title" data-test-id="password-reset-confirmation">Your password has been changed</h1>
+    <section class="identity-forms-message">
 
-    @if(!userIsLoggedIn){
-        <p><a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.</p>
-    }else{
-        @returnUrl.map { url =>
-            <p><a class="u-underline" href="@url" data-link-name="Continue">Continue</a></p>
-        }.getOrElse {
-            <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
-        }
-    }
+        <h1 class="identity-title" data-test-id="password-reset-confirmation">
+            Thank you! Your password has been changed.
+        </h1>
 
-    @registrationFooter(idRequest, idUrlBuilder)
+        <div class="identity-forms-message__body">
+            @if(!userIsLoggedIn){
+                <p>
+                    <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.
+                </p>
+            }else{
+
+                <p>
+                    You've completed your Guardian account. Please click the button below to jump back to where you left off.
+                </p>
+
+                @returnUrl.map { url =>
+                    <p><a class="manage-account__button--icon manage-account__button manage-account__button--main" href="@url" data-link-name="Continue">
+                        @(url match {
+                            case url if url.contains("support.") => "Back to my contribution"
+                            case _ => "Continue"
+                        })
+                        @fragments.inlineSvg("arrow-right", "icon")
+                    </a></p>
+                }.getOrElse {
+                    <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
+                }
+            }
+        </div>
+
+    </section>
+
 </div>

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -27,12 +27,13 @@
                         @inputField(Password(resetPasswordForm("password-confirm"), '_label -> "Repeat password", (Symbol("data-test-id"), "reset-password-repeat")))
 
                         <li class="form-field">
-                            <button type="submit" class="manage-account__button" data-link-name="Save password" data-test-id="reset-pwd">Save password</button>
+                            <button type="submit" class="manage-account__button--icon manage-account__button manage-account__button--main" data-link-name="Save password" data-test-id="reset-pwd">
+                                Save password
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </button>
                         </li>
                     </ul>
                 </div>
             </fieldset>
         </form>
-
-        @registrationFooter(idRequest, idUrlBuilder)
     </div>


### PR DESCRIPTION
## What does this change?
Makes the reset pwd confirmation page a bit nicer and in line with `identity-frontend`.

cc @jranks123 @katyabeer

## Screenshots
![screen shot 2018-06-26 at 12 21 30 pm](https://user-images.githubusercontent.com/11539094/41908328-7ccb94ca-793b-11e8-9ef2-7562f83b1255.png)

## What is the value of this and can you measure success?
More comprehensive flow

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
