### PR TITLE
rewrite imgix parameter q to fastly quality, while updating the values

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -137,7 +137,7 @@ import collection.JavaConverters._
 
         And("I should see the image url")
         el("[itemprop='associatedMedia image'] [itemprop=url]").attribute("content") should
-          include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?width=700&q=55&auto=format&usm=12&fit=max&s=")
+          include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?width=700&quality=85&auto=format&usm=12&fit=max&s=")
 
         And("I should see the image width")
         el("[itemprop='associatedMedia image'] [itemprop=width]").attribute("content") should be("460")
@@ -405,7 +405,7 @@ import collection.JavaConverters._
 
         And("video meta thumbnailUrl should be set")
         $("[itemprop='associatedMedia video'] [itemprop=thumbnailUrl]").attribute("content") should
-          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?width=640&height=360&q=55&auto=format&usm=12&fit=max&s=")
+          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?width=640&height=360&quality=85&auto=format&usm=12&fit=max&s=")
 
         And("video meta uploadDate should be set")
         $("[itemprop='associatedMedia video'] [itemprop=uploadDate]").attribute("content") should be("2014-05-16T16:09:34.000+01:00")

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -44,7 +44,7 @@ sealed trait ElementProfile {
     bestFor(image).flatMap(_.altText)
 
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
-  val qualityparam = if (hidpi) {"q=20"} else {"q=55"}
+  val qualityparam = if (hidpi) {"quality=45"} else {"quality=85"}
   val autoParam = if (autoFormat) "auto=format" else ""
   val sharpParam = "usm=12"
   val fitParam = "fit=max"
@@ -107,7 +107,7 @@ object Video1280 extends VideoProfile(width = Some(1280), height = Some(720)) //
 object GoogleStructuredData extends Profile(width = Some(300), height = Some(300)) // 1:1
 
 class ShareImage(blendImageParam: String, shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
-  override val heightParam = "h=630"
+  override val heightParam = "height=630"
   override val fitParam = "fit=crop"
   val cropParam = "crop=faces%2Centropy"
   val blendModeParam = "bm=normal"
@@ -193,13 +193,13 @@ object FacebookOpenGraphImage extends OverlayBase64 {
 }
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {
-  override val qualityparam = "q=40"
+  override val qualityparam = "quality=60"
   val knownWidth = width.get
 }
 
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) with OverlayBase64 {
   override val fitParam = "fit=crop"
-  override val qualityparam = "q=40"
+  override val qualityparam = "quality=60"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=center"
   val blendImageParam = s"blend64=${overlayUrlBase64("play.png")}"
@@ -211,7 +211,7 @@ object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) wi
 }
 
 object FrontEmailImage extends Profile(width = Some(500), autoFormat = false) {
-  override val qualityparam = "q=40"
+  override val qualityparam = "quality=60"
   val knownWidth = width.get
 }
 
@@ -219,7 +219,7 @@ object SmallFrontEmailImage {
   def apply(customWidth: Int): SmallFrontEmailImage = new SmallFrontEmailImage(customWidth)
 }
 class SmallFrontEmailImage(customWidth: Int) extends Profile(Some(customWidth), autoFormat = false) {
-  override val qualityparam = "q=40"
+  override val qualityparam = "quality=60"
 }
 
 // The imager/images.js base image.

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -84,12 +84,12 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestSrcFor(image).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?width=700&q=55&auto=format&usm=12&fit=max&s=")
+      Item700.bestSrcFor(image).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of a media service to the resizing endpoint with a /media prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestSrcFor(mediaImage).get should startWith (s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?width=700&q=55&auto=format&usm=12&fit=max&s=")
+      Item700.bestSrcFor(mediaImage).get should startWith (s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of the image if it is disabled" in {
@@ -100,13 +100,13 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
   it should "convert the URL of the image if it is a PNG (original image from static.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of the image if it is a PNG (original image from static-secure.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static-secure.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(pngImage).get should startWith (s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {
@@ -123,12 +123,12 @@ class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
   it should "convert the URL of a jpeg s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestSrcFor(s3UploadJpgImage).get should startWith (s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?width=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(s3UploadJpgImage).get should startWith (s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "convert the URL of a png s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestSrcFor(s3UploadPNGImage).get should startWith (s"$imageHost/img/uploads/2016/02/04/gu.png?width=700&q=55&auto=format&usm=12&fit=max&s=")
+    Item700.bestSrcFor(s3UploadPNGImage).get should startWith (s"$imageHost/img/uploads/2016/02/04/gu.png?width=700&quality=85&auto=format&usm=12&fit=max&s=")
   }
 
   it should "not convert the URL of a gif s3 upload (we do not support animated GIF)" in {


### PR DESCRIPTION
### What does this change?

Follow up of: https://github.com/guardian/frontend/pull/20237

Here we use Fastly's `quality`. Note that this required an update of the values. There currently is a more complete mapping in the VCL.

### Tested
- [x] Locally

