### PR TITLE
Remove Close Up revert Film Today newsletters

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -21,7 +21,7 @@
     theFlyer.identityName -> "feature",
     theBreakdown.identityName -> "feature",
     theSpin.identityName -> "feature",
-    closeUp.identityName -> "review",
+    filmToday.identityName -> "media",
     sleeveNotes.identityName -> "review",
     theObserverFoodMonthly.identityName -> "feature",
     firstDogOnTheMoon.identityName -> "media",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.164"
+  val identityLibVersion = "3.166"
   val awsVersion = "1.11.240"
   val capiVersion = "12.7"
   val faciaVersion = "2.6.3"


### PR DESCRIPTION
## What does this change?

Wrong newsletter was asked to be removed.

Related Identity PR: https://github.com/guardian/identity/pull/1385

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
