### PR TITLE
Render picker to support abtest/whitelist

### DIFF
--- a/article/app/services/dotcomponents/RenderType.scala
+++ b/article/app/services/dotcomponents/RenderType.scala
@@ -1,0 +1,5 @@
+package services.dotcomponents
+
+sealed trait RenderType
+case object RemoteRender extends RenderType
+case object LocalRender extends RenderType

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -1,0 +1,34 @@
+package services.dotcomponents
+
+import experiments.{ActiveExperiments, Control, DotcomponentsRendering, Excluded, Participant}
+import model.PageWithStoryPackage
+import play.api.mvc.RequestHeader
+import services.dotcomponents.pickers.{RenderTierPickerStrategy, SimplePagePicker, WhitelistPicker}
+import implicits.Requests._
+
+object RenderingTierPicker {
+
+  // todo: use injection for this
+  val picker: RenderTierPickerStrategy = new SimplePagePicker()
+
+  def getRenderTierFor(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
+
+    // all requests with ?guui automatically get remotely rendered
+
+    if(request.isGuui) {
+      return RemoteRender
+    }
+
+    // otherwise check if we are in the AB test, and are a supported article according to the picker
+
+    val isSupported = picker.getRenderTierFor(page, request)
+
+    ActiveExperiments.groupFor(DotcomponentsRendering) match {
+      case Participant => isSupported
+      case Control => LocalRender
+      case Excluded => LocalRender
+    }
+
+  }
+
+}

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -1,12 +1,13 @@
 package services.dotcomponents
 
+import common.Logging
 import experiments.{ActiveExperiments, Control, DotcomponentsRendering, Excluded, Participant}
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
 import services.dotcomponents.pickers.{RenderTierPickerStrategy, SimplePagePicker, WhitelistPicker}
 import implicits.Requests._
 
-object RenderingTierPicker {
+object RenderingTierPicker extends Logging {
 
   // todo: use injection for this
   val picker: RenderTierPickerStrategy = new SimplePagePicker()
@@ -19,9 +20,16 @@ object RenderingTierPicker {
       return RemoteRender
     }
 
-    // otherwise check if we are in the AB test, and are a supported article according to the picker
+    // log out whenever we find a supported article, for metrics purposes
 
     val isSupported = picker.getRenderTierFor(page, request)
+
+    isSupported match {
+      case RemoteRender => log.info(s"Article was remotely renderable ${page.metadata.id}")
+      case _ =>
+    }
+
+    // We use dotcomponents if we are in the AB test, and are a supported article according to the picker
 
     ActiveExperiments.groupFor(DotcomponentsRendering) match {
       case Participant => isSupported

--- a/article/app/services/dotcomponents/pickers/RenderTierPickerStrategy.scala
+++ b/article/app/services/dotcomponents/pickers/RenderTierPickerStrategy.scala
@@ -1,0 +1,9 @@
+package services.dotcomponents.pickers
+
+import model.PageWithStoryPackage
+import play.api.mvc.RequestHeader
+import services.dotcomponents.RenderType
+
+trait RenderTierPickerStrategy {
+  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType
+}

--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -1,16 +1,13 @@
-package services
+package services.dotcomponents.pickers
 
 import controllers.ArticlePage
 import model.PageWithStoryPackage
 import model.liveblog.{BlockElement, ImageBlockElement, TextBlockElement}
 import play.api.mvc.RequestHeader
+import services.dotcomponents.{LocalRender, RemoteRender, RenderType}
 import views.support.Commercial
 
-sealed trait RenderType
-case object RemoteRender extends RenderType
-case object LocalRender extends RenderType
-
-object RenderingTierPicker {
+class SimplePagePicker extends RenderTierPickerStrategy {
 
   private def isDiscussionDisabled(page: PageWithStoryPackage): Boolean = {
     (! page.article.content.trail.isCommentable) && page.article.content.trail.isClosedForComments
@@ -61,3 +58,4 @@ object RenderingTierPicker {
   }
 
 }
+

--- a/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
+++ b/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
@@ -1,0 +1,23 @@
+package services.dotcomponents.pickers
+import model.PageWithStoryPackage
+import play.api.mvc.RequestHeader
+import services.dotcomponents.{RemoteRender, LocalRender, RenderType}
+
+class WhitelistPicker extends RenderTierPickerStrategy {
+
+  // no real need for this list be config, hardcoding is fine for now
+
+  val whitelist = List(
+    "money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+  )
+
+  override def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType = {
+
+    if(whitelist.contains(page.metadata.id)){
+      RemoteRender
+    } else {
+      LocalRender
+    }
+
+  }
+}

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
-    OldTLSSupportDeprecation
+    OldTLSSupportDeprecation,
+    DotcomponentsRendering
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -48,4 +49,10 @@ object AudioPageChange extends Experiment(
   participationGroup = Perc5A
 )
 
-
+object DotcomponentsRendering extends Experiment(
+  name = "dotcomponents-rendering",
+  description = "This will allow rendering of articles to use dotcomponents, if that page is supported",
+  owners = Seq(Owner.withGithub("MatthewJWalls")),
+  sellByDate = new LocalDate(2018, 12, 31),
+  participationGroup = Perc0A
+)


### PR DESCRIPTION
## What does this change?

* Adds a new 0% abtest for dotcomponents. 
* Modifies the RenderingTierPicker to check the ab test to see if the given page can be rendered with the remote renderer.
* Modifies ArticleController to actually render an article using dotComponents if the picker says it should (which it currently never will because it's using the 0% ABTest)
* Refactors the RenderingTierPicker into a SimplePagePicker and a WhitelistPicker. The whitelist picker just checks articles against a hardcoded whitelist. The whitelist picker is currently unused but will be used when we first go live at the end of the quarter.

## Screenshots

## What is the value of this and can you measure success?

This puts everything in place for using dotcomponents live in production for a subset of our users.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
