### PR TITLE
google docs banner copy

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -155,4 +155,54 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 7, 31),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-from-google-doc-one-variant",
+    "serves an banner with copy from a google doc",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-from-google-doc-two-variants",
+    "Serves an banner with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-from-google-doc-three-variants",
+    "Serves an banner with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-from-google-doc-four-variants",
+    "Serves an banner with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-from-google-doc-five-variants",
+    "Serves an banner with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -54,7 +54,7 @@ declare type InitEpicABTestVariant = {
 declare type InitBannerABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
-    engagementBannerParams: () => Promise<EngagementBannerTemplateParams | {} >
+    engagementBannerParams: () => Promise<?EngagementBannerTemplateParams>
 };
 
 declare type InitEpicABTest = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -6,7 +6,7 @@ declare type Variant = {
     impression?: ListenerFunction,
     success?: ListenerFunction,
     options?: Object,
-    engagementBannerParams?: EngagementBannerParams,
+    engagementBannerParams?: () => Promise<EngagementBannerParams>,
 };
 
 declare type ABTest = {
@@ -49,6 +49,12 @@ declare type InitEpicABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
     options?: Object
+};
+
+declare type InitBannerABTestVariant = {
+    id: string,
+    products: $ReadOnlyArray<OphanProduct>,
+    engagementBannerParams: () => Promise<EngagementBannerTemplateParams | {} >
 };
 
 declare type InitEpicABTest = {

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -18,7 +18,6 @@ declare type EngagementBannerTemplateParams = {
 };
 
 declare type EngagementBannerParams = {
-    minArticles: number,
     campaignCode: string,
     buttonCaption: string,
     linkUrl: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -4,6 +4,8 @@ import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
 
 const epicGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
+const bannerGoogleDocUrl: string =
+    'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
 
 const getGoogleDoc = (url: string): Promise<any> =>
     fetchJSON(url, {
@@ -11,6 +13,7 @@ const getGoogleDoc = (url: string): Promise<any> =>
     });
 
 export const getEpicGoogleDoc: Promise<any> = getGoogleDoc(epicGoogleDocUrl);
+export const getBannerGoogleDoc: Promise<any> = getGoogleDoc(bannerGoogleDocUrl);
 
 export const googleDocEpicControl = (): Promise<AcquisitionsEpicTemplateCopy> =>
     getGoogleDoc(epicGoogleDocUrl).then(res => getEpicParams(res, 'control'));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -13,7 +13,9 @@ const getGoogleDoc = (url: string): Promise<any> =>
     });
 
 export const getEpicGoogleDoc: Promise<any> = getGoogleDoc(epicGoogleDocUrl);
-export const getBannerGoogleDoc: Promise<any> = getGoogleDoc(bannerGoogleDocUrl);
+export const getBannerGoogleDoc: Promise<any> = getGoogleDoc(
+    bannerGoogleDocUrl
+);
 
 export const googleDocEpicControl = (): Promise<AcquisitionsEpicTemplateCopy> =>
     getGoogleDoc(epicGoogleDocUrl).then(res => getEpicParams(res, 'control'));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -482,6 +482,15 @@ const makeGoogleDocBannerVariants = (
     return variants;
 };
 
