### PR TITLE
Added safeguard for reading of Prebid Xaxis buyer ID

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -111,7 +111,9 @@ class PrebidService {
                     {
                         key: 'hb_buyer_id',
                         val(bidResponse) {
-                            return bidResponse.appnexus.buyerMemberId;
+                            return bidResponse.appnexus
+                                ? bidResponse.appnexus.buyerMemberId
+                                : '';
                         },
                     },
                 ],


### PR DESCRIPTION
To avoid an exception when it's not there.
This fixes a bug introduced in #20184 
