### PR TITLE
World cup daily container test - make entire container clickable

### DIFF
--- a/static/src/javascripts/projects/journalism/views/footballWeeklyContainer.html
+++ b/static/src/javascripts/projects/journalism/views/footballWeeklyContainer.html
@@ -22,6 +22,9 @@
                         <%= waveTiny %>
                     </div>
                 </div>
+                <a class="u-faux-block-link__overlay js-headline-text" href="<%= url %>" data-link-name="article" tabindex="-1" aria-hidden="true">
+                    <%= headline %>
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Currently only the headline is clickable
[Original PR](https://github.com/guardian/frontend/pull/19937)

Tested in CODE