### PR TITLE
Disallow CORS on unsupported origins

### DIFF
--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -8,20 +8,25 @@ object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
-  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: String = "*")(implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None)(implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
     request.headers.get("Origin") match {
       case None => result
       case Some(requestOrigin) =>
-        val allowedOrigin = ajax.corsOrigins.find(_ == requestOrigin).getOrElse(fallbackAllowOrigin)
-        val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
-          "Access-Control-Allow-Origin" -> allowedOrigin,
-          "Access-Control-Allow-Headers" -> responseHeaders,
-          "Access-Control-Allow-Credentials" -> "true")
+        val allowedOrigin = ajax.corsOrigins.find(_ == requestOrigin).orElse(fallbackAllowOrigin)
 
-        result.withHeaders(headers: _*)
+        allowedOrigin match {
+          case Some(origin) =>
+            val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
+              "Access-Control-Allow-Origin" -> origin,
+              "Access-Control-Allow-Headers" -> responseHeaders,
+              "Access-Control-Allow-Credentials" -> "true")
+
+            result.withHeaders(headers: _*)
+          case None => Forbidden("Unsupported CORS origin")
+        }
     }
   }
 }

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -7,13 +7,11 @@ import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.test.Helpers._
 
 class CorsTest extends FlatSpec with Matchers {
-  "Cors Helper" should "provide the appropriate standard Cors response headers with any Origin" in {
+  "Cors Helper" should "return forbidden for unsupported origins" in {
     // This test is here to show that we really do accept any origin outside of the whitelist. We should change this policy.
     val fakeHeaders = FakeHeaders(List("Origin" -> "unknown.origin.com"))
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "*")
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Credentials" -> "true")
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With,Origin,Accept,Content-Type")
+    Cors(NoContent)(fakeRequest).header.status shouldBe 403
   }
 
   it should "provide the appropriate standard Cors response headers with an accepted Origin" in {

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -7,11 +7,13 @@ import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.test.Helpers._
 
 class CorsTest extends FlatSpec with Matchers {
-  "Cors Helper" should "return forbidden for unsupported origins" in {
+  "Cors Helper" should "not provide Cors response headers for unsupported origins" in {
     // This test is here to show that we really do accept any origin outside of the whitelist. We should change this policy.
     val fakeHeaders = FakeHeaders(List("Origin" -> "unknown.origin.com"))
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.status shouldBe 403
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Origin") shouldBe None
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Credentials") shouldBe None
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Headers") shouldBe None
   }
 
   it should "provide the appropriate standard Cors response headers with an accepted Origin" in {
@@ -23,9 +25,9 @@ class CorsTest extends FlatSpec with Matchers {
   it should "not provide Cors response headers if the request has no Origin" in {
     val fakeHeaders = FakeHeaders(Nil)
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.headers should not contain ("Access-Control-Allow-Origin" -> "*")
-    Cors(NoContent)(fakeRequest).header.headers should not contain ("Access-Control-Allow-Credentials" -> "true")
-    Cors(NoContent)(fakeRequest).header.headers should not contain ("Access-Control-Allow-Headers" -> "X-Requested-With,Origin,Accept,Content-Type")
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Origin") shouldBe None
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Credentials") shouldBe None
+    Cors(NoContent)(fakeRequest).header.headers.get("Access-Control-Allow-Headers") shouldBe None
   }
 
   it should "provide Cors response with allowed methods" in {

--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -57,9 +57,9 @@ class AuthenticationController(
          val authResponse = signInService.getCookies(api.authBrowser(emailPassword, idRequest.trackingData), rememberMe = false)
          authResponse.map {
            case Right(cookies) =>
-             Cors(NoCache(Ok("{}")), fallbackAllowOrigin = fallbackAccessControlOrigin).withCookies(cookies: _*)
+             Cors(NoCache(Ok("{}")), fallbackAllowOrigin = Some(fallbackAccessControlOrigin)).withCookies(cookies: _*)
            case Left(errors) =>
-             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = fallbackAccessControlOrigin)
+             Cors(NoCache(InternalServerError(Json.toJson(errors))), fallbackAllowOrigin = Some(fallbackAccessControlOrigin))
          }
        }
     )


### PR DESCRIPTION
It's unclear why this was supported before, but allowing CORS on all origins doesn't seem like a sensible default.

Calling code can still provide a fallback origin to support if needed.

It is hard to know up front if this will break things. We have a whitelist of origins in our config with a list of seemingly sensible values, but it's possible there are other origins we need to add too. However, our Kibana logs for Frontend show that in the last 24 hours 100% of requests with an origin value were for `https://www.theguardian.com`, which suggests things should be okay.

## What does this change?

Remove CORS support for non-whitelisted origins.

## What is the value of this and can you measure success?

Reduces future risk of a cors security issue.


