### PR TITLE
Replace all occurrences of %%CURRENCY_SYMBOL%%, not just first

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -70,7 +70,7 @@ export const getCopyFromGoogleDoc = (
             heading: firstRow.heading,
             paragraphs: rows.map(row => row.paragraphs),
             highlightedText: firstRow.highlightedText.replace(
-                '%%CURRENCY_SYMBOL%%',
+                /%%CURRENCY_SYMBOL%%/g,
                 getLocalCurrencySymbol()
             ),
         };


### PR DESCRIPTION
Because we might have more than one in the Google Doc