### PR TITLE
When there is no content, return 410 with a special message

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -68,7 +68,7 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
       index(Edition(request), path, inferPage(request), request.isRss) map {
         case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
         // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
-        case Left(model) if model.contents.isEmpty => NoCache(NotFound)
+        case Left(model) if model.contents.isEmpty => NoCache(Gone)
         case Right(other) => RenderOtherStatus(other)
       }
   }

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -66,7 +66,8 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
     case _ =>
       logGoogleBot(request)
       index(Edition(request), path, inferPage(request), request.isRss) map {
-        case Left(model) => renderFaciaFront(model)
+        case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
+        case Left(model) if model.contents.isEmpty => NoCache(NotFound)
         case Right(other) => RenderOtherStatus(other)
       }
   }

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -2,11 +2,13 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common._
+import common.`package`.Gone
 import model.Cached.WithoutRevalidationResult
 import model._
 import play.api.mvc._
 import services.{Index, IndexPage}
 import views.support.RenderOtherStatus
+import views.support.RenderOtherStatus.gonePage
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -68,7 +70,14 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
       index(Edition(request), path, inferPage(request), request.isRss) map {
         case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
         // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
-        case Left(model) if model.contents.isEmpty => NoCache(Gone)
+        case Left(model) if model.contents.isEmpty =>
+
+          Cached(60)(WithoutRevalidationResult(Gone(
+            views.html.gone(
+              gonePage,
+              "Sorry - there is no content here.",
+              "This could be because the content on this tag page hasn't been published yet or has expired, there was a legal issue, or for another reason.",
+              ))))
         case Right(other) => RenderOtherStatus(other)
       }
   }

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -67,6 +67,7 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
       logGoogleBot(request)
       index(Edition(request), path, inferPage(request), request.isRss) map {
         case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
+        // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
         case Left(model) if model.contents.isEmpty => NoCache(NotFound)
         case Right(other) => RenderOtherStatus(other)
       }

--- a/common/app/views/gone.scala.html
+++ b/common/app/views/gone.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, headlineText: String, explanation: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page){ }{
 <div class="l-side-margins">
@@ -6,7 +6,7 @@
         <header class="content__head">
             <div class="gs-container">
                 <div class="content__main-column">
-                    <h1 itemprop="headline" class="content__headline">Sorry - this page has been removed.</h1>
+                    <h1 itemprop="headline" class="content__headline">@headlineText</h1>
                 </div>
             </div>
         </header>
@@ -16,7 +16,7 @@
                     <div class="js-article__container u-cf">
                         <div class="from-content-api" itemprop="articleBody">
                             <div class="from-content-api">
-                                <p>This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.<p>
+                                <p>@explanation<p>
                                 <p>For further information, please contact:</p>
                                 <ul>
                                     <li>The Readers&apos; editor: <a  href="mailto:guardian.readers@@theguardian.com">guardian.readers@@theguardian.com</a> </li>

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -189,7 +189,10 @@ object RenderOtherStatus {
   def apply(result: Result)(implicit request: RequestHeader, context: ApplicationContext): Result = result.header.status match {
     case 404 => NoCache(NotFound)
     case 410 if request.isJson => Cached(60)(JsonComponent(gonePage, "status" -> "GONE"))
-    case 410 => Cached(60)(WithoutRevalidationResult(Gone(views.html.expired(gonePage))))
+    case 410 => Cached(60)(WithoutRevalidationResult(Gone(views.html.gone(
+      gonePage,
+      "Sorry - this page has been removed.",
+      "This could be because the content on this tag page hasn't been published yet or has expired, there was a legal issue, or for another reason."))))
     case _ => result
   }
 }


### PR DESCRIPTION
## What does this change?

## Screenshots

## What is the value of this and can you measure success?
Currently we have lots of tag pages like [this](http://theguardian.com/good-news-guardian) one where there is no content on the tag - often because it is a commercial microsite which has expired - if you've got guardian google docs access you can see the full list [here](https://docs.google.com/spreadsheets/d/1LXeyLvlNLKi_4jiBQbwYbKDgSw6x_lvMu2pKzTHc0w8/edit#gid=0). This page isn't very helpful to anyone who happens to end up there. As there are hundreds of these pages, redirecting around them isn't really an option - or necessarily the best option - so this PR instead does a similar thing to what we do when commercial content has expired -returning a 410 message, with a slightly updated description:
![screen shot 2018-09-10 at 18 33 43](https://user-images.githubusercontent.com/3606555/45313883-06ab2980-b528-11e8-8c3d-84a842eba663.png)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
