### PR TITLE
Make hosted videos playable

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -79,11 +79,6 @@
                             }
                         </video>
                     }
-                    @if(page.video.youtubeId.isDefined && !Option(page.video.posterUrl).getOrElse("").isEmpty){
-                        <div class="hosted__youtube-poster-image" style="background-image: url(@page.video.posterUrl);">
-                            <div class="hosted__youtube-play-button"></div>
-                        </div>
-                    }
                     <div class="hosted-fading js-hosted-fading">
                         <div class="hosted__video-overlay"></div>
                         <div class="hosted__meta">


### PR DESCRIPTION
This is a workaround until solution found to problem in Chrome 67.0.3396.99

## What does this change?
Temporarily removes the poster image and custom play button from hosted Youtube videos.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1722550/42381632-97779ab2-8129-11e8-834a-8b484f55c139.png)

After:
![image](https://user-images.githubusercontent.com/1722550/42381594-76d159e2-8129-11e8-90f2-b0f19abec006.png)
