### PR TITLE
Fix takedowns for pressed pages

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -51,6 +51,7 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
       .flatMap(_.map(Future.successful).getOrElse(getLocal404Page))
   }
 
+  // Note this code is duplicated in R2PressedController - changes here should be reflected there
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
   def normalise(path: String, zeros: String = ""): String = path match {
     case R1ArtifactUrl(p, artifactOrContextId, extension) =>


### PR DESCRIPTION
We have an issue at the moment that this page https://www.theguardian.com/education/help/page/0,,487650,00.html can't be taken down using the page presser. Turns out this is because when the page presser tries to remove the redirect from Dynamo, it removes `https://www.theguardian.com/education/help/page/0,,487650,00.html` whereas the redirect is actually stored in a 'normalised' form - `http://www.theguardian.com/education/help/page/0,,487650,.html`. The normalised form isn't deleted, and it is this which is used by archive to lookup the redirect, and so the page is still returning the pressed page from S3.

This change sets up the page presser to purge not only the submitted url, but also the 'normalised' form of it, using the same logic as archiver uses to normalise the url. This should ensure that takedowns via the page press tool work properly.

I chose to copy paste the normalise function rather than sticking it in common because common is bad! And we're only likely to ever need this code in 2 apps.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
