### PR TITLE
Enable ad-free for digital subscribers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,17 @@
 - [ ] No
 - [ ] Yes (please give details)
 
+### Does this change break ad-free?
+
+<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
+<!-- merchandising, page skins and paid-for content -->
+<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
+<!-- scenario -->
+
+- [ ] No
+- [ ] It did, but tests caught it and I fixed it
+- [ ] It did, but there was no test coverage so I added that then fixed it
+
 ### Accessibility test checklist
 
 <!-- for changes that affect how a page appears in the browser -->

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -57,10 +57,10 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val AdFreeTrialSwitch = Switch(
+  val AdFreeEmergencyShutdown = Switch(
     Commercial,
-    "ad-free-subscription-trial",
-    "Master switch for trialling ad-free subscription",
+    "ad-free-emergency-shutdown",
+    "When ON, we kill the ad-free service immediately.",
     owners = Seq(Owner.withGithub("JustinPinner")),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -60,10 +60,10 @@ trait CommercialSwitches {
   val AdFreeEmergencyShutdown = Switch(
     Commercial,
     "ad-free-emergency-shutdown",
-    "When ON, we kill the ad-free service immediately.",
+    "When ON, we kill the ad-free service immediately. This is a temporary switch for live-testing.",
     owners = Seq(Owner.withGithub("JustinPinner")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2018, 9, 18),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -203,8 +203,8 @@ const bootStandard = (): void => {
     // Set adtest query if url param declares it
     setAdTestCookie();
 
-    // If we turn off the ad-free trial, immediately remove the cookie
-    if (!config.get('switches.adFreeSubscriptionTrial')) {
+    // If we flip the kill switch over ad-free, immediately remove the cookie
+    if (config.get('switches.adFreeEmergencyShutdown')) {
         removeCookie('GU_AF1');
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -53,9 +53,7 @@ class CommercialFeatures {
 
         // Feature switches
         this.adFree =
-            switches.commercial &&
-            switches.adFreeSubscriptionTrial &&
-            (!!forceAdFree || isAdFreeUser());
+            !!forceAdFree || isAdFreeUser();
 
         this.dfpAdvertising =
             switches.commercial &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -52,8 +52,7 @@ class CommercialFeatures {
             );
 
         // Feature switches
-        this.adFree =
-            !!forceAdFree || isAdFreeUser();
+        this.adFree = !!forceAdFree || isAdFreeUser();
 
         this.dfpAdvertising =
             switches.commercial &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -65,7 +65,6 @@ describe('Commercial features', () => {
             outbrain: true,
             commercial: true,
             enableDiscussionSwitch: true,
-            adFreeSubscriptionTrial: false,
         };
 
         config.get.mockReturnValue('');
@@ -113,7 +112,6 @@ describe('Commercial features', () => {
         });
 
         it('Is enabled for speedcurve tests of ad-free mode', () => {
-            config.switches.adFreeSubscriptionTrial = true;
             window.location.hash = '#noadsaf';
             const features = new CommercialFeatures();
             expect(features.dfpAdvertising).toBe(true);
@@ -149,7 +147,6 @@ describe('Commercial features', () => {
     describe('Article body adverts under ad-free', () => {
         // LOL grammar
         it('are disabled', () => {
-            config.switches.adFreeSubscriptionTrial = true;
             isAdFreeUser.mockReturnValue(true);
             const features = new CommercialFeatures();
             expect(features.articleBodyAdverts).toBe(false);
@@ -165,7 +162,6 @@ describe('Commercial features', () => {
 
     describe('Video prerolls under ad-free', () => {
         it('are disabled', () => {
-            config.switches.adFreeSubscriptionTrial = true;
             isAdFreeUser.mockReturnValue(true);
             const features = new CommercialFeatures();
             expect(features.videoPreRolls).toBe(false);
@@ -194,7 +190,6 @@ describe('Commercial features', () => {
 
     describe('High-relevance commercial component under ad-free', () => {
         beforeEach(() => {
-            config.switches.adFreeSubscriptionTrial = true;
             isAdFreeUser.mockReturnValue(true);
         });
 
@@ -253,7 +248,6 @@ describe('Commercial features', () => {
 
     describe('Third party tags under ad-free', () => {
         beforeEach(() => {
-            config.switches.adFreeSubscriptionTrial = true;
             isAdFreeUser.mockReturnValue(true);
         });
 
@@ -311,7 +305,6 @@ describe('Commercial features', () => {
 
     describe('Outbrain / Plista under ad-free', () => {
         beforeEach(() => {
-            config.switches.adFreeSubscriptionTrial = true;
             isAdFreeUser.mockReturnValue(true);
         });
 
@@ -396,7 +389,6 @@ describe('Commercial features', () => {
 
     describe('Comment adverts under ad-free', () => {
         beforeEach(() => {
-            config.switches.adFreeSubscriptionTrial = true;
             config.page.commentable = true;
             isAdFreeUser.mockReturnValue(true);
         });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -71,12 +71,17 @@ const persistResponse = (JsonResponse: () => void) => {
         addCookie(ACTION_REQUIRED_FOR_COOKIE, JsonResponse.alertAvailableFor);
     }
 
-    if (adFreeDataIsPresent() && !JsonResponse.adFree && !forcedAdFreeMode) {
+    if (switches.adFreeEmergencyShutdown) {
         removeCookie(AD_FREE_USER_COOKIE);
+    } else {
+        if (adFreeDataIsPresent() && !JsonResponse.adFree && !forcedAdFreeMode && !JsonResponse.contectAccess.digitalPack) {
+            removeCookie(AD_FREE_USER_COOKIE);
+        }
+        if (JsonResponse.adFree || JsonResponse.contectAccess.digitalPack) {
+            addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
+        }
     }
-    if (switches.adFreeSubscriptionTrial && JsonResponse.adFree) {
-        addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
-    }
+
 };
 
 const deleteOldData = (): void => {
@@ -216,7 +221,9 @@ const shouldSeeReaderRevenue = (): boolean =>
     !isRecurringContributor() &&
     !isDigitalSubscriber();
 
-const isAdFreeUser = (): boolean => adFreeDataIsPresent() && !adFreeDataIsOld();
+const isAdFreeUser = (): boolean =>
+    !config.switches.adFreeEmergencyShutdown &&
+    (isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld()));
 
 export {
     accountDataUpdateWarning,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -74,14 +74,18 @@ const persistResponse = (JsonResponse: () => void) => {
     if (switches.adFreeEmergencyShutdown) {
         removeCookie(AD_FREE_USER_COOKIE);
     } else {
-        if (adFreeDataIsPresent() && !JsonResponse.adFree && !forcedAdFreeMode && !JsonResponse.contectAccess.digitalPack) {
+        if (
+            adFreeDataIsPresent() &&
+            !JsonResponse.adFree &&
+            !forcedAdFreeMode &&
+            !JsonResponse.contectAccess.digitalPack
+        ) {
             removeCookie(AD_FREE_USER_COOKIE);
         }
         if (JsonResponse.adFree || JsonResponse.contectAccess.digitalPack) {
             addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
         }
     }
-
 };
 
 const deleteOldData = (): void => {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -21,7 +21,6 @@ jest.mock('lib/fetch-json', () => jest.fn(() => Promise.resolve()));
 
 jest.mock('lib/config', () => ({
     switches: {
-        adFreeSubscriptionTrial: true,
         adFreeStrictExpiryEnforcement: true,
     },
     page: {


### PR DESCRIPTION
## What does this change?
Grants ad-free web permission to digital pack subscribers
 
## Screenshots
N/A (see other ad-free PRs for screen caps) 

## What is the value of this and can you measure success?
This removes the 'trial' nature of ad-free (although that will continue to be available for a while longer) that we've used to define and test the feature to date, and instead makes all valid digital subscribers ad-free.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] No, it's web (on-platform) only

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)
Digital subscribers will no longer see GLabs merchandising slots or links to paid-for content. The content pages themselves will remain accessible to those readers though (in the event of search referrals etc)
 
### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [x] Locally
- [x] On CODE (optional)
