### PR TITLE
Audio AB Test 2: Remove image from episode page

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -5,6 +5,9 @@
 @import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
+@import experiments.{ActiveExperiments, AudioHideImage}
+
+@HideImageTest = @{ActiveExperiments.isParticipating(AudioHideImage)}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
     @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
@@ -34,11 +37,12 @@
                                 @media match {
                                     case audio: Audio => {
 
-                                        @audio.elements.images.map { img =>
-                                            @fragments.imageFigure(
-                                                img.images
-                                            )
+                                        @if(!HideImageTest){
+                                            @audio.elements.images.map{ img =>
+                                                @fragments.imageFigure(img.images)
+                                            }
                                         }
+
 
                                         <figure data-component="main audio">
                                         @audio.elements.mainAudio.map { audioElement =>

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,6 +7,7 @@ import play.api.mvc.RequestHeader
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
+    AudioHideImage,
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
@@ -54,5 +55,13 @@ object AudioPageChange extends Experiment(
   description = "Show a different version of the audio page to certain people",
   owners = Owner.group(SwitchGroup.Journalism),
   sellByDate = new LocalDate(2018, 8, 20),
+  participationGroup = Perc0A
+)
+
+object AudioHideImage extends Experiment(
+  name = "audio-hide-image",
+  description = "Test the audio player without an image",
+  owners = Owner.group(SwitchGroup.Journalism),
+  sellByDate = new LocalDate(2018, 7, 31),
   participationGroup = Perc50
 )


### PR DESCRIPTION
## What does this change?
50 percent of users will see the audio episode page without an image. The rest will see the original player.

Because only one test can have a given participation test group at a time, I changed the participation group down to 0 on `AudioPageChange`. 

Again because it is a server side test you need to use Header Hacker to create a request header and also make sure the test is switched on. 

**Data collection**:
  images are included in the `renderedComponents` array. The player already fires a ready and play event so these can be read as usual 

## Screenshots
![screen shot 2018-07-23 at 17 07 30](https://user-images.githubusercontent.com/10324129/43093482-11407a54-8ea8-11e8-87cc-7c0a69a637f2.png)



## What is the value of this and can you measure success?

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
