### PR TITLE
editorial independence banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -156,4 +156,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-editorial-independence",
+    "Test the impact of banner with message focused on editorial independence",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 9, 28),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -162,7 +162,7 @@ trait ABTestSwitches {
     "Test the impact of banner with message focused on editorial independence",
     owners = Seq(Owner.withGithub("tsop14")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 9, 28),
+    sellByDate = new LocalDate(2018, 9, 6),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
@@ -1,0 +1,41 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+
+const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName = 'AcquisitionsBannerEditorialIndependence';
+
+const engagementBannerCopyTest = (): string =>
+    `<strong>The Guardian is editorially independent &ndash; our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.
+    </strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
+
+export const AcquisitionsBannerEditorialIndependence: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-08-06',
+    expiry: '2018-09-06',
+    author: 'Emma Milner',
+    description:
+        'Tests a banner message that highlights editorial independence',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'All web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome: 'Increase in overall AV, and AV from recurring',
+    componentType,
+    showForSensitive: true,
+    canRun: () => true,
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'editorial-independence',
+            options: {
+                engagementBannerParams: {
+                    messageText: engagementBannerCopyTest(),
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
@@ -4,9 +4,7 @@ import { makeBannerABTestVariants } from 'common/modules/commercial/contribution
 const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
 const abTestName: string = 'AcquisitionsBannerEditorialIndependence';
 
-const engagementBannerCopyTest = (): string =>
-    `<strong>The Guardian is editorially independent &ndash; our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.
-    </strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
+const engagementBannerCopyTest: string = `<strong>The Guardian is editorially independent &ndash; our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion. </strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
 
 export const AcquisitionsBannerEditorialIndependence: AcquisitionsABTest = {
     id: abTestName,
@@ -33,7 +31,7 @@ export const AcquisitionsBannerEditorialIndependence: AcquisitionsABTest = {
             id: 'editorial-independence',
             options: {
                 engagementBannerParams: {
-                    messageText: engagementBannerCopyTest(),
+                    messageText: engagementBannerCopyTest,
                 },
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-editorial-independence.js
@@ -1,8 +1,8 @@
-// @flow
+// @flow strict
 import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
 
-const componentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
-const abTestName = 'AcquisitionsBannerEditorialIndependence';
+const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName: string = 'AcquisitionsBannerEditorialIndependence';
 
 const engagementBannerCopyTest = (): string =>
     `<strong>The Guardian is editorially independent &ndash; our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,5 +1,6 @@
 // @flow
+import { AcquisitionsBannerEditorialIndependence } from 'common/modules/experiments/tests/acquisitions-banner-editorial-independence';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsBannerEditorialIndependence];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import { AcquisitionsBannerEditorialIndependence } from 'common/modules/experiments/tests/acquisitions-banner-editorial-independence';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<


### PR DESCRIPTION
## What does this change?
Given the success of recent epic copy with emphasis on editorial independence, adds an AB test to see if banner copy emphasising editorial independence results in more contributions. @ionamckendrick 

## Screenshots
![screen shot 2018-08-03 at 17 57 03](https://user-images.githubusercontent.com/8484757/43655602-35a03748-9747-11e8-811c-200e26e6edfb.jpg)

![screen shot 2018-08-03 at 17 57 20](https://user-images.githubusercontent.com/8484757/43655606-386b49a4-9747-11e8-8408-f546ea7d0079.jpg)


## What is the value of this and can you measure success?


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
