### PR TITLE
Search accessibility improvements

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -85,8 +85,9 @@
                                 data-is-ajax
                                 data-link-name="nav2 : search"
                                 data-toggle="js-search-new"
-                                aria-haspopup="true">
-
+                                aria-controls="js-search-new"
+                                role="button"
+                            >
                                 Search
                             </a>
                         }
@@ -94,7 +95,15 @@
                 }
             </div>
 
-            <div class="popup popup--default popup--search js-search-popup js-search-new is-off"><div class="js-search-placeholder"></div></div>
+            @if(SearchSwitch.isSwitchedOn) {
+                <div class="popup popup--default popup--search js-search-popup js-search-new is-off"
+                     aria-label="search"
+                     role="dialog"
+                     tabindex="-1"
+                >
+                    <div class="js-search-placeholder"></div>
+                </div>
+            }
 
             <ul class="pillars">
                 @navMenu.pillars.map { link =>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -85,9 +85,6 @@
                                 data-is-ajax
                                 data-link-name="nav2 : search"
                                 data-toggle="js-search-new"
-                                aria-controls="search-popup"
-                                aria-haspopup="dialog"
-                                role="button"
                             >
                                 Search
                             </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -85,7 +85,8 @@
                                 data-is-ajax
                                 data-link-name="nav2 : search"
                                 data-toggle="js-search-new"
-                                aria-controls="js-search-new"
+                                aria-controls="search-popup"
+                                aria-haspopup="dialog"
                                 role="button"
                             >
                                 Search
@@ -100,6 +101,7 @@
                      aria-label="search"
                      role="dialog"
                      tabindex="-1"
+                     id="search-popup"
                 >
                     <div class="js-search-placeholder"></div>
                 </div>

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -37,6 +37,15 @@ class Search {
                             return;
                         }
 
+                        fastdom.write(() => {
+                            toggle.setAttribute('role', 'button');
+                            toggle.setAttribute(
+                                'aria-controls',
+                                'search-popup'
+                            );
+                            toggle.setAttribute('aria-haspopup', 'dialog');
+                        });
+
                         fastdom
                             .read(
                                 () =>

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -50,28 +50,37 @@ class Search {
                                 }
 
                                 bean.on(toggle, 'click', e => {
-                                    const handleEsc = (event: Event) => {
-                                        if (event.key === 'Escape') {
-                                            dismissSearchPopup(event);
+                                    const handleEsc = (event: Event): void => {
+                                        const keyboardEvent: KeyboardEvent = (event: any);
+
+                                        if (keyboardEvent.key === 'Escape') {
+                                            // eslint-disable-next-line no-use-before-define
+                                            dismissSearchPopup(keyboardEvent);
                                             toggle.focus();
                                         }
                                     };
-                                    const dismissSearchPopup = (event: Event): void => {
+                                    const dismissSearchPopup = (
+                                        event: Event
+                                    ): void => {
                                         event.preventDefault();
-                                        toggle.classList.remove(
-                                            'is-active'
-                                        );
+                                        toggle.classList.remove('is-active');
                                         popup.classList.add('is-off');
 
                                         bean.off(
                                             document,
                                             'click',
+                                            // eslint-disable-next-line no-use-before-define
                                             maybeDismissSearchPopup
                                         );
-                                        document.removeEventListener('keyup', handleEsc);
+                                        document.removeEventListener(
+                                            'keyup',
+                                            handleEsc
+                                        );
                                     };
-                                    const maybeDismissSearchPopup = (event: Event): void => {
-                                        let el = event.target;
+                                    const maybeDismissSearchPopup = (
+                                        event: Event
+                                    ): void => {
+                                        let el: ?Element = (event.target: any);
                                         let clickedPop = false;
 
                                         while (el && !clickedPop) {
@@ -93,7 +102,7 @@ class Search {
                                                 clickedPop = true;
                                             }
 
-                                            el = el.parentNode;
+                                            el = el && el.parentElement;
                                         }
 
                                         if (!clickedPop) {
@@ -113,7 +122,10 @@ class Search {
                                                 'click',
                                                 maybeDismissSearchPopup
                                             );
-                                            document.addEventListener('keyup', handleEsc);
+                                            document.addEventListener(
+                                                'keyup',
+                                                handleEsc
+                                            );
                                         }
                                     });
 

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -52,21 +52,34 @@ class Search {
                                 bean.on(toggle, 'click', e => {
                                     const handleEsc = (event: Event) => {
                                         if (event.key === 'Escape') {
-                                            if (maybeDismissSearchPopup(event)) {
-                                                toggle.focus();
-                                            }
+                                            dismissSearchPopup(event);
+                                            toggle.focus();
                                         }
                                     };
-                                    const maybeDismissSearchPopup = (event: Event): boolean => {
+                                    const dismissSearchPopup = (event: Event): void => {
+                                        event.preventDefault();
+                                        toggle.classList.remove(
+                                            'is-active'
+                                        );
+                                        popup.classList.add('is-off');
+
+                                        bean.off(
+                                            document,
+                                            'click',
+                                            maybeDismissSearchPopup
+                                        );
+                                        document.removeEventListener('keyup', handleEsc);
+                                    };
+                                    const maybeDismissSearchPopup = (event: Event): void => {
                                         let el = event.target;
                                         let clickedPop = false;
 
                                         while (el && !clickedPop) {
-                                            /* either the search pop-up or the autocomplete resultSetSize
-                                           NOTE: it would be better to check for `.gssb_c`,
+                                            /*  either the search pop-up or the autocomplete resultSetSize
+                                                NOTE: it would be better to check for `.gssb_c`,
                                                  which is the outer autocomplete element, but
                                                  google stops the event bubbling earlier
-                                        */
+                                            */
                                             if (
                                                 el &&
                                                 el.classList &&
@@ -84,23 +97,8 @@ class Search {
                                         }
 
                                         if (!clickedPop) {
-                                            event.preventDefault();
-                                            toggle.classList.remove(
-                                                'is-active'
-                                            );
-                                            popup.classList.add('is-off');
-
-                                            bean.off(
-                                                document,
-                                                'click',
-                                                maybeDismissSearchPopup
-                                            );
-                                            document.removeEventListener('keyup', handleEsc);
-
-                                            return true;
+                                            dismissSearchPopup(event);
                                         }
-
-                                        return false;
                                     };
 
                                     setTimeout(() => {

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -109,6 +109,7 @@ class Search {
                                                 'is-active'
                                             )
                                         ) {
+                                            popup.focus();
                                             bean.on(
                                                 document,
                                                 'click',

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -50,6 +50,11 @@ class Search {
                                 }
 
                                 bean.on(toggle, 'click', e => {
+                                    const handleEsc = (event: Event) => {
+                                        if (event.key === 'Escape') {
+                                            maybeDismissSearchPopup(event);
+                                        }
+                                    };
                                     const maybeDismissSearchPopup = event => {
                                         let el = event.target;
                                         let clickedPop = false;
@@ -88,6 +93,7 @@ class Search {
                                                 'click',
                                                 maybeDismissSearchPopup
                                             );
+                                            document.removeEventListener('keyup', handleEsc);
                                         }
                                     };
 
@@ -102,6 +108,7 @@ class Search {
                                                 'click',
                                                 maybeDismissSearchPopup
                                             );
+                                            document.addEventListener('keyup', handleEsc);
                                         }
                                     });
 

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -52,10 +52,12 @@ class Search {
                                 bean.on(toggle, 'click', e => {
                                     const handleEsc = (event: Event) => {
                                         if (event.key === 'Escape') {
-                                            maybeDismissSearchPopup(event);
+                                            if (maybeDismissSearchPopup(event)) {
+                                                toggle.focus();
+                                            }
                                         }
                                     };
-                                    const maybeDismissSearchPopup = event => {
+                                    const maybeDismissSearchPopup = (event: Event): boolean => {
                                         let el = event.target;
                                         let clickedPop = false;
 
@@ -94,7 +96,11 @@ class Search {
                                                 maybeDismissSearchPopup
                                             );
                                             document.removeEventListener('keyup', handleEsc);
+
+                                            return true;
                                         }
+
+                                        return false;
                                     };
 
                                     setTimeout(() => {


### PR DESCRIPTION
## What does this change?

- search dialog now closes when user hits escape (sadly this does not work if the user has the Google search results iframe in focus)
- search toggle enhances to a button instead of link
- establish link between search toggle and search dialog
- search dialog marked up as dialog (and removed if search switch is off)
- on opening, search dialog receives focus to notify screen reader users what has happened
- on closing, search toggle receives focus

## Screenshots

![aug-01-2018 19-41-21](https://user-images.githubusercontent.com/5931528/43541754-0ff29296-95c3-11e8-8596-5718a4b11fe3.gif)


## What is the value of this and can you measure success?

- Addresses some concerns raised in RNIB accessibility audit
- Makes our site more accessible to screen reader and keyboard users

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)

### Tested

- [x] Locally
