### PR TITLE
Send unsubscribe from all directly to IDAPI

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -13,8 +13,6 @@ import {
     getInfo as getCheckboxInfo,
     removeSpinner,
 } from './modules/switch';
-import { getCsrfTokenFromElement } from './modules/fetchFormFields';
-
 import { prependSuccessMessage } from './modules/prependMessage';
 
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
@@ -108,18 +106,13 @@ const buildConsentUpdatePayload = (
 const getInputFields = (labelEl: HTMLElement): Promise<NodeList<HTMLElement>> =>
     fastdom.read(() => labelEl.querySelectorAll('[name][value]'));
 
-const unsubscribeFromAll = (
-    buttonEl: HTMLButtonElement,
-    csrfToken: string
-): Promise<void> => {
+const unsubscribeFromAll = (buttonEl: HTMLButtonElement): Promise<void> => {
     buttonEl.classList.add(isLoadingClassName);
     return reqwest({
-        url: `/user/email-subscriptions`,
-        method: 'DELETE',
+        url: `${config.get('page.idApiUrl')}/remove/consent/all`,
+        method: 'POST',
         withCredentials: true,
-        headers: {
-            'Csrf-Token': csrfToken,
-        },
+        crossOrigin: true,
     });
 };
 
@@ -167,10 +160,7 @@ const showUnsubscribeConfirmation = (): Promise<void> => {
 const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     buttonEl.addEventListener('click', () => {
         toggleInputsWithSelector(newsletterCheckboxClassName, false);
-        return getCsrfTokenFromElement(
-            document.getElementsByClassName(newsletterCheckboxClassName)[0]
-        )
-            .then(csrfToken => unsubscribeFromAll(buttonEl, csrfToken))
+        unsubscribeFromAll(buttonEl)
             .then(() =>
                 Promise.all([
                     showUnsubscribeConfirmation(),


### PR DESCRIPTION
## What does this change?

* Bypass `/user/email-subscriptions` by hitting IDAPI `/remove/consent/all` directly.
* Related IDAPI PR: https://github.com/guardian/identity/pull/1390

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