+const makeGoogleDocBannerControl = (): InitBannerABTestVariant => ({
+    id: 'control',
+    products: [],
+    engagementBannerParams: () =>
+        getBannerGoogleDoc.then(res =>
+            getAcquisitionsBannerParams(res, 'control')
+        ),
+});
+
 export {
     shouldShowReaderRevenue,
     shouldShowEpic,
@@ -490,6 +499,7 @@ export {
     makeBannerABTestVariants,
     makeGoogleDocEpicVariants,
     makeGoogleDocBannerVariants,
+    makeGoogleDocBannerControl,
     defaultMaxViews,
     isEpicDisplayable,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,6 +1,7 @@
 // @flow
 import { isAbTestTargeted } from 'common/modules/commercial/targeting-tool';
 import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
+import { getAcquisitionsBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import {
     submitClickEvent,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -454,21 +454,29 @@ const makeGoogleDocEpicVariants = (count: number): Array<Object> => {
             id: `variant_${i}`,
             products: [],
             options: {
-                copy: () => getEpicGoogleDoc.then(res => getEpicParams(res, `variant_${i}`)),
+                copy: () =>
+                    getEpicGoogleDoc.then(res =>
+                        getEpicParams(res, `variant_${i}`)
+                    ),
             },
         });
     }
     return variants;
 };
 
-const makeGoogleDocBannerVariants = (count: number): Array<InitBannerABTestVariant> => {
+const makeGoogleDocBannerVariants = (
+    count: number
+): Array<InitBannerABTestVariant> => {
     const variants = [];
 
     for (let i = 1; i <= count; i += 1) {
         variants.push({
             id: `variant_${i}`,
             products: [],
-            engagementBannerParams: () => getBannerGoogleDoc.then(res => getAcquisitionsBannerParams(res, `variant_${i}`)),
+            engagementBannerParams: () =>
+                getBannerGoogleDoc.then(res =>
+                    getAcquisitionsBannerParams(res, `variant_${i}`)
+                ),
         });
     }
     return variants;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -23,6 +23,7 @@ import { supportContributeURL } from 'common/modules/commercial/support-utilitie
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
 import {
     getEpicGoogleDoc,
+    getBannerGoogleDoc,
     googleDocEpicControl,
 } from 'common/modules/commercial/contributions-google-docs';
 
@@ -453,11 +454,21 @@ const makeGoogleDocEpicVariants = (count: number): Array<Object> => {
             id: `variant_${i}`,
             products: [],
             options: {
-                copy: () =>
-                    getEpicGoogleDoc.then(res =>
-                        getEpicParams(res, `variant_${i}`)
-                    ),
+                copy: () => getEpicGoogleDoc.then(res => getEpicParams(res, `variant_${i}`)),
             },
+        });
+    }
+    return variants;
+};
+
+const makeGoogleDocBannerVariants = (count: number): Array<InitBannerABTestVariant> => {
+    const variants = [];
+
+    for (let i = 1; i <= count; i += 1) {
+        variants.push({
+            id: `variant_${i}`,
+            products: [],
+            engagementBannerParams: () => getBannerGoogleDoc.then(res => getAcquisitionsBannerParams(res, `variant_${i}`)),
         });
     }
     return variants;
@@ -470,6 +481,7 @@ export {
     defaultButtonTemplate,
     makeBannerABTestVariants,
     makeGoogleDocEpicVariants,
+    makeGoogleDocBannerVariants,
     defaultMaxViews,
     isEpicDisplayable,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -119,7 +119,7 @@ export const getAcquisitionsBannerParams = (
     return paramsFromGoogleDoc;
 };
 
-export const getUserVariantTemplateParams = (
+export const getUserVariantParams = (
     userVariant: ?Variant
 ): Promise<EngagementBannerTemplateParams | {}> => {
     if (userVariant && userVariant.engagementBannerParams) {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -15,11 +15,8 @@ const engagementBannerControl: string = `<strong>The Guardian is editorially ind
     up a paywall as we want to keep our journalism open and accessible. But the revenue we get from
     advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
 
-const initialContribution = 1;
-
-const supporterCost = (location: string, askAmount: number): string => {
+const supporterCost = (location: string, amount: number = 1 ): string => {
     const countryGroup = getSupporterCountryGroup(location);
-    const amount = askAmount || initialContribution;
 
     if (countryGroup === 'EURCountries') {
         // Format either 4.99 € or €4.99 depending on country
@@ -60,7 +57,6 @@ const supporterCost = (location: string, askAmount: number): string => {
 const supporterEngagementCtaCopyControl = (location: string): string =>
     `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${supporterCost(
         location,
-        initialContribution
     )}.</span>`;
 
 export const defaultEngagementBannerParams = (): EngagementBannerParams => {
@@ -96,9 +92,13 @@ export const getAcquisitionsBannerParams = (
             firstRow.linkUrl
         )
     ) {
-        reportError(new Error('Could not fetch banner copy from Google Doc'), {
-            feature: 'engagement-banner-test',
-        }, true);
+        reportError(
+            new Error('Could not fetch banner copy from Google Doc'),
+            {
+                feature: 'engagement-banner-test',
+            },
+            true
+        );
     }
 
     const ctaText = `<span class="engagement-banner__highlight">${

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -7,6 +7,7 @@ import {
     extendedCurrencySymbol,
 } from 'lib/geolocation';
 import { supportContributeURL } from './support-utilities';
+import { getBannerGoogleDoc } from './contributions-google-docs';
 
 const engagementBannerControl: string = `<strong>The Guardian is editorially independent &ndash;
     our journalism is free from the influence of billionaire owners or politicians.
@@ -78,7 +79,7 @@ export const defaultEngagementBannerParams = (): EngagementBannerParams => {
 export const getAcquisitionsBannerParams = (
     googleDocJson: any,
     sheetName: string
-): EngagementBannerTemplateParams | {} => {
+): ?EngagementBannerTemplateParams => {
     const rows =
         googleDocJson &&
         googleDocJson.sheets &&
@@ -98,7 +99,7 @@ export const getAcquisitionsBannerParams = (
         reportError(new Error('Could not fetch banner copy from Google Doc'), {
             feature: 'engagement-banner-test',
         });
-        return {};
+        return;
     }
 
     const ctaText = `<span class="engagement-banner__highlight">${
@@ -119,12 +120,17 @@ export const getAcquisitionsBannerParams = (
     return paramsFromGoogleDoc;
 };
 
+export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTemplateParams> =>
+    getBannerGoogleDoc.then(json =>
+        getAcquisitionsBannerParams(json, 'control')
+    );
+
 export const getUserVariantParams = (
     userVariant: ?Variant
-): Promise<EngagementBannerTemplateParams | {}> => {
+): Promise<?EngagementBannerParams> => {
     if (userVariant && userVariant.engagementBannerParams) {
         return userVariant.engagementBannerParams();
     }
 
-    return Promise.resolve({});
+    return Promise.resolve();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -98,8 +98,7 @@ export const getAcquisitionsBannerParams = (
     ) {
         reportError(new Error('Could not fetch banner copy from Google Doc'), {
             feature: 'engagement-banner-test',
-        });
-        return;
+        }, true);
     }
 
     const ctaText = `<span class="engagement-banner__highlight">${

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -17,14 +17,14 @@ const engagementBannerControl: string = `<strong>The Guardian is editorially ind
 
 const initialContribution = 1;
 
-const supporterCost = (location: string): string => {
+const supporterCost = (location: string, askAmount: number): string => {
     const countryGroup = getSupporterCountryGroup(location);
+    const amount = askAmount ? askAmount : initialContribution;
 
     if (countryGroup === 'EURCountries') {
         // Format either 4.99 € or €4.99 depending on country
         // See https://en.wikipedia.org/wiki/Linguistic_issues_concerning_the_euro
         const euro = extendedCurrencySymbol.EURCountries;
-        const amount = initialContribution;
 
         const euroAfterCountryCodes = [
             'BG',
@@ -54,12 +54,12 @@ const supporterCost = (location: string): string => {
             : euro + amount;
     }
 
-    return `${extendedCurrencySymbol[countryGroup]}${initialContribution}`;
+    return `${extendedCurrencySymbol[countryGroup]}${amount}`;
 };
 
 const supporterEngagementCtaCopyControl = (location: string): string =>
     `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${supporterCost(
-        location
+        location, initialContribution,
     )}.</span>`;
 
 export const defaultEngagementBannerParams = (): EngagementBannerParams => {
@@ -88,6 +88,7 @@ export const getAcquisitionsBannerParams = (
             firstRow &&
             firstRow.messageText &&
             firstRow.ctaText &&
+            firstRow.askAmount &&
             firstRow.buttonCaption &&
             firstRow.linkUrl
         )
@@ -99,11 +100,13 @@ export const getAcquisitionsBannerParams = (
         return {};
     }
 
+    const ctaText = `<span class="engagement-banner__highlight">${firstRow.ctaText}</span>`;
+
     const location = getGeoLocation();
     const paramsFromGoogleDoc: EngagementBannerTemplateParams = {
         messageText: firstRow.messageText,
-        ctaText: firstRow.ctaText.replace(
-            /%%CURRENCY_SYMBOL%%/g, supporterEngagementCtaCopyControl(location)),
+        ctaText: ctaText.replace(
+            /%%CURRENCY_SYMBOL%%/g, supporterCost(location, firstRow.askAmount)),
         buttonCaption: firstRow.buttonCaption,
         linkUrl: firstRow.linkUrl,
     };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -15,7 +15,7 @@ const engagementBannerControl: string = `<strong>The Guardian is editorially ind
     up a paywall as we want to keep our journalism open and accessible. But the revenue we get from
     advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
 
-const supporterCost = (location: string, amount: number = 1 ): string => {
+const supporterCost = (location: string, amount: number = 1): string => {
     const countryGroup = getSupporterCountryGroup(location);
 
     if (countryGroup === 'EURCountries') {
@@ -56,7 +56,7 @@ const supporterCost = (location: string, amount: number = 1 ): string => {
 
 const supporterEngagementCtaCopyControl = (location: string): string =>
     `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${supporterCost(
-        location,
+        location
     )}.</span>`;
 
 export const defaultEngagementBannerParams = (): EngagementBannerParams => {
@@ -101,7 +101,7 @@ export const getAcquisitionsBannerParams = (
         );
     }
 
-    const ctaText = `<span class="engagement-banner__highlight">${
+    const ctaText = `<span class="engagement-banner__highlight"> ${
         firstRow.ctaText
     }</span>`;
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -114,20 +114,16 @@ const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
         }));
     }
 
-    if (userVariant && userVariant.engagementBannerParams) {
-        const campaignCode: ?{ campaignCode: string } = buildCampaignCode(
-            userTest,
-            userVariant
-        );
+    const campaignCode: ?{ campaignCode: string } = buildCampaignCode(
+        userTest,
+        userVariant
+    );
 
-        return getUserVariantParams(userVariant).then(variantParams => ({
-            ...defaultParams,
-            ...variantParams,
-            ...campaignCode,
-        }));
-    }
-
-    return Promise.resolve({ ...defaultParams });
+    return getUserVariantParams(userVariant).then(variantParams => ({
+        ...defaultParams,
+        ...variantParams,
+        ...campaignCode,
+    }));
 };
 
 const userVariantCanShow = (): boolean => {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -8,7 +8,7 @@ import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import { isInTest, variantFor } from 'common/modules/experiments/segment-util';
 import {
     defaultEngagementBannerParams,
-    getUserVariantTemplateParams,
+    getUserVariantParams,
 } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
@@ -92,6 +92,10 @@ const buildCampaignCode = (
     userVariant: ?Variant
 ): { campaignCode: string } | {} => {
     if (userTest && userVariant) {
+        const params = userVariant.engagementBannerParams;
+        if (params && params.campaignCode) {
+            return params.campaignCode;
+        }
         return { campaignCode: `${userTest.campaignId}_${userVariant.id}` };
     }
     return {};
@@ -102,15 +106,15 @@ const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
     const userVariant: ?Variant = getUserVariant(userTest);
 
     const defaultParams: EngagementBannerParams = defaultEngagementBannerParams();
-    const variantTemplateParamsPromise: Promise<
-        EngagementBannerTemplateParams | {}
-    > = getUserVariantTemplateParams(userVariant);
+    const variantParamsPromise: Promise<
+        EngagementBannerParams | {}
+    > = getUserVariantParams(userVariant);
     const campaignCode: { campaignCode: string } | {} = buildCampaignCode(
         userTest,
         userVariant
     );
 
-    return variantTemplateParamsPromise.then(variantTemplateParams => ({
+    return variantParamsPromise.then(variantTemplateParams => ({
         ...defaultParams,
         ...variantTemplateParams,
         ...campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -106,7 +106,7 @@ const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
     const userVariant: ?Variant = getUserVariant(userTest);
     const defaultParams: EngagementBannerParams = defaultEngagementBannerParams();
 
-    // if the user isn't in a test, use the control in google docs
+    // if the user isn't in a test variant, use the control in google docs
     if (!userVariant) {
         return getControlEngagementBannerParams().then(controlParams => ({
             ...defaultParams,
@@ -119,11 +119,13 @@ const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
         userVariant
     );
 
-    return getUserVariantParams(userVariant).then(variantParams => ({
-        ...defaultParams,
-        ...variantParams,
-        ...campaignCode,
-    })).catch(() => defaultParams);
+    return getUserVariantParams(userVariant)
+        .then(variantParams => ({
+            ...defaultParams,
+            ...variantParams,
+            ...campaignCode,
+        }))
+        .catch(() => defaultParams);
 };
 
 const userVariantCanShow = (): boolean => {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -6,7 +6,10 @@ import mediator from 'lib/mediator';
 import { membershipEngagementBannerTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import { isInTest, variantFor } from 'common/modules/experiments/segment-util';
-import { defaultEngagementBannerParams, getUserVariantTemplateParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
+import {
+    defaultEngagementBannerParams,
+    getUserVariantTemplateParams,
+} from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
@@ -61,7 +64,6 @@ const getUserTest = (): ?AcquisitionsABTest =>
 const getUserVariant = (test: ?ABTest): ?Variant =>
     test ? variantFor(test) : undefined;
 
-
 /*
  * Params for the banner are overlaid in this order, earliest taking precedence:
  *
@@ -85,25 +87,34 @@ const getUserVariant = (test: ?ABTest): ?Variant =>
  *
  */
 
-const buildCampaignCode= (userTest: ?AcquisitionsABTest, userVariant: ?Variant): {campaignCode: string } | {}  => {
+const buildCampaignCode = (
+    userTest: ?AcquisitionsABTest,
+    userVariant: ?Variant
+): { campaignCode: string } | {} => {
     if (userTest && userVariant) {
-        return {campaignCode: `${userTest.campaignId}_${userVariant.id}`}
+        return { campaignCode: `${userTest.campaignId}_${userVariant.id}` };
     }
-    return {}
+    return {};
 };
 
-export const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
+const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
     const userTest: ?AcquisitionsABTest = getUserTest();
-    const userVariant: ?Variant= getUserVariant(userTest);
+    const userVariant: ?Variant = getUserVariant(userTest);
 
     const defaultParams: EngagementBannerParams = defaultEngagementBannerParams();
-    const variantTemplateParamsPromise: Promise<EngagementBannerTemplateParams | {} > = getUserVariantTemplateParams(userVariant);
-    const campaignCode: { campaignCode :string } | {} = buildCampaignCode(userTest, userVariant);
+    const variantTemplateParamsPromise: Promise<
+        EngagementBannerTemplateParams | {}
+    > = getUserVariantTemplateParams(userVariant);
+    const campaignCode: { campaignCode: string } | {} = buildCampaignCode(
+        userTest,
+        userVariant
+    );
 
-    return variantTemplateParamsPromise.then(variantTemplateParams => {
-
-        return {...defaultParams, ...variantTemplateParams, ...campaignCode};
-    });
+    return variantTemplateParamsPromise.then(variantTemplateParams => ({
+        ...defaultParams,
+        ...variantTemplateParams,
+        ...campaignCode,
+    }));
 };
 
 const userVariantCanShow = (): boolean => {
@@ -118,7 +129,6 @@ const userVariantCanShow = (): boolean => {
         return false;
     }
     return true;
-
 };
 
 const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
@@ -203,25 +213,27 @@ const showBanner = (params: EngagementBannerParams): void => {
     }
 };
 
-const show = (): Promise<boolean> => {
-    return deriveBannerParams().then(params => {
+const show = (): Promise<boolean> =>
+    deriveBannerParams().then(params => {
         if (params) {
             showBanner(params);
             return Promise.resolve(true);
         }
         return Promise.resolve(false);
-    })
-};
+    });
 
 const canShow = (): Promise<boolean> => {
     if (!config.get('switches.membershipEngagementBanner') || isBlocked()) {
         return Promise.resolve(false);
     }
 
-    const hasSeenEnoughArticles: boolean =
-        getVisitCount() >= minArticles;
+    const hasSeenEnoughArticles: boolean = getVisitCount() >= minArticles;
 
-    if (hasSeenEnoughArticles && shouldShowReaderRevenue() && userVariantCanShow()) {
+    if (
+        hasSeenEnoughArticles &&
+        shouldShowReaderRevenue() &&
+        userVariantCanShow()
+    ) {
         const userLastClosedBannerAt = userPrefs.get(
             'engagementBannerLastClosedAt'
         );

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -123,7 +123,7 @@ const deriveBannerParams = (): Promise<?EngagementBannerParams> => {
         ...defaultParams,
         ...variantParams,
         ...campaignCode,
-    }));
+    })).catch(() => defaultParams);
 };
 
 const userVariantCanShow = (): boolean => {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -4,10 +4,11 @@ import fakeConfig from 'lib/config';
 import fakeOphan from 'ophan/ng';
 import fetchJson from 'lib/fetch-json';
 import userPrefs from 'common/modules/user-prefs';
-import { defaultEngagementBannerParams as defaultEngagementBannerParams_,
-    getUserVariantTemplateParams as getUserVariantTemplateParams_
+import {
+    defaultEngagementBannerParams as defaultEngagementBannerParams_,
+    getUserVariantTemplateParams as getUserVariantTemplateParams_,
 } from 'common/modules/commercial/membership-engagement-banner-parameters';
-import { membershipEngagementBanner, deriveBannerParams } from 'common/modules/commercial/membership-engagement-banner';
+import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const defaultEngagementBannerParams: any = defaultEngagementBannerParams_;
@@ -85,7 +86,7 @@ jest.mock(
                 messageText: 'test-message-text',
                 ctaText: 'test-cta-text',
             })
-        )
+        ),
     })
 );
 jest.mock('common/modules/experiments/test-can-run-checks', () => ({
@@ -223,21 +224,25 @@ describe('Membership engagement banner', () => {
         });
 
         it('should show the membership engagement banner', () => {
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1)
-            )
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1)
+                );
         });
 
         it('should emit a display event', () => {
-            membershipEngagementBanner.show().then( () =>
-                expect(emitSpy).toHaveBeenCalledWith(
-                    'membership-message:display'
-                )
-            )
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(emitSpy).toHaveBeenCalledWith(
+                        'membership-message:display'
+                    )
+                );
         });
 
         it('should record the component event in ophan with a/b test info', () =>
-            membershipEngagementBanner.show().then( () =>
+            membershipEngagementBanner.show().then(() =>
                 expect(fakeOphan.record).toHaveBeenCalledWith({
                     componentEvent: {
                         component: {
@@ -273,26 +278,29 @@ describe('Membership engagement banner', () => {
             }));
             getUserVariantTemplateParams.mockImplementationOnce(() =>
                 Promise.resolve({
-                id: 'fake-variant-id',
-                engagementBannerParams: {},
-            }));
+                    id: 'fake-variant-id',
+                    engagementBannerParams: {},
+                })
+            );
         });
 
         it('correct campaign code', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(
-                    FakeMessage.mock.calls[0][1].siteMessageComponentName
-                ).toBe('fake-campaign-id_fake-variant-id')
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(
+                        FakeMessage.mock.calls[0][1].siteMessageComponentName
+                    ).toBe('fake-campaign-id_fake-variant-id')
+                ));
 
         it('correct CSS modifier class', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.mock.calls[0][1].cssModifierClass).toBe(
-                    'engagement-banner'
-                )
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.mock.calls[0][1].cssModifierClass).toBe(
+                        'engagement-banner'
+                    )
+                ));
     });
 
     describe('renders message with', () => {
@@ -303,7 +311,7 @@ describe('Membership engagement banner', () => {
                 buttonCaption: 'fake-button-caption',
             }));
             getUserVariantTemplateParams.mockImplementationOnce(() =>
-                Promise.resolve({ })
+                Promise.resolve({})
             );
             fakeConfig.get.mockImplementationOnce(() => true);
             fakeConstructQuery.mockImplementationOnce(
@@ -312,35 +320,39 @@ describe('Membership engagement banner', () => {
         });
 
         it('message text', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-message-text/
-                )
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                        /fake-message-text/
+                    )
+                ));
 
         it('colour class', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /engagement-banner/
-                )
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                        /engagement-banner/
+                    )
+                ));
 
         it('link URL', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-link-url\?fake-query-parameters/
-                )
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                        /fake-link-url\?fake-query-parameters/
+                    )
+                ));
 
         it('button caption', () =>
-            membershipEngagementBanner.show().then( () =>
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-button-caption/
-                )
-            )
-        );
+            membershipEngagementBanner
+                .show()
+                .then(() =>
+                    expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                        /fake-button-caption/
+                    )
+                ));
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -6,13 +6,13 @@ import fetchJson from 'lib/fetch-json';
 import userPrefs from 'common/modules/user-prefs';
 import {
     defaultEngagementBannerParams as defaultEngagementBannerParams_,
-    getUserVariantTemplateParams as getUserVariantTemplateParams_,
+    getUserVariantParams as getUserVariantParams_,
 } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const defaultEngagementBannerParams: any = defaultEngagementBannerParams_;
