### PR TITLE
UX: Improve text on email validation page

### DIFF
--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -21,20 +21,20 @@
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
         @if(isSignupFlow) {
-            <h1 class="identity-title">Please look in your email inbox</h1>
+            <h1 class="identity-title">Please check your inbox</h1>
         } else {
             <h1 class="identity-title">To continue, you must confirm this is your email address</h1>
         }
+        @emailBlock
         <div class="identity-forms-message__body">
             @if(isSignupFlow) {
-                <p>We have sent you a message because we need to confirm your email address. Please click the link in it.</p>
+                <p>We've sent you an email – please open it up and click on the button. This is so we can verify it's you and help you create a password to complete your Guardian account.</p>
             } else {
                 <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
             }
-            @emailBlock
         </div>
         <aside class="identity-forms-message__body">
-            <p class="identity-forms-message__explainer">The link in the email is valid for 30 mins. If you haven’t received an email from us, please check your spam folder, or click below to resend.</p>
+            <p class="identity-forms-message__explainer">Note that the link is only valid for 30 minutes, so be sure to open it soon!</p>
             <a class="manage-account__button manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
         </aside>
         @if(isSignupFlow) {

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -84,7 +84,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "should render the proper view" in {
       when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
       val result = controller.completeRegistration()(testRequest)
-      contentAsString(result) should include("Please look in your email inbox")
+      contentAsString(result) should include("Please check your inbox")
       contentAsString(result) should include("Exit and go to The Guardian home page")
     }
 

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -88,7 +88,7 @@ Messages
 }
 
 .identity-forms-email-wrap {
-
+    padding-top: $gs-baseline * 4;
     header {
         @include fs-headline(3);
         font-weight: 500;


### PR DESCRIPTION
## What does this change?

Text on the page a user will see when the register an account and reach the email validation step. 

## Screenshots

![screen shot 2018-07-18 at 14 58 00](https://user-images.githubusercontent.com/3636251/42886523-b0c37e7a-8a9b-11e8-9020-6b5d56bbc118.png)


## What is the value of this and can you measure success?

Improved user experience, less confusing text. 

## Checklist

NA

### Does this affect other platforms?

No 

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
