### PR TITLE
Integrate with Credentials Management API

### DIFF
--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -8,14 +8,14 @@ object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
-  def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: String = "*")(implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
     request.headers.get("Origin") match {
       case None => result
       case Some(requestOrigin) =>
-        val allowedOrigin = ajax.corsOrigins.find(_ == requestOrigin).getOrElse("*")
+        val allowedOrigin = ajax.corsOrigins.find(_ == requestOrigin).getOrElse(fallbackAllowOrigin)
         val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
           "Access-Control-Allow-Origin" -> allowedOrigin,
           "Access-Control-Allow-Headers" -> responseHeaders,

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: RequestHeader)
 
 @import conf.Configuration
 @import conf.switches.Switches.IdentityProfileNavigationSwitch

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -57,7 +57,7 @@ class AuthenticationController(
          val authResponse = signInService.getCookies(api.authBrowser(emailPassword, idRequest.trackingData), rememberMe = false)
          authResponse.map {
            case Right(cookies) =>
-             Cors(NoCache(Ok("")), fallbackAllowOrigin = fallbackAccessControlOrigin).withCookies(cookies: _*)
+             Cors(NoCache(Ok("{}")), fallbackAllowOrigin = fallbackAccessControlOrigin).withCookies(cookies: _*)
            case Left(errors) =>
              Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = fallbackAccessControlOrigin)
          }

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -1,0 +1,63 @@
+package controllers
+
+import common.ImplicitControllerExecutionContext
+import form.Mappings
+import idapiclient.responses.{CookieResponse, CookiesResponse}
+import idapiclient.{EmailPassword, IdApiClient, TrackingData}
+import model.{ApplicationContext, Cors, NoCache}
+import org.joda.time.DateTime
+import play.api.data.{Form, Forms}
+import play.api.http.HttpConfiguration
+import play.api.libs.json.{Format, JodaWrites, Json, Writes}
+import play.api.mvc._
+import services._
+import utils.SafeLogging
+
+import scala.concurrent.Future
+
+object EmailPasswordForm {
+  val emailPasswordForm = Form(
+    Forms.mapping(
+      "email" -> Forms.email,
+      "password" -> Forms.nonEmptyText,
+      "token" -> Forms.optional(Forms.nonEmptyText)
+    )(EmailPassword.apply)(EmailPassword.unapply)
+  )
+}
+
+trait IdentityJsonProtocol {
+
+  implicit val dtFormat = Format[DateTime](play.api.libs.json.JodaReads.DefaultJodaDateTimeReads, play.api.libs.json.JodaWrites.JodaDateTimeWrites)
+  implicit val cookiesFormat = Json.format[CookieResponse]
+  implicit val cookieFormat = Json.format[CookiesResponse]
+}
+
+class AuthenticationController(
+  api : IdApiClient,
+  idRequestParser: IdRequestParser,
+  idUrlBuilder: IdentityUrlBuilder,
+  authenticationService: AuthenticationService,
+  signInService : PlaySigninService,
+  val controllerComponents: ControllerComponents,
+  val httpConfiguration: HttpConfiguration
+)(implicit context: ApplicationContext)
+  extends BaseController with ImplicitControllerExecutionContext with SafeLogging with Mappings with implicits.Forms with IdentityJsonProtocol {
+  def authenticateUsernamePassword(): Action[AnyContent] = Action.async { implicit request =>
+    val form = EmailPasswordForm.emailPasswordForm.bindFromRequest()
+    form.fold(
+       formWithErrors => {
+         logger.warn("eror with form")
+         Future.successful(NoCache(InternalServerError("")))
+       },
+       emailPassword => {
+         val authResponse = api.authBrowser(emailPassword, TrackingData(None, None, None, None, None, None))
+         authResponse.map {
+           case Right(cookies) =>
+             Cors(NoCache(Ok(Json.toJson(cookies))))
+           case Left(errors) =>
+             Cors(NoCache(InternalServerError(Json.toJson(errors))))
+         }
+       }
+    )
+  }
+}

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -44,6 +44,8 @@ class AuthenticationController(
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging with Mappings with implicits.Forms with IdentityJsonProtocol {
 
+  private val fallbackAccessControlOrigin = Configuration.ajax.corsOrigins.headOption.getOrElse(Configuration.site.host)
+
   def authenticateUsernamePassword(): Action[AnyContent] = Action.async { implicit request =>
     val form = EmailPasswordForm.emailPasswordForm.bindFromRequest()
     form.fold(
@@ -54,9 +56,9 @@ class AuthenticationController(
          val authResponse = api.authBrowser(emailPassword, TrackingData(None, None, None, None, None, None))
          authResponse.map {
            case Right(cookies) =>
-             Cors(NoCache(Ok(Json.toJson(cookies))), fallbackAllowOrigin = Configuration.ajax.corsOrigins.head)
+             Cors(NoCache(Ok(Json.toJson(cookies))), fallbackAllowOrigin = fallbackAccessControlOrigin)
            case Left(errors) =>
-             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = Configuration.ajax.corsOrigins.head)
+             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = fallbackAccessControlOrigin)
          }
        }
     )

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -42,20 +42,20 @@ class AuthenticationController(
   val httpConfiguration: HttpConfiguration
 )(implicit context: ApplicationContext)
   extends BaseController with ImplicitControllerExecutionContext with SafeLogging with Mappings with implicits.Forms with IdentityJsonProtocol {
+
   def authenticateUsernamePassword(): Action[AnyContent] = Action.async { implicit request =>
     val form = EmailPasswordForm.emailPasswordForm.bindFromRequest()
     form.fold(
        formWithErrors => {
-         logger.warn("eror with form")
-         Future.successful(NoCache(InternalServerError("")))
+         Future.successful(NoCache(InternalServerError(Json.toJson(formWithErrors.errors.map(_.toString)))))
        },
        emailPassword => {
          val authResponse = api.authBrowser(emailPassword, TrackingData(None, None, None, None, None, None))
          authResponse.map {
            case Right(cookies) =>
-             Cors(NoCache(Ok(Json.toJson(cookies))))
+             Cors(NoCache(Ok(Json.toJson(cookies))), fallbackAllowOrigin = "null")
            case Left(errors) =>
-             Cors(NoCache(InternalServerError(Json.toJson(errors))))
+             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = "null")
          }
        }
     )

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import common.ImplicitControllerExecutionContext
+import conf.Configuration
 import form.Mappings
 import idapiclient.responses.{CookieResponse, CookiesResponse}
 import idapiclient.{EmailPassword, IdApiClient, TrackingData}
@@ -53,9 +54,9 @@ class AuthenticationController(
          val authResponse = api.authBrowser(emailPassword, TrackingData(None, None, None, None, None, None))
          authResponse.map {
            case Right(cookies) =>
-             Cors(NoCache(Ok(Json.toJson(cookies))), fallbackAllowOrigin = "null")
+             Cors(NoCache(Ok(Json.toJson(cookies))), fallbackAllowOrigin = Configuration.ajax.corsOrigins.head)
            case Left(errors) =>
-             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = "null")
+             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = Configuration.ajax.corsOrigins.head)
          }
        }
     )

