### PR TITLE
More restrictions on what a simple page is

### DIFF
--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -9,6 +9,9 @@ import views.support.Commercial
 
 class SimplePagePicker extends RenderTierPickerStrategy {
 
+  // each function should ideally only check a single value, so that
+  // we can just remove the lines over time as we support more.
+
   private def isDiscussionDisabled(page: PageWithStoryPackage): Boolean = {
     (! page.article.content.trail.isCommentable) && page.article.content.trail.isClosedForComments
   }
@@ -41,13 +44,25 @@ class SimplePagePicker extends RenderTierPickerStrategy {
     page.item.content.shouldHideAdverts || Commercial.isAdFree(request)
   }
 
+  private def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
+
+  private def isNotLiveBlog(page:PageWithStoryPackage): Boolean = ! page.item.isLiveBlog
+
+  private def isNotAReview(page:PageWithStoryPackage): Boolean = ! page.item.tags.isReview
+
+  private def isNotAGallery(page:PageWithStoryPackage): Boolean = ! page.item.tags.isGallery
+  
   def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType = {
 
     val canRemotelyRender = isSupportedType(page) &&
       hasBlocks(page) &&
       hasOnlySupportedElements(page) &&
       isDiscussionDisabled(page) &&
-      isAdFree(page, request)
+      isAdFree(page, request) &&
+      isNotImmersive(page) &&
+      isNotLiveBlog(page) &&
+      isNotAReview(page) &&
+      isNotAGallery(page)
 
     if(canRemotelyRender){
       RemoteRender


### PR DESCRIPTION
## What does this change?

make sure we're not picking immersives, reviews, galleries etc. I still see these occasionally in the logs as being picked, but this should get rid of those.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
