### PR TITLE
(behind switch) Groundwork for "follow" consent boxes

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -25,4 +25,14 @@ trait IdentitySwitches {
     exposeClientSide = true
   )
 
+  val IdentityUseFollowSwitches = Switch(
+    SwitchGroup.Identity,
+    "id-use-follow-switches",
+    "If switched on, some consent boxes will become follow boxes.",
+    owners = Owner.group(SwitchGroup.Identity),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 10, 24),
+    exposeClientSide = false
+  )
+
 }

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -26,16 +26,16 @@
     }
 }
 
-@fragments.form.follow(
-    title = titleProvider(getConsentText(consentField)),
-    subheading = None,
-    description = descriptionProvider(getConsentText(consentField)),
-    behaviour = ConsentSwitch,
-    field = consentField("consented"),
-    extraFields = consentHiddenFormFields,
-)(nonInputFields, messages)
-
-<!--
+@if(conf.switches.Switches.IdentityUseFollowSwitches.isSwitchedOn) {
+    @fragments.form.follow(
+        title = titleProvider(getConsentText(consentField)),
+        subheading = None,
+        description = descriptionProvider(getConsentText(consentField)),
+        behaviour = ConsentSwitch,
+        field = consentField("consented"),
+        extraFields = consentHiddenFormFields,
+    )(nonInputFields, messages)
+} else {
     @fragments.form.switch(
         title = titleProvider(getConsentText(consentField)),
         subheading = None,
@@ -47,4 +47,4 @@
         skin = skin,
         boldTitle = boldTitle
     )(nonInputFields, messages)
--->
+}

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -29,7 +29,6 @@
 @if(conf.switches.Switches.IdentityUseFollowSwitches.isSwitchedOn) {
     @fragments.form.follow(
         title = titleProvider(getConsentText(consentField)),
-        subheading = None,
         description = descriptionProvider(getConsentText(consentField)),
         behaviour = ConsentSwitch,
         field = consentField("consented"),

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -26,14 +26,25 @@
     }
 }
 
-@fragments.form.switch(
+@fragments.form.follow(
     title = titleProvider(getConsentText(consentField)),
     subheading = None,
     description = descriptionProvider(getConsentText(consentField)),
     behaviour = ConsentSwitch,
     field = consentField("consented"),
     extraFields = consentHiddenFormFields,
-    highlighted = highlighted,
-    skin = skin,
-    boldTitle = boldTitle
 )(nonInputFields, messages)
+
+<!--
+    @fragments.form.switch(
+        title = titleProvider(getConsentText(consentField)),
+        subheading = None,
+        description = descriptionProvider(getConsentText(consentField)),
+        behaviour = ConsentSwitch,
+        field = consentField("consented"),
+        extraFields = consentHiddenFormFields,
+        highlighted = highlighted,
+        skin = skin,
+        boldTitle = boldTitle
+    )(nonInputFields, messages)
+-->

--- a/identity/app/views/fragments/form/follow.scala.html
+++ b/identity/app/views/fragments/form/follow.scala.html
@@ -18,7 +18,7 @@
     )
 }
 
-<label class="@views.support.RenderClasses(classes)">
+<div class="@views.support.RenderClasses(classes)">
     <div class="identity-follow__content">
         <p class="identity-follow__copy">
             @title
@@ -27,7 +27,7 @@
             }
         </p>
         @if(description) {
-            <p class="identity-follow__extra">
+            <p class="identity-follow__copy identity-follow__copy--extra">
                 @description.map(Html(_))
             </p>
         }
@@ -35,4 +35,4 @@
         @extraFields
     </div>
     <div class="identity-follow__button-target"></div>
-</label>
+</div>

--- a/identity/app/views/fragments/form/follow.scala.html
+++ b/identity/app/views/fragments/form/follow.scala.html
@@ -10,7 +10,7 @@
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
-<div class="identity-follow" data-behaviour="@switchJsBehaviour(behaviour)">
+<div class="identity-follow" data-behaviour="@switchBehaviour(behaviour)">
     <div class="identity-follow__content">
         <p class="identity-follow__heading">
             @title

--- a/identity/app/views/fragments/form/follow.scala.html
+++ b/identity/app/views/fragments/form/follow.scala.html
@@ -1,0 +1,38 @@
+@import _root_.form.IdFormHelpers.Checkbox
+@import views.support.fragment.Switch._
+
+@(
+    title: String,
+    subheading: Option[String],
+    description: Option[String],
+    behaviour: SwitchBehaviour,
+    field: Field,
+    extraFields: List[Html] = Nil,
+)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
+
+
+@classes = @{
+    Map(
+        ("identity-follow", true),
+        (switchJsBehaviour(behaviour), false)
+    )
+}
+
+<label class="@views.support.RenderClasses(classes)">
+    <div class="identity-follow__content">
+        <p class="identity-follow__copy">
+            @title
+            @if(subheading) {
+                <em>@subheading</em>
+            }
+        </p>
+        @if(description) {
+            <p class="identity-follow__extra">
+                @description.map(Html(_))
+            </p>
+        }
+
+        @extraFields
+    </div>
+    <div class="identity-follow__button-target"></div>
+</label>

