### PR TITLE
Updated the wording in the reauthenticate page privacy policy

### DIFF
--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -18,7 +18,8 @@
             <div class="fieldset__heading">
                 <h2 class="form__heading">Use your social account</h2>
                 <div class="form__note">
-                    By proceeding, you agree to the Guardian's <a class="u-underline" href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of service">Terms of Service</a> and <a class="u-underline" href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy policy">Privacy Policy</a>.
+                    By proceeding, you agree to our <a class="u-underline" href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of service">Terms & Conditions</a>.
+                        To find out what personal data we collect and how we use it, please visit our <a class="u-underline" href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy policy">Privacy Policy</a>.
                 </div>
             </div>
             <div class="fieldset__fields">


### PR DESCRIPTION
## What does this change?
Consistent wording on privacy policy for the re-authenticate page.

## Screenshots
![screen shot 2018-09-14 at 14 54 11](https://user-images.githubusercontent.com/42539745/45554357-1c716500-b82e-11e8-833b-e6d5b694c274.png)

## What is the value of this and can you measure success?
Keep Data Privacy happy 

## Checklist

### Does this affect other platforms? No

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
