### PR TITLE
Update affiliate link disclaimer text.

### DIFF
--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -2,13 +2,22 @@
 
 
 @articleDisclaimer() = {
-    <p><em><sup>This article contains <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">affiliate links</a> to products. Our journalism is independent and is never written to promote these products although we may earn a small commission if a reader makes a purchase.</sup></em></p>
+    <p><em><sup>
+        This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
+        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
+        <br>
+        The links are powered by Skimlinks and further details are set out
+            <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">here</a>.
+        If you do not consent to the use of Skimlinks cookies, you should not click on an affiliate link.
+    </sup></em></p>
 }
 
 @galleryDisclaimer() = {
-    <em>Please note: this gallery contains <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">affiliate links</a>
-        to products. Our journalism is independent and is never written to promote these products although we may earn a small
-        commission if a reader makes a purchase.</em>
+    <br><em>Please note: This gallery contains affiliate links, which means we may earn a small commission if a reader clicks through and
+        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
+
+        The links are powered by Skimlinks and further details are set out <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">here</a>.
+        If you do not consent to the use of Skimlinks cookies, you should not click on an affiliate link.</em>
 }
 
 @{contentType match {

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -6,18 +6,18 @@
         This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
         makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
         <br>
-        The links are powered by Skimlinks and further details are set out
-            <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">here</a>.
-        If you do not consent to the use of Skimlinks cookies, you should not click on an affiliate link.
+        The links are powered by Skimlinks. By clicking on an affiliate link, you accept that Skimlinks cookies will be set.
+        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.
     </sup></em></p>
 }
 
 @galleryDisclaimer() = {
-    <br><em>Please note: This gallery contains affiliate links, which means we may earn a small commission if a reader clicks through and
+    <br><em>Please note: This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
         makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-
-        The links are powered by Skimlinks and further details are set out <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">here</a>.
-        If you do not consent to the use of Skimlinks cookies, you should not click on an affiliate link.</em>
+        <br>
+        The links are powered by Skimlinks. By clicking on an affiliate link, you accept that Skimlinks cookies will be set.
+        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.
+    </em>
 }
 
 @{contentType match {


### PR DESCRIPTION
## What does this change?
This changes the text of the affiliate links disclaimer in line with the final text agreed by legal/editorial

#Screenshots

![screen shot 2018-06-26 at 18 07 15](https://user-images.githubusercontent.com/3606555/41966735-d45d53d8-79f7-11e8-823a-acccdd301f8c.png)
![screen shot 2018-06-26 at 18 04 40](https://user-images.githubusercontent.com/3606555/41966737-d6443a9a-79f7-11e8-8264-72933cccd58f.png)
