### PR TITLE
Add youtube player params

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -97,6 +97,10 @@ const setupPlayer = (
             onStateChange,
             onError,
         },
+        playerVars: {
+            rel: 0,
+            showinfo: 0,
+        },
         embedConfig: {
             adsConfig: {
                 nonPersonalizedAd: !wantPersonalisedAds,


### PR DESCRIPTION
## What does this change?
Appears to be a regression in #19851 (https://github.com/guardian/frontend/pull/19851/files#diff-4d65795318f4ce3e99080f45b62c4556L47)

As defined here https://developers.google.com/youtube/player_parameters:
- `rel` This parameter indicates whether the player should show related videos when playback of the initial video ends
- `showinfo` Setting the parameter's value to 0 causes the player to not display information like the video title and uploader before the video starts playing

These values where agreed with Editorial when we moved to yt.

## Screenshots


## What is the value of this and can you measure success?


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
