### PR TITLE
Make labs great again

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -2,21 +2,18 @@
     background-color: #d9d9d9;
 }
 
-.paid-content .meta__extras {
-    border-color: #999999;
-}
-
 .paid-content .content__meta-container:not(.content__meta-container--no-byline) {
     margin: 0;
 }
 
 .paid-content .social-icon,
-.paid-content .submeta__keywords {
+.paid-content .submeta__keywords,
+.paid-content .meta__extras {
     border-color: #999999;
 }
 
 .paid-content .social-icon svg,
-.paid-content .inline-icon {
+.paid-content .inline-triangle__svg {
     fill: #121212;
 }
 
@@ -63,14 +60,6 @@
     display: block;
 }
 
-.paidfor-input:not(:checked) ~ .tooltip-label svg {
-    transform: rotate(180deg);
-}
-
-.paidfor-input:checked ~ .tooltip-label svg {
-    transform: rotate(0deg);
-}
-
 .paidfor-meta__label {
     align-items: center;
 }
@@ -102,25 +91,6 @@
     border-right: 1px solid rgba(0, 0, 0, .2);
     display: inline-block;
     padding: 19px 10px;
-}
-
-.paidfor-label .tooltip-label::after {
-    content: '';
-    display: inline-block;
-    width: 4px;
-    height: 4px;
-    transform: translateY(-2px) rotate(45deg);
-    border: 1px solid currentColor;
-    border-left: transparent;
-    border-top: transparent;
-    margin-left: 2px;
-    vertical-align: middle;
-}
-
-.paidfor-label .tooltip-label svg {
-    width: 12px;
-    height: 9px;
-    fill: #333;
 }
 
 .popup--paidfor {

--- a/common/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -54,11 +54,8 @@
     display: flex;
 }
 
+.paidfor-input:not(:checked) ~ .popup--paidfor,
 .paidfor-input {
-    display: none;
-}
-
-.paidfor-input:not(:checked) ~ .popup--paidfor {
     display: none;
 }
 
@@ -118,8 +115,6 @@
     border-top: transparent;
     margin-left: 2px;
     vertical-align: middle;
-    -webkit-backface-visibility: hidden;
-    transition: transform 250ms ease-out;
 }
 
 .paidfor-label .tooltip-label svg {
@@ -147,7 +142,7 @@
     margin: 0 0 1em;
 }
 
-.popup--paidfor__link {
+a.popup--paidfor__link {
     color: #69d1ca;
     display: block;
 }

--- a/common/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -92,6 +92,19 @@
     padding: 19px 10px;
 }
 
+.paidfor-label .tooltip-label::after {
+    content: '';
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    transform: translateY(-2px) rotate(45deg);
+    border: 1px solid currentColor;
+    border-left: transparent;
+    border-top: transparent;
+    margin-left: 2px;
+    vertical-align: middle;
+}
+
 .popup--paidfor {
     position: absolute;
     background: #121212;

--- a/common/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -2,8 +2,31 @@
     background-color: #d9d9d9;
 }
 
+.paid-content .meta__extras {
+    border-color: #999999;
+}
+
 .paid-content .content__meta-container:not(.content__meta-container--no-byline) {
     margin: 0;
+}
+
+.paid-content .social-icon,
+.paid-content .submeta__keywords {
+    border-color: #999999;
+}
+
+.paid-content .social-icon svg,
+.paid-content .inline-icon {
+    fill: #121212;
+}
+
+.paid-content .submeta {
+    background-image: -webkit-repeating-linear-gradient(top, #999999, #999999 0.0625rem, transparent 0.0625rem, transparent 0.25rem);
+    background-image: repeating-linear-gradient(to bottom, #999999, #999999 0.0625rem, transparent 0.0625rem, transparent 0.25rem);
+}
+
+.paid-content a {
+    color: #121212;
 }
 
 .badge--alt {
@@ -22,7 +45,7 @@
 }
 
 .paidfor-band .inline-glabs-logo svg {
-  margin-top: 6px;
+    margin-top: 6px;
 }
 
 .paidfor-meta,

--- a/common/app/views/fragments/amp/stylesheets/glabs.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/glabs.scala.html
@@ -82,7 +82,6 @@
 
 .paidfor-label {
     position: relative;
-    cursor: pointer;
     align-items: center;
 }
 

--- a/static/src/stylesheets/amp/_article-tones.scss
+++ b/static/src/stylesheets/amp/_article-tones.scss
@@ -66,29 +66,29 @@
     }
 }
 
