### PR TITLE
Don't deploy diagnostics with the rest of the apps

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -23,8 +23,6 @@ deployments:
     template: frontend
   commercial:
     template: frontend
-  diagnostics:
-    template: frontend
   discussion:
     template: frontend
   facia:


### PR DESCRIPTION
## What does this change?
We're doing some experimentation with diagnostics tomorrow (6th September), for which it's quite convenient if the instances aren't changing all the time. This change removes diagnostics from the dotcom:all deploy. This pr should be reverted once the testing is complete.

Diagnostics doesn't get touched much, so hopefully this won't cause anyone any problems
