### PR TITLE
Update ophan tracker to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-node": "^2.4.1",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.9",
+    "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
     "prebid.js": "https://github.com/guardian/Prebid.js.git#097ada",


### PR DESCRIPTION
## What does this change?
Update  `ophan` tracker to the [latest](https://github.com/guardian/ophan/pull/2907) [changes](https://github.com/guardian/ophan/pull/2908), not mentioned here for obvious reason. 

### Does this affect other platforms?
- [ ] [AMP changes are separated](https://github.com/guardian/ophan/pull/2913)


### Does this affect GLabs Paid Content Pages? 
- [x] yes 

### Does this change break ad-free?
- [x] No