--- a/identity/app/controllers/IdentityControllers.scala
+++ b/identity/app/controllers/IdentityControllers.scala
@@ -34,4 +34,5 @@ trait IdentityControllers extends IdApiComponents
   lazy val formstackController = wire[FormstackController]
   lazy val emailSignupController = wire[EmailSignupController]
   lazy val accountDeletionController = wire[AccountDeletionController]
+  lazy val authenticationController = wire[AuthenticationController]
 }

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -17,6 +17,7 @@ POST        /password/change                        controllers.ChangePasswordCo
 GET         /password/reset-confirmation            controllers.ResetPasswordController.renderPasswordResetConfirmation(returnUrl: Option[String])
 GET         /password/email-sent                    controllers.ResetPasswordController.renderEmailSentConfirmation
 POST        /password/guest                         controllers.editprofile.EditProfileController.guestPasswordSet()
+POST        /actions/auth/ajax                      controllers.AuthenticationController.authenticateUsernamePassword()
 GET         /user/id/:id                            controllers.PublicProfileController.renderProfileFromId(id: String, activityType = "discussions")
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -8,6 +8,9 @@ import mediator from 'lib/mediator';
 import { local } from 'lib/storage';
 import { mergeCalls } from 'common/modules/async-call-merger';
 import { getUrlVars } from 'lib/url';
+import fetch from 'lib/fetch-json';
+
+const qs = require('qs');
 
 let userFromCookieCache = null;
 
@@ -16,6 +19,11 @@ const signOutCookieName = 'GU_SO';
 const fbCheckKey = 'gu.id.nextFbCheck';
 let idApiRoot = null;
 let profileRoot = null;
