### PR TITLE
Fix dedup code behind Show more button for ad-free

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -81,7 +81,7 @@ const dedupShowMore = ($container: bonzo, html: string): bonzo => {
             $article.attr(ARTICLE_ID_ATTRIBUTE) in seenArticles ||
             (isAdFreeUser() &&
                 articleClass &&
-                articleClass.contains('paid-content'))
+                articleClass.includes('paid-content'))
         ) {
             $article.remove();
         }


### PR DESCRIPTION
## What does this change?
Replace `.contains` with `.includes` on `classList` check.

## Screenshots
As seen on CODE:
![ffshowmoreadfree](https://user-images.githubusercontent.com/690395/46029205-ae108a80-c0ea-11e8-8bc5-fa80ea08bfd5.gif)


## What is the value of this and can you measure success?
Makes Firefox show more button clicks work. Annoyingly, this didn't manifest as an exception in Chrome.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None of the above

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A: restores existing behaviour

### Tested

- [x] Locally
- [x] On CODE (FF & Chrome both OK)
