### PR TITLE
Bumped Prebid to v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#c3dd8a0",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#6a13dd8",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#c3dd8a0":
-  version "1.16.0"
-  resolved "https://github.com/guardian/Prebid.js.git#c3dd8a02c3945dff372218ba245e17d48fed3082"
+"prebid.js@https://github.com/guardian/Prebid.js.git#6a13dd8":
+  version "1.18.0"
+  resolved "https://github.com/guardian/Prebid.js.git#6a13dd8dff5dc16093641ba7c3a27f271c1236db"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This is latest release.

See:
* https://github.com/guardian/Prebid.js/pull/39
* https://github.com/prebid/Prebid.js/releases/tag/1.18.0