### PR TITLE
DFP epic - use correct field for component id

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot-utils.js
+++ b/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot-utils.js
@@ -43,7 +43,7 @@ const renderEpicSlot = (epicSlot: HTMLDivElement): Promise<EpicComponent> => {
         componentEvent: {
             component: {
                 componentType: 'ACQUISITIONS_EPIC',
-                componentId: 'gdnwb_copts_memco_epic_native_vs_dfp_v2_dfp',
+                id: 'gdnwb_copts_memco_epic_native_vs_dfp_v2_dfp',
             },
             abTest: {
                 name: 'AcquisitionsEpicNativeVsDfpV2',


### PR DESCRIPTION
## What does this change?

Changes the field used to store component id for DFP epic.

## What is the value of this and can you measure success?

Correct tracking