### PR TITLE
Iframe-based user syncing enabled for all Prebid bidders

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -29,7 +29,8 @@ const consentManagement = {
 };
 
 const userSync = {
-    syncsPerBidder: 0, // allow all syncs
+    // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
+    syncsPerBidder: 999, // temporarily until above bug fixed
     filterSettings: {
         all: {
             bidders: '*', // allow all bidders to sync by iframe or image beacons

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -31,8 +31,8 @@ const consentManagement = {
 const userSync = {
     syncsPerBidder: 0, // allow all syncs
     filterSettings: {
-        iframe: {
-            bidders: '*', // allow all bidders to sync by iframe
+        all: {
+            bidders: '*', // allow all bidders to sync by iframe or image beacons
             filter: 'include',
         },
     },

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -32,7 +32,7 @@ const userSync = {
     syncsPerBidder: 0, // allow all syncs
     filterSettings: {
         iframe: {
-            bidders: ['sonobi'],
+            bidders: '*', // allow all bidders to sync by iframe
             filter: 'include',
         },
     },

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -97,8 +97,8 @@ describe('initialise', () => {
                 syncEnabled: true,
                 syncsPerBidder: 0,
                 filterSettings: {
-                    iframe: {
-                        bidders: ['sonobi'],
+                    all: {
+                        bidders: '*',
                         filter: 'include',
                     },
                 },

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -95,7 +95,7 @@ describe('initialise', () => {
                 pixelEnabled: true,
                 syncDelay: 3000,
                 syncEnabled: true,
-                syncsPerBidder: 0,
+                syncsPerBidder: 999,
                 filterSettings: {
                     all: {
                         bidders: '*',


### PR DESCRIPTION
A bidder was failing to make user sync calls because of the way our Prebid implementation was configured.  Now any bidder is free to sync users in this way.  

In general, user-sync calls can be made by image beacons or iframe beacons.
See http://prebid.org/dev-docs/publisher-api-reference.html#setConfig-ConfigureUserSyncing-HowUserSyncingWorks
