### PR TITLE
Reversed order of labels

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -21,36 +21,16 @@
                 </a>
             </div>
         }
-
-        @if(item.content.isPaidContent && item.content.isImmersive) {
-          <div class="content__section-label--advertisement">
-              <a class="content__section-label__link content__section-label__link--advertisement" href="@LinkTo {/@item.content.sectionLabelLink}">
-                  @Html(Localisation(item.content.sectionLabelName))
-              </a>
-          </div>
-        } else {
-            @if(!(item.content.isImmersive && item.content.tags.isArticle || item.content.isColumn)) {
-              <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">
-                  <a class="content__section-label__link"
-                      data-link-name="article section"
-                      href="@LinkTo {/@item.content.sectionLabelLink}">
-                      <span class="label__link-wrapper">
-                          @Html(Localisation(item.content.sectionLabelName))
-                      </span>
-                  </a>
-              </div>
-          }
-        }
     }
 
     @item.content.blogOrSeriesTag.map { series =>
         <div class="@RenderClasses(Map(
-                "content__series-label--immersive-article" -> (item.content.isImmersive && item.content.tags.isArticle),
+                "content__series-label--immersive-article content__label" -> (item.content.isImmersive && item.content.tags.isArticle),
                 "content__series-label--photo-essay" -> item.content.isPhotoEssay,
                 "content__series-label--column" -> item.content.isColumn
-            ), "content__series-label")
+            ), "content__series-label content__label")
           ">
-            <a class="content__series-label__link" href="@LinkTo {/@series.id}">
+            <a class="content__label__link" href="@LinkTo {/@series.id}">
                 <span class="label__link-wrapper">
                     @series.name
                 </span>
@@ -71,9 +51,31 @@
         }
     }.getOrElse {
         @if(item.content.isFromTheObserver && !item.content.isImmersive) {
-            <div class="content__series-label">
-                <a class="content__series-label__link" href="https://www.theguardian.com/observer">The Observer</a>
+            <div class="content__series-label content__label">
+                <a class="content__label__link" href="https://www.theguardian.com/observer">The Observer</a>
             </div>
+        }
+    }
+
+    @if(!amp) {
+        @if(item.content.isPaidContent && item.content.isImmersive) {
+          <div class="content__section-label--advertisement">
+              <a class="content__label__link content__section-label__link--advertisement" href="@LinkTo {/@item.content.sectionLabelLink}">
+                  @Html(Localisation(item.content.sectionLabelName))
+              </a>
+          </div>
+        } else {
+            @if(!(item.content.isImmersive && item.content.tags.isArticle || item.content.isColumn)) {
+              <div class="content__section-label content__label @if(item.content.tags.isGallery) { content__section-label--gallery }">
+                  <a class="content__label__link"
+                      data-link-name="article section"
+                      href="@LinkTo {/@item.content.sectionLabelLink}">
+                      <span class="label__link-wrapper">
+                          @Html(Localisation(item.content.sectionLabelName))
+                      </span>
+                  </a>
+              </div>
+          }
         }
     }
 </div>

--- a/static/src/stylesheets/amp/_article-tones.scss
+++ b/static/src/stylesheets/amp/_article-tones.scss
@@ -6,7 +6,7 @@
     .tone-colour,
     a.tone-colour,
     .submeta a,
