### PR TITLE
extend switch

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -82,7 +82,7 @@ trait MonitoringSwitches {
     "Sends log messages to kibana whenever an element is removed from an AMP article.",
     Seq(Owner.withGithub("aware")),
     Off,
-    new LocalDate(2018, 9, 8),
+    new LocalDate(2018, 9, 7),
     false
   )
 

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -82,7 +82,7 @@ trait MonitoringSwitches {
     "Sends log messages to kibana whenever an element is removed from an AMP article.",
     Seq(Owner.withGithub("aware")),
     Off,
-    new LocalDate(2018, 8, 8),
+    new LocalDate(2018, 9, 8),
     false
   )
 


### PR DESCRIPTION
Extends my switch on amp logging by a month to get a little time to think about how to go forwards.