### PR TITLE
Use margin-left to avoid horizontal scroll

### DIFF
--- a/static/src/stylesheets/module/site-messages/_support-the-guardian-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_support-the-guardian-banner.scss
@@ -76,11 +76,11 @@
     position: relative;
 
     @include mq(leftCol) {
-        left: gs-span(2) + $gs-gutter;
+        margin-left: gs-span(2) + $gs-gutter;
     }
 
     @include mq(wide) {
-        left: gs-span(3) + $gs-gutter;
+        margin-left: gs-span(3) + $gs-gutter;
     }
 }
 


### PR DESCRIPTION
#19901 introduced a horizontal scroll from the `leftCol` breakpoint, because of the use of `position: relative` with `left` which shifted the container off the edge of the screen.

Using `margin-left` instead fixes the problem (`position: relative` is still needed because of `position: absolute` children)
