### PR TITLE
Add 0% Fastly IO Test

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -127,7 +127,7 @@ class AllIndexController(
       item.section.map( section =>
         IndexPage(
           page = Section.make(section),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
           Tags(Nil),
           date,
           tzOverride = None
@@ -137,7 +137,7 @@ class AllIndexController(
           val tag = Tag.make(apitag)
           IndexPage(
             page = tag,
-            contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+            contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
             Tags(List(tag)),
             date,
             tzOverride = None

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -165,7 +165,7 @@ class CrosswordSearchController(
               val section = Section.make(ApiSection("crosswords", "Crosswords search results", "http://www.theguardian.com/crosswords/search", "", Nil))
               val page = IndexPage(
                 page = section,
-                contents = results.map(IndexPageItem(_)),
+                contents = results.map(IndexPageItem(_, Some(request))),
                 tags = Tags(Nil),
                 date = DateTime.now,
                 tzOverride = None

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -43,7 +43,7 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
     contentApiClient.getResponse(contentApiClient.item(path, edition)
       .showFields("all")
     ).map { response =>
-      val gallery = response.content.map(Content(_))
+      val gallery = response.content.map(Content(_, Some(request)))
       val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, StoryPackages(g, response), index, isTrail) }
 
       ModelOrResult(model, response)

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -53,7 +53,7 @@ class LatestIndexController(
       item.section.map( section =>
         IndexPage(
           page = Section.make(section),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
           tags = Tags(Nil),
           date = DateTime.now,
           tzOverride = None
@@ -61,7 +61,7 @@ class LatestIndexController(
       ).orElse(item.tag.map( tag =>
         IndexPage(
           page = Tag.make(tag),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
           tags = Tags(Nil),
           date = DateTime.now,
           tzOverride = None

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -41,7 +41,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
     )
 
     val result = response map { response =>
-      val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
+      val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
       val model = mediaOption map { media => MediaPage(media, StoryPackages(media, response)) }
 
       ModelOrResult(model, response)

--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -76,7 +76,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
     responses.map { paginatedResults =>
       val urls = for {
         resp <- paginatedResults
-        item <- resp.results.map(Content.apply)
+        item <- resp.results.map(result => Content(result))
       } yield {
         val keywordTags = item.tags.keywords.map(_.metadata.webTitle)
         val sectionTag = item.content.seriesTag.toList.filter(tag => !keywordTags.contains(tag.properties.sectionName)).map(_.metadata.webTitle)

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -76,7 +76,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
     responses.map { paginatedResults =>
       val urls = for {
         resp <- paginatedResults
-        item <- resp.results.map(Content.apply).collect({ case video:Video => video })
+        item <- resp.results.map(result => Content(result)).collect({ case video:Video => video })
       } yield {
         val keywordTags = item.tags.keywords.map(_.metadata.webTitle)
         val sectionTag = item.content.seriesTag.filter(tag => !keywordTags.contains(tag.properties.sectionName)).map(_.metadata.webTitle)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -79,7 +79,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   private def responseToModelOrResult(response: ItemResponse)(implicit request: RequestHeader): Either[ArticlePage, Result] = {
-    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
 
     ModelOrResult(supportedContent, response) match {
       case Left(article:Article) => Left(ArticlePage(article, StoryPackages(article, response)))

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -149,7 +149,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
 
   private def responseToModelOrResult(range: BlockRange)(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
 
-    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
 
     val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -138,7 +138,7 @@
                     }
 
                     case ImageBlockElement(media, data, showCredit) => {
-                        @EmailImage.bestSrcFor(media).map { imageUrl =>
+                        @EmailImage.bestSrcFor(media, Some(request)).map { imageUrl =>
                             @row(Seq("no-pad")) {
                                 @if(article.isTheMinute && block.url.isDefined) {
                                     <a href="@block.url.getOrElse("#")">
@@ -183,7 +183,7 @@
 
                     case ContentAtomBlockElement(atomId) => {
                         @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
-                            @atom.posterImage.flatMap(EmailVideoImage.bestSrcFor).map { imageUrl =>
+                            @atom.posterImage.flatMap(image => EmailVideoImage.bestSrcFor(image, Some(request))).map { imageUrl =>
                                 @atom.activeAssets.headOption.map { asset =>
                                     @row(Seq("padded")) {
                                         @asset.platform match {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -327,7 +327,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object images {
-    lazy val path = configuration.getMandatoryStringProperty("images.path")
+    lazy val imgixHost = configuration.getMandatoryStringProperty("images.path")
     lazy val fastlyIOHost = configuration.getMandatoryStringProperty("fastly-io.host")
     val fallbackLogo = Static("images/fallback-logo.png")
     object backends {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -63,7 +63,7 @@ object FastlyIOImages extends Experiment(
   name = "fastly-io-images",
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
-  sellByDate = new LocalDate(2018, 8, 25),
+  sellByDate = new LocalDate(2018, 8, 27),
   participationGroup = Perc0A
 )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -63,6 +63,6 @@ object FastlyIOImages extends Experiment(
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
   sellByDate = new LocalDate(2018, 8, 25),
-  participationGroup = Perc2A
+  participationGroup = Perc0A
 )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -63,7 +63,7 @@ object FastlyIOImages extends Experiment(
   name = "fastly-io-images",
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
-  sellByDate = new LocalDate(2018, 8, 27),
+  sellByDate = new LocalDate(2018, 8, 29),
   participationGroup = Perc0A
 )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -49,6 +49,7 @@ object AudioPageChange extends Experiment(
   participationGroup = Perc50
 )
 
+
 object ThrasherAdjacentMPU extends Experiment(
   name = "thrasher-adjacent-mpu",
   description = "This will no longer allow an MPU to show adjacent to a thrasher on mobile",
@@ -56,3 +57,12 @@ object ThrasherAdjacentMPU extends Experiment(
   sellByDate = new LocalDate(2018, 9, 7),
   participationGroup = Perc10A
 )
+
+object FastlyIOImages extends Experiment(
+  name = "fastly-io-images",
+  description = "SServe images from fastly-io",
+  owners = Owner.group(SwitchGroup.ServerSideExperiments),
+  sellByDate = new LocalDate(2018, 8, 25),
+  participationGroup = Perc2A
+)
+

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     OrielParticipation,
     OldTLSSupportDeprecation,
-    ThrasherAdjacentMPU
+    ThrasherAdjacentMPU,
+    FastlyIOImages
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -2,6 +2,7 @@ package model
 
 import com.gu.contentapi.client.model.v1.Asset
 import play.api.libs.json.{Json, Writes}
+import play.api.mvc.RequestHeader
 import views.support.{ImgSrc, Naked, Orientation}
 
 object Helpers {
@@ -32,13 +33,23 @@ object Helpers {
 }
 
 object ImageAsset {
-  def make(asset: Asset, index: Int): ImageAsset = {
+  def make(asset: Asset, index: Int, request: Option[RequestHeader] = None): ImageAsset = {
+
+    // TODO: Remove override parameters and below code after fastly-io test
+    val fields: Map[String, String] = Helpers.assetFieldsToMap(asset)
+    val url = asset.typeData.flatMap(_.secureFile).orElse(asset.file)
+    lazy val path: Option[String] = url.map(ImgSrc(_, Naked, request))
+    val thumbnail: Option[String] = fields.get("thumbnail")
+    val thumbnailPath: Option[String] = thumbnail.map(ImgSrc(_, Naked, request))
+
+
     ImageAsset(
       index = index,
       fields = Helpers.assetFieldsToMap(asset),
       mediaType = asset.`type`.name,
       mimeType = asset.mimeType,
-      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
+      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file),
+      path, thumbnailPath)
   }
   implicit val imageAssetWrites: Writes[ImageAsset] = Json.writes[ImageAsset]
 }
@@ -48,12 +59,14 @@ case class ImageAsset(
   fields: Map[String, String],
   mediaType: String,
   mimeType: Option[String],
-  url: Option[String]) {
+  url: Option[String],
+  overridePath: Option[String] = None,
+  overrideThumbnailPath: Option[String] = None) {
 
-  lazy val path: Option[String] = url.map(ImgSrc(_, Naked))
+  lazy val path: Option[String] = if (overridePath.isDefined) overridePath else url.map(ImgSrc(_, Naked))
 
   val thumbnail: Option[String] = fields.get("thumbnail")
-  val thumbnailPath: Option[String] = thumbnail.map(ImgSrc(_, Naked))
+  val thumbnailPath: Option[String] = if (overrideThumbnailPath.isDefined) overrideThumbnailPath else thumbnail.map(ImgSrc(_, Naked))
 
   val width: Int = fields.get("width").map(_.toInt).getOrElse(1)
   val height: Int = fields.get("height").map(_.toInt).getOrElse(1)

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -5,6 +5,7 @@ import org.joda.time.Duration
 import com.gu.contentapi.client.model.v1.{AssetType, ElementType, Element => ApiElement}
 import org.apache.commons.math3.fraction.Fraction
 import play.api.libs.json.{Json, Writes}
+import play.api.mvc.RequestHeader
 
 object ElementProperties {
   def make(capiElement: ApiElement, index: Int): ElementProperties = {
@@ -28,9 +29,9 @@ final case class ElementProperties (
 )
 
 object Element {
-  def apply(capiElement: ApiElement, elementIndex: Int): Element = {
+  def apply(capiElement: ApiElement, elementIndex: Int, request: Option[RequestHeader] = None): Element = {
     val properties = ElementProperties.make(capiElement, elementIndex)
-    val images = ImageMedia.make(capiElement, properties)
+    val images = ImageMedia.make(capiElement, properties, request)
 
     capiElement.`type` match {
       case ElementType.Image => ImageElement(properties, images)
@@ -48,8 +49,8 @@ sealed trait Element {
 }
 
 object ImageMedia {
-  def make(capiElement: ApiElement, properties: ElementProperties): ImageMedia = ImageMedia(
-    allImages = capiElement.assets.filter(_.`type` == AssetType.Image).map(ImageAsset.make(_,properties.index)).sortBy(-_.width)
+  def make(capiElement: ApiElement, properties: ElementProperties, request: Option[RequestHeader] = None): ImageMedia = ImageMedia(
+    allImages = capiElement.assets.filter(_.`type` == AssetType.Image).map(ImageAsset.make(_,properties.index, request)).sortBy(-_.width)
   )
   def make(crops: Seq[ImageAsset]): ImageMedia = ImageMedia(
     allImages = crops

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -18,9 +18,11 @@ import org.jsoup.safety.Whitelist
 import com.github.nscala_time.time.Imports._
 import play.api.libs.json._
 import views.support._
+
 import scala.collection.JavaConverters._
 import scala.util.Try
 import implicits.Booleans._
+import play.api.mvc.RequestHeader
 
 sealed trait ContentType {
   def content: Content
@@ -64,8 +66,7 @@ final case class Content(
   wordCount: Int,
   showByline: Boolean,
   hasStoryPackage: Boolean,
-  rawOpenGraphImage: Option[ImageAsset]
-) {
+  rawOpenGraphImage: Option[ImageAsset]) {
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
   lazy val isSeries: Boolean = tags.series.nonEmpty
@@ -357,8 +358,8 @@ final case class Content(
 
 object Content {
 
-  def apply(apiContent: contentapi.Content): ContentType = {
-    val content = make(apiContent)
+  def apply(apiContent: contentapi.Content, request: Option[RequestHeader] = None): ContentType = {
+    val content = make(apiContent, request)
 
     apiContent match {
       case _ if apiContent.isLiveBlog || apiContent.isArticle || apiContent.isSudoku => Article.make(content)
@@ -370,13 +371,13 @@ object Content {
     }
   }
 
-  def make(apiContent: contentapi.Content): Content = {
+  def make(apiContent: contentapi.Content, request: Option[RequestHeader] = None): Content = {
     val fields = Fields.make(apiContent)
     val metadata = MetaData.make(fields, apiContent)
-    val elements = Elements.make(apiContent)
+    val elements = Elements.make(apiContent, request)
     val tags = Tags.make(apiContent)
     val commercial = Commercial.make(tags, apiContent)
-    val trail = Trail.make(tags, fields, commercial, elements, metadata, apiContent)
+    val trail = Trail.make(tags, fields, commercial, elements, metadata, apiContent, request)
     val sharelinks = ShareLinks(tags, fields, metadata)
     val atoms = Atoms.make(apiContent, sharelinks.pageShares)
     val apifields = apiContent.fields
@@ -764,14 +765,14 @@ case class GalleryLightboxProperties(
 case class GalleryLightbox(
   elements: Elements,
   tags: Tags,
-  properties: GalleryLightboxProperties
-){
+  properties: GalleryLightboxProperties,
+  request: Option[RequestHeader] = None){
   def imageContainer(index: Int): ImageElement = galleryImages(index)
 
   private val facebookImage: ShareImage = if(tags.isComment) FacebookOpenGraphImage.opinions else if(tags.isLiveBlog) FacebookOpenGraphImage.live else FacebookOpenGraphImage.default
   val galleryImages: Seq[ImageElement] = elements.images.filter(_.properties.isGallery)
   val largestCrops: Seq[ImageAsset] = galleryImages.flatMap(_.images.largestImage)
-  val openGraphImages: Seq[String] = largestCrops.flatMap(_.url).map(ImgSrc(_, facebookImage))
+  val openGraphImages: Seq[String] = largestCrops.flatMap(_.url).map(ImgSrc(_, facebookImage, request))
   val size = galleryImages.size
   val landscapes = largestCrops.filter(i => i.width > i.height).sortBy(_.index)
   val portraits = largestCrops.filter(i => i.width < i.height).sortBy(_.index)
@@ -787,8 +788,8 @@ case class GalleryLightbox(
         "caption" -> JsString(img.caption.getOrElse("")),
         "credit" -> JsString(img.credit.getOrElse("")),
         "displayCredit" -> JsBoolean(img.displayCredit),
-        "src" -> JsString(Item700.bestSrcFor(container.images).getOrElse("")),
-        "srcsets" -> JsString(ImgSrc.srcset(container.images, GalleryMedia.lightbox)),
+        "src" -> JsString(Item700.bestSrcFor(container.images, request).getOrElse("")),
+        "srcsets" -> JsString(ImgSrc.srcset(container.images, GalleryMedia.lightbox, request)),
         "sizes" -> JsString(GalleryMedia.lightbox.sizes),
         "ratio" -> Try(JsNumber(img.width.toDouble / img.height.toDouble)).getOrElse(JsNumber(1)),
         "role" -> JsString(img.role.toString)
@@ -810,7 +811,8 @@ case class GenericLightboxProperties(
   shouldHideAdverts: Boolean,
   standfirst: Option[String],
   lightboxableCutoffWidth: Int,
-  includeBodyImages: Boolean)
+  includeBodyImages: Boolean,
+  request: Option[RequestHeader] = None)
 
 case class GenericLightbox(
   elements: Elements,
@@ -832,6 +834,7 @@ case class GenericLightbox(
       container <- lightboxImages
       img <- container.images.largestEditorialCrop
     } yield {
+
       JsObject(Seq(
         "caption" -> JsString(img.caption.getOrElse("")),
         "credit" -> JsString(img.credit.getOrElse("")),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -556,9 +556,9 @@ object IsRatio {
  * designed to add some structure to the data that comes from CAPI
  */
 object Elements {
-  def make(apiContent: contentapi.Content): Elements = {
+  def make(apiContent: contentapi.Content, request: Option[RequestHeader] = None): Elements = {
     Elements(apiContent.elements
-      .map(_.zipWithIndex.map { case (element, index) => Element(element, index) })
+      .map(_.zipWithIndex.map { case (element, index) => Element(element, index, request) })
       .getOrElse(Nil))
   }
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -50,13 +50,13 @@ object Trail {
     commercial: Commercial,
     elements: Elements,
     metadata: MetaData,
-    apiContent: contentapi.Content): Trail = {
+    apiContent: contentapi.Content, request: Option[RequestHeader] = None): Trail = {
 
     Trail(
       webPublicationDate = apiContent.webPublicationDate.map(_.toJoda).getOrElse(DateTime.now),
       headline = apiContent.fields.flatMap(_.headline).getOrElse(""),
       sectionName = apiContent.sectionName.getOrElse(""),
-      thumbnailPath = apiContent.fields.flatMap(_.thumbnail).map(ImgSrc(_, Naked)),
+      thumbnailPath = apiContent.fields.flatMap(_.thumbnail).map(ImgSrc(_, Naked, request)),
       isCommentable = apiContent.fields.flatMap(_.commentable).exists(b => b),
       isClosedForComments = !apiContent.fields.flatMap(_.commentCloseDate).map(_.toJoda).exists(_.isAfterNow),
       byline = apiContent.fields.flatMap(_.byline).map(stripHtml),

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -179,9 +179,9 @@ object IndexPage {
 
 }
 object IndexPageItem {
-  def apply(content: ApiContent): IndexPageItem = {
+  def apply(content: ApiContent, request: Option[RequestHeader] = None): IndexPageItem = {
     IndexPageItem(
-      Content(content),
+      Content(content, request),
       FaciaContentConvert.contentToFaciaContent(content))
   }
 }

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -21,7 +21,7 @@
     @* This adds 15 src options to the srcset from 500 to the largest image width incrementing by 250px *@
     srcset="@{(500 to largestImage.width by 250)
         .toList
-        .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi))
+        .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi, Some(request)))
         .mkString(", ")}" />
 }
 
@@ -48,10 +48,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true, Some(request))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), request = Some(request))" />
     }
 
     <!--[if IE 9]></video><![endif]-->

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -16,10 +16,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true, Some(request))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, Some(request))" />
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -19,7 +19,7 @@
                 srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true, Some(request))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, Some(request))" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, request = Some(request))" />
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -18,7 +18,7 @@
 @if(!amp) {
     @* http://www.chromium.org/developers/design-documents/dns-prefetching *@
     <link rel="dns-prefetch" href="@Configuration.assets.path" />
-    <link rel="dns-prefetch" href="@Configuration.images.path" />
+    <link rel="dns-prefetch" href="@Configuration.images.imgixHost" />
     <link rel="dns-prefetch" href="@Configuration.ajax.url" />
     <link rel="dns-prefetch" href="@AnalyticsHost()" />
     <link rel="dns-prefetch" href="//j.ophan.co.uk" />

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -12,7 +12,7 @@ object EmailHelpers {
     def imageUrl(displayElement: Option[FaciaDisplayElement]): Option[String] = displayElement.flatMap {
       case InlineImage(imageMedia) => SmallFrontEmailImage(width).bestSrcFor(imageMedia)
       case InlineVideo(video, _, _, maybeFallbackImage) => EmailVideoImage.bestSrcFor(video.images).orElse(imageUrl(maybeFallbackImage))
-      case InlineYouTubeMediaAtom(atom, posterOverride) => posterOverride.orElse(atom.posterImage).flatMap(EmailVideoImage.bestSrcFor)
+      case InlineYouTubeMediaAtom(atom, posterOverride) => posterOverride.orElse(atom.posterImage).flatMap(image => EmailVideoImage.bestSrcFor(image))
       case _ => None
     }
     imageUrl(contentCard.displayElement)

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -12,6 +12,7 @@ import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import common.Environment.{app, awsRegion, stage}
 import experiments.{ActiveExperiments, FastlyIOImages}
+import play.api.mvc.RequestHeader
 
 import Function.const
 
@@ -24,8 +25,8 @@ sealed trait ElementProfile {
   def isPng: Boolean
   def autoFormat: Boolean
 
-  private def toSrc(maybeAsset: Option[ImageAsset]): Option[String] =
-    maybeAsset.flatMap(_.url).map(ImgSrc(_, this))
+  private def toSrc(maybeAsset: Option[ImageAsset], requestHeader: Option[RequestHeader] = None): Option[String] =
+    maybeAsset.flatMap(_.url).map(ImgSrc(_, this, requestHeader))
 
   def bestFor(image: ImageMedia): Option[ImageAsset] = {
     if(!ImageServerSwitch.isSwitchedOn) {
@@ -36,7 +37,7 @@ sealed trait ElementProfile {
     }
     else image.largestImage
   }
-  def bestSrcFor(image: ImageMedia): Option[String] = toSrc(bestFor(image))
+  def bestSrcFor(image: ImageMedia, request: Option[RequestHeader] = None): Option[String] = toSrc(bestFor(image), request)
 
   def captionFor(image: ImageMedia): Option[String] =
     bestFor(image).flatMap(_.caption)
@@ -232,8 +233,8 @@ object Naked extends Profile(None, None)
 
 object ImgSrc extends Logging with implicits.Strings {
 
-  def getImageServiceHost: String = {
-    if (stage != "PROD" || ActiveExperiments.isParticipating(FastlyIOImages)) {
+  def getImageServiceHost(request: Option[RequestHeader]): String = {
+    if (request.exists(r => ActiveExperiments.isParticipating(FastlyIOImages)(r))) {
       Configuration.images.fastlyIOHost
     } else {
       Configuration.images.imgixHost
@@ -255,7 +256,8 @@ object ImgSrc extends Logging with implicits.Strings {
 
   def apply(
     url: String,
-    imageType: ElementProfile
+    imageType: ElementProfile,
+    request: Option[RequestHeader] = None
   ): String = {
     try {
       val uri = new URI(url.trim.encodeURI)
@@ -266,7 +268,7 @@ object ImgSrc extends Logging with implicits.Strings {
         .filter(const(isSupportedImage))
         .map { host =>
           val signedPath = ImageUrlSigner.sign(s"${uri.getRawPath}${imageType.resizeString}", host.token)
-          s"$getImageServiceHost/img/${host.prefix}$signedPath"
+          s"${getImageServiceHost(request)}/img/${host.prefix}$signedPath"
         }.getOrElse(url)
     } catch {
       case error: URISyntaxException =>
@@ -275,8 +277,8 @@ object ImgSrc extends Logging with implicits.Strings {
     }
   }
 
-  def srcset(imageContainer: ImageMedia, widths: WidthsByBreakpoint): String = {
-    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer, hidpi = false) } mkString ", "
+  def srcset(imageContainer: ImageMedia, widths: WidthsByBreakpoint, request: Option[RequestHeader] = None): String = {
+    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer, hidpi = false, request) } mkString ", "
   }
 
   def srcsetForBreakpoint(
@@ -284,15 +286,16 @@ object ImgSrc extends Logging with implicits.Strings {
     breakpointWidths: Seq[BreakpointWidth],
     maybePath: Option[String] = None,
     maybeImageMedia: Option[ImageMedia] = None,
-    hidpi: Boolean = false
+    hidpi: Boolean = false,
+    request: Option[RequestHeader] = None
   ): String = {
     val isPng = maybePath.exists(path => path.toLowerCase.endsWith("png"))
     breakpointWidth.toPixels(breakpointWidths)
       .map(browserWidth => Profile(width = Some(browserWidth), hidpi = hidpi, isPng = isPng))
       .map { profile => {
         maybePath
-          .map(url => srcsetForProfile(profile, url, hidpi))
-          .orElse(maybeImageMedia.map(imageContainer => srcsetForProfile(profile, imageContainer, hidpi)))
+          .map(url => srcsetForProfile(profile, url, hidpi, request))
+          .orElse(maybeImageMedia.map(imageContainer => srcsetForProfile(profile, imageContainer, hidpi, request)))
           .getOrElse("")
       } }
       .mkString(", ")
@@ -301,12 +304,13 @@ object ImgSrc extends Logging with implicits.Strings {
   def srcsetForProfile(
     profile: Profile,
     imageContainer: ImageMedia,
-    hidpi: Boolean
+    hidpi: Boolean,
+    request: Option[RequestHeader] = None
   ): String =
-    s"${profile.bestSrcFor(imageContainer).get} ${profile.width.get * (if (hidpi) 2 else 1)}w"
+    s"${profile.bestSrcFor(imageContainer, request).get} ${profile.width.get * (if (hidpi) 2 else 1)}w"
 
-  def srcsetForProfile(profile: Profile, path: String, hidpi: Boolean): String =
-    s"${ImgSrc(path, profile)} ${profile.width.get * (if (hidpi) 2 else 1)}w"
+  def srcsetForProfile(profile: Profile, path: String, hidpi: Boolean, request: Option[RequestHeader]): String =
+    s"${ImgSrc(path, profile, request)} ${profile.width.get * (if (hidpi) 2 else 1)}w"
 
   def getFallbackUrl(ImageElement: ImageMedia): Option[String] =
     Item300.bestSrcFor(ImageElement)

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -76,7 +76,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
         element.getElementsByTag("source").remove()
 
         // add the poster url
-        video.map(_.images).flatMap(Item640.bestSrcFor).foreach(element.attr("poster", _))
+        video.map(_.images).flatMap(image => Item640.bestSrcFor(image)).foreach(element.attr("poster", _))
 
         video.foreach { videoElement =>
           videoElement.videos.encodings.map { encoding => {

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -15,7 +15,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  lazy val imageHost = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
+  lazy val imageHost = if (stage == "PROD") Configuration.images.imgixHost else Configuration.images.fastlyIOHost
 
   val asset = Asset(
     AssetType.Image,

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -15,7 +15,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  lazy val imageHost = if (stage == "PROD") Configuration.images.imgixHost else Configuration.images.fastlyIOHost
+  lazy val imageHost = Configuration.images.imgixHost
 
   val asset = Asset(
     AssetType.Image,

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -55,7 +55,7 @@ class TaggedContentController(
       .tag(tag)
       .pageSize(3)
     ).map { response =>
-        response.results.toList map { Content(_) }
+        response.results.toList map { Content(_, Some(request)) }
     } recover { case ContentApiError(404, message, _) =>
       log.info(s"Got a 404 while calling content api: $message")
       Nil


### PR DESCRIPTION
## What does this change?
Adds a 0% test for serving images from fastly. Also makes the imgix/fastly config naming more specific. 

## What is the value of this and can you measure success?
This will allow us to locally test fastly io images on theguardian.com. Once we're satisfied we can bump this up to a bigger sample group size.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
