### PR TITLE
Fix ozone appnexus keywords

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -6,6 +6,7 @@ import isEmpty from 'lodash/objects/isEmpty';
 import {
     buildAppNexusTargeting,
     buildPageTargeting,
+    buildAppNexusTargetingObject,
     ozoneAppnexusKeysFormat,
 } from 'common/modules/commercial/build-page-targeting';
 import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike';
@@ -411,7 +412,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {
                     placementId: getAppNexusPlacementId(sizes),
                     keywords: ozoneAppnexusKeysFormat(
-                        buildAppNexusTargeting(buildPageTargeting())
+                        buildAppNexusTargetingObject(buildPageTargeting())
                     ), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -7,7 +7,6 @@ import {
     buildAppNexusTargeting,
     buildPageTargeting,
     buildAppNexusTargetingObject,
-    ozoneAppnexusKeysFormat,
 } from 'common/modules/commercial/build-page-targeting';
 import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe';
@@ -411,8 +410,8 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {},
                 {
                     placementId: getAppNexusPlacementId(sizes),
-                    keywords: ozoneAppnexusKeysFormat(
-                        buildAppNexusTargetingObject(buildPageTargeting())
+                    keywords: buildAppNexusTargetingObject(
+                        buildPageTargeting()
                     ), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -6,6 +6,7 @@ import isEmpty from 'lodash/objects/isEmpty';
 import {
     buildAppNexusTargeting,
     buildPageTargeting,
+    ozoneAppnexusKeysFormat,
 } from 'common/modules/commercial/build-page-targeting';
 import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe';
@@ -409,7 +410,9 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {},
                 {
                     placementId: getAppNexusPlacementId(sizes),
-                    keywords: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+                    keywords: ozoneAppnexusKeysFormat(
+                        buildAppNexusTargeting(buildPageTargeting())
+                    ), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
             ),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -55,6 +55,7 @@ const {
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
+    buildAppNexusTargetingObject: () => 'someAppNexusTargetingObject',
     buildPageTargeting: () => 'bla',
     ozoneAppnexusKeysFormat: () => 'someTestAppNexusTargeting',
 }));

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -56,6 +56,7 @@ const {
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
     buildPageTargeting: () => 'bla',
+    ozoneAppnexusKeysFormat: () => 'someTestAppNexusTargeting',
 }));
 
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -57,7 +57,6 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
     buildAppNexusTargetingObject: () => 'someAppNexusTargetingObject',
     buildPageTargeting: () => 'bla',
-    ozoneAppnexusKeysFormat: () => 'someTestAppNexusTargeting',
 }));
 
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
@@ -217,7 +216,7 @@ describe('getDummyServerSideBidders', () => {
         });
         expect(appNexusParams).toEqual({
             placementId: '13915593',
-            keywords: 'someTestAppNexusTargeting',
+            keywords: 'someAppNexusTargetingObject',
             lotame: { some: 'lotamedata' },
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -35,7 +35,7 @@ export type PrebidXaxisParams = {
 
 export type PrebidAppNexusParams = {
     placementId: string,
-    keywords: Array<{}>,
+    keywords: {},
     lotame?: {},
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -35,7 +35,7 @@ export type PrebidXaxisParams = {
 
 export type PrebidAppNexusParams = {
     placementId: string,
-    keywords: string,
+    keywords: Array<{}>,
     lotame?: {},
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -219,15 +219,8 @@ const buildPageTargeting = once(
     }
 );
 
-const ozoneAppnexusKeysFormat = (keyTargeting: Object): Array<{}> =>
-    Object.keys(keyTargeting).map((key: string) => ({
-        key,
-        [key]: keyTargeting[key],
-    }));
-
 export {
     buildPageTargeting,
     buildAppNexusTargeting,
     buildAppNexusTargetingObject,
-    ozoneAppnexusKeysFormat,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -136,26 +136,30 @@ const formatAppNexusTargeting = (obj: Object): string =>
             })
     ).join(',');
 
+const buildAppNexusTargetingObject = once(
+    (pageTargeting: Object): Object => ({
+        sens: pageTargeting.sens,
+        pt1: pageTargeting.url,
+        pt2: pageTargeting.edition,
+        pt3: pageTargeting.ct,
+        pt4: pageTargeting.p,
+        pt5: pageTargeting.k,
+        pt6: pageTargeting.su,
+        pt7: pageTargeting.bp,
+        pt8: pageTargeting.x,
+        pt9: [
+            pageTargeting.gdncrm,
+            pageTargeting.pv,
+            pageTargeting.co,
+            pageTargeting.tn,
+            pageTargeting.slot,
+        ].join('|'),
+    })
+);
+
 const buildAppNexusTargeting = once(
     (pageTargeting: Object): string =>
-        formatAppNexusTargeting({
-            sens: pageTargeting.sens,
-            pt1: pageTargeting.url,
-            pt2: pageTargeting.edition,
-            pt3: pageTargeting.ct,
-            pt4: pageTargeting.p,
-            pt5: pageTargeting.k,
-            pt6: pageTargeting.su,
-            pt7: pageTargeting.bp,
-            pt8: pageTargeting.x,
-            pt9: [
-                pageTargeting.gdncrm,
-                pageTargeting.pv,
-                pageTargeting.co,
-                pageTargeting.tn,
-                pageTargeting.slot,
-            ].join('|'),
-        })
+        formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting))
 );
 
 const buildPageTargeting = once(
@@ -221,4 +225,9 @@ const ozoneAppnexusKeysFormat = (keyTargeting: Object): Array<{}> =>
         [key]: keyTargeting[key],
     }));
 
-export { buildPageTargeting, buildAppNexusTargeting, ozoneAppnexusKeysFormat };
+export {
+    buildPageTargeting,
+    buildAppNexusTargeting,
+    buildAppNexusTargetingObject,
+    ozoneAppnexusKeysFormat,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -215,4 +215,10 @@ const buildPageTargeting = once(
     }
 );
 
-export { buildPageTargeting, buildAppNexusTargeting };
+const ozoneAppnexusKeysFormat = (keyTargeting: Object): Array<{}> =>
+    Object.keys(keyTargeting).map((key: string) => ({
+        key,
+        [key]: keyTargeting[key],
+    }));
+
+export { buildPageTargeting, buildAppNexusTargeting, ozoneAppnexusKeysFormat };


### PR DESCRIPTION
## What does this change?

This fixes AppNexus `keywords` to be a `key: value` object instead of a `string`.

The AppNexus adapter in Prebid subsequently changes this to `{'key': key, key: value}`, for example `{'key': 'a', 'a': 1}`

@guardian/commercial-dev 