### PR TITLE
Strip '=' chars used to pad base64 image overlay.

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -125,7 +125,8 @@ class ShareImage(blendImageParam: String, shouldIncludeOverlay: Boolean) extends
 }
 
 trait OverlayBase64 {
-  def overlayUrlBase64(overlay: String): String = Base64.getUrlEncoder.encodeToString(Static(s"images/overlays/$overlay").getBytes)
+  def overlayUrlBase64(overlay: String): String =
+    Base64.getUrlEncoder.encodeToString(Static(s"images/overlays/$overlay").getBytes).replace("=", "")
 }
 
 object TwitterImage extends OverlayBase64 {


### PR DESCRIPTION
Currently we have an issue with our og:image tags where facebook is url encoding the url we give to it. A side effect of this is that it results in the '=' symbols used by our base64 encoder to pad out the string being encoded as %3D. This new encoding then means that when we check the singature of the url, it doesn't match up (as the `s=` param is set to md5(imageurl with '=' sign) whereas the url facebook is using is md5(imageurl with '%3C'))

This change should solve that issue, by stripping any padding added to the base64 string. It's still [standards compliant](https://tools.ietf.org/html/rfc4648#page-7)

This approach seems to be suggested [by imgix](https://docs.imgix.com/apis/url#base64-variants)! 

Tested on CODE