### PR TITLE
Rename sign in test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,7 +18,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-new-sign-in-experiment",
+    "ab-new-sign-in-experiment-bump",
     "This test will send a % of users to the new sign in experience",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
@@ -47,7 +47,7 @@ const replaceLinks = (links: Element[], newHref: string): void => {
 };
 
 export const newSignInExperiment: ABTest = {
-    id: 'NewSignInExperiment',
+    id: 'NewSignInExperimentBump',
     start: '2018-06-07',
     expiry: '2019-06-07',
     author: 'Laura gonzalez',


### PR DESCRIPTION
The sign in test was not properly picking up its audience. Renaming it fixes that!

Gonna test it on CODE first