### PR TITLE
OpenX direct

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -410,6 +410,16 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+    val prebidOpenx: Switch = Switch(
+    group = Commercial,
+    name = "prebid-openx",
+    description = "Include OpenX adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val prebidTrustx: Switch = Switch(
     group = Commercial,
     name = "prebid-trustx",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#ccc7245",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#7dccca",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.9",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#7dccca",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#097ada",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -40,6 +40,7 @@ import {
     isExcludedGeolocation,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
+    shouldIncludeOpenx,
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
@@ -312,6 +313,31 @@ const appNexusBidder: PrebidBidder = {
     }),
 };
 
+const openxClientSideBidder: PrebidBidder = {
+    name: 'oxd',
+    switchName: 'prebidOpenx',
+    bidParams: (): PrebidOpenXParams => {
+        switch (config.get('page.edition')) {
+            case 'US':
+                return {
+                    delDomain: 'guardian-us-d.openx.net',
+                    unit: '540279544',
+                };
+            case 'AU':
+                return {
+                    delDomain: 'guardian-aus-d.openx.net',
+                    unit: '540279542',
+                };
+            default:
+                // UK and ROW
+                return {
+                    delDomain: 'guardian-d.openx.net',
+                    unit: '540279541',
+                };
+        }
+    },
+};
+
 const sonobiBidder: PrebidBidder = {
     name: 'sonobi',
     switchName: 'prebidSonobi',
@@ -450,6 +476,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
         improveDigitalBidder,
         xaxisBidder,
         ...(shouldIncludeAdYouLike(slotSizes) ? [adYouLikeBidder] : []),
+        ...(shouldIncludeOpenx() ? [openxClientSideBidder] : []),
     ];
 
     const allBidders = indexExchangeBidders(slotSizes)

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -21,6 +21,7 @@ import {
     getRandomIntInclusive as getRandomIntInclusive_,
     shouldIncludeAdYouLike as shouldIncludeAdYouLike_,
     shouldIncludeAppNexus as shouldIncludeAppNexus_,
+    shouldIncludeOpenx as shouldIncludeOpenx_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
 } from './utils';
@@ -34,6 +35,7 @@ const containsMpuOrDmpu: any = containsMpuOrDmpu_;
 const getRandomIntInclusive: any = getRandomIntInclusive_;
 const shouldIncludeAdYouLike: any = shouldIncludeAdYouLike_;
 const shouldIncludeAppNexus: any = shouldIncludeAppNexus_;
+const shouldIncludeOpenx: any = shouldIncludeOpenx_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
@@ -67,6 +69,7 @@ jest.mock('common/modules/experiments/utils');
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
     config.set('switches.prebidAppnexus', true);
+    config.set('switches.prebidOpenx', true);
     config.set('switches.prebidImproveDigital', true);
     config.set('switches.prebidIndexExchange', true);
     config.set('switches.prebidSonobi', true);
