### PR TITLE
Fix open graph images

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -106,7 +106,8 @@
             <meta name="news_keywords" content="@c.item.tags.keywords.take(10).map(_.name).mkString(",")" />
         }
         @c.getOpenGraphProperties.map { case (key, value) =>
-            <meta property="@key" content="@value" />
+
+            <meta property="@key" content="@Html(value)" />
         }
         @c.getTwitterProperties.map{ case (key, value) =>
             <meta name="@key" content="@value" />
@@ -114,7 +115,7 @@
     }
     case s: model.StandalonePage => {
         @s.getOpenGraphProperties.map{ case (key, value) =>
-            <meta property="@key" content="@value" />
+            <meta property="@key" content="@Html(value)" />
         }
         @s.getTwitterProperties.map{ case (key, value) =>
             <meta name="@key" content="@value" />


### PR DESCRIPTION
We need to use the @Html directive to ensure image urls here are not escaped. This breaks the url, including the query parameters which are required, in particular for image signing to work.

The current bug is a bit annoying to notice as browsers tend to mask the escaping. E.g. they display `&amp;` as `&`. curl helped me debug things here. E.g.

     curl https://www.theguardian.com/football/2018/jul/11/zagreb-rocks-croatia-world-cup-semi-final-victory | grep 'og:image'

where you can clearly see the issue.
