### PR TITLE
Interactives should now use pillar colour palette

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -32,7 +32,11 @@
                         "content--foundation-supported" -> isFoundationFundedContent(page),
                         "paid-content" -> isPaidContent
                     ),
-                    "content", "content--interactive", "tonal", s"tonal--${toneClass(interactive)}"
+                    "content",
+                    "content--interactive",
+                    "tonal",
+                    s"tonal--${toneClass(interactive)}",
+                    s"content--pillar-${interactive.metadata.pillar.nameOrDefault}"
                 )"
                 itemscope itemtype="@interactive.metadata.schemaType" role="main">
 

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -303,7 +303,6 @@
     }
 }
 
-.content--interactive,
 .content--pillar-news:not(.paid-content) {
     @include colorPalatte($news-main, $news-dark, $news-bright);
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -605,7 +605,7 @@ $quote-mark: 35px;
 }
 
 /**** sport overrides ****/
-.content--pillar-sport,
+.content--pillar-sport:not(.content--interactive),
 .content--pillar-sport.content--type-feature {
     .content__meta-container {
         background-image: url('data:image/svg+xml,%3Csvg%20width%3D%229%22%20height%3D%2212%22%20viewBox%3D%220%200%209%2012%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22%23DFDFDF%22%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3C/g%3E%3C/svg%3E');


### PR DESCRIPTION
## What does this change?

Since the (Garnett) redesign Interactives have used the News pillar's colour palette. This was recently queried with regards to this article https://www.theguardian.com/football/ng-interactive/2018/jun/03/transfer-window-summer-2018-every-deal-europes-top-five-leagues.

The colour of the byline was questioned because it was red (as per News pillars spec) whilst the article is in the Sport section pillar and all other articles in this section use the Sport pillar's colour palette (blue).

After chatting with @blongden73 (Design) and @superfrank (Interactives) it was agreed that the Interactive template should be updated to use the appropriate palette for the pillar. This PR does that.

## Screenshots

Before...

![screen shot 2018-08-02 at 16 23 08](https://user-images.githubusercontent.com/1590704/43594301-d0eb3800-9671-11e8-8763-2860618caaaf.png)

After...

![screen shot 2018-08-02 at 16 22 32](https://user-images.githubusercontent.com/1590704/43594318-d79c84f6-9671-11e8-9111-3dca73fb8983.png)

## What is the value of this and can you measure success?

Correct pillar colours applied