--- a/identity/app/views/fragments/form/follow.scala.html
+++ b/identity/app/views/fragments/form/follow.scala.html
@@ -3,7 +3,6 @@
 
 @(
     title: String,
-    subheading: Option[String],
     description: Option[String],
     behaviour: SwitchBehaviour,
     field: Field,
@@ -11,23 +10,13 @@
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
-@classes = @{
-    Map(
-        ("identity-follow", true),
-        (switchJsBehaviour(behaviour), false)
-    )
-}
-
-<div class="@views.support.RenderClasses(classes)">
+<div class="identity-follow" data-behaviour="@switchJsBehaviour(behaviour)">
     <div class="identity-follow__content">
-        <p class="identity-follow__copy">
+        <p class="identity-follow__heading">
             @title
-            @if(subheading) {
-                <em>@subheading</em>
-            }
         </p>
         @if(description) {
-            <p class="identity-follow__copy identity-follow__copy--extra">
+            <p class="identity-follow__copy">
                 @description.map(Html(_))
             </p>
         }

--- a/identity/app/views/support/fragment/Switch.scala
+++ b/identity/app/views/support/fragment/Switch.scala
@@ -16,5 +16,13 @@ object Switch {
     }
   }
 
+  def switchBehaviour(behaviour: SwitchBehaviour): String = {
+    behaviour match {
+      case ConsentSwitch => "consent"
+      case NewsletterSwitch => "newsletter"
+      case _ => ""
+    }
+  }
+
 }
 

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -18,6 +18,7 @@ import { initUserEditLink } from 'common/modules/discussion/user-edit-link';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { enhanceAdPrefs } from 'common/modules/identity/ad-prefs';
 import { enhanceAccountCreation } from 'common/modules/identity/upsell/account-creation';
+import { enhanceFollow } from 'common/modules/identity/follow';
 
 const initFormstack = (): void => {
     const attr = 'data-formstack-id';
@@ -66,6 +67,7 @@ const initProfile = (): void => {
         ['enhance-consent-journey', enhanceConsentJourney],
         ['init-header', initHeader],
         ['init-upsell-account-creation', enhanceAccountCreation],
+        ['init-follow', enhanceFollow],
     ];
     catchErrorsWithContext(modules);
 };

--- a/static/src/javascripts/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow.js
@@ -1,21 +1,23 @@
 // @flow
-import loadEnhancers from './modules/loadEnhancers';
+import React, { render } from 'preact-compat';
 import fastdom from 'lib/fastdom-promise';
