### PR TITLE
Add empty string fallback for contentType

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -178,7 +178,7 @@ const shouldAutoplay = (atomId: string): boolean => {
         accessibilityIsOn('flashing-elements');
 
     const isVideoArticle = () =>
-        config.get('page.contentType').toLowerCase() === 'video';
+        config.get('page.contentType', '').toLowerCase() === 'video';
 
     const isFront = () => config.get('page.isFront');
 


### PR DESCRIPTION
## What does this change?

If `page.contentType` is undefined, this is throwing an error, preventing videos from playing.

## What is the value of this and can you measure success?

Makes video atoms playable when embedded on a page without a `contentType`
