### PR TITLE
Extend switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -30,7 +30,7 @@ trait FeatureSwitches {
     "Used to toggle display of special world cup components/text on world cup overview page",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 8, 14),
+    sellByDate = new LocalDate(2018, 8, 21),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Just extends the switch for a week as it's breaking the build. But I'll remove it separately.