### PR TITLE
Implement all capi element types

### DIFF
--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -46,7 +46,7 @@ object JsonComponent extends Results with implicits.Requests {
 
   def jsonFor(items: (String, Any)*): String = {
     import play.api.libs.json.Writes._
-    Json.stringify(toJson(
+    Json.prettyPrint(toJson(
       (items.toMap + ("refreshStatus" -> AutoRefreshSwitch.isSwitchedOn)).map {
         // compress and take the body if value is Html
         case (name, html: Html) => name -> toJson(html.body)

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -46,7 +46,7 @@ object JsonComponent extends Results with implicits.Requests {
 
   def jsonFor(items: (String, Any)*): String = {
     import play.api.libs.json.Writes._
-    Json.prettyPrint(toJson(
+    Json.stringify(toJson(
       (items.toMap + ("refreshStatus" -> AutoRefreshSwitch.isSwitchedOn)).map {
         // compress and take the body if value is Html
         case (name, html: Html) => name -> toJson(html.body)

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -25,9 +25,20 @@ case class VineBlockElement(html: Option[String]) extends BlockElement
 case class MapBlockElement(html: Option[String]) extends BlockElement
 case class UnknownBlockElement(html: Option[String]) extends BlockElement
 
-// these don't appear to have typeData on the capi models so their html field is always None
+case class MembershipBlockElement(
+  originalUrl: Option[String],
+  linkText: Option[String],
+  linkPrefix: Option[String],
+  title: Option[String],
+  venue: Option[String],
+  location: Option[String],
+  identifier: Option[String],
+  image: Option[String],
+  price: Option[String]
+) extends BlockElement
+
+// these don't appear to have typeData on the capi models so we just have empty html
 case class CodeBlockElement(html: Option[String]) extends BlockElement
-case class MembershipBlockElement(html: Option[String]) extends BlockElement
 case class FormBlockElement(html: Option[String]) extends BlockElement
 
 case class RichLinkBlockElement(
@@ -92,6 +103,18 @@ object BlockElement {
         }
         else Some(VideoBlockElement(videoDataFor(element)))
 
+      case Membership => element.membershipTypeData.map(m => MembershipBlockElement(
+        m.originalUrl,
+        m.linkText,
+        m.linkPrefix,
+        m.title,
+        m.venue,
+        m.location,
+        m.identifier,
+        m.image,
+        m.price
+      ))
+
       case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
 
       case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId))
@@ -106,8 +129,8 @@ object BlockElement {
       case Vine => element.vineTypeData.map(d => VineBlockElement(d.html))
       case ElementType.Map => element.mapTypeData.map(d => MapBlockElement(d.html))
       case Code => Some(CodeBlockElement(None))
-      case Membership => Some(MembershipBlockElement(None))
-      case Form => Some(MembershipBlockElement(None))
+      case Form => Some(FormBlockElement(None))
+
       case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
 
     }
@@ -152,7 +175,6 @@ object BlockElement {
   implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]
   implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
   implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
-
 
   implicit val SponsorshipWrites: Writes[Sponsorship] = new Writes[Sponsorship] {
     def writes(sponsorship: Sponsorship): JsObject = Json.obj(


### PR DESCRIPTION
## What does this change?

This adds support for all CAPI block elements. Prior to this change, we only supported a small subset of them usable in liveblogs, and ignored the rest. **The only visible result of this change should be that the .json endpoint will show all elements instead of just a subset of them**

## Screenshots

## What is the value of this and can you measure success?

Usable on the rendering tier, and makes the render tier picker better able to detect simple articles.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
