### PR TITLE
Remove testimonial from control epic and add 5-variant test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -158,6 +158,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-epic-from-google-doc-five-variants",
+    "Serves an epic with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 5),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-engagement-banner-styling-tweaks",
     "Test the impact of some banner styling tweaks",
     owners = Seq(Owner.withGithub("joelochlann")),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -20,7 +20,6 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { noop } from 'lib/noop';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
-import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/templates/acquisitions-epic-testimonial-block';
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'common/modules/commercial/user-features';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic-utils';
@@ -51,9 +50,6 @@ const controlTemplate: EpicTemplate = (
 ) =>
     acquisitionsEpicControlTemplate({
         copy,
-        testimonialBlock: copy.testimonial
-            ? acquisitionsTestimonialBlockTemplate(copy.testimonial)
-            : '',
         componentName: options.componentName,
         buttonTemplate: options.buttonTemplate({
             supportUrl: options.supportURL,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -20,6 +20,7 @@ import { acquisitionsEpicFromGoogleDocOneVariant } from 'common/modules/experime
 import { acquisitionsEpicFromGoogleDocTwoVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-two-variants';
 import { acquisitionsEpicFromGoogleDocThreeVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-three-variants';
 import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-four-variants';
+import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -51,6 +52,7 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicFromGoogleDocTwoVariants,
     acquisitionsEpicFromGoogleDocThreeVariants,
     acquisitionsEpicFromGoogleDocFourVariants,
+    acquisitionsEpicFromGoogleDocFiveVariants,
     acquisitionsEpicAlwaysAskAprilStory,
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants.js
@@ -1,0 +1,34 @@
+// @flow
+import {
+    makeABTest,
+    makeGoogleDocEpicVariants,
+} from 'common/modules/commercial/contributions-utilities';
+
+const abTestName = 'AcquisitionsEpicFromGoogleDocFiveVariants';
+
+export const acquisitionsEpicFromGoogleDocFiveVariants: EpicABTest = makeABTest(
+    {
+        id: abTestName,
+        campaignId: abTestName,
+
+        start: '2018-04-17',
+        expiry: '2019-06-05',
+
+        author: 'Joseph Smith',
+        description: 'Test copy fetched from a Google Doc',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Alternative copy makes more money than the control',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        variants: [
+            {
+                id: 'control',
+                products: [],
+            },
+            ...makeGoogleDocEpicVariants(5),
+        ],
+    }
+);


### PR DESCRIPTION
## Changes

- Remove testimonial from control epic. A recent test showed no significant difference from removing it, and we want to free up space for other experiments
- Allow a 5-variant test with the Google Docs mechanism

## Screenshot: new control (sans testimonial)

![picture 226](https://user-images.githubusercontent.com/5122968/42100977-a302a0b8-7bb9-11e8-9daa-b582b39e014e.png)
