### PR TITLE
Main media captions in immersive style templates

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -29,6 +29,21 @@
                     @fragments.meta.contactAuthor(gallery.item.tags)
                 }
 
+                @defining(gallery.item.content.trail.trailPicture.flatMap(_.masterImage)) {
+                    case Some(masterImage) => {
+                        <figcaption class="caption caption--gallery hide-from-desktop">
+                            Main image:
+                            @masterImage.credit.map { credit =>
+                                @credit
+                            }
+                            @masterImage.caption.map { caption =>
+                                @caption
+                            }
+                        </figcaption>
+                    }
+                    case None => { }
+                }
+
                 @if(!gallery.item.trail.shouldHidePublicationDate) {
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -44,27 +44,24 @@
                 </div>
             </div>
 
-            @defining(model.article.content.trail.trailPicture.flatMap(_.masterImage)) {
-                case Some(masterImage) => {
-                    <div class="gs-container gs-container--immersive">
-                        <figcaption class="caption caption--immersive">
-                            @fragments.inlineSvg("triangle", "icon", List("hide-until-leftcol"))
-                            @masterImage.credit.map { credit =>
-                                @credit
-                            }
-                            @masterImage.caption.map { caption =>
-                                @caption
-                            }
-                        </figcaption>
-                    </div>
-                }
-                case None => { }
-            }
-
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
-
+                        @defining(model.article.content.trail.trailPicture.flatMap(_.masterImage)) {
+                            case Some(masterImage) => {
+                                <figcaption class="caption caption--immersive">
+                                    Main image:
+                                    @masterImage.credit.map { credit =>
+                                        @credit
+                                    }
+                                    @masterImage.caption.map { caption =>
+                                        @caption
+                                    }
+                                </figcaption>
+                            }
+                            case None => { }
+                        }
+                        
                         @fragments.contentMeta(article, model, amp = amp)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -43,6 +43,24 @@
                     </div>
                 </div>
             </div>
+
+            @defining(model.article.content.trail.trailPicture.flatMap(_.masterImage)) {
+                case Some(masterImage) => {
+                    <div class="gs-container gs-container--immersive">
+                    <figcaption class="caption caption--immersive">
+                        @fragments.inlineSvg("triangle", "icon", List("hide-until-leftcol"))
+                        @masterImage.credit.map { credit =>
+                            @credit
+                        }
+                        @masterImage.caption.map { caption =>
+                            @caption
+                        }
+                    </figcaption>
+                </div>
+                }
+                case None => { }
+            }
+
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -47,16 +47,16 @@
             @defining(model.article.content.trail.trailPicture.flatMap(_.masterImage)) {
                 case Some(masterImage) => {
                     <div class="gs-container gs-container--immersive">
-                    <figcaption class="caption caption--immersive">
-                        @fragments.inlineSvg("triangle", "icon", List("hide-until-leftcol"))
-                        @masterImage.credit.map { credit =>
-                            @credit
-                        }
-                        @masterImage.caption.map { caption =>
-                            @caption
-                        }
-                    </figcaption>
-                </div>
+                        <figcaption class="caption caption--immersive">
+                            @fragments.inlineSvg("triangle", "icon", List("hide-until-leftcol"))
+                            @masterImage.credit.map { credit =>
+                                @credit
+                            }
+                            @masterImage.caption.map { caption =>
+                                @caption
+                            }
+                        </figcaption>
+                    </div>
                 }
                 case None => { }
             }

--- a/article/app/views/fragments/immersiveGarnettHeadline.scala.html
+++ b/article/app/views/fragments/immersiveGarnettHeadline.scala.html
@@ -48,6 +48,21 @@
             @Html(page.item.trail.headline)
         </h1>
 
+        @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
+            case Some(masterImage) => {
+                <figcaption class="caption caption--immersive hide-until-leftcol">
+                    @fragments.inlineSvg("triangle", "icon")
+                    @masterImage.credit.map { credit =>
+                        @credit
+                    }
+                    @masterImage.caption.map { caption =>
+                        @caption
+                    }
+                </figcaption>
+            }
+            case None => { }
+        }
+
         @if(isTheMinuteArticle) {
 
             @if(page.item.trail.shouldHidePublicationDate) {

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -36,6 +36,22 @@
                 @Html(page.item.trail.headline)
             </h1>
 
+            @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
+                case Some(masterImage) => {
+                    <figcaption class="caption caption--gallery hide-until-desktop">
+                        @fragments.inlineSvg("triangle", "icon")
+                        Main image:
+                        @masterImage.credit.map { credit =>
+                            @credit
+                        }
+                        @masterImage.caption.map { caption =>
+                            @caption
+                        }
+                    </figcaption>
+                }
+                case None => { }
+            }
+
             @if(page.item.content.hasTonalHeaderByline) {
                 @page.item.trail.byline.map { text =>
                     <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -40,7 +40,6 @@
                 case Some(masterImage) => {
                     <figcaption class="caption caption--gallery hide-until-desktop">
                         @fragments.inlineSvg("triangle", "icon")
-                        Main image:
                         @masterImage.credit.map { credit =>
                             @credit
                         }

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -91,7 +91,6 @@
                         }
                         @Html(page.item.trail.headline)
                     </h1>
-
                     @if(page.item.trail.shouldHidePublicationDate) {
                         @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.fields.firstPublicationDate, page.item.tags.isLiveBlog, page.item.fields.isLive, isTheMinuteArticle)
                     }

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -91,7 +91,7 @@
                         }
                         @Html(page.item.trail.headline)
                     </h1>
-                    
+
                     @if(page.item.trail.shouldHidePublicationDate) {
                         @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.fields.firstPublicationDate, page.item.tags.isLiveBlog, page.item.fields.isLive, isTheMinuteArticle)
                     }

