### PR TITLE
Added Opinion email banner to Opinion AUS email

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -329,6 +329,11 @@ case object FilmToday extends FrontEmailMetadata {
   override val banner = Some("film-today.png")
 }
 
+case object OpinionAus extends FrontEmailMetadata {
+  val name = "Opinion Aus"
+  override val banner = Some("opinion.png")
+}
+
 object EmailAddons {
   private val defaultAddress = "Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396"
   private val defaultBanner = "generic.png"
@@ -390,7 +395,8 @@ object EmailAddons {
     SocietyWeekly,
     TheGuardianToday,
     TheGuardianTodayAustralia,
-    FilmToday
+    FilmToday,
+    OpinionAus
   )
 
   implicit class EmailContentType(p: Page) {


### PR DESCRIPTION
## What does this change?
Added existing Opinion email banner (https://www.theguardian.com/email/opinion) to a new Opinion email for Australia.

## Screenshots
![image](https://user-images.githubusercontent.com/5967941/44848302-2734d300-ac4e-11e8-8cd1-2e7a35e16693.png)

### Tested

No

