### PR TITLE
Move lotame script

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -11,11 +11,11 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, orielScriptTag, lotameScriptTag, titleTag, weAreHiring}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, orielScriptTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.ContentCSSFile
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, AudioPageChange, OldTLSSupportDeprecation}
 
 object ContentHtmlPage extends HtmlPage[Page] {
@@ -55,7 +55,6 @@ object ContentHtmlPage extends HtmlPage[Page] {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.ApplicationContext
@@ -14,7 +14,7 @@ import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, lotameScriptTag, titleTag, weAreHiring}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
 
@@ -43,7 +43,6 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -39,7 +39,6 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -41,7 +41,6 @@ object IndexHtml {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         headContent,

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import controllers.InteractivePage
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.{HtmlPage, Styles}
@@ -48,7 +48,6 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -12,7 +12,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, lotameScriptTag, weAreHiring}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.{ContentCSSFile, SignUpCSSFile}
@@ -35,7 +35,6 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -45,7 +45,6 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -43,7 +43,6 @@ object StoryHtmlPage {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         head,

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -244,6 +244,10 @@ class GuardianConfiguration extends Logging {
     lazy val orielCacheTimeInMinutes: Int = if (environment.isProd) 60 else 5
   }
 
+  object lotame {
+    val lotameScriptUrl: String = "//tags.crwdcntrl.net/c/12666/cc.js"
+  }
+
   object affiliatelinks {
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -41,6 +41,7 @@ function guardianPolyfilled() {
     }) { polyfillioUrl =>
         var scripts = [
             '@polyfillioUrl',
+            '@Configuration.lotame.lotameScriptUrl',
             '@Static(s"javascripts/graun.$bootModule.js")'
         ];
     }

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -1,6 +1,6 @@
 @import conf.Static
 @import conf.Configuration
-@import conf.switches.Switches.{PolyfillIO}
+@import conf.switches.Switches.{PolyfillIO, LotameSwitch}
 
 @(bootModule: String = "standard")(implicit request: RequestHeader)
 
@@ -39,11 +39,18 @@ function guardianPolyfilled() {
     } else {
       Static("javascripts/vendor/polyfillio.fallback.js")
     }) { polyfillioUrl =>
-        var scripts = [
-            '@polyfillioUrl',
-            '@Configuration.lotame.lotameScriptUrl',
-            '@Static(s"javascripts/graun.$bootModule.js")'
-        ];
+        @if(LotameSwitch.isSwitchedOn) {
+            var scripts = [
+                '@polyfillioUrl',
+                '@Configuration.lotame.lotameScriptUrl',
+                '@Static(s"javascripts/graun.$bootModule.js")'
+            ];            
+        } else {
+            var scripts = [
+                '@polyfillioUrl',
+                '@Static(s"javascripts/graun.$bootModule.js")'
+            ];
+        }
     }
 
     function stateChange() {

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -47,7 +47,6 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
         orielScriptTag(),
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         frontMeta(),

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -1,6 +1,6 @@
 package pages
 
-import conf.switches.Switches.{LotameSwitch, WeAreHiring}
+import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -11,7 +11,7 @@ import views.html.fragments._
 import views.html.fragments.page._
 import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, lotameScriptTag, titleTag, weAreHiring}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import html.HtmlPageHelpers.ContentCSSFile
 
 object IdentityHtmlPage {
@@ -35,7 +35,6 @@ object IdentityHtmlPage {
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
-        lotameScriptTag() when LotameSwitch.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),


### PR DESCRIPTION
## What does this change?

This moved the lotame script that's baked into the page server side to before the boot script but after the polyfill script.

We think this is going to be a better location for performance.

@guardian/commercial-dev 