### PR TITLE
Revert #20293

### DIFF
--- a/identity/app/idapiclient/parser/JodaJsonSerializer.scala
+++ b/identity/app/idapiclient/parser/JodaJsonSerializer.scala
@@ -10,16 +10,16 @@ import net.liftweb.json.JsonAST.JString
   */
 object JodaJsonSerializer extends Serializer[DateTime]{
   private val DateTimeClass = classOf[DateTime]
-  val dateTimeFormat = ISODateTimeFormat.dateTimeParser().withZoneUTC()
+  val dateTimeFormatISO8601 = ISODateTimeFormat.dateTimeNoMillis
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, _root_.net.liftweb.json.JValue), DateTime] = {
     case (TypeInfo(DateTimeClass, _), json) => json match {
-      case JString(s) => dateTimeFormat.parseDateTime(s)
+      case JString(s) => dateTimeFormatISO8601.parseDateTime(s)
       case x => throw new MappingException("Can't convert " + x + " to DateTime")
     }
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, _root_.net.liftweb.json.JValue] = {
-    case dt: DateTime => JString(dateTimeFormat.print(dt))
+    case dt: DateTime => JString(dateTimeFormatISO8601.print(dt))
   }
 }

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -125,7 +125,7 @@ class IdApiTest
       whenReady(idApi.authBrowser(Anonymous, trackingParameters)) {
         case Left(result) => fail("Got Left(%s), instead of expected Right".format(result.toString()))
         case Right(cookiesResponse) => {
-          cookiesResponse.expiresAt must equal(ISODateTimeFormat.dateTimeParser().withZoneUTC().parseDateTime("2018-01-08T15:49:19+00:00"))
+          cookiesResponse.expiresAt must equal(ISODateTimeFormat.dateTimeNoMillis.parseDateTime("2018-01-08T15:49:19+00:00"))
           val cookies = cookiesResponse.values
           cookies.size must equal(1)
           cookies(0) must have('key("SC_GU_U"))


### PR DESCRIPTION
## What does this change?
Reverts #20293
## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
