### PR TITLE
Fix guardian today emails on gmail small devices

### DIFF
--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -9,7 +9,7 @@
                 <center class="center-element">
                     <table>
                         <tr>
-                            <td class="no-pad">
+                            <td class="no-pad container-td">
                                 <table align="center" class="container float-center">
                                     <tbody>
                                         <tr>

--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ compile: install
 
 # Compile all assets in development.
 compile-dev: install
-	@NODE_ENV=development @./tools/task-runner/runner compile --dev
+	@NODE_ENV=development ./tools/task-runner/runner compile --dev
 
 # Compile atom-specific JS
 compile-atoms: install

--- a/static/src/stylesheets/email/_util.scss
+++ b/static/src/stylesheets/email/_util.scss
@@ -23,7 +23,10 @@
 // table
 .container {
     background: $container-color;
-    width: $max-width;
     margin: 0 auto;
     text-align: left;
+}
+
+.container-td {
+    width: $max-width;
 }


### PR DESCRIPTION
## What does this change?

Fix width on guardian today emails by setting width on the td and not the table

## What is the value of this and can you measure success?

Emails didn't display correctly on small devices using Gmail.
Now the central column resizes correctly

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
