### PR TITLE
Fix bullet points in paid-for articles

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -188,4 +188,9 @@
         border-color: $brightness-46;
     }
 
+    .bullet {
+        &:before {
+            background-color: $brightness-60;
+        }
+    }
 }


### PR DESCRIPTION
## What does this change?

This fixes bullets in paid-for articles. This was broken by commit fefba24a4e90a6018895e4b0818d48c2078719c9.

Specifically, the change [here](https://github.com/guardian/frontend/commit/fefba24a4e90a6018895e4b0818d48c2078719c9#diff-1318de042509dd3edb29e22650ffd6e1R38) has caused the bullet point to be the same colour as the background by setting it to `$brightness-86`.

## Screenshots

![broken-bullet](https://user-images.githubusercontent.com/445472/42894352-87958d78-8aae-11e8-88a3-7a9da2b88f7f.png)

![fixedbullet](https://user-images.githubusercontent.com/445472/42894354-88ffaeaa-8aae-11e8-810a-9578e3801971.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

@frankie297 @katebee @zeftilldeath 