### PR TITLE
Refactor article controller

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 import java.lang.System.currentTimeMillis
 
 import metrics.TimingMetric
-import services.{LocalRender, RemoteRender, RenderType, RenderingTierPicker}
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
@@ -118,11 +117,6 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
     case article: ArticlePage =>
 
-      RenderingTierPicker.getRenderTierFor(page) match {
-        case RemoteRender => log.logger.info(s"Remotely renderable article $path")
-        case _ =>
-      }
-
       val htmlResponse = () => {
         if (request.isEmail) ArticleEmailHtmlPage.html(article)
         else if (request.isAmp) views.html.articleAMP(article)
@@ -142,7 +136,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       Action.async { implicit request =>
 
         def renderWithRange(range: BlockRange) =
-          mapModel(path, range = Some(range), asArticle=false) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
+          mapModel(path, range = Some(range)) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
             render(path, _)
           }
 
@@ -157,7 +151,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     Action.async { implicit request =>
 
       def renderWithRange(range: BlockRange) =
-        mapModel(path, Some(range), asArticle=false) { model =>
+        mapModel(path, Some(range)) { model =>
           range match {
             case SinceBlockId(lastBlockId) => renderNewerUpdates(model, SinceBlockId(lastBlockId), isLivePage)
             case _ => render(path, model)
@@ -167,7 +161,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       lastUpdate.map(ParseBlockId.fromBlockId) match {
         case Some(ParsedBlockId(id)) => renderWithRange(SinceBlockId(id))
         case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-        case None => if (rendered.contains(false)) mapModel(path, Some(Canonical), asArticle=false) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
+        case None => if (rendered.contains(false)) mapModel(path, Some(Canonical)) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
       }
     }
   }
@@ -210,9 +204,9 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   // for the GUUI demo. Same as mapModel except the render method should return a  Future[Result] instead of Result
-  def mapModelGUUI(path: String, range: Option[BlockRange] = None, asArticle: Boolean=true)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
+  def mapModelGUUI(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
 
-    lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range, asArticle)(itemResp)).recover(convertApiExceptions).flatMap {
+    lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range)(itemResp)).recover(convertApiExceptions).flatMap {
       case Left(model) => render(model)
       case Right(other) => Future.successful(RenderOtherStatus(other))
     }
@@ -235,7 +229,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       } else {
 
         timedFuture(
-          mapModel(path, Some(ArticleBlocks)) {
+          mapModel(path, range = if (request.isEmail) Some(ArticleBlocks) else None) {
             render(path, _)
           },
           ArticleRenderingMetrics.LocalRenderingMetric
@@ -248,8 +242,8 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   // range: None means the url didn't include /live/, Some(...) means it did.  Canonical just means no url parameter
   // if we switch to using blocks instead of body for articles, then it no longer needs to be Optional
-  def mapModel(path: String, range: Option[BlockRange] = None, asArticle: Boolean = true)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
-    lookup(path, range) map responseToModelOrResult(range, asArticle) recover convertApiExceptions map {
+  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
+    lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
       case Left(model) => render(model)
       case Right(other) => RenderOtherStatus(other)
     }
@@ -268,8 +262,8 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
       capiItem.showBlocks(blocksParam)
     }.getOrElse(capiItem)
-
     contentApiClient.getResponse(capiItemWithBlocks)
+
   }
 
   /**
@@ -279,7 +273,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     * @param response
    * @return Either[PageWithStoryPackage, Result]
    */
-  def responseToModelOrResult(range: Option[BlockRange], asArticle:Boolean)(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
+  def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
 
     val supportedContent = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult = ModelOrResult(supportedContent, response)
@@ -289,7 +283,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
         // Enable an email format for 'Minute' content (which are actually composed as a LiveBlog), without changing the non-email display of the page
       case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
         Left(MinutePage(liveBlog, StoryPackages(liveBlog, response)))
-      case liveBlog: Article if liveBlog.isLiveBlog && !asArticle =>
+      case liveBlog: Article if liveBlog.isLiveBlog =>
         range.map {
           createLiveBlogModel(liveBlog, response, _)
         }.getOrElse(Right(NotFound))

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -11,7 +11,7 @@ import play.api.mvc._
 import views.support._
 import metrics.TimingMetric
 import renderers.RemoteRender
-import services.LookerUpper
+import services.CAPILookup
 
 import scala.concurrent.Future
 
@@ -19,7 +19,7 @@ case class ArticlePage(article: Article, related: RelatedContent) extends PageWi
 
 class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
-  val lookerUpper: LookerUpper = new LookerUpper(contentApiClient)
+  val lookerUpper: CAPILookup = new CAPILookup(contentApiClient)
   val remoteRender: RemoteRender = new RemoteRender()
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support._
 import metrics.TimingMetric
-
+import services.LookerUpper
 import scala.concurrent.Future
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
@@ -19,17 +19,13 @@ case class MinutePage(article: Article, related: RelatedContent) extends PageWit
 
 class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
+  val lookerUpper: LookerUpper = new LookerUpper(contentApiClient)
+
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Some(Canonical))(render(path, _))
 
-  private def noAMP(renderPage: => Result)(implicit  request: RequestHeader): Result = {
-    if (request.isAmp) NotFound
-    else renderPage
-  }
-
   def renderJson(path: String): Action[AnyContent] = {
-    println("Rendering article json")
     Action.async { implicit request =>
       mapModel(path, if (request.isGuuiJson) Some(ArticleBlocks) else None) {
         render(path, _)
@@ -39,7 +35,6 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      println("Rendering article")
       mapModel(path, range = Some(ArticleBlocks)) {
         render(path, _)
       }
@@ -48,7 +43,6 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   def renderEmail(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      println("Rendering email")
       mapModel(path, range = Some(ArticleBlocks)) {
         render(path, _)
       }
@@ -56,56 +50,23 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader) = page match {
-    case minute: MinutePage =>
-      noAMP {
-        val htmlResponse = () => {
-          if (request.isEmail) ArticleEmailHtmlPage.html(minute)
-          else MinuteHtmlPage.html(minute)
-        }
-
-        val jsonResponse = () => views.html.fragments.minuteBody(minute)
-        renderFormat(htmlResponse, jsonResponse, minute, Switches.all)
-      }
-
     case article: ArticlePage =>
-
       val htmlResponse = () => {
         if (request.isEmail) ArticleEmailHtmlPage.html(article)
         else if (request.isAmp) views.html.articleAMP(article)
         else ArticleHtmlPage.html(article)
       }
-
       // add extra data for *.json?guui endpoint
       val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-
       val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
       renderFormat(htmlResponse, jsonResponse, article)
   }
 
-  // range: None means the url didn't include /live/, Some(...) means it did.  Canonical just means no url parameter
-  // if we switch to using blocks instead of body for articles, then it no longer needs to be Optional
   def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
-    lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
+    lookerUpper.lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
       case Left(model) => render(model)
       case Right(other) => RenderOtherStatus(other)
     }
-  }
-
-  private def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
-    val edition = Edition(request)
-
-    val capiItem = contentApiClient.item(path, edition)
-      .showTags("all")
-      .showFields("all")
-      .showReferences("all")
-      .showAtoms("all")
-
-    val capiItemWithBlocks = range.map { blockRange =>
-      val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
-      capiItem.showBlocks(blocksParam)
-    }.getOrElse(capiItem)
-    contentApiClient.getResponse(capiItemWithBlocks)
-
   }
 
   /**

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -75,6 +75,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
         else ArticleHtmlPage.html(article)
       }
 
+      // add extra data for *.json?guui endpoint
       val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
 
       val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
@@ -130,5 +131,3 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
 }
-
-

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -19,7 +19,7 @@ case class ArticlePage(article: Article, related: RelatedContent) extends PageWi
 
 class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
-  val lookerUpper: CAPILookup = new CAPILookup(contentApiClient)
+  val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
   val remoteRender: RemoteRender = new RemoteRender()
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
@@ -36,15 +36,9 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      if(request.isGuui){
-          mapModel(path, Some(ArticleBlocks)){
-             remoteRender.render(ws, path, _)
-          }
-      } else {
-          mapModel(path, Some(ArticleBlocks)) {
-            render(path, _)
-          }
-      }
+        mapModel(path, Some(ArticleBlocks)) {
+          if(request.isGuui) remoteRender.render(ws, path, _) else render(path, _)
+        }
     }
   }
 
@@ -56,39 +50,39 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     }
   }
 
-  private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = page match {
-    case article: ArticlePage =>
-      val htmlResponse = () => {
-        if (request.isEmail) ArticleEmailHtmlPage.html(article)
-        else if (request.isAmp) views.html.articleAMP(article)
-        else ArticleHtmlPage.html(article)
-      }
-      // add extra data for *.json?guui endpoint
-      val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      Future { renderFormat(htmlResponse, jsonResponse, article) }
-  }
-
-  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
-    lookerUpper.lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range)(itemResp)).recover(convertApiExceptions).flatMap {
-      case Left(model) => render(model)
-      case Right(other) => Future.successful(RenderOtherStatus(other))
+  private def render(path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
+    val htmlResponse = () => {
+      if (request.isEmail) ArticleEmailHtmlPage.html(article)
+      else if (request.isAmp) views.html.articleAMP(article)
+      else ArticleHtmlPage.html(article)
     }
+    // add extra data for *.json?guui endpoint
+    val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+    val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+    Future { renderFormat(htmlResponse, jsonResponse, article) }
   }
 
-  def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
+  def mapModel(path: String, range: Option[BlockRange] = None)(render: ArticlePage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
+    capiLookup
+      .lookup(path, range)
+      .map(responseToModelOrResult)
+      .recover(convertApiExceptions)
+      .flatMap {
+        case Left(model) => render(model)
+        case Right(other) => Future.successful(RenderOtherStatus(other))
+      }
+  }
 
-    val supportedContent = response.content.filter(isSupported).map(Content(_))
-    val supportedContentResult = ModelOrResult(supportedContent, response)
-    val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {
+  def responseToModelOrResult(response: ItemResponse)(implicit request: RequestHeader): Either[ArticlePage, Result] = {
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
+    val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
+    val content: Either[ArticlePage, Result] = supportedContentResult.left.flatMap {
       case article: Article =>
         Left(ArticlePage(article, StoryPackages(article, response)))
       case _ => Right(NotFound)
 
     }
-
     content
-
   }
 
 }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -12,6 +12,7 @@ import metrics.TimingMetric
 import play.libs.Json
 import renderers.RemoteRender
 import services.CAPILookup
+import implicits.{JsonFormat, AmpFormat, HtmlFormat, EmailFormat}
 
 import scala.concurrent.Future
 
@@ -58,10 +59,10 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   private def render(path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       request.getRequestFormat match {
-        case implicits.Json => common.renderJson(getJson(article), article)
-        case implicits.Email => common.renderEmail(ArticleEmailHtmlPage.html(article), article)
-        case implicits.Html => common.renderHtml(ArticleHtmlPage.html(article), article)
-        case implicits.Amp => common.renderHtml(views.html.articleAMP(article), article)
+        case JsonFormat => common.renderJson(getJson(article), article)
+        case EmailFormat => common.renderEmail(ArticleEmailHtmlPage.html(article), article)
+        case HtmlFormat => common.renderHtml(ArticleHtmlPage.html(article), article)
+        case AmpFormat => common.renderHtml(views.html.articleAMP(article), article)
       }
     }
   }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,171 +1,24 @@
 package controllers
 
+import java.lang.System.currentTimeMillis
+
 import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
-import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
-import model.Cached.{WithoutRevalidationResult}
+import model.LiveBlogHelpers._
 import model.{PageWithStoryPackage, _}
-import LiveBlogHelpers._
-import model.liveblog._
-import org.joda.time.DateTime
-import pages.{ArticleEmailHtmlPage, ArticleHtmlPage, LiveBlogHtmlPage, MinuteHtmlPage}
-import play.api.libs.functional.syntax._
-import play.api.libs.json.{Json, _}
+import pages.{ArticleEmailHtmlPage, ArticleHtmlPage, MinuteHtmlPage}
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support._
+import metrics.TimingMetric
 
 import scala.concurrent.Future
-import java.lang.System.currentTimeMillis
-
-import metrics.TimingMetric
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
-
-
-class ArticleControllerNew(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with Logging with ImplicitControllerExecutionContext {
-
-  val mapperer = new CAPILookup(contentApiClient)
-  val renderer = new Renderer()
-
-  // in nearly every case the first thing to do is look up the content in CAPI and then decide from there what to do
-  // with it.
-
-  // live live blog
-
-  def renderLiveBlog(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {
-    throw new Exception("Not supported yet")
-  }
-
-  // liveblog json
-
-  def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
-    throw new Exception("Not supported yet")
-  }
-
-  // article (incl. non-live liveblogs)
-
-  def renderArticle(path: String): Action[AnyContent] = {
-    Action.async { implicit request =>
-      mapperer.mapModel(path, range = Some(ArticleBlocks)) {
-        renderer.render(path, _)
-      }
-    }
-  }
-
-  // article json
-
-  def renderJson(path: String): Action[AnyContent] = {
-    Action.async { implicit request =>
-      mapperer.mapModel(path, if (request.isGuuiJson) Some(ArticleBlocks) else None) {
-        renderer.render(path, _)
-      }
-    }
-  }
-
-}
-
-class Renderer() {
-
-  private def noAMP(renderPage: => Result)(implicit  request: RequestHeader): Result = {
-    if (request.isAmp) NotFound
-    else renderPage
-  }
-
-  def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader): Result = page match {
-
-    case blog: LiveBlogPage =>
-      val htmlResponse = () => {
-        if (request.isAmp) views.html.liveBlogAMP(blog)
-        else LiveBlogHtmlPage.html(blog)
-      }
-      val jsonResponse = () => views.html.liveblog.liveBlogBody(blog)
-      renderFormat(htmlResponse, jsonResponse, blog, Switches.all)
-
-    case minute: MinutePage =>
-      noAMP {
-        val htmlResponse = () => {
-          if (request.isEmail) ArticleEmailHtmlPage.html(minute)
-          else MinuteHtmlPage.html(minute)
-        }
-
-        val jsonResponse = () => views.html.fragments.minuteBody(minute)
-        renderFormat(htmlResponse, jsonResponse, minute, Switches.all)
-      }
-
-    case article: ArticlePage =>
-
-      val htmlResponse = () => {
-        if (request.isEmail) ArticleEmailHtmlPage.html(article)
-        else if (request.isAmp) views.html.articleAMP(article)
-        else ArticleHtmlPage.html(article)
-      }
-
-      val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      renderFormat(htmlResponse, jsonResponse, article)
-  }
-
-}
-
-
-class CAPILookup(contentApiClient: ContentApiClient) {
-
-  private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
-
-  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
-    lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
-      case Left(model) => render(model)
-      case Right(other) => RenderOtherStatus(other)
-    }
-  }
-
-  private def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
-    val edition = Edition(request)
-
-    val capiItem = contentApiClient.item(path, edition)
-      .showTags("all")
-      .showFields("all")
-      .showReferences("all")
-      .showAtoms("all")
-
-    val capiItemWithBlocks = range.map { blockRange =>
-      val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
-      capiItem.showBlocks(blocksParam)
-    }.getOrElse(capiItem)
-
-    contentApiClient.getResponse(capiItemWithBlocks)
-
-  }
-
-  private def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
-
-    val supportedContent = response.content.filter(isSupported).map(Content(_))
-    val supportedContentResult = ModelOrResult(supportedContent, response)
-    val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {
-      case minute: Article if minute.isTheMinute =>
-        Left(MinutePage(minute, StoryPackages(minute, response)))
-      // Enable an email format for 'Minute' content (which are actually composed as a LiveBlog), without changing the non-email display of the page
-      case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
-        Left(MinutePage(liveBlog, StoryPackages(liveBlog, response)))
-      case liveBlog: Article if liveBlog.isLiveBlog =>
-        range.map {
-          createLiveBlogModel(liveBlog, response, _)
-        }.getOrElse(Right(NotFound))
-      case article: Article =>
-        Left(ArticlePage(article, StoryPackages(article, response)))
-    }
-
-    content
-
-  }
-
-}
-
 
 class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController
     with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
@@ -174,75 +27,12 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Some(Canonical))(render(path, _))
 
-
-  private def renderNewerUpdates(page: PageWithStoryPackage, lastUpdateBlockId: SinceBlockId, isLivePage: Option[Boolean])(implicit request: RequestHeader): Result = {
-    val newBlocks = page.article.fields.blocks.toSeq.flatMap {
-      _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
-    }.takeWhile { block =>
-      block.id != lastUpdateBlockId.lastUpdate
-    }
-    val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
-    val timelineHtml = views.html.liveblog.keyEvents("", model.KeyEventData(newBlocks, Edition(request).timezone))
-    val allPagesJson = Seq(
-      "timeline" -> timelineHtml,
-      "numNewBlocks" -> newBlocks.size
-    )
-    val livePageJson = isLivePage.filter(_ == true).map { _ =>
-      "html" -> blocksHtml
-    }
-    val mostRecent = newBlocks.headOption.map { block =>
-      "mostRecentBlockId" -> s"block-${block.id}"
-    }
-    Cached(page)(JsonComponent(allPagesJson ++ livePageJson ++ mostRecent: _*))
-  }
-
-  implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
-  case class TextBlock(
-    id: String,
-    title: Option[String],
-    publishedDateTime: Option[DateTime],
-    lastUpdatedDateTime: Option[DateTime],
-    body: String
-    )
-
-  implicit val blockWrites = (
-    (__ \ "id").write[String] ~
-      (__ \ "title").write[Option[String]] ~
-      (__ \ "publishedDateTime").write[Option[DateTime]] ~
-      (__ \ "lastUpdatedDateTime").write[Option[DateTime]] ~
-      (__ \ "body").write[String]
-    )(unlift(TextBlock.unapply))
-
-  private def blockText(page: PageWithStoryPackage, number: Int)(implicit request: RequestHeader): Result = page match {
-    case LiveBlogPage(liveBlog, _, _) =>
-      val blocks =
-        liveBlog.blocks.toSeq.flatMap { blocks =>
-        blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq.flatMap { bodyBlocks: Seq[BodyBlock] =>
-          bodyBlocks.collect {
-            case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
-              TextBlock(id, title, publishedAt, updatedAt, summary)
-          }
-        }
-      }.take(number)
-      Cached(page)(JsonComponent("blocks" -> Json.toJson(blocks)))
-    case _ => Cached(600)(WithoutRevalidationResult(NotFound("Can only return block text for a live blog")))
-
-  }
-
   private def noAMP(renderPage: => Result)(implicit  request: RequestHeader): Result = {
     if (request.isAmp) NotFound
     else renderPage
   }
 
   private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader) = page match {
-    case blog: LiveBlogPage =>
-      val htmlResponse = () => {
-        if (request.isAmp) views.html.liveBlogAMP(blog)
-        else LiveBlogHtmlPage.html(blog)
-      }
-      val jsonResponse = () => views.html.liveblog.liveBlogBody(blog)
-      renderFormat(htmlResponse, jsonResponse, blog, Switches.all)
-
     case minute: MinutePage =>
       noAMP {
         val htmlResponse = () => {
@@ -266,43 +56,6 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
       val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
       renderFormat(htmlResponse, jsonResponse, article)
-  }
-
-  def renderLiveBlog(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
-    if (format.contains("email"))
-      renderArticle(path)
-    else
-      Action.async { implicit request =>
-
-        def renderWithRange(range: BlockRange) =
-          mapModel(path, range = Some(range)) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
-            render(path, _)
-          }
-
-        page.map(ParseBlockId.fromPageParam) match {
-          case Some(ParsedBlockId(id)) => renderWithRange(PageWithBlock(id)) // we know the id of a block
-          case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-          case None => renderWithRange(Canonical) // no page param
-        }
-      }
-
-  def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
-    Action.async { implicit request =>
-
-      def renderWithRange(range: BlockRange) =
-        mapModel(path, Some(range)) { model =>
-          range match {
-            case SinceBlockId(lastBlockId) => renderNewerUpdates(model, SinceBlockId(lastBlockId), isLivePage)
-            case _ => render(path, model)
-          }
-        }
-
-      lastUpdate.map(ParseBlockId.fromBlockId) match {
-        case Some(ParsedBlockId(id)) => renderWithRange(SinceBlockId(id))
-        case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-        case None => if (rendered.contains(false)) mapModel(path, Some(Canonical)) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
-      }
-    }
   }
 
   def renderJson(path: String): Action[AnyContent] = {
@@ -319,39 +72,16 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       future
   }
 
-  // for the GUUI demo. Same as mapModel except the render method should return a  Future[Result] instead of Result
-  def mapModelGUUI(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
-
-    lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range)(itemResp)).recover(convertApiExceptions).flatMap {
-      case Left(model) => render(model)
-      case Right(other) => Future.successful(RenderOtherStatus(other))
-    }
-
-  }
-
   def renderArticle(path: String): Action[AnyContent] = {
 
     Action.async { implicit request =>
 
-      if(request.isGuui){
-
-        timedFuture(
-          mapModelGUUI(path, Some(ArticleBlocks)){
-            renderers.RemoteRender.remoteRender(ws, path, _)
-          },
-          ArticleRenderingMetrics.RemoteRenderingMetric
-        )
-
-      } else {
-
-        timedFuture(
-          mapModel(path, range = if (request.isEmail) Some(ArticleBlocks) else None) {
-            render(path, _)
-          },
-          ArticleRenderingMetrics.LocalRenderingMetric
-        )
-
-      }
+      timedFuture(
+        mapModel(path, range = if (request.isEmail) Some(ArticleBlocks) else None) {
+          render(path, _)
+        },
+        ArticleRenderingMetrics.LocalRenderingMetric
+      )
 
     }
   }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -2,24 +2,25 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
-import conf.switches.Switches
 import contentapi.ContentApiClient
 import model.{PageWithStoryPackage, _}
-import pages.{ArticleEmailHtmlPage, ArticleHtmlPage, MinuteHtmlPage}
+import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support._
 import metrics.TimingMetric
+import renderers.RemoteRender
 import services.LookerUpper
+
 import scala.concurrent.Future
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
-case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
 class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
   val lookerUpper: LookerUpper = new LookerUpper(contentApiClient)
+  val remoteRender: RemoteRender = new RemoteRender()
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
@@ -35,8 +36,14 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      mapModel(path, range = Some(ArticleBlocks)) {
-        render(path, _)
+      if(request.isGuui){
+          mapModel(path, Some(ArticleBlocks)){
+             remoteRender.render(ws, path, _)
+          }
+      } else {
+          mapModel(path, Some(ArticleBlocks)) {
+            render(path, _)
+          }
       }
     }
   }
@@ -49,7 +56,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     }
   }
 
-  private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader) = page match {
+  private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = page match {
     case article: ArticlePage =>
       val htmlResponse = () => {
         if (request.isEmail) ArticleEmailHtmlPage.html(article)
@@ -59,32 +66,25 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       // add extra data for *.json?guui endpoint
       val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
       val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      renderFormat(htmlResponse, jsonResponse, article)
+      Future { renderFormat(htmlResponse, jsonResponse, article) }
   }
 
-  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
-    lookerUpper.lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
+  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
+    lookerUpper.lookup(path, range).map((itemResp: ItemResponse) => responseToModelOrResult(range)(itemResp)).recover(convertApiExceptions).flatMap {
       case Left(model) => render(model)
-      case Right(other) => RenderOtherStatus(other)
+      case Right(other) => Future.successful(RenderOtherStatus(other))
     }
   }
 
-  /**
-   * convert a response into something we can render, and return it
-   * optionally, throw a response if we know it's not right to send the content
-    *
-    * @param response
-   * @return Either[PageWithStoryPackage, Result]
-   */
   def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
 
     val supportedContent = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult = ModelOrResult(supportedContent, response)
     val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {
-      case minute: Article if minute.isTheMinute =>
-        Left(MinutePage(minute, StoryPackages(minute, response)))
       case article: Article =>
         Left(ArticlePage(article, StoryPackages(article, response)))
+      case _ => Right(NotFound)
+
     }
 
     content

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -16,4 +16,5 @@ trait ArticleControllers {
   lazy val bookSectionAgent: NewspaperBookSectionTagAgent = wire[NewspaperBookSectionTagAgent]
   lazy val publicationController = wire[PublicationController]
   lazy val articleController = wire[ArticleController]
+  lazy val liveBlogController = wire[LiveBlogController]
 }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -13,6 +13,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CAPILookup
 import views.support.RenderOtherStatus
+import implicits.{JsonFormat, AmpFormat, HtmlFormat, EmailFormat}
 
 import scala.concurrent.Future
 
@@ -110,10 +111,10 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
   private def renderMinute(path: String, minute: MinutePage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       request.getRequestFormat match {
-        case implicits.Json => common.renderJson (views.html.fragments.minuteBody(minute), minute)
-        case implicits.Email => common.renderEmail (ArticleEmailHtmlPage.html(minute), minute)
-        case implicits.Html => common.renderHtml (MinuteHtmlPage.html(minute), minute)
-        case implicits.Amp => NotFound
+        case JsonFormat => common.renderJson (views.html.fragments.minuteBody(minute), minute)
+        case EmailFormat => common.renderEmail (ArticleEmailHtmlPage.html(minute), minute)
+        case HtmlFormat => common.renderHtml (MinuteHtmlPage.html(minute), minute)
+        case AmpFormat => NotFound
       }
     }
   }
