### PR TITLE
article email endpoints

### DIFF
--- a/article/conf/routes
+++ b/article/conf/routes
@@ -24,10 +24,12 @@ GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/
 
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 
 # articles, finished liveblogs
 
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -11,6 +11,7 @@ import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
 import play.api.Logger
+import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
@@ -118,8 +119,14 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     JsonComponent(page, json)
   }
 
-  def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
-    RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html)
+  def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
+    val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
+
+    if (request.isEmailJson) {
+      RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithInlineStyles.toString))))
+    } else {
+      RevalidatableResult.Ok(htmlWithInlineStyles)
+    }
   }
 
 }

--- a/common/test/common/CommonPackageTest.scala
+++ b/common/test/common/CommonPackageTest.scala
@@ -1,0 +1,48 @@
+package common
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.gu.contentapi.client.model.v1._
+import model.SimpleContentPage
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.JsValue
+import play.api.test.Helpers._
+import play.twirl.api.Html
+import test.{TestRequest, WithTestApplicationContext}
+import scala.concurrent.Future
+
+class CommonPackageTest extends FlatSpec with Matchers with WithTestApplicationContext {
+
+  trait PackageTestScope {
+    val article = model.Content(Content(
+      id = "/content",
+      sectionId = None,
+      sectionName = None,
+      webPublicationDate = None,
+      webTitle = "webTitle",
+      webUrl = "webUrl",
+      apiUrl = "apiUrl",
+      tags = Nil,
+      elements = None,
+      fields = None
+    ))
+    val contentPage = SimpleContentPage(article)
+  }
+
+  "renderEmail" should "render an email result page" in new PackageTestScope {
+    val html = Html("")
+    val result = Future.successful(common.renderEmail(html, contentPage)(TestRequest(), testApplicationContext))
+    status(result) shouldBe 200
+    assertThrows[JsonParseException](contentAsJson(result))
+    contentAsString(result) should include ("<html")
+  }
+
+  "renderEmail" should "render an email json result page" in new PackageTestScope {
+    val html = Html("")
+    val result = Future.successful(common.renderEmail(html, contentPage)(TestRequest("/content/email.emailjson"), testApplicationContext))
+
+    val jsonResult: JsValue = contentAsJson(result)
+    val (key, value) = jsonResult.as[Map[String,String]].head
+    key shouldBe "body"
+    value should include ("<html")
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -440,12 +440,14 @@ GET            /$leftSide<[^+]+>+*rightSide                                     
 # Live Blogs
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json                                                                                      controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email                                                                                     controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson                                                                           controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>                                                                                           controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 
 # articles, finished liveblogs
 
 GET     /*path.json                                                                                                              controllers.ArticleController.renderJson(path)
 GET     /*path/email                                                                                                             controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailjson                                                                                                   controllers.ArticleController.renderEmail(path)
 GET     /*path                                                                                                                   controllers.ArticleController.renderArticle(path)
 
 # Formstack form submission

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -197,9 +197,11 @@ GET        /news-alert/alerts                                                   
 # Articles
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 
 
 # Don't forward requests for favicon.ico to the Content API


### PR DESCRIPTION
## What does this change?

Add .emailjson endpoints for articles
.emailjson endpoints will serve a json object in the format {"body":"${html}"}
This is required for the Braze integration 

## What is the value of this and can you measure success?

CMT integration

### Tested

- [x] Locally
- [ ] On CODE (optional)
