### PR TITLE
Add a new #noadsaf for perf testing ad-free

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -26,6 +26,7 @@ class CommercialFeatures {
     constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests
         const noadsUrl = window.location.hash.match(/[#&]noads(&.*)?$/);
+        const forceAdFree = window.location.hash.match(/[#&]noadsaf(&.*)?$/);
         const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
         const sensitiveContent =
             config.page.shouldHideAdverts ||
@@ -55,7 +56,7 @@ class CommercialFeatures {
         this.adFree =
             switches.commercial &&
             switches.adFreeSubscriptionTrial &&
-            isAdFreeUser();
+            (!!forceAdFree || isAdFreeUser());
 
         this.dfpAdvertising =
             switches.commercial && externalAdvertising && !sensitiveContent;

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -108,6 +108,14 @@ describe('Commercial features', () => {
             const features = new CommercialFeatures();
             expect(features.dfpAdvertising).toBe(false);
         });
+
+        it('Is enabled for speedcurve tests of ad-free mode', () => {
+            config.switches.adFreeSubscriptionTrial = true;
+            window.location.hash = '#noadsaf';
+            const features = new CommercialFeatures();
+            expect(features.dfpAdvertising).toBe(true);
+            expect(features.adFree).toBe(true);
+        });
     });
 
     describe('Article body adverts', () => {


### PR DESCRIPTION
## What does this change?
We want to be able to objectively measure the performance of ad-free mode, as a distinctly different feature compared to the existing #noads tests we currently have.

## Screenshots
N/A

## What is the value of this and can you measure success?
Measurement and monitoring of performance

## Checklist

### Does this affect other platforms?

- [x] NO 
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [ ] No
- [x] Yes (please give details)
It enables ad-free mode in which, as per the current specification of that feature, links to paid content pages are removed but the pages themselves will still be available (from deep links, search etc.)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
