### PR TITLE
Implement ad free in render tier picker

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -75,7 +75,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
 
   private def render(path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
 
-    val renderTier = RenderingTierPicker.getRenderTierFor(article)
+    val renderTier = RenderingTierPicker.getRenderTierFor(article, request)
 
     renderTier match {
       case RemoteRender => log.logger.info(s"Remotely renderable article $path");

--- a/article/app/services/RenderingTierPicker.scala
+++ b/article/app/services/RenderingTierPicker.scala
@@ -1,9 +1,10 @@
 package services
 
-import common.Logging
 import controllers.ArticlePage
 import model.PageWithStoryPackage
-import model.liveblog.{BlockElement, BodyBlock, ImageBlockElement, TextBlockElement}
+import model.liveblog.{BlockElement, ImageBlockElement, TextBlockElement}
+import play.api.mvc.RequestHeader
+import views.support.Commercial
 
 sealed trait RenderType
 case object RemoteRender extends RenderType
@@ -39,17 +40,17 @@ object RenderingTierPicker {
     !page.article.blocks.exists(_.body.exists(_.elements.exists(unsupportedElement)))
   }
 
-  private def isAdFree(page: PageWithStoryPackage): Boolean = {
-    page.item.content.shouldHideAdverts
+  private def isAdFree(page: PageWithStoryPackage, request: RequestHeader): Boolean = {
+    page.item.content.shouldHideAdverts || Commercial.isAdFree(request)
   }
 
-  def getRenderTierFor(page: PageWithStoryPackage): RenderType = {
+  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType = {
 
     val canRemotelyRender = isSupportedType(page) &&
       hasBlocks(page) &&
       hasOnlySupportedElements(page) &&
       isDiscussionDisabled(page) &&
-      isAdFree(page)
+      isAdFree(page, request)
 
     if(canRemotelyRender){
       RemoteRender


### PR DESCRIPTION
## What does this change?

Makes the render tier picker aware of the new commercial AdFree project

## Screenshots

## What is the value of this and can you measure success?

More pages should be renderable by the rendering tier

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
