### PR TITLE
Youtube related videos

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -443,6 +443,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val YouTubeRelatedVideos = Switch(
+    SwitchGroup.Feature,
+    "youtube-related-videos",
+    "When ON show YouTube related video suggestions in YouTube media atoms",
+    owners = Seq(Owner.withGithub("siadcock")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 10, 2),
+    exposeClientSide = true
+  )
+
   // Owner: Journalism
   val ReaderAnswersDeliveryMechanism = Switch(
     SwitchGroup.Feature,

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -58,7 +58,8 @@ final case class MediaAtom(
   posterImage: Option[ImageMedia],
   endSlatePath: Option[String],
   expired: Option[Boolean],
-  activeVersion: Option[Long]
+  activeVersion: Option[Long],
+  channelId: Option[String]
 ) extends Atom {
 
   def activeAssets: Seq[MediaAsset] = activeVersion
@@ -332,7 +333,8 @@ object MediaAtom extends common.Logging {
       posterImage = mediaAtom.posterImage.map(imageMediaMake(_, mediaAtom.title)),
       endSlatePath = endSlatePath,
       expired = expired,
-      activeVersion = mediaAtom.activeVersion
+      activeVersion = mediaAtom.activeVersion,
+      channelId = mediaAtom.metadata.flatMap(_.channelId)
     )
   }
 

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,8 +1,14 @@
 @import model.content.MediaWrapper
 @(media: model.content.MediaAtom, displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
+@import conf.switches.Switches.YouTubeRelatedVideos
 
-@defining(media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")) { channelId: String =>
+@defining(
+    if(YouTubeRelatedVideos.isSwitchedOn) {
+        media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")
+    } else {
+        ""
+    }) { channelId: String =>
     @for(asset <- media.activeAssets.headOption) {
         <amp-youtube
             id="gu-video-youtube-@{media.id}"
@@ -11,7 +17,7 @@
             width="16"
             height="9"
             data-param-showinfo="0"
-            data-param-embed_config={"relatedChannels":["@channelId"]}
+            data-param-embed_config='{"relatedChannels":["@{channelId}"], "disableRelatedVideos": @{YouTubeRelatedVideos.isSwitchedOff}}'
         >
         </amp-youtube>
     }

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -2,13 +2,19 @@
 @(media: model.content.MediaAtom, displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
 
-@for(asset <- media.activeAssets.headOption) {
-    <amp-youtube
-    id="gu-video-youtube-@{media.id}"
-    data-videoid="@{asset.id}"
-    layout="responsive"
-    width="16" height="9" data-param-rel="0" data-param-showinfo="0">
-    </amp-youtube>
+@defining(media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")) { channelId: String =>
+    @for(asset <- media.activeAssets.headOption) {
+        <amp-youtube
+            id="gu-video-youtube-@{media.id}"
+            data-videoid="@{asset.id}"
+            layout="responsive"
+            width="16"
+            height="9"
+            data-param-showinfo="0"
+            data-param-embed_config={"relatedChannels":["@channelId"]}
+        >
+        </amp-youtube>
+    }
 }
 
 @if(displayCaption) {

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -5,7 +5,7 @@
 
 @defining(
     if(YouTubeRelatedVideos.isSwitchedOn) {
-        media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")
+        media.channelId.getOrElse("")
     } else {
         ""
     }) { channelId: String =>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -9,6 +9,7 @@
 @import model.content.MediaWrapper
 @import model.content.MediaAsset
 @import conf.switches.Switches.YouTubePosterOverride
+@import conf.switches.Switches.YouTubeRelatedVideos
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
 
@@ -25,14 +26,19 @@
 @defining(media.activeAssets.headOption) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
     @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
-        @defining(media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")){channelId: String =>
+        @defining(
+            if (YouTubeRelatedVideos.isSwitchedOn) {
+                media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")
+            } else {
+                ""
+            }){channelId: String =>
             <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
                 ("u-responsive-ratio", true),
                 ("u-responsive-ratio--hd", sixteenByNine),
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired )
             ))"
-            @for(endSlatePath <- media.endSlatePath if displayEndSlate)  {
+            @for(endSlatePath <- media.endSlatePath if displayEndSlate && !YouTubeRelatedVideos.isSwitchedOn)  {
               data-end-slate="@endSlatePath"
             }
                 data-channel-id="@channelId"

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -28,7 +28,7 @@
     @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
         @defining(
             if (YouTubeRelatedVideos.isSwitchedOn) {
-                media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")
+                media.channelId.getOrElse("")
             } else {
                 ""
             }){channelId: String =>
@@ -39,7 +39,7 @@
                 ("no-player", !playable || expired ),
                 ("youtube-related-videos", YouTubePosterOverride.isSwitchedOn)
             ))"
-            @for(endSlatePath <- media.endSlatePath if displayEndSlate && !YouTubeRelatedVideos.isSwitchedOn)  {
+            @for(endSlatePath <- media.endSlatePath if displayEndSlate && YouTubeRelatedVideos.isSwitchedOff)  {
               data-end-slate="@endSlatePath"
             }
                 data-channel-id="@channelId"

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -24,20 +24,21 @@
 
 @defining(media.activeAssets.headOption) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
-@defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
-
-
-    <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
-        ("u-responsive-ratio", true),
-        ("u-responsive-ratio--hd", sixteenByNine),
-        ("youtube-media-atom", true),
-        ("no-player", !playable || expired )
-    ))"
-    @for(endSlatePath <- media.endSlatePath if displayEndSlate)  {
-      data-end-slate="@endSlatePath"
+    @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
+        @defining(media.channelId.getOrElse("UCHpw8xwDNhU9gdohEcJu4aA")){channelId: String =>
+            <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
+                ("u-responsive-ratio", true),
+                ("u-responsive-ratio--hd", sixteenByNine),
+                ("youtube-media-atom", true),
+                ("no-player", !playable || expired )
+            ))"
+            @for(endSlatePath <- media.endSlatePath if displayEndSlate)  {
+              data-end-slate="@endSlatePath"
+            }
+                data-channel-id="@channelId"
+            >
+        }
     }
-    >
-}
 
         @for(asset <- activeAsset if playable && !expired) {
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -36,7 +36,8 @@
                 ("u-responsive-ratio", true),
                 ("u-responsive-ratio--hd", sixteenByNine),
                 ("youtube-media-atom", true),
-                ("no-player", !playable || expired )
+                ("no-player", !playable || expired ),
+                ("youtube-related-videos", YouTubePosterOverride.isSwitchedOn)
             ))"
             @for(endSlatePath <- media.endSlatePath if displayEndSlate && !YouTubeRelatedVideos.isSwitchedOn)  {
               data-end-slate="@endSlatePath"

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -252,9 +252,9 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
     val contentNoByline = content("video", Nil).content
     val contentWithByline = content("video", Nil, byline).content
 
-    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None))
-    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None))
-    val mediaAtomWithEmptySource = Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None))
+    val mediaAtomWithSource = Some(MediaAtom("", "", Nil, "", None, atomSource, None, None, None, None, None))
+    val mediaAtomWithNoSource = Some(MediaAtom("", "", Nil, "", None, None, None, None, None, None, None))
+    val mediaAtomWithEmptySource = Some(MediaAtom("", "", Nil, "", None, emptySource, None, None, None, None, None))
 
     Video(contentNoByline, None, None).bylineWithSource should be (None)
     Video(contentNoByline, videoSource, None).bylineWithSource should be (videoSource.map(s => s"Source: $s"))

