### PR TITLE
Add a password set form to /complete-consents

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -66,7 +66,7 @@ class ChangePasswordController(
         val idRequest = idRequestParser(request)
         api.passwordExists(request.user.auth) map {
           result =>
-            val pwdExists = result.right.toOption exists {_ == true}
+            val pwdExists = result.right.toOption contains true
             NoCache(Ok(
                 IdentityHtmlPage.html(
                   views.html.password.changePassword(page = page, idRequest = idRequest, idUrlBuilder = idUrlBuilder, passwordForm = form, passwordExists =  pwdExists)
@@ -76,7 +76,7 @@ class ChangePasswordController(
     }
   }
 
-  def renderPasswordConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
+  def renderPasswordConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action { implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     NoCache(Ok(

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -6,7 +6,9 @@ import idapiclient.UserUpdateDTO
 import model.{IdentityPage, NoCache}
 import pages.IdentityHtmlPage
 import play.api.data.Form
-import play.api.data.Forms.{nonEmptyText, single}
+import play.api.data.Forms.{mapping, nonEmptyText, single, text}
+import play.api.data.validation.Constraints
+import play.api.i18n.MessagesProvider
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, Result}
 import utils.ConsentOrder.userWithOrderedConsents
@@ -14,11 +16,40 @@ import utils.ConsentsJourneyType.AnyConsentsJourney
 
 import scala.concurrent.Future
 
+object GuestPasswordForm {
+
+  def form()(implicit messagesProvider: MessagesProvider): Form[GuestPasswordFormData] = Form(
+    mapping(
+        ("password", text.verifying(Constraints.nonEmpty)),
+      ("token", text)
+    )(GuestPasswordFormData.apply)(GuestPasswordFormData.unapply)
+  )
+
+}
+case class GuestPasswordFormData(password: String, token: String)
+
+
 trait ConsentsJourney
     extends EditProfileControllerComponents
     with EditProfileFormHandling {
 
   import authenticatedActions._
+
+  def guestPasswordSet(): Action[AnyContent] = csrfCheck {
+    Action.async { implicit request =>
+      val form = GuestPasswordForm.form().bindFromRequest()
+      form.fold(errorForm => {
+        displayConsentComplete(Some(errorForm))(request)
+      }, completedForm => {
+        identityApiClient.setPasswordGuest(completedForm.password, completedForm.token).flatMap {
+          case Right(resp) if resp.statusCode == 200 =>
+            Future.successful(NoCache(SeeOther(s"/password/confirm")))
+          case _ =>
+            displayConsentComplete(Some(form.withError("error", "An unexpected error occurred, please try again later.")))(request)
+        }
+      })
+    }
+  }
 
   /** GET /consents/thank-you */
   def displayConsentsJourneyThankYou: Action[AnyContent] =
@@ -29,8 +60,8 @@ trait ConsentsJourney
     displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint)
 
   /** GET /complete-consents */
-  def displayConsentComplete: Action[AnyContent] =
-    displayConsentComplete(ConsentJourneyPageDefault, None)
+  def displayConsentComplete(guestPasswordForm: Option[Form[GuestPasswordFormData]] = None): Action[AnyContent] =
+    displayConsentComplete(ConsentJourneyPageDefault, None, guestPasswordForm)
 
   /** POST /complete-consents */
   def submitRepermissionedFlag: Action[AnyContent] =
@@ -86,7 +117,8 @@ trait ConsentsJourney
 
   private def displayConsentComplete(
     page: ConsentJourneyPage,
-    consentHint: Option[String]): Action[AnyContent] =
+    consentHint: Option[String],
+    guestPasswordSetForm: Option[Form[GuestPasswordFormData]]): Action[AnyContent] =
     csrfAddToken {
       consentsRedirectAction.async { implicit request =>
 
@@ -97,14 +129,16 @@ trait ConsentsJourney
 
         consentCompleteView(
           page,
-          returnUrl
+          returnUrl,
+          guestPasswordSetForm
         )
       }
     }
 
   private def consentCompleteView(
    page: IdentityPage,
-   returnUrl : String)(implicit request: AuthRequest[AnyContent]): Future[Result] = {
+   returnUrl : String,
+   guestPasswordSetForm: Option[Form[GuestPasswordFormData]])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
     newsletterService.subscriptions(request.user.id, idRequestParser(request).trackingData).map { emailFilledForm =>
       Ok(IdentityHtmlPage.html(
@@ -113,6 +147,7 @@ trait ConsentsJourney
           idUrlBuilder,
           returnUrl,
           emailFilledForm,
+          guestPasswordSetForm.getOrElse(GuestPasswordForm.form()),
           newsletterService.getEmailSubscriptions(emailFilledForm),
           EmailNewsletters.all)
       )(page, request, context))

--- a/identity/app/controllers/editprofile/EditProfileController.scala
+++ b/identity/app/controllers/editprofile/EditProfileController.scala
@@ -23,6 +23,7 @@ class EditProfileController(
     override val csrfAddToken: CSRFAddToken,
     override val returnUrlVerifier: ReturnUrlVerifier,
     override val newsletterService: NewsletterService,
+    override val signinService: PlaySigninService,
     override implicit val profileFormsMapping: ProfileFormsMapping,
     override implicit val context: ApplicationContext,
     val httpConfiguration: HttpConfiguration,

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -163,7 +163,7 @@ class IdApiClient(
 
   def setPasswordGuest(password: String, token: String): Future[Response[CookiesResponse]] = {
     val body: JObject = "password" -> password
-    put("guest/password", None, None, Some(compactRender(body)), List("X-Guest-Registration-Token" -> token, "Content-Type" -> "application/json")).map(extract(jsonField("cookies")))
+    put("guest/password", None, None, Some(compactRender(body)), List("X-Guest-Registration-Token" -> token, "Content-Type" -> "application/json"), List("validate-email" -> "0")).map(extract(jsonField("cookies")))
   }
 
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {
@@ -191,8 +191,8 @@ class IdApiClient(
     ) map extract[AccountDeletionResult](identity)
   }
 
-  def put(apiPath: String, auth: Option[Auth] = None, trackingParameters: Option[TrackingData] = None, body: Option[String] = None, extraHeaders: Parameters): Future[Response[HttpResponse]] =
-    httpClient.PUT(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth) ++ extraHeaders)
+  def put(apiPath: String, auth: Option[Auth] = None, trackingParameters: Option[TrackingData] = None, body: Option[String] = None, extraHeaders: Parameters, urlParameters: Parameters): Future[Response[HttpResponse]] =
+    httpClient.PUT(apiUrl(apiPath), body, buildParams(auth, trackingParameters) ++ urlParameters, buildHeaders(auth) ++ extraHeaders)
 
   def post(apiPath: String,
            auth: Option[Auth] = None,

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -6,10 +6,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import idapiclient.responses.{AccountDeletionResult, CookiesResponse, Error, HttpResponse}
 import conf.IdConfig
 import idapiclient.parser.IdApiJsonBodyParser
-import net.liftweb.json.JsonAST.JValue
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json.compactRender
+import net.liftweb.json.JsonAST.{JObject, JString, JValue}
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
 import idapiclient.requests.{DeletionBody, PasswordUpdate, TokenPassword}
+import org.json4s.JsonAST.JField
 import org.slf4j.LoggerFactory
 import play.api.libs.ws.WSClient
 
@@ -158,6 +161,11 @@ class IdApiClient(
   def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[Unit]] =
     post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extractUnit
 
+  def setPasswordGuest(password: String, token: String): Future[Response[HttpResponse]] = {
+    val body: JObject = "password" -> password
+    put("guest/password", None, None, Some(compactRender(body)), List("X-Guest-Registration-Token" -> token, "Content-Type" -> "application/json"))
+  }
+
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {
     val extraParams = returnUrlOpt.map(url => List("returnUrl" -> url))
     httpClient.POST(apiUrl("user/send-validation-email"), None, buildParams(Some(auth), Some(trackingParameters), extraParams), buildHeaders(Some(auth))) map extractUnit
@@ -182,6 +190,9 @@ class IdApiClient(
         headers = buildHeaders(Some(auth), extra = Seq(("x-api-key", conf.accountDeletionApiKey)))
     ) map extract[AccountDeletionResult](identity)
   }
+
+  def put(apiPath: String, auth: Option[Auth] = None, trackingParameters: Option[TrackingData] = None, body: Option[String] = None, extraHeaders: Parameters): Future[Response[HttpResponse]] =
+    httpClient.PUT(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth) ++ extraHeaders)
 
   def post(apiPath: String,
            auth: Option[Auth] = None,
@@ -238,6 +249,10 @@ class HttpClient(
   def DELETE(uri: String, body: Option[String], urlParameters: Parameters = Nil, headers: Parameters): Future[Response[HttpResponse]] = {
     makeRequest("DELETE", uri, body, urlParameters, headers)
   }
+
+  def PUT(uri: String, body: Option[String], urlParameters: Parameters = Nil, headers: Parameters): Future[Response[HttpResponse]] =
+    makeRequest("PUT", uri, body, urlParameters, headers)
+
 
   def makeRequest(
       method: String,

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -161,9 +161,9 @@ class IdApiClient(
   def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[Unit]] =
     post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extractUnit
 
-  def setPasswordGuest(password: String, token: String): Future[Response[HttpResponse]] = {
+  def setPasswordGuest(password: String, token: String): Future[Response[CookiesResponse]] = {
     val body: JObject = "password" -> password
-    put("guest/password", None, None, Some(compactRender(body)), List("X-Guest-Registration-Token" -> token, "Content-Type" -> "application/json"))
+    put("guest/password", None, None, Some(compactRender(body)), List("X-Guest-Registration-Token" -> token, "Content-Type" -> "application/json")).map(extract(jsonField("cookies")))
   }
 
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -64,7 +64,7 @@
                             @inputField(Password(setPasswordForm("password"), ('_label, "Password"), ('class, "js-register-password"),
                             ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "password")))
                             <li class="form-field form-field__submit">
-                                <button type="submit" class="manage-account__button manage-account__button--center" data-link-name="Set password" tabindex="4" data-test-id="set-pwd">Set password</button>
+                                <button type="submit" class="manage-account__button manage-account__button--center" data-link-name="set-password" tabindex="4">Set password</button>
                             </li>
                         </div>
                     </div>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,16 +1,21 @@
 @import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 
+@import controllers.editprofile.GuestPasswordFormData
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     returnUrl: String,
     emailPrefsForm: Form[EmailPrefsData],
+    setPasswordForm: Form[GuestPasswordFormData],
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import common.LinkTo
+@import form.IdFormHelpers._
+@import views.html.fragments.form.inputField
+@import views.html.fragments.registrationFooter
 
 @buildIdentityUrl(endpoint: String) = {
 @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
@@ -41,6 +46,29 @@
                         The Guardian's newsletters include content from our website, which may be funded by outside parties. Newsletters may also display information about Guardian News and Media's other products, services or events (such as Guardian Jobs or Masterclasses), chosen charities or online advertisements.
                     </p>
                 </div>
+            </form>
+        }
+
+        @if(request.cookies.get("SC_GU_GUEST_PW_SET").isDefined) {
+            <form class="form js-register-form" novalidate action="/password/guest" role="form" method="post">
+                <fieldset class="fieldset">
+                    @views.html.helper.CSRF.formField
+                    <div>
+                        <h1 class="identity-title--small">Set a Password</h1>
+                        <div class="identity-forms-message__body">
+                            <p>Set a password to manage your email preferences at any time.</p>
+                        </div>
+                        <div class="fieldset__fields">
+                            <input type="hidden" value="@request.cookies.get("SC_GU_GUEST_PW_SET").get.value" name="token" />
+
+                            @inputField(Password(setPasswordForm("password"), ('_label, "Password"), ('class, "js-register-password"),
+                            ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "password")))
+                            <li class="form-field form-field__submit">
+                                <button type="submit" class="manage-account__button manage-account__button--center" data-link-name="Set password" tabindex="4" data-test-id="set-pwd">Set password</button>
+                            </li>
+                        </div>
+                    </div>
+                </fieldset>
             </form>
         }
         <aside class="identity-forms-message__body">

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -54,17 +54,17 @@
                 <fieldset class="fieldset">
                     @views.html.helper.CSRF.formField
                     <div>
-                        <h1 class="identity-title--small">Set a Password</h1>
+                        <h1 class="identity-title--small">Want even more from the Guardian? Create a free account</h1>
                         <div class="identity-forms-message__body">
-                            <p>Set a password to manage your email preferences at any time.</p>
+                            <p>Create your account by setting a password, and manage your email preferences at any time.</p>
                         </div>
                         <div class="fieldset__fields">
                             <input type="hidden" value="@request.cookies.get("SC_GU_GUEST_PW_SET").get.value" name="token" />
 
                             @inputField(Password(setPasswordForm("password"), ('_label, "Password"), ('class, "js-register-password"),
-                            ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "password")))
+                            ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "password"), (Symbol("data-link-name"), "set-password")))
                             <li class="form-field form-field__submit">
-                                <button type="submit" class="manage-account__button manage-account__button--center" data-link-name="set-password" tabindex="4">Set password</button>
+                                <button type="submit" class="manage-account__button manage-account__button--center" tabindex="4">Set password</button>
                             </li>
                         </div>
                     </div>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -16,6 +16,7 @@ GET         /password/change                        controllers.ChangePasswordCo
 POST        /password/change                        controllers.ChangePasswordController.submitForm
 GET         /password/reset-confirmation            controllers.ResetPasswordController.renderPasswordResetConfirmation(returnUrl: Option[String])
 GET         /password/email-sent                    controllers.ResetPasswordController.renderEmailSentConfirmation
+POST        /password/guest                         controllers.editprofile.EditProfileController.guestPasswordSet()
 GET         /user/id/:id                            controllers.PublicProfileController.renderProfileFromId(id: String, activityType = "discussions")
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
@@ -74,7 +75,7 @@ GET         /privacy-settings                       controllers.AdvertsManager.r
 GET         /consents/thank-you                     controllers.editprofile.EditProfileController.displayConsentsJourneyThankYou
 GET         /consents                               controllers.editprofile.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
-GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete
+GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete()
 ########################################################################################################################
 
 ########################################################################################################################

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -55,6 +55,7 @@ import scala.concurrent.Future
     val redirectDecisionService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponent)
     val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser, redirectDecisionService)
 
+    val signinService = mock[PlaySigninService]
     val profileFormsMapping = ProfileFormsMapping(
       new AccountDetailsMapping,
       new PrivacyMapping,
@@ -83,6 +84,7 @@ import scala.concurrent.Future
       csrfAddToken,
       returnUrlVerifier,
       newsletterService,
+      signinService,
       profileFormsMapping,
       testApplicationContext,
       httpConfiguration,

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -57,7 +57,7 @@ import scala.concurrent.Future
 
     val redirectDecisionService = new ProfileRedirectService(newsletterService, idRequestParser, controllerComponent)
     val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser, redirectDecisionService)
-
+    val signinService = mock[PlaySigninService]
     val profileFormsMapping = ProfileFormsMapping(
       new AccountDetailsMapping,
       new PrivacyMapping,
@@ -84,6 +84,7 @@ import scala.concurrent.Future
       csrfAddToken,
       returnUrlVerifier,
       newsletterService,
+      signinService,
       profileFormsMapping,
       testApplicationContext,
       httpConfiguration,


### PR DESCRIPTION
## What does this change?

Allows a user to set a password when they are registered via an email confirmation link (i.e. we created them a guest account). 

## Screenshots

![screen shot 2018-08-13 at 15 15 42](https://user-images.githubusercontent.com/3636251/44038104-e415d4ae-9f0d-11e8-9be6-3aa5d56a539b.png)


## What is the value of this and can you measure success?

Users without passwords will be given a chance to create one. 

### Does this affect other platforms?

NO

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

Related PR: https://github.com/guardian/identity/pull/1340