### PR TITLE
Don't encode og:image urls.

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -106,7 +106,7 @@
             <meta name="news_keywords" content="@c.item.tags.keywords.take(10).map(_.name).mkString(",")" />
         }
         @c.getOpenGraphProperties.map { case (key, value) =>
-            <meta property="@key" content="@value" />
+            <meta property="@key" content="@Html(value)" />
         }
         @c.getTwitterProperties.map{ case (key, value) =>
             <meta name="@key" content="@value" />


### PR DESCRIPTION
## What does this change?
Original gangster image urls were getting parameter encoded. This stops that.

The `&` -> `&amp;` was getting silently fixed by quite a few things, but was breaking for Facebooks OG debugger (but not Facebooks share debugger)

## Screenshots
Object graph tool:
![image](https://user-images.githubusercontent.com/2670496/43652938-873c03e2-973e-11e8-9ea2-5475d695ce7e.png)
Sharing tool:
![image](https://user-images.githubusercontent.com/2670496/43652964-96a48408-973e-11e8-9a17-59ac33fc2060.png)



## What is the value of this and can you measure success?
Echobox should start picking up images again.
## Checklist

### Does this affect other platforms?

- [X] Sharing things

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No

### Accessibility test checklist

Only meta tags changed. 

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
	