### PR TITLE
Refresh top-above-nav ads with the same size as previous displays

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -13,7 +13,7 @@ import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 
 const setSlotAdRefresh = (event: ImpressionViewableEvent): void => {
     const advert: ?Advert = getAdvertById(event.slot.getSlotElementId());
-    const viewabilityThresholdMs = 30000; // 30 seconds
+    const viewabilityThresholdMs = 30000; // 30 seconds refresh
 
     if (advert && advert.shouldRefresh) {
         const onDocumentVisible = () => {


### PR DESCRIPTION
Implements https://trello.com/c/YGJi7BLI by forcing the size of the top-above-nav slot to be the same as the previous one for all refreshes.

Testing has been done on /uk/sport which happens to have some standard creatives of both 728x90 and 970x50.