### PR TITLE
Change content on podcast front test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
@@ -18,11 +18,11 @@ import containerWaveCLarge from 'svgs/journalism/podcast-container/waveform-c.sv
 import containerWaveCTablet from 'svgs/journalism/podcast-container/waveform-c-tablet.svg';
 import containerWaveCMobile from 'svgs/journalism/podcast-container/waveform-c-mobile.svg';
 
-const headline = 'Denialism: what drives people to reject the truth';
+const headline = 'How to be human: the man who was raised by wolves';
 const standfirst =
-    'From vaccines to climate change to genocide, a new age of denialism is upon us. Why have we failed to understand it?';
+    'Abandoned as a child, Marcos Rodríguez Pantoja survived alone in the wild for 15 years. But living with people proved to be even more difficult';
 const episodeUrl =
-    '/news/audio/2018/sep/03/denialism-what-drives-people-to-reject-the-truth-podcast';
+    '/news/audio/2018/sep/10/how-to-be-human-the-man-who-was-raised-by-wolves-podcast';
 const seriesUrl = '/news/series/the-audio-long-read';
 const urlWithCampaign = (url: string, variant: string) =>
     `${url}?CMP=podcast-container-${variant}`;
@@ -140,8 +140,8 @@ const trackImpression = (name: string) => (track: () => void): void => {
 
 export const PodcastContainer = {
     id: 'PodcastContainer',
-    start: '2018-08-21',
-    expiry: '2018-09-23',
+    start: '2018-09-17',
+    expiry: '2018-10-17',
     author: 'Tom Forbes',
     description: 'Test designs for a /uk podcasts container',
     audience: 1,

--- a/static/src/javascripts/projects/journalism/views/podcastContainerA.html
+++ b/static/src/javascripts/projects/journalism/views/podcastContainerA.html
@@ -3,7 +3,7 @@
         <div class="fc-item__container">
             <div class="fc-item__content">
                 <div class="podcast-container-a__logo">
-                    <img src="https://uploads.guim.co.uk/2018/09/06/pod-cast-front-test.png"/>
+                    <img src="https://uploads.guim.co.uk/2018/09/17/wolf.png"/>
                 </div>
                 <div class="fc-item__header">
                     <h2 class="fc-item__title">

--- a/static/src/javascripts/projects/journalism/views/podcastContainerB.html
+++ b/static/src/javascripts/projects/journalism/views/podcastContainerB.html
@@ -3,7 +3,7 @@
         <div class="podcast-container-b__episode">
             <div class="podcast-container-b__episode-image">
                 <%= audioIcon %>
-                <img src="https://uploads.guim.co.uk/2018/09/06/pod-cast-front-test.png"/>
+                <img src="https://uploads.guim.co.uk/2018/09/17/wolf.png"/>
             </div>
             <div class="podcast-container-b__episode-details">
                 <div class="fc-item__header">

--- a/static/src/javascripts/projects/journalism/views/podcastContainerC.html
+++ b/static/src/javascripts/projects/journalism/views/podcastContainerC.html
@@ -1,7 +1,7 @@
 <div class="fc-slice-wrapper">
     <div class="podcast-container-c__main fc-item--type-media">
         <div class="podcast-container-c__episode-image">
-            <img src="https://uploads.guim.co.uk/2018/09/06/pod-cast-front-test.png"/>
+            <img src="https://uploads.guim.co.uk/2018/09/17/wolf.png"/>
         </div>
         <div class="podcast-container-c__episode-kicker podcast-container-c__yellow">Podcast</div>
         <div class="podcast-container-c__episode-empty"></div>


### PR DESCRIPTION
## What does this change?
Updates the content in the network front podcast container test.
I've given the test a duration of a month, so we need to manually switch the test off once we have enough data

## Screenshots
<img width="874" alt="picture 14" src="https://user-images.githubusercontent.com/1513454/45618809-eff85b80-ba6e-11e8-834e-a5a6f4ae3b69.png">
<img width="1160" alt="picture 15" src="https://user-images.githubusercontent.com/1513454/45618810-eff85b80-ba6e-11e8-8a84-7b40d2c94b29.png">
<img width="1259" alt="picture 16" src="https://user-images.githubusercontent.com/1513454/45618811-eff85b80-ba6e-11e8-8868-641a9a1da8c5.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
