### PR TITLE
adds application endpoint for rr contributions banner deploy log

### DIFF
--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -40,6 +40,7 @@ trait ApplicationsControllers {
   lazy val siteVerificationController = wire[SiteVerificationController]
   lazy val shareCountController = wire[ShareCountController]
   lazy val formstackController = wire[CampaignsController]
+  lazy val readerRevenueController = wire[ReaderRevenueController]
 
   //A fake geolocation controller to test it locally
   lazy val geolocationController = wire[FakeGeolocationController]

--- a/applications/app/controllers/ReaderRevenueController.scala
+++ b/applications/app/controllers/ReaderRevenueController.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import common.{ImplicitControllerExecutionContext, Logging}
+import model._
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import services.S3
+
+import scala.concurrent.duration._
+import conf.Configuration.readerRevenue._
+import model.Cached.{RevalidatableResult}
+
+
+class ReaderRevenueController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
+  extends BaseController with ImplicitControllerExecutionContext with Logging {
+
+  private def getContributionsBannerDeployLog(): Option[String] = {
+    S3.get(contributionsBannerDeployLogKey)
+  }
+
+  private def bannerDeployLogUnavailable() = {
+    log.warn(s"Could not get reader revenue contributions-banner deploy log from s3")
+    NoCache(NotFound)
+  }
+
+  def contributionsBannerDeployLog(): Action[AnyContent] = Action { implicit request =>
+    getContributionsBannerDeployLog.fold(bannerDeployLogUnavailable){ bannerDeployLog =>
+      Cached(5.minutes) {
+        RevalidatableResult.Ok(bannerDeployLog)
+      }
+    }
+  }
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -7,6 +7,8 @@ GET         /assets/*path                                                       
 
 GET        /_healthcheck                                                        controllers.HealthCheck.healthCheck()
 
+GET        /reader-revenue/contributions-banner-deploy-log                      controllers.ReaderRevenueController.contributionsBannerDeployLog()
+
 GET        /sitemaps/news.xml                                                   controllers.SiteMapController.renderNewsSiteMap()
 GET        /sitemaps/video.xml                                                  controllers.SiteMapController.renderVideoSiteMap()
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -392,6 +392,13 @@ class GuardianConfiguration extends Logging {
     lazy val witnessApiRoot = configuration.getMandatoryStringProperty("witness.apiRoot")
   }
 
+  object readerRevenue {
+    private lazy val readerRevenueRoot = {
+      configuration.getStringProperty("readerRevenue.s3.root") getOrElse s"${environment.stage.toUpperCase}/reader-revenue"
+    }
+    lazy val contributionsBannerDeployLogKey = s"$readerRevenueRoot/contributions-banner-deploy-log.json"
+  }
+
   object commercial {
 
     lazy val testDomain =

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -4,6 +4,8 @@
 
 GET            /commercial/test-page                                                                                             commercial.controllers.CreativeTestPage.allComponents(k: List[String])
 
+GET            /reader-revenue/contributions-banner-deploy-log                                                                   controllers.ReaderRevenueController.contributionsBannerDeployLog()
+
 GET            /email-newsletters                                                                                                controllers.SignupPageController.renderNewslettersPage()
 
 GET            /survey/:formName/show                                                                                            controllers.SurveyPageController.renderFormStackSurvey(formName)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -26,6 +26,8 @@ GET        /advertiser-content/:campaignName/:pageName                          
 GET        /advertiser-content/:campaignName/:pageName/:cType/onward.json                      commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET        /advertiser-content/:campaignName/:pageName/autoplay.json                           commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
 
+# Reader revenue
+GET       /reader-revenue/contributions-banner-deploy-log                                      controllers.ReaderRevenueController.contributionsBannerDeployLog()
 
 # Onward
 GET        /most-read.json                                                                     controllers.MostPopularController.render(path = "")


### PR DESCRIPTION
This is part of the work to enable non-engineers to redeploy the reader revenue contributions banner.



## What does this change?



- Adds application endpoint

- Returns contributions banner deploy log, which is stored as json file in s3

- Adds endpoint to preview and dev-build.



This endpoint will be called by reader revenue script on .com pages to determine if the contributions banner should be shown (dependent on last deploy timestamp value).



Cache limit is currently 5minutes but this should be changed if s3 calls are too high. 



## What is the value of this and can you measure success?

Currently redeploying the banner [needs a PR](#20018 ), which is inefficient and limited to engineers' office hours. Once this work is finished, deploying can be done at any time by anyone with access to frontend admin. ✨



## Checklist



### Tested



- [x] Locally

- [ ] On CODE (optional)



<!-- AB test? https://git.io/v1V0x -->

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->



TODO
- [x] Add reader revenue folder & .json file to PROD / CODE s3. 

