### PR TITLE
Added Ad-Verification Vendor (Confiant) as a 1% test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -148,6 +148,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-commercial-ad-verification",
+    "Test the impact of verifiyng ads",
+    owners = Seq(Owner.withGithub("jeteve")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-thailand-cave",
     "Always show the epic on thailand cave stories (unlimited)",
     owners = Seq(Owner.withGithub("tsop14")),

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -11,6 +11,7 @@ import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
 import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
 import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
+import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as prepareSonobiTag } from 'commercial/modules/dfp/prepare-sonobi-tag';
 import { init as initCarrotTrafficDriver } from 'commercial/modules/carrot-traffic-driver';
@@ -43,6 +44,7 @@ const commercialModules: Array<Array<any>> = [
 
 if (!commercialFeatures.adFree) {
     commercialModules.push(
+        ['cm-prepare-adverification', prepareAdVerification, true],
         ['cm-prepare-googletag', prepareGoogletag, true],
         ['cm-closeDisabledSlots', closeDisabledSlots],
         ['cm-dfp-epic', initDFPEpicSlot],

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -1,0 +1,34 @@
+// @flow
+
+import { loadScript } from 'lib/load-script';
+import { getTestVariantId } from 'common/modules/experiments/utils.js';
+
+export const init = (start: () => void): Promise<void> => {
+    const host = 'clarium.global.ssl.fastly.net';
+
+    start();
+
+    if (getTestVariantId('CommercialAdVerification') === 'variant') {
+        // vivify the _clrm object
+
+        /* eslint-disable no-underscore-dangle */
+        window._clrm = window._clrm || {};
+        window._clrm.gpt = {
+            propertyId: 'qE4aQtYj644UghGyTZsDnq5Qh_A',
+            confiantCdn: host,
+            mapping:
+                'W3siaSI6MiwidCI6Int7b319Ont7d319eHt7aH19IiwicCI6MCwiRCI6MSwiciI6W119XQ==',
+            activation:
+                '|||MjIxNzg5NDY2OQ==,|||MjE4NTM0MTI3,|||MjE5NzUwMDg3,|||MjM0ODc4NzI3,|||MzcxNjYwOTY3',
+            callback(...args) {
+                console.log('w00t one more bad ad nixed.', args);
+            },
+        };
+        /* eslint-enable no-underscore-dangle */
+
+        // and load the script tag
+        return loadScript(`//${host}/gpt/a/wrap.js`, { async: true });
+    }
+    // Do nothing.
+    return Promise.resolve();
+};

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,6 +3,7 @@ import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
+import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { FootballWeeklyTreatVsContainer } from 'common/modules/experiments/tests/football-weekly-treat-vs-container';
 import { newSignInExperiment } from './tests/new-sign-in-experiment';
 
@@ -10,6 +11,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     newSignInExperiment,
     commercialPrebidSafeframe,
+    commercialAdVerification,
     FootballWeeklyTreatVsContainer,
 ].filter(Boolean);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const commercialAdVerification: ABTest = {
+    id: 'CommercialAdVerification',
+    start: '2018-06-29',
+    expiry: '2019-09-30',
+    author: 'Jerome Eteve',
+    description: 'This test will implemement our ad verification framework',
+    audience: 0.01,
+    audienceOffset: 0.01, // No overlap with PrebidSafeframe
+    successMeasure: 'Impact of ad verification on yield or fillrate',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'No significant impact of ad verification on yield or fillrate',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
This implements https://trello.com/c/ShJLtEhE and puts adding the 'Confiant' tag behind an ABTest for a non-overlapping 1% of our audience.