### PR TITLE
Fix football snap styling

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -1,9 +1,7 @@
 .facia-snap--football {
     $slice-innerHeight: gs-height(5) - $gs-baseline / 3;
 
-    // Dealing with the double embedding of snaps
     overflow: hidden;
-    position: relative;
     padding: 0;
 
     // Generic
@@ -21,12 +19,18 @@
         // this works as a min-height
         height: $gs-baseline*14;
         overflow: visible;
+        position: relative;
     }
 
     .c-football-matches {
-        overflow: hidden;
         background: $brightness-97;
         width: 100%;
+        position: relative;
+    }
+
+    .c-football-matches,
+    .football-embed {
+        overflow: visible; // ensure height expands in container
     }
 
     .table,
@@ -52,7 +56,6 @@
 
     .table__caption--bottom {
         box-sizing: border-box;
-        background: $brightness-97;
         border-width: 0;
         bottom: 0;
         left: 0;
@@ -61,20 +64,33 @@
         position: absolute;
         margin: 0;
         padding: 0;
+        background-color: transparent;
 
         .full-table-link {
             display: inline-block;
         }
 
-        &:after {
-            @include simple-gradient(transparent, #f6f6f6);
-            height: $gs-baseline*1.5;
-            border-bottom: 1px solid $brightness-86;
-            bottom: $gs-baseline*2.75-2;
-            content: ' ';
-            left: 0;
-            position: absolute;
-            width: 100%;
+        tr {
+            background: transparent;
+            display: block;
+            width: auto;
+
+            td {
+                background: $brightness-97;
+                display: block;
+                position: relative; // for the after
+            }
+
+            td:after {
+                @include simple-gradient(transparent, #f6f6f6);
+                height: $gs-baseline*1.5;
+                border-bottom: 1px solid $brightness-86;
+                bottom: $gs-baseline*2.75-2;
+                content: ' ';
+                left: 0;
+                position: absolute;
+                width: 100%;
+            }
         }
     }
 
@@ -86,6 +102,14 @@
     .football-team__name {
         text-overflow: ellipsis;
     }
+
+    .football-match__team--home {
+        padding-right: 14px;
+    }
+    .football-match__team--away {
+        padding-left: 14px;
+    }
+
 
     .football-matches__day:last-child {
         .table__caption--bottom {
@@ -217,7 +241,7 @@ $footballBadgeSizeDesktop: 120px;
 
 .football-embed {
     height: 14rem;
-    position: relative;
+    overflow: visible;
 }
 
 .football-embed.knockout-embed {


### PR DESCRIPTION
Fixes some styling issues with snaps.

There are so many issues with testing/developing snaps. Let me count the ways:

* can't test locally in Dotcom (I use a script to replicate this)
* combination of inline and global CSS for styling
* football snaps rely on code which is used in a variety of contexts, including for non-snaps, which makes it difficult to be confident changes haven't broken things elsewhere

Ideally we would:

* develop snaps outside of dotcom
* not re-use templates for different use cases

At some point we'll have to rewrite football snaps along these lines or jettison them as the cost of maintenance is too high.

TODO: test on CODE.