@@ -121,10 +122,10 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
   private def renderLiveBlog(path: String, blog: LiveBlogPage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       request.getRequestFormat match {
-        case implicits.Json => common.renderJson( views.html.liveblog.liveBlogBody(blog), blog )
-        case implicits.Email => common.renderEmail( LiveBlogHtmlPage.html(blog), blog )
-        case implicits.Html => common.renderHtml( LiveBlogHtmlPage.html(blog), blog )
-        case implicits.Amp => common.renderHtml( views.html.liveBlogAMP(blog), blog )
+        case JsonFormat => common.renderJson( views.html.liveblog.liveBlogBody(blog), blog )
+        case EmailFormat => common.renderEmail( LiveBlogHtmlPage.html(blog), blog )
+        case HtmlFormat => common.renderHtml( LiveBlogHtmlPage.html(blog), blog )
+        case AmpFormat => common.renderHtml( views.html.liveBlogAMP(blog), blog )
       }
     }
   }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -12,7 +12,7 @@ import model.{ApplicationContext, Canonical, _}
 import pages.{ArticleEmailHtmlPage, LiveBlogHtmlPage, MinuteHtmlPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import services.LookerUpper
+import services.CAPILookup
 import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
@@ -21,7 +21,7 @@ case class MinutePage(article: Article, related: RelatedContent) extends PageWit
 
 class LiveBlogController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
-  val lookerUpper: LookerUpper = new LookerUpper(contentApiClient)
+  val lookerUpper: CAPILookup = new CAPILookup(contentApiClient)
 
   // we support liveblogs and also articles, so that minutes work
   private def isSupported(c: ApiContent) = c.isLiveBlog || c.isArticle

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -22,6 +22,9 @@ import scala.concurrent.Future
 import common.RichRequestHeader
 import services.LookerUpper
 
+
+case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
+
 class LiveBlogController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
 
   val lookerUpper: LookerUpper = new LookerUpper(contentApiClient)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -32,7 +32,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
     else renderPage
   }
 
