### PR TITLE
Better event name for podcast onward journey

### DIFF
--- a/onward/app/views/fragments/podcastEpisodes.scala.html
+++ b/onward/app/views/fragments/podcastEpisodes.scala.html
@@ -3,7 +3,7 @@
 @import views.support.Seq2zipWithRowInfo
 
 <div class="most-viewed-container most-viewed-container--media most-viewed-container--audio"
-data-component="most-viewed-audio">
+data-component="podcast-recent-episodes">
 
     <div class="most-viewed-container__header">
         <h3 class="most-viewed-container__heading">More from this series</h3>


### PR DESCRIPTION

Following on from https://github.com/guardian/frontend/pull/20359
For tracking, use a more appropriate name.
This was originally going to be most viewed, but is actually now the most recent episodes
