### PR TITLE
Make captions legible for content--media

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -919,6 +919,9 @@ $quote-mark: 35px;
 .content--media:not(.paid-content) {
     &.content--media {
         background-color: $brightness-7;
+        .caption {
+            color: $brightness-86;
+        }
     }
 
     .content__main {


### PR DESCRIPTION
## What does this change?
Brightens up the colour for captions in content--media.
## Screenshots
![image](https://user-images.githubusercontent.com/2670496/42380622-7743978a-8126-11e8-9fb8-9c554fb45540.png)

![image](https://user-images.githubusercontent.com/2670496/42380526-1fa33af8-8126-11e8-8567-ef94015c4b86.png)

## What is the value of this and can you measure success?
Makes the caption legible.
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
