### PR TITLE
add email padding to free text containers

### DIFF
--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -57,7 +57,7 @@ $container-color: #ffffff;
     font-family: Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 18px;
-    padding: 6px 0;
+    padding: 6px $gutter;
 
     a {
         color: #0084c6;


### PR DESCRIPTION
## What does this change?

Adds padding to email free text containers on Guardian today emails

## What is the value of this and can you measure success?

Text doesn't bleed on mobile devices for free text containers on emails

### Tested

- [x] Locally

