### PR TITLE
Separate mediator and whenRendered events for sticky MPUs, expand tests

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -1,0 +1,62 @@
+// @flow
+import mediator from 'lib/mediator';
+import fastdom from 'lib/fastdom-promise';
+import { addSlot } from 'commercial/modules/dfp/add-slot';
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+
+jest.mock('lib/config', () => ({ page: {}, get: () => false }));
+jest.mock('commercial/modules/dfp/add-slot', () => ({
+    addSlot: jest.fn(),
+}));
+jest.mock('common/modules/commercial/commercial-features', () => ({
+    commercialFeatures: {
+        commentAdverts: true,
+    },
+}));
+
+const commercialFeaturesMock: any = commercialFeatures;
+
+const mockHeight = (height: number) => {
+    jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
+};
+
+describe('Comment Adverts', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        if (document.body) {
+            document.body.innerHTML = `<div class="js-comments">
+            <div class="content__main-column">
+                <div class="js-discussion__ad-slot"></div></div></div>`;
+        }
+    });
+
+    afterEach(() => {
+        if (document.body) {
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('should exist', () => {
+        expect(initCommentAdverts).toBeDefined();
+    });
+
+    it('should return false if commentAdverts are switched off', () => {
+        commercialFeaturesMock.commentAdverts = false;
+        expect(initCommentAdverts()).toBe(false);
+    });
+
+    it('should insert a comment advert when the comments section passes the height threshold', done => {
+        commercialFeaturesMock.commentAdverts = true;
+        mockHeight(800);
+        initCommentAdverts();
+        mediator.emit('modules:comments:renderComments:rendered');
+        mediator.once('page:defaultcommercial:comments', () => {
+            const adSlots = document.querySelectorAll('.js-ad-slot');
+            expect(adSlots.length).toBe(1);
+            expect(addSlot).toHaveBeenCalledTimes(1);
+            done();
+        });
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -29,7 +29,9 @@ const stickyCommentsMpu = (adSlot: HTMLElement) => {
         stickySlot = adSlot;
     }
 
-    const referenceElement: any = document.querySelector('.js-comments');
+    const referenceElement: ?HTMLElement = document.querySelector(
+        '.js-comments'
+    );
 
     if (!referenceElement || !adSlot) {
         return;
@@ -48,16 +50,20 @@ const stickyCommentsMpu = (adSlot: HTMLElement) => {
                 stickyElement.init();
                 register('resize', onResize);
             }
-            mediator.emit('page:commercial:sticky-mpu');
+            mediator.emit('page:commercial:sticky-comments-mpu');
         });
 };
+
+stickyCommentsMpu.whenRendered = new Promise(resolve => {
+    mediator.on('page:commercial:sticky-comments-mpu', resolve);
+});
 
 const stickyMpu = (adSlot: HTMLElement) => {
     if (isStickyMpuSlot(adSlot)) {
         stickySlot = adSlot;
     }
 
-    const referenceElement: any = document.querySelector(
+    const referenceElement: ?HTMLElement = document.querySelector(
         '.js-article__body,.js-liveblog-body-content'
     );
 

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -87,7 +87,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
         .then(() => {
             if (noSticky) {
                 // if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
-                const options = config.page.isPaidContent
+                const options = config.get('page.isPaidContent')
                     ? {
                           top: 43,
                       }

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -1,8 +1,107 @@
 // @flow
-import { stickyMpu } from 'commercial/modules/sticky-mpu';
+import mediator from 'lib/mediator';
+import fastdom from 'lib/fastdom-promise';
+import { stickyMpu, stickyCommentsMpu } from 'commercial/modules/sticky-mpu';
+
+// Workaround to fix issue where dataset is missing from jsdom, and solve the
+// 'cannot set property [...] which has only a getter' TypeError
+Object.defineProperty(HTMLElement.prototype, 'dataset', {
+    writable: true,
+    value: {},
+});
+
+const mockHeight = (height: number) => {
+    jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
+};
 
 describe('Sticky MPU', () => {
+    const domSnippet = `
+        <div class="content__article-body js-article__body"><div>
+    `;
+
+    const adSlotRight: string =
+        '<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        if (document.body) {
+            document.body.innerHTML = `${domSnippet}<div class="ad-slot-container" aria-hidden="true">${adSlotRight}</div>`;
+        }
+    });
+
+    afterEach(() => {
+        if (document.body) {
+            document.body.innerHTML = '';
+        }
+    });
+
     it('should exist', () => {
         expect(stickyMpu).toBeDefined();
+        expect(stickyMpu.whenRendered).toBeDefined();
+    });
+
+    it('should resize the parent container', done => {
+        mockHeight(8000);
+        const targetSlot: HTMLElement = (document.querySelector(
+            '.js-ad-slot'
+        ): any);
+        targetSlot.dataset = {
+            name: targetSlot.getAttribute('data-name') || '',
+        };
+        mediator.once('page:commercial:sticky-mpu', () => {
+            const container: HTMLElement = (document.querySelector(
+                '.ad-slot-container'
+            ): any);
+            expect(container.style.height).toBe('8000px');
+            done();
+        });
+        stickyMpu(targetSlot);
+    });
+});
+
+describe('Sticky Comments MPU', () => {
+    const domSnippet = `
+        <div class="js-comments"><div>
+    `;
+
+    const adSlotComments: string =
+        '<div id="dfp-ad--comments" class="js-ad-slot ad-slot ad-slot--comments" data-name="comments" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        if (document.body) {
+            document.body.innerHTML = `${domSnippet}<div class="ad-slot-container" aria-hidden="true">${adSlotComments}</div>`;
+        }
+    });
+
+    afterEach(() => {
+        if (document.body) {
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('should exist', () => {
+        expect(stickyCommentsMpu).toBeDefined();
+        expect(stickyCommentsMpu.whenRendered).toBeDefined();
+    });
+
+    it('should resize the parent container', done => {
+        mockHeight(10000);
+        const targetSlot: HTMLElement = (document.querySelector(
+            '.js-ad-slot'
+        ): any);
+        targetSlot.dataset = {
+            name: targetSlot.getAttribute('data-name') || '',
+        };
+        mediator.once('page:commercial:sticky-comments-mpu', () => {
+            const container: HTMLElement = (document.querySelector(
+                '.ad-slot-container'
+            ): any);
+            expect(container.style.height).toBe('10000px');
+            done();
+        });
+        stickyCommentsMpu(targetSlot);
     });
 });


### PR DESCRIPTION
## What does this change?

👉 Fire separate mediator events for each type of sticky MPU

👉 Create a whenRendered events for the sticky comments MPU

👉 Expand the test coverage for the sticky MPU module

👉 Switch to using Flow maybe types where possible

## Screenshots

![cathunt](https://user-images.githubusercontent.com/8607683/42387067-2f7c0622-8139-11e8-91c8-eeffa1ef6e9e.gif)

## What is the value of this and can you measure success?

Fighting tech debt and hopefully solving some intermittent bugs along the way! 🌈 🦄 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
