### PR TITLE
Remove thrasher experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,8 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     AudioPageChange,
     CommercialClientLogging,
     OrielParticipation,
-    OldTLSSupportDeprecation,
-    ThrasherAdjacentMPU
+    OldTLSSupportDeprecation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -47,14 +46,6 @@ object AudioPageChange extends Experiment(
   owners = Owner.group(SwitchGroup.Journalism),
   sellByDate = new LocalDate(2018, 9, 27),
   participationGroup = Perc5A
-)
-
-object ThrasherAdjacentMPU extends Experiment(
-  name = "thrasher-adjacent-mpu",
-  description = "This will no longer allow an MPU to show adjacent to a thrasher on mobile",
-  owners = Seq(Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2018, 9, 18),
-  participationGroup = Perc10A
 )
 
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -712,8 +712,6 @@ object setSvgClasses {
 }
 
 case class CommercialMPUForFronts(isNetworkFront: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
-  import experiments.{ ActiveExperiments, ThrasherAdjacentMPU }
-
   override def clean(document: Document): Document = {
 
     def isNetworkFrontWithThrasher(element: Element, index: Int): Boolean = {
@@ -736,8 +734,7 @@ case class CommercialMPUForFronts(isNetworkFront: Boolean)(implicit val request:
     // and remove a container if it, or the next sibling, is a commercial container
     // then we take every other container, up to a maximum of 10, for targeting MPU insertion
     val containersForCommercialMPUs = containers.zipWithIndex.collect {
-      case (x, i) if ActiveExperiments.isParticipating(ThrasherAdjacentMPU) && !isNetworkFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
-      case (x, i) if !ActiveExperiments.isParticipating(ThrasherAdjacentMPU) && !isNetworkFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) => x
+      case (x, i) if !isNetworkFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
     }.zipWithIndex.collect {
       case (x, i) if i % 2 == 0 => x
     }.take(10)


### PR DESCRIPTION
## What does this change?

This removes the test around the impact of less MPUs on network fronts by disallowing them to be adjacent to a thrasher.

@guardian/commercial-dev 