### PR TITLE
Epic iframe test update

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -138,7 +138,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-epic-iframe-test",
+    "ab-acquisitions-epic-iframe-test-v2",
     "Test displaying the Epic inside an iframe (with no Google javascript running)",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
@@ -55,10 +55,10 @@ const createEpicIframe = (url: string): Error | IframeEpicComponent => {
         componentEvent: {
             component: {
                 componentType: 'ACQUISITIONS_EPIC',
-                id: 'iframe_control_epic',
+                id: 'iframe_control_epic_v2',
             },
             abTest: {
-                name: 'iframe_or_not',
+                name: 'iframe_or_not_v2',
                 variant: 'iframe',
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -17,7 +17,7 @@ import { acquisitionsEpicFromGoogleDocTwoVariants } from 'common/modules/experim
 import { acquisitionsEpicFromGoogleDocThreeVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-three-variants';
 import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-four-variants';
 import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
-import { acquisitionsEpicIframeTest } from 'common/modules/experiments/tests/acquisitions-iframe-epic';
+import { acquisitionsEpicIframeTestV2 } from 'common/modules/experiments/tests/acquisitions-iframe-epic-v2';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options) return false;
@@ -46,7 +46,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    acquisitionsEpicIframeTest,
+    acquisitionsEpicIframeTestV2,
     acquisitionsEpicFromGoogleDocOneVariant,
     acquisitionsEpicFromGoogleDocTwoVariants,
     acquisitionsEpicFromGoogleDocThreeVariants,

--- a/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
@@ -14,11 +14,14 @@ export const isExpired = (testExpiry: string): boolean => {
 export const testCanBeRun = (test: ABTest): boolean => {
     const expired = isExpired(test.expiry);
     const isSensitive = config.page.isSensitive;
+    const shouldShowForSensitive = !!test.showForSensitive;
+    const isTestOn = isTestSwitchedOn(test);
+    const canTestBeRun = (!test.canRun || test.canRun());
 
     return (
-        (isSensitive ? !!test.showForSensitive : true) &&
-        isTestSwitchedOn(test) &&
+        (isSensitive ? shouldShowForSensitive : true) &&
+        isTestOn &&
         !expired &&
-        (!test.canRun || test.canRun())
+        canTestBeRun
     );
 };

--- a/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
@@ -16,7 +16,7 @@ export const testCanBeRun = (test: ABTest): boolean => {
     const isSensitive = config.page.isSensitive;
     const shouldShowForSensitive = !!test.showForSensitive;
     const isTestOn = isTestSwitchedOn(test);
-    const canTestBeRun = (!test.canRun || test.canRun());
+    const canTestBeRun = !test.canRun || test.canRun();
 
     return (
         (isSensitive ? shouldShowForSensitive : true) &&

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic-v2.js
@@ -48,7 +48,7 @@ const epicIframeTestV2: ABTest = {
             },
             test: () => {
                 displayIframeEpic(
-                    'https://support.theguardian.com/epic/iframe-or-not-test/index.html'
+                    'https://support.theguardian.com/epic/iframe-or-not-test-v2/index.html'
                 ).then(trackEpic);
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic-v2.js
@@ -10,9 +10,9 @@ import {
 } from 'common/modules/commercial/epic/epic-utils';
 import { displayIframeEpic } from 'common/modules/commercial/epic/iframe-epic-utils';
 
-const epicIframeTest: ABTest = {
-    id: 'AcquisitionsEpicIframeTest',
-    campaignId: 'epic_iframe_test',
+const epicIframeTestV2: ABTest = {
+    id: 'AcquisitionsEpicIframeTestV2',
+    campaignId: 'epic_iframe_test_v2',
     start: '2018-07-31',
     expiry: '2019-07-31',
     author: 'Joseph Smith',
@@ -36,7 +36,7 @@ const epicIframeTest: ABTest = {
                 displayControlEpicInAbTest({
                     // Name corresponds to test name hard coded in the tracking link in the epic:
                     // https://support.theguardian.com/epic/iframe-or-not-test/index.html
-                    name: 'iframe_or_not',
+                    name: 'iframe_or_not_v2',
                     variant: 'not_iframe',
                 }).then(trackEpic);
             },
@@ -55,6 +55,6 @@ const epicIframeTest: ABTest = {
     ],
 };
 
-const acquisitionsEpicIframeTest: AcquisitionsABTest = (epicIframeTest: any);
+const acquisitionsEpicIframeTestV2: AcquisitionsABTest = (epicIframeTestV2: any);
 
-export { acquisitionsEpicIframeTest };
+export { acquisitionsEpicIframeTestV2 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-iframe-epic.js
@@ -25,6 +25,7 @@ const epicIframeTest: ABTest = {
     audience: 0.3,
     audienceOffset: 0,
     canRun: isEpicDisplayable,
+    showForSensitive: true,
     variants: [
         {
             id: 'not_iframe',


### PR DESCRIPTION
## What does this change?

- bumps the version of this test - see [#13](https://github.com/guardian/reader-revenue-components/pull/13) in reader-revenue-components for context

- adds `showForSensitive: true` to the Epic test; required to run the test on sensitive articles since we're still in the half-way house between the testing framework in contribution utilities and the new (utility function based) approach. If we don't want to show the Epic on an article, the process now is to set the hide reader revenue flag to true in composer.

- I've also taken the time to create intermediate variables in the `testCanBeRun()` function; which makes debugging why a test can't be shown easier.


### Tested

Locally
