### PR TITLE
dont auto focus search

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -5,13 +5,6 @@ import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 import config from 'lib/config';
 
-const focusSearchField = (): void => {
-    const $input = $('input.gsc-input');
-    if ($input.length > 0) {
-        $input.focus();
-    }
-};
-
 // TODO refactor to singleton
 class Search {
     gcsUrl: string;
@@ -115,7 +108,6 @@ class Search {
                                     this.load(popup);
 
                                     // Make sure search is always in the correct state
-                                    focusSearchField();
                                     e.preventDefault();
                                 });
                             });
@@ -139,12 +131,6 @@ class Search {
             }))
             .then(els => {
                 const { allSearchPlaceholders, searchPlaceholder } = els;
-
-                // Set so Google know what to do
-                // eslint-disable-next-line no-underscore-dangle
-                window.__gcse = {
-                    callback: focusSearchField,
-                };
 
                 if (!searchPlaceholder) {
                     return;

--- a/static/src/stylesheets/module/_search.scss
+++ b/static/src/stylesheets/module/_search.scss
@@ -42,7 +42,7 @@ span.gscb_a {
 }
 td.gsc-search-button {
     margin: 0 !important;
-    padding: 0 0 0 0 !important;
+    padding: 0 !important;
 }
 .gsc-search-button-v2 {
     border-radius: 0 !important;

--- a/static/src/stylesheets/module/_search.scss
+++ b/static/src/stylesheets/module/_search.scss
@@ -42,7 +42,7 @@ span.gscb_a {
 }
 td.gsc-search-button {
     margin: 0 !important;
-    padding: 5px 0 0 !important;
+    padding: 0 0 0 0 !important;
 }
 .gsc-search-button-v2 {
     border-radius: 0 !important;


### PR DESCRIPTION
## What does this change?
No longer auto focuses the search box's input field, to ensure the google custom search branding is shown- and fixes the padding.
## Screenshots
![image](https://user-images.githubusercontent.com/2670496/42170238-e17a3fe4-7e0d-11e8-8021-7fb0886e3c24.png)
![image](https://user-images.githubusercontent.com/2670496/42170259-f30b9622-7e0d-11e8-890e-d210d9dee6e1.png)

## What is the value of this and can you measure success?
🐝bugfix🐞
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard]*(https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

* This introduces one more interaction to use the custom search in chrome. I couldn't use custom search with the keyboard only in firefox at all.

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
