### PR TITLE
Better Render Tier Logging

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -1,0 +1,53 @@
+package services.dotcomponents
+
+import common.Logging
+import common.LoggingField._
+import play.api.mvc.RequestHeader
+
+import scala.util.Random
+
+case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
+
+  private lazy val customFields: List[LogField] = {
+
+    val requestHeaders: List[LogField] = request.map { r: RequestHeader =>
+      List[LogField](
+        "req.method" -> r.method,
+        "req.url" -> r.uri,
+        "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString
+      )
+    }.getOrElse(Nil)
+
+    requestHeaders
+
+  }
+
+  def toList: List[LogField] = customFields
+
+}
+
+case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
+
+  private def allFields: List[LogField] = DotcomponentsLoggerFields(request).toList
+
+  def withRequestHeaders(rh: RequestHeader): DotcomponentsLogger = {
+    copy(Some(rh))
+  }
+
+  def info(message: String): Unit = {
+    logInfoWithCustomFields(message, allFields)
+  }
+
+  def warn(message: String, error: Throwable): Unit = {
+    logWarningWithCustomFields(message, error, allFields)
+  }
+
+  def error(message: String, error: Throwable): Unit = {
+    logErrorWithCustomFields(message, error, allFields)
+  }
+
+}
+
+object DotcomponentsLogger {
+  def apply(): DotcomponentsLogger = DotcomponentsLogger(None)
+}

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -1,16 +1,19 @@
 package services.dotcomponents
 
-import common.Logging
 import experiments.{ActiveExperiments, Control, DotcomponentsRendering, Excluded, Participant}
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
 import services.dotcomponents.pickers.{RenderTierPickerStrategy, SimplePagePicker, WhitelistPicker}
 import implicits.Requests._
 
-object RenderingTierPicker extends Logging {
+object RenderingTierPicker {
 
   // todo: use injection for this
   val picker: RenderTierPickerStrategy = new SimplePagePicker()
+
+  // use this logger so we get all the log fields populated for free
+  def logRequest(msg:String)(implicit request: RequestHeader): Unit =
+    DotcomponentsLogger().withRequestHeaders(request).info(msg)
 
   def getRenderTierFor(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
 
@@ -25,7 +28,7 @@ object RenderingTierPicker extends Logging {
     val isSupported = picker.getRenderTierFor(page, request)
 
     isSupported match {
-      case RemoteRender => log.info(s"Article was remotely renderable ${page.metadata.id}")
+      case RemoteRender => logRequest("Article was remotely renderable")
       case _ =>
     }
 


### PR DESCRIPTION
## What does this change?

So, I've realised that when we're searching for Kibana logs about renderable pages, we can get results just fine because we essentially have a log message saying the page url, but, you can't do any graphing or analytics on the log message field. So it's impossible to, for example, get a chart our top 10 most visited renderable pages.

This PR introduces a 'proper' logger that populates the url as it's own field rather than it just being part of the log message, so we can actually do graphing on it in Kibana.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
