### PR TITLE
Increase Fastly Images test to 5%.

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -64,6 +64,6 @@ object FastlyIOImages extends Experiment(
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
   sellByDate = new LocalDate(2018, 8, 29),
-  participationGroup = Perc20B
+  participationGroup = Perc5A
 )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -64,6 +64,6 @@ object FastlyIOImages extends Experiment(
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
   sellByDate = new LocalDate(2018, 8, 29),
-  participationGroup = Perc0A
+  participationGroup = Perc20B
 )
 


### PR DESCRIPTION
## What does this change?
Causes images from fastly-io to be served to 5% of users. I'd hoped to do 20% but `Perc20A` is already taken so I'll settle for 5