### PR TITLE
Update openx and oxd (openx direct) to use PT values used by appnexus

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -323,20 +323,26 @@ const openxClientSideBidder: PrebidBidder = {
                 return {
                     delDomain: 'guardian-us-d.openx.net',
                     unit: '540279544',
-                    customParams: buildPageTargeting(),
+                    customParams: buildAppNexusTargetingObject(
+                        buildPageTargeting()
+                    ),
                 };
             case 'AU':
                 return {
                     delDomain: 'guardian-aus-d.openx.net',
                     unit: '540279542',
-                    customParams: buildPageTargeting(),
+                    customParams: buildAppNexusTargetingObject(
+                        buildPageTargeting()
+                    ),
                 };
             default:
                 // UK and ROW
                 return {
                     delDomain: 'guardian-d.openx.net',
                     unit: '540279541',
-                    customParams: buildPageTargeting(),
+                    customParams: buildAppNexusTargetingObject(
+                        buildPageTargeting()
+                    ),
                 };
         }
     },
@@ -429,20 +435,26 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                             return {
                                 delDomain: 'guardian-d.openx.net',
                                 unit: '539997090',
-                                customParams: buildPageTargeting(),
+                                customParams: buildAppNexusTargetingObject(
+                                    buildPageTargeting()
+                                ),
                             };
                         case 'US':
                             return {
                                 delDomain: 'guardian-us-d.openx.net',
                                 unit: '539997087',
-                                customParams: buildPageTargeting(),
+                                customParams: buildAppNexusTargetingObject(
+                                    buildPageTargeting()
+                                ),
                             };
                         default:
                             // AU and rest
                             return {
                                 delDomain: 'guardian-aus-d.openx.net',
                                 unit: '539997046',
-                                customParams: buildPageTargeting(),
+                                customParams: buildAppNexusTargetingObject(
+                                    buildPageTargeting()
+                                ),
                             };
                     }
                 })(),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -205,7 +205,7 @@ describe('getDummyServerSideBidders', () => {
             delDomain: 'guardian-d.openx.net',
             unit: '539997090',
             lotame: { some: 'lotamedata' },
-            customParams: 'bla',
+            customParams: 'someAppNexusTargetingObject',
         });
         expect(appNexusParams).toEqual({
             placementId: '13915593',


### PR DESCRIPTION
## What does this change?

Currently, OpenX received our targeting as we call it in our platform; in AppNexus we convert these to PT values. We have decided to keep the values consistent in both OpenX and AppNexus and thus this PR changes the OpenX to be the same as the AppNexus keys/values.

@guardian/commercial-dev 