-  def renderLiveBlogEmail(path: String): Action[AnyContent] =
+  def renderEmail(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       println("Rendering live blog email")
       mapModel(path, range = Some(ArticleBlocks)) {
@@ -40,7 +40,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
       }
     }
 
-  def renderLiveBlog(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
+  def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
 
       Action.async { implicit request =>
 
@@ -58,7 +58,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
         }
       }
 
-  def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
+  def renderJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
     Action.async { implicit request =>
 
       println("Rendering live blog json")

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -54,6 +54,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
       mapModel(path, Some(range)) {
         case liveblog: LiveBlogPage if rendered.contains(false) => getJsonForFronts(liveblog)
         case liveblog: LiveBlogPage => getJson(path, liveblog, range, isLivePage)
+        case minute: MinutePage => render(path, minute)
         case _ => Future { Cached(600)(WithoutRevalidationResult(NotFound)) }
       }
 
@@ -67,13 +68,13 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
     }
   }
 
-  private def getJsonForFronts(liveblog: LiveBlogPage): Future[Result] = {
+  private def getJsonForFronts(liveblog: LiveBlogPage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       Cached(liveblog)(JsonComponent("blocks" -> model.LiveBlogHelpers.blockTextJson(liveblog, 6)))
     }
   }
 
-  private def getJson(path: String, liveblog: LiveBlogPage, range: BlockRange, isLivePage: Option[Boolean]): Future[Result] = {
+  private def getJson(path: String, liveblog: PageWithStoryPackage, range: BlockRange, isLivePage: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
     range match {
       case SinceBlockId(lastBlockId) => renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage)
       case _ => render(path, liveblog)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -149,8 +149,6 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
 
   private def responseToModelOrResult(range: Option[BlockRange])(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
 
-    // basically this function serves to narrow the result of ModelOrResult's type
-
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
 

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -103,16 +103,20 @@ object LiveBlogHelpers {
         (__ \ "body").write[String]
       )(unlift(TextBlock.unapply))
 
-    Json.toJson(
-      page.article.blocks.toSeq.flatMap { blocks =>
-        blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq.flatMap { bodyBlocks: Seq[BodyBlock] =>
-          bodyBlocks.collect {
-            case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
-              TextBlock(id, title, publishedAt, updatedAt, summary)
-          }
-        }
-      }.take(number)
-    )
+    val firstPageBlocks = for {
+      blocks <- page.article.blocks.toSeq
+      firstPageBlocks <- blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq
+      firstPageBlock <- firstPageBlocks
+    } yield firstPageBlock
+
+    val textBlocks = firstPageBlocks
+      .take(number)
+      .collect {
+        case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
+          TextBlock(id, title, publishedAt, updatedAt, summary)
+      }
+
+    Json.toJson(textBlocks)
 
   }
 

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -50,7 +50,7 @@ object LiveBlogHelpers {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
-    val liveBlogPageModel =
+    val liveBlogPageModel: Option[LiveBlogCurrentPage] =
       liveBlog.content.fields.blocks.map { blocks =>
         LiveBlogCurrentPage(
           pageSize = pageSize,

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -1,0 +1,43 @@
+package renderers
+
+import common.JsonComponent
+import conf.Configuration
+import controllers.ArticlePage
+import model.Cached.RevalidatableResult
+import model.{Cached, ContentFields, PageWithStoryPackage}
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.mvc.{RequestHeader, Result}
+import scala.concurrent.Future
+import play.twirl.api.Html
+import scala.concurrent.duration._
+import common.RichRequestHeader
+
+object RemoteRender {
+
+  // todo: inject WS
+
+  def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
+    .withRequestTimeout(2000.millis)
+    .addHttpHeaders("Content-Type" -> "application/json")
+    .post(payload)
+    .map((response) =>
+      response.body
+    )
+
+  def remoteRender(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
+
+    case article : ArticlePage =>
+      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+
+      remoteRenderArticle(ws, jsonPayload).map(s => {
+        Cached(article){ RevalidatableResult.Ok(Html(s)) }
+      })
+
+    case _ => throw new Exception("Remote render not supported for this content type")
+
+  }
+
+}

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -8,36 +8,39 @@ import model.{Cached, ContentFields, PageWithStoryPackage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import play.twirl.api.Html
+
 import scala.concurrent.duration._
 import common.RichRequestHeader
+import ExecutionContext.Implicits.global
 
 object RemoteRender {
 
-  // todo: inject WS
-
-  def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
-    .withRequestTimeout(2000.millis)
-    .addHttpHeaders("Content-Type" -> "application/json")
-    .post(payload)
-    .map((response) =>
-      response.body
-    )
-
-  def remoteRender(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
-
-    case article : ArticlePage =>
-      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
-
-      remoteRenderArticle(ws, jsonPayload).map(s => {
-        Cached(article){ RevalidatableResult.Ok(Html(s)) }
-      })
-
-    case _ => throw new Exception("Remote render not supported for this content type")
-
-  }
+//  // todo: inject WS
+//
+//  def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
+//    .withRequestTimeout(2000.millis)
+//    .addHttpHeaders("Content-Type" -> "application/json")
+//    .post(payload)
+//    .map((response) =>
+//      response.body
+//    )
+//
+//  def remoteRender(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
+//
+//    case article : ArticlePage =>
+//      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+//      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+//      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+//
+//      remoteRenderArticle(ws, jsonPayload).map(s => {
+//        Cached(article){ RevalidatableResult.Ok(Html(s)) }
+//      })
+//
+//    case _ => throw new Exception("Remote render not supported for this content type")
+//
+//  }
 
 }

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -4,7 +4,7 @@ import common.JsonComponent
 import conf.Configuration
 import controllers.ArticlePage
 import model.Cached.RevalidatableResult
-import model.{Cached, ContentFields, PageWithStoryPackage}
+import model.{ApplicationContext, Cached, ContentFields, PageWithStoryPackage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
@@ -14,33 +14,32 @@ import play.twirl.api.Html
 
 import scala.concurrent.duration._
 import common.RichRequestHeader
+
 import ExecutionContext.Implicits.global
 
-object RemoteRender {
+class RemoteRender(implicit context: ApplicationContext) {
 
-//  // todo: inject WS
-//
-//  def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
-//    .withRequestTimeout(2000.millis)
-//    .addHttpHeaders("Content-Type" -> "application/json")
-//    .post(payload)
-//    .map((response) =>
-//      response.body
-//    )
-//
-//  def remoteRender(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
-//
-//    case article : ArticlePage =>
-//      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-//      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-//      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
-//
-//      remoteRenderArticle(ws, jsonPayload).map(s => {
-//        Cached(article){ RevalidatableResult.Ok(Html(s)) }
-//      })
-//
-//    case _ => throw new Exception("Remote render not supported for this content type")
-//
-//  }
+  private def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
+    .withRequestTimeout(2000.millis)
+    .addHttpHeaders("Content-Type" -> "application/json")
+    .post(payload)
+    .map((response) =>
+      response.body
+    )
+
+  def render(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
+
+    case article : ArticlePage =>
+      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+
+      remoteRenderArticle(ws, jsonPayload).map(s => {
+        Cached(article){ RevalidatableResult.Ok(Html(s)) }
+      })
+
+    case _ => throw new Exception("Remote render not supported for this content type")
+
+  }
 
 }

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -27,18 +27,15 @@ class RemoteRender(implicit context: ApplicationContext) {
       response.body
     )
 
-  def render(ws:WSClient, path: String, model: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = model match {
+  def render(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
 
-    case article : ArticlePage =>
       val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
       val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse:_*)
+      val jsonPayload = JsonComponent.jsonFor(article, jsonResponse:_*)
 
       remoteRenderArticle(ws, jsonPayload).map(s => {
         Cached(article){ RevalidatableResult.Ok(Html(s)) }
       })
-
-    case _ => throw new Exception("Remote render not supported for this content type")
 
   }
 

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -31,8 +31,8 @@ class RemoteRender(implicit context: ApplicationContext) {
 
     case article : ArticlePage =>
       val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
-      val jsonResponse = () => List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse():_*)
+      val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+      val jsonPayload = JsonComponent.jsonFor(model, jsonResponse:_*)
 
       remoteRenderArticle(ws, jsonPayload).map(s => {
         Cached(article){ RevalidatableResult.Ok(Html(s)) }

--- a/article/app/services/CAPILookup.scala
+++ b/article/app/services/CAPILookup.scala
@@ -8,7 +8,7 @@ import play.api.mvc.RequestHeader
 
 import scala.concurrent.Future
 
-class LookerUpper(contentApiClient: ContentApiClient) {
+class CAPILookup(contentApiClient: ContentApiClient) {
 
   def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
     val edition = Edition(request)

--- a/article/app/services/LookerUpper.scala
+++ b/article/app/services/LookerUpper.scala
@@ -1,0 +1,31 @@
+package services
+
+import com.gu.contentapi.client.model.v1.ItemResponse
+import common.Edition
+import contentapi.ContentApiClient
+import model.BlockRange
+import play.api.mvc.RequestHeader
+
+import scala.concurrent.Future
+
+class LookerUpper(contentApiClient: ContentApiClient) {
+
+  def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
+    val edition = Edition(request)
+
+    val capiItem = contentApiClient.item(path, edition)
+      .showTags("all")
+      .showFields("all")
+      .showReferences("all")
+      .showAtoms("all")
+
+    val capiItemWithBlocks = range.map { blockRange =>
+      val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
+      capiItem.showBlocks(blocksParam)
+    }.getOrElse(capiItem)
+
+    contentApiClient.getResponse(capiItemWithBlocks)
+
+  }
+
+}

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -20,9 +20,13 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/03/mainsection
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
+# liveblogs, minutes
+
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
+
+# articles, finished liveblogs
 
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -21,8 +21,10 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
-GET     /*path.json                 controllers.ArticleController.renderJson(path)
-GET     /*path/email                controllers.ArticleController.renderArticle(path)
-# temp route for live blogs so we can paginate without getting the blocks for all articles
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderLiveBlogEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderLiveBlog(path, page: Option[String], format: Option[String])
+
+
+GET     /*path.json                 controllers.ArticleController.renderJson(path)
+GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -20,10 +20,9 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/03/mainsection
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
-GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
-GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderLiveBlogEmail(path)
-GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderLiveBlog(path, page: Option[String], format: Option[String])
-
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -20,9 +20,9 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/03/mainsection
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
-GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderArticle(path)
 # temp route for live blogs so we can paginate without getting the blocks for all articles
-GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderLiveBlog(path, page: Option[String], format: Option[String])
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -81,29 +81,6 @@ import scala.collection.JavaConverters._
 
   val expiredArticle = "football/2012/sep/14/zlatan-ibrahimovic-paris-st-germain-toulouse"
 
-  it should "return the latest blocks of a live blog" in {
-    val lastUpdateBlock = "block-56d03169e4b074a9f6b35baa"
-    val fakeRequest = FakeRequest(GET, s"/football/live/2016/feb/26/fifa-election-who-will-succeed-sepp-blatter-president-live.json?lastUpdate=$lastUpdateBlock")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = articleController.renderLiveBlogJson("/football/live/2016/feb/26/fifa-election-who-will-succeed-sepp-blatter-president-live", Some(lastUpdateBlock), None, Some(true))(fakeRequest)
-    status(result) should be(200)
-
-    val content = contentAsString(result)
-
-    // newer blocks
-    content should include("block-56d03894e4b0bd5a0524cbab")
-    content should include("block-56d039fce4b0d38537b1f61e")
-    content should not include "56d04877e4b0bd5a0524cbe2" // at the moment it only tries 5 either way, reverse this test once we use blocks:published-since
-
-    //this block
-    content should not include lastUpdateBlock
-
-    //older block
-    content should not include "block-56d02bd2e4b0d38537b1f5fa"
-
-  }
-
   it should "know which backend served the request" in {
     val result = route(app, TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")).head
     status(result) should be (200)

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -1,0 +1,51 @@
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import test._
+import controllers.LiveBlogController
+import org.apache.commons.codec.digest.DigestUtils
+import play.api.test._
+import play.api.test.Helpers._
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+@DoNotDiscover class LiveBlogControllerTest extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithMaterializer
+  with WithTestWsClient
+  with WithTestApplicationContext
+  with WithTestContentApiClient {
+
+  val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
+
+  lazy val liveBlogController = new LiveBlogController(
+    testContentApiClient,
+    play.api.test.Helpers.stubControllerComponents(),
+    wsClient
+  )
+
+  it should "return the latest blocks of a live blog" in {
+    val lastUpdateBlock = "block-56d03169e4b074a9f6b35baa"
+    val fakeRequest = FakeRequest(GET, s"/football/live/2016/feb/26/fifa-election-who-will-succeed-sepp-blatter-president-live.json?lastUpdate=$lastUpdateBlock")
+      .withHeaders("host" -> "localhost:9000")
+
+    val result = liveBlogController.renderJson("/football/live/2016/feb/26/fifa-election-who-will-succeed-sepp-blatter-president-live", Some(lastUpdateBlock), None, Some(true))(fakeRequest)
+    status(result) should be(200)
+
+    val content = contentAsString(result)
+
+    // newer blocks
+    content should include("block-56d03894e4b0bd5a0524cbab")
+    content should include("block-56d039fce4b0d38537b1f61e")
+    content should not include "56d04877e4b0bd5a0524cbe2" // at the moment it only tries 5 either way, reverse this test once we use blocks:published-since
+
+    //this block
+    content should not include lastUpdateBlock
+
+    //older block
+    content should not include "block-56d02bd2e4b0d38537b1f5fa"
+
+  }
+
+}

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -106,32 +106,6 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
         RevalidatableResult.Ok(htmlResponse())
     }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   def renderHtml(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
     RevalidatableResult.Ok(html)
   }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -115,7 +115,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
   }
 
   def renderJson(json: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
-    JsonComponent(json)
+    JsonComponent(page, json)
   }
 
   def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -105,6 +105,49 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       else
         RevalidatableResult.Ok(htmlResponse())
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  def renderHtml(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
+    RevalidatableResult.Ok(html)
+  }
+
+  def renderJson(json: List[(String, Any)], page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
+    JsonComponent(page, json:_*)
+  }
+
+  def renderJson(json: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
+    JsonComponent(json)
+  }
+
+  def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
+    RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html)
+  }
+
 }
 
 

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -4,10 +4,10 @@ import conf.Configuration
 import play.api.mvc.RequestHeader
 
 sealed trait RequestFormat
-case object Html extends RequestFormat
-case object Json extends RequestFormat
-case object Email extends RequestFormat
-case object Amp extends RequestFormat
+case object HtmlFormat extends RequestFormat
+case object JsonFormat extends RequestFormat
+case object EmailFormat extends RequestFormat
+case object AmpFormat extends RequestFormat
 
 trait Requests {
 
@@ -23,7 +23,7 @@ trait Requests {
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
 
-    def getRequestFormat: RequestFormat = if(isJson) Json else if (isEmail) Email else if(isAmp) Amp else Html
+    def getRequestFormat: RequestFormat = if(isJson) JsonFormat else if (isEmail) EmailFormat else if(isAmp) AmpFormat else HtmlFormat
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -3,6 +3,12 @@ package implicits
 import conf.Configuration
 import play.api.mvc.RequestHeader
 
+sealed trait RequestFormat
+case object Html extends RequestFormat
+case object Json extends RequestFormat
+case object Email extends RequestFormat
+case object Amp extends RequestFormat
+
 trait Requests {
 
   val EMAIL_SUFFIX = "/email"
@@ -16,6 +22,8 @@ trait Requests {
     def getIntParameter(name: String): Option[Int] = getParameter(name).map(_.toInt)
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
+
+    def getRequestFormat: RequestFormat = if(isJson) Json else if (isEmail) Email else if(isAmp) Amp else Html
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -429,13 +429,16 @@ GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                    
 GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                                          controllers.IndexController.render(path)
 GET            /$leftSide<[^+]+>+*rightSide                                                                                      controllers.IndexController.renderCombiner(leftSide, rightSide)
 
-# Articles
-GET            /$path<[^/]+/([^/]+/)?live/.*>.json                                                                               controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
-GET            /*path.json                                                                                                       controllers.ArticleController.renderJson(path)
-GET            /*path/email                                                                                                      controllers.ArticleController.renderArticle(path)
-# temp route for live blogs so we can paginate without getting the blocks for all articles
-GET            /$path<[^/]+/([^/]+/)?live/.*>                                                                                    controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
-GET            /*path                                                                                                            controllers.ArticleController.renderArticle(path)
+# Live Blogs
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json                                                                                      controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email                                                                                     controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>                                                                                           controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
+
+# articles, finished liveblogs
+
+GET     /*path.json                                                                                                              controllers.ArticleController.renderJson(path)
+GET     /*path/email                                                                                                             controllers.ArticleController.renderEmail(path)
+GET     /*path                                                                                                                   controllers.ArticleController.renderArticle(path)
 
 # Formstack form submission
 POST      /formstack-campaign/submit                                                                                             controllers.CampaignsController.formSubmit()

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -193,9 +193,12 @@ GET        /weatherapi/locations                                                
 GET        /news-alert/alerts                                                                  controllers.NewsAlertController.alerts()
 
 # Articles
-GET        /*path.json                                                                         controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
-GET        /*path/email                                                                        controllers.ArticleController.renderArticle(path)
-GET        /$path<[^/]+/([^/]+/)?live/.*>                                                      controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
+GET     /*path.json                 controllers.ArticleController.renderJson(path)
+GET     /*path/email                controllers.ArticleController.renderEmail(path)
+
 
 # Don't forward requests for favicon.ico to the Content API
 GET        /favicon.ico                                                                        controllers.FaviconController.favicon


### PR DESCRIPTION
## What does this change?

This is the first pass of a refactor to the article controller. I didn't want to change too much at once.

Under this PR the ArticleController has been split into ArticleController and LiveBlogController, with three entrypoints each (article, email, json), which now logically map 1-1 with the routes.

The remote rendering, liveblog jsonning and capi mapping have been extracted out of the controller.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
