### PR TITLE
CALLOUTS: Render description as html & use * for required

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -19,7 +19,7 @@ export const getCampaign = () => {
         } = campaignToShow.fields;
         return {
             title: callout,
-            description,
+            description: description || `<p>&nbsp;</p>`,
             formFields,
             formId,
         };

--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -9,7 +9,7 @@
             </div>
             <div class="heading">
                 <h4 class="campaign--snippet__headline"> <%= data.title %></h4>
-                <p> <%= data.description %></p>
+                <%= data.description %>
             </div>
             <div class="success_box">
                 <p class="success-message">Thank you for your contribution</p>
@@ -41,7 +41,7 @@
         <div class="form_input form_input--<%=field.type%>">
             <div class="form_field">
                 <label for="<%=field.name%>"
-                       class="form_field_label">
+                       class="form_field_label <% if (field.required == '1') { %> required <% } %>" >
                     <%= field.label %>
                     <% if(field.description) { %>
                         <span>(<%= field.description %>)</span>

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -422,6 +422,10 @@
         font-weight: 500;
         font-family: $f-serif-headline;
 
+        &.required:after {
+            content: '*';
+        }
+
         span {
             font-weight: 200;
             margin-right: 10px;

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -422,7 +422,7 @@
         font-weight: 500;
         font-family: $f-serif-headline;
 
-        &.required:after {
+        &.required::after {
             content: '*';
         }
 


### PR DESCRIPTION
## What does this change?
Journalists wanted to use rich text with formatting for the description box in a callout, this allows the subtitle to be rendered as html. 

I have also added an asterisk after labels where the input is required. 

## Screenshots
**Rich text in callout description** 
![screen shot 2018-09-25 at 17 47 00](https://user-images.githubusercontent.com/10324129/46029347-0e9fc780-c0eb-11e8-80c2-cccc3281d451.png)

**Asterisks**
![screen shot 2018-09-25 at 17 44 30](https://user-images.githubusercontent.com/10324129/46029247-c7b1d200-c0ea-11e8-9b09-2efcd91bd259.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
