### PR TITLE
Geotarget Lotame

### DIFF
--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -35,7 +35,9 @@ function shouldServeLotame() {
         }
         return true;
     }
-    catch(e) {};
+    catch(e) {
+        console.log(`shouldServeLotame exception: ${e.toString()}`);
+    };
     return false;
 }
 

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -26,6 +26,19 @@ function guardianPolyfilled() {
     } catch (e) {};
 }
 
+function shouldServeLotame() {
+    try {    
+        var geo = JSON.parse(window.localStorage.getItem("gu.geolocation")).value;
+        console.log(`Geo was: ${geo}`)
+        if (geo === 'US' || geo === 'CA' || geo === 'AU' || geo === 'NZ') {
+            return false;
+        }
+        return true;
+    }
+    catch(e) {};
+    return false;
+}
+
 // Load the app and try to patch the env with polyfill.io
 // Adapted from https://www.html5rocks.com/en/tutorials/speed/script-loading/#toc-aggressive-optimisation
 (function (document, window) {
@@ -41,10 +54,13 @@ function guardianPolyfilled() {
     }) { polyfillioUrl =>
         @if(LotameSwitch.isSwitchedOn) {
             var scripts = [
-                '@polyfillioUrl',
-                '@Configuration.lotame.lotameScriptUrl',
-                '@Static(s"javascripts/graun.$bootModule.js")'
-            ];            
+                '@polyfillioUrl'                
+            ];
+            if (shouldServeLotame() === true) {
+                console.log('I am going to serve lotame');
+                scripts.push('@Configuration.lotame.lotameScriptUrl');
+            }
+            scripts.push('@Static(s"javascripts/graun.$bootModule.js")');
         } else {
             var scripts = [
                 '@polyfillioUrl',

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -29,15 +29,12 @@ function guardianPolyfilled() {
 function shouldServeLotame() {
     try {    
         var geo = JSON.parse(window.localStorage.getItem("gu.geolocation")).value;
-        console.log(`Geo was: ${geo}`)
         if (geo === 'US' || geo === 'CA' || geo === 'AU' || geo === 'NZ') {
             return false;
         }
         return true;
     }
-    catch(e) {
-        console.log(`shouldServeLotame exception: ${e.toString()}`);
-    };
+    catch(e) {};
     return false;
 }
 
@@ -59,7 +56,6 @@ function shouldServeLotame() {
                 '@polyfillioUrl'                
             ];
             if (shouldServeLotame() === true) {
-                console.log('I am going to serve lotame');
                 scripts.push('@Configuration.lotame.lotameScriptUrl');
             }
             scripts.push('@Static(s"javascripts/graun.$bootModule.js")');


### PR DESCRIPTION
## What does this change?

This adds to the head of the document a new function that will attempt to retrieve the `gu.geolocation` key from local storage; this is set by Javascript for each user.

If the region is either undefined/unset, or is in the US/CA/AU/NZ region, then we don't serve the script.

### Tested

- [x] Locally
- [x] On CODE (optional)

@guardian/commercial-dev 
