### PR TITLE
New field to use for render picker to decide if there's no ads

### DIFF
--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -40,7 +40,7 @@ object RenderingTierPicker {
   }
 
   private def isAdFree(page: PageWithStoryPackage): Boolean = {
-    page.metadata.sensitive
+    page.item.content.shouldHideAdverts
   }
 
   def getRenderTierFor(page: PageWithStoryPackage): RenderType = {


### PR DESCRIPTION
## What does this change?

Changing the field that the render tier picker uses to be the same field that the commercial js code seems to end up using. 

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
