### PR TITLE
Add missing women's football tables

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -46,7 +46,9 @@ class LeagueTableController(
         "Scottish Cup",
         "Scottish League Cup",
         "World Cup 2018 Qualifiers",
-        "International friendlies"
+        "International friendlies",
+        "Women's Super League",
+        "Women's FA Cup"
     )
 
   def sortedCompetitions:Seq[Competition] = tableOrder.flatMap(leagueName => competitionsService.competitions.find(_.fullName == leagueName))


### PR DESCRIPTION
Fixes https://www.theguardian.com/football/womens-super-league/table which currently just redirects back to the general football tables page.