### PR TITLE
Remove trail content on pressed emails

### DIFF
--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -41,6 +41,12 @@ case class PressedCollection(
     )
   }
 
+  def withoutTrailTextOnTail: PressedCollection = (curated, backfill) match {
+    case (curatedHead :: tail, _) => copy(curated = curatedHead :: tail.map(_.withoutTrailText), backfill = backfill.map(_.withoutTrailText))
+    case (_, backfillHead :: tail) => copy(backfill = backfillHead :: tail.map(_.withoutTrailText))
+    case _ => this
+  }
+
   def totalSize: Int = curated.size + backfill.size
 
   def lite(visible: Int): PressedCollection = {

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -348,7 +348,9 @@ final case class PressedCard(
   shortUrl: String,
   group: String,
   isLive: Boolean
-)
+) {
+  def withoutTrailText: PressedCard = copy(trailText = None)
+}
 
 // EnrichedContent is an optionally-present field of the PressedContent class.
 // It contains additional content that has been pre-fetched by facia-press, to
@@ -369,6 +371,8 @@ sealed trait PressedContent {
   def display: PressedDisplaySettings
   def maybePillar: Option[Pillar] = Pillar(properties.maybeContent)
   lazy val participatesInDeduplication: Boolean = properties.embedType.isEmpty
+
+  def withoutTrailText: PressedContent
 
   def isPaidFor: Boolean = properties.isPaidFor
 
@@ -412,7 +416,10 @@ final case class CuratedContent(
   override val display: PressedDisplaySettings,
   enriched: Option[EnrichedContent], // This is currently an option, as we introduce the new field. It can then become a value type.
   supportingContent: List[PressedContent],
-  cardStyle: CardStyle ) extends PressedContent
+  cardStyle: CardStyle ) extends PressedContent {
+
+  override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
+}
 
 object SupportingCuratedContent {
   def make(content: fapi.SupportingCuratedContent): SupportingCuratedContent = {
@@ -432,7 +439,9 @@ final case class SupportingCuratedContent(
   override val card: PressedCard,
   override val discussion: PressedDiscussionSettings,
   override val display: PressedDisplaySettings,
-  cardStyle: CardStyle) extends PressedContent
+  cardStyle: CardStyle) extends PressedContent {
+  override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
+}
 
 object LinkSnap {
   def make(content: fapi.LinkSnap): LinkSnap = {
@@ -453,7 +462,9 @@ final case class LinkSnap(
   override val discussion: PressedDiscussionSettings,
   override val display: PressedDisplaySettings,
   enriched: Option[EnrichedContent] // This is currently an option, as we introduce the new field. It can then become a value type.
-) extends PressedContent
+) extends PressedContent {
+  override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
+}
 
 object LatestSnap {
   def make(content: fapi.LatestSnap): LatestSnap = {
@@ -471,7 +482,10 @@ final case class LatestSnap(
   override val header: PressedCardHeader,
   override val card: PressedCard,
   override val discussion: PressedDiscussionSettings,
-  override val display: PressedDisplaySettings) extends PressedContent
+  override val display: PressedDisplaySettings) extends PressedContent {
+
+  override def withoutTrailText: PressedContent = copy(card = card.withoutTrailText)
+}
 
 object KickerProperties {
   def make(kicker: fapiutils.ItemKicker): KickerProperties = KickerProperties(fapiutils.ItemKicker.kickerText(kicker))

--- a/common/test/common/commercial/ContainerModelTest.scala
+++ b/common/test/common/commercial/ContainerModelTest.scala
@@ -1,64 +1,11 @@
 package common.commercial
 
-import common.commercial.FixtureBuilder._
+import common.facia.PressedCollectionBuilder.mkPressedCollection
 import common.editions.Uk
 import model.facia.PressedCollection
-import model.pressed.{CollectionConfig, PressedContent}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 class ContainerModelTest extends FlatSpec with Matchers with OptionValues {
-
-  private val defaultCurated = List(mkPressedContent(1), mkPressedContent(2), mkPressedContent(3))
-  private val defaultBackfill = List(mkPressedContent(4), mkPressedContent(5))
-
-  private def mkPressedCollection(collectionType: String,
-                                  curated: List[PressedContent] = defaultCurated,
-                                  backfill: List[PressedContent] = defaultBackfill,
-                                  hideShowMore: Boolean = false): PressedCollection = {
-
-    val config: CollectionConfig = CollectionConfig(
-      displayName = None,
-      backfill = None,
-      metadata = None,
-      collectionType = "",
-      href = None,
-      description = None,
-      groups = None,
-      uneditable = false,
-      showTags = false,
-      showSections = false,
-      hideKickers = false,
-      showDateHeader = false,
-      showLatestUpdate = false,
-      excludeFromRss = false,
-      showTimestamps = false,
-      hideShowMore,
-      displayHints = None
-    )
-
-    PressedCollection(
-      id = "test-collection-id",
-      displayName = "test-collection-displayName",
-      curated,
-      backfill,
-      treats = Nil,
-      lastUpdated = None,
-      href = Some(
-        "/am-resorts-partner-zone/2016/jan/20/be-a-hero-on-the-half-shell-release-baby-turtles-on-your-next-vacation"
-      ),
-      description = Some("desc"),
-      collectionType,
-      groups = None,
-      uneditable = false,
-      showTags = false,
-      showSections = false,
-      hideKickers = false,
-      showDateHeader = false,
-      showLatestUpdate = false,
-      config,
-      hasMore = false
-    )
-  }
 
   def fromUkPressedCollection: (PressedCollection) => ContainerModel = {
     ContainerModel.fromPressedCollection(Uk)

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -1,4 +1,4 @@
-package common.commercial
+package common.facia
 
 import model.pressed._
 
@@ -45,7 +45,7 @@ object FixtureBuilder {
       id.toString,
       cardStyle = DefaultCardstyle,
       webPublicationDateOption = None,
-      trailText = None,
+      trailText = Some("trail text"),
       mediaType = None,
       starRating = None,
       shortUrlPath = None,

--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -1,0 +1,59 @@
+package common.facia
+
+import FixtureBuilder.mkPressedContent
+import model.facia.PressedCollection
+import model.pressed.{CollectionConfig, PressedContent}
+
+object PressedCollectionBuilder {
+  private val defaultCurated = List(mkPressedContent(1), mkPressedContent(2), mkPressedContent(3))
+  private val defaultBackfill = List(mkPressedContent(4), mkPressedContent(5))
+
+  def mkPressedCollection(collectionType: String = "collectionType",
+                                  curated: List[PressedContent] = defaultCurated,
+                                  backfill: List[PressedContent] = defaultBackfill,
+                                  hideShowMore: Boolean = false): PressedCollection = {
+
+    val config: CollectionConfig = CollectionConfig(
+      displayName = None,
+      backfill = None,
+      metadata = None,
+      collectionType = "",
+      href = None,
+      description = None,
+      groups = None,
+      uneditable = false,
+      showTags = false,
+      showSections = false,
+      hideKickers = false,
+      showDateHeader = false,
+      showLatestUpdate = false,
+      excludeFromRss = false,
+      showTimestamps = false,
+      hideShowMore,
+      displayHints = None
+    )
+
+    PressedCollection(
+      id = "test-collection-id",
+      displayName = "test-collection-displayName",
+      curated,
+      backfill,
+      treats = Nil,
+      lastUpdated = None,
+      href = Some(
+        "/am-resorts-partner-zone/2016/jan/20/be-a-hero-on-the-half-shell-release-baby-turtles-on-your-next-vacation"
+      ),
+      description = Some("desc"),
+      collectionType,
+      groups = None,
+      uneditable = false,
+      showTags = false,
+      showSections = false,
+      hideKickers = false,
+      showDateHeader = false,
+      showLatestUpdate = false,
+      config,
+      hasMore = false
+    )
+  }
+}

--- a/common/test/common/facia/PressedCollectionTest.scala
+++ b/common/test/common/facia/PressedCollectionTest.scala
@@ -1,0 +1,28 @@
+package common.facia
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class PressedCollectionTest extends FlatSpec with Matchers {
+  "withoutTrailTextOnTail" should "remove trail text from curated and backfill content, leaving the curated head" in {
+    val pressedCollection = PressedCollectionBuilder.mkPressedCollection()
+    val withoutTrailText = pressedCollection.withoutTrailTextOnTail
+
+    withoutTrailText.curatedPlusBackfillDeduplicated shouldBe
+      pressedCollection.curatedPlusBackfillDeduplicated.head :: pressedCollection.curatedPlusBackfillDeduplicated.tail.map(_.withoutTrailText)
+  }
+
+  "withoutTrailTextOnTail" should "remove trail text from backfill content, leaving the backfill head" in {
+    val pressedCollection = PressedCollectionBuilder.mkPressedCollection(curated = Nil)
+    val withoutTrailText = pressedCollection.withoutTrailTextOnTail
+
+    withoutTrailText.curatedPlusBackfillDeduplicated shouldBe
+      pressedCollection.curatedPlusBackfillDeduplicated.head :: pressedCollection.curatedPlusBackfillDeduplicated.tail.map(_.withoutTrailText)
+  }
+
+  "withoutTrailTextOnTail" should "execute on empty curated and backfill" in {
+    val pressedCollection = PressedCollectionBuilder.mkPressedCollection(curated = Nil, backfill = Nil)
+    val withoutTrailText = pressedCollection.withoutTrailTextOnTail
+
+    withoutTrailText.curatedPlusBackfillDeduplicated shouldBe pressedCollection.curatedPlusBackfillDeduplicated
+  }
+}

--- a/common/test/layout/CollectionEmailTest.scala
+++ b/common/test/layout/CollectionEmailTest.scala
@@ -1,11 +1,10 @@
 package layout
 
-import common.commercial.FixtureBuilder
+import common.facia.FixtureBuilder
 import model.facia.PressedCollection
 import model.pressed.{CollectionConfig, DisplayHints, PressedContent}
 import model.{FrontProperties, PressedPage, SeoData}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
-import FixtureBuilder.mkPressedContent
 
 class CollectionEmailTest extends FlatSpec with Matchers with OptionValues {
 
@@ -37,7 +36,7 @@ class CollectionEmailTest extends FlatSpec with Matchers with OptionValues {
     result.contentCollections.map(_.displayName) shouldEqual List("Test Collection 1", "Test Collection 3")
   }
 
-  private def mkContent(id: Int): PressedContent = mkPressedContent(id)
+  private def mkContent(id: Int): PressedContent = FixtureBuilder.mkPressedContent(id)
 
   private def mkPressedCollection(id: String, curated: Seq[PressedContent] = IndexedSeq.empty, backfill: Seq[PressedContent] = IndexedSeq.empty, maxItemsToDisplay: Option[Int] = None) = {
     PressedCollection(

--- a/common/test/layout/PaidCardTest.scala
+++ b/common/test/layout/PaidCardTest.scala
@@ -1,6 +1,6 @@
 package layout
 
-import common.commercial.FixtureBuilder.mkPressedContent
+import common.facia.FixtureBuilder.mkPressedContent
 import model.pressed.{FreeHtmlKicker, ItemKicker, KickerProperties}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -116,10 +116,11 @@ trait EmailFrontPress extends Logging {
       collectionIds = collectionsIdsFromConfigForPath(emailFrontPath.path, config)
       pressedCollections <- Response.traverse(collectionIds.map(generateCollectionJsonFromFapiClient))
       extraEmailCollections <- buildExtraEmailCollections(emailFrontPath, config, pressedCollections)
-      allPressedCollections = mergeExtraEmailCollections(pressedCollections, extraEmailCollections)
       seoWithProperties <- Response.Async.Right(getFrontSeoAndProperties(emailFrontPath.path))
     } yield seoWithProperties match {
-      case (seoData, frontProperties) => generatePressedVersions(emailFrontPath.path, allPressedCollections, seoData, frontProperties)
+      case (seoData, frontProperties) =>
+        val allPressedCollections = mergeExtraEmailCollections(pressedCollections, extraEmailCollections).map(_.withoutTrailTextOnTail)
+        generatePressedVersions(emailFrontPath.path, allPressedCollections, seoData, frontProperties)
     }
   }
 

--- a/facia-press/app/frontpress/PressedCollectionVisibility.scala
+++ b/facia-press/app/frontpress/PressedCollectionVisibility.scala
@@ -11,6 +11,8 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
 
   def withVisible(visible: Int): PressedCollectionVisibility = copy(visible = visible)
 
+  def withoutTrailTextOnTail: PressedCollectionVisibility = copy(pressedCollection = pressedCollection.withoutTrailTextOnTail)
+
   lazy val affectsDuplicates: Boolean = Container.affectsDuplicates(pressedCollection.collectionType)
   lazy val affectedByDuplicates: Boolean = Container.affectedByDuplicates(pressedCollection.collectionType)
 


### PR DESCRIPTION
## What does this change?

Remove trail content for all stories on email except for the head

## What is the value of this and can you measure success?

Editorial thinks this will improve clickthroughs

### Tested

- [x] Locally
- [ ] On CODE (optional)
