### PR TITLE
Endpoint to render IAS passbacks

### DIFF
--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -35,4 +35,5 @@ trait CommercialControllers {
   lazy val adsDotTextFileController = wire[AdsDotTextViewController]
   lazy val prebidAnalyticsController = wire[PrebidAnalyticsController]
   lazy val pageViewAnalyticsController = wire[PageViewAnalyticsController]
+  lazy val passbackController = wire[PassbackController]
 }

--- a/commercial/app/controllers/PassbackController.scala
+++ b/commercial/app/controllers/PassbackController.scala
@@ -1,0 +1,39 @@
+package commercial.controllers
+
+import conf.Configuration.commercial._
+import model.Cached.WithoutRevalidationResult
+import model.{CacheTime, Cached}
+import play.api.mvc._
+
+class PassbackController(val controllerComponents: ControllerComponents) extends BaseController {
+
+  private val anHour = 3600
+
+  private val sizePattern = """(\d\d\d)x(\d\d\d)""".r
+
+  private def parsed(size: String) = size match {
+    case sizePattern(width, height) => Some((width.toInt, height.toInt))
+    case _                          => None
+  }
+
+  /*
+   * To be called as src of an iframe where a passback will be served
+   * when the original ad has been blocked for brand safety.
+   */
+  def renderIasPassback(size: String): Action[AnyContent] = Action { implicit request =>
+    parsed(size) map {
+      case (width, height) =>
+        Cached(CacheTime(anHour))(
+          WithoutRevalidationResult(
+            Ok(
+              views.html.passback(
+                dfpNetworkId = dfpAccountId,
+                adUnitName = s"$dfpAdUnitGuRoot/x-passback/ias",
+                passbackTarget = "ias",
+                width,
+                height
+              ))))
+    } getOrElse
+      Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
+  }
+}

--- a/commercial/app/views/passback.scala.html
+++ b/commercial/app/views/passback.scala.html
@@ -1,0 +1,9 @@
+@(dfpNetworkId: String, adUnitName: String, passbackTarget: String, width: Int, height: Int)
+
+<!-- Passback for '@adUnitName' Size: [[@width,@height]] -->
+<script src='https://www.googletagservices.com/tag/js/gpt.js'>
+  googletag.pubads().definePassback('/@dfpNetworkId/@adUnitName', [[@width,@height]])
+  .setTargeting('passback', ['@passbackTarget'])
+  .display();
+</script>
+<!-- End -->

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -47,3 +47,6 @@ GET         /ads.txt                                                        comm
 # Analytics
 POST        /commercial/api/hb                                              commercial.controllers.PrebidAnalyticsController.insert()
 POST        /commercial/api/pv                                              commercial.controllers.PageViewAnalyticsController.insert()
+
+# Passbacks
+GET         /commercial/ias-passback/:size                                  commercial.controllers.PassbackController.renderIasPassback(size)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -282,6 +282,7 @@ GET            /ads.txt                                                         
 GET            /commercial/prebid/revenue                                                                                        controllers.admin.commercial.TeamKPIController.renderPrebidDashboard()
 POST           /commercial/api/hb                                                                                                commercial.controllers.PrebidAnalyticsController.insert()
 POST           /commercial/api/pv                                                                                                commercial.controllers.PageViewAnalyticsController.insert()
+GET            /commercial/ias-passback/:size                                                                                    commercial.controllers.PassbackController.renderIasPassback(size)
 
 # Commercial Admin
 GET         /commercial                                                                                                          controllers.admin.CommercialController.renderCommercialMenu()


### PR DESCRIPTION
This enables us to serve an alternative ad when the original ad has been blocked for brand safety.