--- a/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGarnettMainMedia.scala.html
@@ -91,6 +91,7 @@
                         }
                         @Html(page.item.trail.headline)
                     </h1>
+                    
                     @if(page.item.trail.shouldHidePublicationDate) {
                         @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.fields.firstPublicationDate, page.item.tags.isLiveBlog, page.item.fields.isLive, isTheMinuteArticle)
                     }

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -91,7 +91,7 @@
 
                     @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
                         case Some(masterImage) => {
-                            <figcaption class="caption caption--immersive">
+                            <figcaption class="caption caption--immersive hide-from-leftcol">
                                 Main image:
                                 @masterImage.credit.map { credit =>
                                     @credit

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -64,6 +64,21 @@
                 <h1 class="@if(hasMainMedia){content__headline--immersive--with-main-media} @if(isPaidContent){content__headline--advertisement} content__headline content__headline--immersive content__headline--immersive-article">
                     @Html(page.item.trail.headline)
                 </h1>
+
+                @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
+                    case Some(masterImage) => {
+                        <figcaption class="caption caption--immersive hide-until-leftcol">
+                            @fragments.inlineSvg("triangle", "icon")
+                            @masterImage.credit.map { credit =>
+                                @credit
+                            }
+                            @masterImage.caption.map { caption =>
+                                @caption
+                            }
+                        </figcaption>
+                    }
+                    case None => { }
+                }
             </div>
           </div>
       </div>
@@ -73,6 +88,21 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     @fragments.standfirst(page.item)
+
+                    @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
+                        case Some(masterImage) => {
+                            <figcaption class="caption caption--immersive">
+                                Main image:
+                                @masterImage.credit.map { credit =>
+                                    @credit
+                                }
+                                @masterImage.caption.map { caption =>
+                                    @caption
+                                }
+                            </figcaption>
+                        }
+                        case None => { }
+                    }
                 </div>
             </div>
         </div>

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -179,6 +179,41 @@
     }
 }
 
