### PR TITLE
Audio: Add "how to podcast" link & clean up audioBody

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -54,7 +54,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
     val htmlResponse = () => ContentHtmlPage.html(model)
     // The jsonResponse allows for a json version of each page to be accessed by users eg: https://www.theguardian.com/world/2018/jun/13/kim-jong-un-north-korea-summit-trump-visit-kcna.json
     val jsonResponse = model.media match {
-      case audio: Audio => () => views.html.fragments.audioBody(model, displayCaption = false)
+      case audio: Audio => () => views.html.fragments.audioBody(model, audio)
       case _ => () => views.html.fragments.mediaBody(model, displayCaption = false)
     }
     renderFormat(htmlResponse, jsonResponse, model, Switches.all)

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -35,7 +35,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
 
     def mediaOrAudioBody(page: MediaPage): Html  = {
         page.media match {
-          case _: Audio if (ActiveExperiments.isParticipating(AudioPageChange)) => audioBody(page, displayCaption = false)
+          case audio: Audio if (ActiveExperiments.isParticipating(AudioPageChange)) => audioBody(page, audio)
           case _ => mediaBody(page, displayCaption = false)
         }
     }

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -1,182 +1,75 @@
 
- @* duplicated version of mediaBody page in aid of Audio AB test *@
-
-@(page: MediaPage, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
-
-@import common.LinkTo
-@import model.{Audio, AudioPlayer, Video, VideoPlayer}
+@import model.{Audio}
 @import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
+@import views.support.{RenderClasses}
 
-@defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
-    @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
-    <div class="l-side-margins @if(!isPaidContent) {l-side-margins--media}">
+@(page: MediaPage, audio: Audio)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-        <article id="article" class="@RenderClasses(
-            Map(
-                "content--has-body" -> media.fields.body.nonEmpty,
-                "content--paid-content paid-content" -> isPaidContent,
-                "content--pillar-special-report" -> (toneClass(media) == "tone-special-report")
-            ),
-            "content", "content--media", "new-audio", s"content--pillar-${media.metadata.pillar.nameOrDefault}", s"content--media--$mediaType", "tonal", "tonal--tone-media", s"tonal--${toneClass(media)}"
-        )"
-        itemscope itemtype="@media.metadata.schemaType" role="main">
+@defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
 
-            @if(isPaidContent) {
-                @fragments.guBand()
-            }
+<div class="l-side-margins @if(!isPaidContent) {l-side-margins--media}">
+    <article id="article" class="@RenderClasses(
+        Map(
+            "content--has-body" -> audio.fields.body.nonEmpty,
+            "content--paid-content paid-content" -> isPaidContent,
+            "content--pillar-special-report" -> (toneClass(audio) == "tone-special-report")
+        ),
+        "content", "content--media", "new-audio", s"content--pillar-${audio.metadata.pillar.nameOrDefault}", s"content--media--audio", "tonal", "tonal--tone-media", s"tonal--${toneClass(audio)}"
+    )"
+    itemscope itemtype="@audio.metadata.schemaType" role="main">
 
-            @fragments.headTonal(media, page)
-        <div class="content__main tonal__main tonal__main--@toneClass(media)">
+        @if(isPaidContent) { @fragments.guBand() }
+
+        @fragments.headTonal(audio, page)
+
+        <div class="content__main tonal__main tonal__main--@toneClass(audio)">
             <div class="gs-container">
-                <div class="content__main-column content__main-column--media content__main-column--@mediaType">
+                <div class="content__main-column content__main-column--media content__main-column--audio">
                     <div class="media-body">
 
