### PR TITLE
Refactor getUrlVars

### DIFF
--- a/static/src/javascripts/lib/url.js
+++ b/static/src/javascripts/lib/url.js
@@ -13,6 +13,7 @@ const getCurrentQueryString = (): string =>
 const queryStringToUrlVars = memoize(
     (queryString: string): Object =>
         queryString
+            .replace(/^\?/, '')
             .split('&')
             .filter(Boolean)
             .map(
@@ -30,7 +31,7 @@ const queryStringToUrlVars = memoize(
 // eg ?foo=bar&fizz=buzz returns {foo: 'bar', fizz: 'buzz'}
 // ?foo=bar&foo=baz returns {foo: 'baz'}
 const getUrlVars = (query?: string): Object =>
-    queryStringToUrlVars(query || getCurrentQueryString());
+    queryStringToUrlVars(query || window.location.search);
 
 const updateQueryString = (params: Object, historyFn: Function) => {
     const querystringChanged = getCurrentQueryString() !== params.querystring;

--- a/static/src/javascripts/lib/url.spec.js
+++ b/static/src/javascripts/lib/url.spec.js
@@ -36,11 +36,11 @@ describe('url', () => {
         const origWindowLocation = window.location.href;
         const QUERIES = [
             ['foo', { foo: true }],
-            ['foo=bar', { foo: 'bar' }],
+            ['?foo=bar', { foo: 'bar' }],
             ['foo=bar&foo=baz', { foo: 'baz' }], // The last value wins
-            ['foo=bar&boo=far', { foo: 'bar', boo: 'far' }],
+            ['?foo=bar&boo=far', { foo: 'bar', boo: 'far' }],
             ['foo=bar&boo=far&foo=baz', { foo: 'baz', boo: 'far' }],
-            ['foo=bar&boo=far&', { foo: 'bar', boo: 'far' }],
+            ['?foo=bar&boo=far&', { foo: 'bar', boo: 'far' }],
             ['foo=bar&boo', { foo: 'bar', boo: true }],
             ['', {}],
         ];
@@ -53,8 +53,8 @@ describe('url', () => {
         // get the query from window.location.search
         QUERIES.forEach(([query, expected]) => {
             const preQuery = window.location.href.split('?')[0];
-            window.location.assign(`${preQuery}?${query}`);
-
+            const cleanQuery = query.replace(/^\?/, '');
+            window.location.assign(`${preQuery}?${cleanQuery}`);
             expect(getUrlVars()).toEqual(expected);
         });
 

--- a/static/src/javascripts/lib/url.spec.js
+++ b/static/src/javascripts/lib/url.spec.js
@@ -36,12 +36,15 @@ describe('url', () => {
         const origWindowLocation = window.location.href;
         const QUERIES = [
             ['foo', { foo: true }],
+            ['?foo', { foo: true }],
             ['?foo=bar', { foo: 'bar' }],
-            ['foo=bar&foo=baz', { foo: 'baz' }], // The last value wins
+            ['foo=bar&foo=baz', { foo: 'baz' }], // Last value wins
             ['?foo=bar&boo=far', { foo: 'bar', boo: 'far' }],
             ['foo=bar&boo=far&foo=baz', { foo: 'baz', boo: 'far' }],
             ['?foo=bar&boo=far&', { foo: 'bar', boo: 'far' }],
             ['foo=bar&boo', { foo: 'bar', boo: true }],
+            ['boo=&foo=bar', { foo: 'bar', boo: true }],
+            ['name=J%C3%A9r%C3%B4me', { name: 'Jérôme' }],
             ['', {}],
         ];
 

--- a/static/src/javascripts/lib/url.spec.js
+++ b/static/src/javascripts/lib/url.spec.js
@@ -37,7 +37,9 @@ describe('url', () => {
         const QUERIES = [
             ['foo', { foo: true }],
             ['foo=bar', { foo: 'bar' }],
+            ['foo=bar&foo=baz', { foo: 'baz' }], // The last value wins
             ['foo=bar&boo=far', { foo: 'bar', boo: 'far' }],
+            ['foo=bar&boo=far&foo=baz', { foo: 'baz', boo: 'far' }],
             ['foo=bar&boo=far&', { foo: 'bar', boo: 'far' }],
             ['foo=bar&boo', { foo: 'bar', boo: true }],
             ['', {}],

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -156,7 +156,7 @@ describe('bids', () => {
         setQueryString('pbtest=xhb&pbtest=sonobi');
         config.switches.prebidXaxis = false;
         config.switches.prebidSonobi = false;
-        expect(bidders()).toEqual(['xhb', 'sonobi']);
+        expect(bidders()).toEqual(['sonobi', 'xhb']);
     });
 
     test('should ignore bidder that does not exist', () => {


### PR DESCRIPTION
## What does this change?

This changes the implementation of getUrlVars to leverage the URLSearchParams API (which is implemented by polyfill.io if it's missing in a browser). See URLSearchParams in https://polyfill.io/test/tests?feature=URL )

This new implementation is "test equivalent" to the old one, but brings some performance improvement through the use of memoize, and some code simplification taking advantage of native URL search string parsing implementations.

## Implementation differences:

both '?foo' and '?foo=' turn into { foo: true } *Please advice if this is not desired*
URIEncoded value are decoded.