### PR TITLE
Fix YT player ophan events

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.167"
   val awsVersion = "1.11.240"
-  val capiVersion = "12.7"
-  val faciaVersion = "2.6.3"
+  val capiVersion = "12.10"
+  val faciaVersion = "2.6.4"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.167"
   val awsVersion = "1.11.240"
-  val capiVersion = "12.10"
-  val faciaVersion = "2.6.4"
+  val capiVersion = "12.7"
+  val faciaVersion = "2.6.3"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-tracking.js
@@ -61,6 +61,13 @@ const initYoutubeEvents = (videoId: string): void => {
             );
         });
     });
+
+    ophanRecord({
+        mediaId: videoId,
+        mediaType: 'video',
+        eventType: 'ready',
+        isPreroll: false,
+    });
 };
 
 const trackYoutubeEvent = (event: string, id: string): void => {


### PR DESCRIPTION
## What does this change?

The YouTube player is not sending all the required events the data team needs to measure the performance of video on the site. In particular, the `ready` event should be sent right when the player is ready to play the media.

Given that the YT library is only fired when the user clicks on the "Play" button, the `ready` event is sent right when the bootstrap script has been properly executed.

## Screenshots

<img width="363" alt="screen shot 2018-09-26 at 14 44 47" src="https://user-images.githubusercontent.com/629976/46084191-0010e900-c19b-11e8-9e76-97bda02f3b00.png">
