### PR TITLE
Log out full details of capi error messages in front press.

### DIFF
--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -3,6 +3,7 @@ package frontpress
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+import com.gu.contentapi.client.model.ContentApiError
 import common.{JsonMessageQueue, Logging, Message}
 import org.joda.time.DateTime
 import play.api.libs.json.Reads
@@ -114,7 +115,9 @@ abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionC
     }
 
     getRequest.failed.foreach {
-      error: Throwable => log.error("Encountered error receiving message from queue", error)
+      case error: ContentApiError =>
+        log.error(s"Encountered content api error receiving message from queue: ${error.httpMessage} status: ${error.httpStatus}", error)
+      case error: Throwable => log.error("Encountered error receiving message from queue", error)
     }
 
     getRequest.map(_ => ())


### PR DESCRIPTION
## What does this change?
This should make it easier to debug fronts pressing issues


### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
