### PR TITLE
Resolved z-index order issue on world cup comment cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -458,6 +458,11 @@ $header-image-size-desktop: 100px;
             z-index: 1;
         }
 
+        .fc-sublinks,
+        .fc-item__meta {
+            z-index: 2;
+        }
+
         &.fc-item--half-tablet,
         &.fc-item--standard-tablet,
         &.fc-item--list-media-tablet {


### PR DESCRIPTION
Sublinks on comment cards weren't clickable due to a higher z-index being necessary to the faux block overlay. 