### PR TITLE
Show error when submitting feedback fails

### DIFF
--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -10,14 +10,14 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws._
-import play.api.mvc._
+import play.api.mvc.{request, _}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerComponents) (implicit context: ApplicationContext) extends BaseController with Logging with ImplicitControllerExecutionContext {
 
-  def submitFeedback(path: String): Action[AnyContent] = Action { implicit request =>
+  def submitFeedback(path: String): Action[AnyContent] = Action.async { implicit request =>
 
     val feedbackForm = Form(
       tuple(
@@ -33,7 +33,13 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
 
     log.info(s"feedback submitted for category: $category")
 
-    ws.url(Configuration.feedback.feedpipeEndpoint)
+    val page = model.SimplePage(MetaData.make(
+      request.path,
+      Some(SectionId.fromId("info")),
+      "Your report has been sent"
+    ))
+
+    val sendFeedback: Future[Result] = ws.url(Configuration.feedback.feedpipeEndpoint)
       .withRequestTimeout(6000.millis)
       .post(Json.obj(
         "category" -> java.net.URLEncoder.encode(category, "UTF-8"),
@@ -41,15 +47,19 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
         "user" -> java.net.URLEncoder.encode(user, "UTF-8"),
         "extra" -> java.net.URLEncoder.encode(extra, "UTF-8"),
         "name" -> java.net.URLEncoder.encode(name, "UTF-8")
-      ))
+      )).map((resp: WSResponse) => {
 
-    val page = model.SimplePage(MetaData.make(
-      request.path,
-      Some(SectionId.fromId("info")),
-      "Your report has been sent"
-    ))
+        if(resp.status != 200){
+          throw new Exception("Feedpipe api returned non-200")
+        }
 
-    NoCache(Ok(views.html.feedbackSent(page, path)))
+        NoCache(Ok(views.html.feedbackSent(page, path)))
+
+      }) recover {
+        case t:Throwable => NoCache(Ok(views.html.feedbackError(page, path)))
+      }
+
+    sendFeedback
 
   }
 

--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -8,9 +8,9 @@ import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, MetaData, NoCache, SectionId, SimplePage}
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.Json
 import play.api.libs.ws._
-import play.api.mvc.{request, _}
+import play.api.mvc._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -36,7 +36,7 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
     val page = model.SimplePage(MetaData.make(
       request.path,
       Some(SectionId.fromId("info")),
-      "Your report has been sent"
+      "Submit Feedback"
     ))
 
     val sendFeedback: Future[Result] = ws.url(Configuration.feedback.feedpipeEndpoint)

--- a/onward/app/views/feedbackError.scala.html
+++ b/onward/app/views/feedbackError.scala.html
@@ -1,0 +1,32 @@
+@(page: model.Page, path: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@mainLegacy(page){ } {
+    <div class="l-side-margins">
+        <div class="content content--expired">
+            <header class="content__head">
+                <div class="gs-container">
+                    <div class="content__main-column">
+                        <h1 itemprop="headline" class="content__headline">A problem has occurred</h1>
+                    </div>
+                </div>
+            </header>
+            <div class="content__main">
+                <div class="gs-container">
+                    <div class="content__main-column content__main-column--expired">
+                        <div class="js-article__container u-cf">
+                            <div class="from-content-api" itemprop="articleBody">
+                                <div class="from-content-api">
+                                    <h2>Unable to submit feedback</h2>
+                                    <p>
+                                        Unfortunately there was an error when submitting your feedback. You can try
+                                        again later, or contact us directly at <a href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}


### PR DESCRIPTION
## What does this change?

on gu.com/info/tech-feedback

Shows an error page asking the user to manually email userhelp, if we fail to submit their feedback to the feedpipe backend.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
