### PR TITLE
Solved large spacing above headlines due to series tag

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -149,10 +149,10 @@
 
 .content__labels {
     box-sizing: border-box;
-    padding: ($gs-baseline / 2 + $gs-baseline / 4) 0 0;
     position: relative;
     z-index: 1; // bring-to-front fix to make it clickable
     overflow: hidden;
+    padding-top: $gs-baseline / 4;
 
     @include mq($until: tablet) {
         order: 1;
@@ -162,10 +162,10 @@
         .content__head--column & {
             order: 0;
         }
+    }
 
-        & > .content__section-label  {
-            display: none;
-        }
+    @include mq(leftCol) {
+        padding-top: $gs-baseline / 2 + $gs-baseline / 4;
     }
 }
 


### PR DESCRIPTION
Previously, we had strange space above headlines on articles with no series tag, before tablet breakpoint. Improved logic, now you get a content tag if there is no series tag, and the gap has been reduced. Neater. 

# Before
<img width="378" alt="screen shot 2018-08-13 at 13 46 55" src="https://user-images.githubusercontent.com/14570016/44032860-5f7c6b48-9f00-11e8-8e64-7785b5ada58a.png">

# After
<img width="378" alt="screen shot 2018-08-13 at 13 47 05" src="https://user-images.githubusercontent.com/14570016/44032861-5f8f8200-9f00-11e8-88f3-fde0a470e633.png">
