### PR TITLE
AUDIO AB TEST: Fake audio wave

### DIFF
--- a/static/src/inline-svgs/journalism/audio-player/wave-wide.svg
+++ b/static/src/inline-svgs/journalism/audio-player/wave-wide.svg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="704px" height="42px" viewBox="0 0 704 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>waveform</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="704" height="42"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="OnHover-Volume-control" transform="translate(-359.000000, -436.000000)">
+            <g id="waveform" transform="translate(359.000000, 436.000000)">
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <g id="Mask"></g>
+                <g mask="url(#mask-2)" fill="#999999" fill-rule="nonzero" id="Rectangle-path">
+                    <g transform="translate(-1.000000, 0.000000)">
+                        <rect x="0.996" y="35.914" width="2.249" height="5.621"></rect>
+                        <rect x="4.369" y="20.287" width="2.248" height="21.248"></rect>
+                        <rect x="7.742" y="1.288" width="2.248" height="40.247"></rect>
+                        <rect x="11.114" y="1.963" width="2.249" height="39.572"></rect>
+                        <rect x="14.487" y="2.749" width="2.248" height="38.786"></rect>
+                        <rect x="17.859" y="4.436" width="2.249" height="37.1"></rect>
+                        <rect x="21.232" y="6.347" width="2.248" height="35.188"></rect>
+                        <rect x="24.605" y="8.37" width="2.248" height="33.165"></rect>
+                        <rect x="27.977" y="9.382" width="2.249" height="32.153"></rect>
+                        <rect x="31.35" y="6.685" width="2.248" height="34.851"></rect>
+                        <rect x="34.722" y="7.809" width="2.249" height="33.727"></rect>
+                        <rect x="38.095" y="7.921" width="2.248" height="33.614"></rect>
+                        <rect x="41.469" y="9.72" width="2.248" height="31.815"></rect>
+                        <rect x="44.841" y="11.519" width="2.249" height="30.017"></rect>
+                        <rect x="48.214" y="7.246" width="2.248" height="34.289"></rect>
+                        <rect x="51.586" y="8.596" width="2.249" height="32.939"></rect>
+                        <rect x="54.959" y="6.685" width="2.248" height="34.851"></rect>
+                        <rect x="58.332" y="8.146" width="2.248" height="33.39"></rect>
+                        <rect x="61.704" y="9.607" width="2.249" height="31.928"></rect>
+                        <rect x="65.077" y="11.068" width="2.248" height="30.467"></rect>
+                        <rect x="68.449" y="12.867" width="2.249" height="28.668"></rect>
+                        <rect x="71.822" y="14.441" width="2.248" height="27.094"></rect>
+                        <rect x="75.195" y="16.914" width="2.248" height="24.621"></rect>
+                        <rect x="78.567" y="16.689" width="2.249" height="24.846"></rect>
+                        <rect x="81.94" y="11.743" width="2.248" height="29.792"></rect>
+                        <rect x="85.312" y="12.979" width="2.249" height="28.556"></rect>
+                        <rect x="88.685" y="14.217" width="2.248" height="27.318"></rect>
+                        <rect x="92.058" y="14.778" width="2.248" height="26.757"></rect>
+                        <rect x="95.43" y="15.003" width="2.249" height="26.532"></rect>
+                        <rect x="98.803" y="16.24" width="2.248" height="25.295"></rect>
+                        <rect x="102.177" y="17.477" width="2.248" height="24.059"></rect>
+                        <rect x="105.549" y="18.826" width="2.249" height="22.709"></rect>
+                        <rect x="108.922" y="18.938" width="2.248" height="22.597"></rect>
+                        <rect x="112.294" y="18.488" width="2.249" height="23.047"></rect>
+                        <rect x="115.667" y="19.725" width="2.248" height="21.811"></rect>
+                        <rect x="119.04" y="21.074" width="2.248" height="20.461"></rect>
+                        <rect x="122.412" y="21.974" width="2.249" height="19.562"></rect>
+                        <rect x="125.785" y="9.607" width="2.248" height="31.928"></rect>
+                        <rect x="129.157" y="11.631" width="2.249" height="29.904"></rect>
+                        <rect x="132.53" y="12.192" width="2.248" height="29.343"></rect>
+                        <rect x="135.903" y="11.181" width="2.248" height="30.354"></rect>
+                        <rect x="139.275" y="7.696" width="2.249" height="33.839"></rect>
+                        <rect x="142.648" y="8.708" width="2.248" height="32.827"></rect>
+                        <rect x="146.02" y="9.832" width="2.249" height="31.703"></rect>
+                        <rect x="149.393" y="11.181" width="2.248" height="30.354"></rect>
+                        <rect x="152.766" y="12.643" width="2.248" height="28.893"></rect>
+                        <rect x="156.138" y="13.205" width="2.249" height="28.33"></rect>
+                        <rect x="159.511" y="5.11" width="2.248" height="36.425"></rect>
+                        <rect x="162.884" y="6.01" width="2.249" height="35.525"></rect>
+                        <rect x="166.257" y="5.335" width="2.248" height="36.2"></rect>
+                        <rect x="169.63" y="7.134" width="2.248" height="34.401"></rect>
+                        <rect x="173.002" y="8.37" width="2.249" height="33.165"></rect>
+                        <rect x="176.375" y="10.395" width="2.248" height="31.141"></rect>
+                        <rect x="179.747" y="8.708" width="2.249" height="32.827"></rect>
+                        <rect x="183.12" y="5.11" width="2.248" height="36.425"></rect>
+                        <rect x="186.493" y="4.436" width="2.248" height="37.1"></rect>
+                        <rect x="189.865" y="5.672" width="2.249" height="35.863"></rect>
+                        <rect x="193.238" y="3.648" width="2.248" height="37.887"></rect>
+                        <rect x="196.61" y="4.886" width="2.249" height="36.649"></rect>
+                        <rect x="199.983" y="4.436" width="2.248" height="37.1"></rect>
+                        <rect x="203.356" y="6.01" width="2.248" height="35.525"></rect>
+                        <rect x="206.728" y="7.246" width="2.249" height="34.289"></rect>
+                        <rect x="210.101" y="9.27" width="2.248" height="32.266"></rect>
+                        <rect x="213.474" y="10.619" width="2.248" height="30.916"></rect>
+                        <rect x="216.846" y="13.542" width="2.249" height="27.993"></rect>
+                        <rect x="220.219" y="15.453" width="2.248" height="26.082"></rect>
+                        <rect x="223.592" y="13.767" width="2.249" height="27.769"></rect>
+                        <rect x="226.965" y="6.459" width="2.248" height="35.076"></rect>
+                        <rect x="230.338" y="8.708" width="2.248" height="32.827"></rect>
+                        <rect x="233.71" y="10.507" width="2.249" height="31.028"></rect>
+                        <rect x="237.083" y="11.631" width="2.248" height="29.904"></rect>
+                        <rect x="240.455" y="12.306" width="2.249" height="29.229"></rect>
+                        <rect x="243.828" y="12.755" width="2.248" height="28.78"></rect>
+                        <rect x="247.201" y="14.217" width="2.248" height="27.318"></rect>
+                        <rect x="250.573" y="5.56" width="2.249" height="35.976"></rect>
+                        <rect x="253.946" y="5.897" width="2.248" height="35.638"></rect>
+                        <rect x="257.318" y="7.246" width="2.249" height="34.289"></rect>
+                        <rect x="260.691" y="8.708" width="2.248" height="32.827"></rect>
+                        <rect x="264.064" y="10.281" width="2.248" height="31.254"></rect>
+                        <rect x="267.436" y="9.72" width="2.249" height="31.815"></rect>
+                        <rect x="270.809" y="11.181" width="2.248" height="30.354"></rect>
+                        <rect x="274.181" y="10.731" width="2.249" height="30.804"></rect>
+                        <rect x="277.554" y="11.855" width="2.248" height="29.68"></rect>
+                        <rect x="280.927" y="12.867" width="2.248" height="28.668"></rect>
+                        <rect x="284.3" y="14.217" width="2.249" height="27.318"></rect>
+                        <rect x="287.673" y="15.003" width="2.248" height="26.532"></rect>
+                        <rect x="291.045" y="16.128" width="2.249" height="25.407"></rect>
+                        <rect x="294.418" y="15.565" width="2.248" height="25.97"></rect>
+                        <rect x="297.791" y="14.666" width="2.248" height="26.869"></rect>
+                        <rect x="301.163" y="15.902" width="2.249" height="25.633"></rect>
+                        <rect x="304.536" y="17.14" width="2.248" height="24.396"></rect>
+                        <rect x="307.908" y="18.713" width="2.249" height="22.822"></rect>
+                        <rect x="311.281" y="20.399" width="2.249" height="21.136"></rect>
+                        <rect x="314.654" y="12.979" width="2.248" height="28.556"></rect>
+                        <rect x="318.026" y="14.217" width="2.249" height="27.318"></rect>
+                        <rect x="321.399" y="13.542" width="2.248" height="27.993"></rect>
+                        <rect x="324.772" y="14.778" width="2.248" height="26.757"></rect>
+                        <rect x="328.144" y="16.016" width="2.249" height="25.52"></rect>
+                        <rect x="331.517" y="17.027" width="2.248" height="24.508"></rect>
+                        <rect x="334.889" y="4.323" width="2.249" height="37.212"></rect>
+                        <rect x="338.262" y="7.358" width="2.248" height="34.177"></rect>
+                        <rect x="341.635" y="6.797" width="2.248" height="34.738"></rect>
+                        <rect x="345.008" y="8.258" width="2.249" height="33.277"></rect>
+                        <rect x="348.381" y="9.607" width="2.248" height="31.928"></rect>
+                        <rect x="351.753" y="5.785" width="2.249" height="35.75"></rect>
+                        <rect x="355.126" y="8.033" width="2.248" height="33.502"></rect>
+                        <rect x="358.499" y="10.619" width="2.248" height="30.916"></rect>
+                        <rect x="361.871" y="12.08" width="2.249" height="29.455"></rect>
+                        <rect x="365.244" y="13.542" width="2.248" height="27.993"></rect>
+                        <rect x="368.616" y="14.778" width="2.249" height="26.757"></rect>
+                        <rect x="371.989" y="14.666" width="2.248" height="26.869"></rect>
+                        <rect x="375.362" y="16.353" width="2.248" height="25.183"></rect>
+                        <rect x="378.734" y="16.016" width="2.249" height="25.52"></rect>
+                        <rect x="382.107" y="7.246" width="2.248" height="34.289"></rect>
+                        <rect x="385.479" y="8.033" width="2.249" height="33.502"></rect>
+                        <rect x="388.852" y="9.157" width="2.248" height="32.378"></rect>
+                        <rect x="392.225" y="9.832" width="2.248" height="31.703"></rect>
+                        <rect x="395.597" y="11.519" width="2.249" height="30.017"></rect>
+                        <rect x="398.97" y="11.968" width="2.248" height="29.567"></rect>
+                        <rect x="402.343" y="12.867" width="2.249" height="28.668"></rect>
+                        <rect x="405.716" y="14.329" width="2.248" height="27.206"></rect>
+                        <rect x="409.089" y="13.317" width="2.248" height="28.218"></rect>
+                        <rect x="412.461" y="14.666" width="2.249" height="26.869"></rect>
+                        <rect x="415.834" y="11.406" width="2.248" height="30.129"></rect>
+                        <rect x="419.206" y="12.867" width="2.249" height="28.668"></rect>
+                        <rect x="422.579" y="14.104" width="2.248" height="27.432"></rect>
+                        <rect x="425.952" y="11.406" width="2.248" height="30.129"></rect>
+                        <rect x="429.324" y="12.755" width="2.249" height="28.78"></rect>
+                        <rect x="432.697" y="13.542" width="2.248" height="27.993"></rect>
+                        <rect x="436.069" y="10.169" width="2.249" height="31.366"></rect>
+                        <rect x="439.442" y="11.968" width="2.248" height="29.567"></rect>
+                        <rect x="442.815" y="7.696" width="2.248" height="33.839"></rect>
+                        <rect x="446.187" y="7.358" width="2.249" height="34.177"></rect>
+                        <rect x="449.56" y="8.596" width="2.248" height="32.939"></rect>
+                        <rect x="452.932" y="9.832" width="2.249" height="31.703"></rect>
+                        <rect x="456.305" y="9.944" width="2.248" height="31.591"></rect>
+                        <rect x="459.678" y="5.785" width="2.248" height="35.75"></rect>
+                        <rect x="463.051" y="1.737" width="2.249" height="39.798"></rect>
+                        <rect x="466.424" y="5.223" width="2.248" height="36.312"></rect>
+                        <rect x="469.796" y="6.571" width="2.249" height="34.964"></rect>
+                        <rect x="473.169" y="7.584" width="2.248" height="33.951"></rect>
+                        <rect x="476.542" y="9.607" width="2.248" height="31.928"></rect>
+                        <rect x="479.914" y="1.737" width="2.249" height="39.798"></rect>
+                        <rect x="483.287" y="2.861" width="2.248" height="38.674"></rect>
+                        <rect x="486.659" y="6.347" width="2.249" height="35.188"></rect>
+                        <rect x="490.032" y="8.82" width="2.248" height="32.715"></rect>
+                        <rect x="493.405" y="7.134" width="2.248" height="34.401"></rect>
+                        <rect x="496.777" y="8.82" width="2.249" height="32.715"></rect>
+                        <rect x="500.15" y="9.495" width="2.248" height="32.04"></rect>
+                        <rect x="503.522" y="10.956" width="2.249" height="30.579"></rect>
+                        <rect x="506.895" y="12.08" width="2.248" height="29.455"></rect>
+                        <rect x="510.268" y="13.43" width="2.248" height="28.105"></rect>
+                        <rect x="513.64" y="15.229" width="2.249" height="26.307"></rect>
+                        <rect x="517.013" y="14.329" width="2.248" height="27.206"></rect>
+                        <rect x="520.385" y="13.991" width="2.249" height="27.544"></rect>
+                        <rect x="523.759" y="14.891" width="2.248" height="26.645"></rect>
+                        <rect x="527.132" y="15.116" width="2.248" height="26.419"></rect>
+                        <rect x="530.504" y="4.323" width="2.249" height="37.212"></rect>
+                        <rect x="533.877" y="5.447" width="2.248" height="36.088"></rect>
+                        <rect x="537.249" y="7.471" width="2.249" height="34.064"></rect>
+                        <rect x="540.622" y="8.482" width="2.248" height="33.053"></rect>
+                        <rect x="543.995" y="9.607" width="2.248" height="31.928"></rect>
+                        <rect x="547.367" y="9.27" width="2.249" height="32.266"></rect>
+                        <rect x="550.74" y="2.188" width="2.248" height="39.348"></rect>
+                        <rect x="554.112" y="3.648" width="2.249" height="37.887"></rect>
+                        <rect x="557.485" y="4.886" width="2.248" height="36.649"></rect>
+                        <rect x="560.858" y="7.584" width="2.248" height="33.951"></rect>
+                        <rect x="564.23" y="0.501" width="2.249" height="41.034"></rect>
+                        <rect x="567.603" y="2.975" width="2.248" height="38.561"></rect>
+                        <rect x="570.976" y="3.986" width="2.248" height="37.549"></rect>
+                        <rect x="574.348" y="5.11" width="2.249" height="36.425"></rect>
+                        <rect x="577.721" y="5.672" width="2.248" height="35.863"></rect>
+                        <rect x="581.094" y="3.874" width="2.249" height="37.661"></rect>
+                        <rect x="584.467" y="5.223" width="2.248" height="36.312"></rect>
+                        <rect x="587.84" y="6.347" width="2.248" height="35.188"></rect>
+                        <rect x="591.212" y="8.933" width="2.251" height="32.603"></rect>
+                        <rect x="594.587" y="8.482" width="2.248" height="33.053"></rect>
+                        <rect x="597.959" y="9.72" width="2.249" height="31.815"></rect>
+                        <rect x="601.332" y="12.08" width="2.248" height="29.455"></rect>
+                        <rect x="604.705" y="13.317" width="2.248" height="28.218"></rect>
+                        <rect x="608.077" y="9.944" width="2.249" height="31.591"></rect>
+                        <rect x="611.45" y="11.406" width="2.248" height="30.129"></rect>
+                        <rect x="614.823" y="11.855" width="2.249" height="29.68"></rect>
+                        <rect x="618.196" y="12.867" width="2.248" height="28.668"></rect>
+                        <rect x="621.569" y="14.104" width="2.248" height="27.432"></rect>
+                        <rect x="624.941" y="15.003" width="2.249" height="26.532"></rect>
+                        <rect x="628.314" y="15.229" width="2.248" height="26.307"></rect>
+                        <rect x="631.686" y="16.465" width="2.249" height="25.07"></rect>
+                        <rect x="635.059" y="17.927" width="2.248" height="23.608"></rect>
+                        <rect x="638.432" y="19.051" width="2.248" height="22.484"></rect>
+                        <rect x="641.804" y="20.399" width="2.249" height="21.136"></rect>
+                        <rect x="645.177" y="14.329" width="2.248" height="27.206"></rect>
+                        <rect x="648.55" y="6.347" width="2.248" height="35.188"></rect>
+                        <rect x="651.922" y="7.809" width="2.249" height="33.727"></rect>
+                        <rect x="655.295" y="8.146" width="2.248" height="33.39"></rect>
+                        <rect x="658.667" y="10.169" width="2.249" height="31.366"></rect>
+                        <rect x="662.04" y="11.968" width="2.248" height="29.567"></rect>
+                        <rect x="665.413" y="14.217" width="2.248" height="27.318"></rect>
+                        <rect x="668.785" y="15.678" width="2.249" height="25.857"></rect>
+                        <rect x="672.158" y="15.229" width="2.248" height="26.307"></rect>
+                        <rect x="675.531" y="15.79" width="2.249" height="25.745"></rect>
+                        <rect x="678.904" y="15.565" width="2.248" height="25.97"></rect>
+                        <rect x="682.277" y="17.252" width="2.248" height="24.283"></rect>
+                        <rect x="685.649" y="13.092" width="2.249" height="28.443"></rect>
+                        <rect x="689.022" y="10.507" width="2.248" height="31.028"></rect>
+                        <rect x="692.394" y="11.519" width="2.249" height="30.017"></rect>
+                        <rect x="695.767" y="12.418" width="2.248" height="29.117"></rect>
+                        <rect x="699.14" y="13.767" width="2.248" height="27.769"></rect>
+                        <rect x="702.512" y="16.016" width="2.249" height="25.52"></rect>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## What does this change?

Because of a cross-origin problem with a previous audio visualistation, we are "faking" the audio wave for an AB test. Effectively the svg remains the same for all podcasts, but retains the behaviour of tracking the progress of the playing /seeking. 

* visualisation code removed 
* fake wave svg added 
* play / ff / rw & seek behaviour added to the svg
* some CSS changes to make the svg sit corrrectly 

## Screenshots


### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
