### PR TITLE
Move audio player buttons into body

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -33,7 +33,7 @@
                 <div class="content__main-column content__main-column--media content__main-column--@mediaType">
                     <div class="media-body">
 
-                        <div class="media-primary player">
+
                         @media match {
                             case audio: Audio => {
                                 @audio.elements.images.map{ img =>
@@ -108,7 +108,6 @@
                             }
                             case _ => {}
                         }
-                        </div>
 
                         <div class="content__main-column__body" data-component="body">
                             @media match {

--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -118,24 +118,24 @@ const FakeWave = styled('div')({
     flex: 1,
     svg: {
         width: '100%',
-        transform: `translate(0px, 11px)`,
+        transform: `translate(0px, 18px)`,
         [mobileLandscape]: {
-            transform: `translate(0px, 8px)`,
+            transform: `translate(0px, 16px)`,
         },
         [phablet]: {
-            transform: `translate(0px, 3px)`,
+            transform: `translate(0px, 11px)`,
         },
         [tablet]: {
-            transform: `translate(0px, 2px)`,
+            transform: `translate(0px, 8px)`,
         },
         [desktop]: {
-            transform: `translate(0px, 3px)`,
+            transform: `translate(0px, 10px)`,
         },
         [leftCol]: {
-            transform: `translate(0px, 9px)`,
+            transform: `translate(0px, 15px)`,
         },
         [wide]: {
-            transform: `translate(0px, 10px)`,
+            transform: `translate(0px, 16px)`,
         },
     },
 });

--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -9,6 +9,7 @@ import palette, {
     pillarsHighlight,
 } from '@guardian/dotcom-rendering/packages/pasteup/palette';
 import {
+    mobileMedium,
     mobileLandscape,
     phablet,
     tablet,
@@ -118,7 +119,10 @@ const FakeWave = styled('div')({
     flex: 1,
     svg: {
         width: '100%',
-        transform: `translate(0px, 18px)`,
+        transform: `translate(0px, 20px)`,
+        [mobileMedium]: {
+            transform: `translate(0px, 18px)`,
+        },
         [mobileLandscape]: {
             transform: `translate(0px, 16px)`,
         },

--- a/static/src/stylesheets/module/content-garnett/_media.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.global.scss
@@ -42,24 +42,10 @@
         .player {
             margin-left: -10rem;
         }
-        .content__meta-container {
-            top: auto;
-        }
-
-        figure.media-content {
-            padding-left: 10rem;
-
-            margin-bottom: 0;
-            padding-bottom: 6px;
-            background-color: #121212;
-        }
     }
     @media (min-width: 81.25em) {
         .player {
             margin-left: -15rem;
-        }
-        figure.media-content {
-            padding-left: 15rem;
         }
     }
 


### PR DESCRIPTION
## What does this change?
In the [new audio player test](https://github.com/guardian/frontend/pull/20106), moves the controls out of the left gutter

## Screenshots
<img width="644" alt="picture 15" src="https://user-images.githubusercontent.com/1513454/43722926-5c880c48-998e-11e8-84d3-6df94e4a76c1.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
