### PR TITLE
Rollout Lotame to 100% of audience

### DIFF
--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -2,7 +2,7 @@ package pages
 
 import common.Edition
 import conf.switches.Switches._
-import experiments.{ActiveExperiments, LotameParticipation, OldTLSSupportDeprecation}
+import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.Styles
 import model.{ApplicationContext, Page}
@@ -43,7 +43,7 @@ object StoryHtmlPage {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when ActiveExperiments.isParticipating(LotameParticipation),
+        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         head,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -307,6 +307,16 @@ trait CommercialSwitches {
     exposeClientSide = false
    )
 
+   val LotameSwitch: Switch = Switch(
+     group = Commercial,
+     name = "lotame",
+     description = "When this is switched on the Lotame script will be included on the page",
+     owners = group(Commercial),
+     safeState = Off,
+     sellByDate = never,
+     exposeClientSide = false
+   )
+
   val prebidSwitch: Switch = Switch(
     group = Commercial,
     name = "prebid-header-bidding",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
-    LotameParticipation,
     OldTLSSupportDeprecation,
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -30,14 +29,6 @@ object OrielParticipation extends Experiment(
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 9, 12),
   participationGroup = Perc20A
-)
-
-object LotameParticipation extends Experiment(
-  name = "lotame-participation",
-  description = "A slice of the audience who will participate in Lotame tracking",
-  owners = Seq(Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2018, 9, 12),
-  participationGroup = Perc1D
 )
 
 object OldTLSSupportDeprecation extends Experiment(


### PR DESCRIPTION
## What does this change?

Remove the serverside test and roll out Lotame to 100%

Add a new Commercial switch to allow us to enable / disable Lotame from the admin dashboard


## What is the value of this and can you measure success?

https://trello.com/c/K9vererN/89-rollout-lotame-to-100-of-audience

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
