### PR TITLE
liquid template unsubscribe link for emails in braze

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -324,6 +324,7 @@ class GuardianConfiguration extends Logging {
     lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
     lazy val accountDeletionApiKey = configuration.getStringProperty("id.accountDeletion.apiKey").getOrElse("")
     lazy val accountDeletionApiRoot = configuration.getStringProperty("id.accountDeletion.apiRoot").getOrElse("")
+    lazy val brazeUnsubscribeToken: String = configuration.getStringProperty("id.unsubscribe.token").getOrElse("")
   }
 
   object images {

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,5 +1,6 @@
 package implicits
 
+import common.Logging
 import conf.Configuration
 import play.api.mvc.RequestHeader
 
@@ -65,4 +66,16 @@ trait Requests {
   }
 }
 
+trait EmailRequests extends Requests {
+  implicit class EmailRichRequestHeader(r: RequestHeader) extends Logging {
+    lazy val emailId: String = r.path match {
+      case "/email/uk/daily" => "today-uk"
+      case "/email/us/daily" => "today-us"
+      case "/email/au/daily" => "today-au"
+      case _ => ""
+    }
+  }
+}
+
+object EmailRequests extends EmailRequests
 object Requests extends Requests

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -30,6 +30,8 @@ trait Requests {
 
     lazy val isEmailJson: Boolean = r.path.endsWith(".emailjson")
 
+    lazy val isEmailBraze: Boolean = r.path.endsWith(".emailbraze")
+
     // parameters for moon/guui new rendering layer project.
     lazy val isGuuiJson: Boolean = isJson && isGuui
 
@@ -39,7 +41,7 @@ trait Requests {
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
 
-    lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(EMAIL_SUFFIX) || isEmailJson
+    lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(EMAIL_SUFFIX) || isEmailJson || isEmailBraze
 
     lazy val isModified = isJson || isRss || isEmail
 
@@ -69,9 +71,9 @@ trait Requests {
 trait EmailRequests extends Requests {
   implicit class EmailRichRequestHeader(r: RequestHeader) extends Logging {
     lazy val emailId: String = r.path match {
-      case "/email/uk/daily" => "today-uk"
-      case "/email/us/daily" => "today-us"
-      case "/email/au/daily" => "today-au"
+      case "/email/uk/daily.emailbraze" => "today-uk"
+      case "/email/us/daily.emailbraze" => "today-us"
+      case "/email/au/daily.emailbraze" => "today-au"
       case _ => ""
     }
   }

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -3,6 +3,7 @@
 @import fragments.email._
 @import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
+@import implicits.EmailRequests._
 
 
 <table class="ft">
@@ -15,7 +16,16 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                    @if(request.isEmailJson && request.emailId.nonEmpty) {
+                                        {% assign date_now = "now" | date: "%s" %}
+                                        {% assign path_data = "@request.emailId" | append: external_id  | append: ":" | append: ${date_now} %}
+                                        {% assign hmac_token = path_data | hmac_sha256: "TODO" %}
+                                        {% assign url_encoded_path = path_data | url_encode %}
+                                        {% assign url_encoded_token = hmac_token | url_encode %}
+                                        <a href="https://profile.theguardian.com/unsubscribe/newsletter/{{url_encoded_path}}/{{url_encoded_token}}">Unsubscribe</a> |
+                                    } else {
+                                        <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                    }
                                     <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
                                 </td>
                             </tr>

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -4,7 +4,7 @@
 @import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
 @import implicits.EmailRequests._
-
+@import conf.Configuration.id.brazeUnsubscribeToken
 
 <table class="ft">
     <tr>
@@ -16,10 +16,10 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    @if(request.isEmailJson && request.emailId.nonEmpty) {
+                                    @if(request.isEmailBraze && request.emailId.nonEmpty) {
                                         {% assign date_now = "now" | date: "%s" %}
-                                        {% assign path_data = "@request.emailId" | append: external_id  | append: ":" | append: ${date_now} %}
-                                        {% assign hmac_token = path_data | hmac_sha256: "TODO" %}
+                                        {% assign path_data = "@request.emailId" | append: ":" | append: external_id  | append: ":" | append: date_now %}
+                                        {% assign hmac_token = path_data | hmac_sha1: "@brazeUnsubscribeToken" %}
                                         {% assign url_encoded_path = path_data | url_encode %}
                                         {% assign url_encoded_token = hmac_token | url_encode %}
                                         <a href="https://profile.theguardian.com/unsubscribe/newsletter/{{url_encoded_path}}/{{url_encoded_token}}">Unsubscribe</a> |

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -31,6 +31,7 @@ GET        /rss                                                                 
 GET        /*path/rss                                                               controllers.FaciaController.renderFrontRss(path)
 GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonLite(path)
 GET        /*path.emailjson                                                         controllers.FaciaController.renderFrontJson(path)
+GET        /*path.emailbraze                                                        controllers.FaciaController.renderFrontJson(path)
 GET        /*path.json                                                              controllers.FaciaController.renderFrontJson(path)
 GET        /                                                                        controllers.FaciaController.rootEditionRedirect()
 GET        /*path                                                                   controllers.FaciaController.renderFront(path)


### PR DESCRIPTION
## What does this change?

Adds an unsubscribe link with token for unsubscribing via identity frontend to Braze emails

Do not merge yet, we're not yet certain whether the hmac256 will work in Braze's version of liquid.

## What is the value of this and can you measure success?

Users can unsubscribe from Braze email campaigns

Tested:
- [x] Locally


<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