-.content--pillar-news {
+.content--pillar-news:not(.paid-content) {
     @include PillarColourTwo($news-main, $news-dark);
 }
 
-.content--pillar-opinion {
+.content--pillar-opinion:not(.paid-content) {
     @include PillarColourTwo($opinion-main, $opinion-dark);
 
     background-color: $opinion-faded;
 }
 
-.content--pillar-sport {
+.content--pillar-sport:not(.paid-content) {
     @include PillarColourOne($sport-main, $sport-dark);
 }
 
-.content--pillar-arts {
+.content--pillar-arts:not(.paid-content) {
     @include PillarColourOne($culture-main, $culture-dark);
 }
 
-.content--pillar-lifestyle {
+.content--pillar-lifestyle:not(.paid-content) {
     @include PillarColourOne($lifestyle-main, $lifestyle-dark);
 }
 
-.tonal--tone-special-report {
+.tonal--tone-special-report:not(.paid-content) {
     @include PillarColourOne($special-report-dark, $special-report-dark);
     background-color: #eff1f2;
 

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -109,8 +109,6 @@
 }
 
 .content__dateline-wpd--modified {
-    cursor: pointer;
-
     &:hover,
     &:active,
     &:focus {

--- a/static/src/stylesheets/amp/_hosted-gallery.scss
+++ b/static/src/stylesheets/amp/_hosted-gallery.scss
@@ -86,7 +86,6 @@
     border: 1px solid #ffffff;
     border-radius: 50%;
     padding: 9px;
-    cursor: pointer;
     order: 1;
     height: 16px;
 
@@ -124,7 +123,6 @@
     a {
         color: #ffffff;
         position: relative;
-        cursor: pointer;
         text-decoration: none;
         &:not(.social__action)::after {
             content: '';

--- a/static/src/stylesheets/amp/_hosted.scss
+++ b/static/src/stylesheets/amp/_hosted.scss
@@ -179,7 +179,6 @@ $badge-width: $gs-column-width + $gs-gutter;
     color: #ffffff;
     border: 0;
     padding: 0;
-    cursor: pointer;
     background: transparent;
 }
 
@@ -234,7 +233,6 @@ $badge-width: $gs-column-width + $gs-gutter;
 
     .survey-close {
         position: absolute;
-        cursor: pointer;
         top: 4px;
         right: 8px;
     }

--- a/static/src/stylesheets/amp/_live-blog.scss
+++ b/static/src/stylesheets/amp/_live-blog.scss
@@ -191,7 +191,6 @@
     position: relative;
     display: inline-block;
     box-sizing: border-box;
-    cursor: pointer;
     overflow: hidden;
     height: 36px;
     width: auto;
@@ -284,7 +283,6 @@
 }
 
 .liveblog-navigation__link--disabled {
-    cursor: default;
     color: $brightness-86;
     border-color: $brightness-93;
 }

--- a/static/src/stylesheets/amp/_rich-link.scss
+++ b/static/src/stylesheets/amp/_rich-link.scss
@@ -6,7 +6,6 @@
     background-color: $brightness-93;
     border-top: 1px solid $brightness-86;
     margin-right: $gs-gutter;
-    font-size: 14px;
 
     p {
         font-size: 14px;

--- a/static/src/stylesheets/amp/_social.scss
+++ b/static/src/stylesheets/amp/_social.scss
@@ -3,7 +3,7 @@
     padding: 0;
     list-style: none;
     overflow-y: hidden;
-    height: 32px;
+    height: 36px;
 }
 
 .social--top {

--- a/static/src/stylesheets/amp/nav/_menu-item.scss
+++ b/static/src/stylesheets/amp/nav/_menu-item.scss
@@ -23,7 +23,6 @@
     border: 0;
     box-sizing: border-box;
     color: currentColor;
-    cursor: pointer;
     display: block;
     font-size: 20px;
     font-weight: 400;

--- a/static/src/stylesheets/amp/nav/_pillar-link.scss
+++ b/static/src/stylesheets/amp/nav/_pillar-link.scss
@@ -7,7 +7,6 @@
     padding: 0 4px;
     position: relative;
     color: currentColor;
-    cursor: pointer;
 
     @include mq(mobileMedium) {
         font-size: 16px;

--- a/static/src/stylesheets/amp/nav/_veggie-burger.scss
+++ b/static/src/stylesheets/amp/nav/_veggie-burger.scss
@@ -3,7 +3,6 @@
     top: $gs-baseline * 2;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
     color: $nav-faded;
-    cursor: pointer;
     height: $veggie-burger-small;
     min-width: $veggie-burger-small;
     position: absolute;

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -170,14 +170,16 @@ category: Common
     }
 }
 .paid-content, .paid-content.tonal--tone-media {
-    .social-icon {
-        border: 1px solid $brightness-7;
+    .social-icon,
+    .block-share__item {
+        border: 1px solid $brightness-60;
         &:hover,
         &:active,
         &:focus {
+            border: 1px solid $brightness-7;
             background-color: $brightness-7;
         }
-        .social-icon__svg {
+        svg {
             fill: $brightness-7;
         }
         &:focus,

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -12,10 +12,10 @@
     }
 
     .paid-content & {
-        @include multiline(4, $brightness-46, top);
+        @include multiline(4, $brightness-60, top);
 
         .submeta__keywords {
-            border-color: $brightness-46;
+            border-color: $brightness-60;
         }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1020,7 +1020,7 @@
         color: $labs-main;
     }
     .inline-expand-image {
-      fill: $brightness-100;
+        fill: $brightness-100;
     }
     &.content--article,
     &.content--interactive,

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1019,6 +1019,9 @@
     a.in-body-link--immersive {
         color: $labs-main;
     }
+    .inline-expand-image {
+      fill: $brightness-100;
+    }
     &.content--article,
     &.content--interactive,
     &.tonal--tone-media {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1071,7 +1071,7 @@
     .ad-slot__label,
     .ad-slot--inline {
         background-color: $brightness-86;
-        border-top: 0;
+        border-top-color: $brightness-60;
         color: $brightness-46;
     }
     .content__section-label {
@@ -1082,7 +1082,7 @@
         }
     }
     .meta__extras {
-        border-color: $brightness-20;
+        border-color: $brightness-60;
     }
 
     &.tonal--tone-media {
@@ -1124,7 +1124,7 @@
         .meta__numbers,
         .meta__social,
         .meta__number + .meta__number {
-            border-color: $brightness-86;
+            border-color: $brightness-60;
         }
         .byline {
             .tone-colour {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1041,8 +1041,9 @@
     }
     .tonal__standfirst {
         background-color: transparent;
+        border-top: 1px solid $brightness-60;
         min-height: $gs-baseline*8;
-        padding: $gs-baseline 0 $gs-baseline*2;
+        padding: ($gs-baseline / 4) 0 ($gs-baseline * 2);
         .content__standfirst {
             color: $brightness-7;
         }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1286,12 +1286,7 @@ $quote-mark: 35px;
     }
 
     .content__meta-container {
-        @include multiline(3, $brightness-46, top);
-    }
-
-    .social-icon,
-    .block-share__item {
-        border-color: $brightness-46;
+        @include multiline(3, $brightness-60, top);
     }
 
     .content__article-body::before {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1286,7 +1286,8 @@ $quote-mark: 35px;
     }
 
     .content__meta-container {
-        @include multiline(3, $brightness-60, top);
+        border-top: 1px solid $brightness-60;
+        padding-top: $gs-baseline / 4;
     }
 
     .content__article-body::before {


### PR DESCRIPTION
Small tonal changes to make Labs pages feel a bit more serene. 

# Before
<img width="1300" alt="screen shot 2018-07-20 at 14 47 47" src="https://user-images.githubusercontent.com/14570016/43005931-38261332-8c2c-11e8-99a8-261a4cd1ec06.png">

# After
<img width="1273" alt="screen shot 2018-07-23 at 14 18 36" src="https://user-images.githubusercontent.com/14570016/43078916-adaea50c-8e83-11e8-9080-f753ec45bb04.png">


# Before
<img width="124" alt="screen shot 2018-07-20 at 14 48 15" src="https://user-images.githubusercontent.com/14570016/43005934-3871ff18-8c2c-11e8-8944-75bcabaca271.png">

# After
<img width="119" alt="screen shot 2018-07-20 at 14 48 09" src="https://user-images.githubusercontent.com/14570016/43005933-3859c4ca-8c2c-11e8-817e-7c25e446da0d.png">

# Before
<img width="646" alt="screen shot 2018-07-20 at 14 48 19" src="https://user-images.githubusercontent.com/14570016/43005935-3889dde0-8c2c-11e8-98dc-e2d6cebb199d.png">

# After
<img width="645" alt="screen shot 2018-07-20 at 14 48 23" src="https://user-images.githubusercontent.com/14570016/43005936-389ca0f6-8c2c-11e8-8dc6-9e383cbf4835.png">
