### PR TITLE
Check for existence of more button in nav

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -481,20 +481,26 @@ const showMoreButton = (): void => {
                 return { moreButton, lastChildRect, subnavRect };
             }
         })
-        .then(els => {
-            if (els) {
-                const { moreButton, lastChildRect, subnavRect } = els;
+        .then(
+            (els: {
+                moreButton: ?HTMLElement,
+                lastChildRect: ClientRect,
+                subnavRect: ClientRect,
+            }) => {
+                if (els) {
+                    const { moreButton, lastChildRect, subnavRect } = els;
 
-                // +1 to compensate for the border top on the subnav
-                if (subnavRect.top + 1 === lastChildRect.top) {
-                    fastdom.write(() => {
-                        if (moreButton) {
-                            moreButton.classList.add('is-hidden');
-                        }
-                    });
+                    // +1 to compensate for the border top on the subnav
+                    if (subnavRect.top + 1 === lastChildRect.top) {
+                        fastdom.write(() => {
+                            if (moreButton) {
+                                moreButton.classList.add('is-hidden');
+                            }
+                        });
+                    }
                 }
             }
-        });
+        );
 };
 
 const toggleSubnavSections = (moreButton: HTMLElement): void => {

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -488,7 +488,9 @@ const showMoreButton = (): void => {
                 // +1 to compensate for the border top on the subnav
                 if (subnavRect.top + 1 === lastChildRect.top) {
                     fastdom.write(() => {
-                        moreButton.classList.add('is-hidden');
+                        if (moreButton) {
+                            moreButton.classList.add('is-hidden');
+                        }
                     });
                 }
             }


### PR DESCRIPTION
## What does this change?

Whilst investigating something I noticed the error below in the console

![screen shot 2018-07-17 at 10 27 02](https://user-images.githubusercontent.com/1590704/42809942-a4e6571e-89ae-11e8-9cf9-80faabdafe6a.png)

This occurs on any article using the skinny navigation as the 'more button' is not present. This fix wraps `moreButton.classList.add('is-hidden');` in a conditional check for the existence of  `moreButton`.