### PR TITLE
Put back trouble viewing on email fronts

### DIFF
--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -3,7 +3,6 @@
 @import fragments.email._
 @import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
-@import model.PressedPage
 
 
 <table class="ft">
@@ -16,16 +15,7 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    @page match {
-                                        case _: PressedPage => {
-                                            <a href="%%unsub_center_url%%">Unsubscribe</a>
-                                        }
-                                        case _ => {
-                                            <a href="%%unsub_center_url%%">Unsubscribe</a> |
-                                            <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
-                                        }
-                                    }
-
+                                    <a href="%%unsub_center_url%%">Unsubscribe</a>
                                 </td>
                             </tr>
                             <tr>

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -15,7 +15,8 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    <a href="%%unsub_center_url%%">Unsubscribe</a>
+                                    <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                    <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
## What does this change?

Put back trouble viewing on email fronts

## What is the value of this and can you measure success?

It's been decided that it's preferable to view the front (which changes daily) rather than nothing at all.

### Tested

- [x] Locally


<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
