### PR TITLE
Change AppNexus direct keywords

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -310,7 +310,7 @@ const appNexusBidder: PrebidBidder = {
     switchName: 'prebidAppnexus',
     bidParams: (): PrebidAppNexusParams => ({
         placementId: getAppNexusDirectPlacementId(),
-        keywords: buildAppNexusTargeting(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+        keywords: buildAppNexusTargetingObject(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
     }),
 };
 


### PR DESCRIPTION
## What does this change?

This updates the `keywords` sent directly to `AppNexus` from a string to an object; the AppNexus adapter expects this to be an object and transforms it to another appropriate object; when this is a string it iterates over each character and takes each index as a key and each character as a value.

@guardian/commercial-dev 