### PR TITLE
Fix bullet colours in lists in commercial pages

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -156,6 +156,10 @@
     > li {
         @include faux-bullet-point($right-space: 4px);
 
+        .paid-content & {
+            @include faux-bullet-point($brightness-60, $right-space: 4px);
+        }
+
         > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
             display: inline;
         }


### PR DESCRIPTION
## What does this change?

This is a similar fix to #20041. Except rather than targetting the `.bullet` class, it targets `li` items.

### Tested

- [ ] Locally
- [x] On CODE (optional)

@zeftilldeath @guardian/commercial-dev 
