### PR TITLE
Revert "Main media captions in immersive style templates"

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -29,21 +29,6 @@
                     @fragments.meta.contactAuthor(gallery.item.tags)
                 }
 
-                @defining(gallery.item.content.trail.trailPicture.flatMap(_.masterImage)) {
-                    case Some(masterImage) => {
-                        <figcaption class="caption caption--gallery hide-from-desktop">
-                            Main image:
-                            @masterImage.credit.map { credit =>
-                                @credit
-                            }
-                            @masterImage.caption.map { caption =>
-                                @caption
-                            }
-                        </figcaption>
-                    }
-                    case None => { }
-                }
-
                 @if(!gallery.item.trail.shouldHidePublicationDate) {
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -43,25 +43,10 @@
                     </div>
                 </div>
             </div>
-
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
-                        @defining(model.article.content.trail.trailPicture.flatMap(_.masterImage)) {
-                            case Some(masterImage) => {
-                                <figcaption class="caption caption--immersive">
-                                    Main image:
-                                    @masterImage.credit.map { credit =>
-                                        @credit
-                                    }
-                                    @masterImage.caption.map { caption =>
-                                        @caption
-                                    }
-                                </figcaption>
-                            }
-                            case None => { }
-                        }
-                        
+
                         @fragments.contentMeta(article, model, amp = amp)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {

--- a/article/app/views/fragments/immersiveGarnettHeadline.scala.html
+++ b/article/app/views/fragments/immersiveGarnettHeadline.scala.html
@@ -48,21 +48,6 @@
             @Html(page.item.trail.headline)
         </h1>
 
-        @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
-            case Some(masterImage) => {
-                <figcaption class="caption caption--immersive hide-until-leftcol">
-                    @fragments.inlineSvg("triangle", "icon")
-                    @masterImage.credit.map { credit =>
-                        @credit
-                    }
-                    @masterImage.caption.map { caption =>
-                        @caption
-                    }
-                </figcaption>
-            }
-            case None => { }
-        }
-
         @if(isTheMinuteArticle) {
 
             @if(page.item.trail.shouldHidePublicationDate) {

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -36,21 +36,6 @@
                 @Html(page.item.trail.headline)
             </h1>
 
-            @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
-                case Some(masterImage) => {
-                    <figcaption class="caption caption--gallery hide-until-desktop">
-                        @fragments.inlineSvg("triangle", "icon")
-                        @masterImage.credit.map { credit =>
-                            @credit
-                        }
-                        @masterImage.caption.map { caption =>
-                            @caption
-                        }
-                    </figcaption>
-                }
-                case None => { }
-            }
-
             @if(page.item.content.hasTonalHeaderByline) {
                 @page.item.trail.byline.map { text =>
                     <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -64,21 +64,6 @@
                 <h1 class="@if(hasMainMedia){content__headline--immersive--with-main-media} @if(isPaidContent){content__headline--advertisement} content__headline content__headline--immersive content__headline--immersive-article">
                     @Html(page.item.trail.headline)
                 </h1>
-
-                @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
-                    case Some(masterImage) => {
-                        <figcaption class="caption caption--immersive hide-until-leftcol">
-                            @fragments.inlineSvg("triangle", "icon")
-                            @masterImage.credit.map { credit =>
-                                @credit
-                            }
-                            @masterImage.caption.map { caption =>
-                                @caption
-                            }
-                        </figcaption>
-                    }
-                    case None => { }
-                }
             </div>
           </div>
       </div>
@@ -88,21 +73,6 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     @fragments.standfirst(page.item)
-
-                    @defining(page.item.content.trail.trailPicture.flatMap(_.masterImage)) {
-                        case Some(masterImage) => {
-                            <figcaption class="caption caption--immersive hide-from-leftcol">
-                                Main image:
-                                @masterImage.credit.map { credit =>
-                                    @credit
-                                }
-                                @masterImage.caption.map { caption =>
-                                    @caption
-                                }
-                            </figcaption>
-                        }
-                        case None => { }
-                    }
                 </div>
             </div>
         </div>

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -179,25 +179,6 @@
     }
 }
 
-.caption--immersive {
-    @include mq($until: leftCol) {
-        margin: $gs-baseline 0 ($gs-baseline / 2);
-    }
-
-    @include mq(leftCol) {
-        margin-left: -$gs-gutter;
-        padding-top: $gs-baseline / 4;
-        position: absolute;
-        top: 100px;
-        width: gs-span(2);
-        transform: translateX(-100%);
-    }
-
-    @include mq(wide) {
-        width: gs-span(3);
-    }
-}
-
 .content__standfirst--immersive-article {
     position: relative;
     padding-top: .33em;

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -179,6 +179,7 @@
     .tonal__standfirst {
         max-width: gs-span(4) - $gs-gutter/2;
         margin: 0;
+        order: 2;
 
         @include mq($from: tablet) {
             max-width: gs-span(5) + $gs-gutter;

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -280,33 +280,6 @@
     }
 }
 
-.gs-container--gallery {
-    @include mq(leftCol) {
-        position: static;
-    }
-}
-
-.caption--gallery {
-    color: $brightness-86;
-
-    @include mq($until: desktop) {
-        margin: $gs-baseline 0 ($gs-baseline / 2);
-    }
-
-    @include mq(desktop) {
-        padding-top: $gs-baseline / 4;
-        position: absolute;
-        top: 100px;
-        width: gs-span(3);
-        transform: translateX(-100%);
-        margin-left: -$gs-gutter / 2;
-    }
-
-    .inline-icon__svg {
-        fill: $brightness-86;
-    }
-}
-
 //Picture essay styles - Header
 .immersive-header-container--photo-essay {
     .content__wrapper--standfirst {


### PR DESCRIPTION
## What does this change?

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
