### PR TITLE
Update default appnexus placement ID

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -217,6 +217,7 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
 const getAppNexusDirectPlacementId = (): string => '11016434';
 
 const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
+    const defaultPlacementId: string = '13915593';
     switch (config.get('page.edition')) {
         case 'UK':
             switch (getBreakpointKey()) {
@@ -227,12 +228,12 @@ const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
                     if (containsLeaderboardOrBillboard(sizes)) {
                         return '13366615';
                     }
-                    return '13144370';
+                    return defaultPlacementId;
                 case 'M':
                     if (containsMpu(sizes)) {
                         return '13366904';
                     }
-                    return '13144370';
+                    return defaultPlacementId;
                 case 'T':
                     if (containsMpu(sizes)) {
                         return '13366913';
@@ -240,12 +241,12 @@ const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
                     if (containsLeaderboard(sizes)) {
                         return '13366916';
                     }
-                    return '13144370';
+                    return defaultPlacementId;
                 default:
-                    return '13144370';
+                    return defaultPlacementId;
             }
         default:
-            return '13915593';
+            return defaultPlacementId;
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -245,7 +245,7 @@ const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
                     return '13144370';
             }
         default:
-            return '13144370';
+            return '13915593';
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -117,7 +117,7 @@ describe('getAppNexusPlacementId', () => {
             '13366606',
             '13366615',
             '13366615',
-            '13144370',
+            '13915593',
         ]);
     });
 
@@ -131,10 +131,10 @@ describe('getAppNexusPlacementId', () => {
         containsLeaderboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             '13366913',
-            '13144370',
-            '13144370',
+            '13915593',
+            '13915593',
             '13366916',
-            '13144370',
+            '13915593',
         ]);
     });
 
@@ -144,21 +144,21 @@ describe('getAppNexusPlacementId', () => {
         containsMpu.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             '13366904',
-            '13144370',
-            '13144370',
-            '13144370',
-            '13144370',
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
         ]);
     });
 
     test('should return the default value on all other editions', () => {
         const editions = ['AU', 'US', 'INT'];
         const expected = [
-            '13144370',
-            '13144370',
-            '13144370',
-            '13144370',
-            '13144370',
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
         ];
 
         editions.forEach(edition => {
@@ -213,7 +213,7 @@ describe('getDummyServerSideBidders', () => {
             lotame: { some: 'lotamedata' },
         });
         expect(appNexusParams).toEqual({
-            placementId: '13144370',
+            placementId: '13915593',
             customData: 'someTestAppNexusTargeting',
             lotame: { some: 'lotamedata' },
         });


### PR DESCRIPTION
## What does this change?

This updates the fallback placement ID for AppNexus when we don't know which placement ID to use.

@guardian/commercial-dev 