### PR TITLE
List Guardian Account features on set password component

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -139,6 +139,7 @@ trait ConsentsJourney
 
         consentCompleteView(
           page,
+          request.user,
           returnUrl,
           guestPasswordSetForm
         )
@@ -147,6 +148,7 @@ trait ConsentsJourney
 
   private def consentCompleteView(
    page: IdentityPage,
+   user: User,
    returnUrl : String,
    guestPasswordSetForm: Option[Form[GuestPasswordFormData]])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
@@ -156,6 +158,7 @@ trait ConsentsJourney
           idRequestParser(request),
           idUrlBuilder,
           returnUrl,
+          user.primaryEmailAddress,
           emailFilledForm,
           guestPasswordSetForm.getOrElse(GuestPasswordForm.form()),
           newsletterService.getEmailSubscriptions(emailFilledForm),

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -58,16 +58,6 @@
                 data-csrf="@{play.filters.csrf.CSRF.getToken.map(_.value)}"
             ></div>
         }
-
-        <aside class="identity-forms-message__body">
-            <hr class="manage-account-small-divider" />
-            <a
-            class="manage-account__button manage-account__button--light"
-            data-link-name="complete-consents : cta-bottom"
-            href="@{returnUrl}">
-                Go to The Guardian
-            </a>
-        </aside>
-
+        
     </section>
 </div>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -34,7 +34,7 @@
             <form>
                 @views.html.helper.CSRF.formField
                 <div>
-                    <h1 class="identity-title--small">Before you go...</h1>
+                    <h1 class="identity-upsell-title">Before you go...</h1>
                     <div class="identity-forms-message__body">
                         <p>Did you know that we have <b>more than 40</b> different email newsletters that focus on a range of diverse topics - from politics and the latest tech to documentaries, sport and scientific breakthroughs.</p>
                         <p>Why not take a few seconds to see whether there is anything here for you?</p>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -6,6 +6,7 @@
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     returnUrl: String,
+    email: String,
     emailPrefsForm: Form[EmailPrefsData],
     setPasswordForm: Form[GuestPasswordFormData],
     emailSubscriptions: List[String],
@@ -50,7 +51,23 @@
         }
 
         @request.cookies.get("SC_GU_GUEST_PW_SET").map { passwordSetToken =>
-            <div class="js-identity-upsell-account-creation" data-return-url="@LinkTo(returnUrl)" data-account-token="@{passwordSetToken.value}" data-csrf="@{play.filters.csrf.CSRF.getToken.map(_.value)}"></div>
+            <div
+                class="js-identity-upsell-account-creation"
+                data-email="@{email}"
+                data-account-token="@{passwordSetToken.value}"
+                data-csrf="@{play.filters.csrf.CSRF.getToken.map(_.value)}"
+            ></div>
         }
+
+        <aside class="identity-forms-message__body">
+            <hr class="manage-account-small-divider" />
+            <a
+            class="manage-account__button manage-account__button--light"
+            data-link-name="complete-consents : cta-bottom"
+            href="@{returnUrl}">
+                Go to The Guardian
+            </a>
+        </aside>
+
     </section>
 </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation.js
