### PR TITLE
Do not throw error if window.CSS is not defined

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
@@ -151,7 +151,9 @@ export const PodcastContainer = {
     showForSensitive: true,
     canRun() {
         return (
-            config.page.pageId === 'uk' && window.CSS && window.CSS.supports('display: grid')
+            config.page.pageId === 'uk' &&
+            window.CSS &&
+            window.CSS.supports('display: grid')
         );
     },
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
@@ -151,7 +151,7 @@ export const PodcastContainer = {
     showForSensitive: true,
     canRun() {
         return (
-            config.page.pageId === 'uk' && window.CSS.supports('display: grid')
+            config.page.pageId === 'uk' && window.CSS && window.CSS.supports('display: grid')
         );
     },
 


### PR DESCRIPTION
## What does this change?

Prevents run time error on the podcast test, see [sentry details](https://sentry.io/the-guardian/client-side-prod/issues/668788290/?query=is:unresolved) 

## Screenshots

<img width="1440" alt="screen shot 2018-09-10 at 17 50 21" src="https://user-images.githubusercontent.com/615085/45311766-0ad44880-b522-11e8-8fb4-5c75f21b7b4a.png">


@ajwl 