### PR TITLE
Audio AB Test 3: Change image position

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -5,9 +5,9 @@
 @import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
-@import experiments.{ActiveExperiments, AudioHideImage}
+@import experiments.{ActiveExperiments, AudioChangeImagePosition}
 
-@HideImageTest = @{ActiveExperiments.isParticipating(AudioHideImage)}
+@ImageBelowPlayer = @{ActiveExperiments.isParticipating(AudioChangeImagePosition)}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
     @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
@@ -37,12 +37,11 @@
                                 @media match {
                                     case audio: Audio => {
 
-                                        @if(!HideImageTest){
+                                        @if(!ImageBelowPlayer) {
                                             @audio.elements.images.map{ img =>
                                                 @fragments.imageFigure(img.images)
                                             }
                                         }
-
 
                                         <figure data-component="main audio">
                                         @audio.elements.mainAudio.map { audioElement =>
@@ -57,6 +56,14 @@
                                             )
                                         }
                                         </figure>
+
+                                        @if(ImageBelowPlayer) {
+                                            <figure data-component="image-below">
+                                                @audio.elements.images.map{ img =>
+                                                    @fragments.imageFigure(img.images)
+                                                }
+                                            </figure>
+                                        }
                                     }
                                     case video: Video => {
                                         <figure data-component="main video">

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,7 @@ import play.api.mvc.RequestHeader
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
-    AudioHideImage,
+    AudioChangeImagePosition,
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
@@ -58,10 +58,10 @@ object AudioPageChange extends Experiment(
   participationGroup = Perc0A
 )
 
-object AudioHideImage extends Experiment(
-  name = "audio-hide-image",
-  description = "Test the audio player without an image",
+object AudioChangeImagePosition extends Experiment(
+  name = "audio-change-image-position",
+  description = "Test the position of the image on audio pages",
   owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2018, 7, 31),
+  sellByDate = new LocalDate(2018, 8, 3),
   participationGroup = Perc50
 )


### PR DESCRIPTION
## What does this change?

- Removes the old test that hid the image 
- Adds a new test that trials putting the player above the image vs original player.

- 50:50 test that should run for 3 days 

## Screenshots

![screen shot 2018-07-27 at 16 01 43](https://user-images.githubusercontent.com/10324129/43328637-6cd57b88-91b6-11e8-91fa-97d76c3c30a0.png)

![screen shot 2018-07-27 at 16 01 15](https://user-images.githubusercontent.com/10324129/43328647-74e8971a-91b6-11e8-8d45-68160981e0cf.png)


## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
