### PR TITLE
Reinstate Tweets in emails

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -202,6 +202,10 @@
                         }
                     }
 
+                    case TweetBlockElement(Some(html)) => {
+                        @row(Seq("padded"))(Html(html))
+                    }
+
                     case _ => {}
                 }
             }


### PR DESCRIPTION
## What does this change?

Tweest used to appear in emails as blockquotes. However they stopped doing so when we started correctly interpreting CAPI blocks in #20142.

This change reinstates support for Tweets by explicitly matching for them.

## Screenshots

![picture 659](https://user-images.githubusercontent.com/5931528/45375557-3d974300-b5ed-11e8-8f5f-06534fc50224.png)

## What is the value of this and can you measure success?

Tweets are embedded in emails

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (please specify)

This change only affects emails!

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
