### PR TITLE
Send new settings to Prebid bidders taking part in Safeframe test

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -134,61 +134,89 @@ const containsLeaderboardOrBillboard = (sizes: PrebidSize[]): boolean =>
     containsLeaderboard(sizes) || containsBillboard(sizes);
 
 const getImprovePlacementId = (sizes: PrebidSize[]): number => {
-    switch (config.get('page.edition')) {
-        case 'UK':
-            switch (getBreakpointKey()) {
-                case 'D':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116396;
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return 1116397;
-                    }
-                    return -1;
-                case 'M':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116400;
-                    }
-                    return -1;
-                case 'T':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116398;
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return 1116399;
-                    }
-                    return -1;
-                default:
-                    return -1;
-            }
-        case 'INT':
-            switch (getBreakpointKey()) {
-                case 'D':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116420;
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return 1116421;
-                    }
-                    return -1;
-                case 'M':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116424;
-                    }
-                    return -1;
-                case 'T':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return 1116422;
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return 1116423;
-                    }
-                    return -1;
-                default:
-                    return -1;
-            }
-        default:
-            return -1;
+    if (isInSafeframeTestVariant()) {
+        switch (getBreakpointKey()) {
+            case 'D':
+                if (containsDmpu(sizes)) {
+                    return 1116408;
+                }
+                if (containsMpu(sizes)) {
+                    return 1116407;
+                }
+                if (containsLeaderboardOrBillboard(sizes)) {
+                    return 1116409;
+                }
+                return -1;
+            case 'T':
+                if (containsMpu(sizes)) {
+                    return 1116410;
+                }
+                if (containsLeaderboard(sizes)) {
+                    return 1116411;
+                }
+                return -1;
+            case 'M':
+                return 1116412;
+            default:
+                return -1;
+        }
+    } else {
+        switch (config.get('page.edition')) {
+            case 'UK':
+                switch (getBreakpointKey()) {
+                    case 'D':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116396;
+                        }
+                        if (containsLeaderboardOrBillboard(sizes)) {
+                            return 1116397;
+                        }
+                        return -1;
+                    case 'M':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116400;
+                        }
+                        return -1;
+                    case 'T':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116398;
+                        }
+                        if (containsLeaderboardOrBillboard(sizes)) {
+                            return 1116399;
+                        }
+                        return -1;
+                    default:
+                        return -1;
+                }
+            case 'INT':
+                switch (getBreakpointKey()) {
+                    case 'D':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116420;
+                        }
+                        if (containsLeaderboardOrBillboard(sizes)) {
+                            return 1116421;
+                        }
+                        return -1;
+                    case 'M':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116424;
+                        }
+                        return -1;
+                    case 'T':
+                        if (containsMpuOrDmpu(sizes)) {
+                            return 1116422;
+                        }
+                        if (containsLeaderboardOrBillboard(sizes)) {
+                            return 1116423;
+                        }
+                        return -1;
+                    default:
+                        return -1;
+                }
+            default:
+                return -1;
+        }
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -2,7 +2,10 @@
 /* global jsdom */
 
 import config from 'lib/config';
-import { isInVariant as isInVariant_ } from 'common/modules/experiments/utils';
+import {
+    getVariant as getVariant_,
+    isInVariant as isInVariant_,
+} from 'common/modules/experiments/utils';
 import { _, bids } from './bid-config';
 import type { PrebidBidder, PrebidSize } from './types';
 import {
@@ -16,6 +19,7 @@ const getRandomIntInclusive: any = getRandomIntInclusive_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
+const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
 
 const {
@@ -262,6 +266,76 @@ describe('getImprovePlacementId', () => {
         config.set('page.edition', 'US');
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
     });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in desktop MPU', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('D');
+        expect(getImprovePlacementId([[300, 250]])).toEqual(1116407);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in desktop DMPU', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('D');
+        expect(getImprovePlacementId([[300, 600]])).toEqual(1116408);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in desktop billboard', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('D');
+        expect(getImprovePlacementId([[970, 250]])).toEqual(1116409);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in desktop leaderboard', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('D');
+        expect(getImprovePlacementId([[728, 90]])).toEqual(1116409);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in tablet MPU', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('T');
+        expect(getImprovePlacementId([[300, 250]])).toEqual(1116410);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in tablet leaderboard', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('T');
+        expect(getImprovePlacementId([[728, 90]])).toEqual(1116411);
+    });
+
+    test('should use test placement ID when participating in CommercialPrebidSafeframe test in mobile MPU', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('M');
+        expect(getImprovePlacementId([[300, 250]])).toEqual(1116412);
+    });
 });
 
 describe('getTrustXAdUnitId', () => {
@@ -363,19 +437,31 @@ describe('getIndexSiteId', () => {
         ]);
     });
 
