### PR TITLE
Switch groups updated

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -2,7 +2,7 @@ package conf.switches
 
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
-import conf.switches.SwitchGroup.Commercial
+import conf.switches.SwitchGroup.{Commercial, CommercialPrebid}
 import org.joda.time.LocalDate
 
 trait CommercialSwitches {
@@ -361,7 +361,7 @@ trait CommercialSwitches {
 trait PrebidSwitches {
 
   val prebidSwitch: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-header-bidding",
     description = "Turn on Prebid header bidding (takes priority over Sonobi)",
     owners = group(Commercial),
@@ -371,7 +371,7 @@ trait PrebidSwitches {
   )
 
   val prebidAnalytics: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-analytics",
     description = "Gather analytics from Prebid auctions",
     owners = group(Commercial),
@@ -381,7 +381,7 @@ trait PrebidSwitches {
   )
 
   val prebidSonobi: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-sonobi",
     description = "Include Sonobi adapter in Prebid auctions",
     owners = group(Commercial),
@@ -391,7 +391,7 @@ trait PrebidSwitches {
   )
 
   val prebidAppNexus: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-appnexus",
     description = "Include AppNexus adapter in Prebid auctions",
     owners = group(Commercial),
@@ -401,7 +401,7 @@ trait PrebidSwitches {
   )
 
   val prebidIndexExchange: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-index-exchange",
     description = "Include Index Exchange adapter in Prebid auctions",
     owners = group(Commercial),
@@ -411,7 +411,7 @@ trait PrebidSwitches {
   )
 
   val prebidTrustx: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-trustx",
     description = "Include TrustX adapter in Prebid auctions",
     owners = group(Commercial),
@@ -421,7 +421,7 @@ trait PrebidSwitches {
   )
 
   val prebidImproveDigital: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-improve-digital",
     description = "Include Improve Digital adapter in Prebid auctions",
     owners = group(Commercial),
@@ -431,7 +431,7 @@ trait PrebidSwitches {
   )
 
   val prebidXaxis: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-xaxis",
     description = "Include Xaxis adapter in Prebid auctions",
     owners = group(Commercial),
@@ -441,7 +441,7 @@ trait PrebidSwitches {
   )
 
   val prebidAdYouLike: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-ad-you-like",
     description = "Include AdYouLike adapter in Prebid auctions",
     owners = group(Commercial),
@@ -451,7 +451,7 @@ trait PrebidSwitches {
   )
 
   val prebidS2SOzoneBidder: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-s2sozone",
     description = "Include S2S Ozone project adapter in Prebid auctions",
     owners = group(Commercial),

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -21,9 +21,9 @@ object SwitchGroup {
   val Commercial = SwitchGroup("Commercial")
   val CommercialFeeds = SwitchGroup("Commercial: Feeds",
                             Some("These switches enable the fetching and parsing of the commercial merchandising components."))
-  val CommercialLabs = SwitchGroup(
-    name = "Commercial: Labs",
-    description = Some("Features of, and experiments with, branded content.")
+  val CommercialPrebid = SwitchGroup(
+    name = "Commercial: Prebid",
+    description = Some("Features of our Prebid auction configuration.")
   )
   val Discussion = SwitchGroup("Discussion")
   val Facia = SwitchGroup("Facia")


### PR DESCRIPTION
This change removes a switch group we're not using, and introduces a new switch group we are using:

![image](https://user-images.githubusercontent.com/1722550/44404604-25cd2180-a54f-11e8-9655-f128920aaf92.png)

There's a lot of use of the word 'prebid' but I didn't want to rename active switches.