### PR TITLE
Restrict width of most popular tabs on fronts in ad-free mode

### DIFF
--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -5,14 +5,14 @@
 @import views.html.fragments.items.elements.facia_cards.title
 @import views.support._
 @import TrailCssClasses.toneClass
-@import views.support.MostPopular.{showMPU, tabsPaneCssClass}
+@import views.support.MostPopular.{isAdFree, showMPU, tabsPaneCssClass}
 @import views.support.GetClasses
 @import model.Pillar.RichPillar
 
 @defining(popular.size > 1){ isTabbed =>
     <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular Test" data-test-id="popular-in">
         @if(isTabbed) {
-            <div class="tabs tabs--mostpop u-cf">
+            <div class="tabs tabs--mostpop u-cf @if(isAdFree(containerDefinition) && isFront){tabs--mostpop--without-mpu}">
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
                     @popular.zipWithRowInfo.map{ case (section, info) =>
                     <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">

--- a/common/app/views/support/MostPopular.scala
+++ b/common/app/views/support/MostPopular.scala
@@ -4,9 +4,13 @@ import layout.FaciaContainer
 
 object MostPopular extends implicits.Requests {
 
+  def isAdFree(maybeContainer: Option[FaciaContainer]): Boolean = {
+    maybeContainer.exists(_.commercialOptions.adFree)
+  }
+
   def showMPU(maybeContainer: Option[FaciaContainer]): Boolean = {
     !maybeContainer.exists(_.commercialOptions.omitMPU) &&
-    !maybeContainer.exists(_.commercialOptions.adFree)
+    !isAdFree(maybeContainer)
   }
 
   def tabsPaneCssClass(maybeContainer: Option[FaciaContainer]): String = {

--- a/static/src/stylesheets/module/_tabs-garnett.scss
+++ b/static/src/stylesheets/module/_tabs-garnett.scss
@@ -17,6 +17,12 @@
     }
 }
 
+.tabs--mostpop--without-mpu {
+    @include mq($from: desktop) {
+        width: 100%;
+        max-width: gs-span(8);
+    }
+}
 
 /**
  * Multiple tab sizing

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -17,6 +17,12 @@
     }
 }
 
+.tabs--mostpop--without-mpu {
+    @include mq($from: desktop) {
+        width: 100%;
+        max-width: gs-span(8);
+    }
+}
 
 /**
  * Multiple tab sizing


### PR DESCRIPTION
## What does this change?
The most popular content can be prone to doing odd things when ad-free is active due to additional space being available on the right hand side of the page from desktop breaks.

While Chrome seems happy to have a go at filling the entire area (with its own weird side-effects such as 3-4-3, or 6-4 column layouts, both with dodgy styling), Firefox remains constrained by the outer container and draws a single column.

This change adds a new class to the most popular tabs element so it can be targeted with specific sizes etc for ad-free mode.

## Screenshots
**Before**
![screenshot_2018-07-20 news sport and opinion from the guardian s uk edition the guardian](https://user-images.githubusercontent.com/690395/43014932-dabfd57e-8c45-11e8-949e-97de4d5517d6.jpg)

**After**
![screenshot_2018-07-20_17-46 news sport and opinion from the guardian s uk edition the guardian](https://user-images.githubusercontent.com/690395/43015112-7276a00a-8c46-11e8-8e28-2d00574c81a8.jpg)

## What is the value of this and can you measure success?
I hope it'll make @paperboyo and all of our ad-free users happier

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None of the above

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

- [x] N/A (nothing's changed except to correct the positioning of content)
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
  - [x] 320px
  - [x] 360px
  - [x] 480px
  - [x] 660px
  - [x] 740px
  - [x] 980px
  - [x] 1140px
  - [x] 1300px


- [ ] On CODE