-
-                        @media match {
-                            case audio: Audio => {
-                                @audio.elements.images.map{ img =>
-                                    @fragments.imageFigure(img.images)
-                                }
-
-                                <figure data-component="main audio new-player"
-                                    id="audio-component-container"
-                                    data-media-id="@audio.elements.mainAudio.map{ audioElement => @audioElement.properties.id}"
-                                    data-source="@audio.downloadUrl.map(Audio.acastUrl(_, false))"
-                                    data-itunes-url="@audio.iTunesSubscriptionUrl.getOrElse("#")"
-                                    data-download-url="@audio.downloadUrl.getOrElse("#")">
-                                </figure>
-                            }
-                            case video: Video => {
-                                <figure data-component="main video">
-                                    <meta itemprop="name" content="@Html(video.trail.headline)"/>
-                                    <meta itemprop="headline" content="@Html(video.trail.headline)"/>
-                                    <meta itemprop="url" content="@LinkTo(video.metadata.url)"/>
-                                    @video.fields.trailText.map { t =>
-                                        <meta itemprop="description" content="@StripHtmlTags(t)" />
-                                        <meta itemprop="about" content="@StripHtmlTags(t)" />
-                                    }
-
-                                    <meta itemprop="datePublished" content="@video.trail.webPublicationDate.toString("yyyy-MM-dd")" />
-                                    <meta itemprop="name" content="@video.metadata.webTitle" />
-                                    <meta itemprop="uploadDate" content="@video.trail.webPublicationDate.toString("yyyy-MM-dd")" />
-
-                                    @video.mediaAtom.map { ma =>
-                                        @ma.duration.map { duration =>
-                                            <meta itemprop="duration" content="@ma.isoDuration" />
-                                        }
-                                    }
-
-
-                                    @video.elements.mainVideo.map { mv =>
-                                        <meta itemprop="duration" content="@mv.videos.ISOduration" />
-                                        <meta itemprop="height" content="@mv.videos.height" />
-                                        <meta itemprop="width" content="@mv.videos.width" />
-                                    }
-                                    <meta itemprop="requiresSubscription" content="false" />
-                                    @video.sixteenByNineMetaImage.map{ i =>
-                                        <meta itemprop="image" content="@i" />
-                                    }
-
-                                    @defining(video.elements.thumbnail.map(_.images) orElse video.mediaAtom.flatMap(_.posterImage)) {bestThumbnail =>
-                                        @bestThumbnail.map { thumbnail =>
-                                            <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestSrcFor(thumbnail)" />
-                                            <meta itemprop="thumbnailUrl" content="@SeoOptimisedContentImage.bestSrcFor(thumbnail)" />
-                                        }
-                                    }
-
-                                    @video.mediaAtom.map { mediaAtom =>
-                                        @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None)
-                                    }
-
-                                    @video.elements.mainVideo.map { videoElement =>
-                                        @fragments.media.video(
-                                            VideoPlayer(
-                                                videoElement,
-                                                Video640,
-                                                video.trail.headline,
-                                                autoPlay = true,
-                                                showControlsAtStart = true,
-                                                endSlatePath = video.endSlatePath,
-                                                path = Some(video.metadata.id),
-                                                overrideIsRatioHd = None
-                                            ), enhance = true
-                                        )
-                                    }
-                                </figure>
-                            }
-                            case _ => {}
+                        @audio.elements.images.map{ img =>
+                            @fragments.imageFigure(img.images)
                         }
+
+                        <figure data-component="main audio new-player"
+                            id="audio-component-container"
+                            data-media-id="@audio.elements.mainAudio.map{ audioElement => @audioElement.properties.id}"
+                            data-source="@audio.downloadUrl.map(Audio.acastUrl(_, false))"
+                            data-itunes-url="@audio.iTunesSubscriptionUrl.getOrElse("#")"
+                            data-download-url="@audio.downloadUrl.getOrElse("#")">
+                        </figure>
+
 
                         <div class="content__main-column__body" data-component="body">
-                            @media match {
-                                case v: Video => {
-                                    <div class="tonal__standfirst">
-                                    @fragments.standfirst(v)
-                                    </div>
-                                }
-                                case _ => {}
-                            }
 
-                            @fragments.contentMeta(media, page)
+                            @fragments.contentMeta(audio, page)
 
