### PR TITLE
Set multiple consents at once

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -24,6 +24,11 @@ type PasswordCredential = {
     password: string,
 };
 
+export type SettableConsent = {
+    is: string,
+    consented: boolean,
+};
+
 export type IdentityUser = {
     id: number,
     primaryEmailAddress: string,
@@ -252,16 +257,13 @@ export const getSubscribedNewsletters = () => {
         .catch(() => []);
 };
 
-export const setConsent = (consentId: string, consented: boolean) => {
+export const setConsent = (consents: SettableConsent[]) => {
     const url = `${idApiRoot || ''}/users/me/consents`;
     return fetch(url, {
         mode: 'cors',
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            id: consentId,
-            consented,
-        }),
+        body: JSON.stringify(consents),
         credentials: 'include',
     });
 };

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -10,6 +10,7 @@ import { mergeCalls } from 'common/modules/async-call-merger';
 import { getUrlVars } from 'lib/url';
 import fetch from 'lib/fetch-json';
 import qs from 'qs';
+import reqwest from 'reqwest';
 
 let userFromCookieCache = null;
 
@@ -257,16 +258,16 @@ export const getSubscribedNewsletters = () => {
         .catch(() => []);
 };
 
-export const setConsent = (consents: SettableConsent[]) => {
-    const url = `${idApiRoot || ''}/users/me/consents`;
-    return fetch(url, {
-        mode: 'cors',
+export const setConsent = (consents: SettableConsent[]): Promise<void> =>
+    reqwest({
+        url: `${idApiRoot || ''}/users/me/consents`,
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(consents),
-        credentials: 'include',
+        type: 'json',
+        contentType: 'application/json',
+        withCredentials: true,
+        crossOrigin: true,
+        data: JSON.stringify(consents),
     });
-};
 
 export const ajaxSignIn = (credentials: PasswordCredential) => {
     const url = `${profileRoot || ''}/actions/auth/ajax`;

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -25,7 +25,7 @@ type PasswordCredential = {
 };
 
 export type SettableConsent = {
-    is: string,
+    id: string,
     consented: boolean,
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -14,6 +14,8 @@ import {
     removeSpinner,
 } from './modules/switch';
 import { prependSuccessMessage } from './modules/prependMessage';
+import { setConsent } from './api';
+import type { SettableConsent } from './api';
 
 const consentCheckboxClassName = 'js-manage-account__consentCheckbox';
 const newsletterCheckboxClassName = 'js-manage-account__newsletterCheckbox';
@@ -31,26 +33,13 @@ const UNSUBSCRIPTION_SUCCESS_MESSAGE =
     "You've been unsubscribed from all Guardian marketing newsletters and emails.";
 const ERR_MALFORMED_HTML = 'Something went wrong';
 
-type Consent = {
-    id: string,
-    consented: boolean,
-};
-
 type Newsletter = {
     id: string,
     subscribed: boolean,
 };
 
-const updateConsent = (consent: Consent): Promise<void> =>
-    reqwest({
-        url: `${config.get('page.idApiUrl')}/users/me/consents`,
-        method: 'PATCH',
-        type: 'json',
-        contentType: 'application/json',
-        withCredentials: true,
-        crossOrigin: true,
-        data: JSON.stringify(consent),
-    });
+const updateConsent = (consent: SettableConsent): Promise<void> =>
+    setConsent([consent]);
 
 const updateNewsletter = (newsletter: Newsletter): Promise<void> =>
     reqwest({
@@ -85,7 +74,7 @@ const buildNewsletterUpdatePayload = (
 
 const buildConsentUpdatePayload = (
     fields: NodeList<any> = new NodeList()
-): Consent => {
+): SettableConsent => {
     const consent = {};
     [...fields].forEach((field: HTMLInputElement) => {
         switch (field.type) {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
@@ -1,10 +1,8 @@
 // @flow
 import React, { Component } from 'preact-compat';
 import { Checkbox } from 'common/modules/identity/upsell/checkbox/Checkbox';
-import {
-    get as getConsents,
-    updateRemotely,
-} from 'common/modules/identity/upsell/store/consents';
+import { get as getConsents } from 'common/modules/identity/upsell/store/consents';
+import { setConsent } from 'common/modules/identity/api';
 import type { ConsentType } from 'common/modules/identity/upsell/store/consents';
 
 export class OptOutsList extends Component<
@@ -57,10 +55,11 @@ export class OptOutsList extends Component<
     };
 
     updateChangesRemotely = (): Promise<void> =>
-        Promise.all(
-            this.state.consents.map(c =>
-                updateRemotely(c.isFollowing, c.value.id)
-            )
+        setConsent(
+            this.state.consents.map(c => ({
+                consented: c.isFollowing,
+                id: c.value.id,
+            }))
         );
 
     render() {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
@@ -1,9 +1,5 @@
 // @flow
-import {
-    getAllConsents,
-    getUserFromApi,
-    setConsent,
-} from 'common/modules/identity/api';
+import { getAllConsents, getUserFromApi, setConsent } from 'common/modules/identity/api';
 import type { Followable } from 'common/modules/identity/upsell/consent-card/FollowCard';
 
 type Consent = {
@@ -46,10 +42,5 @@ const get = (): Promise<Followable<Consent>[]> =>
         }))
     );
 
-const updateRemotely = (
-    hasConsented: boolean,
-    consentId: string
-): Promise<void> => setConsent([{ id: consentId, consented: hasConsented }]);
-
 export type { Consent, ConsentType };
-export { get, updateRemotely, fetchConsents };
+export { get, fetchConsents };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
@@ -41,14 +41,15 @@ const get = (): Promise<Followable<Consent>[]> =>
         allConsents.map(consent => ({
             value: consent,
             isFollowing: acceptedConsents.includes(consent.id),
-            onChange: newValue => setConsent(consent.id, newValue),
+            onChange: newValue =>
+                setConsent([{ id: consent.id, consented: newValue }]),
         }))
     );
 
 const updateRemotely = (
     hasConsented: boolean,
     consentId: string
-): Promise<void> => setConsent(consentId, hasConsented);
+): Promise<void> => setConsent([{ id: consentId, consented: hasConsented }]);
 
 export type { Consent, ConsentType };
 export { get, updateRemotely, fetchConsents };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/store/consents.js
@@ -1,5 +1,9 @@
 // @flow
-import { getAllConsents, getUserFromApi, setConsent } from 'common/modules/identity/api';
+import {
+    getAllConsents,
+    getUserFromApi,
+    setConsent,
+} from 'common/modules/identity/api';
 import type { Followable } from 'common/modules/identity/upsell/consent-card/FollowCard';
 
 type Consent = {


### PR DESCRIPTION
## What does this change?
Support setting n consents at once via the new consent api and also centralizes this call in 1 place

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
