### PR TITLE
Add accessibility standards

### DIFF
--- a/docs/04-quality/03-accessibility.md
+++ b/docs/04-quality/03-accessibility.md
@@ -1,0 +1,13 @@
+# Accessibility
+
+We believe that our journalism should be accessible to everyone.
+
+To achieve this, we aim to meet the [BBC HTML accessibility standards](http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html/).
+
+## Testing
+
+We have compiled the following testing guidelines for developers working on theguardian.com:
+
+- [Screen readers](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
+- [Keyboard navigation](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
+- [Colour contrast](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@
 ## [Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)
 - [Browser support principles](04-quality/02-browser-support-principles.md)
+- [Accessibility](04-quality/03-accessibility.md)
 
 ## [Commercial](05-commercial/)
 - [How do DFP adverts work?](05-commercial/01-DFP-Advertising.md)


### PR DESCRIPTION
## What does this change?

This change commits us to adhering to the [BBC HTML Accessibility Standards](http://www.bbc.co.uk/guidelines/futuremedia/accessibility/html).

## What is the value of this and can you measure success?

We currently don't have any accessibility standards. By having standards, we can achieve better support for users of assistive technologies, keyboard users and users with permanent, temporary and situational disabilities. 

The standards will set a benchmark for new work, and will help us identify and fix existing accessibility bugs.
