### PR TITLE
Change unsubscribe link for ET emails

### DIFF
--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -3,6 +3,7 @@
 @import fragments.email._
 @import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
+@import implicits.Requests._
 
 
 <table class="ft">
@@ -15,7 +16,11 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                    @if(request.isEmailJson) {
+                                        <a href="%%unsub_center_url%%">Unsubscribe</a> |
+                                    } else {
+                                        <a href="%%microsite_base_url[default]40543[/default]%%">Unsubscribe</a> |
+                                    }
                                     <a href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
## What does this change?

Use ET macro for unsubscribing from an email link. For Braze emails we still use the old link to find an replace.

## What is the value of this and can you measure success?

The new macro unsubscribes from the individual newsletter rather than all. This is necessary for the ET -> Braze migration.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
