### PR TITLE
Use the same salt for all images.

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -329,12 +329,8 @@ class GuardianConfiguration extends Logging {
   object images {
     lazy val path = configuration.getMandatoryStringProperty("images.path")
     lazy val fastlyIOHost = configuration.getMandatoryStringProperty("fastly-io.host")
+    lazy val signatureSalt: String  = configuration.getMandatoryStringProperty("images.signature-salt")
     val fallbackLogo = Static("images/fallback-logo.png")
-    object backends {
-      lazy val mediaToken: String = configuration.getMandatoryStringProperty("images.media.token")
-      lazy val staticToken: String = configuration.getMandatoryStringProperty("images.static.token")
-      lazy val uploadsToken: String = configuration.getMandatoryStringProperty("images.uploads.token")
-    }
   }
 
   object headlines {

--- a/common/app/views/support/ImageUrlSigner.scala
+++ b/common/app/views/support/ImageUrlSigner.scala
@@ -1,10 +1,11 @@
 package views.support
 
+import conf.Configuration
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 
 object ImageUrlSigner {
-  def sign(path: String, token: String): String = {
+  def sign(path: String): String = {
     val separator = if (path.contains("?")) "&" else "?"
-    s"$path${separator}s=${md5Hex(s"$token$path")}"
+    s"$path${separator}s=${md5Hex(s"${Configuration.images.signatureSalt}$path")}"
   }
 }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -231,16 +231,12 @@ object ImgSrc extends Logging with implicits.Strings {
 
   private val imageServiceHost: String = Configuration.images.fastlyIOHost
 
-  private case class HostMapping(prefix: String, token: String)
-
-  private lazy val hostPrefixMapping: Map[String, HostMapping] = Map(
-    "static.guim.co.uk" -> HostMapping("static", Configuration.images.backends.staticToken),
-    "static-secure.guim.co.uk" -> HostMapping("static", Configuration.images.backends.staticToken),
-    "media.guim.co.uk" -> HostMapping("media", Configuration.images.backends.mediaToken),
-    "uploads.guim.co.uk" -> HostMapping("uploads", Configuration.images.backends.uploadsToken)
+  private lazy val hostPrefixMapping: Map[String, String] = Map(
+    "static.guim.co.uk" -> "static",
+    "static-secure.guim.co.uk" -> "static",
+    "media.guim.co.uk" -> "media",
+    "uploads.guim.co.uk" -> "uploads"
   )
-
-  def tokenFor(host:String): Option[String] = hostPrefixMapping.get(host).map(_.token)
 
   private val supportedImages = Set(".jpg", ".jpeg", ".png")
 
@@ -255,9 +251,9 @@ object ImgSrc extends Logging with implicits.Strings {
       hostPrefixMapping.get(uri.getHost)
         .filter(const(ImageServerSwitch.isSwitchedOn))
         .filter(const(isSupportedImage))
-        .map { host =>
-          val signedPath = ImageUrlSigner.sign(s"${uri.getRawPath}${imageType.resizeString}", host.token)
-          s"$imageServiceHost/img/${host.prefix}$signedPath"
+        .map { hostPrefix =>
+          val signedPath = ImageUrlSigner.sign(s"${uri.getRawPath}${imageType.resizeString}")
+          s"$imageServiceHost/img/$hostPrefix$signedPath"
         }.getOrElse(url)
     } catch {
       case error: URISyntaxException =>

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -21,6 +21,7 @@ weather.api.key=none
 images.media.token=none
 images.static.token=none
 images.uploads.token=none
+images.signature-salt=none
 
 teamcity.host=
 riffraff.url=

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -18,9 +18,6 @@ formstack.oauthToken=none
 
 weather.api.key=none
 
-images.media.token=none
-images.static.token=none
-images.uploads.token=none
 images.signature-salt=none
 
 teamcity.host=


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/fastly-image-service/pull/40, we no longer need to use a different salt for images depending on the origin S3 bucket they're stored in. This change moves frontend over to using the single global salt for all images.

## What is the value of this and can you measure success?
Simplifies our image signing logic

### Tested

Depends on https://github.com/guardian/fastly-image-service/pull/40

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
