### PR TITLE
NHS badge logic

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -41,3 +41,11 @@
         float: none;
     }
 }
+
+// NHS at 70 is a typographic logo so we don't want repetition of the words
+a[href^='https://www.theguardian.com/society/series/nhs-at-70'] {
+    &.content__series-label__link,
+    .fc-container__title__text {
+        display: none;
+    }
+}

--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -46,12 +46,24 @@
 a[href^='https://www.theguardian.com/society/series/nhs-at-70'] {
     &.content__series-label__link,
     .fc-container__title__text {
-        display: none;
+        @include mq(desktop) {
+            display: none;
+        }
     }
 
     & > .badge-slot__img {
+        @include mq($until: desktop) {
+            display: none;
+        }
+
         @include mq($until: leftCol) {
             max-width: gs-span(1);
+        }
+    }
+
+    .fc-container__header__title & .badge-slot {
+        @include mq($until: desktop) {
+            display: none;
         }
     }
 }

--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -48,4 +48,10 @@ a[href^='https://www.theguardian.com/society/series/nhs-at-70'] {
     .fc-container__title__text {
         display: none;
     }
+
+    & > .badge-slot__img {
+        @include mq($until: leftCol) {
+            max-width: gs-span(1);
+        }
+    }
 }


### PR DESCRIPTION
Nhs badge being a widescreen typographic badge has introduced a whole new world of problems. Essentially badging is not robust enough to deal with how varied our badges have become. Next week we will look at standardising them. 