### PR TITLE
Remove jsdom dataset shim in comment-count tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -32,25 +32,6 @@ describe('Comment Count', () => {
                 <div class="trail" data-commentcount-format="content" data-discussion-id="/p/3ghNp"><a href="/article/3">1</a></div>
             </div>`;
         }
-
-        // Workaround to support dataset lookups
-        const trails = document.getElementsByClassName('trail');
-
-        [...trails].forEach(trail => {
-            const data = {
-                discussionClosed: trail.getAttribute('data-discussion-closed'),
-                discussionId: trail.getAttribute('data-discussion-id'),
-                commentcountFormat: trail.getAttribute(
-                    'data-commentcount-format'
-                ),
-            };
-
-            Object.keys(data).forEach(key => {
-                if (data[key]) {
-                    trail.dataset[key] = data[key];
-                }
-            });
-        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
## What does this change?

The comment-count tests currently contain a shim for `Element.dataset`, accounting for an earlier limitation in jsdom (added during ES6 conversion in #17718)

Since [v11.2.0](https://github.com/jsdom/jsdom/blob/master/Changelog.md#1120), jsdom now supports dataset so this shim can be removed.

## What is the value of this and can you measure success?

Less code to maintain. Also, this complexity may be contributing to intermittently failing tests in this module.