+
+type PasswordCredential = {
+    id: string,
+    password: string,
+};
 
 export type IdentityUser = {
     id: number,
@@ -205,4 +213,17 @@ export const updateUsername = (username: string): any => {
     });
 
     return request;
+};
+
+export const ajaxSignIn = (credentials: PasswordCredential) => {
+    const url = `${profileRoot || ''}/actions/auth/ajax`;
+    return fetch(url, {
+        mode: 'cors',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: qs.stringify({
+            email: credentials.id,
+            password: credentials.password,
+        }),
+    });
 };

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -11,7 +11,6 @@ import { getUrlVars } from 'lib/url';
 import fetch from 'lib/fetch-json';
 import qs from 'qs';
 
-
 let userFromCookieCache = null;
 
 const cookieName = 'GU_U';

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -9,8 +9,8 @@ import { local } from 'lib/storage';
 import { mergeCalls } from 'common/modules/async-call-merger';
 import { getUrlVars } from 'lib/url';
 import fetch from 'lib/fetch-json';
+import qs from 'qs';
 
-const qs = require('qs');
 
 let userFromCookieCache = null;
 
@@ -225,5 +225,6 @@ export const ajaxSignIn = (credentials: PasswordCredential) => {
             email: credentials.id,
             password: credentials.password,
         }),
