### PR TITLE
Add tags, byline fields to .json endpoint

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -74,7 +74,9 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   private def getJson(article: ArticlePage)(implicit request: RequestHeader) = {
-    val contentFieldsJson = if (request.isGuuiJson) List("contentFields" -> Json.toJson(ContentFields(article.article))) else List()
+    val contentFieldsJson = if (request.isGuuiJson) List(
+      "contentFields" -> Json.toJson(ContentFields(article.article)),
+      "tags" -> Json.toJson(article.article.tags)) else List()
     List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
   }
 

--- a/common/app/common/Pagination.scala
+++ b/common/app/common/Pagination.scala
@@ -1,5 +1,7 @@
 package common
 
+import play.api.libs.json.{Json, Writes}
+
 case class Pagination(currentPage: Int, lastPage: Int, totalContent: Int) {
 
   val next: Option[Int] = if (lastPage > currentPage) Some(currentPage + 1) else None
@@ -54,4 +56,8 @@ case class Pagination(currentPage: Int, lastPage: Int, totalContent: Int) {
   def getOffset: Int = {
     if (lastPage > 5) 1 else 0
   }
+}
+
+object Pagination {
+  implicit val paginationWrites: Writes[Pagination] = Json.writes[Pagination]
 }

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -66,12 +66,14 @@ object Tag {
       richLinkId = richLinkId
     )
   }
+  implicit val tagWrites: Writes[Tag] = Json.writes[Tag]
 }
 
 object Podcast {
   def make(podcast: ApiPodcast): Podcast = {
     Podcast(podcast.subscriptionUrl, podcast.googlePodcastsUrl, podcast.spotifyUrl)
   }
+  implicit val podcastWrites: Writes[Podcast] = Json.writes[Podcast]
 }
 case class Podcast(
   subscriptionUrl: Option[String],
@@ -108,6 +110,7 @@ object Reference {
       */
     JsObject(Seq(k -> JsString(RelativePathEscaper.escapeLeadingSlashFootballPaths(v))))
   }
+  implicit val referenceWrites: Writes[Reference] = Json.writes[Reference]
 }
 
 case class Reference(
@@ -138,6 +141,8 @@ object TagProperties {
       commercial = Some(CommercialProperties.fromTag(tag))
     )
   }
+
+  implicit val tagPropertiesWrites: Writes[TagProperties] = Json.writes[TagProperties]
 }
 
 case class TagProperties(
@@ -187,4 +192,6 @@ case class Tag (
   val isFootballTeam = properties.references.exists(_.`type` == "pa-football-team")
   val isFootballCompetition = properties.references.exists(_.`type` == "pa-football-competition")
   val contributorImagePath = properties.bylineImageUrl.map(ImgSrc(_, Contributor))
+
+  implicit val tagWrites: Writes[Tag] = Json.writes[Tag]
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -259,7 +259,8 @@ final case class Content(
     ("isImmersive", JsBoolean(isImmersive)),
     ("isColumn", JsBoolean(isColumn)),
     ("isPaidContent", JsBoolean(isPaidContent)),
-    ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
+    ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
+    ("contributorBio", JsString(contributorBio.getOrElse("")))
 
   )
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -792,4 +792,5 @@ object Tags {
   def make(apiContent: contentapi.Content): Tags = {
     Tags(apiContent.tags.toList map { Tag.make(_) })
   }
+  implicit val tagsWrites: Writes[Tags] = Json.writes[Tags]
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -115,6 +115,7 @@ final case class Trail (
     ("isLive", JsBoolean(fields.isLive)),
     ("webPublicationDate", Json.toJson(webPublicationDate)),
     ("headline", JsString(headline)),
-    ("commentable", JsBoolean(isCommentable))
+    ("commentable", JsBoolean(isCommentable)),
+    ("byline", JsString(byline.getOrElse("")))
   )
 }


### PR DESCRIPTION
## What does this change?
Adds tags and byline info to the article json endpoint so that they can be used in dotcom rendering.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
