### PR TITLE
Added appNexus targetting to be sent to ozone

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -272,6 +272,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
             sizes: PrebidSize[]
         ): PrebidAppNexusParams => ({
             placementId: getAppNexusPlacementId(sizes),
+            customData: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
         }),
     };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -8,6 +8,11 @@ import type { PrebidBidder } from 'commercial/modules/prebid/types';
 const getRandomIntInclusive: any = getRandomIntInclusive_;
 const { getDummyServerSideBidders } = _;
 
+jest.mock('common/modules/commercial/build-page-targeting', () => ({
+    buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
+    buildPageTargeting: () => 'bla',
+}));
+
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
     getAdConsentState: jest.fn(),
 }));
@@ -65,6 +70,7 @@ describe('getDummyServerSideBidders', () => {
         });
         expect(appnexusParams).toEqual({
             placementId: '13144370',
+            customData: 'someTestAppNexusTargeting',
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -35,6 +35,7 @@ export type PrebidXaxisParams = {
 
 export type PrebidAppNexusParams = {
     placementId: string,
+    customData: string,
 };
 
 export type PrebidOpenXParams = {


### PR DESCRIPTION
This implements https://trello.com/c/NaHOH1Ui/90-ozone-are-we-sending-custom-appnexus-data-in-the-bid-request 

Nothing much to say, except I like lodash.