### PR TITLE
Stop showing paid content via the content footer in ad-free mode

### DIFF
--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -2,7 +2,7 @@
   related: model.RelatedContent,
   cssClass: String = "",
   isPaidContent: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
-@import views.support.{ContentFooterContainersLayout, RenderClasses}
+@import views.support.{ContentFooterContainersLayout, RenderClasses, Commercial}
 
 <div class="@RenderClasses(Map(
     "content-footer" -> true,
@@ -14,7 +14,10 @@
     @ContentFooterContainersLayout(content.content, isPaidContent) {
         @fragments.storyPackagePlaceholder(content, related, isPaidContent)
     } {
-        @fragments.onwardPlaceholder(isPaidContent)
+        @if(!(Commercial.isAdFree(request) && isPaidContent)) {
+            @fragments.onwardPlaceholder(isPaidContent)
+        }
+
     } {
         <div class="js-repositioned-comments content__repositioned-comments"></div>
     } {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -15,7 +15,7 @@ object Commercial {
   def isAdFree(request: RequestHeader): Boolean = {
     try {
       request.headers.get("X-GU-Commercial-Ad-Free").exists(_.toLowerCase == "true") ||
-        request.cookies.get("GU_AF1").exists(_.value.toInt > 0)
+        request.cookies.get("GU_AF1").exists(_.value.toLong > 0)
     } catch {
        case e: Exception => false   // in case the cookie value can't be converted toInt
     }


### PR DESCRIPTION
## What does this change?
We are developing an ad-free feature that will eventually be offered to digital pack subscribers. However, currently, this will not affect users in PROD outside the trial.

Ad-free users may still read paid-for content (example [here](https://www.theguardian.com/barclays-lets-go-forward/2018/may/31/quiz-how-cavalier-are-you-with-your-data-online#noadsaf)). Still, when a container following an article (including paid content) is full of paid content, in ad-free mode we hide the container. 

## Screenshots
| Page for an ad-free user without this change  | Page for an ad-free user with this change (paid content removed)  | Page for an ad-free user keeps containers that aren't filled with paid content |
| ------------- |-------------| -----|
|  ![image](https://user-images.githubusercontent.com/3072877/42702154-8e119ad0-86c0-11e8-99f2-c865f851f586.png)   | ![image](https://user-images.githubusercontent.com/3072877/42702528-b57a99ae-86c1-11e8-9adb-e50dce0aee91.png)  | ![image](https://user-images.githubusercontent.com/3072877/42702543-c2683748-86c1-11e8-953b-593438244221.png) |

## What is the value of this and can you measure success?

This quarter we are working on finishing the ad-free feature to offer to new and existing Digital-Pack subscribers because past research shows that this is a benefit users find compelling. 

This PR is part of the work to finish the ad-free feature. 

## Checklist

### Does this affect other platforms?
No.
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)
This change will remove containers full of paid content in the content footer for users in the ad-free trial. 

### Accessibility test checklist
I don't think this is applicable since it involves hiding a container under specific conditions and doesn't add anything new. 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
