### PR TITLE
Fix gallery affiliate link disclaimer

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 @import views.support.`package`.Seq2zipWithRowInfo
-@import views.support.{RenderClasses}
+@import views.support.{RenderClasses, RowInfo}
 @import views.GalleryCaptionCleaners
 
 @import model.DotcomContentType
@@ -31,7 +31,7 @@
                         @fragments.witnessCallToAction(page.item.content)
                         <ul class="gallery">
                             @page.item.lightbox.largestCrops.zipWithRowInfo.map { case (image, row) =>
-                                @galleryItem(4, image, row.rowNum, page.item.lightbox.imageContainer(row.rowNum - 1))
+                                @galleryItem(4, image, row, page.item.lightbox.imageContainer(row.rowNum - 1))
                             }
                         </ul>
                         @fragments.witnessCallToAction(page.item.content)
@@ -63,14 +63,14 @@
     @fragments.contentFooter(page.item, page.related, "media", isPaidContent(page))
 </div>
 
-@galleryItem(adInterval: Int, image: ImageAsset, rowNum: Int, imageElement: ImageElement) = {
+@galleryItem(adInterval: Int, image: ImageAsset, rowInfo: RowInfo, imageElement: ImageElement) = {
 
-    <li id="img-@rowNum" class="gallery__item js-gallery-item" data-link-name="Gallery item | @rowNum">
+    <li id="img-@rowInfo.rowNum" class="gallery__item js-gallery-item" data-link-name="Gallery item | @rowInfo.rowNum">
         <figure itemscope itemtype="http://schema.org/ImageObject">
 
             <div class="gallery__figcaption">
                 @image.caption.map { caption =>
-                    <div class="gallery__caption" itemprop="caption">@GalleryCaptionCleaners(page, caption, rowNum)</div>
+                    <div class="gallery__caption" itemprop="caption">@GalleryCaptionCleaners(page, caption, rowInfo.isLast)</div>
                 }
                 @if(image.displayCredit) {
                     @image.credit.map { credit =>
@@ -79,8 +79,8 @@
                 }
 
                 @fragments.share.blockLevelSharing(
-                    "img-" + rowNum.toString,
-                    page.item.sharelinks.elementShares("img-" + rowNum.toString, image.path),
+                    "img-" + rowInfo.rowNum.toString,
+                    page.item.sharelinks.elementShares("img-" + rowInfo.rowNum.toString, image.path),
                     page.item.metadata.contentType.getOrElse(DotcomContentType.Unknown),
                     isNewGallery = true
                 )
@@ -94,7 +94,7 @@
                      * This ensures that the image height never goes above 96vh
                      *@
                     style="max-width: calc(@image.ratioDouble * 96vh)"
-                    href="@LinkTo{@page.item.metadata.url#img-@rowNum}"
+                    href="@LinkTo{@page.item.metadata.url#img-@rowInfo.rowNum}"
                     data-link-name="Launch Gallery Lightbox" data-is-ajax>
                     @fragments.image(
                         imageElement.images,
@@ -108,10 +108,10 @@
         </figure>
     </li>
 
-    @if(!page.item.content.shouldHideAdverts && rowNum % adInterval == 0) {
+    @if(!page.item.content.shouldHideAdverts && rowInfo.rowNum % adInterval == 0) {
         <li class="gallery__item gallery__item--advert">
             <div class="gallery__img-container">
-                @defining(rowNum / adInterval) { inlineId =>
+                @defining(rowInfo.rowNum / adInterval) { inlineId =>
                     @gallerySlot(inlineId)
                     @gallerySlot(inlineId - 1, isMobile = true)
                 }

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -30,10 +30,15 @@ object IndexCleaner {
 }
 
 object GalleryCaptionCleaners {
-  def apply(page: GalleryPage, caption: String, rowNum: Int)(implicit request: RequestHeader, context: ApplicationContext): Html = {
+  def apply(page: GalleryPage, caption: String, isLastRow: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val cleaners = List(
       GalleryCaptionCleaner,
-      AffiliateLinksCleaner(request.uri, page.gallery.content.metadata.sectionId, page.gallery.content.fields.showAffiliateLinks, "gallery", appendDisclaimer = rowNum == 1))
+      AffiliateLinksCleaner(
+        request.uri,
+        page.gallery.content.metadata.sectionId,
+        page.gallery.content.fields.showAffiliateLinks,
+        "gallery",
+        appendDisclaimer = Some(isLastRow && page.item.lightbox.containsAffiliateableLinks)))
 
     val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(caption)) { case (html, cleaner) => cleaner.clean(html) }
     Html(cleanedHtml.toString)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -757,6 +757,7 @@ case class GalleryLightbox(
   val landscapes = largestCrops.filter(i => i.width > i.height).sortBy(_.index)
   val portraits = largestCrops.filter(i => i.width < i.height).sortBy(_.index)
   val isInPicturesSeries = tags.tags.exists(_.id == "lifeandstyle/series/in-pictures")
+  lazy val containsAffiliateableLinks: Boolean = largestCrops.flatMap(_.caption.map(AffiliateLinksCleaner.stringContainsAffiliateableLinks)).contains(true)
 
   val javascriptConfig: JsObject = {
     val imageJson = for {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -817,10 +817,11 @@ object AffiliateLinksCleaner {
 
   def replaceLinksInHtml(html: Document, pageUrl: String, appendDisclaimer: Option[Boolean], contentType: String, skimlinksId: String): Document = {
 
-    val supportedLinks: mutable.Seq[Element] = getAffiliateableLinks(html)
-    supportedLinks.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
+    val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(html)
+    linksToReplace.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
 
-    val shouldAppendDisclaimer = appendDisclaimer.getOrElse(supportedLinks.nonEmpty)
+    // respect appendDisclaimer, or if it's not set then always add the disclaimer if affilate links have been added
+    val shouldAppendDisclaimer = appendDisclaimer.getOrElse(linksToReplace.nonEmpty)
     if (shouldAppendDisclaimer) insertAffiliateDisclaimer(html, contentType)
     else html
   }


### PR DESCRIPTION
## What does this change?
Currently, the affiliate links disclaimer gets inserted to every caption with an affiliate link in it. The desired behaviour is for the disclaimer to be inserted into the last caption, if any of the captions contain an affiliate link. This PR implements that.

The gallery captions are taken from the lightbox bit of the gallery mode. I've had to add a new property - `containsAffiliateableLinks` - to help the cleaner decide whether to insert the disclaimer into a gallery. Sadly this means that we do the same loop through the captions twice - firstly to check if there's any affiliate links, then again to insert the links and the disclaimer.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
