### PR TITLE
Allow always ask by tag to show on interactives

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -18,6 +18,8 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeABTest({
     audience: 1,
     audienceOffset: 0,
     useTargetingTool: true,
+    pageCheck: page =>
+        page.contentType === 'Article' || page.contentType === 'Interactive',
 
     variants: [
         {


### PR DESCRIPTION
The interactive will have to have an empty `<div class="submeta"></div>` at the very bottom for this to work