### PR TITLE
Extend commercial-client-logging switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,7 +19,7 @@ object CommercialClientLogging extends Experiment(
   name = "commercial-client-logging",
   description = "A slice of the audience who will post their commercial js performance data",
   owners = Owner.group(SwitchGroup.Commercial),
-  sellByDate = new LocalDate(2018, 6, 29),
+  sellByDate = new LocalDate(2018, 8, 1),
   participationGroup = Perc1A
 )
 


### PR DESCRIPTION
Until we have considered how to use the results.

/cc @guardian/commercial-dev 