### PR TITLE
Add custom epic copy in Australia related to Fairfax Media story

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -215,4 +215,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 6, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-aus-fairfax",
+    "Tests an epic with custom copy in Australia which alludes to Fairfax Media takeover",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -19,6 +19,7 @@ import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experi
 import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
 import { acquisitionsEpicIframeTestV2 } from 'common/modules/experiments/tests/acquisitions-iframe-epic-v2';
 import { acquisitionsEpicGoogleDocVsHardcoded } from 'common/modules/experiments/tests/acquisitions-epic-google-doc-vs-hardcoded';
+import { acquisitionsEpicAusFairfax } from 'common/modules/experiments/tests/acquisitions-epic-aus-fairfax';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options) return false;
@@ -47,6 +48,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    acquisitionsEpicAusFairfax,
     acquisitionsEpicGoogleDocVsHardcoded,
     acquisitionsEpicIframeTestV2,
     acquisitionsEpicFromGoogleDocOneVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-fairfax.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-fairfax.js
@@ -1,0 +1,60 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+
+const abTestName = 'AcquisitionsEpicAusFairfax';
+
+export const acquisitionsEpicAusFairfax: EpicABTest = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-04-17',
+    expiry: '2019-06-05',
+
+    author: 'Joseph Smith',
+    description: 'Test copy fetched from a Google Doc',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Alternative copy makes more money than the control',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    locations: ['AU'],
+
+    variants: [
+        {
+            id: 'control',
+            products: [],
+        },
+        {
+            id: 'shrinking_media_landscape',
+            products: [],
+            options: {
+                copy: {
+                    paragraphs: [
+                        '… we have a small favour to ask. More people are reading the Guardian’s independent, investigative journalism than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help.',
+                        'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. The Guardian’s editorial independence makes it stand out in a shrinking media landscape, at a time when factual and honest reporting is more critical than ever.',
+                        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+                    ],
+                    highlightedLine:
+                        'For as little as $1, you can support the Guardian – and it only takes a minute. Thank you.',
+                },
+            },
+        },
+        {
+            id: 'shrinking_media_landscape_and_plurality_of_voices',
+            products: [],
+            options: {
+                copy: {
+                    paragraphs: [
+                        '… we have a small favour to ask. More people are reading the Guardian’s independent, investigative journalism than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help.',
+                        'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. The Guardian’s editorial independence makes it stand out in a shrinking media landscape, at a time when factual and honest reporting is more critical than ever. The Guardian offers a plurality of voices when the majority of Australian media give voice to the powerful few.',
+                        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+                    ],
+                    highlightedLine:
+                        'For as little as $1, you can support the Guardian – and it only takes a minute. Thank you.',
+                },
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-fairfax.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-aus-fairfax.js
@@ -31,12 +31,13 @@ export const acquisitionsEpicAusFairfax: EpicABTest = makeABTest({
             products: [],
             options: {
                 copy: {
+                    heading: 'Since you’re here &hellip;',
                     paragraphs: [
                         '… we have a small favour to ask. More people are reading the Guardian’s independent, investigative journalism than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help.',
                         'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. The Guardian’s editorial independence makes it stand out in a shrinking media landscape, at a time when factual and honest reporting is more critical than ever.',
                         'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                     ],
-                    highlightedLine:
+                    highlightedText:
                         'For as little as $1, you can support the Guardian – and it only takes a minute. Thank you.',
                 },
             },
@@ -46,12 +47,13 @@ export const acquisitionsEpicAusFairfax: EpicABTest = makeABTest({
             products: [],
             options: {
                 copy: {
+                    heading: 'Since you’re here &hellip;',
                     paragraphs: [
                         '… we have a small favour to ask. More people are reading the Guardian’s independent, investigative journalism than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help.',
                         'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. The Guardian’s editorial independence makes it stand out in a shrinking media landscape, at a time when factual and honest reporting is more critical than ever. The Guardian offers a plurality of voices when the majority of Australian media give voice to the powerful few.',
                         'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                     ],
-                    highlightedLine:
+                    highlightedText:
                         'For as little as $1, you can support the Guardian – and it only takes a minute. Thank you.',
                 },
             },


### PR DESCRIPTION
The Fairfax Media story in Australia has performed very well with contributions, so we're trying some custom copy. We can't yet target our Google Sheets tests by country so we're doing a bespoke test this time.

## control
![picture 288](https://user-images.githubusercontent.com/5122968/45303808-90e69400-b50e-11e8-9a19-1b4a127f116d.png)

## shrinking_media_landscape
![picture 293](https://user-images.githubusercontent.com/5122968/45311538-4c182880-b521-11e8-80be-2a0372d11e4a.png)


## shrinking_media_landscape_and_plurality_of_voices
![picture 292](https://user-images.githubusercontent.com/5122968/45311533-49b5ce80-b521-11e8-90be-44656337a9d8.png)


