### PR TITLE
Adding a color to the title for most pop video

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -175,6 +175,7 @@
         @include fs-header(2);
         position: relative;
         top: $gs-baseline/4;
+        color: $brightness-86;
     }
 }
 .most-viewed--media {

--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -175,7 +175,7 @@
         @include fs-header(2);
         position: relative;
         top: $gs-baseline/4;
-        color: $brightness-86;
+        color: $brightness-93;
     }
 }
 .most-viewed--media {


### PR DESCRIPTION
## What does this change?
Making sure there is a colour for the most popular title

## Screenshots
It was black before, now it looks like this:

![image](https://user-images.githubusercontent.com/8774970/43456715-7ca08d2e-94bc-11e8-9533-dfe85ab8fb6f.png)


## What is the value of this and can you measure success?
You can read the title!

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
