### PR TITLE
alwaysAskIfTagged should override other tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -46,6 +46,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicThailandCave,
     acquisitionsEpicNativeVsDfpV3,
     acquisitionsEpicFromGoogleDocOneVariant,
@@ -56,7 +57,6 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicAusEnvCampaign,
     acquisitionsEpicUSGunCampaign,
     askFourEarning,
-    acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblogWorldCup,
     acquisitionsEpicLiveblog,
     acquisitionsEpicThankYou,


### PR DESCRIPTION
Since this applies just to a subset of articles, it has to go above other tests if it's to have any effect