### PR TITLE
Extend blockthrough switch by a month

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -293,7 +293,7 @@ trait CommercialSwitches {
     description = "Include the blockthrough script for testing the vendors effectiveness at circumventing ad-blocking.",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 9, 27),
+    sellByDate = new LocalDate(2018, 10, 25),
     exposeClientSide = false
    )
 


### PR DESCRIPTION
## What does this change?

This extends the blockthrough switch by one month.

@guardian/commercial-dev 