### PR TITLE
Audio AB Test: Fix data ready evt

### DIFF
--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -264,6 +264,7 @@ const Links = styled('div')({
 const Button = styled('button')(({ isPlay, pillarColor }) => ({
     background: 'none',
     border: 0,
+    cursor: 'pointer',
     margin: 0,
     ':focus': {
         outline: 'none', // ಠ_ಠ

--- a/static/src/javascripts/projects/common/modules/audio/index.js
+++ b/static/src/javascripts/projects/common/modules/audio/index.js
@@ -54,7 +54,9 @@ const init = (): void => {
         const downloadUrl = placeholder.dataset.downloadUrl;
         const iTunesUrl = placeholder.dataset.itunesUrl;
 
-        sendToOphan(mediaId, 'ready');
+        if (supportsCSSGrid) {
+            sendToOphan(mediaId, 'ready');
+        }
 
         const pillarClassName = Array.from(article.classList).filter(x =>
             x.includes('pillar')


### PR DESCRIPTION
## What does this change?

Have just realised that if the user doesn't have CSS Grid, then they will not see the new player, so we should not fire the ready event for them. 

pointer cursor is supposed to help the performance of this on mobiles. 

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
