### PR TITLE
Load YouTube assets on fronts on placeholder click

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -77,7 +77,7 @@
                 </div>
             }
             @bestPosterImage.map { image =>
-                <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestSrcFor(image))">
+                <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestSrcFor(image))" role="button">
 
                 @if(!expired) {
                     @if(mediaWrapper.contains(ImmersiveMainMedia)) {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -77,7 +77,7 @@
                 </div>
             }
             @bestPosterImage.map { image =>
-                <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestSrcFor(image))" role="button">
+                <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestSrcFor(image))">
 
                 @if(!expired) {
                     @if(mediaWrapper.contains(ImmersiveMainMedia)) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -177,11 +177,14 @@ const shouldAutoplay = (atomId: string): boolean => {
     const flashingElementsAllowed = () =>
         accessibilityIsOn('flashing-elements');
 
+    const isVideoArticle = () => config.get('page.contentType') === 'Video';
+
+    const isFront = () => config.get('page.isFront');
+
     return (
-        config.get('page.contentType') === 'Video' &&
-        isInternalReferrer() &&
+        ((isVideoArticle() && isInternalReferrer() && isMainVideo()) ||
+            isFront()) &&
         !isAutoplayBlockingPlatform() &&
-        isMainVideo() &&
         flashingElementsAllowed()
     );
 };
@@ -268,42 +271,59 @@ const onPlayerReady = (
 const onPlayerStateChange = (atomId: string, event: YoutubePlayerEvent): void =>
     Object.keys(STATES).forEach(checkState.bind(null, atomId, event.data));
 
+const initYoutubePlayerForElem = (el: ?HTMLElement, index: number): void => {
+    fastdom.read(() => {
+        if (!el) return;
+
+        const playerDiv = el.querySelector('div');
+
+        if (!playerDiv) {
+            return;
+        }
+
+        playerDivs.push(playerDiv);
+
+        // append index of atom as atomId must be unique
+        const atomId = `${el.getAttribute('data-media-atom-id') ||
+            ''}/${index}`;
+        // need data attribute with index for unique lookup
+        el.setAttribute('data-unique-atom-id', atomId);
+        const overlay = el.querySelector('.youtube-media-atom__overlay');
+        const channelId = el.getAttribute('data-channel-id') || '';
+
+        initYoutubeEvents(getTrackingId(atomId));
+
+        initYoutubePlayer(
+            playerDiv,
+            {
+                onPlayerReady: onPlayerReady.bind(
+                    null,
+                    atomId,
+                    overlay,
+                    playerDiv
+                ),
+                onPlayerStateChange: onPlayerStateChange.bind(null, atomId),
+            },
+            playerDiv.dataset.assetId,
+            channelId
+        );
+    });
+};
+
 const checkElemForVideo = (elem: ?HTMLElement): void => {
     if (!elem) return;
 
     fastdom.read(() => {
         $('.youtube-media-atom:not(.no-player)', elem).each((el, index) => {
-            const playerDiv = el.querySelector('div');
-
-            if (!playerDiv) {
-                return;
-            }
-
-            playerDivs.push(playerDiv);
-
-            // append index of atom as atomId must be unique
-            const atomId = `${el.getAttribute('data-media-atom-id')}/${index}`;
-            // need data attribute with index for unique lookup
-            el.setAttribute('data-unique-atom-id', atomId);
             const overlay = el.querySelector('.youtube-media-atom__overlay');
-            const channelId = el.getAttribute('data-channel-id');
 
-            initYoutubeEvents(getTrackingId(atomId));
-
-            initYoutubePlayer(
-                playerDiv,
-                {
-                    onPlayerReady: onPlayerReady.bind(
-                        null,
-                        atomId,
-                        overlay,
-                        playerDiv
-                    ),
-                    onPlayerStateChange: onPlayerStateChange.bind(null, atomId),
-                },
-                playerDiv.dataset.assetId,
-                channelId
-            );
+            if (config.get('page.isFront')) {
+                overlay.addEventListener('click', () => {
+                    initYoutubePlayerForElem(el, index);
+                });
+            } else {
+                initYoutubePlayerForElem(el, index);
+            }
         });
     });
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -177,7 +177,8 @@ const shouldAutoplay = (atomId: string): boolean => {
     const flashingElementsAllowed = () =>
         accessibilityIsOn('flashing-elements');
 
-    const isVideoArticle = () => config.get('page.contentType') === 'Video';
+    const isVideoArticle = () =>
+        config.get('page.contentType').toLowerCase() === 'video';
 
     const isFront = () => config.get('page.isFront');
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -102,7 +102,7 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     }
 }
 
-.youtube-media-atom__overlay.vjs-big-play-button {
+.content .youtube-media-atom__overlay.vjs-big-play-button {
     pointer-events: none;
 }
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -102,6 +102,7 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     }
 }
 
+// in articles, youtube iframe is below the overlay, so we should allow users to click through it
 .content .youtube-media-atom__overlay.vjs-big-play-button {
     pointer-events: none;
 }


### PR DESCRIPTION
## What does this change?

Currently, YouTube assets for all videos on a front are loaded up front with the enhanced JavaScript, regardless of whether the user intends to watch any videos. 

This change loads the YouTube assets only when the user clicks on the video placeholder. When the video loads, it immediately starts playing ([`player.playVideo()`](https://developers.google.com/youtube/iframe_api_reference#playVideo) is called programatically)

This does not affect the behaviour of video articles or videos embedded in articles.

## Screenshots

**Before**

![screen shot 2018-09-05 at 14 27 17](https://user-images.githubusercontent.com/5931528/45096177-dc1c3380-b117-11e8-8c4f-d000a6e33c24.png)

**After**

![screen shot 2018-09-05 at 14 26 43](https://user-images.githubusercontent.com/5931528/45096188-e2aaab00-b117-11e8-8a68-9b6f9541ce29.png)

## What is the value of this and can you measure success?

I will flesh this out with some actual numbers, but in general:

- Far fewer requests to YouTube (~30 on the video front)
- Fewer unnecessary assets loaded (~3MB on the video front)
- Shorter time to interactive (TBC)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/) - still bad
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/) - still bad
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
