### PR TITLE
Remove world cup switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -24,16 +24,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val WorldCup2018Chrome = Switch(
-    SwitchGroup.Feature,
-    "world-cup-next-match",
-    "Used to toggle display of special world cup components/text on world cup overview page",
-    owners = Seq(Owner.withGithub("nicl")),
-    safeState = On,
-    sellByDate = new LocalDate(2018, 8, 16),
-    exposeClientSide = false
-  )
-
   val FacebookShareImageLogoOverlay = Switch(
     SwitchGroup.Feature,
     "facebook-share-image-logo-overlay",

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -137,16 +137,13 @@ class LeagueTableController(
         s"${table.competition.fullName} table"
       )
 
-      // For world cup group snaps we are not going to link as we just want to show the full table
-      val isWorldCup = table.competition.id == "700"
-
       val heading = group.round.name
         .map(name => s"${table.competition.fullName} - $name")
         .getOrElse(table.competition.fullName)
 
       val groupTable = Table(table.competition, Seq(group), hasGroups = true)
       val htmlResponse = () => football.views.html.tablesList.tablesPage(TablesPage(page, Seq(groupTable), table.competition.url, filters, Some(table.competition)))
-      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, heading, multiGroup = false, linkToCompetition = !isWorldCup)
+      val jsonResponse = () => football.views.html.tablesList.tablesComponent(table.competition, group, heading, multiGroup = false, linkToCompetition = true)
       renderFormat(htmlResponse, jsonResponse, page)
     }
     response.getOrElse {

--- a/sport/app/football/views/wallchart/wallchart.scala.html
+++ b/sport/app/football/views/wallchart/wallchart.scala.html
@@ -6,49 +6,6 @@
 @(competition: Competition, competitionStages: List[CompetitionStageLike], next: Option[pa.FootballMatch])(implicit request: RequestHeader)
 <div class="l-side-margins wc-overview">
 
-    @* Remove once switch expires (temporary addition for world cup 2018 - competition '700'). *@
-    @if(Switches.WorldCup2018Chrome.isSwitchedOn && competition.id == "700") {
-        <div class="facia-container facia-container--layout-content facia-header">
-            <div class="facia-header__inner gs-container">
-                <div class="facia-header__column">
-                    @fragments.inlineSvg("world_cup_badge", "badges", List("world__cup-svg", "world__cup-badge"))
-                    <h1 class="container__title"><span class="container__title__label">World cup 2018 <span class="container__title__label-secondary">Groups, scores and fixtures</span></span></h1>
-                </div>
-
-                @next.map { nextMatch =>
-                <div class="facia-header__column">
-                    <div class="wc-match__date">
-                        <div class="wc-label wc-label__title">Next match</div>
-                        <div class="wc-label">@nextMatch.date.toString("HH:ss EE d MMM z")</div>
-                    </div>
-                </div>
-                <div class="facia-header__column facia-header__column-flags">
-                    <div class="wc-match__badges">
-                        <span class="wc-label wc-badge__flag">
-                            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{nextMatch.homeTeam.id}.png" />
-                        </span>
-                        <span class="wc-label wc-badge__flag">
-                            <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{nextMatch.awayTeam.id}.png" />
-                        </span>
-                    </div>
-                    <div class="wc-match__teams">
-                        <div class="wc-label wc-label__title">@nextMatch.round.name.getOrElse(nextMatch.round.roundNumber)</div>
-                        <div class="wc-label">@pa.TeamCodes.codeFor(nextMatch.homeTeam) vs @pa.TeamCodes.codeFor(nextMatch.awayTeam)</div>
-                    </div>
-                </div>
-                }.getOrElse{
-                <div class="facia-header__column"></div>
-                <div class="facia-header__column"></div>
-                }
-
-                <div class="facia-header__column">
-                    <span class="wc-player-image wc-player-image__offset"><img src="https://uploads.guim.co.uk/2018/05/24/world_cup_cut_out_1.png"></span>
-                    <span class="wc-player-image"><img src="https://uploads.guim.co.uk/2018/05/24/world_cup_cut_out_2.png"></span>
-                </div>
-            </div>
-        </div>
-    }
-
     @competitionStages.map {
         case knockoutStage: _root_.football.model.KnockoutSpider => {
             <div class="facia-container facia-container--layout-content">
@@ -126,16 +83,5 @@
                 </div>
             </div>
         }
-    }
-
-    @if(Switches.WorldCup2018Chrome.isSwitchedOn && competition.id == "700") {
-        <div class="gs-container">
-            <div class="content__main-column content__main-column--article js-content-main-column">
-                <p><em>Thirty-two nations are playing 64 games across 11 different Russian cities over one month and two days to decide the winner of the World Cup – the greatest prize in football and the most prestigious in world sport. The tournament begins in Moscow's Luzhniki Stadium on 14 June and ends in the same place on 15 July.</em></p>
-                <p><em>Most of the best players in the world are taking part – Lionel Messi of Argentina and Cristiano Ronaldo from Portugal have almost certainly their last chance to win the tournament. Mohamed Salah of Egypt and Kylian Mbappé of France are among the stars trying to cement their growing global reputation.</em></p>
-                <p><em>This year's tournament is the 21st in its 88-year history. Only Russia qualified automatically, as the host nation. Germany, winners in 2014, had to go through a two-year qualifying process to return to the World Cup as one of Europe's 14 representatives (including Russia). The tournament also includes three from North America, five from South America, five from Africa, three from Asia, and Australia. The qualification process finished in November 2017.</em></p>
-                <p><em>Conspicuous non-qualifiers for the tournament include four-time winners Italy, three-time finalists Holland and the USA, who failed to make it to the finals for the first time since 1986.</em></p>
-            </div>
-        </div>
     }
 </div>


### PR DESCRIPTION
## What does this change?

Removes some world cup special code and related switch. This code is nice but not worth keeping the special case now that the competition is over.

## Screenshots

(This is one of the changes)

Before:
![screen shot 2018-08-15 at 10 56 09](https://user-images.githubusercontent.com/858402/44143019-00993946-a07a-11e8-901a-6f69701de0e3.png)

After: (yellow banner is gone)
![screen shot 2018-08-15 at 10 55 59](https://user-images.githubusercontent.com/858402/44143017-007f1df4-a07a-11e8-8a82-ae20a124b7ae.png)

