### PR TITLE
Always send contentFields to dotcom-rendering

### DIFF
--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -29,7 +29,7 @@ class RemoteRender(implicit context: ApplicationContext) {
 
   def render(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
 
-      val contentFieldsJson = if (request.isGuui) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+      val contentFieldsJson = List("contentFields" -> Json.toJson(ContentFields(article.article)))
       val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
       val jsonPayload = JsonComponent.jsonFor(article, jsonResponse:_*)
 


### PR DESCRIPTION
## What does this change?

Always sends `contentFields` to `dotcom-rendering`, regardless of whether the `?guui` param is passed. This allows participants in the AB test to see the page rendered by `dotcom-rendering`. Currently, participants see an explodey page

## Screenshots

<img width="1256" alt="screen shot 2018-09-21 at 16 03 27" src="https://user-images.githubusercontent.com/5931528/45889268-e6952900-bdb7-11e8-9694-fa917f7c0d40.png">


## What is the value of this and can you measure success?

Less explodey

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
