### PR TITLE
Add legal wordings to new email journey

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
@@ -25,14 +25,16 @@ class AccountCreationBlock extends Component<
     render() {
         return !this.state.hasCreatedAccount ? (
             <Block
-                withGrid
+                sideBySide
                 title="Want more from The Guardian?"
                 subtitle="Create your account now to manage your preferences and explore your free benefits.">
                 <AccountCreationForm
                     {...this.props}
                     onAccountCreated={this.onAccountCreated}
                 />
-                <AccountBenefits />
+                <div>
+                    <AccountBenefits />
+                </div>
             </Block>
         ) : (
             <Block title="Start exploring your benefits">

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
@@ -4,18 +4,30 @@ import React, { Component } from 'preact-compat';
 type BlockProps = {
     title: string,
     subtitle: ?string,
-    withGrid: ?boolean,
+    sideBySide: ?boolean,
+    sideBySideBackwards: ?boolean,
     children: any,
 };
 
 export class Block extends Component<BlockProps> {
     render() {
-        const { title, subtitle, children, withGrid } = this.props;
+        const {
+            title,
+            subtitle,
+            children,
+            sideBySide,
+            sideBySideBackwards,
+        } = this.props;
         return (
             <section
                 className={[
                     'identity-upsell-block',
-                    withGrid ? 'identity-upsell-block--with-grid' : '',
+                    sideBySide || sideBySideBackwards
+                        ? 'identity-upsell-block--side-by-side'
+                        : '',
+                    sideBySideBackwards
+                        ? 'identity-upsell-block--side-by-side identity-upsell-block--side-by-side--backwards'
+                        : '',
                 ].join(' ')}>
                 <div className="identity-upsell-title">
                     <h2 className="identity-upsell-title__title">{title}</h2>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
@@ -1,0 +1,9 @@
+import React from 'preact-compat';
+
+const LegalTextBlock = ({children}) => (
+    <div class={"identity-upsell-legal-text-block"}>
+        {children}
+    </div>
+)
+
+export {LegalTextBlock}

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
@@ -1,9 +1,8 @@
+// @flow
 import React from 'preact-compat';
 
-const LegalTextBlock = ({children}) => (
-    <div class={"identity-upsell-legal-text-block"}>
-        {children}
-    </div>
-)
+const LegalTextBlock = ({ children }: { children: any }) => (
+    <div className="identity-upsell-legal-text-block">{children}</div>
+);
 
-export {LegalTextBlock}
+export { LegalTextBlock };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -13,6 +13,7 @@ import {
     getNewsletterConsent,
 } from 'common/modules/identity/upsell/store/consents';
 import { AccountCreationBlock } from './account-creation/AccountCreationBlock';
+import {LegalTextBlock} from "common/modules/identity/upsell/block/LegalTextBlock";
 
 const ConfirmEmailThankYou = (
     <Block title="Interested in any of this content?">
@@ -31,8 +32,12 @@ const ConfirmEmailThankYou = (
 
 const Optouts = (
     <Block
+        withGrid={true}
         title="One more thing..."
         subtitle="These are your privacy settings. You’re in full control of them.">
+        <LegalTextBlock>
+            You can also change these settings any time by visiting our Emails & marketing section of your account.
+        </LegalTextBlock>
         <OptOutsList />
     </Block>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -12,8 +12,8 @@ import {
     getUserConsent,
     getNewsletterConsent,
 } from 'common/modules/identity/upsell/store/consents';
-import { AccountCreationBlock } from './account-creation/AccountCreationBlock';
-import {LegalTextBlock} from "common/modules/identity/upsell/block/LegalTextBlock";
+import { LegalTextBlock } from 'common/modules/identity/upsell/block/LegalTextBlock';
+import { AccountCreationBlock } from 'common/modules/identity/upsell/account-creation/AccountCreationBlock';
 
 const ConfirmEmailThankYou = (
     <Block title="Interested in any of this content?">
@@ -32,11 +32,12 @@ const ConfirmEmailThankYou = (
 
 const Optouts = (
     <Block
-        withGrid={true}
+        sideBySideBackwards
         title="One more thing..."
         subtitle="These are your privacy settings. You’re in full control of them.">
         <LegalTextBlock>
-            You can also change these settings any time by visiting our Emails & marketing section of your account.
+            You can also change these settings any time by visiting our Emails &
+            marketing section of your account.
         </LegalTextBlock>
         <OptOutsList />
     </Block>

--- a/static/src/stylesheets/module/identity/upsell/_layout.scss
+++ b/static/src/stylesheets/module/identity/upsell/_layout.scss
@@ -47,3 +47,7 @@
     }
 }
 
+.identity-upsell-legal-text-block {
+    @include fs-textSans(5);
+    color: $brightness-46;
+}

--- a/static/src/stylesheets/module/identity/upsell/_layout.scss
+++ b/static/src/stylesheets/module/identity/upsell/_layout.scss
@@ -16,15 +16,24 @@
     &:first-child {
         border-top: 0;
     }
-    &.identity-upsell-block--with-grid {
+    &.identity-upsell-block--side-by-side {
         .identity-upsell-block__container {
-            display: grid;
-            grid-row-gap: $gs-baseline;
-            grid-auto-columns: 1fr;
+            & > * {
+                margin-bottom: $gs-baseline;
+                flex: 1 0 0;
+            }
             @include mq(tablet) {
-                display: grid;
-                grid-column-gap: $gs-gutter;
-                grid-template-columns: 1fr 1fr;
+                display: flex;
+                margin: 0 $gs-gutter/2*-1;
+                > * {
+                    margin: 0 $gs-gutter/2;
+                    margin-bottom: 0;
+                }
+            }
+        }
+        &.identity-upsell-block--side-by-side--backwards {
+            .identity-upsell-block__container {
+                flex-direction: row-reverse;
             }
         }
     }


### PR DESCRIPTION
## What does this change?
Adds a `LegalTextBlock` component to display grey-ish legal-ish looking text and a new `sideBySideBackwards` feature to blocks that lets them display content on top on mobile but to the right on desktop.

## Screenshots
![screen shot 2018-09-26 at 2 15 52 pm](https://user-images.githubusercontent.com/11539094/46082294-b0c8b980-c196-11e8-8c48-ecc94842c027.png)


## What is the value of this and can you measure success?

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
