### PR TITLE
Callouts: Add waiting state to callout form submission

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/submit-form.js
+++ b/static/src/javascripts/projects/journalism/modules/submit-form.js
@@ -5,6 +5,16 @@ import fetch from 'lib/fetch';
 const isCheckbox = element => element.type === 'checkbox';
 const isNamed = element => element.name > '';
 
+const disableButton = button => {
+    button.disabled = true;
+};
+
+const enableButton = form => {
+    const button = form.querySelector('button');
+    button.disabled = false;
+    button.textContent = 'Share with the Guardian';
+};
+
 const showConfirmation = () => {
     const callout = document.querySelector('.element-campaign');
     if (callout) {
@@ -17,8 +27,19 @@ const showConfirmation = () => {
 const showError = cForm => {
     const errorField = cForm.querySelector('.error_box');
     fastdom.write(() => {
-        errorField.innerHtml =
-            '<p>Sorry, there was a problem submitting your form. Please try again later.</p>';
+        errorField.innerHTML =
+            '<p class="error">Sorry, there was a problem submitting your form. Please try again later.</p>';
+    });
+    enableButton(cForm);
+};
+
+const showWaiting = cForm => {
+    const button = cForm.querySelector('button');
+    const errorField = cForm.querySelector('.error_box');
+    fastdom.write(() => {
+        button.textContent = 'Sending...';
+        disableButton(button);
+        errorField.innerHTML = '';
     });
 };
 
@@ -44,6 +65,7 @@ export const submitForm = (e: any) => {
     e.preventDefault();
     const cForm = e.target;
     const data = formatData(cForm.elements);
+    showWaiting(cForm);
 
     return fetch('/formstack-campaign/submit', {
         method: 'post',

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -442,6 +442,11 @@
             line-height: 30px;
             padding: 1px 16px;
             border: 0;
+            &:disabled {
+                background-color: transparent;
+                border: 1px $brightness-7 solid;
+
+            }
         }
     }
     .t_and_c {


### PR DESCRIPTION
## What does this change?

This adds a waiting message to the form while waiting for the response from Formstack.
On mobile connections this can be 10-12 seconds so it is important to give the users an indication that something is happening. 

1. As soon as the request is fired, the `showWaiting` function changes the content of the button to a `Sending` message, and disables the button, setting the styles to disabled styles 

2. This is replaced by either a success or error when the request promise completes. If there is an error message, it is appended to the form and the button is re-enabled. 

3. There was also a mistake -  `innerHtml` should be: `innerHTML`

## Screenshots
![screen shot 2018-08-08 at 15 30 55](https://user-images.githubusercontent.com/10324129/43843875-68f15532-9b20-11e8-8b5d-aaae579507a4.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
