### PR TITLE
fix 500 on .json?guui

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -9,7 +9,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support._
 import metrics.TimingMetric
-import play.libs.Json
+import play.api.libs.json.Json
 import renderers.RemoteRender
 import services.CAPILookup
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}


### PR DESCRIPTION
## What does this change?
Uses the scala play json library instead of the Java one.
## Screenshots

## What is the value of this and can you measure success?
We can now serialise `BlockElement` again as the Java serialiser can't handle `sealed trait`s. This is used in the serialisation of `ContentFields` -> `Fields` -> `Block` -> `BodyBlock`. And the failure causes each further serialisation to return a `{}`. So, um, this fixes that.


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
