### PR TITLE
Update admin image purge tool to purge images from Fastly

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -29,10 +29,6 @@ object AdminConfiguration {
     lazy val ajaxServiceId = configuration.getStringProperty("fastly.ajax.serviceId").getOrElse(throw new RuntimeException("Fastly ajax service id not configured"))
   }
 
-  object imgix {
-    lazy val key = configuration.getStringProperty("imgix.key").getOrElse(throw new RuntimeException("Imgix key not configured"))
-  }
-
   object dfpApi {
     lazy val clientId = configuration.getStringProperty("api.dfp.clientId")
     lazy val clientSecret = configuration.getStringProperty("api.dfp.clientSecret")

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -21,8 +21,6 @@ class ImageDecacheController(
   extends BaseController with Logging with ImplicitControllerExecutionContext with AdminAuthController {
     import ImageDecacheController._
 
-  val imageServices = new ImageServices(wsClient)
-
   private val iGuim = """i.guim.co.uk/img/(static|media|uploads|sport)(/.*)""".r
   private val Origin = """(static|media|sport|uploads).guim.co.uk/.*""".r
 
@@ -31,36 +29,36 @@ class ImageDecacheController(
   }
 
   def decache(): Action[AnyContent] = AdminAuthAction.async { implicit request =>
-    getSubmittedImage(request).map(new URI(_)).map{ image =>
+    getSubmittedImage(request).map(new URI(_)).map{ imageUri =>
 
-      val originUrl: String = s"${image.getHost}${image.getPath}" match {
-        case iGuim(host, path) => s"${image.getScheme}://$host.guim.co.uk$path"
-        case Origin(_) => s"${image.getScheme}://${image.getHost}${image.getPath}"
+      // here we limit the url to ones for which purging is supported
+      val originUrl: String = s"${imageUri.getHost}${imageUri.getPath}" match {
+        case iGuim(host, path) => s"${imageUri.getScheme}://$host.guim.co.uk$path"
+        case Origin(_) => s"${imageUri.getScheme}://${imageUri.getHost}${imageUri.getPath}"
 
-        case _ => throw new RuntimeException(image.toString)
+        case _ => throw new RuntimeException(imageUri.toString)
       }
 
       val cacheBust = UUID.randomUUID()
-
       val originUri = new URI(originUrl)
 
-      imageServices.clearFastly(originUri)
+      ImageServices.clearFastly(originUri, wsClient)
 
       val decacheRequest: Future[WSResponse] = wsClient.url(s"$originUrl?cachebust=$cacheBust").get
       decacheRequest.map(_.status).map{
         case NOT_FOUND => Ok(views.html.cache.imageDecache(
           messageType = Cleared,
-          image = image.toString,
+          image = imageUri.toString,
           originImage = Some(originUrl)
         ))
         case OK => Ok(views.html.cache.imageDecache(
           messageType = ImageStillOnOrigin,
-          image = image.toString,
+          image = imageUri.toString,
           originImage = Some(originUrl)
         ))
         case status => Ok(views.html.cache.imageDecache(
           messageType = Error,
-          image = image.toString,
+          image = imageUri.toString,
           originImage = Some(originUrl)
         ))
       }.map(NoCache(_))

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -23,8 +23,8 @@ class ImageDecacheController(
 
   val imageServices = new ImageServices(wsClient)
 
-  private val iGuim = """i.guim.co.uk/img/(static|media|uploads)(/.*)""".r
-  private val Origin = """(static|media).guim.co.uk/.*""".r
+  private val iGuim = """i.guim.co.uk/img/(static|media|uploads|sport)(/.*)""".r
+  private val Origin = """(static|media|sport|uploads).guim.co.uk/.*""".r
 
   def renderImageDecacheForm(): Action[AnyContent] = Action { implicit request =>
     NoCache(Ok(views.html.cache.imageDecache()))
@@ -45,7 +45,6 @@ class ImageDecacheController(
       val originUri = new URI(originUrl)
 
       imageServices.clearFastly(originUri)
-      imageServices.clearImgix(originUri)
 
       val decacheRequest: Future[WSResponse] = wsClient.url(s"$originUrl?cachebust=$cacheBust").get
       decacheRequest.map(_.status).map{

--- a/admin/app/controllers/cache/ImageServices.scala
+++ b/admin/app/controllers/cache/ImageServices.scala
@@ -3,14 +3,18 @@ package controllers.cache
 import java.net.URI
 
 import conf.AdminConfiguration.fastly
+import conf.Configuration.environment.stage
 import play.api.libs.ws.WSClient
 
-class ImageServices(wsClient: WSClient) {
+object ImageServices {
 
   // none of the stuff here is a state secret.
   // it is all authenticated
 
-  private val fastlyIOGuimCoUk = "1L0HRheo6sMtfQHnY1FU6C"
+  private val iGuimCoUk = "1L0HRheo6sMtfQHnY1FU6C"
+  private val iGuimCodeCoUk = "5CSDV7WcKwnIIHipZzt3po"
+
+  private val fastlyIOService = if (stage == "PROD") iGuimCoUk else iGuimCodeCoUk
 
   private val fastlyOriginCdns = Map(
     "static.guim.co.uk" -> "5qHts5Ev0rFxzm1DhCkmyA",
@@ -19,10 +23,10 @@ class ImageServices(wsClient: WSClient) {
     "sport.guim.co.uk" -> "1C2vPr3E26cRb4NXa0wMf3"
   )
 
-  // clear both the origin CDN and i.guim.co.uk
-  private def fastlyServiceIdsforOrigin(host: String): Seq[String] = Seq(fastlyOriginCdns(host), fastlyIOGuimCoUk)
+  // clear both the origin CDN and Fastly IO service (either i.guim.co.uk or i.guimcode.co.uk)
+  private def fastlyServiceIdsforOrigin(host: String): Seq[String] = Seq(fastlyOriginCdns(host), fastlyIOService)
 
-  def clearFastly(originUri: URI) {
+  def clearFastly(originUri: URI, wsClient: WSClient) {
     fastlyServiceIdsforOrigin(originUri.getHost).foreach { serviceId =>
       // This works because the "path" is set as a Surrogate Key for images in i.guim.co.uk
       // https://www.fastly.com/blog/surrogate-keys-part-1/

--- a/admin/app/controllers/cache/ImageServices.scala
+++ b/admin/app/controllers/cache/ImageServices.scala
@@ -2,51 +2,25 @@ package controllers.cache
 
 import java.net.URI
 
-import conf.AdminConfiguration.{fastly, imgix}
-import play.api.libs.json.{JsObject, JsString}
-import play.api.libs.ws.{WSAuthScheme, WSClient}
-import views.support.ImgSrc.tokenFor
-import views.support.ImageUrlSigner.sign
+import conf.AdminConfiguration.fastly
+import play.api.libs.ws.WSClient
 
 class ImageServices(wsClient: WSClient) {
 
   // none of the stuff here is a state secret.
   // it is all authenticated
 
-  private val iGuimCoUk = "YjEge7vUbdglYXtZ56cU1"
+  private val fastlyIOGuimCoUk = "1L0HRheo6sMtfQHnY1FU6C"
 
   private val fastlyOriginCdns = Map(
     "static.guim.co.uk" -> "5qHts5Ev0rFxzm1DhCkmyA",
     "media.guim.co.uk" -> "1NLDlK1ywahkZzRZrmWIYw",
-    "uploads.guim.co.uk" -> "2TmfkSoyUoNo8aFNe6Htjs"
+    "uploads.guim.co.uk" -> "2TmfkSoyUoNo8aFNe6Htjs",
+    "sport.guim.co.uk" -> "1C2vPr3E26cRb4NXa0wMf3"
   )
 
   // clear both the origin CDN and i.guim.co.uk
-  private def fastlyServiceIdsforOrigin(host: String): Seq[String] = Seq(fastlyOriginCdns(host), iGuimCoUk)
-
-
-  private val imgixBackends = Map(
-    "static.guim.co.uk" -> "static-guim.imgix.net",
-    "media.guim.co.uk" -> "media-guim.imgix.net",
-    "uploads.guim.co.uk" -> "uploads-guim.imgix.net"
-  )
-  private def imgixBackendFor(host: String): String = imgixBackends(host)
-
-  def clearImgix(originUri: URI) {
-    val host = originUri.getHost
-    val imgixHost = imgixBackendFor(host)
-    val http = originUri.getScheme
-    val originalPath = originUri.getPath
-    val path = tokenFor(host).map(sign(originalPath, _)).getOrElse(originalPath)
-
-    val url = s"$http://$imgixHost$path"
-    val bodyJson = JsObject(Seq("url" -> JsString(url)))
-
-    wsClient.url("https://api.imgix.com/v2/image/purger")
-      // yeah, they just use the first part of basic auth
-      .withAuth(imgix.key, "", WSAuthScheme.BASIC)
-      .post(bodyJson)
-  }
+  private def fastlyServiceIdsforOrigin(host: String): Seq[String] = Seq(fastlyOriginCdns(host), fastlyIOGuimCoUk)
 
   def clearFastly(originUri: URI) {
     fastlyServiceIdsforOrigin(originUri.getHost).foreach { serviceId =>

--- a/admin/app/views/cache/imageDecache.scala.html
+++ b/admin/app/views/cache/imageDecache.scala.html
@@ -16,7 +16,9 @@
                 </code>
             </p>
             <p>
-                Works with images on <code>i.guim.co.uk</code>, <code>static.guim.co.uk</code> and <code>media.guim.co.uk</code>
+                Works with images on <code>i.guim.co.uk</code>, <code>static.guim.co.uk</code> and <code>media.guim.co.uk</code>.
+                    ALL versions of the image will be cleared - so if you submit an image with query paramter width=20,
+                    the cache will also be busted for the same image with width=50
             </p>
 
             <p>


### PR DESCRIPTION
## What does this change?
This modifies the admin purge tool, removing any imgix specific code and adding the new fastly image service.

## What is the value of this and can you measure success?
We will be able to purge images from our new image service 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
