### PR TITLE
Remove switch references

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-sizes.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-sizes.js
@@ -1,39 +1,31 @@
 // @flow
-import type { GuAdSize, SwitchUnitId } from 'commercial/types';
-import {
-    mpuUnitId,
-    leaderboardUnitId,
-    billboardUnitId,
-} from 'commercial/types';
+import type { GuAdSize } from 'commercial/types';
 
 const getAdSize = (
     width: number,
-    height: number,
-    switchUnitId: ?SwitchUnitId
-): GuAdSize => {
+    height: number): GuAdSize => {
     const toString = (): string =>
         width === height && height === 0 ? 'fluid' : `${width},${height}`;
 
     return Object.freeze({
         width,
         height,
-        switchUnitId,
         toString,
     });
 };
 
 const adSizes: Object = {
     // standard ad sizes
-    billboard: getAdSize(970, 250, billboardUnitId),
-    leaderboard: getAdSize(728, 90, leaderboardUnitId),
-    mpu: getAdSize(300, 250, mpuUnitId),
+    billboard: getAdSize(970, 250),
+    leaderboard: getAdSize(728, 90),
+    mpu: getAdSize(300, 250),
     halfPage: getAdSize(300, 600),
     portrait: getAdSize(300, 1050),
 
     // dfp proprietary ad sizes
     fluid: getAdSize(0, 0),
     outOfPage: getAdSize(1, 1),
-    googleCard: getAdSize(300, 274),
+    googleCardloadAdvert: getAdSize(300, 274),
 
     // guardian proprietary ad sizes
     video: getAdSize(620, 1),

--- a/static/src/javascripts/projects/commercial/modules/ad-sizes.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-sizes.js
@@ -1,9 +1,7 @@
 // @flow
 import type { GuAdSize } from 'commercial/types';
 
-const getAdSize = (
-    width: number,
-    height: number): GuAdSize => {
+const getAdSize = (width: number, height: number): GuAdSize => {
     const toString = (): string =>
         width === height && height === 0 ? 'fluid' : `${width},${height}`;
 
@@ -25,7 +23,7 @@ const adSizes: Object = {
     // dfp proprietary ad sizes
     fluid: getAdSize(0, 0),
     outOfPage: getAdSize(1, 1),
-    googleCardloadAdvert: getAdSize(300, 274),
+    googleCard: getAdSize(300, 274),
 
     // guardian proprietary ad sizes
     video: getAdSize(620, 1),

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -13,7 +13,6 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 type AdSize = {
     width: number,
     height: number,
-    switchUnitId: ?number,
     toString: (_: void) => string,
 };
 

--- a/static/src/javascripts/projects/commercial/types.js
+++ b/static/src/javascripts/projects/commercial/types.js
@@ -94,19 +94,8 @@ export type SlotVisibilityChangedEvent = {
     slot: Slot,
 };
 
-type MPUUnitId = 228;
-type LeaderboardUnitId = 229;
-type BillboardUnitId = 229;
-
-export type SwitchUnitId = MPUUnitId | LeaderboardUnitId | BillboardUnitId;
-
 export type GuAdSize = {
     width: number,
     height: number,
-    switchUnitId: ?SwitchUnitId,
     toString: (_: void) => string,
 };
-
-export const mpuUnitId: MPUUnitId = 228;
-export const leaderboardUnitId: LeaderboardUnitId = 229;
-export const billboardUnitId: BillboardUnitId = 229;


### PR DESCRIPTION
## What does this change?

This removes references to `switchUnitId` which were hardcoded IDs used to recognise our ad-slots on the Switch platform.

They are no longer used.

@guardian/commercial-dev 