### PR TITLE
Enable react devtools in DEV for preact

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -36,6 +36,11 @@ const go = () => {
             });
         }
 
+        // Init preact devtools
+        if (process.env.NODE_ENV !== 'production') {
+            import('preact/devtools');
+        }
+
         // Start downloading these ASAP
 
         // eslint-disable-next-line no-nested-ternary

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -16,6 +16,11 @@ import { capturePerfTimings } from 'lib/capture-perf-timings';
 // eslint-disable-next-line camelcase,no-undef
 __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 
+// Debug preact in DEV
+if (process.env.NODE_ENV !== 'production') {
+    import('preact/debug');
+}
+
 // kick off the app
 const go = () => {
     domready(() => {
@@ -34,11 +39,6 @@ const go = () => {
                     window.console.warn(message);
                 }
             });
-        }
-
-        // Init preact devtools
-        if (process.env.NODE_ENV !== 'production') {
-            import('preact/devtools');
         }
 
         // Start downloading these ASAP


### PR DESCRIPTION
## What does this change?
Lets developers use the react devtools in our preact modules (mostly used within identity but also in crosswords)

## Screenshots
![screen shot 2018-09-05 at 3 11 49 pm](https://user-images.githubusercontent.com/11539094/45099288-d0803b00-b11e-11e8-9883-20f0d30d65b5.png)

## What is the value of this and can you measure success?
Debugging preact modules is a bit harder than it ought to be right now and this fixes that. This should not add any overhead in production either as they are under an env check.

## Checklist
- [x] is `boot.js` the proper place for this?