### PR TITLE
Audio AB Test" Fix width bug in ff

### DIFF
--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -107,6 +107,7 @@ const WaveAndTrack = styled('div')({
     alignItems: 'stretch',
     padding: '0 9px',
     cursor: 'pointer',
+    maxWidth: '100%',
 });
 
 const Track = styled('div')({


### PR DESCRIPTION
## What does this change?
SVGs in Firefox don't obey the same rules which caused a width issue on the new audio player. 
Setting max width on its parent appears to fix the problem 

## Screenshots
### Problem 
![screen shot 2018-08-07 at 11 31 50](https://user-images.githubusercontent.com/10324129/43772178-34f2a3c2-9a39-11e8-8ede-ce1618c156a0.png)

### Fix
![screen shot 2018-08-07 at 11 32 01](https://user-images.githubusercontent.com/10324129/43772192-4051731a-9a39-11e8-9d33-139f7cdc485c.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
