### PR TITLE
Switch DEV and CODE to the Fastly Image Service

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -327,6 +327,7 @@ class GuardianConfiguration extends Logging {
 
   object images {
     lazy val path = configuration.getMandatoryStringProperty("images.path")
+    lazy val fastlyIOHost = configuration.getMandatoryStringProperty("fastly-io.host")
     val fallbackLogo = Static("images/fallback-logo.png")
     object backends {
       lazy val mediaToken: String = configuration.getMandatoryStringProperty("images.media.token")

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -10,6 +10,7 @@ import layout.{BreakpointWidth, WidthsByBreakpoint}
 import model._
 import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
+import common.Environment.{app, awsRegion, stage}
 
 import Function.const
 
@@ -229,7 +230,7 @@ object Naked extends Profile(None, None)
 
 object ImgSrc extends Logging with implicits.Strings {
 
-  private val imageServiceHost: String = Configuration.images.path
+  private val imageServiceHost: String = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
 
   private case class HostMapping(prefix: String, token: String)
 

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -31,6 +31,7 @@ tag_indexes.bucket=aws-frontend-pressed
 
 assets.path=/assets/
 images.path=//i.gucode.co.uk
+fastly-io.host=https://image-io.guim.co.uk.global.prod.fastly.net
 static.path=http://static.guim.co.uk
 static.securePath=https://static-secure.guim.co.uk
 staticSport.path=http://sport.guim.co.uk

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -31,7 +31,7 @@ tag_indexes.bucket=aws-frontend-pressed
 
 assets.path=/assets/
 images.path=//i.gucode.co.uk
-fastly-io.host=https://image-io.guim.co.uk.global.prod.fastly.net
+fastly-io.host=https://image-io.guim.co.uk
 static.path=http://static.guim.co.uk
 static.securePath=https://static-secure.guim.co.uk
 staticSport.path=http://sport.guim.co.uk

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -4,6 +4,7 @@ import java.time.ZoneOffset
 
 import com.gu.contentapi.client.model.v1.{Asset, AssetType, Content, Element, ElementType, Tag, TagType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
+import common.Environment.stage
 import conf.Configuration
 import conf.switches.Switches.ImageServerSwitch
 import implicits.Dates.jodaToJavaInstant
@@ -14,7 +15,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  lazy val imageHost = Configuration.images.path
+  lazy val imageHost = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
 
   val asset = Asset(
     AssetType.Image,


### PR DESCRIPTION
## What does this change?

We are migrating from imgix to Fastly.

Point our image URLs from the original imgix endpoint to the new Fastly image service's endpoint. 

*Only does so for local and CODE instances.*

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [x] Other (please specify)

Affecting, yes. Adversely affecting not as I am aware. This is in CODE anyway. 

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Same answer.

### Tested

- [x] Locally
- [x] On CODE (optional)