### PR TITLE
Tracking code of paid card copes with empty front ID

### DIFF
--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -303,7 +303,7 @@ object Commercial {
           if (isContentPage) "Onward container"
           else "Front container",
         editionId = Edition(request).id,
-        frontId = frontId.getOrElse("unknown front id"),
+        frontId = frontId.filter(_.nonEmpty).getOrElse("unknown front id"),
         containerIndex = containerIndex,
         containerTitle = containerDisplayName.getOrElse("unknown container"),
         sponsorName = card.branding.map(_.sponsorName) getOrElse "unknown",

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -2,7 +2,17 @@ package views.support
 
 import com.gu.commercial.branding._
 import common.commercial._
-import layout.PaidCard
+import layout.cards.Half
+import layout.{
+  ContentCard,
+  DiscussionSettings,
+  DisplaySettings,
+  EditionalisedLink,
+  FaciaCardHeader,
+  ItemClasses,
+  PaidCard
+}
+import model.pressed
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import play.api.test.FakeRequest
 import views.support.Commercial.TrackingCodeBuilder
@@ -94,5 +104,64 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfter
     )(request = FakeRequest().withHeaders("X-Gu-Edition" -> "US"))
     code shouldBe
       "Labs front container | US | front-id | container-3 | container-title | sponsor-name | card-5 | headline-5"
+  }
+
+  it should "generate correct tracking code when front ID has an empty value" in {
+    val code = TrackingCodeBuilder.mkInteractionTrackingCode(
+      containerIndex = 0,
+      cardIndex = 0,
+      card = ContentCard(
+        id = None,
+        header = FaciaCardHeader(
+          quoted = false,
+          isExternal = false,
+          isVideo = false,
+          isGallery = false,
+          isAudio = false,
+          kicker = None,
+          headline = "headline",
+          url = EditionalisedLink(
+            baseUrl = ""
+          )
+        ),
+        byline = None,
+        displayElement = None,
+        cutOut = None,
+        cardStyle = pressed.Review,
+        cardTypes = ItemClasses(
+          mobile = Half,
+          tablet = Half,
+          desktop = None
+        ),
+        sublinks = Nil,
+        starRating = None,
+        discussionSettings = DiscussionSettings(
+          isCommentable = false,
+          isClosedForComments = false,
+          discussionId = None
+        ),
+        snapStuff = None,
+        webPublicationDate = None,
+        trailText = None,
+        mediaType = None,
+        displaySettings = DisplaySettings(
+          isBoosted = false,
+          showBoostedHeadline = false,
+          showQuotedHeadline = false,
+          imageHide = false,
+          showLivePlayable = false
+        ),
+        isLive = false,
+        timeStampDisplay = None,
+        shortUrl = None,
+        useShortByline = false,
+        group = "",
+        branding = None,
+        properties = None
+      ),
+      containerDisplayName = Some("Related content"),
+      frontId = Some("")
+    )(request = FakeRequest())
+    code shouldBe "Onward container | UK | unknown front id | container-1 | Related content | unknown | card-1 | headline"
   }
 }


### PR DESCRIPTION
This change avoids ever having an empty value for the front ID in the component data attribute of a paid card in a container.
The benefit of this is that it makes the attribute value slightly easier to parse when doing analysis in the data lake.