### PR TITLE
Tweaked in article bullet point styling

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -152,7 +152,14 @@
     list-style: none;
 
     > li {
-        @include faux-bullet-point($right-space: 4px);
+        @include faux-bullet-point($right-space: 8px);
+        margin-bottom: $gs-baseline / 2;
+        padding-left: $gs-gutter;
+        overflow: hidden;
+
+        &:before {
+            margin-left: -$gs-gutter;
+        }
 
         .paid-content & {
             @include faux-bullet-point($brightness-60, $right-space: 4px);
@@ -163,7 +170,6 @@
         }
     }
 }
-
 
 /* Captions
    ========================================================================== */
@@ -389,24 +395,6 @@ figure.element--thumbnail + h2 {
                 text-decoration: none;
                 border-bottom: 1px solid $brightness-46;
             }
-        }
-    }
-}
-
-/* Bullet list
-   ========================================================================== */
-
-.from-content-api,
-.from-content-api .block-elements {
-    > ul > li {
-        margin-bottom: $gs-baseline / 2;
-        padding-left: $gs-gutter;
-        overflow: hidden;
-
-        &:before {
-            position: absolute;
-            top: 4px;
-            margin-left: -$gs-gutter;
         }
     }
 }

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -31,14 +31,12 @@
         }
     }
     > ol,
-    > blockquote > ul,
-    > ul {
+    > blockquote > ul {
         margin-top: .8em;
     }
     > li, // sometimes HTML is malformed on purpose by editors
     > ol,
-    > blockquote ul,
-    > ul {
+    > blockquote ul {
         list-style: none;
     }
     > ol {
@@ -391,6 +389,24 @@ figure.element--thumbnail + h2 {
                 text-decoration: none;
                 border-bottom: 1px solid $brightness-46;
             }
+        }
+    }
+}
+
+/* Bullet list
+   ========================================================================== */
+
+.from-content-api,
+.from-content-api .block-elements {
+    > ul > li {
+        margin-bottom: $gs-baseline / 2;
+        padding-left: $gs-gutter;
+        overflow: hidden;
+
+        &:before {
+            position: absolute;
+            top: 4px;
+            margin-left: -$gs-gutter;
         }
     }
 }


### PR DESCRIPTION
Following some useful feedback from Editorial, I have tweaked the styling of in article bullet points. 
The changes are as follows:
- Bullet items are slightly closer together to illustrate that they're all connected.
- When a bullet point wraps onto two lines, they text has a consistent left margin.
- Text has a just a tiiiiny bit more brathing room between the bullet points. 


![screen shot 2018-08-10 at 12 06 16](https://user-images.githubusercontent.com/14570016/43954839-e510a552-9c95-11e8-86d2-59d669b2a5c5.png)
