### PR TITLE
Add more guard clauses and improve Flow typing of CMP

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -131,9 +131,9 @@ describe('cmp', () => {
         const processSpy = jest.spyOn(cmp, 'processCommand');
         cmp.receiveMessage({
             data: {
-                __cmpCall: { command: 'showConsentTool' },
+                __cmpCall: ({ command: 'showConsentTool' }: any),
             },
-            origin: {},
+            origin: 'example',
             source,
         });
         expect(processSpy.mock.calls[0][0]).toMatch('showConsentTool');


### PR DESCRIPTION
## What does this change?

Sometimes, in cmp.js , 'source' is null or undefined:

https://sentry.io/the-guardian/client-side-prod/issues/593441347/events/oldest/

It looks like the issue is particular to one vendor, however adding in another guard clause and more reliance on Flow typing will hopefully silence the alerts. 

If the source is missing, then the addition of logging this to the console should help us debug this issue if it continues, or reappears.

## Screenshots

The really interesting / strange thing about this error is that it currently seems to predominantly affect one article, I can only assume Abba broke the CMP:

<img width="1432" alt="picture 117" src="https://user-images.githubusercontent.com/8607683/42451441-305292ee-837f-11e8-8728-92de427c4a29.png">

😂 😂 

![abba-money](https://user-images.githubusercontent.com/8607683/42451655-cb4642aa-837f-11e8-8811-b59c68c230d1.gif)


## What is the value of this and can you measure success?

👉 One less $FlowFixMe, and better usage of Flow

👉Reduce potential JavaScript errors in the CMP

👉Stop sending this particular error to Sentry

👉Log that this is occurring to the console if CMP debugging is enabled

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
