### PR TITLE
Safeframe ab Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -165,4 +165,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 6, 5),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-prebid-safeframe",
+    "Test the impact of serving prebid ads in safeframes",
+    owners = Seq(Owner.withGithub("jeteve")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -1,6 +1,9 @@
 // @flow
 
 import config from 'lib/config';
+
+import { getTestVariantId } from 'common/modules/experiments/utils.js';
+
 import {
     buildAppNexusTargeting,
     buildPageTargeting,
@@ -214,12 +217,19 @@ const getXaxisPlacementId = (sizes: PrebidSize[]): number => {
 
 const sonobiBidder: PrebidBidder = {
     name: 'sonobi',
-    bidParams: (slotId: string): PrebidSonobiParams => ({
-        ad_unit: config.page.adUnit,
-        dom_id: slotId,
-        appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
-        pageViewId: config.ophan.pageViewId,
-    }),
+    bidParams: (slotId: string): PrebidSonobiParams =>
+        Object.assign(
+            {},
+            {
+                ad_unit: config.page.adUnit,
+                dom_id: slotId,
+                appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
+                pageViewId: config.ophan.pageViewId,
+            },
+            getTestVariantId('CommercialPrebidSafeframe') === 'variant'
+                ? { render: 'safeframe' }
+                : {}
+        ),
 };
 
 const trustXBidder: PrebidBidder = {

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -7,6 +7,7 @@ export type PrebidSonobiParams = {
     dom_id: string,
     appNexusTargeting: string,
     pageViewId: string,
+    render?: string,
 };
 
 export type PrebidIndexExchangeParams = {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,12 +3,14 @@ import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import { PoliticsWeeklyTreat } from 'common/modules/experiments/tests/politics-weekly-treat';
+import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { newSignInExperiment } from './tests/new-sign-in-experiment';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     newSignInExperiment,
     PoliticsWeeklyTreat,
+    commercialPrebidSafeframe,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-safeframe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-safeframe.js
@@ -16,16 +16,11 @@ export const commercialPrebidSafeframe: ABTest = {
     variants: [
         {
             id: 'control',
-            test: (): void => {
-                console.log('In control');
-            },
+            test: (): void => {},
         },
         {
             id: 'variant',
-            test: (): void => {
-                console.log('In variant');
-                // TODO insert code that sends render=safeframe to sonobi prebid
-            },
+            test: (): void => {},
         },
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-safeframe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-safeframe.js
@@ -1,0 +1,31 @@
+// @flow
+
+export const commercialPrebidSafeframe: ABTest = {
+    id: 'CommercialPrebidSafeframe',
+    start: '2018-06-29',
+    expiry: '2019-09-30',
+    author: 'Jerome Eteve',
+    description: 'This test will serve prebid ads via safeframe line items',
+    audience: 0.01,
+    audienceOffset: 0,
+    successMeasure: 'Measurement of prebid ads yield',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'No difference between safeframe and standard',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {
+                console.log('In control');
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {
+                console.log('In variant');
+                // TODO insert code that sends render=safeframe to sonobi prebid
+            },
+        },
+    ],
+};


### PR DESCRIPTION
This implements https://trello.com/c/eY1QyceQ by adding a prebid safeframe AB test with one variant on 1% of the audience and changing the sonobi params accordingly.