### PR TITLE
Ignore extraneous whitespace in postcodes

### DIFF
--- a/identity/app/form/AddressMapping.scala
+++ b/identity/app/form/AddressMapping.scala
@@ -45,12 +45,12 @@ case class AddressFormData(
 
   private val ZipcodePattern = """^\d{5}(?:[-\s]\d{4})?$""".r
   private lazy val isValidUsZipcode = {
-      postcode.isEmpty || ZipcodePattern.findFirstIn(postcode).isDefined
+      postcode.isEmpty || ZipcodePattern.findFirstIn(postcode.trim).isDefined
   }
 
-   private val PostcodePattern = """^(GIR 0AA)|((([A-Z-[QVX]][0-9][0-9]?)|(([A-Z-[QVX]][A-Z-[IJZ]][0-9][0-9]?)|(([A-Z-[QVX]][0-9][A-HJKSTUW])|([A-Z-[QVX]][A-Z-[IJZ]][0-9][ABEHMNPRVWXY])))) [0-9][A-Z-[CIKMOV]]{2})$""".r
+  private val PostcodePattern = """^(GIR 0AA)|((([A-Z-[QVX]][0-9][0-9]?)|(([A-Z-[QVX]][A-Z-[IJZ]][0-9][0-9]?)|(([A-Z-[QVX]][0-9][A-HJKSTUW])|([A-Z-[QVX]][A-Z-[IJZ]][0-9][ABEHMNPRVWXY])))) [0-9][A-Z-[CIKMOV]]{2})$""".r
 
   private lazy val isValidUkPostcode = {
-      postcode.isEmpty || PostcodePattern.findFirstIn(postcode.toUpperCase).isDefined
+      postcode.isEmpty || PostcodePattern.findFirstIn(postcode.trim.toUpperCase).isDefined
   }
 }

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -177,7 +177,7 @@ import scala.concurrent.Future
         val address2 = "London"
         val address3 = ""
         val address4 = ""
-        val postcode = "N1 9GU"
+        val postcode = "N1 9GU "
         val country = Countries.UK
         val billingAddress1 = "Buckingham Palace"
         val billingAddress2 = "London"


### PR DESCRIPTION
## What does this change?

Trims postcodes before validating them. 

## Screenshots

N/A

## What is the value of this and can you measure success?

Users who have trailing spaces in their postcodes can update other fields. 

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
