### PR TITLE
Update insertion logic of the comment slot, expand tests 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import $ from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
@@ -10,14 +10,16 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import type bonzo from 'bonzo';
 
-const createCommentSlot = (canBeDmpu: boolean): HTMLElement => {
+const createCommentSlots = (
+    canBeDmpu: boolean
+): Array<HTMLDivElement | HTMLSpanElement> => {
     const sizes = canBeDmpu ? { desktop: [adSizes.halfPage] } : {};
     const adSlots = createSlots('comments', { sizes });
 
     adSlots.forEach(adSlot => {
         adSlot.classList.add('js-sticky-mpu');
     });
-    return adSlots[0];
+    return adSlots;
 };
 
 const insertCommentAd = (
@@ -25,7 +27,7 @@ const insertCommentAd = (
     $adSlotContainer: bonzo,
     canBeDmpu: boolean
 ): void => {
-    const commentSlot: HTMLElement = createCommentSlot(canBeDmpu);
+    const commentSlots = createCommentSlots(canBeDmpu);
 
     fastdom
         .write(() => {
@@ -36,8 +38,11 @@ const insertCommentAd = (
             ) {
                 $commentMainColumn.addClass('discussion__ad-wrapper-wider');
             }
-            $adSlotContainer.append(commentSlot);
-            return commentSlot;
+            // Append each slot into the adslot container...
+            commentSlots.forEach(adSlot => {
+                $adSlotContainer.append(adSlot);
+            });
+            return commentSlots[0];
         })
         // Add only the fist slot (DFP slot) to GTP
         .then((adSlot: HTMLElement) => {
@@ -96,4 +101,4 @@ export const initCommentAdverts = (): ?boolean => {
     );
 };
 
-export const _ = { createCommentSlot, insertCommentAd };
+export const _ = { createCommentSlots, insertCommentAd };

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -80,7 +80,7 @@ export const initCommentAdverts = (): ?boolean => {
                             false
                         );
                     } else {
-                        mediator.on(
+                        mediator.once(
                             'discussion:comments:get-more-replies',
                             () => {
                                 insertCommentAd(

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -4,35 +4,40 @@ import config from 'lib/config';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
+import { adSizes } from 'commercial/modules/ad-sizes';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import type bonzo from 'bonzo';
 
-const insertCommentAd = (
-    $commentMainColumn: bonzo,
-    $adSlotContainer: bonzo
-): void => {
-    const adSlots = createSlots('comments', {
-        classes: 'mpu-banner-ad',
-    });
+const createCommentSlot = (canBeDmpu: boolean): HTMLElement => {
+    const sizes = canBeDmpu ? { desktop: [adSizes.halfPage] } : {};
+    const adSlots = createSlots('comments', { sizes });
+
     adSlots.forEach(adSlot => {
         adSlot.classList.add('js-sticky-mpu');
     });
+    return adSlots[0];
+};
+
+const insertCommentAd = (
+    $commentMainColumn: bonzo,
+    $adSlotContainer: bonzo,
+    canBeDmpu: boolean
+): void => {
+    const commentSlot: HTMLElement = createCommentSlot(canBeDmpu);
+
     fastdom
         .write(() => {
             $commentMainColumn.addClass('discussion__ad-wrapper');
-
             if (
                 !config.get('page.isLiveBlog') &&
                 !config.get('page.isMinuteArticle')
             ) {
                 $commentMainColumn.addClass('discussion__ad-wrapper-wider');
             }
-
-            adSlots.forEach(adSlot => {
-                $adSlotContainer.append(adSlot);
-            });
-            return adSlots[0];
+            $adSlotContainer.append(commentSlot);
+            return commentSlot;
         })
         // Add only the fist slot (DFP slot) to GTP
         .then((adSlot: HTMLElement) => {
@@ -58,15 +63,30 @@ export const initCommentAdverts = (): ?boolean => {
             fastdom
                 .read(() => $commentMainColumn.dim().height)
                 .then((mainColHeight: number) => {
-                    if (mainColHeight >= 800) {
-                        insertCommentAd($commentMainColumn, $adSlotContainer);
+                    const isLoggedIn: boolean = isUserLoggedIn();
+                    if (
+                        mainColHeight >= 800 ||
+                        (isLoggedIn && mainColHeight >= 600)
+                    ) {
+                        insertCommentAd(
+                            $commentMainColumn,
+                            $adSlotContainer,
+                            true
+                        );
+                    } else if (isLoggedIn) {
+                        insertCommentAd(
+                            $commentMainColumn,
+                            $adSlotContainer,
+                            false
+                        );
                     } else {
-                        mediator.once(
+                        mediator.on(
                             'discussion:comments:get-more-replies',
                             () => {
                                 insertCommentAd(
                                     $commentMainColumn,
-                                    $adSlotContainer
+                                    $adSlotContainer,
+                                    true
                                 );
                             }
                         );
@@ -75,3 +95,5 @@ export const initCommentAdverts = (): ?boolean => {
         }
     );
 };
+
+export const _ = { createCommentSlot, insertCommentAd };

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -2,29 +2,44 @@
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
+import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+import { initCommentAdverts, _ } from 'commercial/modules/comment-adverts';
+
+// Workaround to fix issue where dataset is missing from jsdom, and solve the
+// 'cannot set property [...] which has only a getter' TypeError
+Object.defineProperty(HTMLElement.prototype, 'dataset', {
+    writable: true,
+    value: {},
+});
 
 jest.mock('lib/config', () => ({ page: {}, get: () => false }));
+
 jest.mock('commercial/modules/dfp/add-slot', () => ({
     addSlot: jest.fn(),
 }));
+
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {
         commentAdverts: true,
     },
 }));
 
+jest.mock('common/modules/identity/api', () => ({
+    isUserLoggedIn: jest.fn(),
+}));
+
+const { createCommentSlot } = _;
+
 const commercialFeaturesMock: any = commercialFeatures;
+const isUserLoggedIn: any = isUserLoggedIn_;
 
 const mockHeight = (height: number) => {
     jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
 };
 
-describe('Comment Adverts', () => {
+describe('createCommentSlot', () => {
     beforeEach(() => {
-        jest.resetAllMocks();
-
         if (document.body) {
             document.body.innerHTML = `<div class="js-comments">
             <div class="content__main-column">
@@ -36,10 +51,50 @@ describe('Comment Adverts', () => {
         if (document.body) {
             document.body.innerHTML = '';
         }
+        jest.resetAllMocks();
     });
 
-    it('should exist', () => {
-        expect(initCommentAdverts).toBeDefined();
+    it('should return an ad slot with the correct sizes', () => {
+        const commentMpu: HTMLElement = createCommentSlot(false);
+        const commentDmpu: HTMLElement = createCommentSlot(true);
+        expect(commentMpu.getAttribute('data-desktop')).toBe(
+            '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
+        );
+        expect(commentMpu.getAttribute('data-mobile')).toBe(
+            '1,1|2,2|300,250|300,274|fluid'
+        );
+        expect(commentDmpu.getAttribute('data-desktop')).toBe(
+            '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
+        );
+        expect(commentDmpu.getAttribute('data-mobile')).toBe(
+            '1,1|2,2|300,250|300,274|fluid'
+        );
+    });
+
+    it('should add js-sticky-mpu to the class list', () => {
+        const commentMpu: HTMLElement = createCommentSlot(false);
+        const commentDmpu: HTMLElement = createCommentSlot(true);
+        expect(commentMpu.classList).toContain('js-sticky-mpu');
+        expect(commentDmpu.classList).toContain('js-sticky-mpu');
+    });
+});
+
+describe('initCommentAdverts', () => {
+    beforeEach(() => {
+        isUserLoggedIn.mockReturnValue(false);
+        commercialFeaturesMock.commentAdverts = true;
+        if (document.body) {
+            document.body.innerHTML = `<div class="js-comments">
+            <div class="content__main-column">
+                <div class="js-discussion__ad-slot"></div></div></div>`;
+        }
+    });
+
+    afterEach(() => {
+        if (document.body) {
+            document.body.innerHTML = '';
+        }
+        jest.resetAllMocks();
     });
 
     it('should return false if commentAdverts are switched off', () => {
@@ -47,15 +102,76 @@ describe('Comment Adverts', () => {
         expect(initCommentAdverts()).toBe(false);
     });
 
-    it('should insert a comment advert when the comments section passes the height threshold', done => {
-        commercialFeaturesMock.commentAdverts = true;
+    it('should return false if there is no comments ad slot container', () => {
+        if (document.body) {
+            document.body.innerHTML = `<div class="js-comments">
+                <div class="content__main-column"></div></div>`;
+        }
+        expect(initCommentAdverts()).toBe(false);
+    });
+
+    it('should insert a DMPU slot if there is enough space', done => {
         mockHeight(800);
         initCommentAdverts();
         mediator.emit('modules:comments:renderComments:rendered');
         mediator.once('page:defaultcommercial:comments', () => {
-            const adSlots = document.querySelectorAll('.js-ad-slot');
-            expect(adSlots.length).toBe(1);
+            const adSlot: HTMLElement = (document.querySelector(
+                '.js-ad-slot'
+            ): any);
             expect(addSlot).toHaveBeenCalledTimes(1);
+            expect(adSlot.getAttribute('data-desktop')).toBe(
+                '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
+            );
+            done();
+        });
+    });
+
+    it('should insert a DMPU slot if there is space, and the user is logged in', done => {
+        mockHeight(600);
+        isUserLoggedIn.mockReturnValue(true);
+        initCommentAdverts();
+        mediator.emit('modules:comments:renderComments:rendered');
+        mediator.once('page:defaultcommercial:comments', () => {
+            const adSlot: HTMLElement = (document.querySelector(
+                '.js-ad-slot'
+            ): any);
+            expect(addSlot).toHaveBeenCalledTimes(1);
+            expect(adSlot.getAttribute('data-desktop')).toBe(
+                '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
+            );
+            done();
+        });
+    });
+
+    it('should insert a MPU if a DMPU does not fit, and the user is logged in', done => {
+        mockHeight(300);
+        isUserLoggedIn.mockReturnValue(true);
+        initCommentAdverts();
+        mediator.emit('modules:comments:renderComments:rendered');
+        mediator.once('page:defaultcommercial:comments', () => {
+            const adSlot: HTMLElement = (document.querySelector(
+                '.js-ad-slot'
+            ): any);
+            expect(addSlot).toHaveBeenCalledTimes(1);
+            expect(adSlot.getAttribute('data-desktop')).toBe(
+                '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
+            );
+            done();
+        });
+    });
+
+    it('should upgrade the MPU to a DMPU when there is space', done => {
+        mockHeight(800);
+        initCommentAdverts();
+        mediator.emit('modules:comments:renderComments:rendered');
+        mediator.once('page:defaultcommercial:comments', () => {
+            const adSlot: HTMLDivElement = (document.querySelector(
+                '.js-ad-slot'
+            ): any);
+            expect(addSlot).toHaveBeenCalledTimes(1);
+            expect(adSlot.getAttribute('data-desktop')).toBe(
+                '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
+            );
             done();
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -29,7 +29,7 @@ jest.mock('common/modules/identity/api', () => ({
     isUserLoggedIn: jest.fn(),
 }));
 
-const { createCommentSlot } = _;
+const { createCommentSlots } = _;
 
 const commercialFeaturesMock: any = commercialFeatures;
 const isUserLoggedIn: any = isUserLoggedIn_;
@@ -38,7 +38,7 @@ const mockHeight = (height: number) => {
     jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
 };
 
-describe('createCommentSlot', () => {
+describe('createCommentSlots', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `<div class="js-comments">
@@ -55,8 +55,8 @@ describe('createCommentSlot', () => {
     });
 
     it('should return an ad slot with the correct sizes', () => {
-        const commentMpu: HTMLElement = createCommentSlot(false);
-        const commentDmpu: HTMLElement = createCommentSlot(true);
+        const commentMpu: HTMLElement = createCommentSlots(false)[0];
+        const commentDmpu: HTMLElement = createCommentSlots(true)[0];
         expect(commentMpu.getAttribute('data-desktop')).toBe(
             '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
         );
@@ -72,8 +72,8 @@ describe('createCommentSlot', () => {
     });
 
     it('should add js-sticky-mpu to the class list', () => {
-        const commentMpu: HTMLElement = createCommentSlot(false);
-        const commentDmpu: HTMLElement = createCommentSlot(true);
+        const commentMpu: HTMLElement = createCommentSlots(false)[0];
+        const commentDmpu: HTMLElement = createCommentSlots(true)[0];
         expect(commentMpu.classList).toContain('js-sticky-mpu');
         expect(commentDmpu.classList).toContain('js-sticky-mpu');
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -22,28 +22,6 @@ const inlineDefinition = {
     },
 };
 
-const commentsDefinition = {
-    sizeMappings: {
-        mobile: [
-            adSizes.outOfPage,
-            adSizes.empty,
-            adSizes.mpu,
-            adSizes.googleCard,
-            adSizes.fluid,
-        ],
-        desktop: [
-            adSizes.outOfPage,
-            adSizes.empty,
-            adSizes.mpu,
-            adSizes.video,
-            adSizes.video2,
-            adSizes.googleCard,
-            adSizes.fluid,
-            adSizes.halfPage,
-        ],
-    },
-};
-
 const adSlotToBlockthroughUids = {
     inline1: '5a98587091-157',
     inline2: '5a98587869-157',
@@ -105,7 +83,7 @@ const adSlotDefinitions = {
     },
     inline: inlineDefinition,
     mostpop: inlineDefinition,
-    comments: commentsDefinition,
+    comments: inlineDefinition,
     'top-above-nav': {
         sizeMappings: {
             mobile: [

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -86,7 +86,7 @@ sizeCallbacks[adSizes.mpu] = (_, advert) =>
  */
 sizeCallbacks[adSizes.halfPage] = (_, advert) =>
     fastdom.read(() => {
-        if (advert.node.classList.contains('js-sticky-mpu')) {
+        if (advert.node.classList.contains('ad-slot--right')) {
             stickyMpu(advert.node);
         }
         if (advert.node.classList.contains('ad-slot--comments')) {


### PR DESCRIPTION
## What does this change?

#### 👉 Add more conditions for inserting comment adverts

Can insert the comments MPU for logged in users again

#### 👉Update class name used to apply sticky behaviour

Fixes conditional of sticky MPU callback

#### 👉 Use Flow Strict and expand tests

Type annotations makes me happy, tests make me sleep better at night

## What is the value of this and can you measure success?

MVP of adding a MPU or DMPU for logged in users

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
