### PR TITLE
padding on guardian today email headlines

### DIFF
--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -50,7 +50,7 @@ $container-color: #ffffff;
     padding: 0;
     width: 100%;
     position: relative;
-    min-height: 56px;
+    height: 56px;
 }
 
 .free-text {
@@ -120,7 +120,7 @@ $container-color: #ffffff;
 .byline,
 .trail-text {
     font-weight: normal;
-    padding: 3px $gutter 0;
+    padding: 3px $gutter 5px;
 }
 
 // td


### PR DESCRIPTION
## What does this change?

Fix guardian today headline padding on firefox and old Android versions
Min-height does not work on tables in some browsers

## Screenshots

<img width="527" alt="picture 54" src="https://user-images.githubusercontent.com/29203769/44086977-36deb072-9fb6-11e8-85c7-1607a1c0d52a.png">


## What is the value of this and can you measure success?

Better formatting on emails

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
