### PR TITLE
Remove dead consents form post code

### DIFF
--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -1,11 +1,7 @@
 package controllers.editprofile.tabs
 
 import controllers.editprofile._
-import form.PrivacyFormData
-import play.api.data.Form
-import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
-import scala.concurrent.Future
 
 trait EmailsTab
     extends EditProfileControllerComponents
@@ -28,70 +24,4 @@ trait EmailsTab
           MOVED_PERMANENTLY)
       }
     }
-
-  /** POST /email-prefs */
-  def saveEmailPreferencesAjax: Action[AnyContent] =
-    csrfCheck {
-      consentAuthWithIdapiUserAction.async { implicit request =>
-        newsletterService.savePreferences().map { form  =>
-          if (form.hasErrors) {
-            val errorsAsJson = Json.toJson(
-              form.errors.groupBy(_.key).map { case (key, errors) =>
-                val nonEmptyKey = if (key.isEmpty) "global" else key
-                (nonEmptyKey, errors.map(e => play.api.i18n.Messages(e.message, e.args: _*)))
-              }
-            )
-            Forbidden(errorsAsJson)
-          } else {
-            Ok("updated")
-          }
-        }
-      }
-    }
-
-  def deleteAllSubscriptionsAndMarketingConsents(): Action[AnyContent] =
-    csrfCheck {
-      recentFullAuthWithIdapiUserAction.async { implicit request =>
-        identityApiClient.unsubscribeFromAllEmailsAndOptoutMarketingConsents(request.user.auth).map {
-          case Right(_) => NoContent
-          case Left(errors) =>
-            logger.error(s"Failed to unsubscribe User ${request.user.id} from all")
-            InternalServerError(Json.toJson(errors))
-        }
-      }
-    }
-
-  /** POST /privacy/edit-ajax */
-  def saveConsentPreferencesAjax: Action[AnyContent] =
-    csrfCheck {
-      consentAuthWithIdapiUserAction.async { implicit request =>
-        val userDO = request.user
-        val marketingConsentForm: Form[PrivacyFormData] = Form(profileFormsMapping.privacyMapping.formMapping)
-
-        marketingConsentForm.bindFromRequest.fold(
-          formWithErrors => {
-            val formBindingErrorsJson = Json.toJson(formWithErrors.errors.toList)
-            logger.error(s"Failed to submit marketing consent form for user ${userDO.user.id}: $formBindingErrorsJson")
-            Future(BadRequest(formBindingErrorsJson))
-          },
-
-          privacyFormData => {
-            identityApiClient.saveUser(userDO.id, privacyFormData.toUserUpdateDTOAjax(userDO), userDO.auth) map {
-              case Left(idapiErrors) =>
-                logger.error(s"Failed to process marketing consent form submission for user ${userDO.id}: $idapiErrors")
-                InternalServerError(Json.toJson(idapiErrors))
-
-              case Right(updatedUser) =>
-                val successMsg = s"Successfully updated marketing consent for user ${userDO.id}"
-                logger.info(successMsg)
-                Ok(successMsg)
-            }
-          }
-        ) // end bindFromRequest.fold(
-      } // end authActionWithUser
-    } // end csrfCheck
-
-  /** POST /privacy/edit */
-  def saveConsentPreferences: Action[AnyContent] = submitForm(EmailPrefsProfilePage)
-
 }

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -44,40 +44,12 @@ case class PrivacyFormData(
     allowThirdPartyProfiling: Option[Boolean],
     consents: List[Consent]) extends UserFormData{
 
-  /**
-    * FIXME: Fix the semantic discrepancy between toUserUpdateDTO and toUserUpdateDTOAjax.
-    * In the non-ajax case no value means set it to false while in the ajax case no value means use the old value.
-    *
-    * If a checkbox is unchecked then nothing is sent to dotocom identity frontend,
-    * however IDAPI is expecting Some(false)
-    *
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox:
-    *
-    * "Note: If a checkbox is unchecked when its form is submitted, there is no value submitted to
-    * the server to represent its unchecked state (e.g. value=unchecked); the value is not submitted
-    * to the server at all."
-    */
-
   def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO =
     UserUpdateDTO(
       statusFields = Some(oldUserDO.statusFields.copy(
         allowThirdPartyProfiling = Some(allowThirdPartyProfiling.getOrElse(false))
       )),
       consents = Some(consents))
-
-  def toUserUpdateDTOAjax(oldUserDO: User): UserUpdateDTO = {
-
-    val newAllowThirdPartyProfiling = allowThirdPartyProfiling match {
-      case None => oldUserDO.statusFields.allowThirdPartyProfiling
-      case Some(_) => allowThirdPartyProfiling
-    }
-
-    UserUpdateDTO(
-      statusFields = Some(StatusFields(
-        allowThirdPartyProfiling = newAllowThirdPartyProfiling
-      )),
-      consents = Some(consents))
-  }
 }
 
 object PrivacyFormData extends SafeLogging {

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -152,9 +152,6 @@ class IdApiClient(
   def deleteTelephone(auth: Auth): Future[Response[Unit]] =
     delete("user/me/telephoneNumber", Some(auth)) map extractUnit
 
-  def unsubscribeFromAllEmailsAndOptoutMarketingConsents(auth: Auth): Future[Response[Unit]] =
-    post("remove/consent/all", Some(auth)).map(extractUnit)
-
   // THIRD PARTY SIGN-IN
   def executeAccountDeletionStepFunction(userId: String, email: String, reason: Option[String], auth: Auth): Future[Response[AccountDeletionResult]] = {
     httpClient.POST(

--- a/identity/app/services/NewsletterService.scala
+++ b/identity/app/services/NewsletterService.scala
@@ -36,37 +36,6 @@ class NewsletterService(
         }
     }
 
-  def savePreferences()(implicit request: AuthRequest[AnyContent]): Future[Form[EmailPrefsData]] = {
-    val idRequest = idRequestParser(request)
-    val userId = request.user.id
-    val auth = request.user.auth
-    val trackingParameters = idRequest.trackingData
-
-    emailPrefsForm.bindFromRequest.fold({
-      case formWithErrors: Form[EmailPrefsData] =>
-        Future.successful(formWithErrors)
-    }, {
-      case emailPrefsData: EmailPrefsData =>
-        val form = emailPrefsForm.fill(emailPrefsData)
-
-        val unsubscribeResponse = emailPrefsData.removeEmailSubscriptions.map { id =>
-          api.deleteSubscription(userId, EmailList(id), auth, trackingParameters)
-        }
-
-        val subscribeResponse = emailPrefsData.addEmailSubscriptions.map { id =>
-          api.addSubscription(userId, EmailList(id), auth, trackingParameters)
-        }
-
-        Future.sequence(unsubscribeResponse ++ subscribeResponse).map { responses =>
-          if (responses.exists(_.isLeft)) {
-            form.withGlobalError("There was an error saving your preferences")
-          } else {
-            form
-          }
-        }
-    })
-  }
-
   def getEmailSubscriptions(
      form: Form[EmailPrefsData],
      add: List[String] = List(),

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -56,14 +56,7 @@ GET         /membership/edit                        controllers.editprofile.Edit
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.displayRecurringContributionForm
 GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.displayDigitalPackForm
 
-POST        /privacy/edit                           controllers.editprofile.EditProfileController.saveConsentPreferences
-POST        /privacy/edit-ajax                      controllers.editprofile.EditProfileController.saveConsentPreferencesAjax
-
 GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
-POST        /email-prefs                            controllers.editprofile.EditProfileController.saveEmailPreferencesAjax
-
-DELETE      /user/email-subscriptions               controllers.editprofile.EditProfileController.deleteAllSubscriptionsAndMarketingConsents()
-
 
 ########################################################################################################################
 # PUBLIC EDIT PROFILE


### PR DESCRIPTION
## What does this change?

Remove:

[POST        /privacy/edit](https://logs.gutools.co.uk/goto/854784457547f9ec3f474f8b8d89ab2a)
[POST        /privacy/edit-ajax](https://logs.gutools.co.uk/goto/87005a4bc7661c695cb0c5ce633c7bfa)
[POST        /email-prefs](https://logs.gutools.co.uk/goto/e624d54f449e2f48e2db6ce699944773)
[DELETE      /user/email-subscriptions](https://logs.gutools.co.uk/goto/acd65421592193631c84930414e28dae)


Now, JS hits directly IDAPI to provide above functionality.

## Screenshots

POST        /privacy/edit

![image](https://user-images.githubusercontent.com/13835317/45299050-3cd5b280-b502-11e8-8bb8-df5cf7df59e2.png)

POST        /privacy/edit-ajax

![image](https://user-images.githubusercontent.com/13835317/45299069-5119af80-b502-11e8-91f2-83ffcceef242.png)


POST        /email-prefs:

![image](https://user-images.githubusercontent.com/13835317/45299013-1fa0e400-b502-11e8-8f82-0f84045318d8.png)

DELETE      /user/email-subscriptions

![image](https://user-images.githubusercontent.com/13835317/45299102-6e4e7e00-b502-11e8-856c-683611007d42.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
