### PR TITLE
Test epic with copy from Google Doc against epic with hardcoded copy

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -205,4 +205,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 6, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-google-doc-vs-hardcoded",
+    "Tests an epic which gets its copy from a Google Doc against one whose copy is hardcoded",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -18,6 +18,7 @@ import { acquisitionsEpicFromGoogleDocThreeVariants } from 'common/modules/exper
 import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-four-variants';
 import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
 import { acquisitionsEpicIframeTestV2 } from 'common/modules/experiments/tests/acquisitions-iframe-epic-v2';
+import { acquisitionsEpicGoogleDocVsHardcoded } from 'common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options) return false;
@@ -46,6 +47,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicGoogleDocVsHardcoded,
     acquisitionsEpicIframeTestV2,
     acquisitionsEpicFromGoogleDocOneVariant,
     acquisitionsEpicFromGoogleDocTwoVariants,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded.js
@@ -17,7 +17,7 @@ export const acquisitionsEpicGoogleDocVsHardcoded: EpicABTest = makeABTest({
     idealOutcome: 'Alternative copy makes more money than the control',
 
     audienceCriteria: 'All',
-    audience: 1,
+    audience: 0.5,
     audienceOffset: 0,
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded.js
@@ -1,0 +1,36 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { articleCopy } from 'common/modules/commercial/acquisitions-copy';
+
+const abTestName = 'AcquisitionsEpicGoogleDocVsHardcoded';
+
+export const acquisitionsEpicGoogleDocVsHardcoded: EpicABTest = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-04-17',
+    expiry: '2019-06-05',
+
+    author: 'Joseph Smith',
+    description: 'Test copy fetched from a Google Doc',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Alternative copy makes more money than the control',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    variants: [
+        {
+            id: 'control_which_means_from_google_doc',
+            products: [],
+        },
+        {
+            id: 'hardcoded',
+            products: [],
+            options: {
+                copy: articleCopy,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
We just want to verify (post-hoc) that there's no negative impact on revenue from making the epic dependent on an AJAX call to fetch its copy.

I brought the fallback copy into line with the latest from the Google Docs in #20275. So these screenshots should be identical:

## control_which_means_from_google_doc
![picture 286](https://user-images.githubusercontent.com/5122968/45084150-7919a500-b0f5-11e8-99a7-4a3201a4f539.png)

## hardcoded
![picture 285](https://user-images.githubusercontent.com/5122968/45084053-3788fa00-b0f5-11e8-9f92-576ff6bcd1e5.png)
