### PR TITLE
Safer bid responses

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -196,10 +196,14 @@ class PrebidService {
                                 const bidResponses = window.pbjs.getBidResponses()[
                                     advert.id
                                 ];
-                                const adSlotBidResponses = 
-                                    bidResponses && advert.id in bidResponses ? bidResponses[advert.id] : {};
+                                const adSlotBidResponses =
+                                    bidResponses && advert.id in bidResponses
+                                        ? bidResponses[advert.id]
+                                        : {};
                                 const cpm: number = getHighestCpm(
-                                    (adSlotBidResponses && adSlotBidResponses.bids) || []
+                                    (adSlotBidResponses &&
+                                        adSlotBidResponses.bids) ||
+                                        []
                                 );
                                 if (cpm > 0) {
                                     advert.slot.setTargeting('hb_cpm', cpm);

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -196,8 +196,10 @@ class PrebidService {
                                 const bidResponses = window.pbjs.getBidResponses()[
                                     advert.id
                                 ];
+                                const adSlotBidResponses = 
+                                    bidResponses && advert.id in bidResponses ? bidResponses[advert.id] : {};
                                 const cpm: number = getHighestCpm(
-                                    (bidResponses && bidResponses.bids) || []
+                                    (adSlotBidResponses && adSlotBidResponses.bids) || []
                                 );
                                 if (cpm > 0) {
                                     advert.slot.setTargeting('hb_cpm', cpm);


### PR DESCRIPTION
## What does this change?

This makes the usage of `bidResponses` more safe by checking if the ad-slot ID exists before attempting to get the bids for it.

@guardian/commercial-dev 