### PR TITLE
Prep work for newsletter banners

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -21,7 +21,7 @@ trait IdentitySwitches {
     "If switched on, users coming from newsletters will get prompts to sign in.",
     owners = Seq(Owner.withGithub("walaura")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2018, 10, 24),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -15,4 +15,14 @@ trait IdentitySwitches {
     exposeClientSide = true
   )
 
+  val IdentityEmailSignInUpsellSwitch = Switch(
+    SwitchGroup.Identity,
+    "id-email-sign-in-upsell",
+    "If switched on, users coming from newsletters will get prompts to sign in.",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -19,7 +19,7 @@ import { init as initCookieRefresh } from 'common/modules/identity/cookierefresh
 import { initNavigation } from 'common/modules/navigation/navigation';
 import { Profile } from 'common/modules/navigation/profile';
 import { Search } from 'common/modules/navigation/search';
-import {emailSignInBanner} from 'common/modules/identity/email-sign-in-banner';
+import { emailSignInBanner } from 'common/modules/identity/email-sign-in-banner';
 import {
     initMembership,
     membershipBanner,

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -19,6 +19,7 @@ import { init as initCookieRefresh } from 'common/modules/identity/cookierefresh
 import { initNavigation } from 'common/modules/navigation/navigation';
 import { Profile } from 'common/modules/navigation/profile';
 import { Search } from 'common/modules/navigation/search';
+import {emailSignInBanner} from 'common/modules/identity/email-sign-in-banner';
 import {
     initMembership,
     membershipBanner,
@@ -274,6 +275,7 @@ const initialiseBanner = (): void => {
         membershipBanner,
         membershipEngagementBanner,
         smartAppBanner,
+        emailSignInBanner,
     ];
     initBannerPicker(bannerList);
 };

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
@@ -6,9 +6,9 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 
 const messageCode: string = 'email-sign-in-banner';
 
-const signInLink = `${config.get(
-    'page.idUrl'
-)}/login?returnUrl=https://theguardian.com/email-newsletters`;
+const signInLink = `${config.get('page.idUrl')}/login?returnUrl=${config.get(
+    'page.host'
+)}/email-newsletters`;
 
 const isInExperiment = (): boolean =>
     config.get('switches.idEmailSignInUpsell');

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
@@ -1,0 +1,35 @@
+// @flow
+
+import fastdom from 'lib/fastdom-promise';
+import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
+import config from 'lib/config';
+import type { Banner } from 'common/modules/ui/bannerPicker';
+
+const messageCode: string = 'email-sign-in-banner';
+
+const signInLink = `${config.get('page.idUrl')}/login?returnUrl=https://theguardian.com/email-newsletters`;
+
+const isInExperiment = ():boolean  => config.get('switches.idEmailSignInUpsell');
+
+const canShow: () => Promise<boolean> = () =>
+    Promise.resolve(
+        !hasUserAcknowledgedBanner(messageCode) && isInExperiment()
+    );
+
+const show: () => void = () => {
+    const message = new Message(messageCode, {
+        cssModifierClass: messageCode,
+        trackDisplay: true,
+        siteMessageLinkName: messageCode,
+        siteMessageComponentName: messageCode,
+    });
+    message.show(
+        `Enjoying this newsletter? Sign in to get more.`
+    );
+};
+
+export const emailSignInBanner: Banner = {
+    id: messageCode,
+    show,
+    canShow,
+};

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner.js
@@ -1,15 +1,17 @@
 // @flow
 
-import fastdom from 'lib/fastdom-promise';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import config from 'lib/config';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 const messageCode: string = 'email-sign-in-banner';
 
-const signInLink = `${config.get('page.idUrl')}/login?returnUrl=https://theguardian.com/email-newsletters`;
+const signInLink = `${config.get(
+    'page.idUrl'
+)}/login?returnUrl=https://theguardian.com/email-newsletters`;
 
-const isInExperiment = ():boolean  => config.get('switches.idEmailSignInUpsell');
+const isInExperiment = (): boolean =>
+    config.get('switches.idEmailSignInUpsell');
 
 const canShow: () => Promise<boolean> = () =>
     Promise.resolve(
@@ -24,7 +26,7 @@ const show: () => void = () => {
         siteMessageComponentName: messageCode,
     });
     message.show(
-        `Enjoying this newsletter? Sign in to get more.`
+        `Enjoying this newsletter? <a href="${signInLink}">Sign in</a> to get more.`
     );
 };
 


### PR DESCRIPTION
## What does this change?
Initial groundwork for [the newsletter/sign-in engagement banner](https://trello.com/c/aL676cnY/897-mock-up-build-newsletter-engagement-banner) experiment

## Screenshots
![screen shot 2018-08-10 at 11 26 37 am](https://user-images.githubusercontent.com/11539094/43953788-02ab019c-9c92-11e8-936c-bbcb0b6bf205.png)
Beautiful, just beautiful.

## What is the value of this and can you measure success?
K&T OKR work. Final banner will be tracked to analyse its performance.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
