### PR TITLE
DFP Epic test - V3

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -108,11 +108,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-epic-native-vs-dfp-v2",
+    "ab-acquisitions-epic-native-vs-dfp-v3",
     "See if there is any difference in annualised value between serving the Epic natively vs DFP",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 7, 4),
+    sellByDate = new LocalDate(2018, 7, 11),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot-utils.js
+++ b/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot-utils.js
@@ -43,10 +43,10 @@ const renderEpicSlot = (epicSlot: HTMLDivElement): Promise<EpicComponent> => {
         componentEvent: {
             component: {
                 componentType: 'ACQUISITIONS_EPIC',
-                id: 'gdnwb_copts_memco_epic_native_vs_dfp_v2_dfp',
+                id: 'gdnwb_copts_memco_epic_native_vs_dfp_v3_dfp',
             },
             abTest: {
-                name: 'AcquisitionsEpicNativeVsDfpV2',
+                name: 'AcquisitionsEpicNativeVsDfpV3',
                 variant: 'dfp',
             },
         },

--- a/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/epic/dfp-epic-slot.js
@@ -7,7 +7,7 @@ import {
     displayControlEpic,
     trackEpic,
 } from 'common/modules/commercial/epic-utils';
-import { dfpVariant } from 'common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v2';
+import { dfpVariant } from 'common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3';
 
 const shouldDisplayDFPEpic = (): boolean => {
     const tests = getActiveTests();
@@ -23,7 +23,7 @@ const shouldDisplayDFPEpic = (): boolean => {
 
 export const initDFPEpicSlot = (): void => {
     if (shouldDisplayDFPEpic()) {
-        displayDFPEpic(2000)
+        displayDFPEpic(4000)
             .catch(() => displayControlEpic(dfpVariant))
             .then(trackEpic);
     }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -15,7 +15,7 @@ import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/
 import { acquisitionsEpicAusEnvCampaign } from 'common/modules/experiments/tests/acquisitions-epic-aus-env-campaign';
 import { acquisitionsEpicAlwaysAskAprilStory } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-april-story';
 import { AcquisitionsEpicBorderThankyou } from 'common/modules/experiments/tests/acquisitions-epic-border-thankyou';
-import { acquisitionsEpicNativeVsDfpV2 } from 'common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v2';
+import { acquisitionsEpicNativeVsDfpV3 } from 'common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3';
 import { acquisitionsEpicFromGoogleDocOneVariant } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-one-variant';
 import { acquisitionsEpicFromGoogleDocTwoVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-two-variants';
 import { acquisitionsEpicFromGoogleDocThreeVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-three-variants';
@@ -46,7 +46,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    acquisitionsEpicNativeVsDfpV2,
+    acquisitionsEpicNativeVsDfpV3,
     acquisitionsEpicFromGoogleDocOneVariant,
     acquisitionsEpicFromGoogleDocTwoVariants,
     acquisitionsEpicFromGoogleDocThreeVariants,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
@@ -11,7 +11,7 @@ import {
 
 import type { ABTestVariant } from 'common/modules/commercial/acquisitions-ophan';
 
-const testName = 'AcquisitionsEpicNativeVsDfpV2';
+const testName = 'AcquisitionsEpicNativeVsDfpV3';
 
 const variantOptions = {
     maxViews: defaultMaxViews,
@@ -22,11 +22,11 @@ const dfpVariant: ABTestVariant = {
     variant: 'dfp',
 };
 
-const epicNativeVsDfpV2: ABTest = {
+const epicNativeVsDfpV3: ABTest = {
     id: testName,
-    campaignId: 'epic_native_vs_dfp_v2',
-    start: '2018-06-20',
-    expiry: '2018-07-04',
+    campaignId: 'epic_native_vs_dfp_v3',
+    start: '2018-06-27',
+    expiry: '2018-07-11',
     author: 'Guy Dawson',
     description:
         'See if there is any difference in annualised value between serving the Epic natively vs DFP',
@@ -57,6 +57,6 @@ const epicNativeVsDfpV2: ABTest = {
     ],
 };
 
-const acquisitionsEpicNativeVsDfpV2 = ((epicNativeVsDfpV2: any): AcquisitionsABTest);
+const acquisitionsEpicNativeVsDfpV3 = ((epicNativeVsDfpV3: any): AcquisitionsABTest);
 
-export { dfpVariant, acquisitionsEpicNativeVsDfpV2 };
+export { dfpVariant, acquisitionsEpicNativeVsDfpV3 };


### PR DESCRIPTION
## What does this change?

The DFP Epic load timeout. In the DFP variant, with a timeout of 2 seconds, only 20% of Epics were being served via DFP. This pull request looks to increase this percentage by increasing the timeout.

Corresponding line item named `contributions/test:AcquisitionsEpicNativeVsDfpV3/variant:dfp`.

## What is the value of this and can you measure success?

Continue to investigate whether DFP is a viable solution for serving the Epic.

### Tested

- [x] Locally
- [ ] On CODE (optional)
