### PR TITLE
Fix tracking of podcast container variant A on mobile

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
@@ -111,8 +111,8 @@ const runContainerTest = (variant: string) => (): void => {
     }
 };
 
-const trackClick = (name: string) => (complete: () => void): void => {
-    const component = document.querySelector(`.${name}`);
+const trackClick = (selector: string) => (complete: () => void): void => {
+    const component = document.querySelector(selector);
     if (component) {
         component.onclick = () => {
             complete();
@@ -120,8 +120,8 @@ const trackClick = (name: string) => (complete: () => void): void => {
     }
 };
 
-const trackImpression = (name: string) => (track: () => void): void => {
-    const component = document.querySelector(`.${name}`);
+const trackImpression = (selector: string) => (track: () => void): void => {
+    const component = document.querySelector(selector);
     if (component) {
         const observer = new window.IntersectionObserver(
             (entries, self) => {
@@ -161,20 +161,20 @@ export const PodcastContainer = {
         {
             id: 'a',
             test: runContainerTest('a'),
-            impression: trackImpression('podcast-container-a__main'),
-            success: trackClick('podcast-container-a__main'),
+            impression: trackImpression('#podcast'),
+            success: trackClick('.podcast-container-a__main'),
         },
         {
             id: 'b',
             test: runContainerTest('b'),
-            impression: trackImpression('podcast-container__track'),
-            success: trackClick('podcast-container__track'),
+            impression: trackImpression('.podcast-container__track'),
+            success: trackClick('.podcast-container__track'),
         },
         {
             id: 'c',
             test: runContainerTest('c'),
-            impression: trackImpression('podcast-container-c__main'),
-            success: trackClick('podcast-container__track'),
+            impression: trackImpression('.podcast-container-c__main'),
+            success: trackClick('.podcast-container__track'),
         },
     ],
 };


### PR DESCRIPTION
## What does this change?
Variant A of the front podcast container test sometimes fails to track impression events on mobile only (other variants/widths are fine). We still have no idea what's causing this, but observing the parent element (`#podcast`) fixes the bug.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
