### PR TITLE
Added padding to labels with badge

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -207,6 +207,7 @@
     @include mq(leftCol) {
         font-size: 16px;
         line-height: 18px;
+        margin-bottom: $gs-baseline;
         display: block;
     }
 


### PR DESCRIPTION
Added a bit of much-needed padding beneath labels for when there's a badge. 

# Before
<img width="520" alt="screen shot 2018-07-03 at 11 43 13" src="https://user-images.githubusercontent.com/14570016/42215516-9cece896-7eb6-11e8-9746-b4bbf3bacd46.png">

# After
<img width="572" alt="screen shot 2018-07-03 at 11 43 31" src="https://user-images.githubusercontent.com/14570016/42215520-a0c47844-7eb6-11e8-9e55-db31b5840e84.png">
