### PR TITLE
Sampling 1% of page views for ad consent data

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
@@ -16,8 +16,8 @@ declare type ConsentPayload = {
 };
 
 const shouldTrack = (): boolean => {
-    // gather analytics from 0.1% (1 in 1000) of page views
-    const inSample = getRandomIntInclusive(1, 1000) === 1;
+    // gather analytics from 1% (1 in 100) of page views
+    const inSample = getRandomIntInclusive(1, 100) === 1;
     return (
         config.switches.commercialPageViewAnalytics &&
         (inSample || config.page.isDev)


### PR DESCRIPTION
We're using this data to measure the effect that neither giving or denying consent for personalised ads has on ad revenue.