-    .content__series-label__link {
+    .content__label__link {
         color: $dark;
     }
 
@@ -37,7 +37,7 @@
     a.tone-colour,
     .submeta a,
     a.u-underline,
-    .content__series-label__link {
+    .content__label__link {
         color: $bright;
     }
 
@@ -92,7 +92,7 @@
     @include PillarColourOne($story-package-garnett, $story-package-garnett);
     background-color: #eff1f2;
 
-    .content__series-label__link {
+    .content__label__link {
         background-color: $news-garnett-highlight;
         padding: ($gs-baseline / 4) ($gs-gutter / 4);
     }

--- a/static/src/stylesheets/amp/_fonts.scss
+++ b/static/src/stylesheets/amp/_fonts.scss
@@ -48,7 +48,7 @@
 
 .guardian-egyptian-loaded {
     .byline,
-    .content__section-label__link,
+    .content__label__link,
     .fc-item__header,
     .fc-container__header__title,
     .control__info,

--- a/static/src/stylesheets/inline/article-photo-essay-garnett.scss
+++ b/static/src/stylesheets/inline/article-photo-essay-garnett.scss
@@ -197,7 +197,7 @@
     }
 }
 
-.content__series-label--photo-essay .content__series-label__link {
+.content__series-label--photo-essay .content__label__link {
     color: #ffffff;
 }
 

--- a/static/src/stylesheets/module/content-garnett/_article-column.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-column.scss
@@ -149,14 +149,14 @@
     .content__series-label--column {
         font-size: 20px;
 
-        .content__series-label__link {
+        .content__label__link {
             color: #ffffff;
             font-weight: 700;
         }
     }
 
     &.content--pillar-special-report {
-        .content__series-label__link {
+        .content__label__link {
             color: $news-garnett-highlight;
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -345,7 +345,7 @@
     /* Header
     ========================================================================== */
 
-    .content__series-label__link {
+    .content__label__link {
         color: #ffffff;
     }
 
@@ -371,7 +371,7 @@
         margin: 0;
         padding-top: $gs-baseline / 2;
 
-        .content__section-label__link--advertisement {
+        .content__label__link {
             color: $paid-article-brand;
         }
     }
@@ -621,17 +621,8 @@
             }
         }
 
-        .content__series-label {
-            display: inline;
-        }
-
-        .content__series-label__link {
+        .content__label__link {
             color: #ffffff;
-            font-weight: 700;
-
-            @include mq(desktop) {
-                font-size: 20px;
-            }
         }
         .content__main-column {
             &::before {

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -8,6 +8,10 @@
     .content__series-label .content__label__link {
         box-shadow: -3px 0 0 0 $news-garnett-highlight, 3px 0 0 0 $news-garnett-highlight;
 
+        @include mq(leftCol) {
+            line-height: 24px;
+        }
+
         .label__link-wrapper {
             background: $news-garnett-highlight;
             position: relative;

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -5,19 +5,12 @@
         background-color: $news-garnett-highlight;
     }
 
-    .content__series-label__link,
-    .content__section-label__link {
+    .content__series-label .content__label__link {
         box-shadow: -3px 0 0 0 $news-garnett-highlight, 3px 0 0 0 $news-garnett-highlight;
-    }
 
-    .label__link-wrapper {
-        background: $news-garnett-highlight;
-        position: relative;
-    }
-
-    .content__series-label {
-        @include mq(leftCol) {
-            margin-top: -2px;
+        .label__link-wrapper {
+            background: $news-garnett-highlight;
+            position: relative;
         }
     }
 
@@ -39,7 +32,7 @@
     .content__labels {
         background-color: $news-garnett-highlight;
 
-        .content__series-label__link {
+        .content__label__link {
             color: $garnett-neutral-1;
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -190,7 +190,7 @@
 }
 
 .content__label {
-    @include fs-header(2);
+    @include fs-header(1);
     display: inline;
     padding-right: $gs-gutter / 3;
 
@@ -513,11 +513,8 @@
     border-top: 0;
     color: $garnett-neutral-1;
     font-style: italic;
-    line-height: 20px;
     min-height: 0;
-    margin-top: -$gs-baseline/4;
-    // magic numbers are correcting line heights so vertical alignment appears even
-    padding-top: 4px;
+    margin-bottom: $gs-baseline / 3;
     font-weight: normal;
     width: 100%;
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -149,7 +149,7 @@
 
 .content__labels {
     box-sizing: border-box;
-    padding: $gs-baseline/2 0 0;
+    padding: ($gs-baseline / 2 + $gs-baseline / 4) 0 0;
     position: relative;
     z-index: 1; // bring-to-front fix to make it clickable
     overflow: hidden;
@@ -192,19 +192,27 @@
 .content__label {
     @include fs-header(2);
     display: inline;
-    padding-right: $gs-gutter/3;
+    padding-right: $gs-gutter / 3;
 
     @include mq(leftCol) {
         @include fs-header(4);
-        line-height: get-line-height(header, 2);
+        line-height: 20px;
         padding-right: 0;
     }
 }
 
 .content__label ~ .content__label {
-    @include fs-header(1);
-    display: block;
     font-weight: normal;
+
+    @include mq(leftCol) {
+        font-size: 16px;
+        line-height: 18px;
+        display: block;
+    }
+
+    @include mq($until: tablet) {
+        display: none;
+    }
 }
 
 @include mq(leftCol, wide) {
@@ -501,26 +509,25 @@
 }
 
 .byline {
-    @include fs-bodyHeading(2);
-    margin-bottom: 0;
-    display: inline-block;
-    padding-top: $gs-baseline/3;
+    @include fs-header(1);
+    border-top: 0;
+    color: $garnett-neutral-1;
+    font-style: italic;
     line-height: 20px;
-    color: $neutral-2;
+    min-height: 0;
+    margin-top: -$gs-baseline/4;
+    // magic numbers are correcting line heights so vertical alignment appears even
+    padding-top: 4px;
+    font-weight: normal;
+    width: 100%;
 
-    @include mq(tablet) {
-        line-height: 22px;
+    @include mq($until: phablet) {
+        border-top: 0;
     }
 
-    @include mq(leftCol) {
-        clear: both;
-        margin-right: 0;
-        display: block;
-        border-top: 1px dotted $neutral-5;
-        box-sizing: border-box;
-        padding-top: $gs-baseline/6;
-        padding-bottom: $gs-baseline;
-        min-height: $gs-baseline*4;
+    span[itemprop='author'] {
+        font-weight: 700;
+        font-style: normal;
     }
 
     .content__meta-container--twitter &,

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -189,7 +189,7 @@
     }
 }
 
-.content__section-label {
+.content__label {
     @include fs-header(2);
     display: inline;
     padding-right: $gs-gutter/3;
@@ -199,34 +199,12 @@
         line-height: get-line-height(header, 2);
         padding-right: 0;
     }
-
-    .content--interactive & {
-        padding-right: $gs-gutter/3 !important;
-    }
 }
 
-.content__series-label {
-    display: inline;
-    font-family: $f-serif-headline;
-    font-size: 16px;
-    line-height: 19px;
-
-    @include mq($until: tablet) {
-        font-weight: 800;
-    }
-
-    @include mq(tablet) {
-        display: inline;
-    }
-
-    @include mq(leftCol) {
-        @include fs-headline(2);
-        display: block;
-    }
-}
-
-.content__series-label__link {
-    color: $neutral-2;
+.content__label ~ .content__label {
+    display: block;
+    @include fs-header(1);
+    font-weight: normal;
 }
 
 @include mq(leftCol, wide) {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -202,8 +202,8 @@
 }
 
 .content__label ~ .content__label {
-    display: block;
     @include fs-header(1);
+    display: block;
     font-weight: normal;
 }
 

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -48,7 +48,7 @@
 }
 
 .content__labels--paidgallery {
-    .content__section-label__link {
+    .content__series-label {
         color: $paid-article-brand;
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -25,7 +25,7 @@
 
     .byline,
     .content--media .content__headline,
-    .content__section-label__link,
+    .content__label__link,
     .old-article-message,
     .pullquote-cite,
     a {
@@ -262,7 +262,7 @@
     }
 }
 @mixin mediaPalatte($mediaColor, $pillar) {
-    .content__section-label__link,
+    .content__label__link,
     .youtube-media-atom__bottom-bar__duration {
         color: $mediaColor;
     }
@@ -286,7 +286,7 @@
         fill: $garnett-neutral-4;
     }
 
-    a.content__series-label__link {
+    a.content__label__link {
         color: $garnett-neutral-3;
     }
 
@@ -486,6 +486,6 @@
     }
 }
 
-.immersive-main-media__headline-container .content__series-label__link {
+.immersive-main-media__headline-container .content__label__link {
     color: $garnett-neutral-3;
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -672,8 +672,7 @@ $quote-mark: 35px;
 // *************** Matchreport overrides ****************
 .content--has-scores {
     .content__labels {
-        .content__series-label__link,
-        .content__section-label__link {
+        .content__label__link {
             @include mq(leftCol) {
                 color: $neutral-1;
             }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -102,14 +102,6 @@ $quote-mark: 35px;
         }
     }
 
-    .byline {
-        padding-top: 0;
-        padding-bottom: $gs-baseline*1.5;
-        @include mq($until: phablet) {
-            border-top: 0;
-        }
-    }
-
     .content__meta-container .byline-img {
         max-width: gs-span(1);
         float: left;
@@ -126,26 +118,6 @@ $quote-mark: 35px;
         @include mq(leftCol) {
             margin-top: $gs-baseline/2;
             max-width: none;
-        }
-    }
-
-    .byline {
-        @include fs-bodyCopy(2);
-        border-top: 0;
-        color: $garnett-neutral-1;
-        font-style: italic;
-        line-height: 20px;
-        min-height: 0;
-        margin-top: -$gs-baseline/4;
-        // magic numbers are correcting line heights so vertical alignment appears even
-        padding-top: 4px;
-        font-weight: normal;
-        width: 100%;
-        margin-bottom: -14px;
-
-        span[itemprop='author'] {
-            font-weight: 700;
-            font-style: normal;
         }
     }
 
@@ -995,12 +967,6 @@ $quote-mark: 35px;
         &:hover {
             border-color: $garnett-neutral-4;
         }
-    }
-
-    .byline,
-    .byline span {
-        @include fs-bodyCopy(2);
-        font-style: normal;
     }
 
     .meta__extras,

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -853,7 +853,7 @@ $pillars: (
             background: darken(map-get($palette, pillarColor), 5);
         }
 
-        .content__section-label__link[href] {
+        .content__label__link[href] {
             color: map-get($palette, kickerColor);
         }
 
@@ -875,11 +875,8 @@ $pillars: (
         .content__labels {
             border-bottom-color: $neutral-5;
         }
-        .content__section-label__link {
+        .content__label__link {
             color: $sport-garnett-feature;
-        }
-        .content__series-label__link {
-            color: $sport-garnett-main-1;
         }
         .content__headline {
             color: $garnett-neutral-1;
@@ -899,7 +896,7 @@ $pillars: (
     .content__head,
     .content__standfirst,
     .content__standfirst a[href],
-    .content__series-label__link[href] {
+    .content__label__link[href] {
         color: #ffffff;
     }
 
@@ -956,12 +953,8 @@ $pillars: (
             color: $garnett-neutral-1;
         }
 
-        .content__section-label__link {
+        .content__label__link {
             color: map-get($palette, altKickerColor);
-        }
-
-        .content__series-label__link {
-            color: $garnett-neutral-6;
         }
 
         .content__header {
@@ -996,8 +989,7 @@ $pillars: (
     }
 
     .content__labels {
-        .content__section-label__link,
-        .content__series-label__link {
+        .content__label__link {
             color: $neutral-1;
         }
     }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -230,7 +230,7 @@
     /* Header
     ========================================================================== */
 
-    .content__series-label__link {
+    .content__label__link {
         color: #ffffff;
     }
 
@@ -256,7 +256,7 @@
         margin: 0;
         padding-top: $gs-baseline / 2;
 
-        .content__section-label__link--advertisement {
+        .content__label__link {
             color: $paid-article-brand;
         }
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -200,7 +200,7 @@
     font-weight: bold;
 }
 
-.content__series-label__link {
+.content__label__link {
     color: $neutral-2;
 }
 
@@ -798,7 +798,7 @@
         @include f-textSans;
         font-weight: 400;
 
-        .content__section-label__link {
+        .content__label__link {
             color: $neutral-1;
         }
     }
@@ -845,7 +845,7 @@
         .meta__numbers .sharecount__heading,
         .meta__numbers .commentcount2__heading,
         .content__dateline,
-        .content__series-label__link {
+        .content__label__link {
             color: $neutral-2-contrasted;
         }
 

--- a/static/src/stylesheets/module/content/_gallery.head.scss
+++ b/static/src/stylesheets/module/content/_gallery.head.scss
@@ -51,7 +51,7 @@
 }
 
 .content__labels--paidgallery {
-    .content__section-label__link {
+    .content__label__link {
         color: $paid-article-brand;
     }
 }


### PR DESCRIPTION
Switched the order of the series label and the section label, as it's currently inconsistent. As we hide the section label at mobile, I interpret that as meaning the series label is more useful contextually. Also, the section label can often be a repetition of what sits in the secondary nav:

![screen shot 2018-07-02 at 10 24 09](https://user-images.githubusercontent.com/14570016/42170600-e6f7906a-7e0e-11e8-8a6a-284f02f91a81.png)


- If there's no series label then the section label displays large
- Byline font brought in-line with secondary nav and section label to reduce the array of font-sizes and typefaces in this area.
- Series and section label the same font-size at tablet breakpoints - looks neater than pixel differences
- More typographic consistency at mobile breakpoints also
