### PR TITLE
Skip comment-count tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -20,7 +20,7 @@ jest.mock('lib/fetch-json', () =>
 
 const fetchJsonSpy: any = fetchJson;
 
-describe('Comment Count', () => {
+describe.skip('Comment Count', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `<div class="comment-trails">

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -20,7 +20,7 @@ jest.mock('lib/fetch-json', () =>
 
 const fetchJsonSpy: any = fetchJson;
 
-// TODO: Investigate why these sometimes fails and re-enable these
+// TODO: Investigate why these sometimes fails and re-enable
 describe.skip('Comment Count', () => {
     beforeEach(() => {
         if (document.body) {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -20,6 +20,7 @@ jest.mock('lib/fetch-json', () =>
 
 const fetchJsonSpy: any = fetchJson;
 
+// TODO: Investigate why these sometimes fails and re-enable these
 describe.skip('Comment Count', () => {
     beforeEach(() => {
         if (document.body) {


### PR DESCRIPTION
## What does this change?

Skips the tests for comment-count.js as they're being flakey both locally and on TeamCity, most of the time they'll pass but occassionally they'll fail in a non-deterministic way.

https://github.com/guardian/frontend/pull/20246/files attempted to address the issue but we've had occurences of the same problem despite these changes