### PR TITLE
Fix an ad comments bug when users are signed in

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -51,8 +51,7 @@ export const initCommentAdverts = (): ?boolean => {
                 .read(() => $commentMainColumn.dim().height)
                 .then((mainColHeight: number) => {
                     if (
-                        mainColHeight >= 800 ||
-                        (isUserLoggedIn() && mainColHeight >= 300)
+                        mainColHeight >= 800
                     ) {
                         insertCommentAd($commentMainColumn);
                     } else {

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -7,7 +7,6 @@ import { addSlot } from 'commercial/modules/dfp/add-slot';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import type bonzo from 'bonzo';
-import { isUserLoggedIn } from 'common/modules/identity/api';
 
 export const initCommentAdverts = (): ?boolean => {
     const $adSlotContainer: bonzo = $('.js-discussion__ad-slot');
@@ -50,9 +49,7 @@ export const initCommentAdverts = (): ?boolean => {
             fastdom
                 .read(() => $commentMainColumn.dim().height)
                 .then((mainColHeight: number) => {
-                    if (
-                        mainColHeight >= 800
-                    ) {
+                    if (mainColHeight >= 800) {
                         insertCommentAd($commentMainColumn);
                     } else {
                         mediator.once(


### PR DESCRIPTION
## What does this change?
A small fix so that when a user is signed in they no longer see issues with the comments ad slot.

## What is the value of this and can you measure success?
When a user is signed in they will no longer automatically see an MPU, only if they click on the more comments button. Better user experience.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
