### PR TITLE
Wrap interview header negative bottom margin in supports grid

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -697,7 +697,9 @@ $quote-mark: 35px;
     .content__headline-showcase-wrapper {
         .content__header {
             @include mq($from: desktop) {
-                margin-bottom: calc(-#{$gs-baseline} * 7 - 2px);
+                @supports (display: grid) {
+                    margin-bottom: calc(-#{$gs-baseline} * 7 - 2px);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this change?
Removes the negative bottom margin for interview headlines where grid is not supported.

## Screenshots
![image](https://user-images.githubusercontent.com/2670496/42161090-7b9ac50c-7df1-11e8-8c2d-797ba4f6f642.png)
🔜
![image](https://user-images.githubusercontent.com/2670496/42161130-981d15d6-7df1-11e8-9858-b8fba05e916a.png)

## What is the value of this and can you measure success?
🐞Bugfix.🐛

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Accessibility test checklist

No a11y impacting changes.

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
