### PR TITLE
Add a collapse button to the ExpandableFollowCardList

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/ExpandableFollowCardList.js
@@ -7,6 +7,14 @@ type ExpandableFollowCardListProps<T: CardLike> = {
     list: FollowCardList<T>,
 };
 
+const ExpandButton = (props: { onClick: () => void, text: string }) => (
+    <button
+        className="identity-upsell-expandable-consent-card-list__expand-button"
+        onClick={props.onClick}>
+        {props.text}
+    </button>
+);
+
 class ExpandableFollowCardList<T: CardLike> extends Component<
     ExpandableFollowCardListProps<T>,
     {
@@ -21,16 +29,25 @@ class ExpandableFollowCardList<T: CardLike> extends Component<
     }
     render() {
         if (this.state.expanded) {
-            return this.props.list;
+            return (
+                <div>
+                    {this.props.list}
+                    <ExpandButton
+                        onClick={() => {
+                            this.setState({ expanded: false });
+                        }}
+                        text="Collapse"
+                    />
+                </div>
+            );
         }
         return (
-            <button
-                className="identity-upsell-expandable-consent-card-list__expand-button"
+            <ExpandButton
                 onClick={() => {
                     this.setState({ expanded: true });
-                }}>
-                Expand
-            </button>
+                }}
+                text="Expand"
+            />
         );
     }
 }


### PR DESCRIPTION
## What does this change?

When the expandable list is expanded, it adds a button to the end of the list that will un-expand it. 