### PR TITLE
Fix for tag-targeted pageskins

### DIFF
--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -51,13 +51,28 @@
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")">
 
     <h1>Pageskins</h1>
-    <p>Pages will squish to accommodate pageskins according to these criteria:</p>
+    <p>Pages will squish to accommodate pageskins according to either of these criteria:</p>
     <ol>
-        <li>The Ad Unit must be a <em>front</em>, including the final "/ng" ad unit</li>
-        <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
-        <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
-        <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
-        <li>The viewport must be at least 1300px wide.</li>
+        <li>
+            <h4>Targeting a section front:</h4>
+            <ul>
+                <li>The Ad Unit must be a <em>front</em>, including the final "/ng" ad unit</li>
+                <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
+                <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
+                <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
+                <li>The viewport must be at least 1300px wide.</li>
+            </ul>
+        </li>
+        <li>
+            <h4>Targeting a keyword or series front:</h4>
+            <ul>
+                <li>The line item must target the name (last part) of a <em>keyword</em> or <em>series</em></li>
+                <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
+                <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
+                <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
+                <li>The viewport must be at least 1300px wide.</li>
+            </ul>
+        </li>
     </ol>
 
     <h2>Pageskinned Ad Units</h2>

--- a/common/app/common/dfp/PageSkinSponsorship.scala
+++ b/common/app/common/dfp/PageSkinSponsorship.scala
@@ -35,9 +35,8 @@ object PageSkinSponsorshipReport {
 object PageSkin {
   private val ngFrontSuffix = "/front/ng"
   private val frontSuffix = "/front"
-  private val tagPageSuffix = "/subsection/ng"
 
-  private val validAdUnitSuffixes = Seq(ngFrontSuffix, frontSuffix, tagPageSuffix)
+  private val validAdUnitSuffixes = Seq(ngFrontSuffix, frontSuffix)
 
   def isValidAdUnit(adUnitPath: String): Boolean = validAdUnitSuffixes.exists(suffix => adUnitPath endsWith suffix)
 }

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -1,8 +1,8 @@
 package common.dfp
 
-import common.Edition
 import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues}
+import common.Edition
 import model.MetaData
 
 trait PageskinAdAgent {
@@ -14,27 +14,31 @@ trait PageskinAdAgent {
   // There are two forms of pageskins:
   // - pageskins that target through ad unit (for pressed fronts)
   // - pageskins that target through a keyword (for index page fronts)
-  private def findSponsorships(adUnitPath: String, metaData: MetaData, edition: Edition): Seq[PageSkinSponsorship] = {
+  private[dfp] def findSponsorships(
+    adUnitPath: String,
+    metaData: MetaData,
+    edition: Edition
+  ): Seq[PageSkinSponsorship] = {
 
     val candidates = pageSkinSponsorships filter { sponsorship =>
-      sponsorship.editions.contains(edition) && !sponsorship.isR2Only }
+      sponsorship.editions.contains(edition) && !sponsorship.isR2Only
+    }
 
-    if (metaData.isPressedPage) {
-      if (PageSkin.isValidAdUnit(adUnitPath)) {
-        candidates filter { sponsorship => sponsorship.adUnits.exists(adUnitPath.endsWith) }
-      } else Seq.empty
+    if (PageSkin.isValidAdUnit(adUnitPath)) {
+      candidates filter { sponsorship =>
+        sponsorship.adUnits.exists(adUnitPath.endsWith)
+      }
     } else {
       val targetingMap = toMap(metaData.commercial.map(_.adTargeting(edition)).getOrElse(Set.empty))
 
-      val targetingMapValues = ((map: Map[String, AdTargetParamValue], key: String) =>
+      val targetingMapValues = (map: Map[String, AdTargetParamValue], key: String) =>
         map.get(key) match {
           case Some(values: MultipleValues) => values.values.toSeq
-          case _ => Seq.empty
-        }
-      )
+          case _                            => Seq.empty
+      }
 
-      val keywordTargeting = targetingMapValues( targetingMap , "k" )
-      val seriesTargeting = targetingMapValues( targetingMap , "se" )
+      val keywordTargeting = targetingMapValues(targetingMap, "k")
+      val seriesTargeting  = targetingMapValues(targetingMap, "se")
 
       candidates filter { sponsorship =>
         sponsorship.keywords.intersect(keywordTargeting).nonEmpty ||

--- a/common/test/common/dfp/PageSkinTest.scala
+++ b/common/test/common/dfp/PageSkinTest.scala
@@ -4,8 +4,9 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class PageSkinTest extends FlatSpec with Matchers {
 
-  "isValidAdUnit" should "be true for a keyword page that's been replaced by a pressed front" in {
-    PageSkin.isValidAdUnit("/123456/root/technology/subsection/ng") shouldBe true
+  "isValidAdUnit" should "be false for a keyword page that's been replaced by a pressed front" in {
+    // keyword pages should be targeted by keyword instead of by ad unit
+    PageSkin.isValidAdUnit("/123456/root/technology/subsection/ng") shouldBe false
   }
 
   it should "be true for a section front" in {

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -1,8 +1,7 @@
 package common.dfp
 
-import com.gu.contentapi.client.model.v1.{ Tag, TagType }
 import com.gu.commercial.display.{AdTargetParam, KeywordParam, SeriesParam}
-
+import com.gu.contentapi.client.model.v1.{Tag, TagType}
 import common.Edition.defaultEdition
 import common.commercial.{CommercialProperties, EditionAdTargeting}
 import common.editions.{Au, Uk, Us}
@@ -41,6 +40,8 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
 
   val sportIndexFrontMeta = MetaData.make("", None, "The title", None, isFront = true, commercial = Some(commercialProperties))
   val articleMeta = MetaData.make("", None, "The title", None)
+
+  val keywordPressedFrontMeta = MetaData.make("", None, "The title", None, isFront = true, isPressedPage = true, commercial = Some(commercialProperties))
 
   val examplePageSponsorships = Seq(
     PageSkinSponsorship(
@@ -171,5 +172,26 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     NotProductionTestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta,
       defaultEdition) should be(
       true)
+  }
+
+  "findSponsorships" should "find keyword-targeted sponsorship when keyword page has been overwritten by a pressed front" in {
+    TestPageskinAdAgent.findSponsorships(
+      adUnitPath = "/123456/root/technology/subsection/ng",
+      metaData = keywordPressedFrontMeta,
+      edition = Uk
+    ) shouldBe Seq(
+      PageSkinSponsorship(
+        lineItemName = "lineItemName5",
+        lineItemId = 123458,
+        adUnits = Seq("sport-index"),
+        editions = Seq(Uk),
+        countries = Nil,
+        isR2Only = false,
+        targetsAdTest = false,
+        adTestValue = None,
+        keywords = Seq("sport-keyword"),
+        series = Nil
+      )
+    )
   }
 }


### PR DESCRIPTION
My previous fix (#20355) didn't take into account the different ways in which pageskins can be targeted.

This should fix cases where the page is targeted by a tag, but the tag page has been overridden by a pressed front.
