### PR TITLE
Instrument amp cleaner to see what's getting yanked.

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -1,6 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
+import org.joda.time.LocalDate
 
 trait MonitoringSwitches {
   // Monitoring
@@ -73,6 +74,16 @@ trait MonitoringSwitches {
     safeState = Off,
     never,
     exposeClientSide = true
+  )
+
+  val LogRemovedAmpElements = Switch(
+    SwitchGroup.Monitoring,
+    "log-removed-amp-elements",
+    "Sends log messages to kibana whenever an element is removed from an AMP article.",
+    Seq(Owner.withGithub("aware")),
+    Off,
+    new LocalDate(2018, 8, 8),
+    false
   )
 
 }

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -286,6 +286,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "create an amp-soundcloud element with a trackid from the iframe src that has a src url from soundcloud.com" in {
+
     val result: Document = cleanDocumentWithAudioEmbed("element-audio", "", "", "", soundcloudUrlV2)
     result.getElementsByTag("amp-soundcloud").first.attr("data-trackid") should be(soundcloudTrackid.toString)
   }


### PR DESCRIPTION
## What does this change?

So right now, if an element would cause a validation failure, the element is removed. There is a field in composer (which only appears to be shown for interactives) that states an element is required for publication. 

https://trello.com/c/lm1XaV5G/68-support-this-element-is-required-for-publication-in-amp

This doesn't appear to be fed through from CAPI (see trello) so I'd like to get an idea for how often elements are removed from amp pages with view to not generating amp pages with a failed element. 

The two options for preventing an amp page would be:
	1. Don't render the amp meta tag.
		This would require checking for things which would be removed in multiple places- which I'm not thrilled about.
	2. Output some amp-html that's not valid to cause the validation to fail and for the canonical version to be shown.  

This PR sends log events to Kibana whenever we pull an element from a page, this is behind the `LogRemovedAmpElements` switch. 

When we've got a better idea of what amount of content this is affecting, we can then decide whether we want to stop these pieces generating amp pages.

## Screenshots

📈 ?
📉 ?

## What is the value of this and can you measure success?

If we're removing lots of content from article silently, this is a bad experience for the user. This would also mean central prod wouldn't need to manually cause validation failures to prevent amping. 

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)


<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
