### PR TITLE
Unify sign in / register wording

### DIFF
--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -58,7 +58,7 @@
                         <a href="@{Configuration.id.url}/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
                             data-link-name="amp : nav : sign in"
                             class="menu-item__title">
-                            Sign in/up
+                            Sign in / Register
                         </a>
                     </li>
                 </ul>

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -9,7 +9,7 @@
         data-link-name="nav2 : topbar : signin"
         href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN">
 
-        Sign in
+        Sign in/up
     </a>
 
     <button class="is-hidden dropdown-menu-fallback js-user-account-trigger"

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -9,7 +9,7 @@
         data-link-name="nav2 : topbar : signin"
         href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN">
 
-        Sign in/up
+        Sign in / Register
     </a>
 
     <button class="is-hidden dropdown-menu-fallback js-user-account-trigger"

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -9,7 +9,7 @@
         <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN"
            data-link-name="nav2 : sign in"
            class="menu-item__title">
-            Sign in/up
+            Sign in / Register
         </a>
     </li>
 


### PR DESCRIPTION
## What does this change?
The messaging around sign-in in the mobile/amp/desktop nav was disjointed, not uniform and confusing. This PR brings clarity and purpose to it.

Wording's a bit longer but I've tested it across all breakpoints and on desktop the link still disappears before it can break anything. On mobile the link is still shorter than "Make a Contribution" so we are fine size wise.

## Screenshots
![screen shot 2018-07-30 at 1 44 34 pm](https://user-images.githubusercontent.com/11539094/43398377-da5c9e0c-93ff-11e8-81ca-ede5b5d755be.png)
![screen shot 2018-07-30 at 1 44 44 pm](https://user-images.githubusercontent.com/11539094/43398383-dc584382-93ff-11e8-817a-f5fd55e868e0.png)

## What is the value of this and can you measure success?
Our team is aiming to get more signed in users and this is a very good first step.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
