### PR TITLE
set NODE_ENV=development for development tasks

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ compile: install
 
 # Compile all assets in development.
 compile-dev: install
-	@./tools/task-runner/runner compile --dev
+	@NODE_ENV=development @./tools/task-runner/runner compile --dev
 
 # Compile atom-specific JS
 compile-atoms: install
@@ -58,7 +58,7 @@ compile-atoms: install
 
 # Compile all assets for watch.
 compile-watch: install # PRIVATE
-	@./tools/task-runner/runner compile/index.watch
+	@NODE_ENV=development ./tools/task-runner/runner compile/index.watch
 
 compile-javascript: install # PRIVATE
 	@./tools/task-runner/runner compile/javascript


### PR DESCRIPTION
## What does this change?

We don't currently set `NODE_ENV` for any task other than the [production `compile` task](https://github.com/guardian/frontend/blob/master/makefile#L49).

[Preact's debug tooling](https://github.com/developit/preact/blob/master/README.md#debug-mode) depends on `NODE_ENV` being set to `development` in order to work correctly. 

This change sets our `NODE_ENV` to `development` for development-specific compile tasks.

## What is the value of this and can you measure success?

It is good to be explicit about the environment code is running in.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
