### PR TITLE
Replace client IP query parameter with X-Forwarded-For

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -64,7 +64,7 @@ class ChangePasswordController(
         val form = passwordForm.bindFromFlash.getOrElse(passwordForm)
 
         val idRequest = idRequestParser(request)
-        api.passwordExists(request.user.auth) map {
+        api.passwordExists(request.user.auth, idRequest.trackingData) map {
           result =>
             val pwdExists = result.right.toOption contains true
             NoCache(Ok(

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -95,13 +95,12 @@ class ResetPasswordController(
 
     def onSuccess(form: (String, String, String, Option[String])): Future[Result] = form match {
       case (password, password_confirm, email_address, returnUrl) =>
-
-        val authResponse = api.resetPassword(token,password)
+        val idRequest = idRequestParser(request)
+        val authResponse = api.resetPassword(token, password, idRequest.trackingData)
         signInService.getCookies(authResponse, true) map {
           case Left(errors) =>
             logger.info(s"reset password errors, ${errors.toString()}")
             if (errors.exists("Token expired" == _.message)) {
-              val idRequest = idRequestParser(request)
               NoCache(SeeOther(idUrlBuilder.buildUrl("/reset/resend", idRequest)))
             } else {
               val formWithError = errors.foldLeft(requestPasswordResetForm) { (form, error) =>

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -223,11 +223,11 @@ class IdApiClient(
     def apply(paramsOpt: Option[Parameters]): Parameters = paramsOpt.getOrElse(Iterable.empty)
    }
 
-  private def buildParams(auth: Option[Auth] = None,
-                            tracking: Option[TrackingData] = None,
-                            extra: Parameters = Iterable.empty): Parameters = {
-    extra ++ clientAuth.parameters ++ auth.map(_.parameters)
-  }
+  private def buildParams(
+      auth: Option[Auth] = None,
+      tracking: Option[TrackingData] = None,
+      extra: Parameters = Iterable.empty): Parameters =
+    extra ++ clientAuth.parameters ++ auth.map(_.parameters) ++ tracking.map(_.parameters)
 
   private def buildHeaders(auth: Option[Auth] = None, extra: Parameters = Iterable.empty): Parameters = {
     extra ++ clientAuth.headers ++ auth.map(_.headers)

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -35,7 +35,7 @@ class IdApiClient(
   //   AUTH
   def authBrowser(userAuth: Auth, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
     val params = buildParams(None, Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
-    val headers = buildHeaders(Some(userAuth))
+    val headers = buildHeaders(Some(userAuth), extra = xForwardedForHeader(trackingData))
     val body = write(userAuth)
     val response = httpClient.POST(apiUrl("auth"), Some(body), params, headers)
     response map extract(jsonField("cookies"))
@@ -95,16 +95,17 @@ class IdApiClient(
   def register(user: User, trackingParameters: TrackingData, returnUrl: Option[String] = None): Future[Response[User]] = {
     val userData = write(user)
     val params = buildParams(tracking = Some(trackingParameters), extra = returnUrl.map(url => Iterable("returnUrl" -> url)))
-    val headers = buildHeaders(extra = trackingParameters.ipAddress.map(ip => Iterable("X-Forwarded-For" -> ip)))
+    val headers = buildHeaders(extra = xForwardedForHeader(trackingParameters))
     val response = httpClient.POST(apiUrl("user"), Some(userData), params, headers)
     response map extractUser
   }
 
   // PASSWORD RESET/UPDATE
 
-  def passwordExists( auth: Auth ): Future[Response[Boolean]] = {
+  def passwordExists(auth: Auth, trackingData: TrackingData): Future[Response[Boolean]] = {
     val apiPath = urlJoin("user", "password-exists")
-    val response = httpClient.GET(apiUrl(apiPath), None, buildParams(Some(auth)), buildHeaders(Some(auth)))
+    val headers = buildHeaders(Some(auth), extra = xForwardedForHeader(trackingData))
+    val response = httpClient.GET(apiUrl(apiPath), None, buildParams(Some(auth)), headers)
     response map extract[Boolean](jsonField("passwordExists"))
   }
 
@@ -122,17 +123,18 @@ class IdApiClient(
     response map extractUser
   }
 
-  def resetPassword( token : String, newPassword : String ): Future[Response[CookiesResponse]] = {
+  def resetPassword( token : String, newPassword: String, trackingData: TrackingData): Future[Response[CookiesResponse]] = {
     val apiPath = urlJoin("pwd-reset", "reset-pwd-for-user")
     val postBody = write(TokenPassword(token, newPassword))
-    val response = httpClient.POST(apiUrl(apiPath), Some(postBody), clientAuth.parameters, clientAuth.headers)
+    val headers = clientAuth.headers ++ buildHeaders(extra = xForwardedForHeader(trackingData))
+    val response = httpClient.POST(apiUrl(apiPath), Some(postBody), clientAuth.parameters, headers)
     response map extract(jsonField("cookies"))
   }
 
   def sendPasswordResetEmail(emailAddress : String, trackingParameters: TrackingData): Future[Response[Unit]] = {
     val apiPath = urlJoin("pwd-reset", "send-password-reset-email")
     val params = buildParams(tracking = Some(trackingParameters), extra = Iterable("email-address" -> emailAddress, "type" -> "reset"))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders())
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(extra = xForwardedForHeader(trackingParameters)))
     response map extractUnit
   }
 
@@ -141,7 +143,7 @@ class IdApiClient(
   def userEmails(userId: String, trackingParameters: TrackingData): Future[Response[Subscriber]] = {
     val apiPath = urlJoin("useremails", userId)
     val params = buildParams(tracking = Some(trackingParameters))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders())
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(extra = xForwardedForHeader(trackingParameters)))
     response map extract(jsonField("result"))
   }
 
@@ -168,7 +170,13 @@ class IdApiClient(
 
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData, returnUrlOpt: Option[String]): Future[Response[Unit]] = {
     val extraParams = returnUrlOpt.map(url => List("returnUrl" -> url))
-    httpClient.POST(apiUrl("user/send-validation-email"), None, buildParams(Some(auth), Some(trackingParameters), extraParams), buildHeaders(Some(auth))) map extractUnit
+    httpClient
+      .POST(
+        apiUrl("user/send-validation-email"),
+        None,
+        buildParams(Some(auth), Some(trackingParameters), extraParams),
+        buildHeaders(Some(auth), xForwardedForHeader(trackingParameters)))
+      .map(extractUnit)
   }
 
   def deleteTelephone(auth: Auth): Future[Response[Unit]] =
@@ -197,8 +205,13 @@ class IdApiClient(
   def post(apiPath: String,
            auth: Option[Auth] = None,
            trackingParameters: Option[TrackingData] = None,
-           body: Option[String] = None): Future[Response[HttpResponse]] =
-    httpClient.POST(apiUrl(apiPath), body, buildParams(auth, trackingParameters), buildHeaders(auth))
+           body: Option[String] = None): Future[Response[HttpResponse]] = {
+    httpClient.POST(
+      apiUrl(apiPath),
+      body,
+      buildParams(auth, trackingParameters),
+      buildHeaders(auth, trackingParameters.map(xForwardedForHeader)))
+  }
 
   def delete(apiPath: String,
            auth: Option[Auth] = None,
@@ -213,11 +226,7 @@ class IdApiClient(
   private def buildParams(auth: Option[Auth] = None,
                             tracking: Option[TrackingData] = None,
                             extra: Parameters = Iterable.empty): Parameters = {
-    extra ++ clientAuth.parameters ++
-      auth.map(_.parameters) ++
-      tracking.map({ trackingData =>
-        trackingData.parameters ++ trackingData.ipAddress.map(ip => "ip" -> ip)
-      })
+    extra ++ clientAuth.parameters ++ auth.map(_.parameters)
   }
 
   private def buildHeaders(auth: Option[Auth] = None, extra: Parameters = Iterable.empty): Parameters = {
@@ -231,6 +240,12 @@ class IdApiClient(
       slug.stripPrefix("/").stripSuffix("/")
     }) mkString "/"
   }
+
+  private def xForwardedForHeader(trackingParameters: TrackingData): Parameters =
+    trackingParameters
+      .ipAddress
+      .map(ip => Iterable("X-Forwarded-For" -> ip))
+      .getOrElse(Iterable.empty)
 }
 
 

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -97,12 +97,12 @@ class ResetPasswordControllerTest
 
     val fakeRequest = FakeRequest(POST, "/reset_password" ).withFormUrlEncodedBody("password" -> "newpassword", "password-confirm" -> "newpassword", "email-address" -> "test@somewhere.com")
     "when the token provided is valid" - {
-      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String], MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Right(cookieResponse)))
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Right(cookieList)))
 
       "should call the api the password with the provided new password and token" in Fake {
          resetPasswordController.resetPassword("1234", None)(fakeRequest)
-         verify(api).resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"))
+         verify(api).resetPassword(MockitoMatchers.eq("1234"), MockitoMatchers.eq("newpassword"), MockitoMatchers.eq(identityRequest.trackingData))
       }
       "should return password confirmation view in" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
@@ -112,10 +112,10 @@ class ResetPasswordControllerTest
     }
 
     "when the reset token has expired" - {
-      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String])).thenReturn(Future.successful(Right(cookieResponse)))
+      when(api.resetPassword(MockitoMatchers.any[String], MockitoMatchers.any[String], MockitoMatchers.any[TrackingData])).thenReturn(Future.successful(Right(cookieResponse)))
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(tokenExpired)))
 
-      when(api.resetPassword("1234","newpassword")).thenReturn(Future.successful(Left(tokenExpired)))
+      when(api.resetPassword("1234","newpassword", identityRequest.trackingData)).thenReturn(Future.successful(Left(tokenExpired)))
       "should redirect to request request new password with a token expired" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
         status(result) should equal(SEE_OTHER)
@@ -126,7 +126,7 @@ class ResetPasswordControllerTest
     "when the reset token is not valid" - {
       when(signInService.getCookies(MockitoMatchers.any[Future[Response[CookiesResponse]]], MockitoMatchers.anyBoolean())(MockitoMatchers.any[ExecutionContext])).thenReturn(Future.successful(Left(accesssDenied)))
 
-      when(api.resetPassword("1234", "newpassword")).thenReturn(Future.successful(Left(accesssDenied)))
+      when(api.resetPassword("1234", "newpassword", identityRequest.trackingData)).thenReturn(Future.successful(Left(accesssDenied)))
       "should redirect to request new password with a problem resetting your password" in Fake {
         val result = resetPasswordController.resetPassword("1234", None)(fakeRequest)
         status(result) should equal(SEE_OTHER)


### PR DESCRIPTION
## What does this change?

Forward client IP to IDAPI via `X-Forwarded-For` header instead of `ip` query parameter.

## What is the value of this and can you measure success?

Less sensitive data in logs - IP in query param can leak.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
