### PR TITLE
Re-work of design & copy on the 'membership-action-required' banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -5,11 +5,12 @@ import {
     accountDataUpdateWarning,
 } from 'common/modules/commercial/user-features';
 import fastdom from 'lib/fastdom-promise';
-import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
+import { Message } from 'common/modules/ui/message';
 import config from 'lib/config';
 import bean from 'bean';
 import arrowRight from 'svgs/icon/arrow-right.svg';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import userPrefs from 'common/modules/user-prefs';
 
 const accountDataUpdateLink = accountDataUpdateWarningLink =>
     `${config.get('page.idUrl')}/${
@@ -19,6 +20,18 @@ const accountDataUpdateLink = accountDataUpdateWarningLink =>
     }`;
 
 const messageCode: string = 'membership-action-required';
+
+const bannerCanBeLoadedAgainAfterKey: string =
+    'mmaActionRequiredBannerCanBeShownAgainAfter';
+
+const storeBannerCanBeLoadedAgainAfter = () => {
+    const thisTimeTomorrow = new Date();
+    thisTimeTomorrow.setDate(thisTimeTomorrow.getDate() + 1);
+    userPrefs.set(
+        bannerCanBeLoadedAgainAfterKey,
+        thisTimeTomorrow.toISOString()
+    );
+};
 
 const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
     const gaTracker = config.get('googleAnalytics.trackers.editorial');
@@ -36,6 +49,18 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
                     'in page',
                     'membership action required | banner hidden'
                 );
+                storeBannerCanBeLoadedAgainAfter();
+            });
+
+            bean.on(document, 'click', '.js-mma-update-details-button', () => {
+                window.ga(
+                    `${gaTracker}.send`,
+                    'event',
+                    'click',
+                    'in page',
+                    'membership action required | banner update details clicked'
+                );
+                storeBannerCanBeLoadedAgainAfter();
             });
 
             window.ga(
@@ -53,7 +78,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
             An action is needed on your Guardian account. 
             Please review and update your details as soon as you can. Thank you.
         </span>
-        <a class="button site-message__copy-button" href="${accountDataUpdateLink(
+        <a class="button site-message__copy-button js-mma-update-details-button" href="${accountDataUpdateLink(
             accountDataUpdateWarningLink
         )}">
             Update details ${arrowRight.markup}
@@ -62,10 +87,18 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
 };
 const updateLink = accountDataUpdateWarning();
 
-const canShow: () => Promise<boolean> = () =>
-    Promise.resolve(
-        updateLink !== null && !hasUserAcknowledgedBanner(messageCode)
+const canShow: () => Promise<boolean> = () => {
+    const bannerCanBeLoadedAgainAfter = userPrefs.get(
+        bannerCanBeLoadedAgainAfterKey
     );
+    return Promise.resolve(
+        updateLink !== null &&
+            !(
+                bannerCanBeLoadedAgainAfter &&
+                new Date(bannerCanBeLoadedAgainAfter) > new Date()
+            )
+    );
+};
 
 const show: () => Promise<boolean> = () => {
     if (updateLink) {

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -8,6 +8,7 @@ import fastdom from 'lib/fastdom-promise';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import config from 'lib/config';
 import bean from 'bean';
+import arrowRight from 'svgs/icon/arrow-right.svg';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
 const accountDataUpdateLink = accountDataUpdateWarningLink =>
@@ -46,10 +47,17 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
             );
         },
     });
