### PR TITLE
Consistently send X-Forwarded-For to IDAPI

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -106,7 +106,7 @@ class AuthenticatedActions(
       override val executionContext = ec
 
       def refine[A](request: AuthRequest[A]) =
-        identityApiClient.me(request.user.auth).map {
+        identityApiClient.me(request.user.auth, idRequestParser(request).trackingData).map {
           _.fold(
             errors => {
               logger.warn(s"Failed to look up logged-in user: $errors")

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -64,7 +64,7 @@ class ChangePasswordController(
         val form = passwordForm.bindFromFlash.getOrElse(passwordForm)
 
         val idRequest = idRequestParser(request)
-        api.passwordExists(request.user.auth) map {
+        api.passwordExists(request.user.auth, idRequest.trackingData) map {
           result =>
             val pwdExists = result.right.toOption exists {_ == true}
             NoCache(Ok(

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -96,7 +96,7 @@ class ResetPasswordController(
     def onSuccess(form: (String, String, String, Option[String])): Future[Result] = form match {
       case (password, password_confirm, email_address, returnUrl) =>
 
-        val authResponse = api.resetPassword(token,password)
+        val authResponse = api.resetPassword(token, password, idRequestParser(request).trackingData)
         signInService.getCookies(authResponse, true) map {
           case Left(errors) =>
             logger.info(s"reset password errors, ${errors.toString()}")
@@ -133,7 +133,7 @@ class ResetPasswordController(
 
   def processUpdatePasswordToken(token : String, returnUrl: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     val idRequest = idRequestParser(request)
-    api.userForToken(token) map {
+    api.userForToken(token, idRequest.trackingData) map {
       case Left(errors) =>
         logger.warn(s"Could not retrieve password reset request for token: $token, errors: ${errors.toString()}")
         val idRequest = idRequestParser(request)

--- a/identity/app/controllers/editprofile/EditProfileFormHandling.scala
+++ b/identity/app/controllers/editprofile/EditProfileFormHandling.scala
@@ -71,7 +71,7 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
           formWithErrors => profileFormsView(page, boundProfileForms, userDO),
           success = {
             case formData: AccountFormData if formData.deleteTelephone =>
-              identityApiClient.deleteTelephone(userDO.auth) flatMap {
+              identityApiClient.deleteTelephone(userDO.auth, idRequestParser(request).trackingData) flatMap {
                 case Left(errors) => profileFormsView(page, boundProfileForms.withErrors(errors), userDO)
 
                 case Right(_) => {

--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -52,7 +52,7 @@ trait EmailsTab
   def deleteAllSubscriptionsAndMarketingConsents(): Action[AnyContent] =
     csrfCheck {
       recentFullAuthWithIdapiUserAction.async { implicit request =>
-        identityApiClient.unsubscribeFromAllEmailsAndOptoutMarketingConsents(request.user.auth).map {
+        identityApiClient.unsubscribeFromAllEmailsAndOptoutMarketingConsents(request.user.auth, idRequestParser(request).trackingData).map {
           case Right(_) => NoContent
           case Left(errors) =>
             logger.error(s"Failed to unsubscribe User ${request.user.id} from all")

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -29,10 +29,15 @@ class IdApiClient(
 
   private def extractUser: (Response[HttpResponse]) => Response[User] = extract(jsonField("user"))
 
+  private def xForwardedFor(trackingData: Option[TrackingData]): Parameters =
+    trackingData.flatMap(_.ipAddress).fold(Seq.empty[(String, String)])(ip => Seq("X-Forwarded-For" -> ip))
+
+  private def xForwardedFor(trackingData: TrackingData): Parameters = xForwardedFor(Some(trackingData))
+
   //   AUTH
   def authBrowser(userAuth: Auth, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
     val params = buildParams(None, Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
-    val headers = buildHeaders(Some(userAuth))
+    val headers = buildHeaders(Some(userAuth), extra = xForwardedFor(trackingData))
     val body = write(userAuth)
     val response = httpClient.POST(apiUrl("auth"), Some(body), params, headers)
     response map extract(jsonField("cookies"))
@@ -70,10 +75,10 @@ class IdApiClient(
   def saveUser(userId: String, user: UserUpdateDTO, auth: Auth): Future[Response[User]] =
     post(urlJoin("user", userId), Some(auth), body = Some(write(user))) map extractUser
 
-  def me(auth: Auth): Future[Response[User]] = {
+  def me(auth: Auth, trackingData: TrackingData): Future[Response[User]] = {
     val apiPath = urlJoin("user", "me")
     val params = buildParams(Some(auth))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(Some(auth)))
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(Some(auth), extra = xForwardedFor(trackingData)))
     response map extractUser
   }
 
@@ -92,16 +97,16 @@ class IdApiClient(
   def register(user: User, trackingParameters: TrackingData, returnUrl: Option[String] = None): Future[Response[User]] = {
     val userData = write(user)
     val params = buildParams(tracking = Some(trackingParameters), extra = returnUrl.map(url => Iterable("returnUrl" -> url)))
-    val headers = buildHeaders(extra = trackingParameters.ipAddress.map(ip => Iterable("X-Forwarded-For" -> ip)))
+    val headers = buildHeaders(extra = xForwardedFor(trackingParameters))
     val response = httpClient.POST(apiUrl("user"), Some(userData), params, headers)
     response map extractUser
   }
 
   // PASSWORD RESET/UPDATE
 
-  def passwordExists( auth: Auth ): Future[Response[Boolean]] = {
+  def passwordExists(auth: Auth, trackingData: TrackingData): Future[Response[Boolean]] = {
     val apiPath = urlJoin("user", "password-exists")
-    val response = httpClient.GET(apiUrl(apiPath), None, buildParams(Some(auth)), buildHeaders(Some(auth)))
+    val response = httpClient.GET(apiUrl(apiPath), None, buildParams(Some(auth)), buildHeaders(Some(auth), extra = xForwardedFor(trackingData)))
     response map extract[Boolean](jsonField("passwordExists"))
   }
 
@@ -112,23 +117,23 @@ class IdApiClient(
     response map extractUnit
   }
 
-  def userForToken( token : String ): Future[Response[User]] = {
+  def userForToken(token : String, trackingData: TrackingData): Future[Response[User]] = {
     val apiPath = urlJoin("pwd-reset", "user-for-token")
     val params = buildParams(extra = Iterable("token" -> token))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders())
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(extra = xForwardedFor(trackingData)))
     response map extractUser
   }
 
-  def resetPassword( token : String, newPassword : String ): Future[Response[CookiesResponse]] = {
+  def resetPassword(token : String, newPassword : String, trackingData: TrackingData): Future[Response[CookiesResponse]] = {
     val apiPath = urlJoin("pwd-reset", "reset-pwd-for-user")
     val postBody = write(TokenPassword(token, newPassword))
-    val response = httpClient.POST(apiUrl(apiPath), Some(postBody), clientAuth.parameters, clientAuth.headers)
+    val response = httpClient.POST(apiUrl(apiPath), Some(postBody), clientAuth.parameters, clientAuth.headers ++ xForwardedFor(trackingData))
     response map extract(jsonField("cookies"))
   }
 
   def sendPasswordResetEmail(emailAddress : String, trackingParameters: TrackingData): Future[Response[Unit]] = {
     val apiPath = urlJoin("pwd-reset", "send-password-reset-email")
-    val params = buildParams(tracking = Some(trackingParameters), extra = Iterable("email-address" -> emailAddress, "type" -> "reset"))
+    val params = buildParams(tracking = Some(trackingParameters), extra = Iterable("email-address" -> emailAddress, "type" -> "reset") ++ xForwardedFor(trackingParameters))
     val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders())
     response map extractUnit
   }
@@ -138,7 +143,7 @@ class IdApiClient(
   def userEmails(userId: String, trackingParameters: TrackingData): Future[Response[Subscriber]] = {
     val apiPath = urlJoin("useremails", userId)
     val params = buildParams(tracking = Some(trackingParameters))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders())
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(extra = xForwardedFor(trackingParameters)))
     response map extract(jsonField("result"))
   }
 
@@ -160,14 +165,14 @@ class IdApiClient(
 
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {
     val extraParams = returnUrlOpt.map(url => List("returnUrl" -> url))
-    httpClient.POST(apiUrl("user/send-validation-email"), None, buildParams(Some(auth), Some(trackingParameters), extraParams), buildHeaders(Some(auth))) map extractUnit
+    httpClient.POST(apiUrl("user/send-validation-email"), None, buildParams(Some(auth), Some(trackingParameters), extraParams), buildHeaders(Some(auth), extra = xForwardedFor(trackingParameters))) map extractUnit
   }
 
-  def deleteTelephone(auth: Auth): Future[Response[Unit]] =
-    delete("user/me/telephoneNumber", Some(auth)) map extractUnit
+  def deleteTelephone(auth: Auth, trackingData: TrackingData): Future[Response[Unit]] =
+    delete("user/me/telephoneNumber", Some(auth), Some(trackingData)) map extractUnit
 
-  def unsubscribeFromAllEmailsAndOptoutMarketingConsents(auth: Auth): Future[Response[Unit]] =
-    post("remove/consent/all", Some(auth)).map(extractUnit)
+  def unsubscribeFromAllEmailsAndOptoutMarketingConsents(auth: Auth, trackingData: TrackingData): Future[Response[Unit]] =
+    post("remove/consent/all", Some(auth), Some(trackingData)).map(extractUnit)
 
   // THIRD PARTY SIGN-IN
   def addUserToGroup(groupCode: String, auth: Auth): Future[Response[Unit]] = {
@@ -187,13 +192,13 @@ class IdApiClient(
            auth: Option[Auth] = None,
            trackingParameters: Option[TrackingData] = None,
            body: Option[String] = None): Future[Response[HttpResponse]] =
-    httpClient.POST(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth))
+    httpClient.POST(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth, extra = xForwardedFor(trackingParameters)))
 
   def delete(apiPath: String,
            auth: Option[Auth] = None,
            trackingParameters: Option[TrackingData] = None,
            body: Option[String] = None): Future[Response[HttpResponse]] =
-    httpClient.DELETE(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth))
+    httpClient.DELETE(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth, extra = xForwardedFor(trackingParameters)))
 
   implicit object ParamsOpt2Params extends (Option[Parameters] => Parameters) {
     def apply(paramsOpt: Option[Parameters]): Parameters = paramsOpt.getOrElse(Iterable.empty)

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -5,7 +5,7 @@ import java.net.URLEncoder
 import actions.AuthenticatedActions.AuthRequest
 import com.gu.identity.model.{StatusFields, Subscriber, User}
 import conf.switches.Switches
-import idapiclient.{Auth, IdApiClient, ScGuRp, ScGuU}
+import idapiclient._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
@@ -15,7 +15,6 @@ import play.api.mvc.{AnyContent, _}
 import play.api.test.{FakeRequest, Helpers, Injecting}
 import services.{ProfileRedirect, _}
 import test.{WithTestExecutionContext, WithTestIdConfig}
-import idapiclient.Response
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.Helpers._
 
@@ -67,7 +66,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       def callMock: AuthRequest[AnyContent] => Result = _ => mockFunc.apply(1)
 
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(recentlyAuthedUser))
-      when(client.me(any[Auth])).thenReturn(Future(Right(user)))
+      when(client.me(any[Auth], any[TrackingData])).thenReturn(Future(Right(user)))
       when(mockFunc.apply(1)) thenReturn mock[Result]
       when(profileRedirectService.toProfileRedirect(any[User], any[RequestHeader])).thenReturn(NoRedirect)
 
@@ -104,7 +103,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
 
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(None)
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(Some(userWithRpCookie))
-      when(client.me(any[Auth])).thenReturn(Future(Right(user)))
+      when(client.me(any[Auth], any[TrackingData])).thenReturn(Future(Right(user)))
       when(profileRedirectService.toConsentsRedirect(any[User], any[RequestHeader])).thenReturn(NoRedirect)
 
       val mockFunc = mock[Int => Result]
@@ -123,7 +122,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
 
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(recentlyAuthedUser))
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
-      when(client.me(any[Auth])).thenReturn(Future(Right(user)))
+      when(client.me(any[Auth], any[TrackingData])).thenReturn(Future(Right(user)))
       when(profileRedirectService.toConsentsRedirect(any[User], any[RequestHeader])).thenReturn(NoRedirect)
 
       val mockFunc = mock[Int => Result]

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -62,7 +62,7 @@ import scala.concurrent.Future
     )
 
     when(authService.fullyAuthenticatedUser(any[RequestHeader])) thenReturn Some(authenticatedUser)
-    when(api.me(testAuth)) thenReturn Future.successful(Right(user))
+    when(api.me(MockitoMatchers.eq(testAuth), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(user))
 
     when(idRequest.trackingData) thenReturn trackingData
     when(idRequest.returnUrl) thenReturn None

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -66,7 +66,7 @@ import scala.concurrent.Future
     )
 
     when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
-    when(api.me(testAuth, any[TrackingData])) thenReturn Future.successful(Right(user))
+    when(api.me(MockitoMatchers.eq(testAuth), any[TrackingData])) thenReturn Future.successful(Right(user))
 
     when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
     when(idRequest.trackingData) thenReturn trackingData

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -14,6 +14,7 @@ import controllers.editprofile.EditProfileController
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
+import org.mockito.Matchers.any
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{DoNotDiscover, Matchers, OptionValues, WordSpec}
 import org.scalatest.mockito.MockitoSugar
@@ -65,7 +66,7 @@ import scala.concurrent.Future
     )
 
     when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
-    when(api.me(testAuth)) thenReturn Future.successful(Right(user))
+    when(api.me(testAuth, any[TrackingData])) thenReturn Future.successful(Right(user))
 
     when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
     when(idRequest.trackingData) thenReturn trackingData
@@ -334,13 +335,13 @@ import scala.concurrent.Future
       "delete a telephone number with a delete telephone number request" in new EditProfileFixture {
         val fakeRequest = createFakeRequestDeleteTelephoneNumber
 
-        when(api.deleteTelephone(MockitoMatchers.any[Auth]))
+        when(api.deleteTelephone(MockitoMatchers.any[Auth], any[TrackingData]))
           .thenReturn(Future.successful(Right(())))
 
         val result = controller.submitAccountForm().apply(fakeRequest)
         status(result) should be(200)
 
-        verify(api).deleteTelephone(MockitoMatchers.eq(testAuth))
+        verify(api).deleteTelephone(MockitoMatchers.eq(testAuth), any[TrackingData])
       }
 
       "save the user on the ID API without telephone number request" in new EditProfileFixture {

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -47,7 +47,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
   val phoneNumbers = PhoneNumbers
 
   when(authService.fullyAuthenticatedUser(any[RequestHeader])) thenReturn Some(authenticatedUser)
-  when(api.me(testAuth)) thenReturn Future.successful(Right(user))
+  when(api.me(eql(testAuth), any[TrackingData])) thenReturn Future.successful(Right(user))
 
   val redirectDecisionService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponent)
   val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser, redirectDecisionService)

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -63,10 +63,10 @@ class ResetPasswordControllerTest
   "the handle render method" - {
     val fakeRequest = FakeRequest(GET, "/c/1234")
     "when the token provided is valid" - {
-       when(api.userForToken(MockitoMatchers.any[String])).thenReturn(Future.successful(Right(user)))
+       when(api.userForToken(MockitoMatchers.any[String], MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Right(user)))
        "should pass the token param to to the api" in Fake {
          resetPasswordController.processUpdatePasswordToken("1234", None)(fakeRequest)
-         verify(api).userForToken(MockitoMatchers.eq("1234"))
+         verify(api).userForToken(MockitoMatchers.eq("1234"), MockitoMatchers.any[TrackingData])
        }
 
        "should render the reset password form when the user token has not expired" in Fake {
@@ -84,7 +84,7 @@ class ResetPasswordControllerTest
     }
 
     "should render the reset password form when the user token is not valid" - {
-      when(api.userForToken("1234")).thenReturn(Future.successful(Left(tokenExpired)))
+      when(api.userForToken(MockitoMatchers.eq("1234"), MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Left(tokenExpired)))
       "should render to the the to the request new password form" in Fake {
         val result = resetPasswordController.processUpdatePasswordToken("1234", None)(fakeRequest)
         status(result) should equal(SEE_OTHER)
@@ -97,12 +97,12 @@ class ResetPasswordControllerTest
 
     val fakeRequest = FakeRequest(POST, "/reset_password" ).withFormUrlEncodedBody("password" -> "newpassword", "password-confirm" -> "newpassword", "email-address" -> "test@somewhere.com")
     "when the token provided is valid" - {
-      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String], MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Right(cookieResponse)))
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Right(cookieList)))
 
       "should call the api the password with the provided new password and token" in Fake {
          resetPasswordController.resetPassword("1234", None)(fakeRequest)
-         verify(api).resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"))
+         verify(api).resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"), MockitoMatchers.any[TrackingData])
       }
       "should return password confirmation view in" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
@@ -112,10 +112,10 @@ class ResetPasswordControllerTest
     }
 
     "when the reset token has expired" - {
-      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String], MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Right(cookieResponse)))
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(tokenExpired)))
 
-      when(api.resetPassword("1234","newpassword")).thenReturn(Future.successful(Left(tokenExpired)))
+      when(api.resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"), MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Left(tokenExpired)))
       "should redirect to request request new password with a token expired" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
         status(result) should equal(SEE_OTHER)
@@ -126,7 +126,7 @@ class ResetPasswordControllerTest
     "when the reset token is not valid" - {
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(accesssDenied)))
 
-      when(api.resetPassword("1234", "newpassword")).thenReturn(Future.successful(Left(accesssDenied)))
+      when(api.resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"), MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Left(accesssDenied)))
       "should redirect to request new password with a problem resetting your password" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
         status(result) should equal(SEE_OTHER)


### PR DESCRIPTION
## What does this change?

- Sends `X-Forwarded-For` to IDAPI in a consistent manner.

## Screenshots

N/A

## What is the value of this and can you measure success?

- IDAPI will be able to rate limit clients more effectively. 
- IDAPI's heatmaps will be more correct. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
