### PR TITLE
show engagement banner to ad block users

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -1,7 +1,6 @@
 // @flow
 import config from 'lib/config';
 import { local } from 'lib/storage';
-import { adblockInUse } from 'lib/detect';
 import { Message } from 'common/modules/ui/message';
 import mediator from 'lib/mediator';
 import { membershipEngagementBannerTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
@@ -23,7 +22,7 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 const messageCode = 'engagement-banner-2018-07-13';
 
 const canDisplayMembershipEngagementBanner = (): Promise<boolean> =>
-    adblockInUse.then(adblockUsed => !adblockUsed && shouldShowReaderRevenue());
+    Promise.resolve(shouldShowReaderRevenue());
 
 const getUserTest = (): ?AcquisitionsABTest =>
     membershipEngagementBannerTests.find(


### PR DESCRIPTION
## What does this change?

Shows membership engagement banner to ad block users.

## Screenshots

<img width="1275" alt="eb_ad_blocker" src="https://user-images.githubusercontent.com/4085817/42948624-ce3347e8-8b67-11e8-984d-3b622e81878c.png">

## What is the value of this and can you measure success?

Extend contribution ask to more readers. 

In terms of measuring success, we could run this as an AB test; but given current resource, I am releasing it to the whole audience as it's a quicker piece of work (though this doesn't prevent us from measuring the up lift in the future).

### Tested

Locally.