@@ -20,8 +20,8 @@ const bindAccountCreation = (el): void => {
         render(
             <AccountCreationFlow
                 csrfToken={el.dataset.csrf}
-                returnUrl={el.dataset.returnUrl}
                 accountToken={el.dataset.accountToken}
+                email={el.dataset.email}
             />,
             el
         );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -19,63 +19,62 @@ type ActionableBenefit = Benefit & {
 const benefits: Benefit[] = [
     {
         title: `Get closer to our journalism`,
-        blurb: `Choose from over 40 exclusive newsletters on the variety of topics. Get exclusive offers.`,
+        blurb: `Choose from over 40 exclusive newsletters and updates on the variety of topics that matter to you.`,
     },
     {
         title: `Join the conversation`,
-        blurb: `Comment on articles and make your voice heard.`,
+        blurb: `Get involved – post or recommend comments below an article.`,
     },
     {
-        title: `Take your career to the next level`,
-        blurb: `Create your jobseeker profile and receive job alerts.`,
+        title: `Take your career to the next level `,
+        blurb: `Browse a huge variety of jobs, create your jobseeker profile and receive job alerts for vacancies you want to hear about.`,
     },
     {
         title: `Enjoy our free iOS and Android apps`,
-        blurb: `
-Save articles for later, tailor your news and get notified about topics that matter to you.`,
+        blurb: `Save articles for later, tailor your news and get notified about topics that matter to you.`,
     },
 ];
 
 const actionableBenefits: ActionableBenefit[] = [
     {
-        title: `Explore exclusive content`,
-        blurb: `Browse through over 40 newsletters on the variety of topics or sign up for events, offers, holidays or supporter updates.`,
+        title: `Get closer to our journalism`,
+        blurb: `Browse over 40 curated newsletters on a variety of topics - from daily news headlines to weekly culture highlights, and diverse dedicated topics like science, documentary films and fashion. You can also sign up to receive updates about Guardian events, holidays and offers.`,
         cta: [
             {
-                name: `Find newsletters you'll love`,
+                name: `Find your favourite newsletter`,
                 link: `https://${config.get('page.host')}/email-newsletters`,
             },
         ],
     },
     {
-        title: `Get closer to our journalism`,
-        blurb: `Complete your Guardian profile, pick an article that sparks your interest and that has a little comment icon and join fellow Guardian readers.`,
+        title: `Join the conversation`,
+        blurb: `We believe in having open debate and in giving readers a voice in our journalism. With your Guardian profile, you can recommend comments added by other Guardian readers at the bottom of the articles or contribute your thoughts for other readers to see. Complete your public profile and join the debate.`,
         cta: [
             {
-                name: `Go to The Guardian`,
-                link: `https://${config.get('page.host')}/`,
-            },
-        ],
-    },
-    {
-        title: `Take your career to the next level`,
-        blurb: `Use your Guardian account to access and complete your Guardian Jobs profile. Browse jobs and set up alerts.`,
-        cta: [
-            {
-                name: `Visit Guardian Jobs`,
-                link: `https://jobs.theguardian.com/`,
+                name: `Complete your profile`,
+                link: `${config.get('page.idUrl')}/public/edit`,
             },
         ],
     },
     {
         title: `Download our award-winning app`,
-        blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as mobile alerts when your favourite writers publish an article, or your favourite team scores.`,
+        blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as ‘save for later’ or mobile alerts when your favourite writers publish an article, or your football team scores.`,
         cta: [
             {
-                name: `Get the Guardian App`,
+                name: `Explore our apps`,
                 link: `https://${config.get(
                     'page.host'
                 )}/technology/ng-interactive/2018/may/15/the-guardian-app`,
+            },
+        ],
+    },
+    {
+        title: `Take your career to the next level`,
+        blurb: `Your account allows you to set up a Guardian Jobs profile, browse a huge variety of jobs and be the first to hear about vacancies in your preferred industry.`,
+        cta: [
+            {
+                name: `Browse jobs`,
+                link: `https://jobs.theguardian.com/`,
             },
         ],
     },

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -93,7 +93,10 @@ export const AccountActionableBenefits = () => (
                 <h4>{title}</h4>
                 <p>{blurb}</p>
                 {cta.map(({ name, link }) => (
-                    <a data-link-name={`benefit : ${title}`} href={link} className="manage-account__button manage-account__button--light">
+                    <a
+                        data-link-name={`benefit : ${title}`}
+                        href={link}
+                        className="manage-account__button manage-account__button--light">
                         {name}
                     </a>
                 ))}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'preact-compat';
+import star from 'svgs/icon/star.svg';
 
 const benefits = [
     {
@@ -18,6 +19,72 @@ const benefits = [
         blurb: ` Save articles for later, tailor your news and get notified about topics that matter to you.`
     },
 ];
+
+const actionableBenefits = [
+    {
+        title: `Explore exclusive content `,
+        blurb: `Browse through over 40 newsletters on the variety of topics or sign up for events, offers, holidays or supporter updates.`,
+        cta: [{
+            name: `Find newsletters you'll love`,
+            link: `/newsletters`,
+        }]
+    },
+    {
+        title: `Join the conversation `,
+        blurb: `Complete your Guardian profile, pick an article that sparks your interest and that has a little comment icon and join fellow Guardian readers.`,
+        cta: [{
+            name: `??`,
+            link: `/newsletters`,
+        }]
+    },
+    {
+        title: `Get closer to our journalism `,
+        blurb: `Complete your Guardian profile, pick an article that sparks your interest and that has a little comment icon and join fellow Guardian readers.`,
+        cta: [{
+            name: `Go to The Guardian`,
+            link: `/newsletters`,
+        }]
+    },
+    {
+        title: `Take your career to the next level  `,
+        blurb: `Use your Guardian account to access and complete your Guardian Jobs profile. Browse jobs and set up alerts.`,
+        cta: [{
+            name: `Visit Guardian Jobs`,
+            link: `/newsletters`,
+        }]
+    },
+    {
+        title: `Download our award-winning app `,
+        blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as mobile alerts when your favourite writers publish an article, or your favourite team scores.`,
+        cta: [{
+            name: `Get the Guardian App`,
+            link: `/newsletters`,
+        }]
+    },
+];
+
+export const AccountActionableBenefits = () => {
+    return (
+        <ul class={'identity-upsell-account-creation-superbullets'}>
+            {actionableBenefits.map(({title, blurb, cta})=>(
+                <li>
+                    <span
+                        className={'identity-upsell-account-creation-superbullets__icon'}
+                        // eslint-disable-next-line react/no-danger
+                        dangerouslySetInnerHTML={{
+                            __html: star.markup,
+                        }}
+                    />
+                    <h4>{title}</h4>
+                    <p>{blurb}</p>
+                    {cta.map(({name,link})=>(
+                        <a className={'manage-account__button manage-account__button--light'}>{name}</a>
+                    ))}
+                </li>
+            ))}
+        </ul>
+    )
+}
 
 export const AccountBenefits = () => {
     return (

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'preact-compat';
 import config from 'lib/config';
-import star from 'svgs/icon/star.svg';
 
 type BenefitCta = {
     name: string,
@@ -86,13 +85,6 @@ export const AccountActionableBenefits = () => (
     <ul className="identity-upsell-account-creation-superbullets">
         {actionableBenefits.map(({ title, blurb, cta }) => (
             <li>
-                <span
-                    className="identity-upsell-account-creation-superbullets__icon"
-                    // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{
-                        __html: star.markup,
-                    }}
-                />
                 <h4>{title}</h4>
                 <p>{blurb}</p>
                 {cta.map(({ name, link }) => (

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'preact-compat';
+import config from 'lib/config';
 import star from 'svgs/icon/star.svg';
 
 type BenefitCta = {
@@ -43,7 +44,7 @@ const actionableBenefits: ActionableBenefit[] = [
         cta: [
             {
                 name: `Find newsletters you'll love`,
-                link: `/newsletters`,
+                link: `https://${config.get('page.host')}/email-newsletters`,
             },
         ],
     },
@@ -53,7 +54,7 @@ const actionableBenefits: ActionableBenefit[] = [
         cta: [
             {
                 name: `Go to The Guardian`,
-                link: `/newsletters`,
+                link: `https://${config.get('page.host')}/`,
             },
         ],
     },
@@ -63,7 +64,7 @@ const actionableBenefits: ActionableBenefit[] = [
         cta: [
             {
                 name: `Visit Guardian Jobs`,
-                link: `/newsletters`,
+                link: `https://jobs.theguardian.com/`,
             },
         ],
     },
@@ -73,7 +74,9 @@ const actionableBenefits: ActionableBenefit[] = [
         cta: [
             {
                 name: `Get the Guardian App`,
-                link: `/newsletters`,
+                link: `https://${config.get(
+                    'page.host'
+                )}/technology/ng-interactive/2018/may/15/the-guardian-app`,
             },
         ],
     },

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,100 +1,114 @@
-import React, { Component } from 'preact-compat';
+// @flow
+import React from 'preact-compat';
 import star from 'svgs/icon/star.svg';
 
-const benefits = [
+type BenefitCta = {
+    name: string,
+    link: string,
+};
+
+type Benefit = {
+    title: string,
+    blurb: string,
+};
+
+type ActionableBenefit = Benefit & {
+    cta: BenefitCta[],
+};
+
+const benefits: Benefit[] = [
     {
-        title: `Get closer to our journalism `,
-        blurb: `Choose from over 40 exclusive newsletters on the variety of topics. Get exclusive offers.`
+        title: `Get closer to our journalism`,
+        blurb: `Choose from over 40 exclusive newsletters on the variety of topics. Get exclusive offers.`,
     },
     {
-        title: `Join the conversation  `,
-        blurb: `Comment on articles and make your voice heard.`
+        title: `Join the conversation`,
+        blurb: `Comment on articles and make your voice heard.`,
     },
     {
         title: `Take your career to the next level`,
-        blurb: `Create your jobseeker profile and receive job alerts.`
+        blurb: `Create your jobseeker profile and receive job alerts.`,
     },
     {
         title: `Enjoy our free iOS and Android apps`,
-        blurb: ` Save articles for later, tailor your news and get notified about topics that matter to you.`
+        blurb: `
+Save articles for later, tailor your news and get notified about topics that matter to you.`,
     },
 ];
 
-const actionableBenefits = [
+const actionableBenefits: ActionableBenefit[] = [
     {
-        title: `Explore exclusive content `,
+        title: `Explore exclusive content`,
         blurb: `Browse through over 40 newsletters on the variety of topics or sign up for events, offers, holidays or supporter updates.`,
-        cta: [{
-            name: `Find newsletters you'll love`,
-            link: `/newsletters`,
-        }]
+        cta: [
+            {
+                name: `Find newsletters you'll love`,
+                link: `/newsletters`,
+            },
+        ],
     },
     {
-        title: `Join the conversation `,
+        title: `Get closer to our journalism`,
         blurb: `Complete your Guardian profile, pick an article that sparks your interest and that has a little comment icon and join fellow Guardian readers.`,
-        cta: [{
-            name: `??`,
-            link: `/newsletters`,
-        }]
+        cta: [
+            {
+                name: `Go to The Guardian`,
+                link: `/newsletters`,
+            },
+        ],
     },
     {
-        title: `Get closer to our journalism `,
-        blurb: `Complete your Guardian profile, pick an article that sparks your interest and that has a little comment icon and join fellow Guardian readers.`,
-        cta: [{
-            name: `Go to The Guardian`,
-            link: `/newsletters`,
-        }]
-    },
-    {
-        title: `Take your career to the next level  `,
+        title: `Take your career to the next level`,
         blurb: `Use your Guardian account to access and complete your Guardian Jobs profile. Browse jobs and set up alerts.`,
-        cta: [{
-            name: `Visit Guardian Jobs`,
-            link: `/newsletters`,
-        }]
+        cta: [
+            {
+                name: `Visit Guardian Jobs`,
+                link: `/newsletters`,
+            },
+        ],
     },
     {
-        title: `Download our award-winning app `,
+        title: `Download our award-winning app`,
         blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as mobile alerts when your favourite writers publish an article, or your favourite team scores.`,
-        cta: [{
-            name: `Get the Guardian App`,
-            link: `/newsletters`,
-        }]
+        cta: [
+            {
+                name: `Get the Guardian App`,
+                link: `/newsletters`,
+            },
+        ],
     },
 ];
 
-export const AccountActionableBenefits = () => {
-    return (
-        <ul class={'identity-upsell-account-creation-superbullets'}>
-            {actionableBenefits.map(({title, blurb, cta})=>(
-                <li>
-                    <span
-                        className={'identity-upsell-account-creation-superbullets__icon'}
-                        // eslint-disable-next-line react/no-danger
-                        dangerouslySetInnerHTML={{
-                            __html: star.markup,
-                        }}
-                    />
-                    <h4>{title}</h4>
-                    <p>{blurb}</p>
-                    {cta.map(({name,link})=>(
-                        <a className={'manage-account__button manage-account__button--light'}>{name}</a>
-                    ))}
-                </li>
-            ))}
-        </ul>
-    )
-}
+export const AccountActionableBenefits = () => (
+    <ul className="identity-upsell-account-creation-superbullets">
+        {actionableBenefits.map(({ title, blurb, cta }) => (
+            <li>
+                <span
+                    className="identity-upsell-account-creation-superbullets__icon"
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{
+                        __html: star.markup,
+                    }}
+                />
+                <h4>{title}</h4>
+                <p>{blurb}</p>
+                {cta.map(({ name, link }) => (
+                    <a data-link-name={`benefit : ${title}`} href={link} className="manage-account__button manage-account__button--light">
+                        {name}
+                    </a>
+                ))}
+            </li>
+        ))}
+    </ul>
+);
 
-export const AccountBenefits = () => {
-    return (
-        <ul class={'identity-upsell-account-creation-bullets'}>
-            {benefits.map(benefit=>(
-                <li>
-                    <h4>{benefit.title}</h4>
-                    <p>{benefit.blurb}</p>
-                </li>
-            ))}
-        </ul>
-    )
-}
+export const AccountBenefits = () => (
+    <ul className="identity-upsell-account-creation-bullets">
+        {benefits.map(benefit => (
+            <li>
+                <h4>{benefit.title}</h4>
+                <p>{benefit.blurb}</p>
+            </li>
+        ))}
+    </ul>
+);

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'preact-compat';
+
+const benefits = [
+    {
+        title: `Get closer to our journalism `,
+        blurb: `Choose from over 40 exclusive newsletters on the variety of topics. Get exclusive offers.`
+    },
+    {
+        title: `Join the conversation  `,
+        blurb: `Comment on articles and make your voice heard.`
+    },
+    {
+        title: `Take your career to the next level`,
+        blurb: `Create your jobseeker profile and receive job alerts.`
+    },
+    {
+        title: `Enjoy our free iOS and Android apps`,
+        blurb: ` Save articles for later, tailor your news and get notified about topics that matter to you.`
+    },
+];
+
+export const AccountBenefits = () => {
+    return (
+        <ul class={'identity-upsell-account-creation-bullets'}>
+            {benefits.map(benefit=>(
+                <li>
+                    <h4>{benefit.title}</h4>
+                    <p>{benefit.blurb}</p>
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'preact-compat';
+import {AccountActionableBenefits} from "./AccountBenefits";
+
+type AccountCreationFeaturesProps = {
+    returnUrl: string,
+};
+
+export class AccountCreationFeatures extends Component<AccountCreationFeaturesProps> {
+    render() {
+        return (
+            <div>
+                <hr className="manage-account-small-divider" />
+                <h1 className={'identity-upsell-title'}>
+                    <h1 className={'identity-upsell-title__title'}>
+                        Your account has been created.
+                    </h1>
+                    <p className={'identity-upsell-title__subtitle'}>
+                        Start exploring your benefits.
+                    </p>
+                </h1>
+                <div className="identity-forms-message__body">
+                    <AccountActionableBenefits/>
+                </div>
+            </div>
+        );
+    }
+}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
@@ -1,25 +1,22 @@
+// @flow
 import React, { Component } from 'preact-compat';
-import {AccountActionableBenefits} from "./AccountBenefits";
+import { AccountActionableBenefits } from './AccountBenefits';
 
-type AccountCreationFeaturesProps = {
-    returnUrl: string,
-};
-
-export class AccountCreationFeatures extends Component<AccountCreationFeaturesProps> {
+export class AccountCreationFeatures extends Component {
     render() {
         return (
             <div>
                 <hr className="manage-account-small-divider" />
-                <h1 className={'identity-upsell-title'}>
-                    <h1 className={'identity-upsell-title__title'}>
+                <h1 className="identity-upsell-title">
+                    <h1 className="identity-upsell-title__title">
                         Your account has been created.
                     </h1>
-                    <p className={'identity-upsell-title__subtitle'}>
-                        Start exploring your benefits.
+                    <p className="identity-upsell-title__subtitle">
+                        Start exploring your benefits:
                     </p>
                 </h1>
                 <div className="identity-forms-message__body">
-                    <AccountActionableBenefits/>
+                    <AccountActionableBenefits />
                 </div>
             </div>
         );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -1,14 +1,13 @@
 // @flow
 import React, { Component } from 'preact-compat';
-import {AccountCreationForm} from "./AccountCreationForm";
-import {AccountCreationFeatures} from "./AccountCreationFeatures";
+import { AccountCreationForm } from './AccountCreationForm';
+import { AccountCreationFeatures } from './AccountCreationFeatures';
 
 type AccountCreationFlowProps = {
     csrfToken: string,
     returnUrl: string,
     accountToken: string,
 };
-
 
 class AccountCreationFlow extends Component<
     AccountCreationFlowProps,

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'preact-compat';
-import arrowRight from 'svgs/icon/arrow-right.svg';
-import reqwest from 'reqwest';
+import {AccountCreationForm} from "./AccountCreationForm";
 
 type AccountCreationFlowProps = {
     csrfToken: string,
@@ -9,12 +8,6 @@ type AccountCreationFlowProps = {
     accountToken: string,
 };
 
-type AccountCreationFormProps = {
-    csrfToken: string,
-    accountToken: string,
-    returnUrl: string,
-    onAccountCreated: () => {},
-};
 
 type AccountCreationFeaturesProps = {
     returnUrl: string,
@@ -25,161 +18,26 @@ class AccountCreationFeatures extends Component<AccountCreationFeaturesProps> {
         return (
             <div>
                 <hr className="manage-account-small-divider" />
-                <h1 className="identity-title--small">
-                    Thanks for creating a Guardian account!
-                </h1>
-                <div className="identity-forms-message__body">
-                    <p>
+                <h1 className={'identity-upsell-title'}>
+                    <h1 className={'identity-upsell-title__title'}>
+                        Thanks for creating a Guardian account!
+                    </h1>
+                    <p className={'identity-upsell-title__subtitle'}>>
                         You are now signed in. Start exploring your benefits
                         from our home page.
                     </p>
+                </h1>
+                <div className="identity-forms-message__body">
                 </div>
                 <div className="identity-forms-message__body">
                     <a
-                        className="manage-account__button manage-account__button--icon manage-account__button--main"
+                        className="manage-account__button manage-account__button--main"
                         data-link-name="complete-consents : cta-bottom"
                         href={this.props.returnUrl}>
                         Go to The Guardian
-                        <span
-                            // eslint-disable-next-line react/no-danger
-                            dangerouslySetInnerHTML={{
-                                __html: arrowRight.markup,
-                            }}
-                        />
                     </a>
                 </div>
             </div>
-        );
-    }
-}
-
-class AccountCreationForm extends Component<
-    AccountCreationFormProps,
-    {
-        password?: string,
-        isLoading?: boolean,
-        isError?: boolean,
-        errorReason?: string,
-    }
-> {
-    onSubmit = (ev: Event) => {
-        ev.preventDefault();
-        this.setState({
-            isLoading: true,
-            isError: false,
-        });
-
-        reqwest({
-            url: '/password/guest',
-            method: 'post',
-            data: {
-                csrfToken: this.props.csrfToken,
-                token: this.props.accountToken,
-                password: this.state.password,
-            },
-            success: () => {
-                this.props.onAccountCreated();
-            },
-            error: response => {
-                try {
-                    const apiError = JSON.parse(response.responseText)[0];
-                    this.setState({
-                        isError: true,
-                        errorReason: apiError.description,
-                    });
-                } catch (exception) {
-                    this.setState({ isError: true });
-                }
-            },
-            complete: () => {
-                this.setState({ isLoading: false });
-            },
-        });
-    };
-
-    handlePasswordChange = (ev: Event) => {
-        if (!(ev.target instanceof HTMLInputElement)) {
-            return;
-        }
-        this.setState({ password: ev.target.value });
-    };
-
-    render() {
-        const { isError, errorReason } = this.state;
-        return (
-            <form className="form" onSubmit={this.onSubmit}>
-                <hr className="manage-account-small-divider" />
-                {isError && (
-                    <div className="form__error">
-                        {errorReason || 'Oops. Something went wrong'}
-                    </div>
-                )}
-                <h1 className="identity-title--small">
-                    Want even more from the Guardian? Create a free account
-                </h1>
-                <div className="identity-forms-message__body">
-                    <p>
-                        Create your account by setting a password, and manage
-                        your email preferences at any time.
-                    </p>
-                </div>
-                <div className="fieldset__fields">
-                    <ul>
-                        <li className="form-field" id="password_field">
-                            <label htmlFor="password">
-                                <div className="label">Password</div>
-                                <div className="input">
-                                    <input
-                                        className="text-input"
-                                        type="password"
-                                        id="password"
-                                        name="password"
-                                        value={this.state.password}
-                                        autoComplete="off"
-                                        onChange={this.handlePasswordChange}
-                                        autoCapitalize="off"
-                                        autoCorrect="off"
-                                        spellCheck="false"
-                                        aria-required="true"
-                                        required
-                                    />
-                                </div>
-                            </label>
-                        </li>
-
-                        <li className="form-field form-field__submit">
-                            {this.state.isLoading ? (
-                                <button
-                                    disabled
-                                    className="manage-account__button manage-account__button--light manage-account__button--center">
-                                    Hang on...
-                                </button>
-                            ) : (
-                                <button
-                                    type="submit"
-                                    className="manage-account__button manage-account__button--icon manage-account__button--main">
-                                    Set password{' '}
-                                    <span
-                                        // eslint-disable-next-line react/no-danger
-                                        dangerouslySetInnerHTML={{
-                                            __html: arrowRight.markup,
-                                        }}
-                                    />
-                                </button>
-                            )}
-                        </li>
-                    </ul>
-                </div>
-                <aside className="identity-forms-message__body">
-                    <hr className="manage-account-small-divider" />
-                    <a
-                        className="manage-account__button manage-account__button--light"
-                        data-link-name="complete-consents : cta-bottom"
-                        href={this.props.returnUrl}>
-                        Go to The Guardian
-                    </a>
-                </aside>
-            </form>
         );
     }
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -23,7 +23,7 @@ class AccountCreationFlow extends Component<
     };
 
     render() {
-        return this.state.hasCreatedAccount ? (
+        return !this.state.hasCreatedAccount ? (
             <AccountCreationForm
                 email={this.props.email}
                 csrfToken={this.props.csrfToken}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'preact-compat';
 import {AccountCreationForm} from "./AccountCreationForm";
+import {AccountCreationFeatures} from "./AccountCreationFeatures";
 
 type AccountCreationFlowProps = {
     csrfToken: string,
@@ -8,39 +9,6 @@ type AccountCreationFlowProps = {
     accountToken: string,
 };
 
-
-type AccountCreationFeaturesProps = {
-    returnUrl: string,
-};
-
-class AccountCreationFeatures extends Component<AccountCreationFeaturesProps> {
-    render() {
-        return (
-            <div>
-                <hr className="manage-account-small-divider" />
-                <h1 className={'identity-upsell-title'}>
-                    <h1 className={'identity-upsell-title__title'}>
-                        Thanks for creating a Guardian account!
-                    </h1>
-                    <p className={'identity-upsell-title__subtitle'}>>
-                        You are now signed in. Start exploring your benefits
-                        from our home page.
-                    </p>
-                </h1>
-                <div className="identity-forms-message__body">
-                </div>
-                <div className="identity-forms-message__body">
-                    <a
-                        className="manage-account__button manage-account__button--main"
-                        data-link-name="complete-consents : cta-bottom"
-                        href={this.props.returnUrl}>
-                        Go to The Guardian
-                    </a>
-                </div>
-            </div>
-        );
-    }
-}
 
 class AccountCreationFlow extends Component<
     AccountCreationFlowProps,

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -23,7 +23,7 @@ class AccountCreationFlow extends Component<
     };
 
     render() {
-        return !this.state.hasCreatedAccount ? (
+        return this.state.hasCreatedAccount ? (
             <AccountCreationForm
                 email={this.props.email}
                 csrfToken={this.props.csrfToken}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFlow.js
@@ -7,6 +7,7 @@ type AccountCreationFlowProps = {
     csrfToken: string,
     returnUrl: string,
     accountToken: string,
+    email: string,
 };
 
 class AccountCreationFlow extends Component<
@@ -24,9 +25,9 @@ class AccountCreationFlow extends Component<
     render() {
         return !this.state.hasCreatedAccount ? (
             <AccountCreationForm
+                email={this.props.email}
                 csrfToken={this.props.csrfToken}
                 accountToken={this.props.accountToken}
-                returnUrl={this.props.returnUrl}
                 onAccountCreated={this.onAccountCreated}
             />
         ) : (

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'preact-compat';
 import reqwest from 'reqwest';
 import ophan from 'ophan/ng';
+import reportError from 'lib/report-error';
 import { AccountBenefits } from './AccountBenefits';
 
 type AccountCreationFormProps = {
@@ -43,6 +44,9 @@ class AccountCreationForm extends Component<
                 this.props.onAccountCreated();
             },
             error: response => {
+                reportError(Error(response), {
+                    feature: 'identity-create-account-upsell',
+                });
                 try {
                     const apiError = JSON.parse(response.responseText)[0];
                     this.setState({

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -81,8 +81,8 @@ class AccountCreationForm extends Component<
                 <div className="fieldset__fields">
                     <ul>
                         <li className="form-field" id="email_field" aria-hidden={true}>
-                            <label htmlFor="email">
-                                <div className="label">Email</div>
+                            <label class="identity-forms-input-wrap" htmlFor="email">
+                                <div className="identity-forms-label">Email</div>
                                 <input
                                     className="identity-forms-input"
                                     type="email"
@@ -100,8 +100,8 @@ class AccountCreationForm extends Component<
                         </li>
 
                         <li className="form-field" id="password_field">
-                            <label htmlFor="password">
-                                <div className="label">Password</div>
+                            <label class="identity-forms-input-wrap" htmlFor="password">
+                                <div className="identity-forms-label">Password</div>
                                 <input
                                     className="identity-forms-input"
                                     type="password"

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -1,0 +1,156 @@
+import React, { Component } from 'preact-compat';
+import reqwest from 'reqwest';
+import {AccountBenefits} from "./AccountBenefits";
+
+type AccountCreationFormProps = {
+    csrfToken: string,
+    accountToken: string,
+    returnUrl: string,
+    onAccountCreated: () => {},
+};
+
+class AccountCreationForm extends Component<
+    AccountCreationFormProps,
+    {
+        password?: string,
+        isLoading?: boolean,
+        isError?: boolean,
+        errorReason?: string,
+    }
+    > {
+    onSubmit = (ev: Event) => {
+        ev.preventDefault();
+        this.setState({
+            isLoading: true,
+            isError: false,
+        });
+
+        reqwest({
+            url: '/password/guest',
+            method: 'post',
+            data: {
+                csrfToken: this.props.csrfToken,
+                token: this.props.accountToken,
+                password: this.state.password,
+            },
+            success: () => {
+                this.props.onAccountCreated();
+            },
+            error: response => {
+                try {
+                    const apiError = JSON.parse(response.responseText)[0];
+                    this.setState({
+                        isError: true,
+                        errorReason: apiError.description,
+                    });
+                } catch (exception) {
+                    this.setState({ isError: true });
+                }
+            },
+            complete: () => {
+                this.setState({ isLoading: false });
+            },
+        });
+    };
+
+    handlePasswordChange = (ev: Event) => {
+        if (!(ev.target instanceof HTMLInputElement)) {
+            return;
+        }
+        this.setState({ password: ev.target.value });
+    };
+
+    render() {
+        const { isError, errorReason, isLoading } = this.state;
+        return (
+            <form className="form" onSubmit={this.onSubmit}>
+                <hr className="manage-account-small-divider" />
+                {isError && (
+                    <div className="form__error">
+                        {errorReason || 'Oops. Something went wrong'}
+                    </div>
+                )}
+                <h1 className={'identity-upsell-title'}>
+                    <h1 className={'identity-upsell-title__title'}>
+                        Want more from The Guardian?
+                    </h1>
+                    <p className={'identity-upsell-title__subtitle'}>
+                        Create your account now to manage your preferences and explore your free benefits.
+                    </p>
+                </h1>
+                <div className="fieldset__fields">
+                    <ul>
+                        <li className="form-field" id="email_field" aria-hidden={true}>
+                            <label htmlFor="email">
+                                <div className="label">Email</div>
+                                <input
+                                    className="identity-forms-input"
+                                    type="email"
+                                    id="email"
+                                    value={'tester@test.com'}
+                                    autoComplete="off"
+                                    autoCapitalize="off"
+                                    autoCorrect="off"
+                                    spellCheck="false"
+                                    aria-required="true"
+                                    required
+                                    disabled={true}
+                                />
+                            </label>
+                        </li>
+
+                        <li className="form-field" id="password_field">
+                            <label htmlFor="password">
+                                <div className="label">Password</div>
+                                <input
+                                    className="identity-forms-input"
+                                    type="password"
+                                    id="password"
+                                    name="password"
+                                    value={this.state.password}
+                                    autoComplete="off"
+                                    onChange={this.handlePasswordChange}
+                                    autoCapitalize="off"
+                                    autoCorrect="off"
+                                    spellCheck="false"
+                                    aria-required="true"
+                                    required
+                                />
+                            </label>
+                        </li>
+
+                        <li className="form-field form-field__submit">
+                            {isLoading ? (
+                                <button
+                                    disabled
+                                    className="manage-account__button manage-account__button--light manage-account__button--center">
+                                    Hang on...
+                                </button>
+                            ) : (
+                                <button
+                                    type="submit"
+                                    className="manage-account__button manage-account__button--icon manage-account__button--main">
+                                    Create an account
+                                </button>
+                            )}
+                        </li>
+                    </ul>
+                </div>
+                <aside className={'identity-upsell-account-creation-block'}>
+                    <AccountBenefits/>
+                </aside>
+                <aside className="identity-forms-message__body">
+                    <hr className="manage-account-small-divider" />
+                    <a
+                        className="manage-account__button manage-account__button--light"
+                        data-link-name="complete-consents : cta-bottom"
+                        href={this.props.returnUrl}>
+                        Go to The Guardian
+                    </a>
+                </aside>
+            </form>
+        );
+    }
+}
+
+export {AccountCreationForm}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -1,7 +1,8 @@
+// @flow
 import React, { Component } from 'preact-compat';
 import reqwest from 'reqwest';
 import ophan from 'ophan/ng';
-import {AccountBenefits} from "./AccountBenefits";
+import { AccountBenefits } from './AccountBenefits';
 
 type AccountCreationFormProps = {
     csrfToken: string,
@@ -18,7 +19,7 @@ class AccountCreationForm extends Component<
         isError?: boolean,
         errorReason?: string,
     }
-    > {
+> {
     onSubmit = (ev: Event) => {
         ev.preventDefault();
         this.setState({
@@ -75,37 +76,46 @@ class AccountCreationForm extends Component<
                         {errorReason || 'Oops. Something went wrong'}
                     </div>
                 )}
-                <h1 className={'identity-upsell-title'}>
-                    <h1 className={'identity-upsell-title__title'}>
+                <h1 className="identity-upsell-title">
+                    <h1 className="identity-upsell-title__title">
                         Want more from The Guardian?
                     </h1>
-                    <p className={'identity-upsell-title__subtitle'}>
-                        Create your account now to manage your preferences and explore your free benefits.
+                    <p className="identity-upsell-title__subtitle">
+                        Create your account now to manage your preferences and
+                        explore your free benefits.
                     </p>
                 </h1>
                 <div>
                     <ul className="identity-forms-fields">
-                        <li id="email_field" aria-hidden={true}>
-                            <label class="identity-forms-input-wrap" htmlFor="email">
-                                <div className="identity-forms-label">Email</div>
+                        <li id="email_field" aria-hidden>
+                            <label
+                                className="identity-forms-input-wrap"
+                                htmlFor="email">
+                                <div className="identity-forms-label">
+                                    Email
+                                </div>
                                 <input
                                     className="identity-forms-input"
                                     type="email"
                                     id="email"
-                                    value={'tester@test.com'}
+                                    value="tester@test.com"
                                     autoComplete="off"
                                     autoCapitalize="off"
                                     autoCorrect="off"
                                     spellCheck="false"
                                     aria-required="true"
                                     required
-                                    disabled={true}
+                                    disabled
                                 />
                             </label>
                         </li>
                         <li id="password_field">
-                            <label class="identity-forms-input-wrap" htmlFor="password">
-                                <div className="identity-forms-label">Password</div>
+                            <label
+                                className="identity-forms-input-wrap"
+                                htmlFor="password">
+                                <div className="identity-forms-label">
+                                    Password
+                                </div>
                                 <input
                                     className="identity-forms-input"
                                     type="password"
@@ -139,9 +149,9 @@ class AccountCreationForm extends Component<
                         </li>
                     </ul>
                 </div>
-                <aside className={'identity-upsell-account-creation-block'}>
-                    <hr class="manage-account-small-divider" />
-                    <AccountBenefits/>
+                <aside className="identity-upsell-account-creation-block">
+                    <hr className="manage-account-small-divider" />
+                    <AccountBenefits />
                 </aside>
                 <aside className="identity-forms-message__body">
                     <hr className="manage-account-small-divider" />
@@ -157,4 +167,4 @@ class AccountCreationForm extends Component<
     }
 }
 
-export {AccountCreationForm}
+export { AccountCreationForm };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'preact-compat';
 import reqwest from 'reqwest';
+import ophan from 'ophan/ng';
 import {AccountBenefits} from "./AccountBenefits";
 
 type AccountCreationFormProps = {
@@ -34,6 +35,10 @@ class AccountCreationForm extends Component<
                 password: this.state.password,
             },
             success: () => {
+                ophan.record({
+                    component: 'set-password',
+                    value: 'set-password',
+                });
                 this.props.onAccountCreated();
             },
             error: response => {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -92,28 +92,30 @@ class AccountCreationForm extends Component<
                 </h1>
                 <div>
                     <ul className="identity-forms-fields">
-                        <li id="email_field" aria-hidden>
-                            <label
-                                className="identity-forms-input-wrap"
-                                htmlFor="email">
-                                <div className="identity-forms-label">
-                                    Email
-                                </div>
-                                <input
-                                    className="identity-forms-input"
-                                    type="email"
-                                    id="email"
-                                    value={email}
-                                    autoComplete="off"
-                                    autoCapitalize="off"
-                                    autoCorrect="off"
-                                    spellCheck="false"
-                                    aria-required="true"
-                                    required
-                                    disabled
-                                />
-                            </label>
-                        </li>
+                        {email && (
+                            <li id="email_field" aria-hidden>
+                                <label
+                                    className="identity-forms-input-wrap"
+                                    htmlFor="email">
+                                    <div className="identity-forms-label">
+                                        Email
+                                    </div>
+                                    <input
+                                        className="identity-forms-input"
+                                        type="email"
+                                        id="email"
+                                        value={email}
+                                        autoComplete="off"
+                                        autoCapitalize="off"
+                                        autoCorrect="off"
+                                        spellCheck="false"
+                                        aria-required="true"
+                                        required
+                                        disabled
+                                    />
+                                </label>
+                            </li>
+                        )}
                         <li id="password_field">
                             <label
                                 className="identity-forms-input-wrap"

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -83,9 +83,9 @@ class AccountCreationForm extends Component<
                         Create your account now to manage your preferences and explore your free benefits.
                     </p>
                 </h1>
-                <div className="fieldset__fields">
-                    <ul>
-                        <li className="form-field" id="email_field" aria-hidden={true}>
+                <div>
+                    <ul className="identity-forms-fields">
+                        <li id="email_field" aria-hidden={true}>
                             <label class="identity-forms-input-wrap" htmlFor="email">
                                 <div className="identity-forms-label">Email</div>
                                 <input
@@ -103,8 +103,7 @@ class AccountCreationForm extends Component<
                                 />
                             </label>
                         </li>
-
-                        <li className="form-field" id="password_field">
+                        <li id="password_field">
                             <label class="identity-forms-input-wrap" htmlFor="password">
                                 <div className="identity-forms-label">Password</div>
                                 <input
@@ -123,8 +122,7 @@ class AccountCreationForm extends Component<
                                 />
                             </label>
                         </li>
-
-                        <li className="form-field form-field__submit">
+                        <li>
                             {isLoading ? (
                                 <button
                                     disabled
@@ -142,6 +140,7 @@ class AccountCreationForm extends Component<
                     </ul>
                 </div>
                 <aside className={'identity-upsell-account-creation-block'}>
+                    <hr class="manage-account-small-divider" />
                     <AccountBenefits/>
                 </aside>
                 <aside className="identity-forms-message__body">

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -7,7 +7,7 @@ import { AccountBenefits } from './AccountBenefits';
 type AccountCreationFormProps = {
     csrfToken: string,
     accountToken: string,
-    returnUrl: string,
+    email: string,
     onAccountCreated: () => {},
 };
 
@@ -68,6 +68,7 @@ class AccountCreationForm extends Component<
 
     render() {
         const { isError, errorReason, isLoading } = this.state;
+        const { email } = this.props;
         return (
             <form className="form" onSubmit={this.onSubmit}>
                 <hr className="manage-account-small-divider" />
@@ -98,7 +99,7 @@ class AccountCreationForm extends Component<
                                     className="identity-forms-input"
                                     type="email"
                                     id="email"
-                                    value="tester@test.com"
+                                    value={email}
                                     autoComplete="off"
                                     autoCapitalize="off"
                                     autoCorrect="off"
@@ -152,15 +153,6 @@ class AccountCreationForm extends Component<
                 <aside className="identity-upsell-account-creation-block">
                     <hr className="manage-account-small-divider" />
                     <AccountBenefits />
-                </aside>
-                <aside className="identity-forms-message__body">
-                    <hr className="manage-account-small-divider" />
-                    <a
-                        className="manage-account__button manage-account__button--light"
-                        data-link-name="complete-consents : cta-bottom"
-                        href={this.props.returnUrl}>
-                        Go to The Guardian
-                    </a>
                 </aside>
             </form>
         );

--- a/static/src/stylesheets/head.identity.scss
+++ b/static/src/stylesheets/head.identity.scss
@@ -27,3 +27,5 @@
 @import 'module/identity/ad-prefs';
 @import 'module/identity/consent';
 @import 'module/identity/follow';
+@import 'module/identity/upsell/_base';
+@import 'module/identity/upsell/account-creation';

--- a/static/src/stylesheets/module/identity/_button.scss
+++ b/static/src/stylesheets/module/identity/_button.scss
@@ -26,11 +26,11 @@
 
 .manage-account__button {
     $font-size: 5;
-    $height: $gs-baseline * 3;
+    $height: $gs-baseline * 3.5;
     $padding-vertical: ($height - get-line-height(textSans, $font-size))/2;
-    $padding-horizontal: $gs-gutter * .9;
+    $padding-horizontal: $gs-gutter / 2;
     @include fs-textSans($font-size);
-    @include identity-button($brightness-7)
+    @include identity-button($brightness-7);
     height: $height;
     border-radius: 100px;
     border: 0;
@@ -148,7 +148,8 @@
 }
 
 .manage-account__button--main {
-    @include identity-button($highlight-main)
+    @include identity-button($highlight-main);
+    font-weight: 600;
 }
 
 .manage-account__button--secondary {

--- a/static/src/stylesheets/module/identity/_button.scss
+++ b/static/src/stylesheets/module/identity/_button.scss
@@ -28,7 +28,7 @@
     $font-size: 5;
     $height: $gs-baseline * 3.5;
     $padding-vertical: ($height - get-line-height(textSans, $font-size))/2;
-    $padding-horizontal: $gs-gutter / 2;
+    $padding-horizontal: $gs-gutter;
     @include fs-textSans($font-size);
     @include identity-button($brightness-7);
     height: $height;
@@ -37,7 +37,6 @@
     cursor: pointer;
     float: left;
     padding: $padding-vertical * 1.1 $padding-horizontal $padding-vertical * .9;
-    min-width: $gs-baseline * 14;
     white-space: nowrap;
     text-overflow: clip;
     appearance: none;
@@ -46,7 +45,6 @@
     -ms-appearance: none;
     box-sizing: border-box;
     transition: .15s linear;
-    text-align: left;
 
     &, & > .manage-account__button-flexwrap {
         justify-content: space-between;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -132,6 +132,34 @@ Wrapper
     }
 }
 
+/*
+Interim guui input
+*/
+.identity-forms-input {
+    @include fs-textSans(5);
+    border: 1px solid #dcdcdc;
+    display: block;
+    height: $gs-baseline * 3.5;
+    line-height: $gs-baseline * 1.67;
+    padding: 0 $gs-gutter / 2;
+    width: 100%;
+    transition: all .2s ease-in-out;
+
+    &:hover {
+        box-shadow: 0 0 0 3px #ededed;
+    }
+
+    &:focus {
+      outline: transparent;
+      box-shadow: 0 0 0 3px #ffe500;
+    }
+
+    &[disabled] {
+        background: #EDEDED;
+        pointer-events: none;
+    }
+}
+
 
 
 .identity-forms-wrapper__info {

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -133,9 +133,22 @@ Wrapper
 }
 
 /*
-Interim guui input
+List of fields
 */
+.identity-forms-fields {
+    list-style: none;
+    margin: 0;
+    display: block;
+    li {
+        @include clearfix;
+        margin-bottom: $gs-baseline;
+        display: block;
+    }
+}
 
+/*
+Interim guui inputs
+*/
 .identity-forms-label {
     @include fs-textSans(5);
     font-weight: 700;
@@ -155,6 +168,7 @@ Interim guui input
     padding: 0 $gs-gutter / 2;
     width: 100%;
     transition: all .2s ease-in-out;
+    box-sizing: border-box;
 
     &:hover {
         box-shadow: 0 0 0 3px $brightness-93;

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -175,12 +175,12 @@ Interim guui inputs
     }
 
     &:focus {
-      outline: transparent;
-      box-shadow: 0 0 0 3px #ffe500;
+        outline: transparent;
+        box-shadow: 0 0 0 3px $highlight-main;
     }
 
     &[disabled] {
-        background: #EDEDED;
+        background: $brightness-93;
         pointer-events: none;
     }
 }

--- a/static/src/stylesheets/module/identity/_forms.scss
+++ b/static/src/stylesheets/module/identity/_forms.scss
@@ -135,9 +135,20 @@ Wrapper
 /*
 Interim guui input
 */
+
+.identity-forms-label {
+    @include fs-textSans(5);
+    font-weight: 700;
+}
+
+.identity-forms-input-wrap {
+    .identity-forms-label {
+        margin-bottom: $gs-baseline/3;
+    }
+}
 .identity-forms-input {
     @include fs-textSans(5);
-    border: 1px solid #dcdcdc;
+    border: 1px solid $brightness-86;
     display: block;
     height: $gs-baseline * 3.5;
     line-height: $gs-baseline * 1.67;
@@ -146,7 +157,7 @@ Interim guui input
     transition: all .2s ease-in-out;
 
     &:hover {
-        box-shadow: 0 0 0 3px #ededed;
+        box-shadow: 0 0 0 3px $brightness-93;
     }
 
     &:focus {

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -1,4 +1,4 @@
-.identity-upsell-account-creation-bullets {
+.identity-upsell-account-creation-bullets, .identity-upsell-account-creation-superbullets {
     @include fs-headlineGarnett(0);
     list-style: none;
     margin-bottom: $gs-baseline;
@@ -14,31 +14,5 @@
             width: 1em;
             margin-left: -$gs-gutter;
         }
-    }
-}
-
-.identity-upsell-account-creation-superbullets {
-    $icon-size: $gs-gutter * 2.5;
-    @include fs-headlineGarnett(0);
-    list-style: none;
-    margin-bottom: $gs-baseline;
-    margin-top: $gs-baseline / 3;
-    margin-left: $icon-size + ($gs-gutter/2);
-    li {
-        .identity-upsell-account-creation-superbullets__icon {
-            @include circular;
-            position: absolute;
-            left: ($icon-size + ($gs-gutter/2)) * -1;
-            width: $icon-size;
-            height: $icon-size;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: $brightness-7;
-
-        }
-        @include clearfix;
-        position: relative;
-        margin-bottom: $gs-baseline * 2;
     }
 }

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -4,6 +4,7 @@
     margin-bottom: $gs-baseline;
     margin-top: $gs-baseline / 3;
     li {
+        @include clearfix;
         position: relative;
         margin-bottom: $gs-baseline;
         &:before {
@@ -13,5 +14,31 @@
             width: 1em;
             margin-left: -$gs-gutter;
         }
+    }
+}
+
+.identity-upsell-account-creation-superbullets {
+    $icon-size: $gs-gutter * 2.5;
+    @include fs-headlineGarnett(0);
+    list-style: none;
+    margin-bottom: $gs-baseline;
+    margin-top: $gs-baseline / 3;
+    margin-left: $icon-size + ($gs-gutter/2);
+    li {
+        .identity-upsell-account-creation-superbullets__icon {
+            @include circular;
+            position: absolute;
+            left: ($icon-size + ($gs-gutter/2)) * -1;
+            width: $icon-size;
+            height: $icon-size;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: $brightness-7;
+
+        }
+        @include clearfix;
+        position: relative;
+        margin-bottom: $gs-baseline * 2;
     }
 }

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -1,4 +1,4 @@
-.identity-upsell-account-creation-bullets, .identity-upsell-account-creation-superbullets {
+%identity-upsell-account-creation-bullets {
     @include fs-headlineGarnett(0);
     list-style: none;
     margin-bottom: $gs-baseline;
@@ -14,5 +14,16 @@
             width: 1em;
             margin-left: -$gs-gutter;
         }
+    }
+}
+
+.identity-upsell-account-creation-bullets {
+    @extend %identity-upsell-account-creation-bullets;
+}
+
+.identity-upsell-account-creation-superbullets {
+    @extend %identity-upsell-account-creation-bullets;
+    li {
+        margin-bottom: $gs-baseline * 2;
     }
 }

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -1,6 +1,8 @@
 .identity-upsell-account-creation-bullets {
     @include fs-headlineGarnett(0);
     list-style: none;
+    margin-bottom: $gs-baseline;
+    margin-top: $gs-baseline / 3;
     li {
         position: relative;
         margin-bottom: $gs-baseline;

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -1,0 +1,15 @@
+.identity-upsell-account-creation-bullets {
+    @include fs-headlineGarnett(0);
+    list-style: none;
+    li {
+        position: relative;
+        margin-bottom: $gs-baseline;
+        &:before {
+            position: absolute;
+            content: '•';
+            color: $green-dark;
+            width: 1em;
+            margin-left: -$gs-gutter;
+        }
+    }
+}

--- a/static/src/stylesheets/module/identity/upsell/_base.scss
+++ b/static/src/stylesheets/module/identity/upsell/_base.scss
@@ -1,6 +1,7 @@
 .identity-upsell-title {
     @include fs-headlineGarnett(2);
     font-weight: 600;
+    margin-bottom: $gs-baseline * 2;
     .identity-upsell-title__title {
         font-size: 1em;
     }

--- a/static/src/stylesheets/module/identity/upsell/_base.scss
+++ b/static/src/stylesheets/module/identity/upsell/_base.scss
@@ -1,0 +1,10 @@
+.identity-upsell-title {
+    @include fs-headlineGarnett(2);
+    font-weight: 600;
+    .identity-upsell-title__title {
+        font-size: 1em;
+    }
+    .identity-upsell-title__subtitle {
+        font-weight: 100;
+    }
+}


### PR DESCRIPTION
## What does this change?
Updates (yet again) the "set a password" field to bring it ever so slightly closer to the final look. The code has grown quite a bit so I took the chance to split this up into a couple files; Which makes for a messy diff now (Sorry!) but a cleaner codebase moving ahead.

This is not mergeable **just yet** as the design is an interim half-step between what we actually want and what we can fit in the layout we have now (And we need @zeftilldeath to be okay with it). Also, the copy/cta's need final approval.

_That said, the # of users seeing this component is quite small just yet so it might not be worth it to spend much time polishing anything from this PR that won't be carried over, such as improving the interim design_

## Checklist
- [x] Greenlight interim layout
- [x] Greenlight copy & cta's
- [x] Fix email not showing w/ narrow cookie

## Screenshots
<table>
<tr>
<td>

![screen shot 2018-09-03 at 3 09 33 pm](https://user-images.githubusercontent.com/11539094/44992363-ed860400-af8e-11e8-8149-4f7d82bdc3d4.png)

</td>
<td>

![screen shot 2018-09-04 at 11 29 07 am](https://user-images.githubusercontent.com/11539094/45026316-d9491200-b035-11e8-924e-5e0d25c32f40.png)

</td>
</table>

## What is the value of this and can you measure success?
Improve conversion of this component in order to increase the base of targetable users

### Accessibility test checklist

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)