### PR TITLE
Make the amp removals switch never expire

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -82,7 +82,7 @@ trait MonitoringSwitches {
     "Sends log messages to kibana whenever an element is removed from an AMP article.",
     Seq(Owner.withGithub("aware")),
     Off,
-    new LocalDate(2018, 9, 7),
+    never,
     false
   )
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -53,7 +53,7 @@ object ThrasherAdjacentMPU extends Experiment(
   name = "thrasher-adjacent-mpu",
   description = "This will no longer allow an MPU to show adjacent to a thrasher on mobile",
   owners = Seq(Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2018, 9, 7),
+  sellByDate = new LocalDate(2018, 9, 11),
   participationGroup = Perc10A
 )
 


### PR DESCRIPTION
There's nothing we can do to fix this, but being able to log amp removals when there's a production issue is probably a good thing so I'm leaving this in.

We can't really improve on where we are without the blocks API. 

## What does this change?

Lets us log whenever we yank some embed from an amp article.

## Screenshots

This switch is currently turned on, so you can see in Kibana. 

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
