### PR TITLE
Adding prebid auction ID to dfp slot targeting

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -153,6 +153,24 @@ class PrebidService {
                 () =>
                     new Promise(resolve => {
                         window.pbjs.que.push(() => {
+                            // Capture this specific auction starting
+                            // to set this slot pbaid targeting value
+                            const auctionInitHandler = (data: Object) => {
+                                // Get rid of this handler now.
+                                window.pbjs.offEvent(
+                                    'auctionInit',
+                                    auctionInitHandler
+                                );
+                                advert.slot.setTargeting(
+                                    'pbaid',
+                                    data.auctionId
+                                );
+                            };
+                            window.pbjs.onEvent(
+                                'auctionInit',
+                                auctionInitHandler
+                            );
+
                             window.pbjs.requestBids({
                                 adUnits,
                                 bidsBackHandler() {

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -162,7 +162,7 @@ class PrebidService {
                                     auctionInitHandler
                                 );
                                 advert.slot.setTargeting(
-                                    'pbaid',
+                                    'hb_auction',
                                     data.auctionId
                                 );
                             };


### PR DESCRIPTION
This implements what's missing to get the auction ID in the DFP impression targeting data. (See https://trello.com/c/x67qBkAo/85 )
