### PR TITLE
Move has acknowledge logic out of banner picker

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { local } from 'lib/storage';
-import { Message } from 'common/modules/ui/message';
+import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import mediator from 'lib/mediator';
 import { membershipEngagementBannerTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
@@ -10,7 +10,6 @@ import { engagementBannerParams } from 'common/modules/commercial/membership-eng
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
 import { getSync as getGeoLocation } from 'lib/geolocation';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
-import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 import {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -10,6 +10,7 @@ import { engagementBannerParams } from 'common/modules/commercial/membership-eng
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
 import { getSync as getGeoLocation } from 'lib/geolocation';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 import {
@@ -184,6 +185,10 @@ const show = (): void => {
 
 const canShow = (): Promise<boolean> => {
     if (!config.get('switches.membershipEngagementBanner') || isBlocked()) {
+        return Promise.resolve(false);
+    }
+
+    if (hasUserAcknowledgedBanner(messageCode)) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -93,6 +93,7 @@ jest.mock(
 );
 jest.mock('common/modules/ui/message', () => ({
     Message: jest.fn(),
+    hasUserAcknowledgedBanner: jest.fn((_) => false)
 }));
 jest.mock('ophan/ng', () => ({
     record: jest.fn(),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -93,7 +93,7 @@ jest.mock(
 );
 jest.mock('common/modules/ui/message', () => ({
     Message: jest.fn(),
-    hasUserAcknowledgedBanner: jest.fn((_) => false)
+    hasUserAcknowledgedBanner: jest.fn(() => false),
 }));
 jest.mock('ophan/ng', () => ({
     record: jest.fn(),

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -5,10 +5,9 @@ import {
     accountDataUpdateWarning,
 } from 'common/modules/commercial/user-features';
 import fastdom from 'lib/fastdom-promise';
-import { Message } from 'common/modules/ui/message';
+import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import config from 'lib/config';
 import bean from 'bean';
-import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 const accountDataUpdateLink = accountDataUpdateWarningLink =>
@@ -56,7 +55,9 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
 const updateLink = accountDataUpdateWarning();
 
 const canShow: () => Promise<boolean> = () =>
-    Promise.resolve(updateLink !== null && hasUserAcknowledgedBanner(messageCode));
+    Promise.resolve(
+        updateLink !== null && hasUserAcknowledgedBanner(messageCode)
+    );
 
 const show: () => void = () => {
     if (updateLink) {

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -56,7 +56,7 @@ const updateLink = accountDataUpdateWarning();
 
 const canShow: () => Promise<boolean> = () =>
     Promise.resolve(
-        updateLink !== null && hasUserAcknowledgedBanner(messageCode)
+        updateLink !== null && !hasUserAcknowledgedBanner(messageCode)
     );
 
 const show: () => void = () => {

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -8,6 +8,7 @@ import fastdom from 'lib/fastdom-promise';
 import { Message } from 'common/modules/ui/message';
 import config from 'lib/config';
 import bean from 'bean';
+import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 const accountDataUpdateLink = accountDataUpdateWarningLink =>
@@ -55,7 +56,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
 const updateLink = accountDataUpdateWarning();
 
 const canShow: () => Promise<boolean> = () =>
-    Promise.resolve(updateLink !== null);
+    Promise.resolve(updateLink !== null && hasUserAcknowledgedBanner(messageCode));
 
 const show: () => void = () => {
     if (updateLink) {

--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
@@ -1,6 +1,5 @@
 // @flow
 import ophan from 'ophan/ng';
-import userPrefs from 'common/modules/user-prefs';
 
 export type Banner = {
     id: string,

--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
@@ -38,7 +38,6 @@ const init = (banners: Array<Banner>): Promise<void> => {
 
     return new Promise(resolve => {
         const TIME_LIMIT = 2000;
-        const messageStates = userPrefs.get('messages');
         let bannerPicked = false;
 
         banners.forEach((banner, index) => {
@@ -66,40 +65,28 @@ const init = (banners: Array<Banner>): Promise<void> => {
                 }
             };
 
-            const hasUserAcknowledgedBanner = (): boolean =>
-                messageStates && messageStates.includes(banner.id);
+            let hasTimedOut = false;
 
-            /**
-             * if the banner has been seen and dismissed
-             * we don't want to show it. Previously this rule was
-             * enforced in the show() of Message.js
-             * */
-            if (hasUserAcknowledgedBanner()) {
+            // checks that take longer than TIME_LIMIT are forced to fail
+            const timeout = setTimeout(() => {
+                hasTimedOut = true;
+
                 pushToResults(false);
-            } else {
-                let hasTimedOut = false;
 
-                // checks that take longer than TIME_LIMIT are forced to fail
-                const timeout = setTimeout(() => {
-                    hasTimedOut = true;
+                const trackingObj = {
+                    component: 'banner-picker-timeout',
+                    value: banner.id,
+                };
 
-                    pushToResults(false);
+                ophan.record(trackingObj);
+            }, TIME_LIMIT);
 
-                    const trackingObj = {
-                        component: 'banner-picker-timeout',
-                        value: banner.id,
-                    };
-
-                    ophan.record(trackingObj);
-                }, TIME_LIMIT);
-
-                banner.canShow().then(result => {
-                    if (!hasTimedOut) {
-                        clearTimeout(timeout);
-                        pushToResults(result);
-                    }
-                });
-            }
+            banner.canShow().then(result => {
+                if (!hasTimedOut) {
+                    clearTimeout(timeout);
+                    pushToResults(result);
+                }
+            });
         });
     });
 };

--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.spec.js
@@ -252,32 +252,4 @@ describe('bannerPicker', () => {
             });
         });
     });
-
-    describe('bannerPicker fails banner without calling canShow if it has already been acknowledged by user', () => {
-        it('should call show() for banner at index 1 if index 0 timesout', () => {
-            const banners = [
-                {
-                    id: 'banner-0',
-                    canShow: jest.fn(),
-                    show: jest.fn(),
-                },
-                {
-                    id: 'banner-1',
-                    canShow: jest.fn().mockReturnValue(Promise.resolve(true)),
-                    show: jest.fn(),
-                },
-            ];
-
-            userPrefs.get.mockReturnValueOnce(['banner-0']);
-
-            const asyncTest = init(banners);
-
-            return asyncTest.then(() => {
-                expect(banners[0].canShow).not.toHaveBeenCalled();
-                expect(banners[1].canShow).toHaveBeenCalled();
-                expect(banners[0].show).not.toHaveBeenCalled();
-                expect(banners[1].show).toHaveBeenCalled();
-            });
-        });
-    });
 });

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -105,8 +105,8 @@ const trackInteraction = (interaction: string): void => {
 
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
-        [hasUnsetAdChoices(), isInEU()].every(_ => _ === true) &&
-            hasUserAcknowledgedBanner(messageCode)
+        hasUnsetAdChoices() && isInEU() &&
+            !hasUserAcknowledgedBanner(messageCode)
     );
 
 const track = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
-import { Message } from 'common/modules/ui/message';
+import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import checkIcon from 'svgs/icon/tick.svg';
 import {
     getAdConsentState,
@@ -11,7 +11,6 @@ import {
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
 import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
-import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
@@ -105,7 +104,10 @@ const trackInteraction = (interaction: string): void => {
 };
 
 const canShow = (): Promise<boolean> =>
-    Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true) && hasUserAcknowledgedBanner(messageCode));
+    Promise.resolve(
+        [hasUnsetAdChoices(), isInEU()].every(_ => _ === true) &&
+            hasUserAcknowledgedBanner(messageCode)
+    );
 
 const track = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -105,7 +105,8 @@ const trackInteraction = (interaction: string): void => {
 
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
-        hasUnsetAdChoices() && isInEU() &&
+        hasUnsetAdChoices() &&
+            isInEU() &&
             !hasUserAcknowledgedBanner(messageCode)
     );
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -11,6 +11,7 @@ import {
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
 import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
+import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
@@ -104,7 +105,7 @@ const trackInteraction = (interaction: string): void => {
 };
 
 const canShow = (): Promise<boolean> =>
-    Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true));
+    Promise.resolve([hasUnsetAdChoices(), isInEU()].every(_ => _ === true) && hasUserAcknowledgedBanner(messageCode));
 
 const track = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -43,6 +43,7 @@ jest.mock('lib/config', () => ({
 
 jest.mock('common/modules/ui/message', () => ({
     Message: jest.fn(),
+    hasUserAcknowledgedBanner: jest.fn(() => false),
 }));
 
 jest.mock('common/modules/analytics/google', () => ({

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -17,7 +17,6 @@ import {
     makeHtml as makeFirstPvConsentHtml,
 } from 'common/modules/ui/first-pv-consent-banner';
 import marque36icon from 'svgs/icon/marque-36.svg';
-import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -17,6 +17,7 @@ import {
     makeHtml as makeFirstPvConsentHtml,
 } from 'common/modules/ui/first-pv-consent-banner';
 import marque36icon from 'svgs/icon/marque-36.svg';
+import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -246,5 +246,10 @@ class Message {
     }
 }
 
+const hasUserAcknowledgedBanner = (id: string): boolean => {
+    const messageStates = userPrefs.get('messages');
+    return messageStates && messageStates.includes(id);
+};
+
 export type { MessagePosition };
-export { Message };
+export { Message, hasUserAcknowledgedBanner };

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -7,6 +7,7 @@ import template from 'lodash/utilities/template';
 import { loadCssPromise } from 'lib/load-css-promise';
 import { Message } from 'common/modules/ui/message';
 import config from 'lib/config';
+import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 /**
@@ -64,7 +65,7 @@ const canUseSmartBanner = (): boolean =>
 const canShow = (): Promise<boolean> =>
     new Promise(resolve => {
         const result =
-            !canUseSmartBanner() && isDevice() && validImpressionCount();
+            !canUseSmartBanner() && isDevice() && validImpressionCount() && !hasUserAcknowledgedBanner(messageCode);
         resolve(result);
     });
 

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -5,9 +5,8 @@ import { getCookie, addCookie } from 'lib/cookies';
 import { isIOS, isAndroid, getBreakpoint, getUserAgent } from 'lib/detect';
 import template from 'lodash/utilities/template';
 import { loadCssPromise } from 'lib/load-css-promise';
-import { Message } from 'common/modules/ui/message';
+import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import config from 'lib/config';
-import { hasUserAcknowledgedBanner } from "common/modules/ui/message";
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 /**
@@ -65,7 +64,10 @@ const canUseSmartBanner = (): boolean =>
 const canShow = (): Promise<boolean> =>
     new Promise(resolve => {
         const result =
-            !canUseSmartBanner() && isDevice() && validImpressionCount() && !hasUserAcknowledgedBanner(messageCode);
+            !canUseSmartBanner() &&
+            isDevice() &&
+            validImpressionCount() &&
+            !hasUserAcknowledgedBanner(messageCode);
         resolve(result);
     });
 


### PR DESCRIPTION
## What does this change?

Move `hasUserAcknowledgedBanner()` out of the banner picker logic and have it used in the `canShow()` function of the respective banner (if applicable). 

## What is the value of this and can you measure success?

There are some banners which don't use `message.js`, in which case the `hasUserAcknowledgedBanner()` doesn't make sense. It also relies on the `id` to be available synchronously which isn't always the case (c.f. the updated membership engagement banner logic).

