### PR TITLE
Rename sign in experiment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,7 +18,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-new-sign-in-experiment-bump",
+    "ab-new-sign-in-experiment-bump-again",
     "This test will send a % of users to the new sign in experience",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,7 +18,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-new-sign-in-experiment-bump-again",
+    "ab-new-sign-in-experiment-2",
     "This test will send a % of users to the new sign in experience",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
@@ -47,7 +47,7 @@ const replaceLinks = (links: Element[], newHref: string): void => {
 };
 
 export const newSignInExperiment: ABTest = {
-    id: 'NewSignInExperimentBumpAgain',
+    id: 'NewSignInExperiment2',
     start: '2018-06-07',
     expiry: '2019-06-07',
     author: 'Laura gonzalez',
@@ -67,19 +67,19 @@ export const newSignInExperiment: ABTest = {
                 getSignInLinks().then(links => {
                     replaceLinks(
                         links,
-                        'signin?INTCMP=sign-in-ab-control&from=topnav'
+                        'signin?INTCMP=sign-in-ab-2-control&from=topnav'
                     );
                 });
                 getCommentSignInLinks().then(links => {
                     replaceLinks(
                         links,
-                        'signin?INTCMP=sign-in-ab-control&from=comments-signin'
+                        'signin?INTCMP=sign-in-ab-2-control&from=comments-signin'
                     );
                 });
                 getCommentRegisterLinks().then(links => {
                     replaceLinks(
                         links,
-                        'register?INTCMP=sign-in-ab-control&from=comments-signup'
+                        'register?INTCMP=sign-in-ab-2-control&from=comments-signup'
                     );
                 });
             },
@@ -90,19 +90,19 @@ export const newSignInExperiment: ABTest = {
                 getSignInLinks().then(links => {
                     replaceLinks(
                         links,
-                        'signin/start?INTCMP=sign-in-ab-variant&from=topnav'
+                        'signin/start?INTCMP=sign-in-ab-2-variant&from=topnav'
                     );
                 });
                 getCommentSignInLinks().then(links => {
                     replaceLinks(
                         links,
-                        'signin/start?INTCMP=sign-in-ab-variant&from=comments-signin'
+                        'signin/start?INTCMP=sign-in-ab-2-variant&from=comments-signin'
                     );
                 });
                 getCommentRegisterLinks().then(links => {
                     replaceLinks(
                         links,
-                        'signin/start?INTCMP=sign-in-ab-variant&from=comments-signup'
+                        'signin/start?INTCMP=sign-in-ab-2-variant&from=comments-signup'
                     );
                 });
             },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/new-sign-in-experiment.js
@@ -47,7 +47,7 @@ const replaceLinks = (links: Element[], newHref: string): void => {
 };
 
 export const newSignInExperiment: ABTest = {
-    id: 'NewSignInExperimentBump',
+    id: 'NewSignInExperimentBumpAgain',
     start: '2018-06-07',
     expiry: '2019-06-07',
     author: 'Laura gonzalez',


### PR DESCRIPTION
## What does this change?
Renames the sign in experiment (again) in order to restart the test.  The previous results are invalid due to a related bug.

## Screenshots

## What is the value of this and can you measure success?
More valuable AB test data

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
