### PR TITLE
Handle dotcom-rendering error

### DIFF
--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -4,39 +4,43 @@ import common.JsonComponent
 import conf.Configuration
 import controllers.ArticlePage
 import model.Cached.RevalidatableResult
-import model.{ApplicationContext, Cached, ContentFields, PageWithStoryPackage}
+import model.{ApplicationContext, Cached, ContentFields, NoCache, PageWithStoryPackage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.InternalServerError
 
 import scala.concurrent.{ExecutionContext, Future}
 import play.twirl.api.Html
 
 import scala.concurrent.duration._
 import common.RichRequestHeader
+import staticpages.StaticPages
 
 import ExecutionContext.Implicits.global
 
 class RemoteRender(implicit context: ApplicationContext) {
 
-  private def remoteRenderArticle(ws:WSClient, payload: String): Future[String] = ws.url(Configuration.rendering.renderingEndpoint)
+  private def remoteRenderArticle(ws:WSClient, payload: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = ws.url(Configuration.rendering.renderingEndpoint)
     .withRequestTimeout(2000.millis)
     .addHttpHeaders("Content-Type" -> "application/json")
     .post(payload)
-    .map((response) =>
-      response.body
-    )
+    .map((response) => {
+      response.status match {
+        case 200 =>
+          Cached(article)(RevalidatableResult.Ok(Html(response.body)))
+        case _ =>
+          NoCache(InternalServerError)
+      }
+    })
 
   def render(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
 
-      val contentFieldsJson = List("contentFields" -> Json.toJson(ContentFields(article.article)))
-      val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
-      val jsonPayload = JsonComponent.jsonFor(article, jsonResponse:_*)
+    val contentFieldsJson = List("contentFields" -> Json.toJson(ContentFields(article.article)))
+    val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
+    val jsonPayload = JsonComponent.jsonFor(article, jsonResponse:_*)
 
-      remoteRenderArticle(ws, jsonPayload).map(s => {
-        Cached(article){ RevalidatableResult.Ok(Html(s)) }
-      })
-
+    remoteRenderArticle(ws, jsonPayload, article)
   }
 
 }

--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -25,12 +25,12 @@ class RemoteRender(implicit context: ApplicationContext) {
     .withRequestTimeout(2000.millis)
     .addHttpHeaders("Content-Type" -> "application/json")
     .post(payload)
-    .map((response) => {
+    .map(response => {
       response.status match {
         case 200 =>
           Cached(article)(RevalidatableResult.Ok(Html(response.body)))
         case _ =>
-          NoCache(InternalServerError)
+          NoCache(InternalServerError("Rendering tier failed"))
       }
     })
 


### PR DESCRIPTION
## What does this change?

Currently, if dotcom-rendering returns an error response to frontend, frontend renders the error message (usually a Node.js stack trace) and sends it back to the client as a 200.

This change sends a 500 response to the client if dotcom-rendering responds with an error.

It would be super-useful to get some input on my attempt at Scala 😅 

## What is the value of this and can you measure success?

Users probably don't care about the exact line of JavaScript that dotcom-rendering blew up at.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
