### PR TITLE
Remove the start_url from the web app manifest

### DIFF
--- a/applications/app/templates/webAppManifest.scala.js
+++ b/applications/app/templates/webAppManifest.scala.js
@@ -24,7 +24,6 @@
     ],
     "theme_color": "#e7edef",
     "background_color": "#121212",
-    "start_url": "/uk?INTCMP=webapp",
     "display": "browser",
     "orientation": "portrait",
     "gcm_sender_id":"660236028602",


### PR DESCRIPTION
## What does this change?
Removes the start_url from the web app manifest.		
## Screenshots

## What is the value of this and can you measure success?

Having a start_url means that whenever a user saves a guardian page to their home screen, they're shown the UK front. This is explicitly wrong for other editions and confusing in all cases the user wasn't on the UK front.

https://github.com/guardian/frontend/issues/19746#issuecomment-401401805
https://trello.com/c/gARWsi94/300-rethink-starturl-in-the-webapp-manifest
## Checklist

### Does this affect other platforms?

no

### Tested

- [ ] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
