### PR TITLE
Test of AdYouLike bidder in Prebid auctions

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -1,7 +1,7 @@
 package conf.switches
 
 import common.editions._
-import conf.switches.SwitchGroup.ABTests
+import conf.switches.SwitchGroup.{ABTests, Commercial}
 import org.joda.time.LocalDate
 
 trait ABTestSwitches {
@@ -123,6 +123,16 @@ trait ABTestSwitches {
     owners = Seq(Owner.withGithub("jeteve")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-commercial-prebid-ad-you-like",
+    "Test the rendering of Prebid ads served by AdYouLike",
+    owners = Owner.group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 9, 26),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -317,6 +317,49 @@ trait CommercialSwitches {
      exposeClientSide = false
    )
 
+  val AffiliateLinks: Switch = Switch(
+    group = Commercial,
+    name = "affiliate-links",
+    description = "Enable affiliate links. If off, affiliate links will never be added to content by frontend apps. If on, affiliate links may be added based off other settings",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+  val AffiliateLinkSections: Switch = Switch(
+    group = Commercial,
+    name = "affiliate-links-sections",
+    description = "Add affiliate links to all content in sections in affiliateLinkSections config property when no override exists in capi (showAffiliateLinks field).",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+  val enableConsentManagementService: Switch = Switch(
+    group = Commercial,
+    name = "enable-consent-management-service",
+    description = "Enable our CMP service to run on each page, so that vendors can query the consent status.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 8, 23),
+    exposeClientSide = true
+  )
+
+  val commercialPageViewAnalytics: Switch = Switch(
+    group = Commercial,
+    name = "commercial-page-view-analytics",
+    description = "Gather commercial analytics from page views",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+}
+
+trait PrebidSwitches {
+
   val prebidSwitch: Switch = Switch(
     group = Commercial,
     name = "prebid-header-bidding",
@@ -397,50 +440,20 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val prebidAdYouLike: Switch = Switch(
+    group = Commercial,
+    name = "prebid-ad-you-like",
+    description = "Include AdYouLike adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val prebidS2SOzoneBidder: Switch = Switch(
     group = Commercial,
     name = "prebid-s2sozone",
     description = "Include S2S Ozone project adapter in Prebid auctions",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-  )
-
-  val AffiliateLinks: Switch = Switch(
-    group = Commercial,
-    name = "affiliate-links",
-    description = "Enable affiliate links. If off, affiliate links will never be added to content by frontend apps. If on, affiliate links may be added based off other settings",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false
-  )
-
-  val AffiliateLinkSections: Switch = Switch(
-    group = Commercial,
-    name = "affiliate-links-sections",
-    description = "Add affiliate links to all content in sections in affiliateLinkSections config property when no override exists in capi (showAffiliateLinks field).",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false
-  )
-
-  val enableConsentManagementService: Switch = Switch(
-    group = Commercial,
-    name = "enable-consent-management-service",
-    description = "Enable our CMP service to run on each page, so that vendors can query the consent status.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 8, 23),
-    exposeClientSide = true
-  )
-
-  val commercialPageViewAnalytics: Switch = Switch(
-    group = Commercial,
-    name = "commercial-page-view-analytics",
-    description = "Gather commercial analytics from page views",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -156,6 +156,7 @@ with ServerSideExperimentSwitches
 with FaciaSwitches
 with ABTestSwitches
 with CommercialSwitches
+with PrebidSwitches
 with DiscussionSwitches
 with PerformanceSwitches
 with MonitoringSwitches

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#ccc7245",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -358,7 +358,7 @@ const adYouLikeBidder: PrebidBidder = {
     name: 'adyoulike',
     switchName: 'prebidAdYouLike',
     bidParams: (): PrebidAdYouLikeParams => ({
-        placementId: getAdYouLikePlacementId(),
+        placement: getAdYouLikePlacementId(),
     }),
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -2,29 +2,47 @@
 /* global jsdom */
 
 import config from 'lib/config';
+import { commercialPrebidAdYouLike as CommercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike';
 import {
+    getParticipations as getParticipations_,
     getVariant as getVariant_,
     isInVariant as isInVariant_,
 } from 'common/modules/experiments/utils';
 import { _, bids } from './bid-config';
 import type { PrebidBidder, PrebidSize } from './types';
 import {
-    getRandomIntInclusive as getRandomIntInclusive_,
+    containsBillboard as containsBillboard_,
+    containsDmpu as containsDmpu_,
+    containsLeaderboard as containsLeaderboard_,
+    containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
+    containsMpu as containsMpu_,
+    containsMpuOrDmpu as containsMpuOrDmpu_,
     getBreakpointKey as getBreakpointKey_,
+    getRandomIntInclusive as getRandomIntInclusive_,
+    shouldIncludeAdYouLike as shouldIncludeAdYouLike_,
     shouldIncludeAppNexus as shouldIncludeAppNexus_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
 } from './utils';
 
+const containsBillboard: any = containsBillboard_;
+const containsDmpu: any = containsDmpu_;
+const containsLeaderboard: any = containsLeaderboard_;
+const containsLeaderboardOrBillboard: any = containsLeaderboardOrBillboard_;
+const containsMpu: any = containsMpu_;
+const containsMpuOrDmpu: any = containsMpuOrDmpu_;
 const getRandomIntInclusive: any = getRandomIntInclusive_;
+const shouldIncludeAdYouLike: any = shouldIncludeAdYouLike_;
 const shouldIncludeAppNexus: any = shouldIncludeAppNexus_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
+const getParticipations: any = getParticipations_;
 const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
 
 const {
+    getAdYouLikePlacementId,
     getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,
@@ -55,6 +73,7 @@ const resetConfig = () => {
     config.set('switches.prebidS2sozone', true);
     config.set('switches.prebidTrustx', true);
     config.set('switches.prebidXaxis', true);
+    config.set('switches.prebidAdYouLike', true);
     config.set('ophan', { pageViewId: 'pvid' });
     config.set('page.contentType', 'Article');
     config.set('page.edition', 'UK');
@@ -83,6 +102,12 @@ describe('getAppNexusPlacementId', () => {
 
     test('should return the expected values when on UK Edition and desktop device', () => {
         getBreakpointKey.mockReturnValue('D');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             '13366606',
             '13366606',
@@ -94,6 +119,12 @@ describe('getAppNexusPlacementId', () => {
 
     test('should return the expected values when on UK Edition and tablet device', () => {
         getBreakpointKey.mockReturnValue('T');
+        containsMpu.mockReturnValueOnce(true);
+        containsMpu.mockReturnValue(false);
+        containsLeaderboard.mockReturnValueOnce(false);
+        containsLeaderboard.mockReturnValueOnce(false);
+        containsLeaderboard.mockReturnValueOnce(true);
+        containsLeaderboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             '13366913',
             '13144370',
@@ -105,6 +136,8 @@ describe('getAppNexusPlacementId', () => {
 
     test('should return the expected values when on UK Edition and mobile device', () => {
         getBreakpointKey.mockReturnValue('M');
+        containsMpu.mockReturnValueOnce(true);
+        containsMpu.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             '13366904',
             '13144370',
@@ -208,6 +241,12 @@ describe('getImprovePlacementId', () => {
 
     test('should return the expected values when on the UK Edition and desktop device', () => {
         getBreakpointKey.mockReturnValue('D');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             1116396,
             1116396,
@@ -219,6 +258,12 @@ describe('getImprovePlacementId', () => {
 
     test('should return the expected values when on the UK Edition and tablet device', () => {
         getBreakpointKey.mockReturnValue('T');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             1116398,
             1116398,
@@ -230,12 +275,24 @@ describe('getImprovePlacementId', () => {
 
     test('should return the expected values when on the UK Edition and mobile device', () => {
         getBreakpointKey.mockReturnValue('M');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([1116400, 1116400, -1, -1, -1]);
     });
 
     test('should return the expected values when on the INT Edition and desktop device', () => {
         config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('D');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             1116420,
             1116420,
@@ -248,6 +305,12 @@ describe('getImprovePlacementId', () => {
     test('should return the expected values when on the INT Edition and tablet device', () => {
         config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('T');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             1116422,
             1116422,
@@ -260,6 +323,9 @@ describe('getImprovePlacementId', () => {
     test('should return the expected values when on the INT Edition and mobile device', () => {
         config.set('page.edition', 'INT');
         getBreakpointKey.mockReturnValue('M');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
         expect(generateTestIds()).toEqual([1116424, 1116424, -1, -1, -1]);
     });
 
@@ -277,6 +343,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
+        containsMpu.mockReturnValue(true);
         expect(getImprovePlacementId([[300, 250]])).toEqual(1116407);
     });
 
@@ -287,6 +354,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
+        containsDmpu.mockReturnValue(true);
         expect(getImprovePlacementId([[300, 600]])).toEqual(1116408);
     });
 
@@ -297,6 +365,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
+        containsLeaderboardOrBillboard.mockReturnValue(true);
         expect(getImprovePlacementId([[970, 250]])).toEqual(1116409);
     });
 
@@ -307,6 +376,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
+        containsLeaderboardOrBillboard.mockReturnValue(true);
         expect(getImprovePlacementId([[728, 90]])).toEqual(1116409);
     });
 
@@ -317,6 +387,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
+        containsMpu.mockReturnValue(true);
         expect(getImprovePlacementId([[300, 250]])).toEqual(1116410);
     });
 
@@ -327,6 +398,7 @@ describe('getImprovePlacementId', () => {
         });
         isInVariant.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
+        containsLeaderboard.mockReturnValue(true);
         expect(getImprovePlacementId([[728, 90]])).toEqual(1116411);
     });
 
@@ -359,6 +431,33 @@ describe('getTrustXAdUnitId', () => {
     test('should return the expected values for dfp-ad--inline10', () => {
         expect(getTrustXAdUnitId('dfp-ad--inline10', true)).toBe('3840');
         expect(getTrustXAdUnitId('dfp-ad--inline10', false)).toBe('3841');
+    });
+});
+
+describe('getAdYouLikePlacementId', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+    });
+
+    test('should serve expected style when in aylStyle variant', () => {
+        getParticipations.mockReturnValue({
+            CommercialPrebidAdYouLike: { variant: 'aylStyle' },
+        });
+        getVariant.mockReturnValue(CommercialPrebidAdYouLike.variants[0]);
+        expect(getAdYouLikePlacementId()).toBe(
+            '0da4f71dbe8e1af5c0e4739f53366020'
+        );
+    });
+
+    test('should serve expected style when in guardianStyle variant', () => {
+        getParticipations.mockReturnValue({
+            CommercialPrebidAdYouLike: { variant: 'aylStyle' },
+        });
+        getVariant.mockReturnValue(CommercialPrebidAdYouLike.variants[1]);
+        expect(getAdYouLikePlacementId()).toBe(
+            '2b4d757e0ec349583ce704699f1467dd'
+        );
     });
 });
 
@@ -473,10 +572,18 @@ describe('getIndexSiteId', () => {
 
 describe('bids', () => {
     beforeEach(() => {
+        containsBillboard.mockReturnValue(false);
+        containsDmpu.mockReturnValue(false);
+        containsLeaderboard.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
+        containsMpu.mockReturnValue(false);
+        containsMpuOrDmpu.mockReturnValue(false);
         getRandomIntInclusive.mockReturnValue(5);
+        shouldIncludeAdYouLike.mockReturnValue(true);
         shouldIncludeAppNexus.mockReturnValue(false);
         shouldIncludeTrustX.mockReturnValue(false);
         stripMobileSuffix.mockImplementation(str => str);
+        getVariant.mockReturnValue(CommercialPrebidAdYouLike.variants[0]);
         resetConfig();
     });
 
@@ -503,6 +610,7 @@ describe('bids', () => {
             'ix',
             'sonobi',
             'improvedigital',
+            'adyoulike',
             'openx',
             'appnexus',
         ]);
@@ -510,12 +618,22 @@ describe('bids', () => {
 
     test('should not include Ozone bidders when fate is against them', () => {
         config.set('switches.prebidXaxis', false);
-        expect(bidders()).toEqual(['ix', 'sonobi', 'improvedigital']);
+        expect(bidders()).toEqual([
+            'ix',
+            'sonobi',
+            'improvedigital',
+            'adyoulike',
+        ]);
     });
 
     test('should not include ix bidders when switched off', () => {
         config.set('switches.prebidIndexExchange', false);
-        expect(bidders()).toEqual(['sonobi', 'improvedigital', 'xhb']);
+        expect(bidders()).toEqual([
+            'sonobi',
+            'improvedigital',
+            'xhb',
+            'adyoulike',
+        ]);
     });
 
     test('should include AppNexus directly if in target geolocation', () => {
@@ -526,6 +644,7 @@ describe('bids', () => {
             'and',
             'improvedigital',
             'xhb',
+            'adyoulike',
         ]);
     });
 
@@ -537,6 +656,7 @@ describe('bids', () => {
             'trustx',
             'improvedigital',
             'xhb',
+            'adyoulike',
         ]);
     });
 
@@ -549,6 +669,7 @@ describe('bids', () => {
             'sonobi',
             'improvedigital',
             'xhb',
+            'adyoulike',
         ]);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -44,7 +44,7 @@ export type PrebidOpenXParams = {
 };
 
 export type PrebidAdYouLikeParams = {
-    placementId: string,
+    placement: string,
 };
 
 export type PrebidSlotKey =

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -43,6 +43,10 @@ export type PrebidOpenXParams = {
     unit: string,
 };
 
+export type PrebidAdYouLikeParams = {
+    placementId: string,
+};
+
 export type PrebidSlotKey =
     | 'top-above-nav'
     | 'right'
@@ -82,7 +86,8 @@ export type PrebidBidder = {
         | PrebidImproveParams
         | PrebidXaxisParams
         | PrebidAppNexusParams
-        | PrebidOpenXParams,
+        | PrebidOpenXParams
+        | PrebidAdYouLikeParams,
     labelAny?: PrebidBidLabel[],
     labelAll?: PrebidBidLabel[],
 };
@@ -96,7 +101,8 @@ export type PrebidBid = {
         | PrebidImproveParams
         | PrebidXaxisParams
         | PrebidAppNexusParams
-        | PrebidOpenXParams,
+        | PrebidOpenXParams
+        | PrebidAdYouLikeParams,
     labelAny?: PrebidBidLabel[],
     labelAll?: PrebidBidLabel[],
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -63,6 +63,7 @@ export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {
         testCanBeRun(test) &&
         participations !== undefined &&
         participations[test.id] !== undefined &&
+        participations[test.id].variant !== 'notintest' &&
         containsMpu(slotSizes)
     );
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -2,11 +2,36 @@
 
 import { getBreakpoint } from 'lib/detect';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike';
+import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
+import { getParticipations } from 'common/modules/experiments/utils';
+import type { PrebidSize } from './types';
 
 const stripSuffix = (s: string, suffix: string): string => {
     const re = new RegExp(`${suffix}$`);
     return s.replace(re, '');
 };
+
+const contains = (sizes: PrebidSize[], size: PrebidSize): boolean =>
+    Boolean(sizes.find(s => s[0] === size[0] && s[1] === size[1]));
+
+export const containsMpu = (sizes: PrebidSize[]): boolean =>
+    contains(sizes, [300, 250]);
+
+export const containsDmpu = (sizes: PrebidSize[]): boolean =>
+    contains(sizes, [300, 600]);
+
+export const containsLeaderboard = (sizes: PrebidSize[]): boolean =>
+    contains(sizes, [728, 90]);
+
+export const containsBillboard = (sizes: PrebidSize[]): boolean =>
+    contains(sizes, [970, 250]);
+
+export const containsMpuOrDmpu = (sizes: PrebidSize[]): boolean =>
+    containsMpu(sizes) || containsDmpu(sizes);
+
+export const containsLeaderboardOrBillboard = (sizes: PrebidSize[]): boolean =>
+    containsLeaderboard(sizes) || containsBillboard(sizes);
 
 export const getBreakpointKey = (): string => {
     switch (getBreakpoint()) {
@@ -30,6 +55,17 @@ export const shouldIncludeAppNexus = (): boolean =>
     geolocationGetSync() === 'AU';
 
 export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';
+
+export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {
+    const test = commercialPrebidAdYouLike;
+    const participations = getParticipations();
+    return (
+        testCanBeRun(test) &&
+        participations !== undefined &&
+        participations[test.id] !== undefined &&
+        containsMpu(slotSizes)
+    );
+};
 
 export const isExcludedGeolocation = (): boolean => {
     const excludedGeos = ['US', 'CA', 'NZ', 'AU'];

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -98,9 +98,19 @@ describe('Utils', () => {
         expect(stripTrailingNumbersAbove1('inline456')).toBe('inline');
     });
 
-    test('shouldIncludeAdYouLike when not in AdYouLike test', () => {
+    test('shouldIncludeAdYouLike when not in any tests', () => {
         testCanBeRun.mockReturnValue(true);
         getParticipations.mockReturnValue(undefined);
+        expect(shouldIncludeAdYouLike([[300, 250]])).toBe(false);
+        expect(shouldIncludeAdYouLike([[300, 600], [300, 250]])).toBe(false);
+        expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
+    });
+
+    test('shouldIncludeAdYouLike when not in AdYouLike test', () => {
+        testCanBeRun.mockReturnValue(true);
+        getParticipations.mockReturnValue({
+            CommercialPrebidAdYouLike: { variant: 'notintest' },
+        });
         expect(shouldIncludeAdYouLike([[300, 250]])).toBe(false);
         expect(shouldIncludeAdYouLike([[300, 600], [300, 250]])).toBe(false);
         expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,6 +2,7 @@
 import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
+import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike.js';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { FootballWeeklyTreatVsContainer } from 'common/modules/experiments/tests/football-weekly-treat-vs-container';
@@ -9,6 +10,7 @@ import { FootballWeeklyTreatVsContainer } from 'common/modules/experiments/tests
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
     commercialPrebidSafeframe,
+    commercialPrebidAdYouLike,
     commercialAdVerification,
     FootballWeeklyTreatVsContainer,
 ].filter(Boolean);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-adyoulike.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-prebid-adyoulike.js
@@ -1,0 +1,32 @@
+// @flow strict
+
+export const commercialPrebidAdYouLike: ABTest = {
+    id: 'CommercialPrebidAdYouLike',
+    start: '2018-08-20',
+    expiry: '2018-09-26',
+    author: 'Kelvin Chappell',
+    description: 'Serve different styles of AdYouLike creatives',
+    audience: 0,
+    audienceOffset: 0,
+    successMeasure: 'Successful rendering of creative',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'All variants render successfully',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'aylStyle',
+            options: {
+                placementId: '0da4f71dbe8e1af5c0e4739f53366020',
+            },
+            test: (): void => {},
+        },
+        {
+            id: 'guardianStyle',
+            options: {
+                placementId: '2b4d757e0ec349583ce704699f1467dd',
+            },
+            test: (): void => {},
+        },
+    ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a":
-  version "1.18.0"
-  resolved "https://github.com/guardian/Prebid.js.git#94f8681abcfc6e48d7a2aa254fd9279a647a844a"
+"prebid.js@https://github.com/guardian/Prebid.js.git#ccc7245":
+  version "1.20.0"
+  resolved "https://github.com/guardian/Prebid.js.git#ccc7245ded5373b2c18c2e07ea8f46ae6ee4d0ef"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This sets up two variants for a test of the AdYouLike adapter.
Currently the sample size is 0, as this is going to be a manual opt-in only test.
