### PR TITLE
Remove left padding in photo essay captions

### DIFF
--- a/static/src/stylesheets/inline/article-photo-essay-garnett.scss
+++ b/static/src/stylesheets/inline/article-photo-essay-garnett.scss
@@ -229,6 +229,7 @@
         margin-right: 1%;
         line-height: 14px;
         padding-top: $gs-baseline / 2;
+        padding-left: 0 !important; // override padding applied in from-content-api.scss
         border-top: 1px solid $guardian-brand;
 
         &::before {


### PR DESCRIPTION
## What does this change?

In #20165, left padding was added to bullet points. This inadvertently added padding to photo essay picture captions, pushing the caption too close to the body copy.

This change removes the left padding. Unfortunately, it was necessary to use `!important` to override the [highly specific selector in `_from-content-api.scss`](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/external/_from-content-api.scss#L157)

## Screenshots

**Before**

![screen shot 2018-09-12 at 09 15 54](https://user-images.githubusercontent.com/5931528/45411730-e2a53080-b66c-11e8-8677-e7d9a1b05ece.png)

**After**

![screen shot 2018-09-12 at 09 15 45](https://user-images.githubusercontent.com/5931528/45411743-e9cc3e80-b66c-11e8-9eda-65b13ce3b3eb.png)

## What is the value of this and can you measure success?

Captions look less cramped

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
