### PR TITLE
Prevent veggie menu click propagation

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -530,6 +530,7 @@ const addEventHandler = (): void => {
 
                 if (parent) {
                     event.preventDefault();
+                    event.stopPropagation();
                     toggleMenuSection(parent);
                 }
             }


### PR DESCRIPTION
## What does this change?

In desktop Safari at high zoom, the veggie burger menu becomes visible. When a user opens the menu and clicks to expand a pillar, the menu closes.

This change ensures the click event does not propagate up to the event listener that closes the menu.

## Screenshots

![aug-01-2018 16-03-51](https://user-images.githubusercontent.com/5931528/43530056-8b8a5db8-95a4-11e8-9ec0-5334c20839f2.gif)

## What is the value of this and can you measure success?

Better support for high zoom users 

## Checklist

### Tested

- [x] Locally
