### PR TITLE
extend the DFP Epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "See if there is any difference in annualised value between serving the Epic natively vs DFP",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 7, 18),
+    sellByDate = new LocalDate(2018, 7, 25),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-native-vs-dfp-v3.js
@@ -26,7 +26,7 @@ const epicNativeVsDfpV3: ABTest = {
     id: testName,
     campaignId: 'epic_native_vs_dfp_v3',
     start: '2018-06-27',
-    expiry: '2018-07-18',
+    expiry: '2018-07-25',
     author: 'Guy Dawson',
     description:
         'See if there is any difference in annualised value between serving the Epic natively vs DFP',


### PR DESCRIPTION
## What does this change?

Extends the DFP Epic test. Note: it is currently off (via the switchboard). Tomorrow we'll decide whether to remove it from the code base completely, or turn it on again.

