### PR TITLE
Redisplay and fix most pop on video pages

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -15,7 +15,7 @@ import { MostPopular } from 'common/modules/onward/popular';
 import { related } from 'common/modules/onward/related';
 import { TonalComponent } from 'common/modules/onward/tonal';
 import { loadShareCounts } from 'common/modules/social/share-count';
-// import { onwardVideo } from 'common/modules/video/onward-container';
+import { onwardVideo } from 'common/modules/video/onward-container';
 import { moreInSeriesContainerInit } from 'common/modules/video/more-in-series-container';
 
 const initMoreInSection = (): void => {
@@ -95,10 +95,6 @@ const initRelated = () => {
     }
 };
 
-/**
- * TODO: reinstate this when styling is correct
- * https://trello.com/c/dq7QQQZ1
-
 const initOnwardVideoContainer = (): void => {
     if (
         config.get('page.contentType') !== 'Audio' &&
@@ -118,7 +114,6 @@ const initOnwardVideoContainer = (): void => {
         onwardVideo(el, mediaType);
     });
 };
- */
 
 const initOnwardContent = () => {
     insertOrProximity('.js-onward', () => {
@@ -137,9 +132,8 @@ const initOnwardContent = () => {
                 });
         }
     });
-    // TODO: reinstate this when styling is correct
-    // https://trello.com/c/dq7QQQZ1
-    // initOnwardVideoContainer();
+
+    initOnwardVideoContainer();
 };
 
 const initDiscussion = () => {

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -994,7 +994,7 @@ $ima-controls-height: 70px;
     padding-right: $gs-gutter/2;
 
     &.fc-item {
-        max-width: 25%;
+        width: 25%;
         background-color: transparent;
         margin-left: 0;
         margin-right: 0;


### PR DESCRIPTION
## What does this change?
We [temporarily](https://github.com/guardian/frontend/pull/19896) removed the most pop container until the styling was reimplemented. 

@zeftilldeath kindly pointed out that the styling was mostly there, but there was just some investigation needed.

This PR reinstates it, removes the offending line of css, and gives the title a colour.

Trello Card: https://trello.com/c/dq7QQQZ1/271-video-articles-most-viewed-videos-container-to-the-right-of-the-video-doesnt-appear-correctly

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/43401701-c5061e58-9408-11e8-87ce-b814aedaa2b2.png)


After:
*Desktop*
![image](https://user-images.githubusercontent.com/8774970/43401682-b79e8b06-9408-11e8-90ba-115f309395fa.png)

*Mobile*
![image](https://user-images.githubusercontent.com/8774970/43401783-f53ebb3e-9408-11e8-851d-d21b38bf044e.png)



## What is the value of this and can you measure success?
Onward journeys on media pages

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
