### PR TITLE
uses conf, adds ajax service id in cdn purge

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -26,6 +26,7 @@ object AdminConfiguration {
   object fastly {
     lazy val key = configuration.getStringProperty("fastly.key").getOrElse(throw new RuntimeException("Fastly key not configured"))
     lazy val serviceId = configuration.getStringProperty("fastly.serviceId").getOrElse(throw new RuntimeException("Fastly service id not configured"))
+    lazy val ajaxServiceId = configuration.getStringProperty("fastly.ajax.serviceId").getOrElse(throw new RuntimeException("Fastly ajax service id not configured"))
   }
 
   object imgix {

--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -48,7 +48,7 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
 
   private def purgeDeployLogCache(): Future[WSResponse] = {
     val path = "/reader-revenue/contributions-banner-deploy-log"
-    CdnPurge.soft(wsClient, DigestUtils.md5Hex(path))
+    CdnPurge.soft(wsClient, DigestUtils.md5Hex(path), CdnPurge.AjaxHost)
   }
 
   private def bannerRedeploySuccessful(message: String): Result = {

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -26,7 +26,7 @@ class PageDecacheController(wsClient: WSClient, val controllerComponents: Contro
 
   def decache(): Action[AnyContent] = AdminAuthAction.async { implicit request =>
     getSubmittedUrl(request).map(new URI(_)).map{ urlToDecache =>
-      CdnPurge.soft(wsClient, DigestUtils.md5Hex(urlToDecache.getPath))
+      CdnPurge.soft(wsClient, DigestUtils.md5Hex(urlToDecache.getPath), CdnPurge.GuardianHost)
         .map { _ => "Purge request successfully sent" }
         .recover { case e => s"Purge request was not successful, please report this issue: '${e.getLocalizedMessage}'" }
         .map { message => NoCache(Ok(views.html.cache.pageDecache(message))) }

--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -5,18 +5,22 @@ import conf.AdminConfiguration.fastly
 import conf.Configuration.environment
 import implicits.Dates
 import play.api.libs.ws.{WSClient, WSResponse}
+import conf.AdminConfiguration.fastly
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object CdnPurge extends Dates with Logging {
 
-  private val serviceId = "2eYr6Wx3ZCUoVPShlCM61l"
+  sealed trait FastlyService { def serviceId: String }
+  case object GuardianHost extends FastlyService { val serviceId = fastly.serviceId }
+  case object AjaxHost extends FastlyService { val serviceId = fastly.ajaxServiceId }
 
   // Performs soft purge which will still serve stale if there is an error
-  def soft(wsClient: WSClient, key:String)(implicit executionContext: ExecutionContext): Future[WSResponse] = {
+  def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[WSResponse] = {
     // under normal circumstances we only ever want this called from PROD.
     // Don't want too much decaching going on.
     if (environment.isProd) {
+      val serviceId = fastlyService.serviceId
       wsClient.url(s"https://api.fastly.com/service/$serviceId/purge/$key")
         .withHttpHeaders(
           "Fastly-Key" -> fastly.key,

--- a/admin/app/views/readerRevenue/bannerDeploys.scala.html
+++ b/admin/app/views/readerRevenue/bannerDeploys.scala.html
@@ -1,12 +1,13 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext, flash: Flash)
 @import common.LinkTo
+@import conf.Configuration
 
 
 @admin_main("Redeploy Contributions Banner", isAuthed = true) {
 
     <h1>Contributions Banner Redeploy</h1>
 
-    <p><a href="@LinkTo("/reader-revenue/contributions-banner-deploy-log")">Timestamp of last banner redeploy</a></p>
+    <p><a href="@Configuration.ajax.url/reader-revenue/contributions-banner-deploy-log">Timestamp of last banner redeploy</a></p>
     <p>Click this button to redeploy contributions (engagement) banner</p>
 
     <form action="@controllers.admin.routes.ReaderRevenueAdminController.redeployContributionsBanner()" method="POST">

--- a/admin/app/views/readerRevenue/readerRevenueMenu.scala.html
+++ b/admin/app/views/readerRevenue/readerRevenueMenu.scala.html
@@ -1,5 +1,4 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext)
-@import conf.Configuration
 
 @admin_main("Reader Revenue Tools", isAuthed = true) {
 


### PR DESCRIPTION
## What does this change?
The timestamp used to determine if a user should see the contributions banner sits on the ajax url. When the contributions banner is redeployed in admin tool we need to purge the cache so the new timestamp value (on ajax url) is available to fetch from frontend. 

- Adds ability to soft purge the Fastly ajax host (by setting correct serviceId)
- Pulls service ids from config, removes hard coded values (the guardian host id was already there and @philmcmahon has added the ajax service id so it will be available to load).

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
