### PR TITLE
Guardian today formatting

### DIFF
--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -9,8 +9,7 @@
                 <center class="center-element">
                     <table>
                         <tr>
-                            <td></td>
-                            <td>
+                            <td class="no-pad">
                                 <table align="center" class="container float-center">
                                     <tbody>
                                         <tr>
@@ -22,7 +21,6 @@
                                     </tbody>
                                 </table>
                             </td>
-                            <td></td>
                         </tr>
                     </table>
                 </center>

--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -7,15 +7,23 @@
         <tr>
             <td class="center no-pad" align="center" valign="top">
                 <center class="center-element">
-                    <table align="center" class="container float-center">
-                        <tbody>
-                            <tr>
-                                <td class="no-pad">
-                                    @content
-                                    @fragments.email.footer(page)
-                                </td>
-                            </tr>
-                        </tbody>
+                    <table>
+                        <tr>
+                            <td></td>
+                            <td>
+                                <table align="center" class="container float-center">
+                                    <tbody>
+                                        <tr>
+                                            <td class="no-pad">
+                                                @content
+                                                @fragments.email.footer(page)
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                            <td></td>
+                        </tr>
                     </table>
                 </center>
             </td>


### PR DESCRIPTION
## What does this change?

Fixes formatting on Guardian today emails where the width override doesn't work on chrome Gmail on an Android phone.

## Screenshots
Before:
![picture 61](https://user-images.githubusercontent.com/29203769/45167404-055cc280-b1f1-11e8-8f90-e475016aa8fa.png)

After:
![picture 62](https://user-images.githubusercontent.com/29203769/45167418-0d1c6700-b1f1-11e8-98bb-3277178f700a.png)

## What is the value of this and can you measure success?

Users can read email content on gmail in chrome on an Android phone.

### Tested

- [x] Locally
- [ ] On CODE (optional)
