### PR TITLE
Remove dead newsletters format choice

### DIFF
--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -130,9 +130,6 @@ class IdApiClient(
     delete(urlJoin("useremails", userId, "subscriptions"), Some(auth), Some(trackingParameters), Some(write(emailList))) map extractUnit
   }
 
-  def updateUserEmails(userId: String, subscriber: Subscriber, auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] =
-    post(urlJoin("useremails", userId), Some(auth), Some(trackingParameters), Some(write(subscriber))) map extractUnit
-
   def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[Unit]] =
     post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extractUnit
 

--- a/identity/app/services/NewsletterService.scala
+++ b/identity/app/services/NewsletterService.scala
@@ -57,10 +57,7 @@ class NewsletterService(
           api.addSubscription(userId, EmailList(id), auth, trackingParameters)
         }
 
-        val newSubscriber = Subscriber("HTML", Nil) //TODO: remove the htmlPreference property from Subscriber as no longer used
-        val updatePreferencesResponse = api.updateUserEmails(userId, newSubscriber, auth, trackingParameters)
-
-        Future.sequence(updatePreferencesResponse :: unsubscribeResponse ++ subscribeResponse).map { responses =>
+        Future.sequence(unsubscribeResponse ++ subscribeResponse).map { responses =>
           if (responses.exists(_.isLeft)) {
             form.withGlobalError("There was an error saving your preferences")
           } else {

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -72,7 +72,6 @@ import scala.concurrent.Future
     when(returnUrlVerifier.defaultReturnUrl) thenReturn "http://1234.67"
     when(returnUrlVerifier.getVerifiedReturnUrl(any[RequestHeader])) thenReturn None
     when(api.userEmails(anyString(), any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
-    when(api.updateUserEmails(anyString(), any[Subscriber], any[Auth], any[TrackingData])) thenReturn Future.successful(Right(()))
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -72,7 +72,6 @@ import scala.concurrent.Future
     when(idRequest.returnUrl) thenReturn None
 
     when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
-    when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(()))
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,
@@ -442,25 +441,19 @@ import scala.concurrent.Future
     "saveEmailPreferences method is called with valid form body" should {
       "respond with success body if IDAPI post email endpoint returns 200" in new EditProfileFixture {
         val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken)
-        when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(()))
 
         val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should be(200)
         contentAsString(result) should include ("updated")
-
-        verify(api).updateUserEmails(userId, Subscriber("HTML", Nil), testAuth, trackingData)
       }
 
       "respond with error body if IDAPI post email endpoint returns error" in new EditProfileFixture {
         val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken)
         val errors = List(Error("Test message", "Test description", 500))
-        when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Left(errors))
 
         val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should not be(200)
         contentAsString(result) should include ("There was an error saving your preferences")
-
-        verify(api).updateUserEmails(userId, Subscriber("HTML", Nil), testAuth, trackingData)
       }
     }
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -440,7 +440,11 @@ import scala.concurrent.Future
 
     "saveEmailPreferences method is called with valid form body" should {
       "respond with success body if IDAPI post email endpoint returns 200" in new EditProfileFixture {
-        val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken)
+        val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken).withFormUrlEncodedBody(
+          "addEmailSubscriptions[]" -> "4151",
+          "currentEmailSubscriptions[]" -> "1234"
+        )
+        when(api.addSubscription(MockitoMatchers.anyString(), MockitoMatchers.any[EmailList], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right({}))
 
         val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should be(200)
@@ -448,8 +452,12 @@ import scala.concurrent.Future
       }
 
       "respond with error body if IDAPI post email endpoint returns error" in new EditProfileFixture {
-        val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken)
+        val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken).withFormUrlEncodedBody(
+          "addEmailSubscriptions[]" -> "4151",
+          "currentEmailSubscriptions[]" -> "1234"
+        )
         val errors = List(Error("Test message", "Test description", 500))
+        when(api.addSubscription(MockitoMatchers.anyString(), MockitoMatchers.any[EmailList], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Left(errors))
 
         val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should not be(200)


### PR DESCRIPTION
## What does this change?

We no longer support text format of newsletters, so HTML is by default.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
