### PR TITLE
Fix yank issue when twitter images resize

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -188,3 +188,8 @@ category: Common
         }
     }
 }
+
+// prevent yank and spacefinder issue when embedded tweets resize
+.tweet-main-image {
+    width: 100%;
+}

--- a/static/src/stylesheets/module/content-garnett/_tweets.scss
+++ b/static/src/stylesheets/module/content-garnett/_tweets.scss
@@ -78,7 +78,6 @@
 }
 
 .tweet-main-image {
-    width: 100%;
     margin-bottom: $gs-gutter;
 }
 

--- a/static/src/stylesheets/module/content/_tweets.scss
+++ b/static/src/stylesheets/module/content/_tweets.scss
@@ -78,7 +78,6 @@
 }
 
 .tweet-main-image {
-    width: 100%;
     margin-bottom: $gs-gutter;
 }
 


### PR DESCRIPTION
## What does this change?
Change the CSS to run with the initial rendering of the page rather than asynchronously. This fixes an issue with spacefinder thinking the image is larger than what it is, causing bugs with overlapping of the most viewed/pop container. 

Example article where issue can occur:
https://www.theguardian.com/technology/2018/jun/27/elon-musk-farting-unicorn-mug-cartoon-tom-edwards

## Screenshots
Before
![picture 16](https://user-images.githubusercontent.com/19835654/42333763-80a8c6e6-8073-11e8-892b-0f404fb4942d.png)

After
![picture 17](https://user-images.githubusercontent.com/19835654/42333762-808fb7f0-8073-11e8-8de5-31b408b2e986.png)

## What is the value of this and can you measure success?
Ensures that spacefinder finds the correct space when the pages is rendered

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
