### PR TITLE
Add stickiness to the comments MPU

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -16,6 +16,9 @@ export const initCommentAdverts = (): ?boolean => {
         const adSlots = createSlots('comments', {
             classes: 'mpu-banner-ad',
         });
+        adSlots.forEach(adSlot => {
+            adSlot.classList.add('js-sticky-mpu');
+        });
         fastdom
             .write(() => {
                 $commentMainColumn.addClass('discussion__ad-wrapper');

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -5,7 +5,7 @@ import raven from 'lib/raven';
 import fastdom from 'lib/fastdom-promise';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { adSizes } from 'commercial/modules/ad-sizes';
-import { stickyMpu } from 'commercial/modules/sticky-mpu';
+import { stickyMpu, stickyCommentsMpu } from 'commercial/modules/sticky-mpu';
 import { applyCreativeTemplate } from 'commercial/modules/dfp/apply-creative-template';
 import { renderAdvertLabel } from 'commercial/modules/dfp/render-advert-label';
 import { geoMostPopular } from 'common/modules/onward/geo-most-popular';
@@ -70,7 +70,12 @@ sizeCallbacks[adSizes.fluid] = (renderSlotEvent: any, advert: Advert) =>
  */
 sizeCallbacks[adSizes.mpu] = (_, advert) => {
     if (advert.node.classList.contains('js-sticky-mpu')) {
-        stickyMpu(advert.node);
+        if (advert.node.classList.contains('ad-slot--right')) {
+            stickyMpu(advert.node);
+        }
+        if (advert.node.classList.contains('ad-slot--comments')) {
+            stickyCommentsMpu(advert.node);
+        }
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -10,21 +10,52 @@ const noSticky: boolean = !!(
     document.documentElement.classList.contains('has-no-sticky')
 );
 let stickyElement: Sticky;
-let rightSlot: HTMLElement;
+let stickySlot: HTMLElement;
 
 const onResize = (specs, _, iframe: ?HTMLElement) => {
-    if (rightSlot.contains(iframe)) {
+    if (stickySlot.contains(iframe)) {
         unregister('resize', onResize);
         stickyElement.updatePosition();
     }
 };
 
-const stickyMpu = (adSlot: HTMLElement) => {
-    if (adSlot.getAttribute('data-name') !== 'right') {
+const isStickyMpuSlot = (adSlot: HTMLElement) => {
+    const dataName = adSlot.dataset.name;
+    return dataName === 'comments' || dataName === 'right';
+};
+
+const stickyCommentsMpu = (adSlot: HTMLElement) => {
+    if (isStickyMpuSlot(adSlot)) {
+        stickySlot = adSlot;
+    }
+
+    const referenceElement: any = document.querySelector('.js-comments');
+
+    if (!referenceElement || !adSlot) {
         return;
     }
 
-    rightSlot = adSlot;
+    fastdom
+        .read(() => referenceElement.offsetHeight - 600)
+        .then(newHeight =>
+            fastdom.write(() => {
+                (adSlot.parentNode: any).style.height = `${newHeight}px`;
+            })
+        )
+        .then(() => {
+            if (noSticky) {
+                stickyElement = new Sticky(adSlot);
+                stickyElement.init();
+                register('resize', onResize);
+            }
+            mediator.emit('page:commercial:sticky-mpu');
+        });
+};
+
+const stickyMpu = (adSlot: HTMLElement) => {
+    if (isStickyMpuSlot(adSlot)) {
+        stickySlot = adSlot;
+    }
 
     const referenceElement: any = document.querySelector(
         '.js-article__body,.js-liveblog-body-content'
@@ -67,4 +98,4 @@ stickyMpu.whenRendered = new Promise(resolve => {
     mediator.on('page:commercial:sticky-mpu', resolve);
 });
 
-export { stickyMpu };
+export { stickyMpu, stickyCommentsMpu };

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -19,7 +19,7 @@
     background-color: lighten($media-background, 2.5%);
 }
 
-.ad-slot--right {
+.ad-slot--right, .ad-slot--comments {
     position: sticky;
     top: 0;
 


### PR DESCRIPTION
## What does this change?
Adds stickiness to the comments MPU slot

## Screenshots
![stickycommentmpu](https://user-images.githubusercontent.com/19835654/41967139-d7c7c426-79f8-11e8-8306-c0c11a83cff4.gif)
## What is the value of this and can you measure success?
Higher ad view-ability meaning more chance for extra revenue using ad refresh

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
