### PR TITLE
Make video overlay clickthroughable everywhere except fronts

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -102,9 +102,14 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     }
 }
 
-// in articles, youtube iframe is below the overlay, so we should allow users to click through it
-.content .youtube-media-atom__overlay.vjs-big-play-button {
+// youtube iframe is below the overlay, so we should allow users to click through it...
+.youtube-media-atom__overlay.vjs-big-play-button {
     pointer-events: none;
+
+    // ...however on fronts, clicking the overlay is what loads the iframe
+    .facia-page & {
+        pointer-events: auto;
+    }
 }
 
 .youtube-media-atom__overlay {


### PR DESCRIPTION
## What does this change?

Currently, the video overlay has `pointer-events: none` in articles, allowing the user to click through the overlay to play the video below.

The change #20286 prevents this from happening in embeds ([such as this one](https://embed.theguardian.com/embed/atom/media/dd416ed8-d52e-49d1-9fdb-97ec3b3651c4)), which is also breaking the iPad Daily Edition

## What is the value of this and can you measure success?

Makes videos playable in iPad Daily Edition
