### PR TITLE
Update 'is digital subscriber' logic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -162,8 +162,7 @@ const isRecurringContributor = (): boolean =>
     supportSiteRecurringCookiePresent();
 
 const isDigitalSubscriber = (): boolean =>
-    // If the user is logged in, but has no cookie yet, play it safe and assume they're a digital subscriber
-    isUserLoggedIn() && getCookie(DIGITAL_SUBSCRIBER_COOKIE) !== 'false';
+    getCookie(DIGITAL_SUBSCRIBER_COOKIE) === 'true';
 
 /*
     Whenever the checks are updated, please make sure to update

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -296,10 +296,10 @@ describe('The isDigitalSubscriber getter', () => {
             expect(isDigitalSubscriber()).toBe(false);
         });
 
-        it('Is true when the user has no digital subscriber cookie', () => {
+        it('Is false when the user has no digital subscriber cookie', () => {
             // If we don't know, we err on the side of caution, rather than annoy paying users
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
-            expect(isDigitalSubscriber()).toBe(true);
+            expect(isDigitalSubscriber()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -297,7 +297,6 @@ describe('The isDigitalSubscriber getter', () => {
         });
 
         it('Is false when the user has no digital subscriber cookie', () => {
-            // If we don't know, we err on the side of caution, rather than annoy paying users
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
             expect(isDigitalSubscriber()).toBe(false);
         });


### PR DESCRIPTION
## What does this change?

Consider a user a digital subscriber if and only if they have the digital subscriber equal to `'true'`.

## What is the value of this and can you measure success?

Potentially expands the pool of signed in users we can ask for money.

