### PR TITLE
 replace imgix parameters w and h by Fastly's width and height

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -405,7 +405,7 @@ import collection.JavaConverters._
 
         And("video meta thumbnailUrl should be set")
         $("[itemprop='associatedMedia video'] [itemprop=thumbnailUrl]").attribute("content") should
-          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?w=640&h=360&q=55&auto=format&usm=12&fit=max&s=")
+          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?width=640&height=360&q=55&auto=format&usm=12&fit=max&s=")
 
         And("video meta uploadDate should be set")
         $("[itemprop='associatedMedia video'] [itemprop=uploadDate]").attribute("content") should be("2014-05-16T16:09:34.000+01:00")

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -137,7 +137,7 @@ import collection.JavaConverters._
 
         And("I should see the image url")
         el("[itemprop='associatedMedia image'] [itemprop=url]").attribute("content") should
-          include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=")
+          include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?width=700&q=55&auto=format&usm=12&fit=max&s=")
 
         And("I should see the image width")
         el("[itemprop='associatedMedia image'] [itemprop=width]").attribute("content") should be("460")

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -55,15 +55,14 @@ sealed trait ElementProfile {
       "dpr=2"
     }
   } else {""}
-  val heightParam = height.map(pixels => s"h=$pixels").getOrElse("")
-  val widthParam = width.map(pixels => s"w=$pixels").getOrElse("")
+  val heightParam = height.map(pixels => s"height=$pixels").getOrElse("")
+  val widthParam = width.map(pixels => s"width=$pixels").getOrElse("")
 
   def resizeString: String = {
     val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam).filter(_.nonEmpty).mkString("&")
     s"?$params"
   }
-
-
+  
 }
 
 case class Profile(

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -62,7 +62,7 @@ sealed trait ElementProfile {
     val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam).filter(_.nonEmpty).mkString("&")
     s"?$params"
   }
-  
+
 }
 
 case class Profile(

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -84,12 +84,12 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestSrcFor(image).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?w=700&q=55&auto=format&usm=12&fit=max&s=")
+      Item700.bestSrcFor(image).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of a media service to the resizing endpoint with a /media prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestSrcFor(mediaImage).get should startWith (s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=")
+      Item700.bestSrcFor(mediaImage).get should startWith (s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of the image if it is disabled" in {
@@ -100,13 +100,13 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
   it should "convert the URL of the image if it is a PNG (original image from static.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of the image if it is a PNG (original image from static-secure.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static-secure.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {
@@ -123,12 +123,12 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
   it should "convert the URL of a jpeg s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestSrcFor(s3UploadJpgImage).get should startWith (s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(s3UploadJpgImage).get should startWith (s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of a png s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestSrcFor(s3UploadPNGImage).get should startWith (s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(s3UploadPNGImage).get should startWith (s"$imageHost/img/uploads/2016/02/04/gu.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of a gif s3 upload (we do not support animated GIF)" in {


### PR DESCRIPTION
### What does this change?

Change the image URLs we generate to use Fastly's `weigth` and `height` parameters instead of imgix's `w` and `h`. This happens because we are moving to Fastly IO. Note that currently the rewrite is done in the VCL. 

### Tested

- [x] Locally
- [x] On CODE (optional)

PROD: https://i.guim.co.uk/img/media/43545bb8657309b456d512d319e7cae7f3410260/0_234_3500_2100/master/3500.jpg?w=1300&q=55&auto=format&usm=12&fit=max&s=db419a8d76ba59b4c0cc91aa3b2ada24

CODE: https://fastly-io-code.guim.co.uk/img/media/43545bb8657309b456d512d319e7cae7f3410260/0_234_3500_2100/master/3500.jpg?width=1300&q=55&auto=format&usm=12&fit=max&s=173bb559886249ca8bd505fbcf236e8f

From: https://www.theguardian.com/global-development/2018/aug/24/rohingya-one-year-after-attacks