### PR TITLE
title special case for theobserver sectionid

### DIFF
--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -33,10 +33,16 @@ object Title {
     s"${title.trim} | The Guardian"
   }
 
+  private def titleFromSectionId(sectionId: String): String = sectionId.toLowerCase match {
+    case "theobserver" => "The Observer"
+    case _ => sectionId
+  }
+
   private def getSectionConsideringWebtitle(webTitle: String, section: Option[String]): String =
     section.filter(_.nonEmpty)
       .filterNot(_.toLowerCase == webTitle.toLowerCase)
       .filterNot(SectionsToIgnore.contains)
+      .map(titleFromSectionId)
       .fold("") { s => s" | ${s.capitalize}"}
 
   private def pagination(page: Page) = page.metadata.pagination.filterNot(_.isFirstPage).map{ pagination =>


### PR DESCRIPTION
## What does this change?

Changes the page title from `Opinion | Theobserver | The Guardian` to `Opinion | The Observer | The Guardian`

It seems strange that the Title.scala uses section ids to derive page titles. This PR implements the least invasive change. It would be preferable if the webTitle from capi included the section title.

## What is the value of this and can you measure success?

Improved page titles for pages within `theobserver` section

### Tested

- [x] Locally


