### PR TITLE
Podcast episodes onward journeys

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -154,7 +154,7 @@
                                     </div>
                                 }
                             }
-                            case a: Audio if conf.switches.Switches.AudioMostViewedSwitch.isSwitchedOn => {
+                            case a: Audio if conf.switches.Switches.AudioOnwardJourneySwitch.isSwitchedOn => {
                                 <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
                                 aria-hidden="true">
                                     <div class="js-audio-components-container"></div>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -154,6 +154,17 @@
                                     </div>
                                 }
                             }
+                            case a: Audio if conf.switches.Switches.AudioMostViewedSwitch.isSwitchedOn => {
+                                <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
+                                aria-hidden="true">
+                                    <div class="js-audio-components-container"></div>
+                                    @if(a.fields.body.nonEmpty) {
+                                        <br/>
+                                        @fragments.commercial.standardAd("right", Seq("dark"), Map("desktop" -> Seq("300,250", "300,274", "fluid")))
+                                    }
+                                </div>
+                            }
+
                             case a: Audio if a.fields.body.nonEmpty => {
                                 <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
                                 aria-hidden="true">

--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -22,4 +22,14 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val AudioMostViewedSwitch = Switch(
+    SwitchGroup.Journalism,
+    "audio-most-viewed-switch",
+    "Display most viewed audio on audio pages",
+    owners = Seq(Owner.withName("journalism team")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -23,10 +23,10 @@ trait JournalismSwitches {
     exposeClientSide = true
   )
 
-  val AudioMostViewedSwitch = Switch(
+  val AudioOnwardJourneySwitch = Switch(
     SwitchGroup.Journalism,
-    "audio-most-viewed-switch",
-    "Display most viewed audio on audio pages",
+    "audio-onward-journey-switch",
+    "Display latest podcast episodes on audio pages",
     owners = Seq(Owner.withName("journalism team")),
     safeState = Off,
     sellByDate = never,

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -335,6 +335,7 @@ GET            /football-mf2/api/match-summary/:year/:month/:day/:home/:away.jso
 GET            /editionalised-nav.json                                                                                           controllers.NavigationController.renderAmpNav()
 
 # Onward journeys
+GET            /audio/series/*path.json                                                                                          controllers.SeriesController.renderPodcastEpisodes(path)
 GET            /series/*path.json                                                                                                controllers.SeriesController.renderSeriesStories(path)
 
 # opt-in/out routes

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -48,6 +48,14 @@ class SeriesController(
     }
   }
 
+  def renderPodcastEpisodes(seriesId: String): Action[AnyContent] = Action.async { implicit request =>
+    lookup(Edition(request), seriesId) map {
+      _.map(series => Cached(900) {
+        JsonComponent(views.html.fragments.podcastEpisodes(series.trails.items.take(4).map(_.content)))
+      }).getOrElse(NotFound)
+    }
+  }
+
   private def lookup( edition: Edition, seriesId: String)(implicit request: RequestHeader): Future[Option[Series]] = {
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
     log.info(s"Fetching content in series: $seriesId the ShortUrl $currentShortUrl" )

--- a/onward/app/views/fragments/mediaItem.scala.html
+++ b/onward/app/views/fragments/mediaItem.scala.html
@@ -16,7 +16,10 @@
             }
             <h4 class="fc-item__title">
                 @content match {
-                    case a: Audio => { @a.metadata.webTitle }
+                    case a: Audio => {
+                        @fragments.inlineSvg("volume-high", "icon", List("yellow"))
+                        @a.metadata.webTitle
+                    }
                     case v: Video => {
                         @fragments.inlineSvg("video-icon", "icon", List("yellow"))
                         @v.videoLinkText

--- a/onward/app/views/fragments/podcastEpisodes.scala.html
+++ b/onward/app/views/fragments/podcastEpisodes.scala.html
@@ -1,0 +1,17 @@
+@(audios: Seq[model.ContentType])(implicit request: RequestHeader)
+
+@import views.support.Seq2zipWithRowInfo
+
+<div class="most-viewed-container most-viewed-container--media most-viewed-container--audio"
+data-component="most-viewed-audio">
+
+    <div class="most-viewed-container__header">
+        <h3 class="most-viewed-container__heading">More from this series</h3>
+    </div>
+    <ul class="u-cf u-unstyled most-viewed--media most-viewed--audio items--media items--audio" data-link-name="More from this series">
+    @audios.zipWithRowInfo.map{ case (audio, row) =>
+        @fragments.mediaItem(audio, row.rowNum)
+    }
+    </ul>
+
+</div>

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -61,6 +61,7 @@ GET        /gallery/most-viewed                       controllers.MostViewedGall
 # Experimental
 GET        /cards/opengraph/*path.json                controllers.CardController.opengraph(path)
 GET        /tagged.json                               controllers.TaggedContentController.renderJson(tag: String)
+GET        /audio/series/*path.json                   controllers.SeriesController.renderPodcastEpisodes(path)
 GET        /series/*path.json                         controllers.SeriesController.renderSeriesStories(path)
 
 # Business data

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -118,7 +118,7 @@ const initOnwardVideoContainer = (): void => {
 
 const initOnwardAudioContainer = (): void => {
     if (config.get('page.contentType') === 'Audio') {
-        $('.js-audio-components-container').each(el => onwardAudio(el))
+        $('.js-audio-components-container').each(el => onwardAudio(el));
     }
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -16,6 +16,7 @@ import { related } from 'common/modules/onward/related';
 import { TonalComponent } from 'common/modules/onward/tonal';
 import { loadShareCounts } from 'common/modules/social/share-count';
 import { onwardVideo } from 'common/modules/video/onward-container';
+import { onwardAudio } from 'common/modules/audio/onward-container';
 import { moreInSeriesContainerInit } from 'common/modules/video/more-in-series-container';
 
 const initMoreInSection = (): void => {
@@ -115,6 +116,12 @@ const initOnwardVideoContainer = (): void => {
     });
 };
 
+const initOnwardAudioContainer = (): void => {
+    if (config.get('page.contentType') === 'Audio') {
+        $('.js-audio-components-container').each(el => onwardAudio(el))
+    }
+};
+
 const initOnwardContent = () => {
     insertOrProximity('.js-onward', () => {
         if (
@@ -134,6 +141,7 @@ const initOnwardContent = () => {
     });
 
     initOnwardVideoContainer();
+    initOnwardAudioContainer();
 };
 
 const initDiscussion = () => {

--- a/static/src/javascripts/projects/common/modules/audio/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/audio/onward-container.js
@@ -1,0 +1,29 @@
+// @flow
+
+import config from 'lib/config';
+import { Component } from 'common/modules/component';
+
+const createComponent = (
+    el: HTMLElement,
+    endpoint: string,
+    manipulationType: string
+): Promise<void> => {
+    const component = new Component();
+
+    component.manipulationType = manipulationType;
+    component.endpoint = `${endpoint}?shortUrl=${config.page.shortUrl}`;
+    el.innerHTML = '';
+
+    return component.fetch(el, 'html');
+};
+
+const onwardAudio = (el: HTMLElement) => {
+    if (config.page.seriesId) {
+        const manipulationType = 'append';
+        const endpoint = `/audio/series/${config.page.seriesId}.json`;
+
+        createComponent(el, endpoint, manipulationType);
+    }
+};
+
+export { onwardAudio };

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -1043,7 +1043,7 @@ $ima-controls-height: 70px;
         font-weight: 500;
         text-align: left; //Required for end slate items
         height: get-line-height(headline, 1) * 3;
-        .inline-video-icon {
+        .inline-video-icon, .inline-volume-high {
             fill: $highlight-main;
             svg {
                 height: .75em;


### PR DESCRIPTION
## What does this change?
Changes audio pages to display the latest 4 episodes of the current podcast on the right hand side. Uses the same styling as the existing "Most viewed videos" component on video pages.

We will track clicks (using the `data-component`) but this is not an a/b test.

## Screenshots
<img width="984" alt="picture 13" src="https://user-images.githubusercontent.com/1513454/45499158-b9bb9300-b773-11e8-8c7c-caec6f5d7cd0.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
