### PR TITLE
AUDIO A/B Test: Fix visualisation bug, add new data events

### DIFF
--- a/static/src/javascripts/projects/common/modules/audio/index.js
+++ b/static/src/javascripts/projects/common/modules/audio/index.js
@@ -5,8 +5,8 @@ import {
     React,
     render,
 } from '@guardian/dotcom-rendering/packages/guui';
-import ophan from 'ophan/ng';
 import Player from './AudioPlayer';
+import { sendToOphan } from './utils';
 
 type Props = {
     source: string,
@@ -32,15 +32,6 @@ class AudioContainer extends Component<Props, *> {
     }
 }
 
-const sendToOphan = id => {
-    ophan.record({
-        audio: {
-            id,
-            eventType: 'audio:content:ready',
-        },
-    });
-};
-
 const getPillar = pillarClass => {
     const pillarMatches = /pillar-([a-z]+)/g.exec(pillarClass);
     const pillar = pillarMatches ? pillarMatches[1].toLowerCase() : 'news';
@@ -63,7 +54,7 @@ const init = (): void => {
         const downloadUrl = placeholder.dataset.downloadUrl;
         const iTunesUrl = placeholder.dataset.itunesUrl;
 
-        sendToOphan(mediaId);
+        sendToOphan(mediaId, 'ready');
 
         const pillarClassName = Array.from(article.classList).filter(x =>
             x.includes('pillar')

--- a/static/src/javascripts/projects/common/modules/audio/utils.js
+++ b/static/src/javascripts/projects/common/modules/audio/utils.js
@@ -1,6 +1,8 @@
 // @flow
 // eslint disable:no-use-before-define
 
+import ophan from 'ophan/ng';
+
 const format = (t: number) => t.toFixed(0).padStart(2, '0');
 
 const formatTime = (t: number) => {
@@ -22,4 +24,25 @@ const range = (min: number, max: number) => {
     return ret;
 };
 
-export { format, formatTime, range };
+const sendToOphan = (id: string, eventName: string) => {
+    ophan.record({
+        audio: {
+            id,
+            eventType: `audio:content:${eventName}`,
+        },
+    });
+};
+
+const checkForTimeEvents = (id: string, percent: number) => {
+    if (percent === 25) {
+        sendToOphan(id, '25');
+    } else if (percent === 50) {
+        sendToOphan(id, '50');
+    } else if (percent === 75) {
+        sendToOphan(id, '75');
+    } else if (percent === 100) {
+        sendToOphan(id, 'end');
+    }
+};
+
+export { format, formatTime, range, sendToOphan, checkForTimeEvents };


### PR DESCRIPTION
## What does this change?

1) A bug in the visualisation of the Audio Player stopped the audio data being directed back to the users' speakers - resulting in the audio not being played. This line fixes that:
```
      this.analyser.connect(this.context.destination);
```

2) This adds 4 new data events for Ophan: 25% played, 50% played, 75% played & `end`. 

NB: audio files will still not play until Acast changes the headers on their audio files to allow Cross Origin access. 

## What is the value of this and can you measure success?
Parity with data collection on old player 

Audio should actually work 

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
