### PR TITLE
Include interactives in always insert epic test on thailand keyword

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thailand-cave.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thailand-cave.js
@@ -20,6 +20,8 @@ export const acquisitionsEpicThailandCave: EpicABTest = makeABTest({
     audience: 1,
     audienceOffset: 0,
     canRun: () => keywordExists(['Thailand cave rescue']),
+    pageCheck: page =>
+        page.contentType === 'Article' || page.contentType === 'Interactive',
 
     variants: [
         {
@@ -27,6 +29,8 @@ export const acquisitionsEpicThailandCave: EpicABTest = makeABTest({
             products: [],
             options: {
                 isUnlimited: true,
+                insertAtSelector:
+                    '.submeta, .content__main-column.content__meta-footer > .content__meta-container.js-content-meta.js-football-meta.u-cf',
             },
         },
     ],


### PR DESCRIPTION
We had a request from @fcage to insert the epic on the interactive at https://www.theguardian.com/world/ng-interactive/2018/jul/03/thailand-cave-rescue-where-were-the-boys-found-and-how-can-they-be-rescued

# Screenshot
![picture 232](https://user-images.githubusercontent.com/5122968/42523899-f01576d6-8466-11e8-8c3c-a2902ba53b3d.png)
