### PR TITLE
Remove Fastly IO AB test, serve 100% images from fastly

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -127,7 +127,7 @@ class AllIndexController(
       item.section.map( section =>
         IndexPage(
           page = Section.make(section),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
           Tags(Nil),
           date,
           tzOverride = None
@@ -137,7 +137,7 @@ class AllIndexController(
           val tag = Tag.make(apitag)
           IndexPage(
             page = tag,
-            contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
+            contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
             Tags(List(tag)),
             date,
             tzOverride = None

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -165,7 +165,7 @@ class CrosswordSearchController(
               val section = Section.make(ApiSection("crosswords", "Crosswords search results", "http://www.theguardian.com/crosswords/search", "", Nil))
               val page = IndexPage(
                 page = section,
-                contents = results.map(IndexPageItem(_, Some(request))),
+                contents = results.map(IndexPageItem(_)),
                 tags = Tags(Nil),
                 date = DateTime.now,
                 tzOverride = None

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -43,7 +43,7 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
     contentApiClient.getResponse(contentApiClient.item(path, edition)
       .showFields("all")
     ).map { response =>
-      val gallery = response.content.map(Content(_, Some(request)))
+      val gallery = response.content.map(Content(_))
       val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, StoryPackages(g, response), index, isTrail) }
 
       ModelOrResult(model, response)

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -53,7 +53,7 @@ class LatestIndexController(
       item.section.map( section =>
         IndexPage(
           page = Section.make(section),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
           tags = Tags(Nil),
           date = DateTime.now,
           tzOverride = None
@@ -61,7 +61,7 @@ class LatestIndexController(
       ).orElse(item.tag.map( tag =>
         IndexPage(
           page = Tag.make(tag),
-          contents = item.results.getOrElse(Nil).map(IndexPageItem(_, Some(request))),
+          contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
           tags = Tags(Nil),
           date = DateTime.now,
           tzOverride = None

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -41,7 +41,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
     )
 
     val result = response map { response =>
-      val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
+      val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
       val model = mediaOption map { media => MediaPage(media, StoryPackages(media, response)) }
 
       ModelOrResult(model, response)

--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -76,7 +76,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
     responses.map { paginatedResults =>
       val urls = for {
         resp <- paginatedResults
-        item <- resp.results.map(result => Content(result))
+        item <- resp.results.map(Content.apply)
       } yield {
         val keywordTags = item.tags.keywords.map(_.metadata.webTitle)
         val sectionTag = item.content.seriesTag.toList.filter(tag => !keywordTags.contains(tag.properties.sectionName)).map(_.metadata.webTitle)

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -76,7 +76,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
     responses.map { paginatedResults =>
       val urls = for {
         resp <- paginatedResults
-        item <- resp.results.map(result => Content(result)).collect({ case video:Video => video })
+        item <- resp.results.map(Content.apply).collect({ case video:Video => video })
       } yield {
         val keywordTags = item.tags.keywords.map(_.metadata.webTitle)
         val sectionTag = item.content.seriesTag.filter(tag => !keywordTags.contains(tag.properties.sectionName)).map(_.metadata.webTitle)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -79,7 +79,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   private def responseToModelOrResult(response: ItemResponse)(implicit request: RequestHeader): Either[ArticlePage, Result] = {
-    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
 
     ModelOrResult(supportedContent, response) match {
       case Left(article:Article) => Left(ArticlePage(article, StoryPackages(article, response)))

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -149,7 +149,7 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
 
   private def responseToModelOrResult(range: BlockRange)(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
 
-    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_, Some(request)))
+    val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
 
     val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -138,7 +138,7 @@
                     }
 
                     case ImageBlockElement(media, data, showCredit) => {
-                        @EmailImage.bestSrcFor(media, Some(request)).map { imageUrl =>
+                        @EmailImage.bestSrcFor(media).map { imageUrl =>
                             @row(Seq("no-pad")) {
                                 @if(article.isTheMinute && block.url.isDefined) {
                                     <a href="@block.url.getOrElse("#")">
@@ -183,7 +183,7 @@
 
                     case ContentAtomBlockElement(atomId) => {
                         @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
-                            @atom.posterImage.flatMap(image => EmailVideoImage.bestSrcFor(image, Some(request))).map { imageUrl =>
+                            @atom.posterImage.flatMap(EmailVideoImage.bestSrcFor).map { imageUrl =>
                                 @atom.activeAssets.headOption.map { asset =>
                                     @row(Seq("padded")) {
                                         @asset.platform match {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -327,7 +327,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object images {
-    lazy val imgixHost = configuration.getMandatoryStringProperty("images.path")
+    lazy val path = configuration.getMandatoryStringProperty("images.path")
     lazy val fastlyIOHost = configuration.getMandatoryStringProperty("fastly-io.host")
     val fallbackLogo = Static("images/fallback-logo.png")
     object backends {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,8 +11,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     OrielParticipation,
     OldTLSSupportDeprecation,
-    ThrasherAdjacentMPU,
-    FastlyIOImages
+    ThrasherAdjacentMPU
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -50,20 +49,11 @@ object AudioPageChange extends Experiment(
   participationGroup = Perc5A
 )
 
-
 object ThrasherAdjacentMPU extends Experiment(
   name = "thrasher-adjacent-mpu",
   description = "This will no longer allow an MPU to show adjacent to a thrasher on mobile",
   owners = Seq(Owner.withGithub("janua")),
   sellByDate = new LocalDate(2018, 9, 7),
   participationGroup = Perc10A
-)
-
-object FastlyIOImages extends Experiment(
-  name = "fastly-io-images",
-  description = "SServe images from fastly-io",
-  owners = Owner.group(SwitchGroup.ServerSideExperiments),
-  sellByDate = new LocalDate(2018, 8, 29),
-  participationGroup = Perc50
 )
 

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -2,7 +2,6 @@ package model
 
 import com.gu.contentapi.client.model.v1.Asset
 import play.api.libs.json.{Json, Writes}
-import play.api.mvc.RequestHeader
 import views.support.{ImgSrc, Naked, Orientation}
 
 object Helpers {
@@ -33,23 +32,13 @@ object Helpers {
 }
 
 object ImageAsset {
-  def make(asset: Asset, index: Int, request: Option[RequestHeader] = None): ImageAsset = {
-
-    // TODO: Remove override parameters and below code after fastly-io test
-    val fields: Map[String, String] = Helpers.assetFieldsToMap(asset)
-    val url = asset.typeData.flatMap(_.secureFile).orElse(asset.file)
-    lazy val path: Option[String] = url.map(ImgSrc(_, Naked, request))
-    val thumbnail: Option[String] = fields.get("thumbnail")
-    val thumbnailPath: Option[String] = thumbnail.map(ImgSrc(_, Naked, request))
-
-
+  def make(asset: Asset, index: Int): ImageAsset = {
     ImageAsset(
       index = index,
       fields = Helpers.assetFieldsToMap(asset),
       mediaType = asset.`type`.name,
       mimeType = asset.mimeType,
-      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file),
-      path, thumbnailPath)
+      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
   implicit val imageAssetWrites: Writes[ImageAsset] = Json.writes[ImageAsset]
 }
@@ -59,14 +48,12 @@ case class ImageAsset(
   fields: Map[String, String],
   mediaType: String,
   mimeType: Option[String],
-  url: Option[String],
-  overridePath: Option[String] = None,
-  overrideThumbnailPath: Option[String] = None) {
+  url: Option[String]) {
 
-  lazy val path: Option[String] = if (overridePath.isDefined) overridePath else url.map(ImgSrc(_, Naked))
+  lazy val path: Option[String] = url.map(ImgSrc(_, Naked))
 
   val thumbnail: Option[String] = fields.get("thumbnail")
-  val thumbnailPath: Option[String] = if (overrideThumbnailPath.isDefined) overrideThumbnailPath else thumbnail.map(ImgSrc(_, Naked))
+  val thumbnailPath: Option[String] = thumbnail.map(ImgSrc(_, Naked))
 
   val width: Int = fields.get("width").map(_.toInt).getOrElse(1)
   val height: Int = fields.get("height").map(_.toInt).getOrElse(1)

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -5,7 +5,6 @@ import org.joda.time.Duration
 import com.gu.contentapi.client.model.v1.{AssetType, ElementType, Element => ApiElement}
 import org.apache.commons.math3.fraction.Fraction
 import play.api.libs.json.{Json, Writes}
-import play.api.mvc.RequestHeader
 
 object ElementProperties {
   def make(capiElement: ApiElement, index: Int): ElementProperties = {
@@ -29,9 +28,9 @@ final case class ElementProperties (
 )
 
 object Element {
-  def apply(capiElement: ApiElement, elementIndex: Int, request: Option[RequestHeader] = None): Element = {
+  def apply(capiElement: ApiElement, elementIndex: Int): Element = {
     val properties = ElementProperties.make(capiElement, elementIndex)
-    val images = ImageMedia.make(capiElement, properties, request)
+    val images = ImageMedia.make(capiElement, properties)
 
     capiElement.`type` match {
       case ElementType.Image => ImageElement(properties, images)
@@ -49,8 +48,8 @@ sealed trait Element {
 }
 
 object ImageMedia {
-  def make(capiElement: ApiElement, properties: ElementProperties, request: Option[RequestHeader] = None): ImageMedia = ImageMedia(
-    allImages = capiElement.assets.filter(_.`type` == AssetType.Image).map(ImageAsset.make(_,properties.index, request)).sortBy(-_.width)
+  def make(capiElement: ApiElement, properties: ElementProperties): ImageMedia = ImageMedia(
+    allImages = capiElement.assets.filter(_.`type` == AssetType.Image).map(ImageAsset.make(_,properties.index)).sortBy(-_.width)
   )
   def make(crops: Seq[ImageAsset]): ImageMedia = ImageMedia(
     allImages = crops

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -556,9 +556,9 @@ object IsRatio {
  * designed to add some structure to the data that comes from CAPI
  */
 object Elements {
-  def make(apiContent: contentapi.Content, request: Option[RequestHeader] = None): Elements = {
+  def make(apiContent: contentapi.Content): Elements = {
     Elements(apiContent.elements
-      .map(_.zipWithIndex.map { case (element, index) => Element(element, index, request) })
+      .map(_.zipWithIndex.map { case (element, index) => Element(element, index) })
       .getOrElse(Nil))
   }
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -50,13 +50,13 @@ object Trail {
     commercial: Commercial,
     elements: Elements,
     metadata: MetaData,
-    apiContent: contentapi.Content, request: Option[RequestHeader] = None): Trail = {
+    apiContent: contentapi.Content): Trail = {
 
     Trail(
       webPublicationDate = apiContent.webPublicationDate.map(_.toJoda).getOrElse(DateTime.now),
       headline = apiContent.fields.flatMap(_.headline).getOrElse(""),
       sectionName = apiContent.sectionName.getOrElse(""),
-      thumbnailPath = apiContent.fields.flatMap(_.thumbnail).map(ImgSrc(_, Naked, request)),
+      thumbnailPath = apiContent.fields.flatMap(_.thumbnail).map(ImgSrc(_, Naked)),
       isCommentable = apiContent.fields.flatMap(_.commentable).exists(b => b),
       isClosedForComments = !apiContent.fields.flatMap(_.commentCloseDate).map(_.toJoda).exists(_.isAfterNow),
       byline = apiContent.fields.flatMap(_.byline).map(stripHtml),

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -179,9 +179,9 @@ object IndexPage {
 
 }
 object IndexPageItem {
-  def apply(content: ApiContent, request: Option[RequestHeader] = None): IndexPageItem = {
+  def apply(content: ApiContent): IndexPageItem = {
     IndexPageItem(
-      Content(content, request),
+      Content(content),
       FaciaContentConvert.contentToFaciaContent(content))
   }
 }

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -21,7 +21,7 @@
     @* This adds 15 src options to the srcset from 500 to the largest image width incrementing by 250px *@
     srcset="@{(500 to largestImage.width by 250)
         .toList
-        .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi, Some(request)))
+        .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi))
         .mkString(", ")}" />
 }
 
@@ -48,10 +48,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true, Some(request))" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), request = Some(request))" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))" />
     }
 
     <!--[if IE 9]></video><![endif]-->

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -16,10 +16,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true, Some(request))" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, request = Some(request))" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -18,7 +18,7 @@
 @if(!amp) {
     @* http://www.chromium.org/developers/design-documents/dns-prefetching *@
     <link rel="dns-prefetch" href="@Configuration.assets.path" />
-    <link rel="dns-prefetch" href="@Configuration.images.imgixHost" />
+    <link rel="dns-prefetch" href="@Configuration.images.path" />
     <link rel="dns-prefetch" href="@Configuration.ajax.url" />
     <link rel="dns-prefetch" href="@AnalyticsHost()" />
     <link rel="dns-prefetch" href="//j.ophan.co.uk" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -18,7 +18,7 @@
 @if(!amp) {
     @* http://www.chromium.org/developers/design-documents/dns-prefetching *@
     <link rel="dns-prefetch" href="@Configuration.assets.path" />
-    <link rel="dns-prefetch" href="@Configuration.images.path" />
+    <link rel="dns-prefetch" href="@Configuration.images.fastlyIOHost" />
     <link rel="dns-prefetch" href="@Configuration.ajax.url" />
     <link rel="dns-prefetch" href="@AnalyticsHost()" />
     <link rel="dns-prefetch" href="//j.ophan.co.uk" />

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -12,7 +12,7 @@ object EmailHelpers {
     def imageUrl(displayElement: Option[FaciaDisplayElement]): Option[String] = displayElement.flatMap {
       case InlineImage(imageMedia) => SmallFrontEmailImage(width).bestSrcFor(imageMedia)
       case InlineVideo(video, _, _, maybeFallbackImage) => EmailVideoImage.bestSrcFor(video.images).orElse(imageUrl(maybeFallbackImage))
-      case InlineYouTubeMediaAtom(atom, posterOverride) => posterOverride.orElse(atom.posterImage).flatMap(image => EmailVideoImage.bestSrcFor(image))
+      case InlineYouTubeMediaAtom(atom, posterOverride) => posterOverride.orElse(atom.posterImage).flatMap(EmailVideoImage.bestSrcFor)
       case _ => None
     }
     imageUrl(contentCard.displayElement)

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -231,7 +231,7 @@ object Naked extends Profile(None, None)
 
 object ImgSrc extends Logging with implicits.Strings {
 
-  private val imageServiceHost: String = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
+  private val imageServiceHost: String = Configuration.images.fastlyIOHost
 
   private case class HostMapping(prefix: String, token: String)
 

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -76,7 +76,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
         element.getElementsByTag("source").remove()
 
         // add the poster url
-        video.map(_.images).flatMap(image => Item640.bestSrcFor(image)).foreach(element.attr("poster", _))
+        video.map(_.images).flatMap(Item640.bestSrcFor).foreach(element.attr("poster", _))
 
         video.foreach { videoElement =>
           videoElement.videos.encodings.map { encoding => {

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -15,7 +15,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  lazy val imageHost = Configuration.images.imgixHost
+  lazy val imageHost = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
 
   val asset = Asset(
     AssetType.Image,

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -15,7 +15,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
-  lazy val imageHost = if (stage == "PROD") Configuration.images.path else Configuration.images.fastlyIOHost
+  lazy val imageHost = Configuration.images.fastlyIOHost
 
   val asset = Asset(
     AssetType.Image,

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -55,7 +55,7 @@ class TaggedContentController(
       .tag(tag)
       .pageSize(3)
     ).map { response =>
-        response.results.toList map { Content(_, Some(request)) }
+        response.results.toList map { Content(_) }
     } recover { case ContentApiError(404, message, _) =>
       log.info(s"Got a 404 while calling content api: $message")
       Nil


### PR DESCRIPTION
## What does this change?
This is mainly a revert of https://github.com/guardian/frontend/pull/20183 to remove the server side experiment - the other changes simply set fastly as the default image host - see https://github.com/guardian/frontend/commit/4f2876c4ea1e960985f8fef8fd2921c95291413c 


## Screenshots

## What is the value of this and can you measure success?
Serving 100% of images from our new image service woohoo! 🎉 🤞 

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