@@ -581,6 +584,7 @@ describe('bids', () => {
         getRandomIntInclusive.mockReturnValue(5);
         shouldIncludeAdYouLike.mockReturnValue(true);
         shouldIncludeAppNexus.mockReturnValue(false);
+        shouldIncludeAppNexus.mockReturnValue(false);
         shouldIncludeTrustX.mockReturnValue(false);
         stripMobileSuffix.mockImplementation(str => str);
         getVariant.mockReturnValue(CommercialPrebidAdYouLike.variants[0]);
@@ -645,6 +649,18 @@ describe('bids', () => {
             'improvedigital',
             'xhb',
             'adyoulike',
+        ]);
+    });
+
+    test('should include OpenX directly if in target geolocation', () => {
+        shouldIncludeOpenx.mockReturnValue(true);
+        expect(bidders()).toEqual([
+            'ix',
+            'sonobi',
+            'improvedigital',
+            'xhb',
+            'adyoulike',
+            'oxd',
         ]);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -95,6 +95,9 @@ class PrebidService {
 
         window.pbjs.setConfig(pbjsConfig);
 
+        // Add aliases
+        window.pbjs.aliasBidder('openx', 'oxd');
+
         // gather analytics from 20% (1 in 5) of page views
         const inSample = getRandomIntInclusive(1, 5) === 1;
         if (
@@ -193,11 +196,14 @@ class PrebidService {
                                             .sort()
                                             .pop()) ||
                                     0;
-                                const bidResponses = window.pbjs.getBidResponses()[
-                                    advert.id
-                                ];
+                                const bidResponses = window.pbjs.getBidResponses();
+                                const adslotBids =
+                                    advert.id in bidResponses
+                                        ? bidResponses[advert.id]
+                                        : [];
+
                                 const cpm: number = getHighestCpm(
-                                    (bidResponses && bidResponses.bids) || []
+                                    (adslotBids && adslotBids.bids) || []
                                 );
                                 if (cpm > 0) {
                                     advert.slot.setTargeting('hb_cpm', cpm);

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -95,9 +95,6 @@ class PrebidService {
 
         window.pbjs.setConfig(pbjsConfig);
 
-        // Add aliases
-        window.pbjs.aliasBidder('openx', 'oxd');
-
         // gather analytics from 20% (1 in 5) of page views
         const inSample = getRandomIntInclusive(1, 5) === 1;
         if (
@@ -196,14 +193,12 @@ class PrebidService {
                                             .sort()
                                             .pop()) ||
                                     0;
-                                const bidResponses = window.pbjs.getBidResponses();
-                                const adslotBids =
-                                    advert.id in bidResponses
-                                        ? bidResponses[advert.id]
-                                        : [];
+                                const bidResponses = window.pbjs.getBidResponses()[
+                                    advert.id
+                                ];
 
                                 const cpm: number = getHighestCpm(
-                                    (adslotBids && adslotBids.bids) || []
+                                    (bidResponses && bidResponses.bids) || []
                                 );
                                 if (cpm > 0) {
                                     advert.slot.setTargeting('hb_cpm', cpm);

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -54,7 +54,8 @@ export const getBreakpointKey = (): string => {
 export const shouldIncludeAppNexus = (): boolean =>
     geolocationGetSync() === 'AU';
 
-export const shouldIncludeOpenx = (): boolean => geolocationGetSync() === 'UK';
+export const shouldIncludeOpenx = (): boolean => 
+    !['US', 'CA', 'AU', 'NZ'].includes(geolocationGetSync());
 
 export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -54,6 +54,8 @@ export const getBreakpointKey = (): string => {
 export const shouldIncludeAppNexus = (): boolean =>
     geolocationGetSync() === 'AU';
 
+export const shouldIncludeOpenx = (): boolean => geolocationGetSync() === 'UK';
+
 export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';
 
 export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -54,7 +54,7 @@ export const getBreakpointKey = (): string => {
 export const shouldIncludeAppNexus = (): boolean =>
     geolocationGetSync() === 'AU';
 
-export const shouldIncludeOpenx = (): boolean => 
+export const shouldIncludeOpenx = (): boolean =>
     !['US', 'CA', 'AU', 'NZ'].includes(geolocationGetSync());
 
 export const shouldIncludeTrustX = (): boolean => geolocationGetSync() === 'US';

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -63,8 +63,16 @@ describe('Utils', () => {
         expect(shouldIncludeOpenx()).toBe(true);
     });
 
-    test('shouldIncludeOpenx should otherwise return false', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'CA', 'US', 'AU'];
+    test('shouldIncludeOpenx should return true if within ROW region', () => {
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'IE'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValueOnce(testGeos[i]);
+            expect(shouldIncludeOpenx()).toBe(true);
+        }
+    });
+
+    test('shouldIncludeOpenx should return false if within AU/US region', () => {
+        const testGeos = ['NZ', 'CA', 'US', 'AU'];
         for (let i = 0; i < testGeos.length; i += 1) {
             getSync.mockReturnValueOnce(testGeos[i]);
             expect(shouldIncludeOpenx()).toBe(false);

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -8,6 +8,7 @@ import {
     isExcludedGeolocation,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
+    shouldIncludeOpenx,
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
@@ -54,6 +55,19 @@ describe('Utils', () => {
         for (let i = 0; i < testGeos.length; i += 1) {
             getSync.mockReturnValueOnce(testGeos[i]);
             expect(shouldIncludeAppNexus()).toBe(false);
+        }
+    });
+
+    test('shouldIncludeOpenx should return true if geolocation is UK', () => {
+        getSync.mockReturnValueOnce('UK');
+        expect(shouldIncludeOpenx()).toBe(true);
+    });
+
+    test('shouldIncludeOpenx should otherwise return false', () => {
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'CA', 'US', 'AU'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValueOnce(testGeos[i]);
+            expect(shouldIncludeOpenx()).toBe(false);
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#7dccca":
+"prebid.js@https://github.com/guardian/Prebid.js.git#097ada":
   version "1.20.0"
-  resolved "https://github.com/guardian/Prebid.js.git#7dccca859513d7d3f1ca0e5c399de952ff01994b"
+  resolved "https://github.com/guardian/Prebid.js.git#097adac622ac9a8c6dfc232e7569a912b351f117"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,9 +7836,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#ccc7245":
+"prebid.js@https://github.com/guardian/Prebid.js.git#7dccca":
   version "1.20.0"
-  resolved "https://github.com/guardian/Prebid.js.git#ccc7245ded5373b2c18c2e07ea8f46ae6ee4d0ef"
+  resolved "https://github.com/guardian/Prebid.js.git#7dccca859513d7d3f1ca0e5c399de952ff01994b"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?

This adds OpenX into Prebid which means we will be directly calling OpenX from Prebid. This will only happen in the `UK/ROW` regions; with the other regions not having any direct OpenX integration.

## What is the value of this and can you measure success?

Testing how lucrative OpenX is when going direct; perhaps because of better matching rates.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
