### PR TITLE
Expose pillar in JavaScript config

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -275,7 +275,8 @@ final case class MetaData (
     ("buildNumber", JsString(buildNumber)),
     ("revisionNumber", JsString(revision)),
     ("isFront", JsBoolean(isFront)),
-    ("contentType", JsString(contentType.map(_.name).getOrElse("")))
+    ("contentType", JsString(contentType.map(_.name).getOrElse(""))),
+    ("pillar", JsString(pillar.map(_.toString).getOrElse("")))
   )
 
   def opengraphProperties: Map[String, String] = {


### PR DESCRIPTION
## What does this change?

Adds the `pillar` to `guardian.config.page`, to pass to dotcom-rendering

## What is the value of this and can you measure success?

Allows us to determine the pillar of a piece of content consistently in the new rendering tier.
