### PR TITLE
extends epic test by a week, updates switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "See if there is any difference in annualised value between serving the Epic natively vs DFP",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 7, 11),
+    sellByDate = new LocalDate(2018, 7, 18),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
@@ -26,7 +26,7 @@ const epicNativeVsDfpV3: ABTest = {
     id: testName,
     campaignId: 'epic_native_vs_dfp_v3',
     start: '2018-06-27',
-    expiry: '2018-07-11',
+    expiry: '2018-07-18',
     author: 'Guy Dawson',
     description:
         'See if there is any difference in annualised value between serving the Epic natively vs DFP',


### PR DESCRIPTION
## What does this change?
Extends native v dfp epic test by a week and updates switch (expired Wednesday 18th July)
