### PR TITLE
better logging for amp removals

### DIFF
--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -164,8 +164,8 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner with Logging {
             iframeElement.replaceWith(createAmpIframeElement(document, src, width, height, frameBorder))
           } else {
             iframeElement.remove()
-            //Here is where I would emit some broken html to force a validation failure
-            logAmpRemoval(s"AMP cleaner an iframe was removed as it was missing attributes. ${article.content.metadata.id}")
+            val attrs  = iframeElement.attributes().asList().asScala.map(_.getKey).mkString(", ")
+            logAmpRemoval(s"AMP cleaner an audio element iframe with src ${iframeElement.attr("src")} and attributes ${attrs} was removed as it was missing attributes.  ${article.content.metadata.id}")
           }
         }
       }
@@ -240,8 +240,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner with Logging {
           interactive.appendChild(iframe)
         } else {
           interactive.remove()
-          //break the page
-          logAmpRemoval(s"AMP cleaner an interactive was removed as it was missing attributes. ${article.content.metadata.id}")
+          logAmpRemoval(s"AMP cleaner an interactive was removed. ${article.content.metadata.id}")
         }
     }
   }
@@ -317,7 +316,8 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner with Logging {
             iframeElement.replaceWith(soundcloudElement.get)
           } else
             iframeElement.remove()
-            logAmpRemoval(s"AMP cleaner a soundcloud embed was removed. ${article.content.metadata.id}")
+            val src = iframeElement.attr("src")
+            logAmpRemoval(s"AMP cleaner an embed was removed with an src of ${src}. ${article.content.metadata.id}")
       })
   }
 


### PR DESCRIPTION
## What does this change?
changes the log messages from my previous pr to give more useful and correct information
## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
