### PR TITLE
Fix crossword content label at leftCol breakpoint

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -181,6 +181,10 @@
         width: $left-column;
         margin-left: -($left-column + $gs-gutter);
         margin-bottom: $gs-baseline;
+
+        &.content__labels--crossword {
+            width: inherit;
+        }
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?

At the `leftCol` breakpoint, the publication date of crosswords sometimes wraps, causing the date to collide with the crossword.

This change removes the width restriction for content labels for crosswords at this breakpoint, preventing the wrapping from occurring.

The correct solution would be to refactor the crossword header using CSS grid similar to the article, but this is a reasonably low risk quick fix for now.

## Screenshots

**Before**

<img width="822" alt="screen shot 2018-09-07 at 12 04 20" src="https://user-images.githubusercontent.com/5931528/45215744-4bb82d00-b296-11e8-8d9d-6310cdeddeee.png">

**After**

<img width="829" alt="screen shot 2018-09-07 at 12 04 56" src="https://user-images.githubusercontent.com/5931528/45215755-51157780-b296-11e8-9f87-86d7150ba62f.png">

## What is the value of this and can you measure success?

Crosswords look nicer on many laptop screens.

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
