### PR TITLE
Sonobi Prebid adapter has iframe-based user syncing

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -28,6 +28,16 @@ const consentManagement = {
     allowAuctionWithoutConsent: true,
 };
 
+const userSync = {
+    syncsPerBidder: 0, // allow all syncs
+    filterSettings: {
+        iframe: {
+            bidders: ['sonobi'],
+            filter: 'include',
+        },
+    },
+};
+
 const s2sConfig = {
     accountId: '1',
     enabled: true,
@@ -75,6 +85,7 @@ class PrebidService {
             {
                 bidderTimeout,
                 priceGranularity,
+                userSync,
             },
             config.get('switches.enableConsentManagementService', false)
                 ? { consentManagement }

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -115,7 +115,13 @@ describe('initialise', () => {
                 pixelEnabled: true,
                 syncDelay: 3000,
                 syncEnabled: true,
-                syncsPerBidder: 5,
+                syncsPerBidder: 0,
+                filterSettings: {
+                    iframe: {
+                        bidders: ['sonobi'],
+                        filter: 'include',
+                    },
+                },
             },
         });
     });


### PR DESCRIPTION
The Sonobi Prebid adapter requires iframe-based user syncing to be enabled to match users.

I've just followed the Prebid [config documentation](http://prebid.org/dev-docs/publisher-api-reference.html#setConfig-ConfigureUserSyncing-UserSyncProperties) to achieve this.
