### PR TITLE
contributions banner redeploy

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -37,11 +37,16 @@ const hasBannerBeenRedeployedSinceClosed = (): Promise<boolean> =>
     getTimestampOfLastBannerDeploy()
         .then(timestamp => {
             const bannerLastDeployedAt = new Date(timestamp);
-            const userLastClosedBannerAt = new Date(
-                userPrefs.get('engagementBannerLastClosedAt')
+            const userLastClosedBannerAt = userPrefs.get(
+                'engagementBannerLastClosedAt'
             );
 
-            return bannerLastDeployedAt > userLastClosedBannerAt;
+            if (!userLastClosedBannerAt) {
+                // show the banner if we can't get a value for this
+                return true;
+            }
+
+            return bannerLastDeployedAt > new Date(userLastClosedBannerAt);
         })
         .catch(err => {
             // Capture in sentry

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -12,7 +12,7 @@ import { getSync as getGeoLocation } from 'lib/geolocation';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import bean from 'bean';
-import fetchJSON from 'lib/fetch-json';
+import fetchJson from 'lib/fetch-json';
 
 import {
     submitComponentEvent,
@@ -30,15 +30,13 @@ const messageCode = 'engagement-banner';
 const canDisplayMembershipEngagementBanner = (): Promise<boolean> =>
     Promise.resolve(shouldShowReaderRevenue());
 
-const getTimestampOfLastBannerDeploy = fetchJSON(
-    '/reader-revenue/contributions-banner-deploy-log',
-    {
+const getTimestampOfLastBannerDeploy = (): Promise<string> =>
+    fetchJson('/reader-revenue/contributions-banner-deploy-log', {
         mode: 'cors',
-    }
-).then((resp: BannerDeployLog) => resp && resp.time);
+    }).then((resp: BannerDeployLog) => resp && resp.time);
 
 const hasBannerBeenRedeployedSinceClosed = (): Promise<boolean> =>
-    getTimestampOfLastBannerDeploy
+    getTimestampOfLastBannerDeploy()
         .then(timestamp => {
             const bannerLastDeployedAt = new Date(timestamp);
             const userLastClosedBannerAt = new Date(

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -30,12 +30,16 @@ const messageCode = 'engagement-banner';
 const canDisplayMembershipEngagementBanner = (): Promise<boolean> =>
     Promise.resolve(shouldShowReaderRevenue());
 
-const getTimestampOfLastBannerDeploy = fetchJSON('/reader-revenue/contributions-banner-deploy-log', {
-    mode: 'cors',
-}).then( (resp: BannerDeployLog) => resp && resp.time);
+const getTimestampOfLastBannerDeploy = fetchJSON(
+    '/reader-revenue/contributions-banner-deploy-log',
+    {
+        mode: 'cors',
+    }
+).then((resp: BannerDeployLog) => resp && resp.time);
 
-const hasBannerBeenRedeployedSinceClosed = (): Promise<boolean> => {
-    return getTimestampOfLastBannerDeploy.then(timestamp => {
+const hasBannerBeenRedeployedSinceClosed = (): Promise<boolean> =>
+    getTimestampOfLastBannerDeploy
+        .then(timestamp => {
             const bannerLastDeployedAt = new Date(timestamp);
             const userLastClosedBannerAt = new Date(
                 userPrefs.get('engagementBannerLastClosedAt')
@@ -44,7 +48,6 @@ const hasBannerBeenRedeployedSinceClosed = (): Promise<boolean> => {
             return bannerLastDeployedAt > userLastClosedBannerAt;
         })
         .catch(() => false);
-};
 
 const getUserTest = (): ?AcquisitionsABTest =>
     membershipEngagementBannerTests.find(
@@ -136,7 +139,6 @@ const selectSequentiallyFrom = (array: Array<string>): string =>
 
 const hideBanner = (banner: Message) => {
     banner.hide();
-    console.log('hide banner called')
 
     // Store timestamp in localStorage
     userPrefs.set('engagementBannerLastClosedAt', new Date().toISOString());
@@ -230,21 +232,20 @@ const canShow = (): Promise<boolean> => {
     }
 
     bannerParams = deriveBannerParams(getGeoLocation());
-    const hasSeenEnoughArticles = bannerParams && getVisitCount() >= bannerParams.minArticles;
+    const hasSeenEnoughArticles =
+        bannerParams && getVisitCount() >= bannerParams.minArticles;
 
     if (hasSeenEnoughArticles) {
         return hasBannerBeenRedeployedSinceClosed().then(hasBeenRedeployed => {
             if (hasBeenRedeployed) {
                 return canDisplayMembershipEngagementBanner();
             }
-            else {
-                return Promise.resolve(false);
-            }
-        })
+
+            return Promise.resolve(false);
+        });
     }
 
-    return Promise.resolve(false)
-
+    return Promise.resolve(false);
 };
 
 const membershipEngagementBanner: Banner = {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { local } from 'lib/storage';
-import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
+import { Message } from 'common/modules/ui/message';
 import mediator from 'lib/mediator';
 import { membershipEngagementBannerTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
@@ -222,10 +222,6 @@ const show = (): void => {
 
 const canShow = (): Promise<boolean> => {
     if (!config.get('switches.membershipEngagementBanner') || isBlocked()) {
-        return Promise.resolve(false);
-    }
-
-    if (hasUserAcknowledgedBanner(messageCode)) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -12,7 +12,7 @@ export const acquisitionsBannerControlTemplate = (
         <div class="engagement-banner__roundel">
             ${marque36icon.markup}
         </div>
-        <button class="button engagement-banner__close-button js-site-message js-engagement-banner-close-button" data-link-name="hide release message">
+        <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
             <span class="u-h">Close</span>
             ${closeCentralIcon.markup}
         </button>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -12,7 +12,7 @@ export const acquisitionsBannerControlTemplate = (
         <div class="engagement-banner__roundel">
             ${marque36icon.markup}
         </div>
-        <button class="button engagement-banner__close-button js-site-message-close" data-link-name="hide release message">
+        <button class="button engagement-banner__close-button js-site-message js-engagement-banner-close-button" data-link-name="hide release message">
             <span class="u-h">Close</span>
             ${closeCentralIcon.markup}
         </button>


### PR DESCRIPTION
Final step of redeploying the contributions (engagement) banner without dev help.
(Step 1 #20019, Step 2 #20063)

## What does this change?
- Fetches timestamp from application route (this timestamp can be updated from the admin console)
- Compares to timestamp in local storage when user closed banner (this will not exist initially and the date will then be set to `1970-01-01T00:00:00Z`)
- If there has been a redeploy since the banner was closed, shows the banner again. 

## What is the value of this and can you measure success?
Currently redeploying the banner needs a PR, which is inefficient and limited to engineers' office hours. Once this work is finished, deploying can be done at any time by anyone with access to frontend admin. ✨

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)


### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
