### PR TITLE
Revert "Set the liveblog date to publishedDate"

### DIFF
--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -22,7 +22,7 @@ object KeyEventData {
     val bodyBlocks = (latestSummary.toSeq ++ keyEvents).sortBy(_.lastModifiedDate.getOrElse(new DateTime(0)).toInstant.getMillis).reverse.take(TimelineMaxEntries)
 
     bodyBlocks.map { bodyBlock =>
-      KeyEventData(bodyBlock.id, bodyBlock.publishedDate.map(LiveBlogDate(_, timezone)), bodyBlock.title)
+      KeyEventData(bodyBlock.id, bodyBlock.publishedCreatedDate(timezone), bodyBlock.title)
     }
   }
 

--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -2,8 +2,8 @@
 
 @(date: Option[LiveBlogDate])
 
-@date.map { case LiveBlogDate(publishedDate, hhmm, ampm, gmt) =>
-    <time datetime="@publishedDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
+@date.map { case LiveBlogDate(createdDate, hhmm, ampm, gmt) =>
+    <time datetime="@createdDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
     <span class="block-time__absolute">@hhmm</span>
 }
 

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -35,11 +35,11 @@
         <p class="block-time published-time">
             @if(amp){
                 <a href="@LinkTo{/@article.metadata.id?page=with:block-@block.id#block-@block.id}" itemprop="url" class="block-time__link">
-                    @views.html.liveblog.dateBlock(block.publishedDate.map(LiveBlogDate(_, timezone)))
+                    @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
                 </a>
             } else {
                 <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-                    @views.html.liveblog.dateBlock(block.publishedDate.map(LiveBlogDate(_, timezone)))
+                    @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
                 </a>
             }
         </p>

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -128,6 +128,8 @@ object BlockAttributes {
     new BlockAttributes(blockAttributes.keyEvent.getOrElse(false), blockAttributes.summary.getOrElse(false), blockAttributes.membershipPlaceholder.map(mp => MembershipPlaceholder(mp.campaignCode)))
 
   implicit val blockAttributes: Writes[BlockAttributes] = Json.writes[BlockAttributes]
+
+
 }
 
 case class BlockAttributes(keyEvent: Boolean, summary: Boolean, membershipPlaceholder: Option[MembershipPlaceholder])


### PR DESCRIPTION
Reverts guardian/frontend#20036

The original change affects the order in which blog posts appear, which is a side effect we did not intend to introduce.