### PR TITLE
Add blocks with headings to new consent screen 

### DIFF
--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -3,9 +3,9 @@
 @import conf.Configuration
 @import views.support.DropdownMenus.accountDropdownMenu
 
-<div class="new-header__user-account-container hide-until-desktop">
+<div class="new-header__user-account-container hide-until-tablet">
 
-    <a class="top-bar__item hide-until-desktop js-navigation-sign-in"
+    <a class="top-bar__item hide-until-tablet js-navigation-sign-in"
         data-link-name="nav2 : topbar : signin"
         href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN">
 

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -20,14 +20,14 @@
 }
 
 <div class="identity-upsell-container">
-    <div class="js-identity-upsell-block">
+    <span class="js-identity-upsell-block">
 
-    </div>
-    <div class="@(s"js-identity-upsell-${pageVariant.jsName}")">
+    </span>
+    <span class="@(s"js-identity-upsell-${pageVariant.jsName}")">
         @noJsBehaviour
-    </div>
-    <div
+    </span>
+    <span
     class="js-identity-upsell-optputs"
-    ></div>
+    ></span>
 </div>
 

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -20,7 +20,7 @@
 }
 
 <div class="identity-upsell-container">
-    <div class="js-identity-block-list">
+    <div class="js-identity-block-list" data-page-variant="@{pageVariant.jsName}">
         @noJsBehaviour
     </div>
 </div>

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -20,6 +20,9 @@
 }
 
 <div class="identity-upsell-container">
+    <div class="js-identity-upsell-block">
+
+    </div>
     <div class="@(s"js-identity-upsell-${pageVariant.jsName}")">
         @noJsBehaviour
     </div>
@@ -27,3 +30,4 @@
     class="js-identity-upsell-optputs"
     ></div>
 </div>
+

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -20,14 +20,8 @@
 }
 
 <div class="identity-upsell-container">
-    <span class="js-identity-upsell-block">
-
-    </span>
-    <span class="@(s"js-identity-upsell-${pageVariant.jsName}")">
+    <div class="js-identity-block-list">
         @noJsBehaviour