--- a/common/test/views/fragments/atoms/YoutubeSpec.scala
+++ b/common/test/views/fragments/atoms/YoutubeSpec.scala
@@ -26,7 +26,8 @@ class YoutubeSpec extends MixedPlaySpec {
         posterImage = None,
         endSlatePath = None,
         expired = None,
-        activeVersion = None
+        activeVersion = None,
+        channelId = None
       )
       val displayCaption = false
       val view           = views.html.fragments.atoms.youtube(mediaAtom, displayCaption)(FakeRequest())

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -38,7 +38,8 @@ class AtomCleanerTest extends FlatSpec
       posterImage = Some(image),
       endSlatePath = Some("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z"),
       expired = None,
-      activeVersion = None)
+      activeVersion = None,
+      channelId = None)
     ),
     interactives = Nil,
     recipes = Nil,

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -89,9 +89,9 @@ const setupPlayer = (
 ) => {
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
-    // YouTube onward video suggestions will be scoped to this channel
-    // If no channel is specified, no onward suggestions will appear
-    const relatedChannels = channelId ? [channelId] : [];
+    const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
+    const relatedChannels = (!disableRelatedVideos && channelId) ? [channelId] : [];
+
 
     return new window.YT.Player(eltId, {
         videoId,
@@ -107,6 +107,7 @@ const setupPlayer = (
                 'nonPersonalizedAd': !wantPersonalisedAds,
             },
             relatedChannels,
+            disableRelatedVideos,
         },
     });
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -82,12 +82,15 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
 const setupPlayer = (
     eltId: string,
     videoId: string,
+    channelId?: string,
     onReady,
     onStateChange,
     onError
 ) => {
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    const relatedChannels = channelId ? [channelId] : [];
+
     return new window.YT.Player(eltId, {
         videoId,
         width: '100%',
@@ -97,14 +100,11 @@ const setupPlayer = (
             onStateChange,
             onError,
         },
-        playerVars: {
-            rel: 0,
-            showinfo: 0,
-        },
         embedConfig: {
-            adsConfig: {
-                nonPersonalizedAd: !wantPersonalisedAds,
+            'adsConfig': {
+                'nonPersonalizedAd': !wantPersonalisedAds,
             },
+            relatedChannels,
         },
     });
 };
@@ -117,7 +117,8 @@ const getPlayerIframe = videoId =>
 export const initYoutubePlayer = (
     el: HTMLElement,
     handlers: Handlers,
-    videoId: string
+    videoId: string,
+    channelId?: string,
 ): Promise<void> => {
     loadYoutubeJs();
     return promise.then(() => {
@@ -140,6 +141,7 @@ export const initYoutubePlayer = (
         return setupPlayer(
             el.id,
             videoId,
+            channelId,
             onPlayerReady,
             onPlayerStateChange,
             onPlayerError

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -90,6 +90,7 @@ const setupPlayer = (
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
     const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
+    // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
     const relatedChannels =
         !disableRelatedVideos && channelId ? [channelId] : [];
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -89,6 +89,8 @@ const setupPlayer = (
 ) => {
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    // YouTube onward video suggestions will be scoped to this channel
+    // If no channel is specified, no onward suggestions will appear
     const relatedChannels = channelId ? [channelId] : [];
 
     return new window.YT.Player(eltId, {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -90,8 +90,8 @@ const setupPlayer = (
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
     const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
-    const relatedChannels = (!disableRelatedVideos && channelId) ? [channelId] : [];
-
+    const relatedChannels =
+        !disableRelatedVideos && channelId ? [channelId] : [];
 
     return new window.YT.Player(eltId, {
         videoId,
@@ -103,8 +103,8 @@ const setupPlayer = (
             onError,
         },
         embedConfig: {
-            'adsConfig': {
-                'nonPersonalizedAd': !wantPersonalisedAds,
+            adsConfig: {
+                nonPersonalizedAd: !wantPersonalisedAds,
             },
             relatedChannels,
             disableRelatedVideos,
@@ -121,7 +121,7 @@ export const initYoutubePlayer = (
     el: HTMLElement,
     handlers: Handlers,
     videoId: string,
-    channelId?: string,
+    channelId?: string
 ): Promise<void> => {
     loadYoutubeJs();
     return promise.then(() => {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -279,6 +279,7 @@ const checkElemForVideo = (elem: ?HTMLElement): void => {
             // need data attribute with index for unique lookup
             el.setAttribute('data-unique-atom-id', atomId);
             const overlay = el.querySelector('.youtube-media-atom__overlay');
+            const channelId = el.getAttribute('data-channel-id');
 
             initYoutubeEvents(getTrackingId(atomId));
 
@@ -293,7 +294,8 @@ const checkElemForVideo = (elem: ?HTMLElement): void => {
                     ),
                     onPlayerStateChange: onPlayerStateChange.bind(null, atomId),
                 },
-                playerDiv.dataset.assetId
+                playerDiv.dataset.assetId,
+                channelId,
             );
         });
     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -241,6 +241,7 @@ const onPlayerReady = (
 
         if (
             !!config.get('page.section') &&
+            !config.get('switches.youtubeRelatedVideos') &&
             isBreakpoint({
                 min: 'desktop',
             })

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -296,7 +296,7 @@ const checkElemForVideo = (elem: ?HTMLElement): void => {
                     onPlayerStateChange: onPlayerStateChange.bind(null, atomId),
                 },
                 playerDiv.dataset.assetId,
-                channelId,
+                channelId
             );
         });
     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -96,14 +96,20 @@ const setProgressTracker = (atomId: string): IntervalID => {
 
 const onPlayerPlaying = (atomId: string): void => {
     const player = players[atomId];
+    const currentVideo = player.player.getVideoUrl().split('?v=')[1];
+    const originalVideo = player.iframe.dataset.assetId;
 
     if (!player) {
         return;
     }
 
     killProgressTracker(atomId);
-    setProgressTracker(atomId);
-    trackYoutubeEvent('play', getTrackingId(atomId));
+
+    // TODO: implement progress tracking for related videos
+    if (currentVideo === originalVideo) {
+        setProgressTracker(atomId);
+        trackYoutubeEvent('play', getTrackingId(atomId));
+    }
 
     const mainMedia =
         (player.iframe && player.iframe.closest('.immersive-main-media')) ||

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -93,9 +93,9 @@
     transition-duration: 500ms;
 }
 
-.youtube-media-atom__iframe.youtube__video-ended.youtube__video-started ~ .youtube-media-atom__overlay {
+youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.youtube__video-ended.youtube__video-started ~ .youtube-media-atom__overlay {
     @include fade-in;
-}
+ }
 
 .youtube-media-atom__iframe.youtube__video-ended.youtube__video-started ~ .end-slate-container {
     @include mq($from: tablet) {


### PR DESCRIPTION
## What does this change?

When feature is turned on, replaces our video end slate with YouTube's related videos. Clicking a related video will open the video in the same player, with no changes to the page furniture.

Related videos will be scoped to the current video's channel.

This change also adds related videos to YouTube videos in AMP articles, which currently do not display any related content.

In the future, it would be useful to add click and progress tracking for related videos, but I'd like to do that in a separate PR as it is predicated on changes to the [MediaPlayback Thrift definition](https://github.com/guardian/ophan/blob/master/event-model/src/main/thrift/media.thrift).

## Screenshots

![screen shot 2018-08-21 at 15 43 34](https://user-images.githubusercontent.com/5931528/44417082-8159d800-a56c-11e8-87cc-afc536c36424.png)

## What is the value of this and can you measure success?

Currently only 4 suggested videos are displayed in the end slate. With YouTube's related videos, there is a potential for up to 12 videos from a channel. Suggested videos will be optimised for clicks using YouTube's algorithms. They will appear as larger thumbnails. Additionally, they will appear when the video is paused.

Clicks on the you tube end slate do not change the page furniture, which is potentially a good thing if a user is on an article page. They can come straight back to where they left off on the article, even if they choose to consume multiple videos within that iframe/embed.

We will track clicks and progress (25%, 50%, 75%, 100%) on suggested videos via Ophan.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

Adds related videos to AMP

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
