### PR TITLE
Only fetch epic and banner copy when needed

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -12,10 +12,10 @@ const getGoogleDoc = (url: string): Promise<any> =>
         mode: 'cors',
     });
 
-export const getEpicGoogleDoc: Promise<any> = getGoogleDoc(epicGoogleDocUrl);
-export const getBannerGoogleDoc: Promise<any> = getGoogleDoc(
-    bannerGoogleDocUrl
-);
+export const getEpicGoogleDoc = (): Promise<any> =>
+    getGoogleDoc(epicGoogleDocUrl);
+export const getBannerGoogleDoc = (): Promise<any> =>
+    getGoogleDoc(bannerGoogleDocUrl);
 
 export const googleDocEpicControl = (): Promise<AcquisitionsEpicTemplateCopy> =>
     getGoogleDoc(epicGoogleDocUrl).then(res => getEpicParams(res, 'control'));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -455,7 +455,7 @@ const makeGoogleDocEpicVariants = (count: number): Array<Object> => {
             products: [],
             options: {
                 copy: () =>
-                    getEpicGoogleDoc.then(res =>
+                    getEpicGoogleDoc().then(res =>
                         getEpicParams(res, `variant_${i}`)
                     ),
             },
@@ -474,7 +474,7 @@ const makeGoogleDocBannerVariants = (
             id: `variant_${i}`,
             products: [],
             engagementBannerParams: () =>
-                getBannerGoogleDoc.then(res =>
+                getBannerGoogleDoc().then(res =>
                     getAcquisitionsBannerParams(res, `variant_${i}`)
                 ),
         });
@@ -486,7 +486,7 @@ const makeGoogleDocBannerControl = (): InitBannerABTestVariant => ({
     id: 'control',
     products: [],
     engagementBannerParams: () =>
-        getBannerGoogleDoc.then(res =>
+        getBannerGoogleDoc().then(res =>
             getAcquisitionsBannerParams(res, 'control')
         ),
 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -120,7 +120,7 @@ export const getAcquisitionsBannerParams = (
 };
 
 export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTemplateParams> =>
-    getBannerGoogleDoc.then(json =>
+    getBannerGoogleDoc().then(json =>
         getAcquisitionsBannerParams(json, 'control')
     );
 


### PR DESCRIPTION
We were actually making the `fetch()` call when these promises were defined, since execution of code in a promise begins immediately and isn't dependent on calling `.then()`

This means we'd be fetching banner & epic copy even on pages where neither was displayed

So I've made them functions that return promises, rather than straight-up promises