### PR TITLE
Remove font colour on crossword__anagram-helper__cell

### DIFF
--- a/static/src/stylesheets/module/crosswords/_anagram-helper.scss
+++ b/static/src/stylesheets/module/crosswords/_anagram-helper.scss
@@ -113,7 +113,6 @@
 
     &.has-value {
         background: $brightness-86;
-        color: $brightness-86;
     }
 }
 


### PR DESCRIPTION
## What does this change?

A [bug](https://trello.com/c/VqFmaquX/298-crosswords-anagram-helper-is-failing-to-include-already-filled-in-letters) has been reported where the anagram helper isn't showing the letters from the cells already completed in the crossword grid.

This is simply occurring as the background colour of `.crossword__anagram-helper__cell` is the same as the the font colour, so the letter is there in the DOM, it's just not visible!  

Removing the `color` css property on `.crossword__anagram-helper__cell` fixes this.

## Screenshots

Before...

![screen shot 2018-08-02 at 17 40 18](https://user-images.githubusercontent.com/1590704/43598146-e88e6892-967b-11e8-9a15-37315d0e7b11.png)

After...

![screen shot 2018-08-02 at 17 39 52](https://user-images.githubusercontent.com/1590704/43598160-f106cc4e-967b-11e8-9155-26a1baf07da3.png)