### PR TITLE
Rename test container id

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/football-weekly-treat-vs-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/football-weekly-treat-vs-container.js
@@ -23,7 +23,7 @@ const getHeadlineText = (el: Element): string =>
 
 const runTreatTest = (): void => {
     // Get the headline from podcast container and insert the test treat
-    const podcastContainer = document.getElementById('world-cup-daily-podcast');
+    const podcastContainer = document.getElementById('podcast');
     const headlinesContainer = document.getElementById('headlines');
 
     if (headlinesContainer && podcastContainer) {
@@ -77,7 +77,7 @@ const runTreatTest = (): void => {
 
 const runContainerTest = (): void => {
     // Find existing container and replace its body with test design
-    const podcastContainer = document.getElementById('world-cup-daily-podcast');
+    const podcastContainer = document.getElementById('podcast');
     const headlinesContainer = document.getElementById('headlines');
 
     if (headlinesContainer && podcastContainer) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/football-weekly-treat-vs-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/football-weekly-treat-vs-container.js
@@ -23,7 +23,7 @@ const getHeadlineText = (el: Element): string =>
 
 const runTreatTest = (): void => {
     // Get the headline from podcast container and insert the test treat
-    const podcastContainer = document.getElementById('world-cup-daily');
+    const podcastContainer = document.getElementById('world-cup-daily-podcast');
     const headlinesContainer = document.getElementById('headlines');
 
     if (headlinesContainer && podcastContainer) {
@@ -77,7 +77,7 @@ const runTreatTest = (): void => {
 
 const runContainerTest = (): void => {
     // Find existing container and replace its body with test design
-    const podcastContainer = document.getElementById('world-cup-daily');
+    const podcastContainer = document.getElementById('world-cup-daily-podcast');
     const headlinesContainer = document.getElementById('headlines');
 
     if (headlinesContainer && podcastContainer) {

--- a/static/src/stylesheets/module/journalism/_football-weekly-container.scss
+++ b/static/src/stylesheets/module/journalism/_football-weekly-container.scss
@@ -1,4 +1,4 @@
-#world-cup-daily-podcast.football-weekly-container__visible {
+#podcast.football-weekly-container__visible {
     display: block;
 }
 

--- a/static/src/stylesheets/module/journalism/_football-weekly-container.scss
+++ b/static/src/stylesheets/module/journalism/_football-weekly-container.scss
@@ -1,4 +1,4 @@
-#world-cup-daily.football-weekly-container__visible {
+#world-cup-daily-podcast.football-weekly-container__visible {
     display: block;
 }
 

--- a/static/src/stylesheets/module/journalism/_football-weekly-hidden-container.scss
+++ b/static/src/stylesheets/module/journalism/_football-weekly-hidden-container.scss
@@ -1,3 +1,3 @@
-#world-cup-daily {
+#world-cup-daily-podcast {
     display: none;
 }

--- a/static/src/stylesheets/module/journalism/_football-weekly-hidden-container.scss
+++ b/static/src/stylesheets/module/journalism/_football-weekly-hidden-container.scss
@@ -1,3 +1,3 @@
-#world-cup-daily-podcast {
+.facia-page #podcast {
     display: none;
 }


### PR DESCRIPTION
Allows the title of the test container to be changed - see https://github.com/guardian/frontend/pull/19937 for details
The title determines the id of the container element

Tested in CODE