### PR TITLE
Fix metadata description for tag combiner pages

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -527,7 +527,7 @@ case class TagCombiner(
     section = leftTag.metadata.section,
     webTitle = webTitle,
     pagination = pagination,
-    description = Some(DotcomContentType.TagIndex.toString),
+    description = Some(DotcomContentType.TagIndex.name),
     commercial = Some(
       //We only use the left tag for CommercialProperties
       CommercialProperties(


### PR DESCRIPTION
Currently if you search for 'brexit ireland' in an incognito google search you get a result like this:
<img width="492" alt="screen shot 2018-07-17 at 14 04 53" src="https://user-images.githubusercontent.com/3606555/42819082-6960e288-89ca-11e8-93c4-c08655e62f89.png">

This fixes that - using the 'name' field of TagIndex rather than converting the model toString.