### PR TITLE
Remove variant A from front podcast test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/podcast-container.js
@@ -1,16 +1,9 @@
 // @flow
 import template from 'lodash/utilities/template';
-import containerAHtml from 'raw-loader!journalism/views/podcastContainerA.html';
 import containerBHtml from 'raw-loader!journalism/views/podcastContainerB.html';
 import containerCHtml from 'raw-loader!journalism/views/podcastContainerC.html';
 import config from 'lib/config';
 import { addClassesAndTitle } from 'common/views/svg';
-
-import containerWaveALarge from 'svgs/journalism/podcast-container/waveform.svg';
-import containerWaveATablet from 'svgs/journalism/podcast-container/waveform-tablet.svg';
-import containerWaveAMobile from 'svgs/journalism/podcast-container/waveform-mobile.svg';
-import containerWaveATiny from 'svgs/journalism/podcast-container/waveform-tiny.svg';
-import containerButton from 'svgs/journalism/podcast-container/play-btnbig.svg';
 
 import audioIcon from 'svgs/journalism/podcast-container/audio-icon.svg';
 
@@ -38,33 +31,6 @@ const runContainerTest = (variant: string) => (): void => {
             podcastContainer.className += ' podcast-container__visible';
 
             switch (variant) {
-                case 'a':
-                    oldBody.innerHTML = template(containerAHtml, {
-                        headline,
-                        standfirst,
-                        url: urlWithCampaign(episodeUrl, variant),
-                        button: addClassesAndTitle(containerButton.markup, [
-                            `podcast-container-a__button`,
-                        ]),
-                        waveLarge: addClassesAndTitle(
-                            containerWaveALarge.markup,
-                            [`podcast-container-a__wave-large`]
-                        ),
-                        waveTablet: addClassesAndTitle(
-                            containerWaveATablet.markup,
-                            [`podcast-container-a__wave-tablet`]
-                        ),
-                        waveMobile: addClassesAndTitle(
-                            containerWaveAMobile.markup,
-                            [`podcast-container-a__wave-mobile`]
-                        ),
-                        waveTiny: addClassesAndTitle(
-                            containerWaveATiny.markup,
-                            [`podcast-container-a__wave-tiny`]
-                        ),
-                    });
-
-                    break;
                 case 'b':
                     oldBody.innerHTML = template(containerBHtml, {
                         headline,
@@ -158,12 +124,6 @@ export const PodcastContainer = {
     },
 
     variants: [
-        {
-            id: 'a',
-            test: runContainerTest('a'),
-            impression: trackImpression('#podcast'),
-            success: trackClick('.podcast-container-a__main'),
-        },
         {
             id: 'b',
             test: runContainerTest('b'),


### PR DESCRIPTION
## What does this change?
Removes one of the 3 variants as it is less important, and this will allow us to reach statistical significance faster.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
