### PR TITLE
Plain text Braze emails

### DIFF
--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -30,7 +30,8 @@ class LatestIndexController(
   }
 
   private def handleSeriesBlogs(index: IndexPage)(implicit request: RequestHeader) = index.trails.headOption match {
-    case Some(latest) if request.isEmailJson || request.isHeadlineText =>
+    case Some(latest) if request.isEmailJson || request.isEmailTxt || request.isHeadlineText =>
+      // We perform an internal redirect for Braze. It cannot handle 30Xs
       emailInternalRedirect(latest)
 
     case Some(latest) if request.isEmail =>
@@ -47,9 +48,10 @@ class LatestIndexController(
 
   private def emailInternalRedirect(latest: Content)(implicit request: RequestHeader) = {
     val emailJsonSuffix = if (request.isEmailJson) EMAIL_JSON_SUFFIX else ""
+    val emailTxtSuffix = if (request.isEmailTxt) EMAIL_TXT_SUFFIX else ""
     val headlineSuffix = if (request.isHeadlineText) HEADLINE_SUFFIX else ""
 
-    val url = s"${latest.metadata.url}/email$emailJsonSuffix$headlineSuffix"
+    val url = s"${latest.metadata.url}/email$emailTxtSuffix$emailJsonSuffix$headlineSuffix"
     val urlWithoutSlash = if (url.startsWith("/")) url.drop(1) else url
 
     InternalRedirect.internalRedirect("type/article", urlWithoutSlash, None)

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -75,6 +75,7 @@ GET        /$path<.+>/latest                                                    
 GET        /$path<.+>/latest/email                                              controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/latest/email/headline.txt                                 controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/latest/email.emailjson                                    controllers.LatestIndexController.latest(path)
+GET        /$path<.+>/latest/email.emailtxt                                     controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all             controllers.AllIndexController.allOn(path, day, month, year)
 GET        /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/altdate         controllers.AllIndexController.altDate(path, day, month, year)
 GET        /$path<.+>/all                                                       controllers.AllIndexController.all(path)

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -38,6 +38,13 @@ import play.api.test.Helpers._
     header("X-Accel-Redirect", result).head should endWith ("/email.emailjson")
   }
 
+  it should "redirect to latest emailtxt for a blog" in {
+    val result = latestIndexController.latest("fashion/fashion-blog")(TestRequest("/fashion/fashion-blog/email.emailtxt"))
+    status(result) should be(OK)
+    header("X-Accel-Redirect", result).head should include ("/fashion-blog/")
+    header("X-Accel-Redirect", result).head should endWith ("/email.emailtxt")
+  }
+
   it should "redirect with URL parameter format=email-headline for a blog" in {
     val result = latestIndexController.latest("fashion/fashion-blog")(TestRequest("/fashion/fashion-blog/email/headline.txt"))
     status(result) should be(OK)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -26,6 +26,7 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.rende
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email/headline.txt controllers.ArticleController.renderHeadline(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 
 # articles, finished liveblogs
@@ -34,4 +35,5 @@ GET     /*path.json                 controllers.ArticleController.renderJson(pat
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email/headline.txt   controllers.ArticleController.renderHeadline(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/common/app/common/HtmlTextExtractor.scala
+++ b/common/app/common/HtmlTextExtractor.scala
@@ -1,0 +1,43 @@
+package common
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Node, TextNode}
+import play.twirl.api.Html
+
+import scala.collection.JavaConverters._
+
+object HtmlTextExtractor {
+
+  private val newLineNodeNames = Set("br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "tr")
+
+  def apply(html: Html): String = {
+    val documentBody = Jsoup.parseBodyFragment(html.toString).body()
+    documentBody.setBaseUri("https://www.theguardian.com")
+
+    val text = filterImagesAndFlattenNodes(documentBody)
+      .collect {
+        case node if node.nodeName() == "a" => node.absUrl("href").trim() + "\n"
+        case node: TextNode if node.parent().nodeName() == "span" => node.text().trim + " "
+        case node: TextNode if node.text().trim.nonEmpty => node.text().trim + "\n"
+        case node if newLineNodeNames.contains(node.nodeName()) => "\n"
+      }
+      .mkString
+
+    removeTripleNewline(text)
+
+  }
+
+  private def filterImagesAndFlattenNodes(node: Node): Seq[Node] = {
+    val children = node.childNodes.asScala
+    if (children.exists(child => child.nodeName() == "img" && child.attr("class") == "full-width"))
+      Nil
+    else
+      node +: children.flatMap(filterImagesAndFlattenNodes)
+  }
+
+  private def removeTripleNewline(text: String): String = {
+    val modified = "\n\\s*\n\\s*\n\\s*\n".r.replaceAllIn(text, "\n\n\n")
+    if (modified == text) modified else removeTripleNewline(modified)
+  }
+
+}

--- a/common/app/common/HtmlTextExtractor.scala
+++ b/common/app/common/HtmlTextExtractor.scala
@@ -29,6 +29,7 @@ object HtmlTextExtractor {
 
   private def filterImagesAndFlattenNodes(node: Node): Seq[Node] = {
     val children = node.childNodes.asScala
+    // only filter the large full width images since they contain duplicated links
     if (children.exists(child => child.nodeName() == "img" && child.attr("class") == "full-width"))
       Nil
     else

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -124,6 +124,8 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
     if (request.isEmailJson) {
       Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithInlineStyles.toString)))))
+    } else if (request.isEmailTxt) {
+      Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(HtmlTextExtractor(htmlWithInlineStyles))))))
     } else {
       Cached(page)(RevalidatableResult.Ok(htmlWithInlineStyles))
     }

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -14,6 +14,7 @@ trait Requests {
   val EMAIL_SUFFIX = "/email"
   val HEADLINE_SUFFIX = "/headline.txt"
   val EMAIL_JSON_SUFFIX = ".emailjson"
+  val EMAIL_TXT_SUFFIX = ".emailtxt"
 
   implicit class RichRequestHeader(r: RequestHeader) {
 
@@ -31,6 +32,8 @@ trait Requests {
 
     lazy val isEmailJson: Boolean = r.path.endsWith(EMAIL_JSON_SUFFIX)
 
+    lazy val isEmailTxt: Boolean = r.path.endsWith(EMAIL_TXT_SUFFIX)
+
     // parameters for moon/guui new rendering layer project.
     lazy val isGuuiJson: Boolean = isJson && isGuui
 
@@ -40,7 +43,7 @@ trait Requests {
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
 
-    lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(EMAIL_SUFFIX) || isEmailJson
+    lazy val isEmail: Boolean = r.getQueryString("format").exists(_.contains("email")) || r.path.endsWith(EMAIL_SUFFIX) || isEmailJson || isEmailTxt
 
     lazy val isHeadlineText: Boolean = r.getQueryString("format").contains("email-headline") || r.path.endsWith(HEADLINE_SUFFIX)
 

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -16,7 +16,7 @@
                             <tr>
                                 <td class="ft__links">
                                     <a href="https://profile.theguardian.com/email-prefs">Manage your emails</a> |
-                                    @if(request.isEmailJson) {
+                                    @if(request.isEmailJson || request.isEmailTxt) {
                                         <a href="%%unsub_center_url%%">Unsubscribe</a> |
                                     } else {
                                         <a href="%%microsite_base_url[default]40543[/default]%%">Unsubscribe</a> |

--- a/common/test/common/CommonPackageTest.scala
+++ b/common/test/common/CommonPackageTest.scala
@@ -46,4 +46,14 @@ class CommonPackageTest extends FlatSpec with Matchers with WithTestApplicationC
     value should include ("<html")
   }
 
+  "renderEmail" should "render an email txt result page" in new PackageTestScope {
+    val html = Html("")
+    val result = Future.successful(common.renderEmail(html, contentPage)(TestRequest("/content/email.emailtxt"), testApplicationContext))
+
+    val jsonResult: JsValue = contentAsJson(result)
+    val (key, value) = jsonResult.as[Map[String,String]].head
+    key shouldBe "body"
+    value should not include ("<html")
+  }
+
 }

--- a/common/test/common/CommonPackageTest.scala
+++ b/common/test/common/CommonPackageTest.scala
@@ -53,7 +53,7 @@ class CommonPackageTest extends FlatSpec with Matchers with WithTestApplicationC
     val jsonResult: JsValue = contentAsJson(result)
     val (key, value) = jsonResult.as[Map[String,String]].head
     key shouldBe "body"
-    value should not include ("<html")
+    value should not include "<html"
   }
 
 }

--- a/common/test/common/HtmlTextExtractorTest.scala
+++ b/common/test/common/HtmlTextExtractorTest.scala
@@ -1,0 +1,74 @@
+package common
+
+import org.scalatest.{FlatSpec, Matchers}
+import play.twirl.api.Html
+
+class HtmlTextExtractorTest extends FlatSpec with Matchers {
+
+  "HtmlTextExtractor" should "extract text from html" in {
+    val rawHtml =
+      """
+        |<!DOCTYPE html>
+        |<html>
+        |<body>
+        |
+        |<h2>Heading text</h2>
+        |
+        |<p>Paragraph.</p>
+        |<br/>
+        |<div>
+        |  <span>My name is:</span> Bill
+        |</div>
+        |
+        |<a href="/link/">some link</a>
+        |
+        |<table>
+        |  <tr>
+        |    <td>The brown</td>
+        |    <td>fox jumped</td>
+        |    <td>over</td>
+        |  </tr>
+        |  <tr>
+        |    <td>a</td>
+        |    <td>cat on</td>
+        |    <td>the window</td>
+        |  </tr>
+        |  <tr>
+        |    <td>next to the</td>
+        |    <td>kitchen</td>
+        |    <td>in the house</td>
+        |  </tr>
+        |</table>
+        |
+        |<hr>
+        |
+        |</body>
+        |</html>""".stripMargin
+
+    val expectedText =
+      """
+        |Heading text
+        |
+        |Paragraph.
+        |
+        |My name is: Bill
+        |https://www.theguardian.com/link/
+        |some link
+        |
+        |The brown
+        |fox jumped
+        |over
+        |
+        |a
+        |cat on
+        |the window
+        |
+        |next to the
+        |kitchen
+        |in the house
+        |""".stripMargin
+
+    HtmlTextExtractor(Html(rawHtml)) shouldBe expectedText
+  }
+
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -378,6 +378,7 @@ GET            /$path<.+>/latest                                                
 GET            /$path<.+>/latest/email                                                                                           controllers.LatestIndexController.latest(path)
 GET            /$path<.+>/latest/email/headline.txt                                                                              controllers.LatestIndexController.latest(path)
 GET            /$path<.+>/latest/email.emailjson                                                                                 controllers.LatestIndexController.latest(path)
+GET            /$path<.+>/latest/email.emailtxt                                                                                  controllers.LatestIndexController.latest(path)
 GET            /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all                                                          controllers.AllIndexController.allOn(path, day, month, year)
 GET            /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/altdate                                                      controllers.AllIndexController.altDate(path, day, month, year)
 GET            /$path<.+>/all                                                                                                    controllers.AllIndexController.all(path)
@@ -404,6 +405,7 @@ GET            /$path<email/.*>                                                 
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
 GET            /*path/headline.txt                                                                                               controllers.FaciaController.renderFrontHeadline(path)
 GET            /*path.emailjson                                                                                                  controllers.FaciaController.renderFrontJson(path)
+GET            /*path.emailtxt                                                                                                   controllers.FaciaController.renderFrontJson(path)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET            /container/*id.json                                                                                               controllers.FaciaController.renderContainerJson(id)
 GET            /most-relevant-container/*path.json                                                                               controllers.FaciaController.renderMostRelevantContainerJson(path)
@@ -445,6 +447,7 @@ GET     /$path<[^/]+/([^/]+/)?live/.*>.json                                     
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email                                                                                     controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email/headline.txt                                                                        controllers.ArticleController.renderHeadline(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson                                                                           controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt                                                                            controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>                                                                                           controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 
 # articles, finished liveblogs
@@ -453,6 +456,7 @@ GET     /*path.json                                                             
 GET     /*path/email                                                                                                             controllers.ArticleController.renderEmail(path)
 GET     /*path/email/headline.txt                                                                                                controllers.ArticleController.renderHeadline(path)
 GET     /*path/email.emailjson                                                                                                   controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailtxt                                                                                                    controllers.ArticleController.renderEmail(path)
 GET     /*path                                                                                                                   controllers.ArticleController.renderArticle(path)
 
 # Formstack form submission

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -168,6 +168,9 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
     if (request.isEmailJson) {
       val emailJson = JsObject(Map("body" -> JsString(htmResponseInlined.toString)))
       RevalidatableResult.Ok(emailJson)
+    } else if (request.isEmailTxt) {
+      val emailTxtJson = JsObject(Map("body" -> JsString(HtmlTextExtractor(htmResponseInlined))))
+      RevalidatableResult.Ok(emailTxtJson)
     } else {
       RevalidatableResult.Ok(htmResponseInlined)
     }

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -31,6 +31,7 @@ GET        /rss                                                                 
 GET        /*path/rss                                                               controllers.FaciaController.renderFrontRss(path)
 GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonLite(path)
 GET        /*path.emailjson                                                         controllers.FaciaController.renderFrontJson(path)
+GET        /*path.emailtxt                                                          controllers.FaciaController.renderFrontJson(path)
 GET        /*path.json                                                              controllers.FaciaController.renderFrontJson(path)
 GET        /*path/headline.txt                                                      controllers.FaciaController.renderFrontHeadline(path)
 GET        /                                                                        controllers.FaciaController.rootEditionRedirect()

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -198,6 +198,16 @@ import scala.concurrent.Await
     html should include ("<!DOCTYPE html")
   }
 
+  it should "render txt email fronts" in {
+    val emailRequest = FakeRequest("GET", "/email/uk/daily.emailtxt")
+    val emailJsonResponse = faciaController.renderFront("email/uk/daily")(emailRequest)
+    status(emailJsonResponse) shouldBe 200
+    val jsonResponse = contentAsJson(emailJsonResponse)
+    val (key, html) = jsonResponse.as[Map[String,String]].head
+    key shouldBe "body"
+    html should not include "<!DOCTYPE html"
+  }
+
   it should "render email fronts" in {
     val emailRequest = FakeRequest("GET", "/email/uk/daily")
     val emailJsonResponse = faciaController.renderFront("email/uk/daily")(emailRequest)

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -203,9 +203,10 @@ import scala.concurrent.Await
     val emailJsonResponse = faciaController.renderFront("email/uk/daily")(emailRequest)
     status(emailJsonResponse) shouldBe 200
     val jsonResponse = contentAsJson(emailJsonResponse)
-    val (key, html) = jsonResponse.as[Map[String,String]].head
+    val (key, text) = jsonResponse.as[Map[String,String]].head
     key shouldBe "body"
-    html should not include "<!DOCTYPE html"
+    text should not include "<!DOCTYPE html"
+    text should include ("The Guardian Today | The Guardian")
   }
 
   it should "render email fronts" in {

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -153,6 +153,7 @@ GET        /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                      
 GET        /$path<.+>/latest                                                                   controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/latest/email                                                             controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/latest/email.emailjson                                                   controllers.LatestIndexController.latest(path)
+GET        /$path<.+>/latest/email.emailtxt                                                    controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all                            controllers.AllIndexController.allOn(path, day, month, year)
 GET        /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/altdate                        controllers.AllIndexController.altDate(path, day, month, year)
 GET        /$path<.+>/all                                                                      controllers.AllIndexController.all(path)
@@ -198,10 +199,12 @@ GET        /news-alert/alerts                                                   
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
+GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt  controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
+GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
 
 
 # Don't forward requests for favicon.ico to the Content API


### PR DESCRIPTION
## What does this change?

Adds plain text emails for Braze connected content. Braze does not generate plain text versions of emails.

## What is the value of this and can you measure success?

Users can view valid plain text emails from campaigns sent via Braze

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
