### PR TITLE
Immersive headline clipped

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -55,14 +55,14 @@
 
         @include mq(tablet) {
             padding-left: 0;
+            position: relative;
+            z-index: 1;
         }
 
         @include mq(desktop) {
             font-size: 50px;
             line-height: 54px;
             width: gs-span(8) - ($gs-gutter / 2);
-            z-index: 1;
-            position: relative;
         }
     }
 


### PR DESCRIPTION
z-index in the wrong MQ resulted in some chopped off text at tablet breakpoint for the immersive head in galleries. 

# Before
<img width="737" alt="screen shot 2018-08-14 at 09 10 14" src="https://user-images.githubusercontent.com/14570016/44079770-e9f8ad94-9fa1-11e8-819b-e523f8955b6d.png">

# After
<img width="750" alt="screen shot 2018-08-14 at 09 10 05" src="https://user-images.githubusercontent.com/14570016/44079771-eb7448ea-9fa1-11e8-868d-052cfcb72f23.png">
