### PR TITLE
Remove ad-free kill switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -57,16 +57,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val AdFreeEmergencyShutdown = Switch(
-    Commercial,
-    "ad-free-emergency-shutdown",
-    "When ON, we kill the ad-free service immediately. This is a temporary switch for live-testing.",
-    owners = Seq(Owner.withGithub("JustinPinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 9, 18),
-    exposeClientSide = true
-  )
-
   val AdFreeStrictExpiryEnforcement = Switch(
     Commercial,
     "ad-free-strict-expiry-enforcement",

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -203,11 +203,6 @@ const bootStandard = (): void => {
     // Set adtest query if url param declares it
     setAdTestCookie();
 
-    // If we flip the kill switch over ad-free, immediately remove the cookie
-    if (config.get('switches.adFreeEmergencyShutdown')) {
-        removeCookie('GU_AF1');
-    }
-
     // set a short-lived cookie to trigger server-side ad-freeness
     // if the user is genuinely ad-free, this one will be overwritten
     // in user-features

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -54,7 +54,6 @@ const timeInDaysFromNow = (daysFromNow: number): string => {
 };
 
 const persistResponse = (JsonResponse: () => void) => {
-    const switches = config.switches;
     addCookie(USER_FEATURES_EXPIRY_COOKIE, timeInDaysFromNow(1));
     addCookie(PAYING_MEMBER_COOKIE, JsonResponse.contentAccess.paidMember);
     addCookie(

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -71,20 +71,17 @@ const persistResponse = (JsonResponse: () => void) => {
         addCookie(ACTION_REQUIRED_FOR_COOKIE, JsonResponse.alertAvailableFor);
     }
 
-    if (switches.adFreeEmergencyShutdown) {
+    if (
+        adFreeDataIsPresent() &&
+        !JsonResponse.adFree &&
+        !forcedAdFreeMode &&
+        !JsonResponse.contentAccess.digitalPack
+    ) {
         removeCookie(AD_FREE_USER_COOKIE);
-    } else {
-        if (
-            adFreeDataIsPresent() &&
-            !JsonResponse.adFree &&
-            !forcedAdFreeMode &&
-            !JsonResponse.contentAccess.digitalPack
-        ) {
-            removeCookie(AD_FREE_USER_COOKIE);
-        }
-        if (JsonResponse.adFree || JsonResponse.contentAccess.digitalPack) {
-            addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
-        }
+    }
+
+    if (JsonResponse.adFree || JsonResponse.contentAccess.digitalPack) {
+        addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
     }
 };
 
@@ -226,8 +223,7 @@ const shouldSeeReaderRevenue = (): boolean =>
     !isDigitalSubscriber();
 
 const isAdFreeUser = (): boolean =>
-    !config.switches.adFreeEmergencyShutdown &&
-    (isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld()));
+    isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
 
 export {
     accountDataUpdateWarning,


### PR DESCRIPTION
## What does this change?
Removes an expiring switch

## Screenshots
N/A

## What is the value of this and can you measure success?
The feature has been active for months, and fully live for nearly two weeks now. We don't want it to be possible to deactivate it accidentally, so the switch can go.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [x] Locally
- [x] On CODE (optional)
