### PR TITLE
Ad Manager raw cpm

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -174,15 +174,22 @@ class PrebidService {
                                 auctionInitHandler
                             );
 
-                            const onAuctionEndHandler = ({auctionId}) => {
-                                const getHighestCpm = (bids): number => bids && bids.map(_ => _.cpm).sort().pop() || 0;
-                                const bidResponses = window.pbjs.getBidResponses()[advert.id];
-                                const cpm: number = getHighestCpm(bidResponses && bidResponses.bids || []);
+                            const onAuctionEndHandler = () => {
+                                const getHighestCpm = (auctionBids): number =>
+                                    (auctionBids &&
+                                        auctionBids
+                                            .map(_ => _.cpm)
+                                            .sort()
+                                            .pop()) ||
+                                    0;
+                                const bidResponses = window.pbjs.getBidResponses()[
+                                    advert.id
+                                ];
+                                const cpm: number = getHighestCpm(
+                                    (bidResponses && bidResponses.bids) || []
+                                );
                                 if (cpm > 0) {
-                                    advert.slot.setTargeting(
-                                        'hb_cpm',
-                                        cpm
-                                    );
+                                    advert.slot.setTargeting('hb_cpm', cpm);
                                 }
                                 window.pbjs.offEvent(
                                     'auctionEnd',

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -174,6 +174,27 @@ class PrebidService {
                                 auctionInitHandler
                             );
 
+                            const onAuctionEndHandler = ({auctionId}) => {
+                                const getHighestCpm = (bids): number => bids && bids.map(_ => _.cpm).sort().pop() || 0;
+                                const bidResponses = window.pbjs.getBidResponses()[advert.id];
+                                const cpm: number = getHighestCpm(bidResponses && bidResponses.bids || []);
+                                if (cpm > 0) {
+                                    advert.slot.setTargeting(
+                                        'hb_cpm',
+                                        cpm
+                                    );
+                                }
+                                window.pbjs.offEvent(
+                                    'auctionEnd',
+                                    onAuctionEndHandler
+                                );
+                            };
+
+                            window.pbjs.onEvent(
+                                'auctionEnd',
+                                onAuctionEndHandler
+                            );
+
                             window.pbjs.requestBids({
                                 adUnits,
                                 bidsBackHandler() {


### PR DESCRIPTION
## What does this change?

This changes prebid so that it submits a new field for a slots custom targeting; `hb_cpm`, which is the highest bid CPM of the auction.

## What is the value of this and can you measure success?

Currently, we only know what auctions close at via the buckets in Ad Manager; however, we don't know the original CPMs that were submitted for each auction. This will allow us to see how efficient how buckets are performing and allow us to calculate how much money we are losing from the rounding that happens.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/commercial-dev 