-                            @media match {
-                                case a: Audio if a.fields.body.nonEmpty => {
-                                    <div class="from-content-api">
-                                    @Html(a.fields.body)
-                                    </div>
-                                }
-                                case _ => {}
-                            }
+                            @if(audio.fields.body.nonEmpty) {
+                                <div class="from-content-api">
+                                    @Html(audio.fields.body)
+                                </div>
+                               }
 
-                            @fragments.submeta(media)
+                            @fragments.submeta(audio)
                         </div>
                     </div>
-                </div>
 
-                @media match {
-                    case v: Video => {
-                        @if(!isPaidContent) {
-                            <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
-                            aria-hidden="true">
-                                <div class="js-video-components-container"></div>
-                            </div>
-                        }
-                    }
-                    case a: Audio if a.fields.body.nonEmpty => {
-                        <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
-                        aria-hidden="true">
-                        @fragments.commercial.standardAd("right", Seq("dark"), Map("desktop" -> Seq("300,250", "300,274", "fluid")))
-                        </div>
-                    }
-                    case _ => {}
-                }
+                     @if(audio.fields.body.nonEmpty) {
+                         <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
+                         aria-hidden="true">
+                             @fragments.commercial.standardAd("right", Seq("dark"), Map("desktop" -> Seq("300,250", "300,274", "fluid")))
+                         </div>
+                     }
+                </div>
             </div>
         </div>
-        </article>
+    </article>
 
-        @if(mediaType != "video" && mediaType != "audio" && isPaidContent) {
-            <div class="fc-container fc-container--media">
-                <div class="js-media-popular tonal--@toneClass(media)">
-                    <div class="fc-container fc-container--popular">
-                        <div class="fc-container__inner">
-                            <div class="fc-container__header">
-                                <h2 class="fc-container__header__title">
-                                    <a class="most-viewed-no-js tone-colour" href="@LinkTo {/@mediaType/most-viewed}" data-link-name="Most viewed @mediaType">
-                                        More @mediaType</a>
-                                </h2>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        }
-    </div>
+</div>
 
-    <div class="l-side-margins">
-    @fragments.contentFooter(media, page.related, "media", isPaidContent)
-    </div>
-    }
+<div class="l-side-margins">
+    @fragments.contentFooter(audio, page.related, "media", isPaidContent)
+</div>
 }
 

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,4 +1,5 @@
 @import common.Edition
+@import common.LinkTo
 @import model.ContentType
 @import views.support.{BulletCleaner, ContributorLinks, InBodyLinkCleaner, RenderClasses, withJsoup}
 
@@ -37,5 +38,17 @@
                 InBodyLinkCleaner("in standfirst link")
             )
         }
+    }
+    @if(item.tags.isAudio) {
+        <p class="content__standfirst">
+            <span class="bullet"></span>
+
+            <a href="@LinkTo("/media/2017/oct/07/how-to-listen-to-podcasts-everything-you-need-to-know?CMP=podcast-help")"
+            data-component="podcast-help"
+            data-link-name="podcast-help-link"
+            class="u-underline">
+                How to listen to podcasts: everything you need to know
+            </a>
+        </p>
     }
 </div>


### PR DESCRIPTION
## What does this change?

This adds a link to the audio pages which directs users to a "How To Podcast" page. 

* Design figured this would look best in the standfirst... so have added this into the standfirst template. But it should only show for audio pages. It will work for both version of the player. 

* Data wanted this to have: `data-component`, `data-link-name`, and a query string on the url: `?CMP=podcast-help`

* I have also cleaned up `audioBody.scala.html` which currently holds the player variant. I removed all the code relating to video. 


NB: Originally thought I needed to put the link in the `audioBody` so it seemed worth clearing it out... actually it's not in there anymore. But decided to continue with the clear-up regardless. 

## Screenshots

![screen shot 2018-08-09 at 16 33 01](https://user-images.githubusercontent.com/10324129/43909337-ffc9e68c-9bf1-11e8-9dc9-aa998df43c83.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