-const getUserVariantTemplateParams: any = getUserVariantTemplateParams_;
+const getUserVariantParams: any = getUserVariantParams_;
 
 jest.mock('lib/mediator');
 jest.mock('lib/storage', () => ({
@@ -79,7 +79,7 @@ jest.mock(
             products: ['CONTRIBUTION'],
             linkUrl: 'fake-link-url',
         })),
-        getUserVariantTemplateParams: jest.fn(() =>
+        getUserVariantParams: jest.fn(() =>
             Promise.resolve({
                 buttonCaption: 'test-button-caption',
                 linkUrl: 'test-link-url',
@@ -276,7 +276,7 @@ describe('Membership engagement banner', () => {
             defaultEngagementBannerParams.mockImplementationOnce(() => ({
                 linkUrl: 'fake-link-url',
             }));
-            getUserVariantTemplateParams.mockImplementationOnce(() =>
+            getUserVariantParams.mockImplementationOnce(() =>
                 Promise.resolve({
                     id: 'fake-variant-id',
                     engagementBannerParams: {},
@@ -310,7 +310,7 @@ describe('Membership engagement banner', () => {
                 linkUrl: 'fake-link-url',
                 buttonCaption: 'fake-button-caption',
             }));
-            getUserVariantTemplateParams.mockImplementationOnce(() =>
+            getUserVariantParams.mockImplementationOnce(() =>
                 Promise.resolve({})
             );
             fakeConfig.get.mockImplementationOnce(() => true);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
@@ -2,6 +2,7 @@
 import {
     makeBannerABTestVariants,
     makeGoogleDocBannerVariants,
+    makeGoogleDocBannerControl,
 } from 'common/modules/commercial/contributions-utilities';
 
 const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
@@ -31,9 +32,7 @@ const acquisitionsBannerGoogleDocTest = (
         canRun: () => true,
 
         variants: makeBannerABTestVariants([
-            {
-                id: 'control',
-            },
+            makeGoogleDocBannerControl(),
             ...makeGoogleDocBannerVariants(noOfVariants),
         ]),
     };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
@@ -1,0 +1,40 @@
+// @flow strict
+import { makeBannerABTestVariants, makeGoogleDocBannerVariants } from 'common/modules/commercial/contributions-utilities';
+
+const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const getTestName = (variantName: string): string => `AcquisitionsBannerFromGoogleDoc${variantName}`;
+
+const acquisitionsBannerGoogleDocTest = (noOfVariants: number, variantName: string): AcquisitionsABTest => {
+    const abTestName = getTestName(variantName);
+
+    return {
+        id: abTestName,
+        campaignId: abTestName,
+        start: '2018-08-06',
+        expiry: '2019-06-06',
+        author: 'Emma Milner',
+        description:
+            'Tests a banner with copy defined in google doc',
+        audience: 1,
+        audienceOffset: 0,
+        audienceCriteria: 'All web traffic.',
+        successMeasure: 'AV 2.0',
+        idealOutcome: 'Increase in overall AV, and AV from recurring',
+        componentType,
+        showForSensitive: true,
+        canRun: () => true,
+
+        variants: makeBannerABTestVariants([
+            {
+                id: 'control',
+            },
+            ...makeGoogleDocBannerVariants(noOfVariants),
+        ]),
+    }
+};
+
+export const AcquisitionsBannerGoogleDocTestOneVariant = acquisitionsBannerGoogleDocTest(1, 'OneVariant');
+export const AcquisitionsBannerGoogleDocTestTwoVariants = acquisitionsBannerGoogleDocTest(2, 'TwoVariants');
+export const AcquisitionsBannerGoogleDocTestThreeVariants = acquisitionsBannerGoogleDocTest(3, 'ThreeVariants');
+export const AcquisitionsBannerGoogleDocTestFourVariants = acquisitionsBannerGoogleDocTest(4, 'FourVariants');
+export const AcquisitionsBannerGoogleDocTestFiveVariants = acquisitionsBannerGoogleDocTest(5, 'FiveVariants');

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-from-google-doc.js
@@ -1,10 +1,17 @@
 // @flow strict
-import { makeBannerABTestVariants, makeGoogleDocBannerVariants } from 'common/modules/commercial/contributions-utilities';
+import {
+    makeBannerABTestVariants,
+    makeGoogleDocBannerVariants,
+} from 'common/modules/commercial/contributions-utilities';
 
 const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
-const getTestName = (variantName: string): string => `AcquisitionsBannerFromGoogleDoc${variantName}`;
+const getTestName = (variantName: string): string =>
+    `AcquisitionsBannerFromGoogleDoc${variantName}`;
 
-const acquisitionsBannerGoogleDocTest = (noOfVariants: number, variantName: string): AcquisitionsABTest => {
+const acquisitionsBannerGoogleDocTest = (
+    noOfVariants: number,
+    variantName: string
+): AcquisitionsABTest => {
     const abTestName = getTestName(variantName);
 
     return {
@@ -13,8 +20,7 @@ const acquisitionsBannerGoogleDocTest = (noOfVariants: number, variantName: stri
         start: '2018-08-06',
         expiry: '2019-06-06',
         author: 'Emma Milner',
-        description:
-            'Tests a banner with copy defined in google doc',
+        description: 'Tests a banner with copy defined in google doc',
         audience: 1,
         audienceOffset: 0,
         audienceCriteria: 'All web traffic.',
@@ -30,11 +36,26 @@ const acquisitionsBannerGoogleDocTest = (noOfVariants: number, variantName: stri
             },
             ...makeGoogleDocBannerVariants(noOfVariants),
         ]),
-    }
+    };
 };
 
-export const AcquisitionsBannerGoogleDocTestOneVariant = acquisitionsBannerGoogleDocTest(1, 'OneVariant');
-export const AcquisitionsBannerGoogleDocTestTwoVariants = acquisitionsBannerGoogleDocTest(2, 'TwoVariants');
-export const AcquisitionsBannerGoogleDocTestThreeVariants = acquisitionsBannerGoogleDocTest(3, 'ThreeVariants');
-export const AcquisitionsBannerGoogleDocTestFourVariants = acquisitionsBannerGoogleDocTest(4, 'FourVariants');
-export const AcquisitionsBannerGoogleDocTestFiveVariants = acquisitionsBannerGoogleDocTest(5, 'FiveVariants');
+export const AcquisitionsBannerGoogleDocTestOneVariant = acquisitionsBannerGoogleDocTest(
+    1,
+    'OneVariant'
+);
+export const AcquisitionsBannerGoogleDocTestTwoVariants = acquisitionsBannerGoogleDocTest(
+    2,
+    'TwoVariants'
+);
+export const AcquisitionsBannerGoogleDocTestThreeVariants = acquisitionsBannerGoogleDocTest(
+    3,
+    'ThreeVariants'
+);
+export const AcquisitionsBannerGoogleDocTestFourVariants = acquisitionsBannerGoogleDocTest(
+    4,
+    'FourVariants'
+);
+export const AcquisitionsBannerGoogleDocTestFiveVariants = acquisitionsBannerGoogleDocTest(
+    5,
+    'FiveVariants'
+);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -8,4 +8,9 @@ import {AcquisitionsBannerGoogleDocTestOneVariant,
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [AcquisitionsBannerGoogleDocTestOneVariant];
+> = [AcquisitionsBannerGoogleDocTestOneVariant,
+    AcquisitionsBannerGoogleDocTestTwoVariants,
+    AcquisitionsBannerGoogleDocTestThreeVariants,
+    AcquisitionsBannerGoogleDocTestFourVariants,
+    AcquisitionsBannerGoogleDocTestFiveVariants,
+];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,5 +1,11 @@
 // @flow strict
+import {AcquisitionsBannerGoogleDocTestOneVariant,
+        AcquisitionsBannerGoogleDocTestTwoVariants,
+        AcquisitionsBannerGoogleDocTestThreeVariants,
+        AcquisitionsBannerGoogleDocTestFourVariants,
+        AcquisitionsBannerGoogleDocTestFiveVariants,
+} from 'common/modules/experiments/tests/acquisitions-banner-from-google-doc';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsBannerGoogleDocTestOneVariant];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,14 +1,16 @@
 // @flow strict
-import {AcquisitionsBannerGoogleDocTestOneVariant,
-        AcquisitionsBannerGoogleDocTestTwoVariants,
-        AcquisitionsBannerGoogleDocTestThreeVariants,
-        AcquisitionsBannerGoogleDocTestFourVariants,
-        AcquisitionsBannerGoogleDocTestFiveVariants,
+import {
+    AcquisitionsBannerGoogleDocTestOneVariant,
+    AcquisitionsBannerGoogleDocTestTwoVariants,
+    AcquisitionsBannerGoogleDocTestThreeVariants,
+    AcquisitionsBannerGoogleDocTestFourVariants,
+    AcquisitionsBannerGoogleDocTestFiveVariants,
 } from 'common/modules/experiments/tests/acquisitions-banner-from-google-doc';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [AcquisitionsBannerGoogleDocTestOneVariant,
+> = [
+    AcquisitionsBannerGoogleDocTestOneVariant,
     AcquisitionsBannerGoogleDocTestTwoVariants,
     AcquisitionsBannerGoogleDocTestThreeVariants,
     AcquisitionsBannerGoogleDocTestFourVariants,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -1,9 +1,8 @@
 // @flow
 import { Message } from 'common/modules/ui/message';
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
-import { engagementBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
+import { defaultEngagementBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { addTrackingCodesToUrl } from 'common/modules/commercial/acquisitions-ophan';
 import {
     messageCode as engagementMessageCode,
@@ -20,9 +19,7 @@ import marque36icon from 'svgs/icon/marque-36.svg';
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 
-const bannerParams: EngagementBannerParams = engagementBannerParams(
-    geolocationGetSync()
-);
+const bannerParams: EngagementBannerParams = defaultEngagementBannerParams();
 
 const bannerTemplateParams: EngagementBannerTemplateParams = {
     messageText: bannerParams.messageText,


### PR DESCRIPTION
## What does this change?

Changes to ab testing code:
- Adds ability to run copy tests on engagement banner using google docs. 
- Adds (5) new tests for up to five variants. 
- The google docs can set `EngagementBannerTemplateParams` only. 
- The google doc has the following editable fields: 

messageText | ctaText | askAmount | buttonCaption | linkUrl
-- | -- | -- | -- | --
- Other tests can be run with custom `EngagementBannerParams`. 
- Previously variant values were set to `variant.options.engagementBanner`, now values are set to [`variant.engagementBannerParams`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/__flow__/types/ab-tests.js#L9). 


Changes to membership engagement banner code:

- Previously, getting user variant variables was synchronous, now we are using google docs json this has been split into getting the values relevant for `canShow` (still synchronous) and getting the template variables (which returns a promise).  
- If the banner is successfully picked and is going to be shown, fetch relevant parameters from json.
- Hard codes the minimum number of articles a user must have read before seeing the banner to 2. 

Changes to tests:
- As the initialisation of banner parameters has been moved out of `canShow`, tests can call `show` directly, removes `canShow().then...`.
- As `getUserVariantTemplateParams` is now a promise this is mocked in the tests.
- Updates mock objects to set values to `variant.engagementBanner`.

## Screenshots

## What is the value of this and can you measure success?
🤓Non-engineers can set up tests, keeps process of running banner tests in line with epic tests. 
@ionamckendrick 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
