### PR TITLE
Correctly handle script loading error

### DIFF
--- a/static/src/javascripts/lib/load-script.js
+++ b/static/src/javascripts/lib/load-script.js
@@ -1,5 +1,5 @@
 // @flow
-const loadScript = (src: string, props?: Object): Promise<any> => {
+const loadScript = (src: string, props?: Object): Promise<void> => {
     if (document.querySelector(`script[src="${src}"]`)) {
         return Promise.resolve();
     }

--- a/static/src/javascripts/lib/load-script.js
+++ b/static/src/javascripts/lib/load-script.js
@@ -17,7 +17,9 @@ const loadScript = (src: string, props?: Object): Promise<any> => {
             Object.assign(script, props);
         }
         script.onload = resolve;
-        script.onerror = reject;
+        script.onerror = () => {
+            reject(new Error(`Failed to load script ${src}`));
+        };
         if (ref.parentNode) {
             ref.parentNode.insertBefore(script, ref);
         }

--- a/static/src/javascripts/lib/load-script.js
+++ b/static/src/javascripts/lib/load-script.js
@@ -1,10 +1,5 @@
 // @flow
 const loadScript = (src: string, props?: Object): Promise<any> => {
-    // #? type checks like this should be redundant post es6/flow conversion
-    if (typeof src !== 'string') {
-        return Promise.reject(new Error('no src supplied'));
-    }
-
     if (document.querySelector(`script[src="${src}"]`)) {
         return Promise.resolve();
     }

--- a/static/src/javascripts/lib/load-script.spec.js
+++ b/static/src/javascripts/lib/load-script.spec.js
@@ -93,8 +93,8 @@ describe('loadScript', () => {
         expect(scripts).toHaveLength(0);
 
         loadScript('xxx', {})
-            .catch(msg => {
-                expect(msg).toBe('fail');
+            .catch(err => {
+                expect(err.message).toBe('Failed to load script xxx');
 
                 if (scripts[0]) {
                     scripts[0].remove();


### PR DESCRIPTION
## What does this change?

Defines a handler for script loading errors. If a script fails to load, the handler calls the Promise `reject` handler with a meaningful error message. 

Previously, this module set [`element.onerror`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#element.onerror) to be the Promise `reject` handler. As a result, when the error was reported to Sentry, Sentry received the `Event` object passed to `element.onerror`, which made it difficult to debug.

Also fixed up types in this module a little bit

## Screenshots

![screen shot 2018-09-03 at 14 57 11](https://user-images.githubusercontent.com/5931528/44990681-b2350680-af89-11e8-84f2-64f7d164a60c.png)

## What is the value of this and can you measure success?

Better error reporting and debugging

