### PR TITLE
Redirect profile.theguardian.com/membership/edit TO manage.theguardian.com/membership

### DIFF
--- a/identity/app/controllers/editprofile/editprofile.scala
+++ b/identity/app/controllers/editprofile/editprofile.scala
@@ -7,7 +7,6 @@ package object editprofile {
   object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
   object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
   object EmailPrefsProfilePage extends IdentityPage("/email-prefs", "Emails")
-  object MembershipEditProfilePage extends IdentityPage("/membership/edit", "Membership")
   object recurringContributionPage extends IdentityPage("/contribution/recurring/edit", "Contributions")
   object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
 

--- a/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
+++ b/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
@@ -10,8 +10,12 @@ trait SupporterTabs
     extends EditProfileControllerComponents
     with EditProfileFormHandling {
 
-  /** GET /membership/edit */
-  def displayMembershipForm: Action[AnyContent] = displayForm(MembershipEditProfilePage)
+  /** Redirect /membership/edit to manage.theguardian.com/membership */
+  def redirectToManageMembership: Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      url = "https://manage.theguardian.com/membership",
+      MOVED_PERMANENTLY)
+  }
 
   /** GET /contribution/recurring/edit */
   def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -52,7 +52,7 @@ POST        /public/edit                            controllers.editprofile.Edit
 GET         /account/edit                           controllers.editprofile.EditProfileController.displayAccountForm
 POST        /account/edit                           controllers.editprofile.EditProfileController.submitAccountForm
 
-GET         /membership/edit                        controllers.editprofile.EditProfileController.displayMembershipForm
+GET         /membership/edit                        controllers.editprofile.EditProfileController.redirectToManageMembership
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.displayRecurringContributionForm
 GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.displayDigitalPackForm
 


### PR DESCRIPTION
## What does this change?
The "membership" tab on `profile.theguardian.com` will now redirect to `manage.theguardian.com/membership`

## What is the value of this and can you measure success?

We're moving over to manage.theguardian.com for quicker iteration and a single location to manage memberships, contributions and digi packs

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
