### PR TITLE
updates epic-google-doc logic in prep for sharing with banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -1,0 +1,16 @@
+// @flow
+import fetchJSON from 'lib/fetch-json';
+import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
+
+const epicGoogleDocUrl: string =
+    'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
+
+const getGoogleDoc = (url: string): Promise<any> =>
+    fetchJSON(url, {
+        mode: 'cors',
+    });
+
+export const getEpicGoogleDoc: Promise<any> = getGoogleDoc(epicGoogleDocUrl);
+
+export const googleDocEpicControl = (): Promise<AcquisitionsEpicTemplateCopy> =>
+    getGoogleDoc(epicGoogleDocUrl).then(res => getEpicParams(res, 'control'));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,9 +1,6 @@
 // @flow
 import { isAbTestTargeted } from 'common/modules/commercial/targeting-tool';
-import {
-    control as acquisitionsCopyControl,
-    getCopyFromGoogleDoc,
-} from 'common/modules/commercial/acquisitions-copy';
+import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import {
     submitClickEvent,
@@ -23,6 +20,10 @@ import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templ
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'common/modules/commercial/user-features';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
+import {
+    getEpicGoogleDoc,
+    googleDocEpicControl,
+} from 'common/modules/commercial/contributions-google-docs';
 
 type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
@@ -260,7 +261,7 @@ const makeABTestVariant = (
 
             const copyPromise: Promise<AcquisitionsEpicTemplateCopy> =
                 (options.copy && Promise.resolve(options.copy)) ||
-                acquisitionsCopyControl();
+                googleDocEpicControl();
 
             const render = (templateFn: ?EpicTemplate) =>
                 copyPromise
@@ -451,7 +452,10 @@ const makeGoogleDocEpicVariants = (count: number): Array<Object> => {
             id: `variant_${i}`,
             products: [],
             options: {
-                copy: () => getCopyFromGoogleDoc(`variant_${i}`),
+                copy: () =>
+                    getEpicGoogleDoc.then(res =>
+                        getEpicParams(res, `variant_${i}`)
+                    ),
             },
         });
     }

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -6,7 +6,7 @@ import { elementInView } from 'lib/element-inview';
 import reportError from 'lib/report-error';
 import mediator from 'lib/mediator';
 
-import { control as epicControlCopy } from 'common/modules/commercial/acquisitions-copy';
+import { googleDocEpicControl } from 'common/modules/commercial/contributions-google-docs';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
@@ -41,7 +41,7 @@ const controlEpicComponent = (
     const epicComponentType = 'ACQUISITIONS_EPIC';
     const testimonialBlock = '';
 
-    return epicControlCopy().then(copy => {
+    return googleDocEpicControl().then(copy => {
         const rawEpic = acquisitionsEpicControlTemplate({
             copy,
             componentName: '', // TODO: confirm data-component not needed

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -60,7 +60,7 @@ export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicThankYou,
 ];
 
-export const getTest = (): ?ABTest => {
+export const getTest = (): ?AcquisitionsABTest => {
     const forcedTests = getForcedTests()
         .map(({ testId }) => acquisitionsTests.find(t => t.id === testId))
         .filter(Boolean);


### PR DESCRIPTION
## What does this change?
Does not change current implementation. 
Prep for adding ability to run banner AB tests with copy from google docs by abstracting logic used for epic. 
New file for logic rather than adding into existing utilities in order to avoid circular dependencies.

## What is the value of this and can you measure success?
Working towards running AB tests on banner copy using google docs

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