+.gs-container--immersive {
+    @include mq(leftCol) {
+        position: static;
+    }
+}
+
+.caption--immersive {
+    @include mq($until: leftCol) {
+        margin: $gs-baseline 0 ($gs-baseline / 4);
+        min-height: 0;
+
+        @include mq(desktop) {
+            margin-left: -$gs-gutter / 2;
+        }
+
+        &:before {
+            content: 'Main image: ';
+        }
+    }
+
+    @include mq(leftCol) {
+        padding-top: $gs-baseline / 4;
+        position: absolute;
+        left: 50%;
+        top: 100px;
+        margin-left: -(gs-span(7) + ($gs-gutter / 2));
+        width: gs-span(2);
+    }
+
+    @include mq(wide) {
+        margin-left: -(gs-span(8) + ($gs-gutter / 2));
+        width: gs-span(3);
+    }
+}
+
 .content__standfirst--immersive-article {
     position: relative;
     padding-top: .33em;

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -170,6 +170,8 @@
 }
 
 .content--immersive {
+    position: relative;
+    
     .content__main {
         padding-top: 0;
 

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -171,7 +171,7 @@
 
 .content--immersive {
     position: relative;
-    
+
     .content__main {
         padding-top: 0;
 
@@ -181,37 +181,21 @@
     }
 }
 
-.gs-container--immersive {
-    @include mq(leftCol) {
-        position: static;
-    }
-}
-
 .caption--immersive {
     @include mq($until: leftCol) {
-        margin: $gs-baseline 0 ($gs-baseline / 4);
-        min-height: 0;
-
-        @include mq(desktop) {
-            margin-left: -$gs-gutter / 2;
-        }
-
-        &:before {
-            content: 'Main image: ';
-        }
+        margin: $gs-baseline 0 ($gs-baseline / 2);
     }
 
     @include mq(leftCol) {
+        margin-left: -$gs-gutter;
         padding-top: $gs-baseline / 4;
         position: absolute;
-        left: 50%;
         top: 100px;
-        margin-left: -(gs-span(7) + ($gs-gutter / 2));
         width: gs-span(2);
+        transform: translateX(-100%);
     }
 
     @include mq(wide) {
-        margin-left: -(gs-span(8) + ($gs-gutter / 2));
         width: gs-span(3);
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -170,8 +170,6 @@
 }
 
 .content--immersive {
-    position: relative;
-
     .content__main {
         padding-top: 0;
 

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -179,7 +179,6 @@
     .tonal__standfirst {
         max-width: gs-span(4) - $gs-gutter/2;
         margin: 0;
-        order: 2;
 
         @include mq($from: tablet) {
             max-width: gs-span(5) + $gs-gutter;

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -280,6 +280,33 @@
     }
 }
 
+.gs-container--gallery {
+    @include mq(leftCol) {
+        position: static;
+    }
+}
+
+.caption--gallery {
+    color: $brightness-86;
+
+    @include mq($until: desktop) {
+        margin: $gs-baseline 0 ($gs-baseline / 2);
+    }
+
+    @include mq(desktop) {
+        padding-top: $gs-baseline / 4;
+        position: absolute;
+        top: 100px;
+        width: gs-span(3);
+        transform: translateX(-100%);
+        margin-left: -$gs-gutter / 2;
+    }
+
+    .inline-icon__svg {
+        fill: $brightness-86;
+    }
+}
+
 //Picture essay styles - Header
 .immersive-header-container--photo-essay {
     .content__wrapper--standfirst {


### PR DESCRIPTION
Captions are now visible on templates with an immersive style header. As requested by photo editors. Due to template restraints, I've had to insert the code twice in different templates. 

<img width="1296" alt="screen shot 2018-07-12 at 15 20 12" src="https://user-images.githubusercontent.com/14570016/42639137-388f7e80-85e7-11e8-9323-d7102de1c616.png">
<img width="1423" alt="screen shot 2018-07-12 at 15 20 26" src="https://user-images.githubusercontent.com/14570016/42639138-38b6880e-85e7-11e8-90b6-6c8467fa7ee4.png">
<img width="358" alt="screen shot 2018-07-12 at 15 20 38" src="https://user-images.githubusercontent.com/14570016/42639139-38d412e8-85e7-11e8-93e8-d0dde8786e03.png">
<img width="1162" alt="screen shot 2018-07-12 at 15 20 51" src="https://user-images.githubusercontent.com/14570016/42639140-38e97318-85e7-11e8-8fa0-5d6fed1e8e08.png">

Thanks @QuarpT for the twirly goodness. 