### PR TITLE
Include Ozone in 5% of Prebid auctions outside US and AU regions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -462,7 +462,6 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
             ),
     };
 
-    // Experimental. Only 0.01% of the PVs.
     if (
         inPbTestOr(
             config.get('switches.prebidS2sozone') && shouldIncludeOzone()

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -87,7 +87,8 @@ export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {
 };
 
 export const shouldIncludeOzone = (): boolean =>
-    !isInUsRegion() && !isInAuRegion() && getRandomIntInclusive(1, 10000) === 1;
+    // include in 1 in 20 (5%) of auctions
+    !isInUsRegion() && !isInAuRegion() && getRandomIntInclusive(1, 20) === 1;
 
 export const stripMobileSuffix = (s: string): string =>
     stripSuffix(s, '--mobile');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -87,7 +87,7 @@ export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {
 };
 
 export const shouldIncludeOzone = (): boolean =>
-    // include in 1 in 20 (5%) of auctions
+    // include in 1 in 20 (5%) of page views
     !isInUsRegion() && !isInAuRegion() && getRandomIntInclusive(1, 20) === 1;
 
 export const stripMobileSuffix = (s: string): string =>


### PR DESCRIPTION
This is to check that the Ozone bidder infrastructure works before scaling it up.