### PR TITLE
Remove World Cup 2018 links from navigation

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -67,23 +67,8 @@ object NavLinks {
 
   /* SPORT */
 
-  // TODO remove after world cup
-  val worldCup2018 = NavLink(
-    title = "World Cup 2018",
-    url = "/football/world-cup-2018",
-    children = List(
-      NavLink("Fixtures and tables", "/football/world-cup-2018/overview"),
-      NavLink("Golden Boot", "/football/ng-interactive/2018/jun/14/golden-boot-standings-top-scorers-for-russia-2018-world-cup"),
-      NavLink("Player-by-player guide", "/football/ng-interactive/2018/jun/05/world-cup-2018-complete-guide-players-ratings-goals-caps"),
-      NavLink("Experts' Network", "/football/series/world-cup-2018-guardian-experts-network"),
-      NavLink("All-time XIs", "/football/series/world-cup-all-time-xis"),
-      NavLink("Football", "/football") // Note, non-ideal for US audience :(
-    )
-  )
-
   val football = NavLink("Football", "/football",
     children = List(
-      worldCup2018,
       NavLink("Live scores", "/football/live", "football/live"),
       NavLink("Tables", "/football/tables", "football/tables"),
       NavLink("Fixtures", "/football/fixtures", "football/fixtures"),
@@ -210,7 +195,6 @@ object NavLinks {
       ukNews,
       world,
       ukBusiness,
-      worldCup2018,
       football,
       politics,
       ukEnvironment,
@@ -228,7 +212,6 @@ object NavLinks {
       world,
       auPolitics,
       auEnvironment,
-      worldCup2018,
       football,
       indigenousAustralia,
       auImmigration,
@@ -242,7 +225,6 @@ object NavLinks {
       usNews,
       world,
       ukEnvironment,
-      worldCup2018,
       soccer,
       usPolitics,
       usBusiness,
@@ -258,7 +240,6 @@ object NavLinks {
       science,
       cities,
       globalDevelopment,
-      worldCup2018,
       football,
       tech,
       ukBusiness,
@@ -609,7 +590,6 @@ object NavLinks {
     "football/competitions",
     "football/results",
     "football/fixtures",
-    "football/world-cup-2018", // TODO remove after world cup
     "education",
     "crosswords/crossword-blog",
     "crosswords/series/crossword-editor-update",

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -289,7 +289,6 @@ object NavLinks {
   //Sport Pillar
   val ukSportPillar = NavLink("Sport", "/sport", longTitle = "Sport home", iconName = "home",
     List(
-      worldCup2018,
       football,
       rugbyUnion,
       cricket,
@@ -305,7 +304,6 @@ object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
-      worldCup2018,
       football,
       AFL,
       NRL,
@@ -317,7 +315,6 @@ object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      worldCup2018,
       soccer,
       NFL,
       tennis,
@@ -329,7 +326,6 @@ object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      worldCup2018,
       football,
       rugbyUnion,
       cricket,


### PR DESCRIPTION
## What does this change?
Football didn't come home and everyone can return to their normal lives...


## Screenshots
No screenshot locally yet - Will run it on CODE.


<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
