### PR TITLE
Downgrade yarn to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "tools/amp-validation"
   ],
   "engines": {
-    "yarn": "1.9.2"
+    "yarn": "1.8.0"
   },
   "dependencies": {
     "@guardian/atom-renderer": "0.14.6",


### PR DESCRIPTION
## What does this change?

We have noticed a significant increase in the time taken to install new JavaScript dependencies using Yarn 1.9.2. This appears to be a known issue (yarnpkg/yarn#6210). For now, we're downgrading to 1.8.0, which is a lot faster.

## What is the value of this and can you measure success?

Fast JS package installation
