### PR TITLE
Identity: Add whitelist to ConsentCardList, expandable ConsentCardList

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ConsentCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ConsentCardList.js
@@ -8,14 +8,18 @@ import {
 import { ConsentCard } from './ConsentCard';
 import type { Consent } from './ConsentCard';
 
+type ConsentCardListProps = {
+    displayWhiteList: string[],
+};
+
 class ConsentCardList extends Component<
-    {},
+    ConsentCardListProps,
     {
         acceptedConsents: string[],
         allConsents: Consent[],
     }
 > {
-    constructor(props: {}) {
+    constructor(props: ConsentCardListProps) {
         super(props);
         this.setState({
             acceptedConsents: [],
@@ -35,7 +39,8 @@ class ConsentCardList extends Component<
         getAllConsents().then(allConsents => {
             const filteredConsents = allConsents.filter(
                 consent =>
-                    consent.isOptOut === false && consent.isChannel === false
+                    this.props.displayWhiteList.filter(id => consent.id === id)
+                        .length > 0
             );
             this.setState({
                 allConsents: filteredConsents,

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableConsentCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableConsentCardList.js
@@ -1,0 +1,37 @@
+// @flow
+import React, { Component } from 'preact-compat';
+import { ConsentCardList } from './ConsentCardList';
+
+type CollapsibleConsentCardListProps = {
+    list: ConsentCardList,
+};
+
+class ExpandableConsentCardList extends Component<
+    CollapsibleConsentCardListProps,
+    {
+        expanded: boolean,
+    }
+> {
+    constructor(props: {}) {
+        super(props);
+        this.setState({
+            expanded: false,
+        });
+    }
+    render() {
+        if (this.state.expanded) {
+            return this.props.list;
+        }
+        return (
+            <button
+                className="identity-upsell-expandable-consent-card-list__expand-button"
+                onClick={() => {
+                    this.setState({ expanded: true });
+                }}>
+                Expand
+            </button>
+        );
+    }
+}
+
+export { ExpandableConsentCardList };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -4,6 +4,7 @@ import React, { render } from 'preact-compat';
 import fastdom from 'lib/fastdom-promise';
 import ophan from 'ophan/ng';
 import { ConsentCardList } from 'common/modules/identity/upsell/consent-card/ConsentCardList';
+import { ExpandableConsentCardList } from 'common/modules/identity/upsell/consent-card/ExpandableConsentCardList';
 import loadEnhancers from './../modules/loadEnhancers';
 import { AccountCreationFlow } from './account-creation/AccountCreationFlow';
 import { OptOutsList } from './opt-outs/OptOutsList';
@@ -38,7 +39,19 @@ const bindOptouts = (el): void => {
 
 const bindConfirmEmailThankYou = (el): void => {
     fastdom.write(() => {
-        render(<ConsentCardList />, el);
+        render(
+            <div>
+                <ConsentCardList displayWhiteList={['supporter']} />
+                <ExpandableConsentCardList
+                    list={
+                        <ConsentCardList
+                            displayWhiteList={['jobs', 'offers']}
+                        />
+                    }
+                />
+            </div>,
+            el
+        );
     });
 };
 


### PR DESCRIPTION
## What does this change?

Adds a component that expands a ConsentCardList, adds a whitelist prop to ConsentCardList to only display consent ids that are provided in the whitelist. 