+
     newMessage.show(
-        `An action is needed on your Guardian account. Please <a href='${accountDataUpdateLink(
+        `<span class="site-message__copy-text">
+            An action is needed on your Guardian account. 
+            Please review and update your details as soon as you can. Thank you.
+        </span>
+        <a class="button site-message__copy-button" href="${accountDataUpdateLink(
             accountDataUpdateWarningLink
-        )}'>update your details</a>`
+        )}">
+            Update details ${arrowRight.markup}
+        </a>`
     );
 };
 const updateLink = accountDataUpdateWarning();

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -1,18 +1,140 @@
+@mixin padding {
+    padding: $gs-baseline 0;
+
+    @include mq(tablet) {
+        padding: $gs-baseline $gs-gutter;
+    }
+}
+
 .site-message--membership-action-required {
     color: $brightness-100;
-    background: $brightness-7;
-    &:after {
-        @include multiline(3, $brightness-20, top);
-        content: '';
-        display: block;
-        height: 4px * 3; /*height of multiline (4px) times the number of lines (3)*/
-        margin-bottom: -1px;
-        width: 100%;
+    background: $sport-dark;
+
+    .site-message__inner {
+        width: auto;
     }
+
     a {
-        color: $brightness-100;
+        color: $brightness-7;
         font-weight: 900;
         text-decoration: underline;
+    }
+
+    .site-message__roundel {
+        position: absolute;
+        padding: 0;
+        width: auto;
+        height: auto;
+
+        .inline-icon {
+            fill: $brightness-100;
+            path:last-child {
+                fill: $brightness-7;
+            }
+        }
+
+        display: block;
+        bottom: $gs-baseline;
+        right: $gs-baseline;
+        svg {
+            width: 32px;
+            height: 32px;
+        }
+
+        @include mq(desktop) {
+            top: $gs-baseline;
+            left: $gs-gutter;
+            right: auto;
+            bottom: auto;
+            svg {
+                width: inherit;
+                height: inherit;
+            }
+        }
+
+        @include mq(tablet) {
+            right: $gs-gutter;
+        }
+
+    }
+
+    .site-message__close-btn {
+        position: absolute;
+        top: $gs-baseline;
+        right: $gs-baseline;
+
+        .inline-icon {
+            fill: $brightness-100;
+        }
+
+        @include mq(tablet) {
+            right: $gs-gutter;
+        }
+
+    }
+
+    .site-message__copy {
+        @include padding;
+        @include mq(desktop) {
+            display: flex;
+            margin-left: gs-span(1);
+        }
+        @include mq(leftCol) {
+            margin-left: 0;
+        }
+    }
+
+    .site-message__copy-text {
+        @include banner-copy-alignment;
+        display: block;
+        margin-bottom: 12px;
+        margin-right: 24px;
+        font-size: 16px;
+        line-height: 20px;
+        @include mq(phablet) {
+            font-size: 18px;
+            line-height: 24px;
+            width: auto;
+            margin-right: gs-span(1);
+        }
+        @include mq(desktop) {
+            flex-basis: gs-span(6) + $gs-gutter*3;
+            margin-right: gs-span(2);
+        }
+        @include mq(leftCol) {
+            margin-bottom: 0;
+            margin-right: gs-span(3);
+            flex-basis: gs-span(6) + $gs-gutter*2;
+        }
+    }
+
+    .site-message__copy-button {
+        color: $brightness-7;
+        background-color: $highlight-main;
+        border-color: $highlight-main;
+        font-size: 14px;
+        line-height: 36px;
+        height: 36px;
+        vertical-align: middle;
+        padding-right: 0;
+        text-decoration: none;
+        svg {
+            fill: $brightness-7;
+            float: right;
+            margin-left: 36px;
+            padding-top: 3px;
+}
+
+        &:hover, &:focus {
+            border-color: mix($highlight-main, $brightness-7, 80%);
+            background-color: mix($highlight-main, $brightness-7, 80%);
+        }
+
+        &:focus {
+            outline: auto;
+            outline-color: $sport-bright;
+            outline-width: 5px; 
+        }
     }
 
 }


### PR DESCRIPTION
**_Supersedes https://github.com/guardian/frontend/pull/20233_**

## What does this change?
- Re-work of design & copy on the 'membership-action-required' banner
- Banner will re-show 24hours after dismissal
- 'Update details' call to action will also dismiss the banner

## Screenshots
![desktop](https://user-images.githubusercontent.com/19289579/44588899-e7ce3880-a7ae-11e8-8ca3-1c95ab78f646.png)
![mobile](https://user-images.githubusercontent.com/19289579/44588921-f87eae80-a7ae-11e8-90f8-b361f93471b6.png)



## What is the value of this and can you measure success?
This should drive more people to update their card details for membership / contributions / digipack - measurable via ophan and GA.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
