### PR TITLE
Update params for Ozone AppNexus and Openx

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -310,7 +310,7 @@ const appNexusBidder: PrebidBidder = {
     switchName: 'prebidAppnexus',
     bidParams: (): PrebidAppNexusParams => ({
         placementId: getAppNexusDirectPlacementId(),
-        customData: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+        keywords: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
     }),
 };
 
@@ -406,7 +406,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {},
                 {
                     placementId: getAppNexusPlacementId(sizes),
-                    customData: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+                    keywords: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
             ),
@@ -424,17 +424,20 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                             return {
                                 delDomain: 'guardian-d.openx.net',
                                 unit: '539997090',
+                                customParams: buildPageTargeting(),
                             };
                         case 'US':
                             return {
                                 delDomain: 'guardian-us-d.openx.net',
                                 unit: '539997087',
+                                customParams: buildPageTargeting(),
                             };
                         default:
                             // AU and rest
                             return {
                                 delDomain: 'guardian-aus-d.openx.net',
                                 unit: '539997046',
+                                customParams: buildPageTargeting(),
                             };
                     }
                 })(),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -323,17 +323,20 @@ const openxClientSideBidder: PrebidBidder = {
                 return {
                     delDomain: 'guardian-us-d.openx.net',
                     unit: '540279544',
+                    customParams: buildPageTargeting(),
                 };
             case 'AU':
                 return {
                     delDomain: 'guardian-aus-d.openx.net',
                     unit: '540279542',
+                    customParams: buildPageTargeting(),
                 };
             default:
                 // UK and ROW
                 return {
                     delDomain: 'guardian-d.openx.net',
                     unit: '540279541',
+                    customParams: buildPageTargeting(),
                 };
         }
     },

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -211,10 +211,11 @@ describe('getDummyServerSideBidders', () => {
             delDomain: 'guardian-d.openx.net',
             unit: '539997090',
             lotame: { some: 'lotamedata' },
+            customParams: 'bla',
         });
         expect(appNexusParams).toEqual({
             placementId: '13915593',
-            customData: 'someTestAppNexusTargeting',
+            keywords: 'someTestAppNexusTargeting',
             lotame: { some: 'lotamedata' },
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -35,7 +35,8 @@ export type PrebidXaxisParams = {
 
 export type PrebidAppNexusParams = {
     placementId: string,
-    customData: string,
+    keywords?: string,
+    customData?: string,
     lotame?: {},
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -35,14 +35,14 @@ export type PrebidXaxisParams = {
 
 export type PrebidAppNexusParams = {
     placementId: string,
-    keywords?: string,
-    customData?: string,
+    keywords: string,
     lotame?: {},
 };
 
 export type PrebidOpenXParams = {
     delDomain: string,
     unit: string,
+    customParams: {},
     lotame?: {},
 };
 


### PR DESCRIPTION
## What does this change?

This updates the parameters sent to AppNexus and OpenX via Ozone, and in the case of OpenX, directly to OpenX.

For AppNexus, we send them via `keywords` which are translated to keywords used within AppNexus itself.

For OpenX, we directly pass our own keywords to OpenX both directly and via Ozone.

@kelvin-chappell Does this look correct to you?

@guardian/commercial-dev 
