### PR TITLE
Adding a switch to turn off most viewed on fronts

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -74,6 +74,16 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val MostViewedFronts = Switch(
+    SwitchGroup.Feature,
+    "most-viewed-fronts",
+    "If this is switched off, most viewed will not show on fronts",
+    owners = Seq(Owner.withName("dotcom platform")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val FontSwitch = Switch(
     SwitchGroup.Feature,
     "web-fonts",

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -5,6 +5,7 @@
 @import views.html.fragments.containers.facia_cards._
 @import views.support.Commercial.container.shouldRenderAsPaidContainer
 @import views.support.GetClasses
+@import conf.switches.Switches.MostViewedFronts
 
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties = model.FrontProperties.empty,
@@ -76,9 +77,11 @@
                     }
 
                     case MostPopular => {
-                        <div class="fc-container__inner">
+                        @if(MostViewedFronts.isSwitchedOn) {
+                            <div class="fc-container__inner">
                             @mostPopularContainer(containerDefinition, frontProperties)
-                        </div>
+                            </div>
+                        }
                     }
 
                     case _ => {}


### PR DESCRIPTION
## What does this change?

We had an incident which meant that we had old content showing up in the most viewed component. Even though the problem was upstream, it would have been good to have a way to automatically hide the component on dotcom.

## What is the value of this and can you measure success?

We have a simply way of turning off most viewed on fronts without making a code change in the moment

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
