### PR TITLE
Bumped up prebid.js to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#cb2a61311b11e747a5fb3ae58cac91fdc40f447d",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#0cad94d7e9c88a3475f6d57327ee3112742217a1",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,9 +7488,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#cb2a61311b11e747a5fb3ae58cac91fdc40f447d":
-  version "1.12.0"
-  resolved "https://github.com/guardian/Prebid.js.git#cb2a61311b11e747a5fb3ae58cac91fdc40f447d"
+"prebid.js@https://github.com/guardian/Prebid.js.git#0cad94d7e9c88a3475f6d57327ee3112742217a1":
+  version "1.15.0"
+  resolved "https://github.com/guardian/Prebid.js.git#0cad94d7e9c88a3475f6d57327ee3112742217a1"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This bumps up our prebid.js version to 1.15.0 (see https://trello.com/c/9uqBjzRi).