### PR TITLE
Increase Fastly IO test to 50%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -47,7 +47,7 @@ object AudioPageChange extends Experiment(
   description = "Show a different version of the audio page to certain people",
   owners = Owner.group(SwitchGroup.Journalism),
   sellByDate = new LocalDate(2018, 8, 27),
-  participationGroup = Perc50
+  participationGroup = Perc5A
 )
 
 
@@ -64,6 +64,6 @@ object FastlyIOImages extends Experiment(
   description = "SServe images from fastly-io",
   owners = Owner.group(SwitchGroup.ServerSideExperiments),
   sellByDate = new LocalDate(2018, 8, 29),
-  participationGroup = Perc5A
+  participationGroup = Perc50
 )
 


### PR DESCRIPTION
## What does this change?
Serves images from Fastly to 50% of users, as things look ok for 5% of users
![screen shot 2018-08-21 at 15 59 09](https://user-images.githubusercontent.com/3606555/44410118-a560ed80-a55b-11e8-94b5-1896fa5826c5.png)


cc @shtukas feel free to merge this once you've checked the few errors we're still getting
