### PR TITLE
Correct Byline Display

### DIFF
--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -32,7 +32,7 @@
 
                 @if(article.tags.isInterview) {
                     @article.trail.byline.map { text =>
-                        <span class="content__headline--byline-interview">By @ContributorLinks(text, article.tags.contributors)</span>
+                        <span class="content__headline--byline-interview">@ContributorLinks(text, article.tags.contributors)</span>
                     }
                 }
             </div>
@@ -61,7 +61,7 @@
 
                 @if(article.tags.isInterview) {
                     @article.trail.byline.map { text =>
-                        <span class="content__headline--byline-interview">By @ContributorLinks(text, article.tags.contributors)</span>
+                        <span class="content__headline--byline-interview">@ContributorLinks(text, article.tags.contributors)</span>
                     }
                 }
                 @if(article.content.hasTonalHeaderIllustration) {


### PR DESCRIPTION
## What does this change?

Remove the fragment "By" from the byline on interview pages.

## Screenshots

**Before**

![screen shot 2018-06-27 at 15 21 57](https://user-images.githubusercontent.com/6035518/41980238-e4e9f9d8-7a1d-11e8-8b4a-e867c6051322.png)

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
