### PR TITLE
Show/Hide Safari bug

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -453,6 +453,7 @@ $header-image-size-desktop: 100px;
     padding: 0;
     color: $brightness-46;
     text-align: right;
+    // min-width needed to ensure button is visible on Safari
     min-width: gs-span(1);
 
     &:hover,

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -453,7 +453,7 @@ $header-image-size-desktop: 100px;
     padding: 0;
     color: $brightness-46;
     text-align: right;
-    min-width: 60px;
+    min-width: gs-span(1);
 
     &:hover,
     &:focus {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -453,6 +453,7 @@ $header-image-size-desktop: 100px;
     padding: 0;
     color: $brightness-46;
     text-align: right;
+    min-width: 60px;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Show/Hide on fronts containers isn't visible in Safari. Fixed it by giving the absolutely positioned button a min-width, if you can think of a better way of doing it please let me know.