-    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on desktop', () => {
+    test('should use test site ID when participating in CommercialPrebidSafeframe test on desktop', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
         expect(getIndexSiteId()).toEqual('287246');
     });
 
-    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on tablet', () => {
+    test('should use test site ID when participating in CommercialPrebidSafeframe test on tablet', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
         expect(getIndexSiteId()).toEqual('287247');
     });
 
-    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on mobile', () => {
+    test('should use test site ID when participating in CommercialPrebidSafeframe test on mobile', () => {
+        getVariant.mockReturnValue({
+            id: 'variant',
+            test: (): void => {},
+        });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         expect(getIndexSiteId()).toEqual('287248');

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -2,20 +2,21 @@
 /* global jsdom */
 
 import config from 'lib/config';
-import { _, bids } from 'commercial/modules/prebid/bid-config';
+import { isInVariant as isInVariant_ } from 'common/modules/experiments/utils';
+import { _, bids } from './bid-config';
+import type { PrebidBidder, PrebidSize } from './types';
 import {
     getRandomIntInclusive as getRandomIntInclusive_,
     getBreakpointKey as getBreakpointKey_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
-} from 'commercial/modules/prebid/utils';
-
-import type { PrebidBidder, PrebidSize } from 'commercial/modules/prebid/types';
+} from './utils';
 
 const getRandomIntInclusive: any = getRandomIntInclusive_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
+const isInVariant: any = isInVariant_;
 
 const {
     getAppNexusPlacementId,
@@ -37,17 +38,19 @@ jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
 
 jest.mock('./utils');
 
+jest.mock('common/modules/experiments/utils');
+
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
-    config.switches.prebidImproveDigital = true;
-    config.switches.prebidIndexExchange = true;
-    config.switches.prebidSonobi = true;
-    config.switches.prebidS2sozone = true;
-    config.switches.prebidTrustx = true;
-    config.switches.prebidXaxis = true;
-    config.ophan = { pageViewId: 'pvid' };
-    config.page.contentType = 'Article';
-    config.page.edition = 'UK';
+    config.set('switches.prebidImproveDigital', true);
+    config.set('switches.prebidIndexExchange', true);
+    config.set('switches.prebidSonobi', true);
+    config.set('switches.prebidS2sozone', true);
+    config.set('switches.prebidTrustx', true);
+    config.set('switches.prebidXaxis', true);
+    config.set('ophan', { pageViewId: 'pvid' });
+    config.set('page.contentType', 'Article');
+    config.set('page.edition', 'UK');
 };
 
 describe('getAppNexusPlacementId', () => {
@@ -115,7 +118,7 @@ describe('getAppNexusPlacementId', () => {
         ];
 
         editions.forEach(edition => {
-            config.page.edition = edition;
+            config.set('page.edition', edition);
             expect(generateTestIds()).toEqual(expected);
         });
     });
@@ -124,7 +127,7 @@ describe('getAppNexusPlacementId', () => {
 describe('getDummyServerSideBidders', () => {
     beforeEach(() => {
         getRandomIntInclusive.mockReturnValue(1);
-        config.switches.prebidS2sozone = true;
+        config.set('switches.prebidS2sozone', true);
     });
 
     afterEach(() => {
@@ -133,7 +136,7 @@ describe('getDummyServerSideBidders', () => {
     });
 
     test('should return an empty array if the switch is off', () => {
-        config.switches.prebidS2sozone = false;
+        config.set('switches.prebidS2sozone', false);
         expect(getDummyServerSideBidders()).toEqual([]);
     });
 
@@ -224,7 +227,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when on the INT Edition and desktop device', () => {
-        config.page.edition = 'INT';
+        config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('D');
         expect(generateTestIds()).toEqual([
             1116420,
@@ -236,7 +239,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when on the INT Edition and tablet device', () => {
-        config.page.edition = 'INT';
+        config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('T');
         expect(generateTestIds()).toEqual([
             1116422,
@@ -248,15 +251,15 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when on the INT Edition and mobile device', () => {
-        config.page.edition = 'INT';
+        config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('M');
         expect(generateTestIds()).toEqual([1116424, 1116424, -1, -1, -1]);
     });
 
     test('should return -1 if on the US or AU Editions', () => {
-        config.page.edition = 'AU';
+        config.set('page.edition', 'AU');
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
-        config.page.edition = 'US';
+        config.set('page.edition', 'US');
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
     });
 });
@@ -285,11 +288,11 @@ describe('getTrustXAdUnitId', () => {
 describe('indexExchangeBidders', () => {
     beforeEach(() => {
         getBreakpointKey.mockReturnValue('D');
-        config.page.pbIndexSites = [
+        config.set('page.pbIndexSites', [
             { bp: 'D', id: 123456 },
             { bp: 'M', id: 234567 },
             { bp: 'T', id: 345678 },
-        ];
+        ]);
     });
 
     afterEach(() => {
@@ -333,18 +336,18 @@ describe('getIndexSiteId', () => {
     });
 
     test('should return an empty string if pbIndexSites is empty', () => {
-        config.page.pbIndexSites = [];
+        config.set('page.pbIndexSites', []);
         getBreakpointKey.mockReturnValue('D');
         expect(getIndexSiteId()).toBe('');
         expect(getIndexSiteId().length).toBe(0);
     });
 
     test('should find the correct ID for the breakpoint', () => {
-        config.page.pbIndexSites = [
+        config.set('page.pbIndexSites', [
             { bp: 'D', id: 123456 },
             { bp: 'M', id: 234567 },
             { bp: 'T', id: 345678 },
-        ];
+        ]);
         const breakpoints = ['M', 'D', 'M', 'T', 'D'];
         const results = [];
         for (let i = 0; i < breakpoints.length; i += 1) {
@@ -358,6 +361,24 @@ describe('getIndexSiteId', () => {
             '345678',
             '123456',
         ]);
+    });
+
+    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on desktop', () => {
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('D');
+        expect(getIndexSiteId()).toEqual('287246');
+    });
+
+    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on tablet', () => {
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('T');
+        expect(getIndexSiteId()).toEqual('287247');
+    });
+
+    test('should send test site ID in ix bid request when participating in CommercialPrebidSafeframe test on mobile', () => {
+        isInVariant.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('M');
+        expect(getIndexSiteId()).toEqual('287248');
     });
 });
 
@@ -386,7 +407,7 @@ describe('bids', () => {
         bids('dfp-ad--top-above-nav', [[728, 90]]).map(bid => bid.bidder);
 
     test('should only include bidders that are switched on if no bidders being tested', () => {
-        config.switches.prebidXaxis = false;
+        config.set('switches.prebidXaxis', false);
         getRandomIntInclusive.mockReturnValue(1);
         expect(bidders()).toEqual([
             'ix',
@@ -398,12 +419,12 @@ describe('bids', () => {
     });
 
     test('should not include Ozone bidders when fate is against them', () => {
-        config.switches.prebidXaxis = false;
+        config.set('switches.prebidXaxis', false);
         expect(bidders()).toEqual(['ix', 'sonobi', 'improvedigital']);
     });
 
     test('should not include ix bidders when switched off', () => {
-        config.switches.prebidIndexExchange = false;
+        config.set('switches.prebidIndexExchange', false);
         expect(bidders()).toEqual(['sonobi', 'improvedigital', 'xhb']);
     });
 
@@ -437,14 +458,14 @@ describe('bids', () => {
 
     test('should only include bidder being tested, even when its switch is off', () => {
         setQueryString('pbtest=xhb');
-        config.switches.prebidXaxis = false;
+        config.set('switches.prebidXaxis', false);
         expect(bidders()).toEqual(['xhb']);
     });
 
     test('should only include multiple bidders being tested, even when their switches are off', () => {
         setQueryString('pbtest=xhb&pbtest=sonobi');
-        config.switches.prebidXaxis = false;
-        config.switches.prebidSonobi = false;
+        config.set('switches.prebidXaxis', false);
+        config.set('switches.prebidSonobi', false);
         expect(bidders()).toEqual(['sonobi', 'xhb']);
     });
 


### PR DESCRIPTION
For *Index* and *Improve* bidders, we're going to send some test values so that they can measure effect of serving creatives in safeframes.
