### PR TITLE
Audio AB Test 4: new player vs old player with image in optimal position 

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -36,6 +36,10 @@
                         <div class="media-primary player">
                         @media match {
                             case audio: Audio => {
+                                @audio.elements.images.map{ img =>
+                                    @fragments.imageFigure(img.images)
+                                }
+
                                 <figure data-component="main audio new-player"
                                     id="audio-component-container"
                                     data-media-id="@audio.elements.mainAudio.map{ audioElement => @audioElement.properties.id}"
@@ -112,11 +116,6 @@
                                     <div class="tonal__standfirst">
                                     @fragments.standfirst(v)
                                     </div>
-                                }
-                                case a: Audio => {
-                                    @a.elements.images.map{ img =>
-                                        @fragments.imageFigure(img.images)
-                                    }
                                 }
                                 case _ => {}
                             }

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -113,6 +113,11 @@
                                     @fragments.standfirst(v)
                                     </div>
                                 }
+                                case a: Audio => {
+                                    @a.elements.images.map{ img =>
+                                        @fragments.imageFigure(img.images)
+                                    }
+                                }
                                 case _ => {}
                             }
 

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -5,9 +5,6 @@
 @import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
-@import experiments.{ActiveExperiments, AudioChangeImagePosition}
-
-@ImageBelowPlayer = @{ActiveExperiments.isParticipating(AudioChangeImagePosition)}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
     @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
@@ -37,12 +34,6 @@
                                 @media match {
                                     case audio: Audio => {
 
-                                        @if(!ImageBelowPlayer) {
-                                            @audio.elements.images.map{ img =>
-                                                @fragments.imageFigure(img.images)
-                                            }
-                                        }
-
                                         <figure data-component="main audio">
                                         @audio.elements.mainAudio.map { audioElement =>
                                             @fragments.media.audio(
@@ -57,12 +48,8 @@
                                         }
                                         </figure>
 
-                                        @if(ImageBelowPlayer) {
-                                            <figure data-component="image-below">
-                                                @audio.elements.images.map{ img =>
-                                                    @fragments.imageFigure(img.images)
-                                                }
-                                            </figure>
+                                        @audio.elements.images.map{ img =>
+                                            @fragments.imageFigure(img.images)
                                         }
                                     }
                                     case video: Video => {

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -34,6 +34,10 @@
                                 @media match {
                                     case audio: Audio => {
 
+                                        @audio.elements.images.map{ img =>
+                                            @fragments.imageFigure(img.images)
+                                        }
+
                                         <figure data-component="main audio">
                                         @audio.elements.mainAudio.map { audioElement =>
                                             @fragments.media.audio(
@@ -47,10 +51,6 @@
                                             )
                                         }
                                         </figure>
-
-                                        @audio.elements.images.map{ img =>
-                                            @fragments.imageFigure(img.images)
-                                        }
                                     }
                                     case video: Video => {
                                         <figure data-component="main video">

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import play.api.mvc.RequestHeader
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
-    AudioChangeImagePosition,
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
@@ -46,13 +45,5 @@ object AudioPageChange extends Experiment(
   description = "Show a different version of the audio page to certain people",
   owners = Owner.group(SwitchGroup.Journalism),
   sellByDate = new LocalDate(2018, 8, 20),
-  participationGroup = Perc0A
-)
-
-object AudioChangeImagePosition extends Experiment(
-  name = "audio-change-image-position",
-  description = "Test the position of the image on audio pages",
-  owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2018, 8, 3),
   participationGroup = Perc50
 )

--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -43,12 +43,15 @@
             margin-left: -10rem;
         }
         .content__meta-container {
-            top: auto;
+            top: 175px;
         }
     }
     @media (min-width: 81.25em) {
         .player {
             margin-left: -15rem;
+        }
+        .content__meta-container {
+            top: 235px;
         }
     }
 

--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -43,15 +43,23 @@
             margin-left: -10rem;
         }
         .content__meta-container {
-            top: 175px;
+            top: auto;
+        }
+
+        figure.media-content {
+            padding-left: 10rem;
+
+            margin-bottom: 0;
+            padding-bottom: 6px;
+            background-color: #121212;
         }
     }
     @media (min-width: 81.25em) {
         .player {
             margin-left: -15rem;
         }
-        .content__meta-container {
-            top: 235px;
+        figure.media-content {
+            padding-left: 15rem;
         }
     }
 


### PR DESCRIPTION
## What does this change?
Audio Tests 2 and 3 ascertained the optimal position for the image on the episode page.

Test 4 uses the winning image position (above the player), adds it to the new player and runs it against the old player 

50% test
Should run for 3 days

## Screenshots
<img width="719" alt="picture 12" src="https://user-images.githubusercontent.com/1513454/43644192-d1d4e32e-9725-11e8-8247-9c1f62eb484b.png">

**VS**

<img width="727" alt="picture 13" src="https://user-images.githubusercontent.com/1513454/43644194-d52a3240-9725-11e8-9712-6fadfcfdffad.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