-    </span>
-    <span
-    class="js-identity-upsell-optputs"
-    ></span>
+    </div>
 </div>
 

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
@@ -11,10 +11,16 @@ export class Block extends Component<BlockProps> {
     render() {
         const { title, subtitle, children } = this.props;
         return (
-            <section className={'identity-upsell-block'}>
-                <h2 className={'identity-upsell-block__title'}>{title}</h2>
-                {subtitle && <h3 className={'identity-upsell-block__subtitle'}>{subtitle}</h3>}
-                <div className={'identity-upsell-block__container'}>{children}</div>
+            <section className="identity-upsell-block">
+                <h2 className="identity-upsell-block__title">{title}</h2>
+                {subtitle && (
+                    <h3 className="identity-upsell-block__subtitle">
+                        {subtitle}
+                    </h3>
+                )}
+                <div className="identity-upsell-block__container">
+                    {children}
+                </div>
             </section>
         );
     }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
@@ -11,10 +11,10 @@ export class Block extends Component<BlockProps> {
     render() {
         const { title, subtitle, children } = this.props;
         return (
-            <section>
-                <h2>{title}</h2>
-                {subtitle && <h3>{subtitle}</h3>}
-                <div>{children}</div>
+            <section className={'identity-upsell-block'}>
+                <h2 className={'identity-upsell-block__title'}>{title}</h2>
+                {subtitle && <h3 className={'identity-upsell-block__subtitle'}>{subtitle}</h3>}
+                <div className={'identity-upsell-block__container'}>{children}</div>
             </section>
         );
     }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
@@ -1,0 +1,21 @@
+// @flow
+import React, { Component } from 'preact-compat';
+
+type BlockProps = {
+    title: string,
+    subtitle: ?string,
+    children: any,
+};
+
+export class Block extends Component<BlockProps> {
+    render() {
+        const { title, subtitle, children } = this.props;
+        return (
+            <section>
+                <h2>{title}</h2>
+                {subtitle && <h3>{subtitle}</h3>}
+                <div>{children}</div>
+            </section>
+        );
+    }
+}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -10,6 +10,21 @@ import { AccountCreationFlow } from 'common/modules/identity/upsell/account-crea
 import { OptOutsList } from 'common/modules/identity/upsell/opt-outs/OptOutsList';
 import { Block } from 'common/modules/identity/upsell/block/Block';
 
+const ConfirmEmailThankYou = (<Block title="Interested in any of this content?">
+    <FollowCardList displayWhiteList={['supporter']} />
+    <ExpandableFollowCardList
+        list={
+            <FollowCardList displayWhiteList={['jobs', 'offers']} />
+        }
+    />
+</Block>)
+
+const Optouts = (<Block
+    title="One more thing..."
+    subtitle="These are your privacy settings. You’re in full control of them.">
+    <OptOutsList />
+</Block>)
+
 const trackInteraction = (interaction: string): void => {
     ophan.record({
         component: 'set-password',
@@ -32,50 +47,18 @@ const bindAccountCreation = (el): void => {
     });
 };
 
-const bindOptouts = (el): void => {
+
+const bindBlockList = (el): void => {
     fastdom.write(() => {
-        render(
-            <Block
-                title="One more thing..."
-                subtitle="These are your privacy settings. You’re in full control of them.">
-                <OptOutsList />
-            </Block>,
-            el
-        );
+        render(<div>{ConfirmEmailThankYou}{Optouts}</div>, el);
     });
 };
 
-const bindBlock = (el): void => {
-    fastdom.write(() => {
-        render(<Block title="Hello!">Test</Block>, el);
-    });
-};
-
-const bindConfirmEmailThankYou = (el): void => {
-    fastdom.write(() => {
-        render(
-            <Block title="Interested in any of this content?">
-                <FollowCardList displayWhiteList={['supporter']} />
-                <ExpandableFollowCardList
-                    list={
-                        <FollowCardList displayWhiteList={['jobs', 'offers']} />
-                    }
-                />
-            </Block>,
-            el
-        );
-    });
-};
 
 const enhanceUpsell = (): void => {
     loadEnhancers([
         ['.js-identity-upsell-account-creation', bindAccountCreation],
-        ['.js-identity-upsell-optputs', bindOptouts],
-        [
-            '.js-identity-upsell-confirm-email-thank-you',
-            bindConfirmEmailThankYou,
-        ],
-        ['.js-identity-upsell-block', bindBlock],
+        ['.js-identity-block-list', bindBlockList]
     ]);
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -5,9 +5,10 @@ import fastdom from 'lib/fastdom-promise';
 import ophan from 'ophan/ng';
 import { FollowCardList } from 'common/modules/identity/upsell/consent-card/FollowCardList';
 import { ExpandableFollowCardList } from 'common/modules/identity/upsell/consent-card/ExpandableFollowCardList';
-import loadEnhancers from './../modules/loadEnhancers';
-import { AccountCreationFlow } from './account-creation/AccountCreationFlow';
-import { OptOutsList } from './opt-outs/OptOutsList';
+import loadEnhancers from 'common/modules/identity/modules/loadEnhancers';
+import { AccountCreationFlow } from 'common/modules/identity/upsell/account-creation/AccountCreationFlow';
+import { OptOutsList } from 'common/modules/identity/upsell/opt-outs/OptOutsList';
+import { Block } from 'common/modules/identity/upsell/block/Block';
 
 const trackInteraction = (interaction: string): void => {
     ophan.record({
@@ -33,21 +34,34 @@ const bindAccountCreation = (el): void => {
 
 const bindOptouts = (el): void => {
     fastdom.write(() => {
-        render(<OptOutsList />, el);
+        render(
+            <Block
+                title="One more thing..."
+                subtitle="These are your privacy settings. You’re in full control of them.">
+                <OptOutsList />
+            </Block>,
+            el
+        );
+    });
+};
+
+const bindBlock = (el): void => {
+    fastdom.write(() => {
+        render(<Block title="Hello!">Test</Block>, el);
     });
 };
 
 const bindConfirmEmailThankYou = (el): void => {
     fastdom.write(() => {
         render(
-            <div>
+            <Block title="Interested in any of this content?">
                 <FollowCardList displayWhiteList={['supporter']} />
                 <ExpandableFollowCardList
                     list={
                         <FollowCardList displayWhiteList={['jobs', 'offers']} />
                     }
                 />
-            </div>,
+            </Block>,
             el
         );
     });
@@ -61,6 +75,7 @@ const enhanceUpsell = (): void => {
             '.js-identity-upsell-confirm-email-thank-you',
             bindConfirmEmailThankYou,
         ],
+        ['.js-identity-upsell-block', bindBlock],
     ]);
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -10,20 +10,22 @@ import { AccountCreationFlow } from 'common/modules/identity/upsell/account-crea
 import { OptOutsList } from 'common/modules/identity/upsell/opt-outs/OptOutsList';
 import { Block } from 'common/modules/identity/upsell/block/Block';
 
-const ConfirmEmailThankYou = (<Block title="Interested in any of this content?">
-    <FollowCardList displayWhiteList={['supporter']} />
-    <ExpandableFollowCardList
-        list={
-            <FollowCardList displayWhiteList={['jobs', 'offers']} />
-        }
-    />
-</Block>)
+const ConfirmEmailThankYou = (
+    <Block title="Interested in any of this content?">
+        <FollowCardList displayWhiteList={['supporter']} />
+        <ExpandableFollowCardList
+            list={<FollowCardList displayWhiteList={['jobs', 'offers']} />}
+        />
+    </Block>
+);
 
-const Optouts = (<Block
-    title="One more thing..."
-    subtitle="These are your privacy settings. You’re in full control of them.">
-    <OptOutsList />
-</Block>)
+const Optouts = (
+    <Block
+        title="One more thing..."
+        subtitle="These are your privacy settings. You’re in full control of them.">
+        <OptOutsList />
+    </Block>
+);
 
 const trackInteraction = (interaction: string): void => {
     ophan.record({
@@ -47,18 +49,22 @@ const bindAccountCreation = (el): void => {
     });
 };
 
-
 const bindBlockList = (el): void => {
     fastdom.write(() => {
-        render(<div>{ConfirmEmailThankYou}{Optouts}</div>, el);
+        render(
+            <div>
+                {ConfirmEmailThankYou}
+                {Optouts}
+            </div>,
+            el
+        );
     });
 };
-
 
 const enhanceUpsell = (): void => {
     loadEnhancers([
         ['.js-identity-upsell-account-creation', bindAccountCreation],
-        ['.js-identity-block-list', bindBlockList]
+        ['.js-identity-block-list', bindBlockList],
     ]);
 };
 

--- a/static/src/stylesheets/module/identity/upsell/_base.scss
+++ b/static/src/stylesheets/module/identity/upsell/_base.scss
@@ -100,10 +100,13 @@
 
 .identity-upsell-block {
     width: 100%;
-    border-top: 2px solid pink;
-    padding: 10px;
+    border-top: 2px solid $brightness-86;
+    padding: $gs-baseline 0;
+    .identity-upsell-block__title, .identity-upsell-block__subtitle {
+        @include fs-headlineGarnett(2);
+    }
+    .identity-upsell-block__title {
+        font-weight: 900;
+    }
 }
 
-.identity-upsell-block__title, .identity-upsell-block__subtitle {
-    @include fs-headlineGarnett(2);
-}

--- a/static/src/stylesheets/module/identity/upsell/_base.scss
+++ b/static/src/stylesheets/module/identity/upsell/_base.scss
@@ -97,3 +97,13 @@
     }
 
 }
+
+.identity-upsell-block {
+    width: 100%;
+    border-top: 2px solid pink;
+    padding: 10px;
+}
+
+.identity-upsell-block__title, .identity-upsell-block__subtitle {
+    @include fs-headlineGarnett(2);
+}


### PR DESCRIPTION
## What does this change?
Work in progress for new consents journey for email. Added new block list to add headers to the components. Created a master react component to hold other components on the page. 

## Screenshots
<img width="1552" alt="screen shot 2018-09-11 at 14 25 01" src="https://user-images.githubusercontent.com/42539745/45363138-986d7200-b5ce-11e8-8a2c-b0482cf9640d.png">
<img width="1552" alt="screen shot 2018-09-11 at 14 25 09" src="https://user-images.githubusercontent.com/42539745/45363139-986d7200-b5ce-11e8-97de-51de2285acd0.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
