### PR TITLE
Move gallery disclaimer to first image caption.

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -70,7 +70,7 @@
 
             <div class="gallery__figcaption">
                 @image.caption.map { caption =>
-                    <div class="gallery__caption" itemprop="caption">@GalleryCaptionCleaners(page, caption, rowInfo.isLast)</div>
+                    <div class="gallery__caption" itemprop="caption">@GalleryCaptionCleaners(page, caption, rowInfo.rowNum == 1)</div>
                 }
                 @if(image.displayCredit) {
                     @image.credit.map { credit =>

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -30,7 +30,7 @@ object IndexCleaner {
 }
 
 object GalleryCaptionCleaners {
-  def apply(page: GalleryPage, caption: String, isLastRow: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
+  def apply(page: GalleryPage, caption: String, isFirstRow: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val cleaners = List(
       GalleryCaptionCleaner,
       AffiliateLinksCleaner(
@@ -38,7 +38,7 @@ object GalleryCaptionCleaners {
         page.gallery.content.metadata.sectionId,
         page.gallery.content.fields.showAffiliateLinks,
         "gallery",
-        appendDisclaimer = Some(isLastRow && page.item.lightbox.containsAffiliateableLinks)))
+        appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks)))
 
     val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(caption)) { case (html, cleaner) => cleaner.clean(html) }
     Html(cleanedHtml.toString)

--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -12,7 +12,7 @@
 }
 
 @galleryDisclaimer() = {
-    <br><em>Please note: This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
+    <br><em>This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
         makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
         <br>
         The links are powered by Skimlinks. By clicking on an affiliate link, you accept that Skimlinks cookies will be set.


### PR DESCRIPTION
Having moved this, I've been asked to move it back. Tested locally