### PR TITLE
Send marketing consents directly to IDAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "classnames": "~2.2.0",
     "core-js": "^2.5.3",
     "curl": "cujojs/curl#0.8.9",
-    "debounce-promise": "^3.1.0",
     "domready": "^1.0.8",
     "emotion": "^9.2.4",
     "emotion-server": "^9.2.4",

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -33,10 +33,12 @@ const UNSUBSCRIPTION_SUCCESS_MESSAGE =
     "You've been unsubscribed from all Guardian marketing newsletters and emails.";
 const ERR_MALFORMED_HTML = 'Something went wrong';
 
-const updateConsent = (consent: {
+type Consent = {
     id: string,
     consented: boolean,
-}): Promise<void> =>
+};
+
+const updateConsent = (consent: Consent): Promise<void> =>
     reqwest({
         url: `${config.get('page.idApiUrl')}/users/me/consents`,
         method: 'PATCH',
@@ -80,7 +82,7 @@ const submitNewsletterAction = (
 
 const buildConsentUpdatePayload = (
     fields: NodeList<any> = new NodeList()
-): { id: string, consented: boolean } => {
+): Consent => {
     const consent = {};
     [...fields].forEach((field: HTMLInputElement) => {
         switch (field.type) {

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -1,17 +1,17 @@
 // @flow
 
 import reqwest from 'reqwest';
-import debounce from 'debounce-promise';
 import fastdom from 'lib/fastdom-promise';
+import config from 'lib/config';
 import loadEnhancers from './modules/loadEnhancers';
 
 import { push as pushError } from './modules/show-errors';
 import {
     addSpinner,
-    removeSpinner,
+    bindAnalyticsEventsOnce as bindCheckboxAnalyticsEventsOnce,
     flip as flipCheckbox,
     getInfo as getCheckboxInfo,
-    bindAnalyticsEventsOnce as bindCheckboxAnalyticsEventsOnce,
+    removeSpinner,
 } from './modules/switch';
 import { getCsrfTokenFromElement } from './modules/fetchFormFields';
 
@@ -27,35 +27,25 @@ const isLoadingClassName = 'loading';
 const optOutClassName = 'fieldset__fields--opt-out';
 const optInClassName = 'fieldset__fields--opt-in';
 
-const requestDebounceTimeout = 150;
-
 const LC_CHECK_ALL = 'Select all';
 const LC_UNCHECK_ALL = 'Deselect all';
 const UNSUBSCRIPTION_SUCCESS_MESSAGE =
     "You've been unsubscribed from all Guardian marketing newsletters and emails.";
 const ERR_MALFORMED_HTML = 'Something went wrong';
 
-const submitPartialConsentFormDebouncedRq: ({}) => Promise<void> = debounce(
-    formData =>
-        reqwest({
-            url: '/privacy/edit-ajax',
-            method: 'POST',
-            data: formData,
-        }),
-    requestDebounceTimeout
-);
-const submitPartialConsentFormData = {};
-
-const submitPartialConsentForm = (formData: {}): Promise<void> => {
-    Object.assign(submitPartialConsentFormData, formData);
-    return submitPartialConsentFormDebouncedRq(
-        submitPartialConsentFormData
-    ).then(() => {
-        Object.keys(submitPartialConsentFormData).forEach(_ => {
-            delete submitPartialConsentFormData[_];
-        });
+const updateConsent = (consent: {
+    id: string,
+    consented: boolean,
+}): Promise<void> =>
+    reqwest({
+        url: `${config.get('page.idApiUrl')}/users/me/consents`,
+        method: 'PATCH',
+        type: 'json',
+        contentType: 'application/json',
+        withCredentials: true,
+        crossOrigin: true,
+        data: JSON.stringify(consent),
     });
-};
 
 const submitNewsletterAction = (
     csrfToken: string,
@@ -88,25 +78,24 @@ const submitNewsletterAction = (
     });
 };
 
-const buildFormDataForFields = (
-    csrfToken: string,
+const buildConsentUpdatePayload = (
     fields: NodeList<any> = new NodeList()
-): {} => {
-    const formData: { csrfToken: string } = {
-        csrfToken,
-    };
+): { id: string, consented: boolean } => {
+    const consent = {};
     [...fields].forEach((field: HTMLInputElement) => {
         switch (field.type) {
             case 'checkbox':
-                formData[field.name] = field.checked.toString();
+                consent.consented = field.checked;
                 break;
             default:
-                formData[field.name] = field.value.toString();
+                if (field.name.includes('.id')) {
+                    consent.id = field.value;
+                }
                 break;
         }
     });
 
-    return formData;
+    return consent;
 };
 
 const getInputFields = (labelEl: HTMLElement): Promise<NodeList<HTMLElement>> =>
@@ -229,13 +218,9 @@ const bindNewsletterSwitch = (labelEl: HTMLElement): void => {
 };
 
 const updateConsentSwitch = (labelEl: HTMLElement): Promise<void> =>
-    Promise.all([
-        getCsrfTokenFromElement(labelEl),
-        getInputFields(labelEl),
-        addSpinner(labelEl),
-    ])
-        .then(([token, fields]) => buildFormDataForFields(token, fields))
-        .then((formData: {}) => submitPartialConsentForm(formData))
+    Promise.all([getInputFields(labelEl), addSpinner(labelEl)])
+        .then(([fields]) => buildConsentUpdatePayload(fields))
+        .then(consent => updateConsent(consent))
         .catch((err: Error) => {
             pushError(err, 'reload').then(() => {
                 window.scrollTo(0, 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,10 +2790,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debounce-promise@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debounce-promise/-/debounce-promise-3.1.0.tgz#25035f4b45017bd51a7bef8b3bd9f6401dc47423"
-
 debug-fabulous@1.X:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/debug-fabulous/-/debug-fabulous-1.1.0.tgz#af8a08632465224ef4174a9f06308c3c2a1ebc8e"


### PR DESCRIPTION
## What does this change?

* Bypass `/privacy/edit-ajax` form post by hitting IDAPI `/users/me/consents` directly with JSON.
* Currently affects only marketing consents.
* Related IDAPI PR: https://github.com/guardian/identity/pull/1383

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
