### PR TITLE
Add page for purging ajax API

### DIFF
--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -11,7 +11,7 @@ import services.S3
 import conf.Configuration.readerRevenue._
 import org.apache.commons.codec.digest.DigestUtils
 import play.api.libs.ws.{WSClient, WSResponse}
-import purge.CdnPurge
+import purge.{AjaxHost, CdnPurge}
 
 import scala.concurrent.Future
 
@@ -46,9 +46,9 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
     Future(S3.putPublic(contributionsBannerDeployLogKey, bannerDeployLogJson, defaultJsonEncoding))
   }
 
-  private def purgeDeployLogCache(): Future[WSResponse] = {
+  private def purgeDeployLogCache(): Future[String] = {
     val path = "/reader-revenue/contributions-banner-deploy-log"
-    CdnPurge.soft(wsClient, DigestUtils.md5Hex(path), CdnPurge.AjaxHost)
+    CdnPurge.soft(wsClient, DigestUtils.md5Hex(path), AjaxHost)
   }
 
   private def bannerRedeploySuccessful(message: String): Result = {

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -43,13 +43,13 @@ class PageDecacheController(wsClient: WSClient, val controllerComponents: Contro
   }
 
   private def getSubmittedUrlPathMd5(request: AuthenticatedRequest[AnyContent, UserIdentity]): Option[String] = {
-    val url = request
+    request
       .body.asFormUrlEncoded
       .getOrElse(Map.empty)
       .get("url")
       .flatMap(_.headOption)
       .map(_.trim)
-    url.map(url => DigestUtils.md5Hex(new URI(url).getPath))
+      .map(url => DigestUtils.md5Hex(new URI(url).getPath))
   }
 
 }

--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -9,17 +9,18 @@ import conf.AdminConfiguration.fastly
 
 import scala.concurrent.{ExecutionContext, Future}
 
+
+sealed trait FastlyService { def serviceId: String }
+case object GuardianHost extends FastlyService { val serviceId = fastly.serviceId }
+case object AjaxHost extends FastlyService { val serviceId = fastly.ajaxServiceId }
+
 object CdnPurge extends Dates with Logging {
 
-  sealed trait FastlyService { def serviceId: String }
-  case object GuardianHost extends FastlyService { val serviceId = fastly.serviceId }
-  case object AjaxHost extends FastlyService { val serviceId = fastly.ajaxServiceId }
-
   // Performs soft purge which will still serve stale if there is an error
-  def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[WSResponse] = {
+  def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[String] = {
     // under normal circumstances we only ever want this called from PROD.
     // Don't want too much decaching going on.
-    if (environment.isProd) {
+    val result: Future[WSResponse] = if (environment.isProd) {
       val serviceId = fastlyService.serviceId
       wsClient.url(s"https://api.fastly.com/service/$serviceId/purge/$key")
         .withHttpHeaders(
@@ -39,5 +40,7 @@ object CdnPurge extends Dates with Logging {
     } else {
       Future.failed(new RuntimeException("Purging is disabled in non-production environment"))
     }
+    result.map { _ => "Purge request successfully sent" }
+      .recover { case e => s"Purge request was not successful, please report this issue: '${e.getLocalizedMessage}'" }
   }
 }

--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -20,7 +20,7 @@ object CdnPurge extends Dates with Logging {
   def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[String] = {
     // under normal circumstances we only ever want this called from PROD.
     // Don't want too much decaching going on.
-    val result: Future[WSResponse] = if (environment.isProd) {
+    val result: Future[WSResponse] = if (environment.isProd ||environment.isCode) {
       val serviceId = fastlyService.serviceId
       wsClient.url(s"https://api.fastly.com/service/$serviceId/purge/$key")
         .withHttpHeaders(

--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -20,7 +20,7 @@ object CdnPurge extends Dates with Logging {
   def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[String] = {
     // under normal circumstances we only ever want this called from PROD.
     // Don't want too much decaching going on.
-    val result: Future[WSResponse] = if (environment.isProd ||environment.isCode) {
+    val result: Future[WSResponse] = if (environment.isProd ) {
       val serviceId = fastlyService.serviceId
       wsClient.url(s"https://api.fastly.com/service/$serviceId/purge/$key")
         .withHttpHeaders(

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -32,6 +32,7 @@
                         <li><a href="@controllers.admin.routes.RedirectController.redirect()">Redirects</a></li>
                         <li><a href="@controllers.cache.routes.ImageDecacheController.renderImageDecacheForm()">Clear cache (images)</a></li>
                         <li><a href="@controllers.cache.routes.PageDecacheController.renderPageDecache()">Clear cache (content)</a></li>
+                        <li><a href="@controllers.cache.routes.PageDecacheController.renderAjaxDecache()">Clear cache (ajax - guardianapps.co.uk)</a></li>
                         <li><a href="@controllers.routes.AppConfigController.renderAppConfig()">App Config</a></li>
                     </ul>
                 </div>

--- a/admin/app/views/cache/ajaxDecache.scala.html
+++ b/admin/app/views/cache/ajaxDecache.scala.html
@@ -1,0 +1,31 @@
+@(message: String = "")(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@admin_main("Purge Ajax Cache", isAuthed = true) {
+
+    <h1>Purge Ajax Cache</h1>
+
+    <h3>Warnings:</h3>
+    <ul>
+        <li>This tool performs a <strong><i>soft</i></strong> purge of the cached content on api.nextgen.guardianapps.co.uk. This will <strong>immediately attempt to refresh the cached content</strong>.</li>
+        <li>If the backend service that provides the content is not healthy, <strong>stale content will continue to be served.</strong></li>
+        <li>If you are trying to resolve an issue and have not already done so, please use the <a href="@controllers.admin.routes.TroubleshooterController.index()">Troubleshoot Tool</a></li>
+    </ul>
+
+    <h3>Usage:</h3>
+    <ol>
+        <li>
+            Paste the url of the page (content) you want to clear below, including the entire url. Only works on <code>api.nextgen.guardianapps.co.uk</code>.
+            <br>
+            E.g. <code>https://api.nextgen.guardianapps.co.uk/politics/blog/live/2018/aug/01/chequers-brexit-plan-would-cost-economy-equivalent-of-500-per-head-says-thinktank-politics-live.json</code>
+        </li>
+        <li>Click <i>Purge</i> to clear the page from the cache.</li>
+    </ol>
+    <hr/>
+
+    <form method="POST">
+        <input class="img-url form-control" name="url" type="text" value="" placeholder="https://api.nextgen.guardianapps.co.uk/politics/blog/xx.json"/>
+        <button class="btn btn-default" type="submit">Purge</button>
+    </form>
+
+    @if(!message.isEmpty) { <p class="bg-info purge-message">@message</p> }
+}

--- a/admin/app/views/cache/pageDecache.scala.html
+++ b/admin/app/views/cache/pageDecache.scala.html
@@ -18,8 +18,7 @@
             <br>
             E.g. <code>https://www.theguardian.com/artanddesign/2015/nov/17/12-designs-that-revolutionised-cycling-fold-up-helmets-and-sandwich-bikes</code>
         </li>
-        <li>Click <i>Test</i> to check the page can still be served by the backend.</li>
-        <li>Click <i>Purge</i> to clear the page from the cache.  You may purge even if the test fails, but be aware it may stop users reaching the content, or continue to serve stale content.</li>
+        <li>Click <i>Purge</i> to clear the page from the cache.</li>
     </ol>
     <hr/>
 

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -41,7 +41,10 @@ GET         /images/clear                                                       
 POST        /images/clear                                                                           controllers.cache.ImageDecacheController.decache()
 
 GET         /page/clear                                                                             controllers.cache.PageDecacheController.renderPageDecache()
-POST        /page/clear                                                                             controllers.cache.PageDecacheController.decache()
+POST        /page/clear                                                                             controllers.cache.PageDecacheController.decachePage()
+
+GET         /ajax/clear                                                                             controllers.cache.PageDecacheController.renderAjaxDecache()
+POST        /ajax/clear                                                                             controllers.cache.PageDecacheController.decacheAjax()
 
 # Development endpoints
 GET         /dev/switchboard                                                                        controllers.admin.SwitchboardController.renderSwitchboard()


### PR DESCRIPTION
## What does this change?
Adds a new page to admin - 'Purge Ajax Cache' - which enables the purging of stuff on api.nextgen.guardianapps.co.uk 

## What is the value of this and can you measure success?
We had an [incident](https://github.com/guardian/incidents-retrospectives/blob/master/projects/frontend/2018-08-01-liveblog-block.md) last week where a live blog post being pulled in via AJAX kept appearing despite being taken down. This was because we don't currently purge stuff from the ajax cache automatically - we just wait for it to expire. The fix was to manually purge the item from fastly. 

This change adds a simple UI for achieving this to frontend.gutools in case the issue happens again in future. 

Tested
- [x] Locally
- [x] On CODE (though it's hard to test caching, I at least checked that the correct log messages were being generated)
