### PR TITLE
Change name of switch

### DIFF
--- a/commercial/app/controllers/PageViewAnalyticsController.scala
+++ b/commercial/app/controllers/PageViewAnalyticsController.scala
@@ -13,7 +13,7 @@ class PageViewAnalyticsController(val controllerComponents: ControllerComponents
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
 
   def insert(): Action[Map[String, Seq[String]]] = Action(parse.formUrlEncoded) { implicit request =>
-    val stream = Analytics.storeJsonBody(Switches.pageViewAnalytics, pageViewAnalyticsStream, log) _
+    val stream = Analytics.storeJsonBody(Switches.commercialPageViewAnalytics, pageViewAnalyticsStream, log) _
 
     request.body.keys.headOption map { analytics =>
       stream(analytics)

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -417,9 +417,9 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val pageViewAnalytics: Switch = Switch(
+  val commercialPageViewAnalytics: Switch = Switch(
     group = Commercial,
-    name = "page-view-analytics",
+    name = "commercial-page-view-analytics",
     description = "Gather commercial analytics from page views",
     owners = group(Commercial),
     safeState = Off,

--- a/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
@@ -18,7 +18,10 @@ declare type ConsentPayload = {
 const shouldTrack = (): boolean => {
     // gather analytics from 0.1% (1 in 1000) of page views
     const inSample = getRandomIntInclusive(1, 1000) === 1;
-    return config.switches.pageViewAnalytics && (inSample || config.page.isDev);
+    return (
+        config.switches.commercialPageViewAnalytics &&
+        (inSample || config.page.isDev)
+    );
 };
 
 const buildPayload = (


### PR DESCRIPTION
To make its purpose clearer.

At the moment it appears to be for any page-view analytics, but it's specifically for commercial data.