### PR TITLE
Support rss redirects and redirects for individual tags in tag combiners

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -84,7 +84,9 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
     }
   }
 
-  private def destinationFor(path: String): Future[Option[Destination]] = redirects.destinationFor(normalise(path))
+  private def destinationFor(path: String): Future[Option[Destination]] = {
+    redirects.getDestination(normalise(path))
+  }
 
   private object Combiner {
     def unapply(path: String): Option[String] = {

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -84,9 +84,7 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
     }
   }
 
-  private def destinationFor(path: String): Future[Option[Destination]] = {
-    redirects.getDestination(normalise(path))
-  }
+  private def destinationFor(path: String): Future[Option[Destination]] = redirects.getDestination(normalise(path))
 
   private object Combiner {
     def unapply(path: String): Option[String] = {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -21,7 +21,7 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
   with WithTestWsClient {
 
   lazy val mockRedirects = new RedirectService {
-    override def destinationFor(source: String) = Future.successful(None)
+    override def lookupRedirectDestination(source: String) = Future.successful(None)
   }
   lazy val archiveController = new ArchiveController(mockRedirects, play.api.test.Helpers.stubControllerComponents(), wsClient)
 

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -21,7 +21,15 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
   with WithTestWsClient {
 
   lazy val mockRedirects = new RedirectService {
-    override def lookupRedirectDestination(source: String) = Future.successful(None)
+    override def lookupRedirectDestination(source: String) = {
+      if (source == "/lifeandstyle/restaurants"){
+        Future.successful(Some(PermanentRedirect(source, "https://www.theguardian.com/food/cookityourselflazy")))
+      } else if (source == "books/politics") {
+        Future.successful(Some(PermanentRedirect(source, "https://www.theguardian.com/books/nopasaran")))
+      } else {
+        Future.successful(None)
+      }
+    }
   }
   lazy val archiveController = new ArchiveController(mockRedirects, play.api.test.Helpers.stubControllerComponents(), wsClient)
 
@@ -107,6 +115,32 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
   it should "not redirect a random URL that contains the word century" in {
     val result = archiveController.lookup("/discover-culture/2014/jul/22/mid-century-textiles-then-and-now")(TestRequest())
     status(result) should be (404)
+  }
+
+  it should "redirect combiners to the the redirect location of individual tags" in {
+    val result = archiveController.lookup("/lifeandstyle/restaurants+media/chris-evans")(TestRequest())
+    status(result) should be (301)
+    location(result) should be ("/food/cookityourselflazy+media/chris-evans")
+
+    val result2 = archiveController.lookup("/lifeandstyle/restaurants+books/politics")(TestRequest())
+    status(result2) should be (301)
+    location(result2) should be ("/food/cookityourselflazy+books/nopasaran")
+  }
+
+  it should "redirect rss requests to redirect location of associated tag " in {
+    val result = archiveController.lookup("/lifeandstyle/restaurants/rss")(TestRequest())
+    status(result) should be (301)
+    location(result) should be ("/food/cookityourselflazy/rss")
+  }
+
+  it should "redirect rss combiners to the the redirect location of individual tags" in {
+    val result = archiveController.lookup("/lifeandstyle/restaurants+media/chris-evans/rss")(TestRequest())
+    status(result) should be (301)
+    location(result) should be ("/food/cookityourselflazy+media/chris-evans/rss")
+
+    val result2 = archiveController.lookup("/lifeandstyle/restaurants+books/politics/rss")(TestRequest())
+    status(result2) should be (301)
+    location(result2) should be ("/food/cookityourselflazy+books/nopasaran/rss")
   }
 
   it should "redirect failed combiners to the (non-editionalised) section" in {


### PR DESCRIPTION
## What does this change?
The original motivation for this PR was a reader complaining that their RSS feed for guardian restaurant reviews - http://theguardian.com/lifeandstyle/restaurants+tone/reviews/rss - was redirecting to just a standard lifeandstyle rss feed. This is due to a kind of catch all behaviour in archive where if it can't find a redirect for a tag page then it just redirects to the section page, which is pretty reasonable behaviour but not really ideal.

This PR adds support for:
 -  redirects for rss pages - e.g. www.theguardian.com/lifeandstyle/food/rss  - simply by stripping any `/rss` suffix from a url before looking up the redirect, then adding it back on afterwards
 - redirects for tag combiner pages - by breaking up the tag combiner url into the individual tags and checking those individually for any redirects 

## What is the value of this and can you measure success?
We get free redirects for rss pages and tag combiners without any extra effort from central production

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
