### PR TITLE
Fix immersive arabic captions

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -563,6 +563,58 @@
     .element--halfWidth {
         float: none;
     }
+
+    [lang='ar'] {
+        figure.element--showcase {
+            .caption {
+                @include mq(leftCol) {
+                    left: 0;
+                }
+            }
+        }
+
+        figure.fig--narrow-caption.img--portrait {
+            @include mq(tablet) {
+                .caption {
+                    float: left;
+                    padding-left: 0;
+                }
+
+                &:after {
+                    visibility: hidden;
+                    display: block;
+                    font-size: 0;
+                    content: '';
+                    clear: both;
+                    height: 0;
+                }
+            }
+        }
+
+        figure.fig--narrow-caption.img--landscape {
+             @include mq($from: tablet, $until:leftCol) {
+                .caption {
+                    float: left;
+                    padding-left: 0;
+                }
+
+                &:after {
+                    visibility: hidden;
+                    display: block;
+                    font-size: 0;
+                    content: '';
+                    clear: both;
+                    height: 0;
+                }
+            }
+
+            @include mq(leftCol) {
+                .caption {
+                    left: 0
+                }
+            }
+        }
+    }
 }
 
 //overides the immersive article — done like this to keep gallery's and photo eassy in ok shape

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -592,7 +592,7 @@
         }
 
         figure.fig--narrow-caption.img--landscape {
-             @include mq($from: tablet, $until:leftCol) {
+            @include mq($from: tablet, $until: leftCol) {
                 .caption {
                     float: left;
                     padding-left: 0;

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -801,6 +801,16 @@
                 bottom: -$gs-baseline * 3;
             }
         }
+
+        &[lang='ar'] {
+            @include mq(leftCol) {
+                margin-left: auto;
+
+                &:before {
+                    display: none;
+                }
+            }
+        }
     }
 
     .content__meta-container {


### PR DESCRIPTION
## What does this change?

Builds upon https://github.com/guardian/frontend/pull/20135 by fixing `figcaption`s on the following image types from the body: showcase (`figure.element--showcase`), inline-portrait (`figure.fig--narrow-caption.img--portrait`) and inline-landscape (`.figure.fig--narrow-caption.img--portrait`).

Also fixes alignment of the standfirst (`.content__standfirst--immersive-article`).

## Screenshots

**Standfirst before**
![screen shot 2018-08-06 at 15 34 42](https://user-images.githubusercontent.com/1590704/43722907-4f763b10-998e-11e8-8d63-f6e1c1d96d2d.png)

**Standfirst after**
![screen shot 2018-08-06 at 15 34 09](https://user-images.githubusercontent.com/1590704/43722925-5c83a82e-998e-11e8-9913-1a8d8a2d6bb0.png)

**Portrait before**
![screen shot 2018-08-06 at 15 27 32](https://user-images.githubusercontent.com/1590704/43722551-6a671ada-998d-11e8-974d-58875bd994d6.png)

**Portrait after**
![screen shot 2018-08-06 at 15 31 06](https://user-images.githubusercontent.com/1590704/43722783-fffda050-998d-11e8-8455-ab9766ac100c.png)

**Landscape before**
![screen shot 2018-08-06 at 15 27 54](https://user-images.githubusercontent.com/1590704/43722572-7514c748-998d-11e8-8813-312308130867.png)

**Landscape after**
![screen shot 2018-08-06 at 15 31 14](https://user-images.githubusercontent.com/1590704/43722727-df0b2f52-998d-11e8-93da-151050bd176f.png)

**Showcase before**
![screen shot 2018-08-06 at 15 28 05](https://user-images.githubusercontent.com/1590704/43722600-8a4f5aa6-998d-11e8-8c56-9cbb8ef29434.png)

**Showcase after**
![screen shot 2018-08-06 at 15 31 06](https://user-images.githubusercontent.com/1590704/43722751-eba35f6e-998d-11e8-8552-1f01861ef0a6.png)