### PR TITLE
Support DateTimes with Milliseconds returned from identity

### DIFF
--- a/identity/app/idapiclient/parser/JodaJsonSerializer.scala
+++ b/identity/app/idapiclient/parser/JodaJsonSerializer.scala
@@ -10,7 +10,7 @@ import net.liftweb.json.JsonAST.JString
   */
 object JodaJsonSerializer extends Serializer[DateTime]{
   private val DateTimeClass = classOf[DateTime]
-  val dateTimeFormatISO8601 = ISODateTimeFormat.dateTimeNoMillis
+  val dateTimeFormatISO8601 = ISODateTimeFormat.dateTimeParser().withZoneUTC()
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, _root_.net.liftweb.json.JValue), DateTime] = {
     case (TypeInfo(DateTimeClass, _), json) => json match {

--- a/identity/app/idapiclient/parser/JodaJsonSerializer.scala
+++ b/identity/app/idapiclient/parser/JodaJsonSerializer.scala
@@ -10,16 +10,16 @@ import net.liftweb.json.JsonAST.JString
   */
 object JodaJsonSerializer extends Serializer[DateTime]{
   private val DateTimeClass = classOf[DateTime]
-  val dateTimeFormatISO8601 = ISODateTimeFormat.dateTimeParser().withZoneUTC()
+  val dateTimeFormat = ISODateTimeFormat.dateTimeParser().withZoneUTC()
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, _root_.net.liftweb.json.JValue), DateTime] = {
     case (TypeInfo(DateTimeClass, _), json) => json match {
-      case JString(s) => dateTimeFormatISO8601.parseDateTime(s)
+      case JString(s) => dateTimeFormat.parseDateTime(s)
       case x => throw new MappingException("Can't convert " + x + " to DateTime")
     }
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, _root_.net.liftweb.json.JValue] = {
-    case dt: DateTime => JString(dateTimeFormatISO8601.print(dt))
+    case dt: DateTime => JString(dateTimeFormat.print(dt))
   }
 }

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -125,7 +125,7 @@ class IdApiTest
       whenReady(idApi.authBrowser(Anonymous, trackingParameters)) {
         case Left(result) => fail("Got Left(%s), instead of expected Right".format(result.toString()))
         case Right(cookiesResponse) => {
-          cookiesResponse.expiresAt must equal(ISODateTimeFormat.dateTimeNoMillis.parseDateTime("2018-01-08T15:49:19+00:00"))
+          cookiesResponse.expiresAt must equal(ISODateTimeFormat.dateTimeParser().withZoneUTC().parseDateTime("2018-01-08T15:49:19+00:00"))
           val cookies = cookiesResponse.values
           cookies.size must equal(1)
           cookies(0) must have('key("SC_GU_U"))


### PR DESCRIPTION
## What does this change?

Support DateTimes with or without milliseconds returned from identity

## Screenshots

N/A

## What is the value of this and can you measure success?

Will fix the displaying of joined date on users' public profiles. 

## Checklist

### Does this affect other platforms?

No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
