### PR TITLE
TrustX bids only in US auctions rather than North American auctions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -24,6 +24,7 @@ import {
     getBreakpointKey,
     getRandomIntInclusive,
     isExcludedGeolocation,
+    shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
 } from 'commercial/modules/prebid/utils';
@@ -335,7 +336,7 @@ const indexExchangeBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
 
 const otherBidders: PrebidBidder[] = [
     sonobiBidder,
-    trustXBidder,
+    ...(shouldIncludeTrustX() ? [trustXBidder] : []),
     improveDigitalBidder,
     xaxisBidder,
 ];

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -334,13 +334,6 @@ const indexExchangeBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     }));
 };
 
-const otherBidders: PrebidBidder[] = [
-    sonobiBidder,
-    ...(shouldIncludeTrustX() ? [trustXBidder] : []),
-    improveDigitalBidder,
-    xaxisBidder,
-];
-
 const biddersBeingTested: (PrebidBidder[]) => PrebidBidder[] = allBidders => {
     const bidderNamesBeingTested = new URL(
         window.location.href
@@ -360,6 +353,13 @@ const biddersSwitchedOn: (PrebidBidder[]) => PrebidBidder[] = allBidders => {
 };
 
 const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
+    const otherBidders: PrebidBidder[] = [
+        sonobiBidder,
+        ...(shouldIncludeTrustX() ? [trustXBidder] : []),
+        improveDigitalBidder,
+        xaxisBidder,
+    ];
+
     const allBidders = indexExchangeBidders(slotSizes)
         .concat(otherBidders)
         .concat(getDummyServerSideBidders());

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -26,6 +26,8 @@ export const getBreakpointKey = (): string => {
     }
 };
 
+export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';
+
 export const isExcludedGeolocation = (): boolean => {
     const excludedGeos = ['US', 'CA', 'NZ', 'AU'];
     return excludedGeos.includes(geolocationGetSync());


### PR DESCRIPTION
## What does this change?

#### 👉 Add util function to determine if TrustX should run

TrustX only bids in US auctions rather than North American auctions. The geolocation module can locate a reader to the country level, so will generally be more precise than the current continent locator.

#### 👉 Testing. Testing. Testing

Getting that 100% test coverage because it feels so good.

<img width="693" alt="picture 152" src="https://user-images.githubusercontent.com/8607683/43087081-e1089350-8e96-11e8-965a-fbcd373d6801.png">

Some of these utils are fairly straightforward, so maybe the testing is overkill considering the amount of mocking going on. However adding these tests allows at least some record of the business logic, along with a first line defence against these values being changed.

## What is the value of this and can you measure success?

This avoids including TrustX in auctions where it is never going to bid, since this may create potential performance / efficiency issues we can otherwise avoid:

https://trello.com/c/7dIApLNB
