### PR TITLE
Email headlines for articles

### DIFF
--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -32,9 +32,11 @@ class LatestIndexController(
   private def handleSeriesBlogs(index: IndexPage)(implicit request: RequestHeader) = (index.trails.headOption, request.isEmail) match {
     case (Some(latest), true) =>
       val queryString = request.campaignCode.fold(Map.empty[String, Seq[String]])(c => Map("CMP" -> Seq(c)))
+      val queryStringWithFormat = if (request.isEmailHeadlineText) queryString + ("format" -> Seq("email-headline")) else queryString
+
       val emailJsonPrefix = if (request.isEmailJson) ".emailjson" else ""
       val url = s"${latest.metadata.url}/email$emailJsonPrefix"
-      Redirect(url, queryString)
+      Redirect(url, queryStringWithFormat)
 
     case (Some(latest), false) =>
       Found(latest.metadata.url)

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -38,6 +38,14 @@ import play.api.test.Helpers._
     header("Location", result).head should endWith ("/email.emailjson")
   }
 
+
+  it should "redirect with URL parameter format=email-headline for a blog" in {
+    val result = latestIndexController.latest("fashion/fashion-blog")(TestRequest("/fashion/fashion-blog/email?format=email-headline"))
+    status(result) should be(SeeOther)
+    header("Location", result).head should include ("/fashion-blog/")
+    header("Location", result).head should endWith ("/email?format=email-headline")
+  }
+
   it should "redirect to latest for a blog" in {
     val result = latestIndexController.latest("fashion/fashion-blog")(TestRequest())
     status(result) should be(Found)

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -122,7 +122,9 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
   def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
 
-    if (request.isEmailJson) {
+    if (request.isEmailHeadlineText) {
+      RevalidatableResult.Ok(page.metadata.webTitle)
+    } else if (request.isEmailJson) {
       RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithInlineStyles.toString))))
     } else {
       RevalidatableResult.Ok(htmlWithInlineStyles)

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -40,6 +40,8 @@ trait Requests {
 
     lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(EMAIL_SUFFIX) || isEmailJson
 
+    lazy val isEmailHeadlineText: Boolean = r.getQueryString("format").contains("email-headline")
+
     lazy val isModified = isJson || isRss || isEmail
 
     lazy val pathWithoutModifiers: String =

--- a/common/test/common/CommonPackageTest.scala
+++ b/common/test/common/CommonPackageTest.scala
@@ -45,4 +45,10 @@ class CommonPackageTest extends FlatSpec with Matchers with WithTestApplicationC
     key shouldBe "body"
     value should include ("<html")
   }
+
+  "renderEmail" should "output the article title used by the email subject if the format parameter is set to email-headline" in new PackageTestScope {
+    val html = Html("")
+    val result = Future.successful(common.renderEmail(html, contentPage)(TestRequest("/content/email?format=email-headline"), testApplicationContext))
+    contentAsString(result) shouldBe "webTitle"
+  }
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -98,9 +98,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
     (editionalisedPath != path) && request.getQueryString("page").isEmpty
   }
 
-  private[this] def shouldOnlyReturnHeadline(request: RequestHeader): Boolean =
-    request.getQueryString("format").contains("email-headline")
-
   def redirectTo(path: String)(implicit request: RequestHeader): Future[Result] = successful {
     val params = request.rawQueryStringOption.map(q => s"?$q").getOrElse("")
     Cached(CacheTime.Facia)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
@@ -136,7 +133,7 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   }
 
   private def renderEmail(faciaPage: PressedPage)(implicit request: RequestHeader) = {
-    if (shouldOnlyReturnHeadline(request)) {
+    if (request.isEmailHeadlineText) {
       renderEmailHeadline(faciaPage)
     } else {
       renderEmailFront(faciaPage)


### PR DESCRIPTION
## What does this change?

Retrieve email headlines for articles

## Screenshots

![picture 60](https://user-images.githubusercontent.com/29203769/44576965-c9a11200-a787-11e8-8669-4611a1d3e0da.png)

## What is the value of this and can you measure success?

Required for the Braze migration for generating email subjects

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
