### PR TITLE
Refactor ConsentCard to be a generic FollowCard

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -44,7 +44,7 @@ class AdPrefsWrapper extends Component<
         const consentsWithState = [...this.state.consentsWithState];
         const changesPending =
             this.props.getAdConsentState(
-                consentsWithState[consentId].consent
+                consentsWithState[consentId].followable
             ) !== state;
         consentsWithState[consentId].state = state;
         if (this.SubmitButtonRef) {
@@ -62,7 +62,7 @@ class AdPrefsWrapper extends Component<
         this.state.consentsWithState.forEach(consentWithState => {
             if (typeof consentWithState.state === 'boolean') {
                 this.props.setAdConsentState(
-                    consentWithState.consent,
+                    consentWithState.followable,
                     consentWithState.state
                 );
             }
@@ -85,9 +85,9 @@ class AdPrefsWrapper extends Component<
                     {this.state.consentsWithState.map(
                         (consentWithState, index) => (
                             <ConsentBox
-                                consent={consentWithState.consent}
+                                consent={consentWithState.followable}
                                 state={consentWithState.state}
-                                key={consentWithState.consent.cookie}
+                                key={consentWithState.followable.cookie}
                                 onUpdate={(state: ?boolean) => {
                                     this.onUpdate(index, state);
                                 }}

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -44,7 +44,7 @@ class AdPrefsWrapper extends Component<
         const consentsWithState = [...this.state.consentsWithState];
         const changesPending =
             this.props.getAdConsentState(
-                consentsWithState[consentId].followable
+                consentsWithState[consentId].consent
             ) !== state;
         consentsWithState[consentId].state = state;
         if (this.SubmitButtonRef) {
@@ -62,7 +62,7 @@ class AdPrefsWrapper extends Component<
         this.state.consentsWithState.forEach(consentWithState => {
             if (typeof consentWithState.state === 'boolean') {
                 this.props.setAdConsentState(
-                    consentWithState.followable,
+                    consentWithState.consent,
                     consentWithState.state
                 );
             }
@@ -85,9 +85,9 @@ class AdPrefsWrapper extends Component<
                     {this.state.consentsWithState.map(
                         (consentWithState, index) => (
                             <ConsentBox
-                                consent={consentWithState.followable}
+                                consent={consentWithState.consent}
                                 state={consentWithState.state}
-                                key={consentWithState.followable.cookie}
+                                key={consentWithState.consent.cookie}
                                 onUpdate={(state: ?boolean) => {
                                     this.onUpdate(index, state);
                                 }}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
@@ -1,13 +1,13 @@
 // @flow
 import React, { Component } from 'preact-compat';
-import { ConsentCardList } from './ConsentCardList';
+import { FollowCardList } from './FollowCardList';
 
-type CollapsibleConsentCardListProps = {
-    list: ConsentCardList,
+type ExpandableConsentCardListProps = {
+    list: FollowCardList,
 };
 
-class ExpandableConsentCardList extends Component<
-    CollapsibleConsentCardListProps,
+class ExpandableFollowCardList extends Component<
+    ExpandableConsentCardListProps,
     {
         expanded: boolean,
     }
@@ -34,4 +34,4 @@ class ExpandableConsentCardList extends Component<
     }
 }
 
-export { ExpandableConsentCardList };
+export { ExpandableFollowCardList };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
@@ -2,12 +2,12 @@
 import React, { Component } from 'preact-compat';
 import { FollowCardList } from './FollowCardList';
 
-type ExpandableConsentCardListProps = {
+type ExpandableFollowCardListProps = {
     list: FollowCardList,
 };
 
 class ExpandableFollowCardList extends Component<
-    ExpandableConsentCardListProps,
+    ExpandableFollowCardListProps,
     {
         expanded: boolean,
     }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'preact-compat';
 import { FollowButtonWrap } from 'common/modules/identity/follow/FollowButtonWrap';
-import type { Consent } from 'common/modules/identity/upsell/store/consents';
 
 /**
  * Type for things that can be rendered in a Follow Card
@@ -11,7 +10,6 @@ export type CardLike = {
     name: string,
     description: string,
 };
-
 
 export type Followable<T: CardLike> = {
     value: T,

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -3,9 +3,9 @@ import React, { Component } from 'preact-compat';
 import { FollowButtonWrap } from 'common/modules/identity/follow/FollowButtonWrap';
 
 /**
- * Things that are Followable, i.e. Consents and EmailNewsletters.
+ * Type for things that can be rendered in a Follow Card
  */
-export type Followable = {
+export type CardLike = {
     id: string,
     name: string,
     description: string,
@@ -19,30 +19,40 @@ export type Consent = {
     isChannel: boolean,
 };
 
-type FollowCardProps = {
-    followable: Followable,
-    hasFollowed: boolean,
-    onToggleFollow: boolean => void,
+export type Followable<T: CardLike> = {
+    value: T,
+    onChange: boolean => void,
 };
 
-class FollowCard extends Component<FollowCardProps, {}> {
+type FollowCardProps<T: CardLike> = {
+    followable: Followable<T>,
+    hasFollowed: boolean,
+};
+
+class FollowCard<T: CardLike> extends Component<FollowCardProps<T>, {}> {
     render() {
         const { hasFollowed } = this.props;
         return (
             <div className="identity-upsell-consent-card">
                 <h1 className="identity-upsell-consent-card__title">
-                    {this.props.followable.name}
+                    {this.props.followable.value.name}
                 </h1>
                 <p className="identity-upsell-consent-card__description">
-                    {this.props.followable.description}
+                    {this.props.followable.value.description}
                 </p>
                 <FollowButtonWrap
                     following={hasFollowed}
                     onFollow={() => {
-                        this.props.onToggleFollow(true);
+                        this.props.followable.onChange(
+                            true,
+                            this.props.followable.value
+                        );
                     }}
                     onUnfollow={() => {
-                        this.props.onToggleFollow(false);
+                        this.props.followable.onChange(
+                            false,
+                            this.props.followable.value
+                        );
                     }}
                 />
             </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -2,6 +2,15 @@
 import React, { Component } from 'preact-compat';
 import { FollowButtonWrap } from 'common/modules/identity/follow/FollowButtonWrap';
 
+/**
+ * Things that are Followable, i.e. Consents and EmailNewsletters.
+ */
+export type Followable = {
+    id: string,
+    name: string,
+    description: string,
+};
+
 export type Consent = {
     id: string,
     name: string,
@@ -10,30 +19,30 @@ export type Consent = {
     isChannel: boolean,
 };
 
-type ConsentCardProps = {
-    consent: Consent,
-    hasConsented: boolean,
-    onToggleConsent: boolean => void,
+type FollowCardProps = {
+    followable: Followable,
+    hasFollowed: boolean,
+    onToggleFollow: boolean => void,
 };
 
-class ConsentCard extends Component<ConsentCardProps, {}> {
+class FollowCard extends Component<FollowCardProps, {}> {
     render() {
-        const { hasConsented } = this.props;
+        const { hasFollowed } = this.props;
         return (
             <div className="identity-upsell-consent-card">
                 <h1 className="identity-upsell-consent-card__title">
-                    {this.props.consent.name}
+                    {this.props.followable.name}
                 </h1>
                 <p className="identity-upsell-consent-card__description">
-                    {this.props.consent.description}
+                    {this.props.followable.description}
                 </p>
                 <FollowButtonWrap
-                    following={hasConsented}
+                    following={hasFollowed}
                     onFollow={() => {
-                        this.props.onToggleConsent(true);
+                        this.props.onToggleFollow(true);
                     }}
                     onUnfollow={() => {
-                        this.props.onToggleConsent(false);
+                        this.props.onToggleFollow(false);
                     }}
                 />
             </div>
@@ -41,4 +50,4 @@ class ConsentCard extends Component<ConsentCardProps, {}> {
     }
 }
 
-export { ConsentCard };
+export { FollowCard };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -43,16 +43,10 @@ class FollowCard<T: CardLike> extends Component<FollowCardProps<T>, {}> {
                 <FollowButtonWrap
                     following={hasFollowed}
                     onFollow={() => {
-                        this.props.followable.onChange(
-                            true,
-                            this.props.followable.value
-                        );
+                        this.props.followable.onChange(true);
                     }}
                     onUnfollow={() => {
-                        this.props.followable.onChange(
-                            false,
-                            this.props.followable.value
-                        );
+                        this.props.followable.onChange(false);
                     }}
                 />
             </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -81,11 +81,13 @@ class FollowCardList extends Component<
                         0;
                     return (
                         <FollowCard
-                            followable={consent}
+                            followable={{
+                                value: consent,
+                                onChange: newValue => {
+                                    this.toggleConsent(newValue, consent.id);
+                                },
+                            }}
                             hasFollowed={hasConsented}
-                            onToggleFollow={hasConsent =>
-                                this.toggleConsent(hasConsent, consent.id)
-                            }
                         />
                     );
                 })}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -5,21 +5,21 @@ import {
     getUserFromApi,
     setConsent,
 } from 'common/modules/identity/api';
-import { ConsentCard } from './ConsentCard';
-import type { Consent } from './ConsentCard';
+import { FollowCard } from './FollowCard';
+import type { Consent } from './FollowCard';
 
-type ConsentCardListProps = {
+type FollowCardListProps = {
     displayWhiteList: string[],
 };
 
-class ConsentCardList extends Component<
-    ConsentCardListProps,
+class FollowCardList extends Component<
+    FollowCardListProps,
     {
         acceptedConsents: string[],
         allConsents: Consent[],
     }
 > {
-    constructor(props: ConsentCardListProps) {
+    constructor(props: FollowCardListProps) {
         super(props);
         this.setState({
             acceptedConsents: [],
@@ -80,10 +80,10 @@ class ConsentCardList extends Component<
                         acceptedConsents.filter(e => e === consent.id).length >
                         0;
                     return (
-                        <ConsentCard
-                            consent={consent}
-                            hasConsented={hasConsented}
-                            onToggleConsent={hasConsent =>
+                        <FollowCard
+                            followable={consent}
+                            hasFollowed={hasConsented}
+                            onToggleFollow={hasConsent =>
                                 this.toggleConsent(hasConsent, consent.id)
                             }
                         />
@@ -94,4 +94,4 @@ class ConsentCardList extends Component<
     }
 }
 
-export { ConsentCardList };
+export { FollowCardList };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -56,19 +56,17 @@ class FollowCardList extends Component<
         const { consents } = this.state;
         return (
             <div>
-                {consents.map(consent => {
-                    return (
-                        <FollowCard
-                            followable={{
-                                value: consent.consent,
-                                onChange: newValue => {
-                                    this.toggleConsent(newValue, consent.consent);
-                                },
-                            }}
-                            hasFollowed={consent.hasConsented}
-                        />
-                    );
-                })}
+                {consents.map(consent => (
+                    <FollowCard
+                        followable={{
+                            value: consent.consent,
+                            onChange: newValue => {
+                                this.toggleConsent(newValue, consent.consent);
+                            },
+                        }}
+                        hasFollowed={consent.hasConsented}
+                    />
+                ))}
             </div>
         );
     }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -3,8 +3,8 @@ import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import React, { render } from 'preact-compat';
 import fastdom from 'lib/fastdom-promise';
 import ophan from 'ophan/ng';
-import { ConsentCardList } from 'common/modules/identity/upsell/consent-card/ConsentCardList';
-import { ExpandableConsentCardList } from 'common/modules/identity/upsell/consent-card/ExpandableConsentCardList';
+import { FollowCardList } from 'common/modules/identity/upsell/consent-card/FollowCardList';
+import { ExpandableFollowCardList } from 'common/modules/identity/upsell/consent-card/ExpandableFollowCardList';
 import loadEnhancers from './../modules/loadEnhancers';
 import { AccountCreationFlow } from './account-creation/AccountCreationFlow';
 import { OptOutsList } from './opt-outs/OptOutsList';
@@ -41,12 +41,10 @@ const bindConfirmEmailThankYou = (el): void => {
     fastdom.write(() => {
         render(
             <div>
-                <ConsentCardList displayWhiteList={['supporter']} />
-                <ExpandableConsentCardList
+                <FollowCardList displayWhiteList={['supporter']} />
+                <ExpandableFollowCardList
                     list={
-                        <ConsentCardList
-                            displayWhiteList={['jobs', 'offers']}
-                        />
+                        <FollowCardList displayWhiteList={['jobs', 'offers']} />
                     }
                 />
             </div>,


### PR DESCRIPTION
## What does this change?

Refactors ConsentCard & ConsentCardList types to be a generic FollowCards, so we may use them for email lists (eventually). 

Introduces a `CardLike` type that the Card(List) accepts: a CardLike has an `id`, a `name`, and a `description`. Introduces a `Followable<T: CardLike>` type that can encapsulate the logic of actually doing a follow... example usage:

```js
                        <FollowCard
                            followable={{
                                value: consent,
                                onChange: newValue => {
                                    this.toggleConsent(newValue, consent.id);
                                },
                            }}
                            hasFollowed={hasConsented}
                        />
```