### PR TITLE
Return a 404 when a tag index page has no content on it

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -66,7 +66,8 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
     case _ =>
       logGoogleBot(request)
       index(Edition(request), path, inferPage(request), request.isRss) map {
-        case Left(model) => renderFaciaFront(model)
+        case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
+        case Left(model) if model.contents.isEmpty => NoCache(NotFound)
         case Right(other) => RenderOtherStatus(other)
       }
   }

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -67,6 +67,7 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
       logGoogleBot(request)
       index(Edition(request), path, inferPage(request), request.isRss) map {
         case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
+        // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
         case Left(model) if model.contents.isEmpty => NoCache(NotFound)
         case Right(other) => RenderOtherStatus(other)
       }


### PR DESCRIPTION
## What does this change?
Currently we've got lots of pages on the website which look like this: https://www.theguardian.com/visit-wales - typically because of an expired microsite or similar. The fact the page returns a 200 means that the redirect tool doesn't work, so CP can't do anything with these pages. This change modifies the behaviour so that if there is no content on an index page (so tag page, section etc.) then we return a 404. 

## Screenshots

## What is the value of this and can you measure success?
CP can redirect around empty expired microsites. 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
