### PR TITLE
Always display endslate for Youtube atoms

### DIFF
--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -8,7 +8,7 @@
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
-        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
+        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = true, mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case storyquestions: StoryQuestionsAtom if !amp => Html(ArticleAtomRenderer.getHTML(storyquestions.atom, config))
         case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp, inApp = false)


### PR DESCRIPTION
## What does this change?

YouTube atoms embedded in articles don't have an endslate unless they are the main media for the article. This change ensures all YouTube atoms embedded in an article have an endslate

## Screenshots

**Before**

![screen shot 2018-07-31 at 17 18 06](https://user-images.githubusercontent.com/5931528/43472607-c243ed0c-94e5-11e8-995e-cadbcc4ed283.png)

**After**

![screen shot 2018-07-31 at 17 18 15](https://user-images.githubusercontent.com/5931528/43472615-c71388c4-94e5-11e8-9600-3c9ca1e6875f.png)

## What is the value of this and can you measure success?

Fixes https://trello.com/c/bpAliBTA

Adds an onward journey for all YouTube atoms. I can't think of any reason why we wouldn't want the end slate to appear? (Related: #15660)

## Checklist

### Tested

- [x] Locally
