### PR TITLE
Fix ad-free state based on digi-pack sub

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -118,7 +118,6 @@ const cleanupCookies = (): void => {
         'GU_ALPHA',
         'GU_ME',
         'at',
-        'gu_adfree_user',
         'gu_join_date',
     ]);
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -78,11 +78,11 @@ const persistResponse = (JsonResponse: () => void) => {
             adFreeDataIsPresent() &&
             !JsonResponse.adFree &&
             !forcedAdFreeMode &&
-            !JsonResponse.contectAccess.digitalPack
+            !JsonResponse.contentAccess.digitalPack
         ) {
             removeCookie(AD_FREE_USER_COOKIE);
         }
-        if (JsonResponse.adFree || JsonResponse.contectAccess.digitalPack) {
+        if (JsonResponse.adFree || JsonResponse.contentAccess.digitalPack) {
             addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
         }
     }


### PR DESCRIPTION
## What does this change?
I included a typo in the cookie handler - this fixes that, and removes an old cleanup operation that hasn't been needed for over a year.

## Screenshots
N/A

## What is the value of this and can you measure success?
Makes the feature deployed in https://github.com/guardian/frontend/pull/20265 work as it should

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it
- [x] Ironically, it fixes a bug introduced in the enabling of ad-free

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