-import {FollowButtonWrap} from "./follow/FollowButtonWrap";
-import React, { Component, render } from 'preact-compat';
-
+import { FollowButtonWrap } from './follow/FollowButtonWrap';
+import loadEnhancers from './modules/loadEnhancers';
 
 const bindFollow = (el): void => {
-
     fastdom
         .read(() => el.querySelector('.identity-follow__button-target'))
         .then((wrapperEl: HTMLElement) => {
             fastdom.write(() => {
                 render(
                     <FollowButtonWrap
-                        initiallyFollowing={true}
-                        onFollow={()=>{console.log('following')}}
-                        onUnfollow={()=>{console.log('not following')}}
+                        initiallyFollowing
+                        onFollow={() => {
+                            console.log('following');
+                        }}
+                        onUnfollow={() => {
+                            console.log('not following');
+                        }}
                     />,
                     wrapperEl
                 );
@@ -24,9 +26,7 @@ const bindFollow = (el): void => {
 };
 
 const enhanceFollow = (): void => {
-    loadEnhancers([
-        ['.identity-follow', bindFollow],
-    ]);
+    loadEnhancers([['.identity-follow', bindFollow]]);
 };
 
 export { enhanceFollow };

--- a/static/src/javascripts/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow.js
@@ -1,0 +1,32 @@
+// @flow
+import loadEnhancers from './modules/loadEnhancers';
+import fastdom from 'lib/fastdom-promise';
+import {FollowButtonWrap} from "./follow/FollowButtonWrap";
+import React, { Component, render } from 'preact-compat';
+
+
+const bindFollow = (el): void => {
+
+    fastdom
+        .read(() => el.querySelector('.identity-follow__button-target'))
+        .then((wrapperEl: HTMLElement) => {
+            fastdom.write(() => {
+                render(
+                    <FollowButtonWrap
+                        initiallyFollowing={true}
+                        onFollow={()=>{console.log('following')}}
+                        onUnfollow={()=>{console.log('not following')}}
+                    />,
+                    wrapperEl
+                );
+            });
+        });
+};
+
+const enhanceFollow = (): void => {
+    loadEnhancers([
+        ['.identity-follow', bindFollow],
+    ]);
+};
+
+export { enhanceFollow };

--- a/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'preact-compat';
+
+type FollowButtonWrapProps = {
+    initiallyFollowing: boolean,
+    onFollow: () => void,
+    onUnfollow: () => void,
+};
+
+class FollowButtonWrap extends Component<FollowButtonWrapProps, {
+    following: boolean
+}> {
+
+    constructor(props: FollowButtonWrapProps): void {
+        super(props);
+        this.state = {
+            following: props.initiallyFollowing,
+        };
+    }
+
+    updateFollowing = (to: boolean) => {
+        this.setState({following: to});
+        if(to){
+            this.props.onFollow();
+        }
+        else {
+            this.props.onUnfollow();
+        }
+    };
+
+    render() {
+        if (this.state.following === true) {
+            return (
+                <button type="button" onClick={(ev)=>{this.updateFollowing(false)}}>
+                    Following – click to unfollow
+                </button>
+            )
+        }
+        else {
+            return (
+                <button type="button" onClick={(ev)=>{this.updateFollowing(true)}}>
+                    Follow
+                </button>
+            );
+        }
+    }
+}
+
+export { FollowButtonWrap };

--- a/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
@@ -1,3 +1,4 @@
+// @flow
 import React, { Component } from 'preact-compat';
 
 type FollowButtonWrapProps = {
@@ -6,10 +7,12 @@ type FollowButtonWrapProps = {
     onUnfollow: () => void,
 };
 
-class FollowButtonWrap extends Component<FollowButtonWrapProps, {
-    following: boolean
-}> {
-
+class FollowButtonWrap extends Component<
+    FollowButtonWrapProps,
+    {
+        following: boolean,
+    }
+> {
     constructor(props: FollowButtonWrapProps): void {
         super(props);
         this.state = {
@@ -18,11 +21,10 @@ class FollowButtonWrap extends Component<FollowButtonWrapProps, {
     }
 
     updateFollowing = (to: boolean) => {
-        this.setState({following: to});
-        if(to){
+        this.setState({ following: to });
+        if (to) {
             this.props.onFollow();
-        }
-        else {
+        } else {
             this.props.onUnfollow();
         }
     };
@@ -30,18 +32,25 @@ class FollowButtonWrap extends Component<FollowButtonWrapProps, {
     render() {
         if (this.state.following === true) {
             return (
-                <button type="button" onClick={(ev)=>{this.updateFollowing(false)}}>
+                <button
+                    type="button"
+                    onClick={() => {
+                        this.updateFollowing(false);
+                    }}>
                     Following – click to unfollow
-                </button>
-            )
-        }
-        else {
-            return (
-                <button type="button" onClick={(ev)=>{this.updateFollowing(true)}}>
-                    Follow
                 </button>
             );
         }
+
+        return (
+            <button
+                type="button"
+                onClick={() => {
+                    this.updateFollowing(true);
+                }}>
+                Follow
+            </button>
+        );
     }
 }
 

--- a/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow/FollowButtonWrap.js
@@ -3,8 +3,8 @@ import React, { Component } from 'preact-compat';
 
 type FollowButtonWrapProps = {
     initiallyFollowing: boolean,
-    onFollow: () => void,
-    onUnfollow: () => void,
+    onFollow: () => Promise<void>,
+    onUnfollow: () => Promise<void>,
 };
 
 class FollowButtonWrap extends Component<

--- a/static/src/stylesheets/head.identity.scss
+++ b/static/src/stylesheets/head.identity.scss
@@ -26,3 +26,4 @@
 @import 'module/identity/switches';
 @import 'module/identity/ad-prefs';
 @import 'module/identity/consent';
+@import 'module/identity/follow';

--- a/static/src/stylesheets/module/identity/_follow.scss
+++ b/static/src/stylesheets/module/identity/_follow.scss
@@ -1,0 +1,5 @@
+.identity-follow {
+    background: #fff;
+    padding: 3px 6px 6px;
+    display: block;
+}

--- a/static/src/stylesheets/module/identity/_follow.scss
+++ b/static/src/stylesheets/module/identity/_follow.scss
@@ -1,5 +1,3 @@
 .identity-follow {
-    background: #fff;
-    padding: 3px 6px 6px;
     display: block;
 }


### PR DESCRIPTION
## What does this change?
This PR begins laying the groundwork for the new style consent + newsletter boxes. There's a lot of unknowns up in the air but what we know so far is:

- Some consent checkboxes will become twitter-like follow/unfollow buttons
- Some consent checkboxes (the opt-outs) _might_ become smaller and have new styling
- Some consent checkboxes will remain in the old style with no changes after these new boxes ship (such as the ones in email prefs)


This gives us a great opportunity to try to simplify and refactor the existing checkbox code (Which on the js side is mixing together visuals with functionality with _queuing_ and on the HTML side is carrying over a tonne of legacy features) 
  - To do so the new ones use a react button, with `onFollow` and `onUnfollow` callbacks. The idea here is to, later on, take out consent & newsletter follow & unfollow requests out from `consents.js` and into their own space, while providing clearer function signatures (they submit hidden forms now).

This PR is a first go at getting the basics out (behind a switch) so we have something to build on top of!

## Screenshots
It's beautiful i know right
![screen shot 2018-08-17 at 2 49 43 pm](https://user-images.githubusercontent.com/11539094/44269924-cc52b300-a22d-11e8-905a-2509c67fc6ca.png)

## What is the value of this and can you measure success?
K&T OKR

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Accessibility test checklist
TODO: ensure the button change is properly signposted

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)