### PR TITLE
use 303 redirect for ET latest endpoints

### DIFF
--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -30,8 +30,13 @@ class LatestIndexController(
   }
 
   private def handleSeriesBlogs(index: IndexPage)(implicit request: RequestHeader) = index.trails.headOption match {
-    case Some(latest) if request.isEmail || request.isHeadlineText =>
+    case Some(latest) if request.isEmailJson || request.isHeadlineText =>
       emailInternalRedirect(latest)
+
+    case Some(latest) if request.isEmail =>
+      val queryString = request.campaignCode.fold(Map.empty[String, Seq[String]])(c => Map("CMP" -> Seq(c)))
+      val url = s"${latest.metadata.url}/email"
+      Redirect(url, queryString)
 
     case Some(latest) =>
       Found(latest.metadata.url)

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -15,6 +15,7 @@ import play.api.test.Helpers._
 
   private val MovedPermanently = 301
   private val Found = 302
+  private val SeeOther = 303
   lazy val latestIndexController = new LatestIndexController(testContentApiClient, play.api.test.Helpers.stubControllerComponents())
 
   it should "redirect to latest for a series" in {
@@ -25,9 +26,9 @@ import play.api.test.Helpers._
 
   it should "redirect to latest email for a blog" in {
     val result = latestIndexController.latest("fashion/fashion-blog")(TestRequest("/fashion/fashion-blog/email"))
-    status(result) should be(OK)
-    header("X-Accel-Redirect", result).head should include ("/fashion-blog/")
-    header("X-Accel-Redirect", result).head should endWith ("/email")
+    status(result) should be(SeeOther)
+    header("Location", result).head should include ("/fashion-blog/")
+    header("Location", result).head should endWith ("/email")
   }
 
   it should "redirect to latest emailjson for a blog" in {

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -7,6 +7,7 @@ import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
 import conf.switches.Switches.InlineEmailStyles
+import model.CacheTime.RecentlyUpdated
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
@@ -119,13 +120,12 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     JsonComponent(page, json)
   }
 
-  def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
+  def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = {
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
-
     if (request.isEmailJson) {
-      RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithInlineStyles.toString))))
+      Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithInlineStyles.toString)))))
     } else {
-      RevalidatableResult.Ok(htmlWithInlineStyles)
+      Cached(page)(RevalidatableResult.Ok(htmlWithInlineStyles))
     }
   }
 


### PR DESCRIPTION
## What does this change?

Use 303 redirect for ET latest endpoints
There may be caching issues with the internal redirect. We will continue to use 303s for ET

Set a short cache period for .emailjson endpoints since they are served behind the latest email page

## What is the value of this and can you measure success?

Emails can be sent out continuously via ET


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
