### PR TITLE
adds test to display epic (unlimited) on Thailand cave rescue stories

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -166,4 +166,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-thailand-cave",
+    "Always show the epic on thailand cave stories (unlimited)",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 9, 30),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -172,7 +172,7 @@ trait ABTestSwitches {
     "Always show the epic on thailand cave stories (unlimited)",
     owners = Seq(Owner.withGithub("tsop14")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 9, 30),
+    sellByDate = new LocalDate(2018, 9, 28),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -19,6 +19,7 @@ import { acquisitionsEpicFromGoogleDocTwoVariants } from 'common/modules/experim
 import { acquisitionsEpicFromGoogleDocThreeVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-three-variants';
 import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-four-variants';
 import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
+import { acquisitionsEpicThailandCave } from 'common/modules/experiments/tests/acquisitions-epic-thailand-cave';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
@@ -45,6 +46,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicThailandCave,
     acquisitionsEpicNativeVsDfpV3,
     acquisitionsEpicFromGoogleDocOneVariant,
     acquisitionsEpicFromGoogleDocTwoVariants,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thailand-cave.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thailand-cave.js
@@ -1,0 +1,33 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { keywordExists } from 'lib/page';
+
+const abTestName = 'AcquisitionsEpicThailandCave';
+
+export const acquisitionsEpicThailandCave: EpicABTest = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-07-09',
+    expiry: '2018-08-09',
+
+    author: 'Emma Milner',
+    description: 'Always show the epic on Thailand cave stories (unlimited)',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'We convert lots of readers',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    canRun: () => keywordExists(['Thailand cave rescue']),
+
+    variants: [
+        {
+            id: 'control',
+            products: [],
+            options: {
+                isUnlimited: true,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
Adds test to display epic (unlimited) on Thailand cave rescue stories - note does not have a control / variant. 

## What is the value of this and can you measure success?
Thailand Cave story live blog was responsible for high % of £AV on Sunday. Therefore, decided to always display epic on articles with relevant tag.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
