### PR TITLE
Fix flow server issues on teamcity by forcing a restart

### DIFF
--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -11,6 +11,24 @@ set -x
 
 echo "Asset compilation"
 
+cd static/src/javascripts
+
+set +x
+echo "Moved to flow root directory $PWD"
+set -x
+
+$(npm bin)/flow stop
+
+set +x
+echo "Stopped flow server"
+set -x
+
+cd -
+
+set +x
+echo "Returned to directory $PWD"
+set -x
+
 set +x
 echo "##teamcity[progressStart 'asset validation and tests']"
 set -x
@@ -26,4 +44,8 @@ set -x
 
 set +x
 echo "##teamcity[progressFinish 'asset dist']"
+set -x
+
+set +x
+echo "Exit "
 set -x


### PR DESCRIPTION
## What does this change?

A recent upgrade of our `flow` dependencies caused issues on Teamcity with the `flow` server hanging. This change stops `flow` server on Teamcity, meaning the next time `flow` runs on a Teamcity agent it will restart the server afresh.

It revives the unmerged changes from this PR https://github.com/guardian/frontend/pull/17796