### PR TITLE
Fix meta styling issue on comment sport pieces

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -605,7 +605,7 @@ $quote-mark: 35px;
 }
 
 /**** sport overrides ****/
-.content--pillar-sport:not(.content--interactive),
+.content--pillar-sport:not(.content--interactive):not(.content--type-comment),
 .content--pillar-sport.content--type-feature {
     .content__meta-container {
         background-image: url('data:image/svg+xml,%3Csvg%20width%3D%229%22%20height%3D%2212%22%20viewBox%3D%220%200%209%2012%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22%23DFDFDF%22%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3C/g%3E%3C/svg%3E');


### PR DESCRIPTION
Fixes a small styling issue with metadata on pieces within the sport section that are also comment pieces.

It is a good example of the difficulties of global CSS.

Before:
![screen shot 2018-09-05 at 15 42 54](https://user-images.githubusercontent.com/858402/45101009-708b9380-b122-11e8-9111-4c4d46deb24e.png)

After:
![screen shot 2018-09-05 at 15 43 09](https://user-images.githubusercontent.com/858402/45101015-75504780-b122-11e8-8b96-6a3715f9d9f9.png)
