### PR TITLE
Audio AB Test: Extend Audio AB test switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -53,6 +53,6 @@ object AudioPageChange extends Experiment(
   name = "audio-page-change",
   description = "Show a different version of the audio page to certain people",
   owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2018, 7, 20),
+  sellByDate = new LocalDate(2018, 8, 20),
   participationGroup = Perc50
 )


### PR DESCRIPTION
## What does this change?

I am extending the life of the switch that lets us run tests on the audio player. It is switched off. 
However because we are likely to use it again for a new player in the short-term, I'm not going to remove the test code yet. 


## Screenshots

## What is the value of this and can you measure success?

## Checklist

