### PR TITLE
Revert "preact/debug doesn't include devtools"

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -19,7 +19,6 @@ __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 // Debug preact in DEV
 if (process.env.NODE_ENV !== 'production') {
     import('preact/debug');
-    import('preact/devtools');
 }
 
 // kick off the app


### PR DESCRIPTION
Reverts guardian/frontend#20298 because of #20301