### PR TITLE
Implement known issues display on the feedback page

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -142,6 +142,7 @@ class GuardianConfiguration extends Logging {
 
   object feedback {
     lazy val feedpipeEndpoint = configuration.getMandatoryStringProperty("feedback.feedpipeEndpoint")
+    lazy val feedbackHelpConfig = configuration.getMandatoryStringProperty("feedback.helpconfig")
   }
 
   object rendering {

--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -6,7 +6,7 @@ import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, MetaData, NoCache, SectionId}
 import play.api.data.Form
 import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import play.api.mvc._
 import play.api.libs.ws._
 import play.api.data.Forms._
 
@@ -70,7 +70,7 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
           val jsConfig: JsValue = Json.parse(resp.body)
           val alerts: List[String] = (jsConfig \ "alerts").get.as[List[String]]
 
-          Cached(900)(RevalidatableResult.Ok(views.html.feedback(
+          Cached(60)(RevalidatableResult.Ok(views.html.feedback(
             page,
             path,
             Option(alerts)))
@@ -79,7 +79,7 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
       })).getOrElse(
 
         Future.successful(
-          Cached(900)(RevalidatableResult.Ok(views.html.feedback(
+          Cached(60)(RevalidatableResult.Ok(views.html.feedback(
             page,
             path,
             Option.empty

--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.lang.Throwable
+
 import common._
 import conf.Configuration
 import model.Cached.RevalidatableResult
@@ -76,8 +78,9 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
 
         }) recover {
 
-        case _ =>
-          this.logException(new Exception("Failed to get known issues for user feedback"))
+        case t: Throwable =>
+
+          this.logException(new Exception("Failed to get known issues for user feedback", t))
           Cached(60)(RevalidatableResult.Ok(views.html.feedback(
             page,
             path,

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, path: String, alerts: Option[List[String]])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, path: String, alerts: List[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 
@@ -19,10 +19,10 @@
                             <div class="from-content-api" itemprop="articleBody">
                                 <div class="from-content-api">
 
-                                    @if(alerts.getOrElse(List()).nonEmpty){
+                                    @if(alerts.nonEmpty) {
                                         <div class="feedback__alertbox">
                                             <h2><span class="feedback__exclamation">!</span>Known Issues</h2>
-                                            @for(alert <- alerts.get){
+                                            @for(alert <- alerts) {
                                                 <p class="feedback__alert">@alert</p>
                                             }
                                         </div>

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -19,10 +19,10 @@
                             <div class="from-content-api" itemprop="articleBody">
                                 <div class="from-content-api">
 
-                                    @if(alerts.nonEmpty){
+                                    @if(alerts.getOrElse(List()).nonEmpty){
                                         <div class="feedback__alertbox">
                                             <h2><span class="feedback__exclamation">!</span>Known Issues</h2>
-                                            @for(alert <- alerts){
+                                            @for(alert <- alerts.get){
                                                 <p class="feedback__alert">@alert</p>
                                             }
                                         </div>
@@ -88,16 +88,13 @@
 
                                     <p id="feedback__explainer"></p>
 
-                                </form>
+                                </div>
+
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div class="facia-container facia-container--layout-content">
-        @fragments.mostPopularPlaceholder("/")
         </div>
     </div>
 }

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, path: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, path: String, alerts: Option[List[String]])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 
@@ -18,6 +18,15 @@
                         <div class="js-article__container u-cf">
                             <div class="from-content-api" itemprop="articleBody">
                                 <div class="from-content-api">
+
+                                    @if(alerts.nonEmpty){
+                                        <div class="feedback__alertbox">
+                                            <h2><span class="feedback__exclamation">!</span>Known Issues</h2>
+                                            @for(alert <- alerts){
+                                                <p class="feedback__alert">@alert</p>
+                                            }
+                                        </div>
+                                    }
 
                                     <h2>Contact us</h2>
 

--- a/static/src/stylesheets/module/onward-garnett/_feedback.scss
+++ b/static/src/stylesheets/module/onward-garnett/_feedback.scss
@@ -59,7 +59,7 @@
 
 .feedback__exclamation {
     margin-right: .5em;
-    border: 1px solid #ffe0e0;
+    border: 2px solid #ffe0e0;
     border-radius: 99px;
     width: 1.5em;
     text-align: center;

--- a/static/src/stylesheets/module/onward-garnett/_feedback.scss
+++ b/static/src/stylesheets/module/onward-garnett/_feedback.scss
@@ -50,9 +50,9 @@
 
 .feedback__alertbox {
     background-color: $news-garnett-main-1;
-    color: white;
+    color: #ffffff;
     font-size: 1.2em;
-    padding: 0.5em;
+    padding: .5em;
     line-height: 1.7em;
     margin-bottom: 2em;
 }
@@ -72,7 +72,7 @@
 .feedback__alert {
     margin-top: 1em;
     border-top: solid 1px #f97070;
-    padding-top: 0.5em;
+    padding-top: .5em;
 }
 
 .feedback__entry--mandatory-failed {

--- a/static/src/stylesheets/module/onward-garnett/_feedback.scss
+++ b/static/src/stylesheets/module/onward-garnett/_feedback.scss
@@ -49,7 +49,7 @@
 }
 
 .feedback__alertbox {
-    background-color: #ca5353;
+    background-color: $news-garnett-main-1;
     color: white;
     font-size: 1.2em;
     padding: 0.5em;
@@ -62,11 +62,11 @@
     border: 2px solid #ffe0e0;
     border-radius: 99px;
     width: 1.5em;
+    height: 1.5em;
     text-align: center;
     display: inline-block;
     font-weight: bold;
     line-height: 1.7em;
-    height: 1.5em;
 }
 
 .feedback__alert {

--- a/static/src/stylesheets/module/onward-garnett/_feedback.scss
+++ b/static/src/stylesheets/module/onward-garnett/_feedback.scss
@@ -49,7 +49,7 @@
 }
 
 .feedback__alertbox {
-    background-color: $news-garnett-main-1;
+    background-color: $news-main;
     color: #ffffff;
     font-size: 1.2em;
     padding: .5em;

--- a/static/src/stylesheets/module/onward-garnett/_feedback.scss
+++ b/static/src/stylesheets/module/onward-garnett/_feedback.scss
@@ -48,6 +48,33 @@
     width: 80%;
 }
 
+.feedback__alertbox {
+    background-color: #ca5353;
+    color: white;
+    font-size: 1.2em;
+    padding: 0.5em;
+    line-height: 1.7em;
+    margin-bottom: 2em;
+}
+
+.feedback__exclamation {
+    margin-right: .5em;
+    border: 1px solid #ffe0e0;
+    border-radius: 99px;
+    width: 1.5em;
+    text-align: center;
+    display: inline-block;
+    font-weight: bold;
+    line-height: 1.7em;
+    height: 1.5em;
+}
+
+.feedback__alert {
+    margin-top: 1em;
+    border-top: solid 1px #f97070;
+    padding-top: 0.5em;
+}
+
 .feedback__entry--mandatory-failed {
     border-color: $news-main;
 }


### PR DESCRIPTION
## What does this change?

This implements a 'current issues' box at the top of the [feedback page](gu.com/info/tech-feedback). An addition that has been requested by userhelp to reduce the number of incomming emails e.g. when discussion is down.

The data for the known issues box is just a config file in s3. Responsibility for it's population and clearing will be down to the qa team. We have provided a mechanism for populating this data outside of frontend so don't need to worry about that here.

## Screenshots

![image](https://user-images.githubusercontent.com/1218561/42279215-011848f4-7f95-11e8-93ad-9a29ba84d5f7.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
