### PR TITLE
Remove fit parameter from email video images.

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -198,14 +198,13 @@ object EmailImage extends Profile(width = Some(580), autoFormat = false) {
 }
 
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) with OverlayBase64 {
-  override val fitParam = "fit=crop"
   override val qualityparam = "quality=60"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=center"
   val blendImageParam = s"blend64=${overlayUrlBase64("play.png")}"
 
   override def resizeString: String = {
-    val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
+    val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
     s"?$params"
   }
 }


### PR DESCRIPTION
## What does this change?
Changes the behaviour of email video images so that they are just resized rather than cropped. The motivation for this is that in fastly IO in order to do `fit=crop` you have to specify a `height`, which we're unsure of for email images.

## Screenshots

## What is the value of this and can you measure success?
Fixes tiny play button in email video pictures 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
