### PR TITLE
Log out the url of renderable articles

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -119,7 +119,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     case article: ArticlePage =>
 
       RenderingTierPicker.getRenderTierFor(page) match {
-        case RemoteRender => log.logger.info("This was a remotely renderable article")
+        case RemoteRender => log.logger.info(s"Remotely renderable article $path")
         case _ =>
       }
 


### PR DESCRIPTION
## What does this change?

I incorrectly assumed that log messages from the article controller were automatically given the path as a parameter in kibana but they are not so I'm just modifying to log message. There's probably a way to pass it as a proper log param but I'm short on time and this is going to be removed this afternoon anyway!

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
