### PR TITLE
Updated logic for parsing date of last contribution from cookie

### DIFF
--- a/static/src/javascripts/lib/time-utils.js
+++ b/static/src/javascripts/lib/time-utils.js
@@ -1,19 +1,26 @@
 // @flow
 
-const daysSince = (date: ?string): number => {
-    const oneDay = 24 * 60 * 60 * 1000;
+// TODO: remove
+// const daysSince = (date: ?string): number => {
+//     const oneDay = 24 * 60 * 60 * 1000;
+//
+//     if (date !== null && date !== undefined) {
+//         try {
+//             const ms = Date.parse(date);
+//
+//             if (Number.isNaN(ms)) return Infinity;
+//             return (new Date() - ms) / oneDay;
+//         } catch (e) {
+//             return Infinity;
+//         }
+//     }
+//     return Infinity;
+// };
 
-    if (date !== null && date !== undefined) {
-        try {
-            const ms = Date.parse(date);
-
-            if (Number.isNaN(ms)) return Infinity;
-            return (new Date() - ms) / oneDay;
-        } catch (e) {
-            return Infinity;
-        }
-    }
-    return Infinity;
+const dateDiffDays = (from: Date, to: Date): number => {
+    const diffMs = to - from;
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    return Math.floor(diffMs / oneDayMs)
 };
 
-export { daysSince };
+export { dateDiffDays };

--- a/static/src/javascripts/lib/time-utils.js
+++ b/static/src/javascripts/lib/time-utils.js
@@ -1,6 +1,7 @@
 // @flow
 
-const dateDiffDays = (from: Date, to: Date): number => {
+// from and to should be Epoch time in milliseconds
+const dateDiffDays = (from: number, to: number): number => {
     const oneDayMs = 1000 * 60 * 60 * 24;
     const diffMs = to - from;
     return Math.floor(diffMs / oneDayMs);

--- a/static/src/javascripts/lib/time-utils.js
+++ b/static/src/javascripts/lib/time-utils.js
@@ -1,25 +1,8 @@
 // @flow
 
-// TODO: remove
-// const daysSince = (date: ?string): number => {
-//     const oneDay = 24 * 60 * 60 * 1000;
-//
-//     if (date !== null && date !== undefined) {
-//         try {
-//             const ms = Date.parse(date);
-//
-//             if (Number.isNaN(ms)) return Infinity;
-//             return (new Date() - ms) / oneDay;
-//         } catch (e) {
-//             return Infinity;
-//         }
-//     }
-//     return Infinity;
-// };
-
 const dateDiffDays = (from: Date, to: Date): number => {
+    const oneDayMs = 1000 * 60 * 60 * 24;
     const diffMs = to - from;
-    const oneDayMs = 24 * 60 * 60 * 1000;
     return Math.floor(diffMs / oneDayMs);
 };
 

--- a/static/src/javascripts/lib/time-utils.js
+++ b/static/src/javascripts/lib/time-utils.js
@@ -20,7 +20,7 @@
 const dateDiffDays = (from: Date, to: Date): number => {
     const diffMs = to - from;
     const oneDayMs = 24 * 60 * 60 * 1000;
-    return Math.floor(diffMs / oneDayMs)
+    return Math.floor(diffMs / oneDayMs);
 };
 
 export { dateDiffDays };

--- a/static/src/javascripts/lib/time-utils.spec.js
+++ b/static/src/javascripts/lib/time-utils.spec.js
@@ -1,29 +1,16 @@
 // @flow
-import { daysSince } from 'lib/time-utils';
+import { dateDiffDays } from 'lib/time-utils';
 
-describe('Days since', () => {
-    it('should return a correct duration give a valid date string', () => {
-        const mockDate = new Date('2017-06-09T15:00:00Z');
-        const originalDate = global.Date;
-        const correctDateString = '2017-06-08T15:00:00Z';
-        const correctDateTime = 1496934000000;
+describe('calculating the difference between 2 dates', () => {
+    it('should return the correct duration', () => {
+        const oneDayMs = 1000 * 60 * 60 * 24;
 
-        global.Date = jest.fn(() => mockDate);
-        global.Date.parse = jest.fn(() => correctDateTime);
+        const now = Date.now();
 
-        expect(daysSince(correctDateString)).toBe(1);
+        expect(dateDiffDays(now, now + oneDayMs)).toBe(1);
 
-        global.Date = originalDate;
-        global.Date.parse = originalDate.parse;
-    });
+        expect(dateDiffDays(now, now + oneDayMs - 1)).toBe(0);
 
-    it('should return infinity for an incorrect give a invalid date string', () => {
-        const incorrectDateString = 'blah';
-        expect(daysSince(incorrectDateString)).toBe(Infinity);
-    });
-
-    it('should return infinity for an null value', () => {
-        const incorrectDateString = null;
-        expect(daysSince(incorrectDateString)).toBe(Infinity);
+        expect(dateDiffDays(now, now + 4 * oneDayMs - 1)).toBe(3);
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -6,7 +6,7 @@ import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import {
     isPayingMember as isPayingMember_,
-    isRecentContributor as isRecentContributor_,
+    isRecentOneOffContributor as isRecentContributor_,
     shouldSeeReaderRevenue as shouldSeeReaderRevenue_,
     isAdFreeUser as isAdFreeUser_,
 } from 'common/modules/commercial/user-features';

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -6,13 +6,16 @@ import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import {
     isPayingMember as isPayingMember_,
-    isRecentOneOffContributor as isRecentContributor_,
+    isRecentOneOffContributor as isRecentOneOffContributor_,
     shouldSeeReaderRevenue as shouldSeeReaderRevenue_,
     isAdFreeUser as isAdFreeUser_,
 } from 'common/modules/commercial/user-features';
 
 const isPayingMember: JestMockFn<*, *> = (isPayingMember_: any);
-const isRecentContributor: JestMockFn<*, *> = (isRecentContributor_: any);
+const isRecentOneOffContributor: JestMockFn<
+    *,
+    *
+> = (isRecentOneOffContributor_: any);
 const shouldSeeReaderRevenue: JestMockFn<*, *> = (shouldSeeReaderRevenue_: any);
 const isAdFreeUser: JestMockFn<*, *> = (isAdFreeUser_: any);
 const getBreakpoint: any = getBreakpoint_;
@@ -29,7 +32,7 @@ jest.mock('lib/config', () => ({
 
 jest.mock('common/modules/commercial/user-features', () => ({
     isPayingMember: jest.fn(),
-    isRecentContributor: jest.fn(),
+    isRecentOneOffContributor: jest.fn(),
     shouldSeeReaderRevenue: jest.fn(),
     isAdFreeUser: jest.fn(),
 }));
@@ -73,7 +76,7 @@ describe('Commercial features', () => {
 
         getBreakpoint.mockReturnValue('desktop');
         isPayingMember.mockReturnValue(false);
-        isRecentContributor.mockReturnValue(false);
+        isRecentOneOffContributor.mockReturnValue(false);
         shouldSeeReaderRevenue.mockReturnValue(true);
         isAdFreeUser.mockReturnValue(false);
         isUserLoggedIn.mockReturnValue(true);

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -151,7 +151,8 @@ const isPayingMember = (): boolean =>
     isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
 
 // number returned is Epoch time in milliseconds.
-const getLastContributionDate = (): ?number => {
+// null value signifies no last contribution date.
+const getLastOneOffContributionDate = (): ?number => {
     const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
 
     if (!cookie) {
@@ -181,8 +182,8 @@ const getLastContributionDate = (): ?number => {
     return null;
 };
 
-const getDaysSinceLastContribution = (): ?number => {
-    const lastContributionDate = getLastContributionDate();
+const getDaysSinceLastOneOffContribution = (): ?number => {
+    const lastContributionDate = exports.getLastOneOffContributionDate();
     if (!lastContributionDate) {
         return null;
     }
@@ -190,8 +191,8 @@ const getDaysSinceLastContribution = (): ?number => {
 };
 
 // in last six months
-const isRecentContributor = (): boolean => {
-    const daysSinceLastContribution = getDaysSinceLastContribution();
+const isRecentOneOffContributor = (): boolean => {
+    const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (!daysSinceLastContribution) {
         return false;
     }
@@ -214,7 +215,7 @@ const isDigitalSubscriber = (): boolean =>
 */
 const shouldSeeReaderRevenue = (): boolean =>
     !isPayingMember() &&
-    !isRecentContributor() &&
+    !isRecentOneOffContributor() &&
     !isRecurringContributor() &&
     !isDigitalSubscriber();
 
@@ -224,10 +225,12 @@ export {
     accountDataUpdateWarning,
     isAdFreeUser,
     isPayingMember,
-    isRecentContributor,
+    isRecentOneOffContributor,
     isRecurringContributor,
     isDigitalSubscriber,
     shouldSeeReaderRevenue,
     refresh,
     deleteOldData,
+    getLastOneOffContributionDate,
+    getDaysSinceLastOneOffContribution,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -165,31 +165,19 @@ const getLastOneOffContributionDate = (): ?number => {
     // then a value in ISO 8601 format would parse (incorrectly) e.g. 2018-08-17T16:11:10Z => 2018
     // So first attempt to parse cookie in ISO 8601 format.
 
-    const parseIso = (c: string) => {
-        try {
-            const ms = Date.parse(c);
-            if (Number.isInteger(ms)) {
-                return ms;
-            }
-        } catch (_) {
-            return null;
-        }
-        return null;
-    };
+    let ms;
 
-    const parseEpoch = (c: string) => {
-        try {
-            const ms = parseInt(c, 10);
-            if (Number.isInteger(ms)) {
-                return ms;
-            }
-        } catch (_) {
-            return null;
-        }
-        return null;
-    };
+    ms = Date.parse(cookie);
+    if (Number.isInteger(ms)) {
+        return ms;
+    }
 
-    return parseIso(cookie) || parseEpoch(cookie);
+    ms = parseInt(cookie, 10);
+    if (Number.isInteger(ms)) {
+        return ms;
+    }
+
+    return null;
 };
 
 const getDaysSinceLastOneOffContribution = (): ?number => {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -165,25 +165,35 @@ const getLastOneOffContributionDate = (): ?number => {
     // then a value in ISO 8601 format would parse (incorrectly) e.g. 2018-08-17T16:11:10Z => 2018
     // So first attempt to parse cookie in ISO 8601 format.
 
-    try {
-        const ms = Date.parse(cookie);
-        if (Number.isInteger(ms)) {
-            return ms;
+    const parseIso = (c: string) => {
+        try {
+            const ms = Date.parse(c);
+            if (Number.isInteger(ms)) {
+                return ms;
+            }
+        } catch (_) {
+            return null;
         }
-    } catch (_) {} // FIXME: Empty block statement
+        return null;
+    };
 
-    try {
-        const ms = parseInt(cookie, 10);
-        if (Number.isInteger(ms)) {
-            return ms;
+    const parseEpoch = (c: string) => {
+        try {
+            const ms = parseInt(c, 10);
+            if (Number.isInteger(ms)) {
+                return ms;
+            }
+        } catch (_) {
+            return null;
         }
-    } catch (_) {} // FIXME: Empty block statement
+        return null;
+    };
 
-    return null;
+    return parseIso(cookie) || parseEpoch(cookie);
 };
 
 const getDaysSinceLastOneOffContribution = (): ?number => {
-    const lastContributionDate = exports.getLastOneOffContributionDate();
+    const lastContributionDate = getLastOneOffContributionDate();
     if (!lastContributionDate) {
         return null;
     }

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -160,7 +160,7 @@ const getLastContributionDate = (): ?number => {
 
     // Contributions frontend set date time of last contribution using ISO 8601 format.
     // Support frontend set date time of last contribution in Epoch milliseconds.
-    // If we first attempted to parse cookie in Epoch milliseconds format,
+    // If we first attempted to parse cookie in Epoch milliseconds format (parseInt()),
     // then a value in ISO 8601 format would parse (incorrectly) e.g. 2018-08-17T16:11:10Z => 2018
     // So first attempt to parse cookie in ISO 8601 format.
 
@@ -169,14 +169,14 @@ const getLastContributionDate = (): ?number => {
         if (Number.isInteger(ms)) {
             return ms;
         }
-    } catch (_) {}
+    } catch (_) {} // FIXME: Empty block statement
 
     try {
-        const ms = parseInt(cookie);
+        const ms = parseInt(cookie, 10);
         if (Number.isInteger(ms)) {
             return ms;
         }
-    } catch (_) {}
+    } catch (_) {} // FIXME: Empty block statement
 
     return null;
 };
@@ -188,11 +188,6 @@ const getDaysSinceLastContribution = (): ?number => {
     }
     return dateDiffDays(lastContributionDate, Date.now());
 };
-
-// Don't bother trying to parse one-off contribution cookie.
-// Enough to check that the cookie has been set.
-const isContributor = (): boolean =>
-    getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE) != null; // TODO: is this check ok
 
 // in last six months
 const isRecentContributor = (): boolean => {
@@ -229,7 +224,6 @@ export {
     accountDataUpdateWarning,
     isAdFreeUser,
     isPayingMember,
-    isContributor,
     isRecentContributor,
     isRecurringContributor,
     isDigitalSubscriber,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -425,13 +425,12 @@ describe('getting the last one-off contribution date of a user', () => {
 describe('getting the days since last contribution', () => {
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
-    global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
-
     it('returns null if the last one-off contribution date is null', () => {
         expect(getDaysSinceLastOneOffContribution()).toBe(null);
     });
 
     it('returns the difference in days between the last contribution date and now if the last contribution date is set', () => {
+        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
         expect(getDaysSinceLastOneOffContribution()).toBe(5);
     });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -395,7 +395,7 @@ describe('Storing new feature data', () => {
         }));
 });
 
-const setOneOffContributionCookie = (value: string): void =>
+const setOneOffContributionCookie = (value: any): void =>
     addCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, value);
 
 describe('getting the last one-off contribution date of a user', () => {
@@ -423,8 +423,7 @@ describe('getting the last one-off contribution date of a user', () => {
 });
 
 describe('getting the days since last contribution', () => {
-    const contributionDateTimeISO8601 = '2018-08-01T12:00:30Z';
-    const contributionDateTimeEpoch = Date.parse(contributionDateTimeISO8601);
+    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
     global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-    isRecentContributor,
+    isRecentOneOffContributor,
     isPayingMember,
 } from 'common/modules/commercial/user-features';
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
@@ -26,7 +26,7 @@ export const acquisitionsEpicThankYou = makeABTest({
 
     showToContributorsAndSupporters: true,
 
-    canRun: () => isPayingMember() || isRecentContributor(),
+    canRun: () => isPayingMember() || isRecentOneOffContributor(),
 
     useLocalViewLog: true,
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -3,7 +3,7 @@ import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import config from 'lib/config';
 import {
     isPayingMember,
-    isRecentContributor,
+    isRecentOneOffContributor,
 } from 'common/modules/commercial/user-features';
 
 const campaignTag = 'us-news/series/break-the-cycle';
@@ -14,7 +14,7 @@ const tagsMatch = () =>
         .split(',')
         .includes(campaignTag);
 
-const isTargetReader = () => isPayingMember() || isRecentContributor();
+const isTargetReader = () => isPayingMember() || isRecentOneOffContributor();
 
 const isTargetPage = () => tagsMatch() && !config.page.shouldHideReaderRevenue;
 


### PR DESCRIPTION
## What does this change?

The last contribution timestamp can have 2 different formats - ISO 8601 (contributions-frontend) and Epoch time in milliseconds (support-frontend). The updated logic accounts for that.

I've also updated the method name `isRecentContributor` to `isRecentOneOffContributor` since we now accept recurring contributions as well.