### PR TITLE
make type of banner show a Promise<boolean>

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -220,10 +220,12 @@ const showBanner = (params: EngagementBannerParams): void => {
 
 let bannerParams;
 
-const show = (): void => {
+const show = (): Promise<boolean> => {
     if (bannerParams) {
         showBanner(bannerParams);
+        return Promise.resolve(true);
     }
+    return Promise.resolve(false);
 };
 
 const canShow = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
@@ -65,7 +65,7 @@ const sideEffects: () => void = () => {
     }
 };
 
-const show: () => void = () => {
+const show: () => Promise<boolean> = () => {
     trackInteraction(displayEventKey);
     const store = userPrefs.get(userPrefsStoreKey) || {};
     if (!store || !store.utm) {
@@ -84,12 +84,15 @@ const show: () => void = () => {
         siteMessageLinkName: messageCode,
         siteMessageComponentName: messageCode,
     });
-    message.show(
-        makeTemplate({
-            campaign,
-            signInLink,
-            emailPrefsLink,
-        })
+
+    return Promise.resolve(
+        message.show(
+            makeTemplate({
+                campaign,
+                signInLink,
+                emailPrefsLink,
+            })
+        )
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -59,10 +59,13 @@ const canShow: () => Promise<boolean> = () =>
         updateLink !== null && !hasUserAcknowledgedBanner(messageCode)
     );
 
-const show: () => void = () => {
+const show: () => Promise<boolean> = () => {
     if (updateLink) {
         showAccountDataUpdateWarningMessage(updateLink);
+        return Promise.resolve(true);
     }
+
+    return Promise.resolve(false);
 };
 
 export const membershipBanner: Banner = {

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -159,7 +159,7 @@ const renderSpectre = ($breakingNews: bonzo): bonzo =>
         .addClass('breaking-news--spectre')
         .removeClass('breaking-news--fade-in breaking-news--hidden');
 
-const show = (): void => {
+const show = (): Promise<boolean> => {
     const $body = bonzo(document.body);
     const $breakingNews = bonzo(qwery('.js-breaking-news-placeholder'));
 
@@ -188,6 +188,8 @@ const show = (): void => {
             markAlertAsSeen(alertToShow.id);
         });
     }, alertDelay);
+
+    return Promise.resolve(true);
 };
 
 const canShow = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
+++ b/static/src/javascripts/projects/common/modules/ui/bannerPicker.js
@@ -4,7 +4,7 @@ import ophan from 'ophan/ng';
 export type Banner = {
     id: string,
     canShow: () => Promise<boolean>,
-    show: () => void,
+    show: () => Promise<boolean>,
 };
 
 const init = (banners: Array<Banner>): Promise<void> => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -123,7 +123,7 @@ const bindClickHandlers = (msg: Message): void => {
     );
 };
 
-const show = (): void => {
+const show = (): Promise<boolean> => {
     track();
 
     const msg = new Message(messageCode, {
@@ -133,7 +133,8 @@ const show = (): void => {
             bindClickHandlers(msg);
         },
     });
-    msg.show(makeHtml());
+
+    return Promise.resolve(msg.show(makeHtml()));
 };
 
 const firstPvConsentBanner: Banner = {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -122,13 +122,15 @@ const engagementMessage = new SubMessage(
     firstPvConsentPlusEngagementMessage
 );
 
-const show = (): void => {
+const show = (): Promise<boolean> => {
     trackFirstPvConsent();
     if (document.body) {
         document.body.insertAdjacentHTML('beforeend', bannerHtml);
     }
     bindFirstPvConsentClickHandlers(firstPvConsentMessage);
     engagementMessage.bindCloseHandler();
+
+    return Promise.resolve(true);
 };
 
 const firstPvConsentPlusEngagementBanner: Banner = {

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -71,7 +71,7 @@ const canShow = (): Promise<boolean> =>
         resolve(result);
     });
 
-const show = (): void => {
+const show = (): Promise<boolean> =>
     loadCssPromise.then(() => {
         const msg = new Message(messageCode, { position: 'top' });
         const fullTemplate = tmp + (getBreakpoint() === 'mobile' ? '' : tablet);
@@ -87,8 +87,9 @@ const show = (): void => {
                 window.scrollTo(window.scrollX, window.scrollY + bannerHeight);
             }
         });
+
+        return true;
     });
-};
 
 const smartAppBanner: Banner = {
     id: messageCode,


### PR DESCRIPTION
## What does this change?
Updates type of `Banner.show` to `Promise<boolean>`. Currently implementations of `show` do not return values and are used for side effects (have type `void`). Several implementations call a function of type `Boolean` so this is now wrapped in a promise and returned. Those without a Boolean available now return `Promise.resolve(true)`. 

## Screenshots

## What is the value of this and can you measure success?
Prep work for making the contributions banner's `show` function asynchronous. 
Easier to test `show` and easier to add functionality around if the banner did / did not show in the future. 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
