### PR TITLE
Fix video fronts for unenhanceable devices (iPad)

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -78,7 +78,6 @@
     }
 }
 
-.youtube-media-atom:not(.no-player) .youtube-media-atom__iframe:not(.youtube__video-ready) ~ .youtube-media-atom__overlay,
 .youtube-media-atom__iframe.youtube__video-ended ~ .youtube-media-atom__overlay {
     @include hide;
 }

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -471,10 +471,15 @@ $video-width-desktop: 700px;
     .youtube-media-atom.no-player {
         z-index: 0;
     }
+}
 
+.fc-item__video-container,
+.video-playlist__item {
     .youtube-media-atom__iframe:not(.youtube__video-ready) {
         ~ .youtube-media-atom__overlay {
-            visibility: hidden;
+            .youtube-media-atom__play-button {
+                visibility: hidden;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -473,14 +473,3 @@ $video-width-desktop: 700px;
         }
     }
 }
-
-.fc-item__video-container,
-.video-playlist__item {
-    .youtube-media-atom__iframe:not(.youtube__video-ready) {
-        ~ .youtube-media-atom__overlay {
-            .youtube-media-atom__play-button {
-                visibility: hidden;
-            }
-        }
-    }
-}

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -466,10 +466,11 @@ $video-width-desktop: 700px;
 .fc-item__video-container {
     .youtube-media-atom {
         z-index: 1;
-    }
 
-    .youtube-media-atom.no-player {
-        z-index: 0;
+        &.no-player,
+        .is-not-modern & {
+            z-index: 0;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

[iPads do not run enhanced JavaScript on fronts](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js#L43).

In #19851, a change was made to initialise YouTube atoms in the enhanced JavaScript, as opposed to embedding the YouTube iframe on the server side.

The result for iPad users is that on fronts, YouTube atoms appear as unclickable grey squares, without even a placeholder image. A dismal experience.

To address this, this change:

- shows the placeholder image by default. This was previously hidden because the YouTube iframe was embedded in the server-rendered HTML and enhanced on the client (see #15277). Now the iframe is added as an enhancement on the client, we can safely show the placeholder straight away
- makes the YouTube atom clickable when not enhanced. If the browser is not modern, clicking the atom navigates the user to the canonical video page.

## Screenshots

**Before**

![screen shot 2018-09-04 at 18 07 40](https://user-images.githubusercontent.com/5931528/45046253-87bc7980-b06d-11e8-9ff7-caa2e0e0f6e6.png)

**After**

![sep-04-2018 18-06-08](https://user-images.githubusercontent.com/5931528/45046154-3b713980-b06d-11e8-93fc-1cb387295c5f.gif)


## What is the value of this and can you measure success?

Improves the experience on iPad by showing placeholder images when available.

For future consideration:

- Embed iframe in server-rendered HTML if YouTube atom doesn't have a placeholder image. I think @GHaberis warned me that this is possible. Note that in this instance we will not be able to check whether user wants personalised ads.
- Inject iframe only when user clicks (shows intent) on the placeholder. This will save us forcing the user to download a bunch of YouTube JavaScript that may not get executed

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/) - still unaccessible 😞 
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/) - still non-navigable 😞 
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
