### PR TITLE
Increase Interview headline line-height from tablet breakpoint

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -721,7 +721,7 @@ $quote-mark: 35px;
         padding: 0;
         line-height: 35px;
 
-        @include mq($from: desktop) {
+        @include mq($from: tablet) {
             line-height: 42px;
         }
 


### PR DESCRIPTION
## What does this change?

Increases Interview headline line-height to `42px` from `tablet` breakpoint. This fixes this bug on Trello: https://trello.com/c/lfhehVCf/250-interview-headline-line-height-at-tablet-breakpoint

The font-size jumps from `28px` to `34px` at `tablet` breakpoint, the line-height however remained `35px` which caused the bug.

## Screenshots

Before...

![screen_shot_2018-06-08_at_15 41 07](https://user-images.githubusercontent.com/1590704/43474077-bfbb833e-94e9-11e8-9bde-de319261ff28.png)

After...

![screen shot 2018-07-31 at 17 48 15](https://user-images.githubusercontent.com/1590704/43474178-077a16e0-94ea-11e8-808b-921a41c2aeda.png)