### PR TITLE
Max caption size

### DIFF
--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -69,11 +69,9 @@
                     case Some(masterImage) => {
                         <figcaption class="caption caption--immersive hide-until-leftcol">
                             @fragments.inlineSvg("triangle", "icon")
-                            @masterImage.credit.map { credit =>
-                                @credit
-                            }
-                            @masterImage.caption.map { caption =>
-                                @caption
+                            @masterImage.caption.map(Html(_))
+                            @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
+                                @masterImage.credit.map(Html(_))
                             }
                         </figcaption>
                     }

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -180,6 +180,13 @@
 }
 
 .caption--immersive {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: $gs-baseline * 9;
+    display: -webkit-box;
+    -webkit-line-clamp: 7;
+    -webkit-box-orient: vertical;
+
     @include mq($until: leftCol) {
         margin: $gs-baseline 0 ($gs-baseline / 2);
     }

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -211,15 +211,6 @@
     padding-bottom: $gs-baseline;
     margin-bottom: 0;
 
-    .u-underline {
-        color: $brightness-93;
-        border-bottom: 1px solid rgba($brightness-93, .4);
-
-        &:hover {
-            border-bottom-color: rgba($brightness-93, 1);
-        }
-    }
-
     &.content__standfirst--advertisement {
         font-family: $f-sans-serif-text;
     }

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -270,6 +270,13 @@
 
 .caption.caption--gallery {
     color: $brightness-86;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: $gs-baseline * 9;
+    display: -webkit-box;
+    -webkit-line-clamp: 7;
+    -webkit-box-orient: vertical;
+    z-index: 1;
 
     @include mq($until: desktop) {
         margin: $gs-baseline 0 ($gs-baseline / 2);


### PR DESCRIPTION
Limiting the number of lines in a main media caption to 7. Whilst it is deceptive as composer lets you add more, it's better than seeing text spill out over the meta area. The whole template may need to be rebuilt with css grid if we want it all to be flexible enough to cope with huge captions. Couple of bugs fixed in here too.   