### PR TITLE
Remove commercially-oriented thrashers when ad-free

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
@@ -39,6 +39,10 @@ const adFreeSlotRemove = once(
             '.fc-container'
         ).filter(shouldRemoveFaciaContainerWhenAdFree);
 
+        const commercialThrashers: Array<Element> = qwery(
+            '.commercial-thrasher'
+        );
+
         return fastdom.write(() => {
             if (bodyEl) {
                 if (bodyEl.classList.toString().includes('has-page-skin')) {
@@ -56,6 +60,14 @@ const adFreeSlotRemove = once(
             );
             commercialFaciaContainersToRemove.forEach(
                 (faciaContainer: Element) => faciaContainer.classList.add('u-h')
+            );
+            commercialThrashers.forEach(
+                (thrasher: Element) => {
+                    const closestFaciaContainer = thrasher.closest('.fc-container--thrasher');
+                    if (closestFaciaContainer) {
+                        closestFaciaContainer.remove();
+                    }
+                }
             );
         });
     }

--- a/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
@@ -61,14 +61,14 @@ const adFreeSlotRemove = once(
             commercialFaciaContainersToRemove.forEach(
                 (faciaContainer: Element) => faciaContainer.classList.add('u-h')
             );
-            commercialThrashers.forEach(
-                (thrasher: Element) => {
-                    const closestFaciaContainer = thrasher.closest('.fc-container--thrasher');
-                    if (closestFaciaContainer) {
-                        closestFaciaContainer.remove();
-                    }
+            commercialThrashers.forEach((thrasher: Element) => {
+                const closestFaciaContainer = thrasher.closest(
+                    '.fc-container--thrasher'
+                );
+                if (closestFaciaContainer) {
+                    closestFaciaContainer.remove();
                 }
-            );
+            });
         });
     }
 );


### PR DESCRIPTION
## What does this change?
Thrashers that contain or link through to commercially-oriented content should be suppressed for ad-free users.

## Screenshots

(You're interested in the bit between Spotlight and Opinion)

**Before**
![screencapture-theguardian-uk-2018-09-24-16_41_02](https://user-images.githubusercontent.com/690395/45962532-f9f2ff00-c018-11e8-922f-04a36e1dff45.png)

**After**
![screencapture-m-thegulocal-uk-2018-09-24-16_21_14](https://user-images.githubusercontent.com/690395/45962549-05462a80-c019-11e8-90f5-cdef186f1f1d.png)

## What is the value of this and can you measure success?
Ad-free users are subscribers by definition, and ASA guidance says we cannot show this type of content under the ad-free terms.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None of the above

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No (it actually makes it better)
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A (content was removed)

### Tested

- [x] Locally
- [x] On CODE (optional)
