### PR TITLE
Option for including AppNexus as a direct Prebid adapter is AUS

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -347,6 +347,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val prebidAppNexus: Switch = Switch(
+    group = Commercial,
+    name = "prebid-appnexus",
+    description = "Include AppNexus adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val prebidIndexExchange: Switch = Switch(
     group = Commercial,
     name = "prebid-index-exchange",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -352,7 +352,7 @@ trait CommercialSwitches {
     name = "prebid-appnexus",
     description = "Include AppNexus adapter in Prebid auctions",
     owners = group(Commercial),
-    safeState = On,
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true
   )

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#6a13dd8",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#a847a7f",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -108,7 +108,7 @@ const getIndexSiteId = (): string => {
     } else {
         const site = config
             .get('page.pbIndexSites')
-            .find(s => s.bp === getBreakpointKey());
+            .find(s => s.bp === getBreakpointKey(), []);
         return site && site.id ? site.id.toString() : '';
     }
 };
@@ -277,18 +277,22 @@ const getXaxisPlacementId = (sizes: PrebidSize[]): number => {
 /* testing instrument */
 // Returns a map { <bidderName>: true } of bidders
 // according to the pbtest URL parameter
-const pbTestNameMap = memoize(
-    (): {} =>
+
+type TestNameMap = { [string]: boolean };
+
+const pbTestNameMap: () => TestNameMap = memoize(
+    (): TestNameMap =>
         new URLSearchParams(window.location.search)
             .getAll('pbtest')
             .reduce((acc, value) => {
                 acc[value] = true;
                 return acc;
             }, {}),
-    (): String =>
+    (): string =>
         // Same implicit parameter as the memoized function
         window.location.search
 );
+
 // Is pbtest being used?
 const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 // Helper for conditions
@@ -296,8 +300,8 @@ const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
 const appNexusBidder: PrebidBidder = {
-    name: 'appnexus',
-    switchName: 'prebidAppNexus',
+    name: 'appnexusDirect',
+    switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams => ({
         placementId: getAppNexusPlacementId(sizes),
         customData: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -107,8 +107,8 @@ const getIndexSiteId = (): string => {
         }
     } else {
         const site = config
-            .get('page.pbIndexSites')
-            .find(s => s.bp === getBreakpointKey(), []);
+            .get('page.pbIndexSites', [])
+            .find(s => s.bp === getBreakpointKey());
         return site && site.id ? site.id.toString() : '';
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -26,6 +26,7 @@ import {
     getBreakpointKey,
     getRandomIntInclusive,
     isExcludedGeolocation,
+    shouldIncludeAppNexus,
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
@@ -294,6 +295,15 @@ const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
+const appNexusBidder: PrebidBidder = {
+    name: 'appnexus',
+    switchName: 'prebidAppNexus',
+    bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams => ({
+        placementId: getAppNexusPlacementId(sizes),
+        customData: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+    }),
+};
+
 const sonobiBidder: PrebidBidder = {
     name: 'sonobi',
     switchName: 'prebidSonobi',
@@ -342,7 +352,7 @@ const xaxisBidder: PrebidBidder = {
 const getDummyServerSideBidders = (): Array<PrebidBidder> => {
     const dummyServerSideBidders: Array<PrebidBidder> = [];
 
-    const appnexusBidder: PrebidBidder = {
+    const appnexusServerSideBidder: PrebidBidder = {
         name: 'appnexus',
         switchName: 'prebidS2sozone',
         bidParams: (
@@ -354,7 +364,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
         }),
     };
 
-    const openxBidder: PrebidBidder = {
+    const openxServerSideBidder: PrebidBidder = {
         name: 'openx',
         switchName: 'prebidS2sozone',
         bidParams: (): PrebidOpenXParams => {
@@ -386,9 +396,9 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 getRandomIntInclusive(1, 10000) === 1
         )
     ) {
-        dummyServerSideBidders.push(openxBidder);
+        dummyServerSideBidders.push(openxServerSideBidder);
         if (inPbTestOr(!isExcludedGeolocation())) {
-            dummyServerSideBidders.push(appnexusBidder);
+            dummyServerSideBidders.push(appnexusServerSideBidder);
         }
     }
     return dummyServerSideBidders;
@@ -420,6 +430,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         sonobiBidder,
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
+        ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
         improveDigitalBidder,
         xaxisBidder,
     ];

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -300,7 +300,7 @@ const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
 const appNexusBidder: PrebidBidder = {
-    name: 'appnexusDirect',
+    name: 'and',
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams => ({
         placementId: getAppNexusPlacementId(sizes),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -523,7 +523,7 @@ describe('bids', () => {
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
-            'appnexusDirect',
+            'and',
             'improvedigital',
             'xhb',
         ]);

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -48,7 +48,7 @@ jest.mock('common/modules/experiments/utils');
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
-    config.set('switches.prebidAppNexus', true);
+    config.set('switches.prebidAppnexus', true);
     config.set('switches.prebidImproveDigital', true);
     config.set('switches.prebidIndexExchange', true);
     config.set('switches.prebidSonobi', true);
@@ -523,7 +523,7 @@ describe('bids', () => {
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
-            'appnexus',
+            'appnexusDirect',
             'improvedigital',
             'xhb',
         ]);

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -11,11 +11,13 @@ import type { PrebidBidder, PrebidSize } from './types';
 import {
     getRandomIntInclusive as getRandomIntInclusive_,
     getBreakpointKey as getBreakpointKey_,
+    shouldIncludeAppNexus as shouldIncludeAppNexus_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
 } from './utils';
 
 const getRandomIntInclusive: any = getRandomIntInclusive_;
+const shouldIncludeAppNexus: any = shouldIncludeAppNexus_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
@@ -46,6 +48,7 @@ jest.mock('common/modules/experiments/utils');
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
+    config.set('switches.prebidAppNexus', true);
     config.set('switches.prebidImproveDigital', true);
     config.set('switches.prebidIndexExchange', true);
     config.set('switches.prebidSonobi', true);
@@ -166,12 +169,12 @@ describe('getDummyServerSideBidders', () => {
     test('should include methods in the response that generate the correct bid params', () => {
         const bidders: Array<PrebidBidder> = getDummyServerSideBidders();
         const openxParams = bidders[0].bidParams('type', [[1, 2]]);
-        const appnexusParams = bidders[1].bidParams('type', [[1, 2]]);
+        const appNexusParams = bidders[1].bidParams('type', [[1, 2]]);
         expect(openxParams).toEqual({
             delDomain: 'guardian-d.openx.net',
             unit: '539997090',
         });
-        expect(appnexusParams).toEqual({
+        expect(appNexusParams).toEqual({
             placementId: '13144370',
             customData: 'someTestAppNexusTargeting',
         });
@@ -471,6 +474,7 @@ describe('getIndexSiteId', () => {
 describe('bids', () => {
     beforeEach(() => {
         getRandomIntInclusive.mockReturnValue(5);
+        shouldIncludeAppNexus.mockReturnValue(false);
         shouldIncludeTrustX.mockReturnValue(false);
         stripMobileSuffix.mockImplementation(str => str);
         resetConfig();
@@ -512,6 +516,17 @@ describe('bids', () => {
     test('should not include ix bidders when switched off', () => {
         config.set('switches.prebidIndexExchange', false);
         expect(bidders()).toEqual(['sonobi', 'improvedigital', 'xhb']);
+    });
+
+    test('should include AppNexus directly if in target geolocation', () => {
+        shouldIncludeAppNexus.mockReturnValue(true);
+        expect(bidders()).toEqual([
+            'ix',
+            'sonobi',
+            'appnexus',
+            'improvedigital',
+            'xhb',
+        ]);
     });
 
     test('should include TrustX if in target geolocation', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -68,7 +68,7 @@ class PrebidAdUnit {
     }
 }
 
-class PrebidService {
+export class PrebidService {
     static initialise(): void {
         const pbjsConfig = Object.assign(
             {},
@@ -76,10 +76,10 @@ class PrebidService {
                 bidderTimeout,
                 priceGranularity,
             },
-            config.get('switches.enableConsentManagementService')
+            config.get('switches.enableConsentManagementService', false)
                 ? { consentManagement }
                 : {},
-            config.get('switches.prebidS2sozone') ? { s2sConfig } : {}
+            config.get('switches.prebidS2sozone', false) ? { s2sConfig } : {}
         );
 
         window.pbjs.setConfig(pbjsConfig);
@@ -87,8 +87,8 @@ class PrebidService {
         // gather analytics from 20% (1 in 5) of page views
         const inSample = getRandomIntInclusive(1, 5) === 1;
         if (
-            config.get('switches.prebidAnalytics') &&
-            (inSample || config.get('page.isDev'))
+            config.get('switches.prebidAnalytics', false) &&
+            (inSample || config.get('page.isDev', false))
         ) {
             window.pbjs.enableAnalytics([
                 {
@@ -105,7 +105,7 @@ class PrebidService {
         // allows dynamic assignment.
         window.pbjs.bidderSettings = {};
 
-        if (config.get('switches.prebidXaxis')) {
+        if (config.get('switches.prebidXaxis', false)) {
             window.pbjs.bidderSettings.xhb = {
                 adserverTargeting: [
                     {
@@ -116,6 +116,10 @@ class PrebidService {
                     },
                 ],
             };
+        }
+
+        if (config.get('switches.prebidAppnexus', false)) {
+            window.pbjs.aliasBidder('appnexus', 'appnexusDirect');
         }
     }
 
@@ -132,7 +136,7 @@ class PrebidService {
             return PrebidService.requestQueue;
         }
 
-        const adUnits = slots
+        const adUnits: Array<PrebidAdUnit> = slots
             .filter(slot =>
                 stripTrailingNumbersAbove1(
                     stripMobileSuffix(advert.id)

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -117,10 +117,6 @@ export class PrebidService {
                 ],
             };
         }
-
-        if (config.get('switches.prebidAppnexus', false)) {
-            window.pbjs.aliasBidder('appnexus', 'appnexusDirect');
-        }
     }
 
     static requestQueue: Promise<void> = Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -68,7 +68,7 @@ class PrebidAdUnit {
     }
 }
 
-export class PrebidService {
+class PrebidService {
     static initialise(): void {
         const pbjsConfig = Object.assign(
             {},

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -14,6 +14,7 @@ jest.mock('commercial/modules/prebid/bid-config', () => ({
 describe('initialise', () => {
     beforeEach(() => {
         config.set('switches.enableConsentManagementService', true);
+        config.set('switches.prebidAppNexus', true);
         config.set('switches.prebidS2sozone', true);
         config.set('switches.prebidSonobi', true);
         config.set('switches.prebidXaxis', true);

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -26,6 +26,9 @@ export const getBreakpointKey = (): string => {
     }
 };
 
+export const shouldIncludeAppNexus = (): boolean =>
+    geolocationGetSync() === 'AU';
+
 export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';
 
 export const isExcludedGeolocation = (): boolean => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -4,6 +4,7 @@ import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import {
     getBreakpointKey,
     isExcludedGeolocation,
+    shouldIncludeAppNexus,
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
@@ -35,13 +36,26 @@ describe('Utils', () => {
         expect(results).toEqual(['M', 'M', 'T', 'D', 'D']);
     });
 
+    test('shouldIncludeAppNexus should return true if geolocation is AU', () => {
+        getSync.mockReturnValueOnce('AU');
+        expect(shouldIncludeAppNexus()).toBe(true);
+    });
+
+    test('shouldIncludeAppNexus should otherwise return false', () => {
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'CA', 'US'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValueOnce(testGeos[i]);
+            expect(shouldIncludeAppNexus()).toBe(false);
+        }
+    });
+
     test('shouldIncludeTrustX should return true if geolocation is US', () => {
         getSync.mockReturnValueOnce('US');
         expect(shouldIncludeTrustX()).toBe(true);
     });
 
     test('shouldIncludeTrustX should otherwise return false', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'CA'];
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'CA', 'AU'];
         for (let i = 0; i < testGeos.length; i += 1) {
             getSync.mockReturnValueOnce(testGeos[i]);
             expect(shouldIncludeTrustX()).toBe(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#6a13dd8":
+"prebid.js@https://github.com/guardian/Prebid.js.git#a847a7f":
   version "1.18.0"
-  resolved "https://github.com/guardian/Prebid.js.git#6a13dd8dff5dc16093641ba7c3a27f271c1236db"
+  resolved "https://github.com/guardian/Prebid.js.git#a847a7f17ace3d49e6f392915393fe8338dbf011"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?

#### 👉 Conditionally adds AppNexus directly to Prebid based on geolocation

- If the switch is on and geolocation is AUS
- Commercial switch to expand our death by switches

#### 👉 Add alias for AppNexusDirect and a switch

- Using alias `and` for AppNexus Direct to avoid clash with s2s Prebid
- Alias also ensures that the pbtest params can still work for different adaptors

#### 👉 Refer to alias from Prebid module for AppNexus Direct

Rather than having to using alias in the Prebid setup in frontend, we can detail the alias in our fork of Prebid and then refer to the alias: https://github.com/guardian/Prebid.js/pull/40

## What is the value of this and can you measure success?

Option for including AppNexus as a direct Prebid adapter is AUS

Commercial Trello link: https://trello.com/c/DFm02Hwi

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

### Tested

- [x] Locally
- [ ] On CODE (optional)

### TODO: 

- [x] Update reference to Prebid once the [associated PR](https://github.com/guardian/Prebid.js/pull/40) is merged
