### PR TITLE
Add config for Flow Strict and start using it in Commercial modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,11 @@
 
 [include]
 
+[strict]
+unclear-type
+unsafe-getters-setters
+untyped-type-import
+sketchy-null
 
 [libs]
 ####### STATIC APP #######

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import config from 'lib/config';
 import { getTestVariantId } from 'common/modules/experiments/utils.js';
@@ -231,7 +231,7 @@ const getXaxisPlacementId = (sizes: PrebidSize[]): number => {
 // Returns a map { <bidderName>: true } of bidders
 // according to the pbtest URL parameter
 const pbTestNameMap = memoize(
-    (): Object =>
+    (): {} =>
         new URLSearchParams(window.location.search)
             .getAll('pbtest')
             .reduce((acc, value) => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/labels.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/labels.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
@@ -28,7 +28,7 @@ switch (getBreakpointKey()) {
     // do nothing
 }
 
-if (config.page.contentType === 'Article') {
+if (config.get('page.contentType') === 'Article') {
     slotLabels.push('article');
 } else {
     slotLabels.push('non-article');
@@ -36,7 +36,7 @@ if (config.page.contentType === 'Article') {
 
 const bidLabels: PrebidBidLabel[] = [];
 
-switch (config.page.edition) {
+switch (config.get('page.edition')) {
     case 'UK':
         bidLabels.push('edn-UK');
         break;
@@ -55,7 +55,7 @@ switch (getCookie('GU_geo_continent')) {
     // do nothing
 }
 
-if (config.page.isDev || getRandomIntInclusive(1, 10) === 1)
+if (config.get('page.isDev') || getRandomIntInclusive(1, 10) === 1)
     bidLabels.push('deal-FirstLook');
 
 export const labels: PrebidLabel[] = slotLabels.concat(bidLabels);

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import 'prebid.js/build/dist/prebid';
 import config from 'lib/config';
@@ -146,7 +146,9 @@ class PrebidService {
                         window.pbjs.que.push(() => {
                             // Capture this specific auction starting
                             // to set this slot pbaid targeting value
-                            const auctionInitHandler = (data: Object) => {
+                            const auctionInitHandler = (data: {
+                                auctionId: string,
+                            }) => {
                                 // Get rid of this handler now.
                                 window.pbjs.offEvent(
                                     'auctionInit',

--- a/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import type { PrebidPriceGranularity } from 'commercial/modules/prebid/types';
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import type { PrebidSlot } from 'commercial/modules/prebid/types';
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 export type PrebidSize = [number, number];
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import { getBreakpoint } from 'lib/detect';
 import { getSync as geolocationGetSync } from 'lib/geolocation';


### PR DESCRIPTION
## What does this change?

- Adds a [strict] section to the .flowconfig and lists some basic lint rules to enable.

- Updates the flow header in all of the commercial Prebid modules to enable strict mode

- Fixes all of the linter warnings for Commercial/Prebid

Fixes include switching to `{}` from `Object` as a type annotation, since `any`, `Object`, or `Function` are considered unsafe types and should be avoided as much as possible. Flow Strict now enforces this. 🎉 💎 

This also resolves the warnings from our internal rule for `no-direct-access-config` since the preferred approach is to access properties on config using the `get()` method. See https://github.com/guardian/frontend/pull/17711

## What is the value of this and can you measure success?

#### 👉 Enable stricter type checking on a file-by-file basis

> Flow was designed for easy adoption, so it allows you opt-out of type checking in certain situations, permitting unsafe behaviors. But since many codebases now have a high adoption of Flow types, this trade-off can be flipped [...] you can implement these stronger guarantees incrementally, on a file-by-file basis.

https://flow.org/en/docs/strict/

#### 👉 Using Flow Strict will disallow previously-allowed unsafe patterns

`unclear-type`: error when using Object, Function, or any in a type annotation
`untyped-type-import`:  error when importing a type from an untyped module
`unsafe-getters-setters`: error when using getters and setters, which can be unsafe
`sketchy-null`: error when doing an existence check on a value that could be null/undefined/falsey

😎 🤘 