### PR TITLE
Lotame CMP

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -9,6 +9,7 @@ import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
+import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
 import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as prepareSonobiTag } from 'commercial/modules/dfp/prepare-sonobi-tag';
@@ -37,6 +38,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-thirdPartyTags', initThirdPartyTags],
     ['cm-checkDispatcher', initCheckDispatcher],
+    ['cm-lotame-cmp', initLotameCmp],
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -37,6 +37,7 @@ const setLotameConsent = (consent: boolean) =>
     local.set(lotameConsent, consent ? 1 : 0);
 
 const lotameCallback = (data: LotameSuccess | LotameError): void => {
+    console.log(`lotameCallback: ${JSON.stringify(data)}`);
     if ('error' in data) {
         setLotameConsent(false);
     } else if ('consent' in data) {
@@ -81,13 +82,14 @@ const init = () => {
         if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
             getLotameAdConsent()
                 .then(isConsentingData)
-                .then(isConsenting =>
-                    window.LOTCC.setConsent(
+                .then(isConsenting => {
+                    console.log(`isConsenting: ${isConsenting.toString()}`);
+                    return window.LOTCC.setConsent(
                         lotameCallback,
                         clientId,
                         lotameConsentData(isConsenting)
-                    )
-                );
+                    );
+                });
         }
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -31,7 +31,7 @@ const lotameConsentData = (isConsenting: boolean) => ({
     targeting: isConsenting,
 });
 
-const getLotameConsent = () => local.get(lotameConsent);
+const getLotameConsent = (): number => local.get(lotameConsent);
 
 const setLotameConsent = (consent: boolean) =>
     local.set(lotameConsent, consent ? 1 : 0);
@@ -78,19 +78,21 @@ const getLotameAdConsent = (): Promise<any> =>
 
 const init = () => {
     console.log(`Initialising lotame consent`);
-    if (!getLotameConsent()) {
-        if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
-            getLotameAdConsent()
-                .then(isConsentingData)
-                .then(isConsenting => {
-                    console.log(`isConsenting: ${isConsenting.toString()}`);
+    if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
+        getLotameAdConsent()
+            .then(isConsentingData)
+            .then(isConsenting => {
+                console.log(`isConsenting: ${isConsenting.toString()}`);
+                const localConsenting: boolean = !!getLotameConsent();
+                if (localConsenting !== isConsenting) {
+                    setLotameConsent(isConsenting);
                     return window.LOTCC.setConsent(
                         lotameCallback,
                         clientId,
                         lotameConsentData(isConsenting)
                     );
-                });
-        }
+                }
+            });
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -48,8 +48,10 @@ const isConsentingData = (consentData): boolean => {
     try {
         const vendorConsents = consentData.vendorConsents;
         const purposeConsents = consentData.purposeConsents;
-        return Object.keys(vendorConsents).every(k => vendorConsents[k]) &&
-            Object.keys(purposeConsents).every(k => purposeConsents[k]);
+        return (
+            Object.keys(vendorConsents).every(k => vendorConsents[k]) &&
+            Object.keys(purposeConsents).every(k => purposeConsents[k])
+        );
     } catch (e) {
         return false;
     }

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -36,12 +36,14 @@ const getLotameConsent = (): number => local.get(lotameConsent);
 const setLotameConsent = (consent: boolean) =>
     local.set(lotameConsent, consent ? 1 : 0);
 
-const lotameCallback = (data: LotameSuccess | LotameError): void => {
+const lotameCallback = (isConsenting: boolean) => (
+    data: LotameSuccess | LotameError
+): void => {
     console.log(`lotameCallback: ${JSON.stringify(data)}`);
     if ('error' in data) {
         setLotameConsent(false);
     } else if ('consent' in data) {
-        setLotameConsent(true);
+        setLotameConsent(isConsenting);
     }
 };
 
@@ -85,9 +87,8 @@ const init = () => {
                 console.log(`isConsenting: ${isConsenting.toString()}`);
                 const localConsenting: boolean = !!getLotameConsent();
                 if (localConsenting !== isConsenting) {
-                    setLotameConsent(isConsenting);
                     return window.LOTCC.setConsent(
-                        lotameCallback,
+                        lotameCallback(isConsenting),
                         clientId,
                         lotameConsentData(isConsenting)
                     );

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -92,7 +92,10 @@ const init = () => {
                         lotameConsentData(isConsenting)
                     );
                 }
-            });
+            })
+            .catch(error =>
+                console.error(`Error with lotame: ${error.toString()}`)
+            );
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -20,9 +20,9 @@ type LotameSuccess = {
     consent: Array<LotameClientConsent>,
 };
 
-const clientId = 12666;
-const lotameVendorId = 95;
-const lotameConsent = 'lotameConsent';
+const clientId: number = 12666;
+const lotameVendorId: number = 95;
+const lotameConsentKey: string = 'lotameConsent';
 
 const lotameConsentData = (isConsenting: boolean) => ({
     analytics: isConsenting,
@@ -31,15 +31,14 @@ const lotameConsentData = (isConsenting: boolean) => ({
     targeting: isConsenting,
 });
 
-const getLotameConsent = (): number => local.get(lotameConsent);
+const getLotameConsent = (): number => local.get(lotameConsentKey);
 
 const setLotameConsent = (consent: boolean) =>
-    local.set(lotameConsent, consent ? 1 : 0);
+    local.set(lotameConsentKey, consent ? 1 : 0);
 
 const lotameCallback = (isConsenting: boolean) => (
     data: LotameSuccess | LotameError
 ): void => {
-    console.log(`lotameCallback: ${JSON.stringify(data)}`);
     if ('error' in data) {
         setLotameConsent(false);
     } else if ('consent' in data) {
@@ -60,7 +59,7 @@ const isConsentingData = (consentData): boolean => {
     }
 };
 
-const getLotameAdConsent = (): Promise<any> =>
+const getLotameAdConsentFromCmp = (): Promise<any> =>
     new Promise((resolve, reject) => {
         if ('__cmp' in window) {
             /*eslint-disable */
@@ -79,12 +78,10 @@ const getLotameAdConsent = (): Promise<any> =>
     });
 
 const init = () => {
-    console.log(`Initialising lotame consent`);
     if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
-        getLotameAdConsent()
+        getLotameAdConsentFromCmp()
             .then(isConsentingData)
             .then(isConsenting => {
-                console.log(`isConsenting: ${isConsenting.toString()}`);
                 const localConsenting: boolean = !!getLotameConsent();
                 if (localConsenting !== isConsenting) {
                     return window.LOTCC.setConsent(
@@ -95,7 +92,9 @@ const init = () => {
                 }
             })
             .catch(error =>
-                console.error(`Error with lotame: ${error.toString()}`)
+                console.error(
+                    `Error with lotame initialisation: ${error.toString()}`
+                )
             );
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -31,10 +31,10 @@ const lotameConsentData = (isConsenting: boolean) => ({
     targeting: isConsenting,
 });
 
-const getLotameConsent = (): number => local.get(lotameConsentKey);
+const getLotameConsent = (): boolean => local.get(lotameConsentKey);
 
 const setLotameConsent = (consent: boolean) =>
-    local.set(lotameConsentKey, consent ? 1 : 0);
+    local.set(lotameConsentKey, consent);
 
 const lotameCallback = (isConsenting: boolean) => (
     data: LotameSuccess | LotameError
@@ -77,7 +77,7 @@ const getLotameAdConsentFromCmp = (): Promise<any> =>
         }
     });
 
-const init = () => {
+const init = (): void => {
     if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
         getLotameAdConsentFromCmp()
             .then(isConsentingData)

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -48,19 +48,14 @@ const isConsentingData = (consentData): boolean => {
     try {
         const vendorConsents = consentData.vendorConsents;
         const purposeConsents = consentData.purposeConsents;
-        if (
-            Object.keys(vendorConsents).every(k => vendorConsents[k]) &&
-            Object.keys(purposeConsents).every(k => purposeConsents[k])
-        ) {
-            return true;
-        }
-        return false;
+        return Object.keys(vendorConsents).every(k => vendorConsents[k]) &&
+            Object.keys(purposeConsents).every(k => purposeConsents[k]);
     } catch (e) {
         return false;
     }
 };
 
-const getLotameAdConsent = async (): Promise<boolean> =>
+const getLotameAdConsent = (): Promise<any> =>
     new Promise((resolve, reject) => {
         if ('__cmp' in window) {
             /*eslint-disable */
@@ -70,7 +65,7 @@ const getLotameAdConsent = async (): Promise<boolean> =>
                 [lotameVendorId],
                 (consentData, success) =>
                     success
-                        ? resolve(isConsentingData(consentData))
+                        ? resolve(consentData)
                         : reject(Error('Error calling getVendorConsents'))
             );
         } else {
@@ -82,13 +77,15 @@ const init = () => {
     console.log(`Initialising lotame consent`);
     if (!getLotameConsent()) {
         if ('LOTCC' in window && 'setConsent' in window.LOTCC) {
-            getLotameAdConsent().then(isConsenting =>
-                window.LOTCC.setConsent(
-                    lotameCallback,
-                    clientId,
-                    lotameConsentData(isConsenting)
-                )
-            );
+            getLotameAdConsent()
+                .then(isConsentingData)
+                .then(isConsenting =>
+                    window.LOTCC.setConsent(
+                        lotameCallback,
+                        clientId,
+                        lotameConsentData(isConsenting)
+                    )
+                );
         }
     }
 };


### PR DESCRIPTION
## What does this change?

This adds the module `lotame-cmp` which takes the permissions for Lotame out of the `window.__cmp` object to directly notify Lotame via their library of the users preferences.

If the user has changed their permission, this will update Lotame; we only need to tell Lotame once for a user until they have changed their permission.

### Does this affect other platforms?

No

### Tested

- [x] Locally
- [x] On CODE (optional)

@guardian/commercial-dev 
