### PR TITLE
Move figcaptions into leftCol when arabic lang detected in immersive

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -192,7 +192,7 @@
         width: gs-span(2);
         transform: translateX(-100%);
 
-        [lang="ar"] & {
+        [lang='ar'] & {
             left: 0;
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -191,6 +191,10 @@
         top: 100px;
         width: gs-span(2);
         transform: translateX(-100%);
+
+        [lang="ar"] & {
+            left: 0;
+        }
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?

Move `figcaption` into the `leftCol` when `[lang='ar']` attribute detected in immersive articles.

## Screenshots

Before...

![screen shot 2018-08-06 at 12 11 52](https://user-images.githubusercontent.com/1590704/43714528-349122ba-9975-11e8-9d67-198202bb0db8.png)

After...

![screen shot 2018-08-06 at 12 11 23](https://user-images.githubusercontent.com/1590704/43714535-38e3b4e0-9975-11e8-90a1-54ed1a57a02a.png)

## What is the value of this and can you measure success?

Unobscured content