### PR TITLE
Simplify IdentityUseFollowSwitches switch

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -28,7 +28,7 @@ trait IdentitySwitches {
   val IdentityUseFollowSwitches = Switch(
     SwitchGroup.Identity,
     "id-use-follow-switches",
-    "If switched on, some consent boxes will become follow boxes.",
+    "If switched on, access to the new consent journeys will be enabled.",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = Off,
     sellByDate = new LocalDate(2018, 10, 24),

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -28,11 +28,6 @@
 
 @selectAllCheckboxContent = {
     <div class="manage-account__switches">
-        @if(conf.switches.Switches.IdentityUseFollowSwitches.isSwitchedOn) {
-            <div
-                class="js-identity-upsell-optputs"
-            ></div>
-        }
         <ul>
             <li>
                 <label class="manage-account__switch @skin.map(s => s"manage-account__switch--$s") manage-account__switch--no-box manage-account__switch--no-padding js-manage-account__check-allCheckbox" style="visibility:hidden;pointer-events:none;" data-link-name-template="mma switch : (consents - all) : [action]" data-wrapper="body">

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -26,24 +26,14 @@
     }
 }
 
-@if(conf.switches.Switches.IdentityUseFollowSwitches.isSwitchedOn) {
-    @fragments.form.follow(
-        title = titleProvider(getConsentText(consentField)),
-        description = descriptionProvider(getConsentText(consentField)),
-        behaviour = ConsentSwitch,
-        field = consentField("consented"),
-        extraFields = consentHiddenFormFields,
-    )(nonInputFields, messages)
-} else {
-    @fragments.form.switch(
-        title = titleProvider(getConsentText(consentField)),
-        subheading = None,
-        description = descriptionProvider(getConsentText(consentField)),
-        behaviour = ConsentSwitch,
-        field = consentField("consented"),
-        extraFields = consentHiddenFormFields,
-        highlighted = highlighted,
-        skin = skin,
-        boldTitle = boldTitle
-    )(nonInputFields, messages)
-}
+@fragments.form.switch(
+    title = titleProvider(getConsentText(consentField)),
+    subheading = None,
+    description = descriptionProvider(getConsentText(consentField)),
+    behaviour = ConsentSwitch,
+    field = consentField("consented"),
+    extraFields = consentHiddenFormFields,
+    highlighted = highlighted,
+    skin = skin,
+    boldTitle = boldTitle
+)(nonInputFields, messages)

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -23,4 +23,7 @@
     <div class="@(s"js-identity-upsell-${pageVariant.jsName}")">
         @noJsBehaviour
     </div>
+    <div
+    class="js-identity-upsell-optputs"
+    ></div>
 </div>


### PR DESCRIPTION
## What does this change?
Updates the follow button switch to only prevent access to the new consents journey vs turning the current one into ah hodgepodge of new & old components