### PR TITLE
Add Acast switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -473,4 +473,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val Acast = Switch(
+    SwitchGroup.Feature,
+    "acast",
+    "When ON, requests to audio files will be routed to Acast if advertising is enabled",
+    owners = Seq(Owner.withName("journalism team")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -584,8 +584,8 @@ object Audio {
     Audio(contentOverrides)
   }
 
-  def acastUrl(player: AudioPlayer, url: String, isAdFree: Boolean): String = url
-  def acastUrl(url: String, isAdFree: Boolean): String = if (!isAdFree) "https://flex.acast.com/" + url.replace("https://", "") else url
+  def acastUrl(player: AudioPlayer, url: String, isAdFree: Boolean): String = if (player.audio.tags.isPodcast) acastUrl(url, isAdFree) else url
+  def acastUrl(url: String, isAdFree: Boolean): String = if (!isAdFree && conf.switches.Switches.Acast.isSwitchedOn) "https://flex.acast.com/" + url.replace("https://", "") else url
 }
 
 final case class Audio (override val content: Content) extends ContentType {


### PR DESCRIPTION
## What does this change?
Allows us to disable acast (and send requests direct to fastly). This is useful when there is a problem on Acast's side.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
