### PR TITLE
Bigger emails on Android

### DIFF
--- a/static/src/stylesheets/email/_normalise.scss
+++ b/static/src/stylesheets/email/_normalise.scss
@@ -45,7 +45,6 @@ img {
 
 center {
     width: 100%;
-    min-width: $max-width;
 }
 
 a img {


### PR DESCRIPTION
## What does this change?
Make the text on android emails slightly bigger by removing the width definition for `<center>`. (This sadly needs testing)

## Screenshots
<table>
<td>

![screen shot 2018-08-22 at 12 48 39 pm](https://user-images.githubusercontent.com/11539094/44462205-be28dc00-a60b-11e8-82aa-2be6fe27f3e2.png)

</td>
<td>

![screen shot 2018-08-22 at 12 49 13 pm](https://user-images.githubusercontent.com/11539094/44462210-c719ad80-a60b-11e8-959c-e3e1512894c0.png)

</td>
</table>

### Tested

- [x] Locally
- [ ] On CODE (optional)