### PR TITLE
Add error reporting to FollowCardList

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -3,6 +3,7 @@ import React, { Component } from 'preact-compat';
 import reqwest from 'reqwest';
 import ophan from 'ophan/ng';
 import reportError from 'lib/report-error';
+import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
 type AccountCreationFormProps = {
     csrfToken: string,
@@ -16,15 +17,21 @@ class AccountCreationForm extends Component<
     {
         password?: string,
         isLoading?: boolean,
-        hasError?: boolean,
-        errorReason?: string,
+        errors: string[],
     }
 > {
+    constructor(props: AccountCreationFormProps) {
+        super(props);
+        this.setState({
+            errors: [],
+        });
+    }
+
     onSubmit = (ev: Event) => {
         ev.preventDefault();
         this.setState({
             isLoading: true,
-            hasError: false,
+            errors: [],
         });
 
         reqwest({
@@ -53,11 +60,10 @@ class AccountCreationForm extends Component<
                 try {
                     const apiError = JSON.parse(response.responseText)[0];
                     this.setState({
-                        hasError: true,
-                        errorReason: apiError.description,
+                        errors: [apiError.description],
                     });
                 } catch (exception) {
-                    this.setState({ hasError: true });
+                    this.setState({ errors: [genericErrorStr] });
                 }
             },
             complete: () => {
@@ -74,18 +80,12 @@ class AccountCreationForm extends Component<
     };
 
     render() {
-        const { hasError, errorReason, isLoading } = this.state;
+        const { errors, isLoading } = this.state;
         const { email } = this.props;
         return (
             <form onSubmit={this.onSubmit}>
                 <ul className="identity-forms-fields">
-                    <li aria-live="polite">
-                        {hasError && (
-                            <div className="form__error" role="alert">
-                                {errorReason || 'Oops. Something went wrong'}
-                            </div>
-                        )}
-                    </li>
+                    <ErrorBar tagName="li" errors={errors} />
                     {email && (
                         <li id="email_field" aria-hidden>
                             <label

--- a/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
@@ -13,11 +13,6 @@ export class ErrorBar extends Component<ErrorBarProps> {
         tagName: 'div',
     };
 
-    constructor(props: ErrorBarProps) {
-        super(props);
-        console.error(props);
-    }
-
     render() {
         const { errors } = this.props;
         const TagName = this.props.tagName;

--- a/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
@@ -1,0 +1,34 @@
+// @flow
+import React, { Component } from 'preact-compat';
+
+type ErrorBarProps = {
+    errors: string[],
+    tagName: ?string,
+};
+
+export const genericErrorStr = 'Oops! Something went wrong';
+
+export class ErrorBar extends Component<ErrorBarProps> {
+    static defaultProps = {
+        tagName: 'div',
+    };
+
+    constructor(props: ErrorBarProps) {
+        super(props);
+        console.error(props);
+    }
+
+    render() {
+        const { errors } = this.props;
+        const TagName = this.props.tagName;
+        return (
+            <TagName aria-live="polite">
+                {errors.map(error => (
+                    <div className="form__error" role="alert">
+                        {error}
+                    </div>
+                ))}
+            </TagName>
+        );
+    }
+}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
@@ -20,12 +20,20 @@ class FollowButtonWrap extends Component<
         this.setState({
             mousedOutOnce: false,
         });
+        this.hoverTimeout = null;
     }
 
+    onMouseIn = () => {
+        clearTimeout(this.hoverTimeout);
+    };
+
     onMouseOut = () => {
-        this.setState({
-            mousedOutOnce: true,
-        });
+        clearTimeout(this.hoverTimeout);
+        setTimeout(() => {
+            this.setState({
+                mousedOutOnce: true,
+            });
+        }, 50);
     };
 
     updateFollowing = (to: boolean) => {
@@ -57,6 +65,12 @@ class FollowButtonWrap extends Component<
                     }}
                     onBlur={() => {
                         this.onMouseOut();
+                    }}
+                    onMouseOver={() => {
+                        this.onMouseIn();
+                    }}
+                    onFocus={() => {
+                        this.onMouseIn();
                     }}>
                     <div
                         role="alert"

--- a/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
@@ -17,15 +17,15 @@ class FollowButtonWrap extends Component<
 > {
     constructor(props: FollowButtonWrapProps) {
         super(props);
-        this.setState(() => ({
+        this.setState({
             mousedOutOnce: false,
-        }));
+        });
     }
 
     onMouseOut = () => {
-        this.setState(() => ({
+        this.setState({
             mousedOutOnce: true,
-        }));
+        });
     };
 
     updateFollowing = (to: boolean) => {
@@ -34,9 +34,9 @@ class FollowButtonWrap extends Component<
         } else {
             this.props.onUnfollow();
         }
-        this.setState(() => ({
+        this.setState({
             mousedOutOnce: false,
-        }));
+        });
     };
 
     render() {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/follow/FollowButtonWrap.js
@@ -20,20 +20,12 @@ class FollowButtonWrap extends Component<
         this.setState({
             mousedOutOnce: false,
         });
-        this.hoverTimeout = null;
     }
 
-    onMouseIn = () => {
-        clearTimeout(this.hoverTimeout);
-    };
-
     onMouseOut = () => {
-        clearTimeout(this.hoverTimeout);
-        setTimeout(() => {
-            this.setState({
-                mousedOutOnce: true,
-            });
-        }, 50);
+        this.setState({
+            mousedOutOnce: true,
+        });
     };
 
     updateFollowing = (to: boolean) => {
@@ -65,12 +57,6 @@ class FollowButtonWrap extends Component<
                     }}
                     onBlur={() => {
                         this.onMouseOut();
-                    }}
-                    onMouseOver={() => {
-                        this.onMouseIn();
-                    }}
-                    onFocus={() => {
-                        this.onMouseIn();
                     }}>
                     <div
                         role="alert"

--- a/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
@@ -6,6 +6,7 @@ import {
     setConsentsInApi,
 } from 'common/modules/identity/upsell/store/consents';
 import type { ConsentWithState } from 'common/modules/identity/upsell/store/types';
+import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
 export class OptOutsList extends Component<
     {},
@@ -13,14 +14,14 @@ export class OptOutsList extends Component<
         consents: ConsentWithState[],
         isLoading: boolean,
         hasUnsavedChanges: boolean,
-        hasError: boolean,
+        errors: string[],
     }
 > {
     constructor(props: {}) {
         super(props);
         this.state = {
             isLoading: false,
-            hasError: false,
+            errors: [],
             hasUnsavedChanges: true,
             consents: [],
         };
@@ -48,7 +49,7 @@ export class OptOutsList extends Component<
         ev.preventDefault();
         this.setState({
             isLoading: true,
-            hasError: false,
+            errors: [],
         });
         setConsentsInApi(this.state.consents)
             .then(() => {
@@ -59,24 +60,18 @@ export class OptOutsList extends Component<
             })
             .catch(() => {
                 this.setState({
-                    hasError: true,
+                    errors: [genericErrorStr],
                     isLoading: false,
                 });
             });
     };
 
     render() {
-        const { hasUnsavedChanges, isLoading, consents, hasError } = this.state;
+        const { hasUnsavedChanges, isLoading, consents, errors } = this.state;
         return (
             <form onSubmit={ev => this.onSubmit(ev)}>
                 <ul className="identity-forms-fields">
-                    <li aria-live="polite">
-                        {hasError && (
-                            <div className="form__error" role="alert">
-                                Oops. Something went wrong
-                            </div>
-                        )}
-                    </li>
+                    <ErrorBar errors={errors} tagName="li" />
                     <li>
                         {consents.map(consent => (
                             <Checkbox

--- a/static/src/javascripts/projects/common/modules/identity/upsell/store/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/store/types.js
@@ -23,6 +23,10 @@ class ConsentWithState {
     setState(hasConsented: boolean) {
         this.hasConsented = hasConsented;
     }
+
+    flipState() {
+        this.hasConsented = !this.hasConsented;
+    }
 }
 
 class UserConsentWithState extends ConsentWithState {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -20,12 +20,11 @@ const ConfirmEmailThankYou = (
             consents={[
                 getUserConsent('supporter'),
                 getNewsletterConsent('today-uk'),
-            ]}
-            expandableConsents={[
                 getUserConsent('jobs'),
                 getUserConsent('holidays'),
                 getNewsletterConsent('today-us'),
             ]}
+            cutoff={2}
         />
     </Block>
 );

--- a/static/src/stylesheets/module/identity/upsell/_card.scss
+++ b/static/src/stylesheets/module/identity/upsell/_card.scss
@@ -2,6 +2,9 @@
     display: grid;
     grid-row-gap: $gs-baseline;
     grid-auto-columns: 1fr;
+    &:not(:first-child) {
+        margin-top: $gs-baseline;
+    }
     @include mq(tablet) {
         display: grid;
         grid-column-gap: $gs-gutter;


### PR DESCRIPTION
## What does this change?
Bit of a twofer, refactored the error handling into its own thing and made some QoL updates to `FollowCardList` such as having 1 list of consents and a trim point instead of two lists (which looks very obvious in retrospect).

And of course, the main attraction, should following fail, the card will revert itself to its original state and display an error

## Screenshots
![screen shot 2018-09-19 at 4 39 22 pm](https://user-images.githubusercontent.com/11539094/45764571-e9164800-bc2a-11e8-9453-08e8c74ddd3f.png)

## What is the value of this and can you measure success?
We are legally required to notify users if their action didn't actually go through and it makes for a less confusing experience