### PR TITLE
Add Pubmatic to Prebid

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -400,10 +400,20 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
-    val prebidOpenx: Switch = Switch(
+  val prebidOpenx: Switch = Switch(
     group = Commercial,
     name = "prebid-openx",
     description = "Include OpenX adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val prebidPubmatic: Switch = Switch(
+    group = Commercial,
+    name = "prebid-pubmatic",
+    description = "Include Pubmatic adapter in Prebid auctions",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#f638594",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#1aaeef7",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -13,7 +13,7 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import {
     getParticipations,
     getVariant,
-    isInVariant,
+    isInVariant
 } from 'common/modules/experiments/utils';
 import type {
     PrebidAdYouLikeParams,
@@ -45,6 +45,8 @@ import {
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
+    isInUsRegion,
+    isInAuRegion
 } from './utils';
 
 const isInSafeframeTestVariant = (): boolean => {
@@ -365,16 +367,13 @@ const sonobiBidder: PrebidBidder = {
         ),
 };
 
-const getPubmaticPublisherId = (edition: string): string => {
-    switch (edition) {
-        case 'US':
-            return '157206';
-        case 'AU':
-            return '157203';
-        case 'UK':
-        default:
-            return '157207';
-    }
+const getPubmaticPublisherId = (): string => {
+    if (isInUsRegion()) {
+        return '157206';
+    } else if (isInAuRegion()) {
+        return '157203';
+    }   
+    return '157207';
 };
 
 const pubmaticBidder: PrebidBidder = {
@@ -384,7 +383,7 @@ const pubmaticBidder: PrebidBidder = {
         Object.assign(
             {},
             {
-                publisherId: getPubmaticPublisherId(config.get('page.edition')),
+                publisherId: getPubmaticPublisherId(),
                 adSlot: slotId,
             }
         ),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -13,7 +13,7 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import {
     getParticipations,
     getVariant,
-    isInVariant
+    isInVariant,
 } from 'common/modules/experiments/utils';
 import type {
     PrebidAdYouLikeParams,
@@ -46,7 +46,7 @@ import {
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
     isInUsRegion,
-    isInAuRegion
+    isInAuRegion,
 } from './utils';
 
 const isInSafeframeTestVariant = (): boolean => {
@@ -372,7 +372,7 @@ const getPubmaticPublisherId = (): string => {
         return '157206';
     } else if (isInAuRegion()) {
         return '157203';
-    }   
+    }
     return '157207';
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -24,6 +24,7 @@ import type {
     PrebidImproveSizeParam,
     PrebidIndexExchangeParams,
     PrebidOpenXParams,
+    PrebidPubmaticParams,
     PrebidSize,
     PrebidSonobiParams,
     PrebidTrustXParams,
@@ -364,6 +365,31 @@ const sonobiBidder: PrebidBidder = {
         ),
 };
 
+const getPubmaticPublisherId = (edition: string): string => {
+    switch(edition) {
+        case 'US':
+            return '157206'
+        case 'AU':
+            return '157203'
+        case 'UK':
+        default:
+            return '157207'
+    }
+}
+
+const pubmaticBidder: PrebidBidder = {
+    name: 'pubmatic',
+    switchName: 'prebidPubmatic',
+    bidParams: (slotId: string): PrebidPubmaticParams =>
+        Object.assign(
+            {},
+            {
+                publisherId: getPubmaticPublisherId(config.get('page.edition')),
+                adSlot: slotId,
+            }
+        ),
+};
+
 const trustXBidder: PrebidBidder = {
     name: 'trustx',
     switchName: 'prebidTrustx',
@@ -503,6 +529,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
         ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
         improveDigitalBidder,
         xaxisBidder,
+        pubmaticBidder,
         ...(shouldIncludeAdYouLike(slotSizes) ? [adYouLikeBidder] : []),
         ...(shouldIncludeOpenx() ? [openxClientSideBidder] : []),
     ];

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -366,16 +366,16 @@ const sonobiBidder: PrebidBidder = {
 };
 
 const getPubmaticPublisherId = (edition: string): string => {
-    switch(edition) {
+    switch (edition) {
         case 'US':
-            return '157206'
+            return '157206';
         case 'AU':
-            return '157203'
+            return '157203';
         case 'UK':
         default:
-            return '157207'
+            return '157207';
     }
-}
+};
 
 const pubmaticBidder: PrebidBidder = {
     name: 'pubmatic',

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -370,7 +370,8 @@ const sonobiBidder: PrebidBidder = {
 const getPubmaticPublisherId = (): string => {
     if (isInUsRegion()) {
         return '157206';
-    } else if (isInAuRegion()) {
+    }
+    if (isInAuRegion()) {
         return '157203';
     }
     return '157207';

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -12,7 +12,7 @@ export type PrebidSonobiParams = {
 
 export type PrebidPubmaticParams = {
     publisherId: string,
-    adSlot: string
+    adSlot: string,
 };
 
 export type PrebidIndexExchangeParams = {

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -95,7 +95,8 @@ export type PrebidBidder = {
         | PrebidXaxisParams
         | PrebidAppNexusParams
         | PrebidOpenXParams
-        | PrebidAdYouLikeParams,
+        | PrebidAdYouLikeParams
+        | PrebidPubmaticParams,
     labelAny?: PrebidBidLabel[],
     labelAll?: PrebidBidLabel[],
 };
@@ -110,7 +111,8 @@ export type PrebidBid = {
         | PrebidXaxisParams
         | PrebidAppNexusParams
         | PrebidOpenXParams
-        | PrebidAdYouLikeParams,
+        | PrebidAdYouLikeParams
+        | PrebidPubmaticParams,
     labelAny?: PrebidBidLabel[],
     labelAll?: PrebidBidLabel[],
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -10,6 +10,11 @@ export type PrebidSonobiParams = {
     render?: string,
 };
 
+export type PrebidPubmaticParams = {
+    publisherId: string,
+    adSlot: string
+};
+
 export type PrebidIndexExchangeParams = {
     siteId: string,
     size: PrebidSize,

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -15,12 +15,14 @@ const stripSuffix = (s: string, suffix: string): string => {
 
 const currentGeoLocation = once((): string => geolocationGetSync());
 
-export const isInUsRegion = (): boolean => ['US', 'CA'].includes(currentGeoLocation());
-
-export const isInAuRegion = (): boolean => ['AU', 'NZ'].includes(currentGeoLocation());
-
 const contains = (sizes: PrebidSize[], size: PrebidSize): boolean =>
     Boolean(sizes.find(s => s[0] === size[0] && s[1] === size[1]));
+
+export const isInUsRegion = (): boolean =>
+    ['US', 'CA'].includes(currentGeoLocation());
+
+export const isInAuRegion = (): boolean =>
+    ['AU', 'NZ'].includes(currentGeoLocation());
 
 export const containsMpu = (sizes: PrebidSize[]): boolean =>
     contains(sizes, [300, 250]);

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -15,9 +15,9 @@ const stripSuffix = (s: string, suffix: string): string => {
 
 const currentGeoLocation = once((): string => geolocationGetSync());
 
-const isInUsRegion = (): boolean => ['US', 'CA'].includes(currentGeoLocation());
+export const isInUsRegion = (): boolean => ['US', 'CA'].includes(currentGeoLocation());
 
-const isInAuRegion = (): boolean => ['AU', 'NZ'].includes(currentGeoLocation());
+export const isInAuRegion = (): boolean => ['AU', 'NZ'].includes(currentGeoLocation());
 
 const contains = (sizes: PrebidSize[], size: PrebidSize): boolean =>
     Boolean(sizes.find(s => s[0] === size[0] && s[1] === size[1]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7832,9 +7832,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#f638594":
+"prebid.js@https://github.com/guardian/Prebid.js.git#1aaeef7":
   version "1.24.0"
-  resolved "https://github.com/guardian/Prebid.js.git#f638594ea9ea7f1c0119625cc43fabf7244f9478"
+  resolved "https://github.com/guardian/Prebid.js.git#1aaeef78b6761609d19297888693db6587f0285c"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?

This adds the Pubmatic adapter to Prebid with different account IDs per edition rather than region.

@guardian/commercial-dev 