### PR TITLE
Add an AB test for setting and reading CMP consent cookies

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -8,6 +8,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-commercial-cmp-customise",
+    "change the location and format of your CMP data",
+    owners = Seq(Owner.withGithub("katebee")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-ask-four-earning",
     "This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -69,7 +69,7 @@ const generateStore = (isInTest: boolean): CmpStore => {
         CMP_ID,
         CMP_VERSION,
         COOKIE_VERSION,
-        isInTest ? readConsentCookie(COOKIE_NAME) : null,
+        readConsentCookie(COOKIE_NAME),
         globalVendorList,
         isInTest
     );

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -6,11 +6,7 @@ import { getVariant, isInVariant } from 'common/modules/experiments/utils';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise';
 import { log } from './log';
 import { CmpStore } from './store';
-import {
-    encodeVendorConsentData,
-    readVendorConsentCookie,
-    writeVendorConsentCookie,
-} from './cookie';
+import { encodeVendorConsentData } from './cookie';
 import { vendorList as globalVendorList } from './vendorlist';
 
 import {

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -1,10 +1,18 @@
 // @flow strict
 
-import { log } from 'commercial/modules/cmp/log';
-import { CmpStore } from 'commercial/modules/cmp/store';
 import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
-import { vendorList as globalVendorList } from 'commercial/modules/cmp/vendorlist';
+import { getVariant, isInVariant } from 'common/modules/experiments/utils';
+import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise';
+import { log } from './log';
+import { CmpStore } from './store';
+import {
+    encodeVendorConsentData,
+    readVendorConsentCookie,
+    writeVendorConsentCookie,
+} from './cookie';
+import { vendorList as globalVendorList } from './vendorlist';
+
 import {
     defaultConfig,
     CMP_GLOBAL_NAME,
@@ -12,15 +20,14 @@ import {
     CMP_VERSION,
     COOKIE_VERSION,
     COOKIE_NAME,
-} from 'commercial/modules/cmp/cmp-env';
-import { encodeVendorConsentData } from 'commercial/modules/cmp/cookie';
+} from './cmp-env';
 
 import type {
     CmpConfig,
     ConsentDataResponse,
     VendorList,
     VendorConsentResponse,
-} from 'commercial/modules/cmp/types';
+} from './types';
 
 type MessageData = {
     __cmpCall: ?{
@@ -54,6 +61,23 @@ const readConsentCookie = (cookieName: string): boolean | null => {
     if (cookieVal && cookieVal.split('.')[0] === '1') return true;
     if (cookieVal && cookieVal.split('.')[0] === '0') return false;
     return null;
+};
+
+const isInCmpCustomiseTest = (): boolean => {
+    const variant = getVariant(commercialCmpCustomise, 'variant');
+    return variant ? isInVariant(commercialCmpCustomise, variant) : false;
+};
+
+const generateStore = (isInTest: boolean): CmpStore => {
+    const store = new CmpStore(
+        CMP_ID,
+        CMP_VERSION,
+        COOKIE_VERSION,
+        isInTest ? readConsentCookie(COOKIE_NAME) : null,
+        globalVendorList,
+        isInTest
+    );
+    return store;
 };
 
 const isInEU = (): boolean =>
@@ -181,7 +205,7 @@ class CmpService {
         } else {
             log.info(
                 `Proccess command: ${command}, parameter: ${parameter ||
-                    'unkonwn'}`
+                    'unknown'}`
             );
             this.commands[command](parameter, callback);
         }
@@ -253,14 +277,9 @@ export const init = (): void => {
     if (window[CMP_GLOBAL_NAME]) {
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};
+        const shouldAccessTestCookie = isInCmpCustomiseTest();
         // Initialize the store with all of our consent data
-        const store = new CmpStore(
-            CMP_ID,
-            CMP_VERSION,
-            COOKIE_VERSION,
-            readConsentCookie(COOKIE_NAME),
-            globalVendorList
-        );
+        const store = generateStore(shouldAccessTestCookie);
         const cmp = new CmpService(store);
         // Expose `processCommand` as the CMP implementation
         window[CMP_GLOBAL_NAME] = cmp.processCommand;
@@ -272,6 +291,10 @@ export const init = (): void => {
 
         cmp.cmpReady = true;
         cmp.notify('cmpReady');
+
+        if (shouldAccessTestCookie) {
+            log.info('CMP customise is ACTIVE');
+        }
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/cookie.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cookie.js
@@ -204,14 +204,14 @@ const decodeVendorConsentData = (cookieValue: string): VendorConsentData => {
     return cookieData;
 };
 
-const readVendorConsentCookie = (): Promise<VendorConsentData | false> => {
+const readVendorConsentCookie = (): VendorConsentData | false => {
     const cookieVal: ?string = getCookie(VENDOR_CONSENT_COOKIE_NAME);
     if (cookieVal) {
-        log.debug(`Read consent data from cookie: ${cookieVal}`);
-        return Promise.resolve(decodeVendorConsentData(cookieVal));
+        log.info(`Read consent data from cookie: ${cookieVal}`);
+        return decodeVendorConsentData(cookieVal);
     }
-    log.warn('Unable to read from CMP cookie');
-    return Promise.resolve(false);
+    log.info('Unable to read from CMP cookie');
+    return false;
 };
 
 const writeVendorConsentCookie = (

--- a/static/src/javascripts/projects/commercial/modules/cmp/cookie.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cookie.spec.js
@@ -24,6 +24,7 @@ jest.mock('commercial/modules/cmp/log', () => ({
         debug: jest.fn(),
         error: jest.fn(),
         warn: jest.fn(),
+        info: jest.fn(),
     },
 }));
 
@@ -199,15 +200,14 @@ describe('CMP cookie', () => {
         ).toEqual(vendorConsentData);
     });
 
-    it('writes and reads the local cookie', () =>
-        writeVendorConsentCookie(vendorConsentData).then(() =>
-            readVendorConsentCookie().then(fromCookie => {
-                expect(document.cookie).toEqual(
-                    'euconsent=BAAAAAAAAAAAAABABBENABwAAAAApoA; path=/; expires=Fri, 07 Jul 94226 23:00:00 GMT; domain=.theguardian.com'
-                );
-                expect(fromCookie).toEqual(vendorConsentData);
-            })
-        ));
+    it('writes and reads the local cookie', () => {
+        writeVendorConsentCookie(vendorConsentData).then(() => {
+            expect(document.cookie).toEqual(
+                'euconsent=BAAAAAAAAAAAAABABBENABwAAAAApoA; path=/; expires=Fri, 07 Jul 94226 23:00:00 GMT; domain=.theguardian.com'
+            );
+            expect(readVendorConsentCookie()).toEqual(vendorConsentData);
+        });
+    });
 
     it('converts selected vendor list to a range', () => {
         const maxId = Math.max(...vendorList.vendors.map(vendor => vendor.id));

--- a/static/src/javascripts/projects/commercial/modules/cmp/store.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/store.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import { log } from 'commercial/modules/cmp/log';
 
 import type {
@@ -8,6 +8,8 @@ import type {
     VendorConsentData,
     VendorConsentResponse,
 } from 'commercial/modules/cmp/types';
+
+import { readVendorConsentCookie } from './cookie';
 
 type ConsentSelection = {
     maxVendorId: number,
@@ -102,8 +104,14 @@ const getVendorConsentData = (
     cmpVersion: number,
     cookieVersion: number,
     canPersonalise: boolean | null,
-    vendorList: VendorList
+    vendorList: VendorList,
+    isRunningCmpCustomise: boolean = false
 ): ?VendorConsentData => {
+    if (isRunningCmpCustomise) {
+        log.info('getVendorConsentData: Running Cmp Customise');
+        const cookieVal = readVendorConsentCookie();
+        if (cookieVal) return { ...cookieVal };
+    }
     if (typeof canPersonalise === 'boolean') {
         const consentData = generateConsentData(
             cmpId,
@@ -131,7 +139,8 @@ export class CmpStore {
         cmpVersion: number,
         cookieVersion: number,
         canPersonalise: boolean | null,
-        vendorList: VendorList
+        vendorList: VendorList,
+        isRunningCmpCustomise: boolean = false
     ) {
         this.vendorList = vendorList;
         this.canPersonalise = canPersonalise;
@@ -147,7 +156,8 @@ export class CmpStore {
             cmpVersion,
             cookieVersion,
             canPersonalise,
-            vendorList
+            vendorList,
+            isRunningCmpCustomise
         );
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,6 +5,7 @@ import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquis
 import { commercialPrebidAdYouLike } from 'common/modules/experiments/tests/commercial-prebid-adyoulike.js';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
+import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { PodcastContainer } from 'common/modules/experiments/tests/podcast-container';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
@@ -12,6 +13,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialPrebidAdYouLike,
     commercialAdVerification,
+    commercialCmpCustomise,
     PodcastContainer,
 ].filter(Boolean);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-customise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-customise.js
@@ -1,0 +1,22 @@
+// @flow
+
+export const commercialCmpCustomise: ABTest = {
+    id: 'CommercialCmpCustomise',
+    start: '2018-08-13',
+    expiry: '2019-09-30',
+    author: 'Kate Whalen',
+    description: '0% participation AB test for customising CMP data',
+    audience: 0,
+    audienceOffset: 0,
+    successMeasure: 'Customisation of CMP data',
+    audienceCriteria: 'internal',
+    dataLinkNames: '',
+    idealOutcome: 'Different CMP result',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

- zero percent participation AB test that Guardian employees can opt into.

- Opting into the AB test changes the read and write location of the consent data.

## Screenshots

<img width="609" alt="screen shot 2018-08-28 at 14 39 25" src="https://user-images.githubusercontent.com/8607683/44780210-54638180-ab79-11e8-8717-6da3200b24f0.png">

## What is the value of this and can you measure success?

https://trello.com/c/dZSssM4J

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

