### PR TITLE
Update the prebid bid-config to account for new business logic

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -29,7 +29,7 @@ import {
 } from 'commercial/modules/prebid/utils';
 
 const isDesktopArticle =
-    getBreakpointKey() === 'D' && config.page.contentType === 'Article';
+    getBreakpointKey() === 'D' && config.get('page.contentType') === 'Article';
 
 const getTrustXAdUnitId = (slotId: string): string => {
     switch (stripMobileSuffix(slotId)) {
@@ -81,9 +81,9 @@ const getTrustXAdUnitId = (slotId: string): string => {
 };
 
 const getIndexSiteId = (): string => {
-    const site = config.page.pbIndexSites.find(
-        s => s.bp === getBreakpointKey()
-    );
+    const site = config
+        .get('page.pbIndexSites')
+        .find(s => s.bp === getBreakpointKey());
     return site && site.id ? site.id.toString() : '';
 };
 
@@ -109,7 +109,7 @@ const containsLeaderboardOrBillboard = (sizes: PrebidSize[]): boolean =>
     containsLeaderboard(sizes) || containsBillboard(sizes);
 
 const getImprovePlacementId = (sizes: PrebidSize[]): number => {
-    switch (config.page.edition) {
+    switch (config.get('page.edition')) {
         case 'UK':
             switch (getBreakpointKey()) {
                 case 'D':
@@ -168,7 +168,7 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
 };
 
 const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
-    switch (config.page.edition) {
+    switch (config.get('page.edition')) {
         case 'UK':
             switch (getBreakpointKey()) {
                 case 'D':
@@ -225,10 +225,10 @@ const sonobiBidder: PrebidBidder = {
         Object.assign(
             {},
             {
-                ad_unit: config.page.adUnit,
+                ad_unit: config.get('page.adUnit'),
                 dom_id: slotId,
                 appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
-                pageViewId: config.ophan.pageViewId,
+                pageViewId: config.get('ophan.pageViewId'),
             },
             getTestVariantId('CommercialPrebidSafeframe') === 'variant'
                 ? { render: 'safeframe' }
@@ -272,7 +272,7 @@ const appnexusBidder: PrebidBidder = {
 const openxBidder: PrebidBidder = {
     name: 'openx',
     bidParams: (): PrebidOpenXParams => {
-        switch (config.page.edition) {
+        switch (config.get('page.edition')) {
             case 'UK':
                 return {
                     delDomain: 'guardian-d.openx.net',
@@ -296,7 +296,10 @@ const openxBidder: PrebidBidder = {
 const dummyServerSideBidders: PrebidBidder[] = [];
 
 // Experimental. Only 0.01% of the PVs.
-if (config.switches.prebidS2sozone && getRandomIntInclusive(1, 10000) === 1) {
+if (
+    config.get('switches.prebidS2sozone') &&
+    getRandomIntInclusive(1, 10000) === 1
+) {
     dummyServerSideBidders.push(appnexusBidder);
     dummyServerSideBidders.push(openxBidder);
 }
@@ -305,7 +308,7 @@ if (config.switches.prebidS2sozone && getRandomIntInclusive(1, 10000) === 1) {
 
 // There's an IX bidder for every size that the slot can take
 const indexExchangeBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
-    if (config.switches.prebidIndexExchange) {
+    if (config.get('switches.prebidIndexExchange')) {
         const indexSiteId = getIndexSiteId();
         return slotSizes.map(size => ({
             name: 'ix',
@@ -319,16 +322,16 @@ const indexExchangeBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
 };
 
 const otherBidders: PrebidBidder[] = [];
-if (config.switches.prebidSonobi) {
+if (config.get('switches.prebidSonobi')) {
     otherBidders.push(sonobiBidder);
 }
-if (config.switches.prebidTrustx) {
+if (config.get('switches.prebidTrustx')) {
     otherBidders.push(trustXBidder);
 }
-if (config.switches.prebidImproveDigital) {
+if (config.get('switches.prebidImproveDigital')) {
     otherBidders.push(improveDigitalBidder);
 }
-if (config.switches.prebidXaxis) {
+if (config.get('switches.prebidXaxis')) {
     otherBidders.push(xaxisBidder);
 }
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -178,12 +178,12 @@ const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
                     if (containsLeaderboardOrBillboard(sizes)) {
                         return '13366615';
                     }
-                    return '';
+                    return '13144370';
                 case 'M':
                     if (containsMpu(sizes)) {
                         return '13366904';
                     }
-                    return '';
+                    return '13144370';
                 case 'T':
                     if (containsMpu(sizes)) {
                         return '13366913';
@@ -191,12 +191,12 @@ const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
                     if (containsLeaderboard(sizes)) {
                         return '13366916';
                     }
-                    return '';
+                    return '13144370';
                 default:
-                    return '';
+                    return '13144370';
             }
         default:
-            return '';
+            return '13144370';
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -1,0 +1,70 @@
+// @flow
+import config from 'lib/config';
+import { _ } from 'commercial/modules/prebid/bid-config';
+import { getRandomIntInclusive as getRandomIntInclusive_ } from 'commercial/modules/prebid/utils';
+
+import type { PrebidBidder } from 'commercial/modules/prebid/types';
+
+const getRandomIntInclusive: any = getRandomIntInclusive_;
+const { getDummyServerSideBidders } = _;
+
+jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
+    getAdConsentState: jest.fn(),
+}));
+
+jest.mock('./utils', () => ({
+    isExcludedGeolocation: jest.fn(() => false),
+    getRandomIntInclusive: jest.fn(),
+    getBreakpointKey: jest.fn(() => 'D'),
+}));
+
+jest.mock('lib/geolocation', () => ({
+    getSync: jest.fn(() => 'GB'),
+}));
+
+/* eslint-disable guardian-frontend/no-direct-access-config */
+describe('getDummyServerSideBidders', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        getRandomIntInclusive.mockReturnValue(1);
+        config.switches.prebidS2sozone = true;
+        config.page.edition = 'UK';
+    });
+
+    test('should return an empty array if the switch is off', () => {
+        config.switches.prebidS2sozone = false;
+        expect(getDummyServerSideBidders()).toEqual([]);
+    });
+
+    test('should return an empty array if outside the test sample', () => {
+        getRandomIntInclusive.mockReturnValueOnce(3);
+        expect(getDummyServerSideBidders()).toEqual([]);
+    });
+
+    test('should otherwise return the expected array of bidders', () => {
+        const bidders: Array<PrebidBidder> = getDummyServerSideBidders();
+        expect(bidders).toEqual([
+            expect.objectContaining({
+                name: 'openx',
+                bidParams: expect.any(Function),
+            }),
+            expect.objectContaining({
+                name: 'appnexus',
+                bidParams: expect.any(Function),
+            }),
+        ]);
+    });
+
+    test('should include methods in the response that generate the correct bid params', () => {
+        const bidders: Array<PrebidBidder> = getDummyServerSideBidders();
+        const openxParams = bidders[0].bidParams('type', [[1, 2]]);
+        const appnexusParams = bidders[1].bidParams('type', [[1, 2]]);
+        expect(openxParams).toEqual({
+            delDomain: 'guardian-d.openx.net',
+            unit: '539997090',
+        });
+        expect(appnexusParams).toEqual({
+            placementId: '13144370',
+        });
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -39,7 +39,7 @@ const s2sConfig = {
     adapter: 'prebidServer',
     is_debug: 'false',
     endpoint: 'https://elb.the-ozone-project.com/openrtb2/auction',
-    syncEndpoint: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
+    syncEndpoint: 'https://elb.the-ozone-project.com/cookie_sync',
     cookieSet: true,
     cookiesetUrl: 'https://acdn.adnxs.com/cookieset/cs.js',
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -76,10 +76,10 @@ class PrebidService {
                 bidderTimeout,
                 priceGranularity,
             },
-            config.switches.enableConsentManagementService
+            config.get('switches.enableConsentManagementService')
                 ? { consentManagement }
                 : {},
-            config.switches.prebidS2sozone ? { s2sConfig } : {}
+            config.get('switches.prebidS2sozone') ? { s2sConfig } : {}
         );
 
         window.pbjs.setConfig(pbjsConfig);
@@ -87,15 +87,15 @@ class PrebidService {
         // gather analytics from 20% (1 in 5) of page views
         const inSample = getRandomIntInclusive(1, 5) === 1;
         if (
-            config.switches.prebidAnalytics &&
-            (inSample || config.page.isDev)
+            config.get('switches.prebidAnalytics') &&
+            (inSample || config.get('page.isDev'))
         ) {
             window.pbjs.enableAnalytics([
                 {
                     provider: 'gu',
                     options: {
-                        ajaxUrl: config.page.ajaxUrl,
-                        pv: config.ophan.pageViewId,
+                        ajaxUrl: config.get('page.ajaxUrl'),
+                        pv: config.get('ophan.pageViewId'),
                     },
                 },
             ]);
@@ -105,14 +105,14 @@ class PrebidService {
         // allows dynamic assignment.
         window.pbjs.bidderSettings = {};
 
-        if (config.switches.prebidSonobi) {
+        if (config.get('switches.prebidSonobi')) {
             window.pbjs.bidderSettings.sonobi = {
                 // for Jetstream deals
                 alwaysUseBid: true,
             };
         }
 
-        if (config.switches.prebidXaxis) {
+        if (config.get('switches.prebidXaxis')) {
             window.pbjs.bidderSettings.xhb = {
                 // for First Look deals
                 alwaysUseBid: true,

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { getBreakpoint } from 'lib/detect';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const stripSuffix = (s: string, suffix: string): string => {
     const re = new RegExp(`${suffix}$`);
@@ -23,6 +24,11 @@ export const getBreakpointKey = (): string => {
         default:
             return 'D';
     }
+};
+
+export const isExcludedGeolocation = (): boolean => {
+    const excludedGeos = ['US', 'CA', 'NZ', 'AU'];
+    return excludedGeos.includes(geolocationGetSync());
 };
 
 export const stripMobileSuffix = (s: string): string =>

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -1,7 +1,34 @@
 // @flow
-import { stripMobileSuffix, stripTrailingNumbersAbove1 } from './utils';
+import { getSync as getSync_ } from 'lib/geolocation';
+import {
+    isExcludedGeolocation,
+    stripMobileSuffix,
+    stripTrailingNumbersAbove1,
+} from './utils';
+
+const getSync: any = getSync_;
+
+jest.mock('lib/geolocation', () => ({
+    getSync: jest.fn(() => 'GB'),
+}));
 
 describe('Utils', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('isExcludedGeolocation should return true for excluded geolocations', () => {
+        const excludedGeos = ['US', 'CA', 'NZ', 'AU'];
+        for (let i = 0; i < excludedGeos.length; i += 1) {
+            getSync.mockReturnValueOnce(excludedGeos[i]);
+            expect(isExcludedGeolocation()).toBe(true);
+        }
+    });
+
+    test('isExcludedGeolocation should otherwise return false', () => {
+        expect(isExcludedGeolocation()).toBe(false);
+    });
+
     test('stripMobileSuffix', () => {
         expect(stripMobileSuffix('top-above-nav--mobile')).toBe(
             'top-above-nav'


### PR DESCRIPTION
## What does this change?

#### 👉 Update the AppNexus fallback ID

Rather than returning an empty string we now return '13144370'

#### 👉 Update endpoint for Cookie Sync

syncEndpoint has been changed to the new URL

#### 👉Exclude AppNexus bids from US, CA, NZ and AU geolocations

We will be able to configure dummyServerSideBidders based on geolocation

#### 👉Make the linter happy and increase test coverage

Our eslint rules include one called guardian-frontend/no-direct-access-config, so switching to using `config.get` should solve some of the linter warnings.

This PR moves some logic into a function to help with testing and adds basic tests for the new function.

## Screenshots

## What is the value of this and can you measure success?

Commercial business as usual

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