+        credentials: 'include',
     });
 };

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -13,7 +13,7 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
         return navigator.credentials
             .get({
                 password: true,
-                mediation: 'optional',
+                mediation: 'required',
             })
             .then(creds => {
                 if (creds) {

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -32,9 +32,7 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
             .then(creds => {
                 if (creds) {
                     return ajaxSignIn(creds)
-                        .then(() => {
-                            return storeCredsAndResolvePromise(creds);
-                        })
+                        .then(() => storeCredsAndResolvePromise(creds))
                         .catch(() => Promise.resolve(false));
                 }
                 recordOphanCredentialsApiInteraction('impression');

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -1,7 +1,5 @@
 // @flow
-import {
-    identityFeatures,
-} from 'common/modules/identity/identity-features';
+import { identityFeatures } from 'common/modules/identity/identity-features';
 import { ajaxSignIn } from 'common/modules/identity/api';
 import ophan from 'ophan-tracker-js';
 

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -1,0 +1,52 @@
+// @flow
+import {
+    IdentityCookies,
+    identityFeatures,
+} from 'common/modules/identity/identity-features';
+import { ajaxSignIn } from 'common/modules/identity/api';
+import ophan from 'ophan-tracker-js';
+import { addCookie } from 'lib/cookies';
+
+const ONE_DAY_IN_MILLIS = 86400000;
+
+export const signInWithSavedCredentials = (): Promise<boolean> => {
+    if (identityFeatures.promptForSignIn) {
+        // $FlowFixMe
+        return navigator.credentials
+            .get({
+                password: true,
+                mediation: 'optional',
+            })
+            .then(creds => {
+                if (creds) {
+                    return ajaxSignIn(creds)
+                        .then(cookies => {
+                            const expiryDate = new Date(cookies.expiresAt);
+                            const daysUntilExpiry =
+                                (expiryDate.getTime() - new Date().getTime()) /
+                                ONE_DAY_IN_MILLIS;
+                            ophan.record({
+                                component: 'pwmanager-api',
+                                value: 'conversion',
+                            });
+                            cookies.values.forEach(cookie => {
+                                addCookie(
+                                    cookie.key,
+                                    cookie.value,
+                                    daysUntilExpiry
+                                );
+                            });
+                            return Promise.resolve(true);
+                        })
+                        .catch(() => Promise.resolve(false));
+                }
+                ophan.record({
+                    component: 'pwmanager-api',
+                    value: 'impression',
+                });
+                addCookie(IdentityCookies.PW_MANAGER_DISMISSED, 'true', 7);
+                return Promise.resolve(false);
+            });
+    }
+    return Promise.resolve(false);
+};

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -1,11 +1,9 @@
 // @flow
 import {
-    IdentityCookies,
     identityFeatures,
 } from 'common/modules/identity/identity-features';
 import { ajaxSignIn } from 'common/modules/identity/api';
 import ophan from 'ophan-tracker-js';
-import { addCookie } from 'lib/cookies';
 
 const recordOphanCredentialsApiInteraction = (interactionType): void => {
     ophan.record({
@@ -36,7 +34,6 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
                         .catch(() => Promise.resolve(false));
                 }
                 recordOphanCredentialsApiInteraction('impression');
-                addCookie(IdentityCookies.PW_MANAGER_DISMISSED, 'true', 7);
                 return Promise.resolve(false);
             });
     }

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -29,6 +29,8 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
                                 component: 'pwmanager-api',
                                 value: 'conversion',
                             });
+                            // $FlowFixMe
+                            navigator.credentials.store(creds);
                             cookies.values.forEach(cookie => {
                                 addCookie(
                                     cookie.key,

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -7,6 +7,20 @@ import { ajaxSignIn } from 'common/modules/identity/api';
 import ophan from 'ophan-tracker-js';
 import { addCookie } from 'lib/cookies';
 
+const recordOphanCredentialsApiInteraction = (interactionType): void => {
+    ophan.record({
+        component: 'pwmanager-api',
+        value: interactionType,
+    });
+};
+
+const storeCredsAndResolvePromise = (creds): Promise<boolean> => {
+    // $FlowFixMe
+    navigator.credentials.store(creds);
+    recordOphanCredentialsApiInteraction('conversion');
+    return Promise.resolve(true);
+};
+
 export const signInWithSavedCredentials = (): Promise<boolean> => {
     if (identityFeatures.promptForSignIn) {
         // $FlowFixMe
@@ -19,20 +33,11 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
                 if (creds) {
                     return ajaxSignIn(creds)
                         .then(() => {
-                            ophan.record({
-                                component: 'pwmanager-api',
-                                value: 'conversion',
-                            });
-                            // $FlowFixMe
-                            navigator.credentials.store(creds);
-                            return Promise.resolve(true);
+                            return storeCredsAndResolvePromise(creds);
                         })
                         .catch(() => Promise.resolve(false));
                 }
-                ophan.record({
-                    component: 'pwmanager-api',
-                    value: 'impression',
-                });
+                recordOphanCredentialsApiInteraction('impression');
                 addCookie(IdentityCookies.PW_MANAGER_DISMISSED, 'true', 7);
                 return Promise.resolve(false);
             });

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -18,7 +18,7 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
             .then(creds => {
                 if (creds) {
                     return ajaxSignIn(creds)
-                        .then(_ => {
+                        .then(() => {
                             ophan.record({
                                 component: 'pwmanager-api',
                                 value: 'conversion',

--- a/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/credentials-api-sign-in.js
@@ -7,8 +7,6 @@ import { ajaxSignIn } from 'common/modules/identity/api';
 import ophan from 'ophan-tracker-js';
 import { addCookie } from 'lib/cookies';
 
-const ONE_DAY_IN_MILLIS = 86400000;
-
 export const signInWithSavedCredentials = (): Promise<boolean> => {
     if (identityFeatures.promptForSignIn) {
         // $FlowFixMe
@@ -20,24 +18,13 @@ export const signInWithSavedCredentials = (): Promise<boolean> => {
             .then(creds => {
                 if (creds) {
                     return ajaxSignIn(creds)
-                        .then(cookies => {
-                            const expiryDate = new Date(cookies.expiresAt);
-                            const daysUntilExpiry =
-                                (expiryDate.getTime() - new Date().getTime()) /
-                                ONE_DAY_IN_MILLIS;
+                        .then(_ => {
                             ophan.record({
                                 component: 'pwmanager-api',
                                 value: 'conversion',
                             });
                             // $FlowFixMe
                             navigator.credentials.store(creds);
-                            cookies.values.forEach(cookie => {
-                                addCookie(
-                                    cookie.key,
-                                    cookie.value,
-                                    daysUntilExpiry
-                                );
-                            });
                             return Promise.resolve(true);
                         })
                         .catch(() => Promise.resolve(false));

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -6,10 +6,8 @@ class IdentityFeatures {
     constructor() {
         this.promptForSignIn =
             // $FlowFixMe
-            navigator.credentials &&
-            window.PasswordCredential;
+            navigator.credentials && window.PasswordCredential;
     }
 }
 
 export const identityFeatures = new IdentityFeatures();
-

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -14,8 +14,7 @@ class IdentityFeatures {
             // $FlowFixMe
             navigator.credentials &&
             window.PasswordCredential &&
-            getCookie(CookieNames.PW_MANAGER_DISMISSED) === null &&
-            getCookie(CookieNames.GU_SO) === null;
+            getCookie(CookieNames.PW_MANAGER_DISMISSED) === null;
     }
 }
 

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -1,0 +1,24 @@
+// @flow
+import { getCookie } from 'lib/cookies';
+
+const CookieNames = {
+    PW_MANAGER_DISMISSED: 'GU_PWMANAGER_DISMISSED',
+    GU_SO: 'GU_SO',
+};
+
+class IdentityFeatures {
+    promptForSignIn: any;
+
+    constructor() {
+        this.promptForSignIn =
+            // $FlowFixMe
+            navigator.credentials &&
+            window.PasswordCredential &&
+            getCookie(CookieNames.PW_MANAGER_DISMISSED) === null &&
+            getCookie(CookieNames.GU_SO) === null;
+    }
+}
+
+export const identityFeatures = new IdentityFeatures();
+
+export const IdentityCookies = CookieNames;

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -7,7 +7,7 @@ const CookieNames = {
 };
 
 class IdentityFeatures {
-    promptForSignIn: any;
+    promptForSignIn: boolean;
 
     constructor() {
         this.promptForSignIn =

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -1,10 +1,4 @@
 // @flow
-import { getCookie } from 'lib/cookies';
-
-const CookieNames = {
-    PW_MANAGER_DISMISSED: 'GU_PWMANAGER_DISMISSED',
-    GU_SO: 'GU_SO',
-};
 
 class IdentityFeatures {
     promptForSignIn: boolean;
@@ -13,11 +7,9 @@ class IdentityFeatures {
         this.promptForSignIn =
             // $FlowFixMe
             navigator.credentials &&
-            window.PasswordCredential &&
-            getCookie(CookieNames.PW_MANAGER_DISMISSED) === null;
+            window.PasswordCredential;
     }
 }
 
 export const identityFeatures = new IdentityFeatures();
 
-export const IdentityCookies = CookieNames;

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -573,8 +573,7 @@ const bindCredentialsApiSignIn = (): void => {
                 ...document.querySelectorAll('.js-navigation-sign-in'),
             ],
         }))
-        .then(els => {
-            const { signInLinks } = els;
+        .then(({ signInLinks }) => {
             signInLinks.forEach(signInLink => {
                 signInLink.addEventListener(
                     'click',

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -8,6 +8,7 @@ import fastdom from 'lib/fastdom-promise';
 import { local } from 'lib/storage';
 import { scrollToElement } from 'lib/scroller';
 import { addEventListener } from 'lib/events';
+import { signInWithSavedCredentials } from 'common/modules/identity/credentials-api-sign-in';
 import { showMyAccountIfNecessary } from './user-account';
 
 type MenuAndTriggerEls = {
@@ -565,11 +566,41 @@ const addEventHandler = (): void => {
     }
 };
 
+const bindCredentialsApiSignIn = (): void => {
+    fastdom
+        .read(() => ({
+            signInLinks: [
+                ...document.querySelectorAll('.js-navigation-sign-in'),
+            ],
+        }))
+        .then(els => {
+            const { signInLinks } = els;
+            signInLinks.forEach(signInLink => {
+                signInLink.addEventListener(
+                    'click',
+                    e => {
+                        e.preventDefault();
+                        signInWithSavedCredentials().then(wasSignedIn => {
+                            if (!wasSignedIn) {
+                                window.location = signInLink.getAttribute(
+                                    'href'
+                                );
+                            }
+                            return showMyAccountIfNecessary();
+                        });
+                    },
+                    false
+                );
+            });
+        });
+};
+
 export const newHeaderInit = (): void => {
     enhanceMenuToggles();
     showMoreButton();
     addEventHandler();
     showMyAccountIfNecessary();
+    bindCredentialsApiSignIn();
     initiateUserAccountDropdown();
     closeAllMenuSections();
     trackRecentSearch();

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -1,5 +1,4 @@
 // @flow
-
 import fastdom from 'lib/fastdom-promise';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 


### PR DESCRIPTION
## What does this change?

Picks any saved credentials from the user's browser when they click `Sign In` on the header, using the [Browser Credentials API](https://www.w3.org/TR/credential-management-1). 

## Screenshots

When a user has a saved password, the first click will require mediation (the popup/account chooser), to sort out the cross-domaininess of the saved creds.

![mediated](https://user-images.githubusercontent.com/3636251/44989652-70ef2780-af86-11e8-9488-c276c9a6d417.gif)

After they go through that process once, they will be signed in without mediation: 

![unmediated](https://user-images.githubusercontent.com/3636251/44989691-87957e80-af86-11e8-826a-87635ec415fb.gif)


## What is the value of this and can you measure success?

Users with saved passwords will be signed in better, harder, faster, longer etc. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
