### PR TITLE
Track display of the set pwd module

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -40,7 +40,9 @@ trait ConsentsJourney
 
   def guestPasswordSet(): Action[AnyContent] = csrfCheck {
 
-    val returnUrlWithTracking = s"${returnUrlVerifier.defaultReturnUrl}?INTCMP=uppsala-signin-upsell"
+    val returnUrlWithTracking  = idUrlBuilder.appendQueryParams(
+      returnUrlVerifier.defaultReturnUrl, List("INTCMP" -> "uppsala-signin-upsell")
+    )
 
     Action.async { implicit request =>
       val form = GuestPasswordForm.form().bindFromRequest()

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -39,6 +39,9 @@ trait ConsentsJourney
   def signinService: PlaySigninService
 
   def guestPasswordSet(): Action[AnyContent] = csrfCheck {
+
+    val returnUrlWithTracking = s"${returnUrlVerifier.defaultReturnUrl}?INTCMP=uppsala-signin-upsell"
+
     Action.async { implicit request =>
       val form = GuestPasswordForm.form().bindFromRequest()
       form.fold(errorForm => {
@@ -47,7 +50,7 @@ trait ConsentsJourney
         val authResponse = identityApiClient.setPasswordGuest(completedForm.password, completedForm.token)
         signinService.getCookies(authResponse, rememberMe = false).flatMap {
           case Right(cookies) =>
-            Future.successful(NoCache(SeeOther(returnUrlVerifier.defaultReturnUrl).withCookies(cookies: _*).discardingCookies(DiscardingCookie("SC_GU_GUEST_PW_SET"))))
+            Future.successful(NoCache(SeeOther(returnUrlWithTracking).withCookies(cookies: _*).discardingCookies(DiscardingCookie("SC_GU_GUEST_PW_SET"))))
           case _ =>
             displayConsentComplete(Some(form.withError("error", "An unexpected error occurred, please try again later.")))(request)
         }

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -41,7 +41,7 @@ trait ConsentsJourney
   def guestPasswordSet(): Action[AnyContent] = csrfCheck {
 
     val returnUrlWithTracking  = idUrlBuilder.appendQueryParams(
-      returnUrlVerifier.defaultReturnUrl, List("INTCMP" -> "uppsala-signin-upsell")
+      returnUrlVerifier.defaultReturnUrl, List("INTCMP" -> "upsell-account-creation")
     )
 
     Action.async { implicit request =>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -50,7 +50,7 @@
         }
 
         @if(request.cookies.get("SC_GU_GUEST_PW_SET").isDefined) {
-            <form class="form js-identity-uppsala-account-upsell" novalidate action="/password/guest" role="form" method="post">
+            <form class="form js-identity-upsell-account-creation" novalidate action="/password/guest" role="form" method="post">
                 <fieldset class="fieldset">
                     @views.html.helper.CSRF.formField
                     <div>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -50,7 +50,7 @@
         }
 
         @if(request.cookies.get("SC_GU_GUEST_PW_SET").isDefined) {
-            <form class="form js-register-form" novalidate action="/password/guest" role="form" method="post">
+            <form class="form js-identity-uppsala-account-upsell" novalidate action="/password/guest" role="form" method="post">
                 <fieldset class="fieldset">
                     @views.html.helper.CSRF.formField
                     <div>

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -17,7 +17,7 @@ import { initUserAvatars } from 'common/modules/discussion/user-avatars';
 import { initUserEditLink } from 'common/modules/discussion/user-edit-link';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { enhanceAdPrefs } from 'common/modules/identity/ad-prefs';
-import { enhanceAccountUpsell } from 'common/modules/identity/uppsala/account-upsell';
+import { enhanceAccountCreation } from 'common/modules/identity/upsell/account-creation';
 
 const initFormstack = (): void => {
     const attr = 'data-formstack-id';
@@ -65,7 +65,7 @@ const initProfile = (): void => {
         ['enhance-form-ajax', enhanceFormAjax],
         ['enhance-consent-journey', enhanceConsentJourney],
         ['init-header', initHeader],
-        ['init-account-upsell', enhanceAccountUpsell],
+        ['init-upsell-account-creation', enhanceAccountCreation],
     ];
     catchErrorsWithContext(modules);
 };

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -17,6 +17,7 @@ import { initUserAvatars } from 'common/modules/discussion/user-avatars';
 import { initUserEditLink } from 'common/modules/discussion/user-edit-link';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { enhanceAdPrefs } from 'common/modules/identity/ad-prefs';
+import { enhanceAccountUpsell } from 'common/modules/identity/uppsala/account-upsell';
 
 const initFormstack = (): void => {
     const attr = 'data-formstack-id';
@@ -64,6 +65,7 @@ const initProfile = (): void => {
         ['enhance-form-ajax', enhanceFormAjax],
         ['enhance-consent-journey', enhanceConsentJourney],
         ['init-header', initHeader],
+        ['init-account-upsell', enhanceAccountUpsell],
     ];
     catchErrorsWithContext(modules);
 };

--- a/static/src/javascripts/projects/common/modules/identity/uppsala/account-upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/uppsala/account-upsell.js
@@ -1,0 +1,22 @@
+// @flow
+import { trackNonClickInteraction } from 'common/modules/analytics/google';
+import ophan from 'ophan/ng';
+import loadEnhancers from './../modules/loadEnhancers';
+
+const trackInteraction = (interaction: string): void => {
+    ophan.record({
+        component: 'set-password',
+        value: interaction,
+    });
+    trackNonClickInteraction(interaction);
+};
+
+const bindAccountUpsell = (): void => {
+    trackInteraction('set-password : display');
+};
+
+const enhanceAccountUpsell = (): void => {
+    loadEnhancers([['.js-identity-uppsala-account-upsell', bindAccountUpsell]]);
+};
+
+export { enhanceAccountUpsell };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation.js
@@ -11,12 +11,14 @@ const trackInteraction = (interaction: string): void => {
     trackNonClickInteraction(interaction);
 };
 
-const bindAccountUpsell = (): void => {
+const bindAccountCreation = (): void => {
     trackInteraction('set-password : display');
 };
 
-const enhanceAccountUpsell = (): void => {
-    loadEnhancers([['.js-identity-uppsala-account-upsell', bindAccountUpsell]]);
+const enhanceAccountCreation = (): void => {
+    loadEnhancers([
+        ['.js-identity-upsell-account-creation', bindAccountCreation],
+    ]);
 };
 
-export { enhanceAccountUpsell };
+export { enhanceAccountCreation };


### PR DESCRIPTION
## What does this change?
Update to #20170 to

- Track displays of the "set password" module, to better establish its CVR when it's displayed in the page
- Add an INTCMP label to the returnUrl to better track users setting passwords (vs click events)