### PR TITLE
Change US politics to midterms temporarily

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -14,7 +14,7 @@ object NavLinks {
   val indigenousAustralia = NavLink("Indigenous Australia", "/australia-news/indigenous-australians")
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = "US news")
-  val usPolitics = NavLink("US politics", "/us-news/us-politics", longTitle = "US politics")
+  val usPolitics = NavLink("US midterms 2018", "/us-news/us-midterm-elections-2018", longTitle = "US politics")
   val teachers = NavLink("Teachers", "/teacher-network")
   val education = NavLink("Education", "/education", children = List(teachers))
   val society = NavLink("Society", "/society")


### PR DESCRIPTION
## What does this change?
Updates the destination of the US politics nav link to go to the midterms page instead.
## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
