### PR TITLE
AUDIO: Fix - adding loading state for slow mobile connections

### DIFF
--- a/static/src/javascripts/projects/common/modules/audio/inArticlePlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/inArticlePlayer.js
@@ -16,11 +16,12 @@ const setPauseButton = el => {
 };
 
 // design hack to give immediate feedback on the progress bar for a play event
-const showStarterBlockOnFirstPlay = () => {
+const showStarterBlockOnFirstPlay = timePlayedSpan => {
     const scrubberBar: ?HTMLElement = document.querySelector(
         '.inline-audio_content_progress-bar'
     );
     if (scrubberBar) scrubberBar.classList.add('started');
+    timePlayedSpan.textContent = 'loading...';
 };
 
 // PLAYER ACTION FUNCTIONS
@@ -40,13 +41,13 @@ const updateTime = (el: HTMLElement, player, progressBar: HTMLElement) => {
     });
 };
 
-const activateAudioControls = (el, player, id) => {
+const activateAudioControls = (el, player, id, timePlayedSpan) => {
     el.addEventListener('click', () => {
         if (player.paused) {
             sendToOphan(id, 'play');
             player.play();
             setPauseButton(el);
-            showStarterBlockOnFirstPlay();
+            showStarterBlockOnFirstPlay(timePlayedSpan);
         } else {
             player.pause();
             setPlayButton(el);
@@ -110,7 +111,7 @@ const init = () => {
         durationSpan
     ) {
         playerObserved(container, mediaId);
-        activateAudioControls(buttonDiv, player, mediaId);
+        activateAudioControls(buttonDiv, player, mediaId, timePlayedSpan);
         updateTime(timePlayedSpan, player, progressBar);
 
         // should run on Chrome, FF


### PR DESCRIPTION
## What does this change?
Loading on mobiles for the in-article player is very slow. I want to show a loading state after play has been clicked but before the time updates, to indicate to users that the loading is working. 

The loading state is literally just the word 'loading...' where the current time stamp usually is. It appears whenever the user hits play, but gets overwritten as soon as the time updates. 

This is the simplest change with the least code that I could think of.

## Screenshots

![screen shot 2018-09-27 at 12 20 48](https://user-images.githubusercontent.com/10324129/46142863-33fa1600-c250-11e8-8618-309777892bd8.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
