### PR TITLE
Fix CSS to stop Carrot breaking at different breakpoints

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -418,7 +418,7 @@
 }
 
 .ad-slot--carrot {
-    min-height: 250px;
+    min-height: 10px;
     padding: 0;
     margin: 5px $gs-gutter $gs-baseline 0;
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -435,10 +435,6 @@
         width: gs-span(3);
     }
 
-    @include mq(leftCol) {
-        margin-left: -1 * (gs-span(2) + $gs-gutter);
-    }
-
     @include mq(wide) {
         margin-left: -1 * (gs-span(3) + $gs-gutter);
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -418,7 +418,7 @@
 }
 
 .ad-slot--carrot {
-    min-height: 10px;
+    min-height: 0px;
     padding: 0;
     margin: 5px $gs-gutter $gs-baseline 0;
 

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -36,7 +36,7 @@
             padding-right: gs-span(1) + $gs-gutter;
 
             // Unruly video expands to 100%; this negative right margin affects Unruly on Tablet
-            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly) {
+            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly):not(.ad-slot--carrot) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }
 


### PR DESCRIPTION
## What does this change?
Based on how the inline merchandising unit works, the Carrot no longer covers the text at Tablet breakpoint, and it sits within the article body at leftCol breakpoint (not half in half out)
## Screenshots
Before:
![picture 37](https://user-images.githubusercontent.com/19835654/43316003-b0cbc0ee-918f-11e8-93c2-5dfa78d7601a.png)
![picture 39](https://user-images.githubusercontent.com/19835654/43316018-b84352b0-918f-11e8-8762-09e93d09e7ce.png)

After:
![picture 43](https://user-images.githubusercontent.com/19835654/43316124-163a0dd2-9190-11e8-97c4-10a0508bf7e3.png)
![picture 42](https://user-images.githubusercontent.com/19835654/43316125-164cdd4a-9190-11e8-8bcd-2e7e1a174442.png)

## What is the value of this and can you measure success?
We can make the Carrot live on Desktop

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
