### PR TITLE
New version of prebid with sonobi render parameter passing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#a847a7f",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#a847a7f":
+"prebid.js@https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a":
   version "1.18.0"
-  resolved "https://github.com/guardian/Prebid.js.git#a847a7f17ace3d49e6f392915393fe8338dbf011"
+  resolved "https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This fixes https://trello.com/c/MnzvRWUD by upgrading the Prebid.js version to one that sends the 'render' parameter to Sonobi.