### PR TITLE
MMA banner CTA now goes straight into the payment update flow (membership only)

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -319,6 +319,7 @@ class GuardianConfiguration extends Logging {
     lazy val domain = """^https?://(?:profile\.)?([^/:]+)""".r.unapplySeq(url).flatMap(_.headOption).getOrElse("theguardian.com")
     lazy val apiClientToken = configuration.getStringProperty("id.apiClientToken").getOrElse("")
     lazy val oauthUrl = configuration.getStringProperty("id.oauth.url").getOrElse("")
+    lazy val mmaUrl = configuration.getStringProperty("id.manage.url").getOrElse("https://manage.theguardian.com")
     lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
     lazy val supportUrl = configuration.getStringProperty("id.support.url").getOrElse("https://support.theguardian.com")
     lazy val optimizeEpicUrl = configuration.getStringProperty("id.support.optimize-epic-url").getOrElse("https://support.theguardian.com/epic/control/index.html")

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -70,6 +70,7 @@ object JavaScriptPage {
       ("isDev", JsBoolean(!environment.isProd)),
       ("isProd", JsBoolean(Configuration.environment.isProd)),
       ("idUrl", JsString(Configuration.id.url)),
+      ("mmaUrl", JsString(Configuration.id.mmaUrl)),
       ("beaconUrl", JsString(Configuration.debug.beaconUrl)),
       ("assetsPath", JsString(Configuration.assets.path)),
       ("isPreview", JsBoolean(isPreview)),

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -17,7 +17,7 @@ const accountDataUpdateLink = accountDataUpdateWarningLink => {
         case 'contribution':
             return `${config.get('page.idUrl')}/contribution/recurring/edit`;
         case 'membership':
-            return `https://manage.theguardian.com/banner/membership`;
+            return `${config.get('page.mmaUrl')}/banner/membership`;
         default:
             return `${config.get(
                 'page.idUrl'

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -17,7 +17,7 @@ const accountDataUpdateLink = accountDataUpdateWarningLink => {
         case 'contribution':
             return `${config.get('page.idUrl')}/contribution/recurring/edit`;
         case 'membership':
-            return `https://manage.theguardian.com/payment/membership?INTCMP=BANNER`;
+            return `https://manage.theguardian.com/banner/membership`;
         default:
             return `${config.get(
                 'page.idUrl'


### PR DESCRIPTION
## What does this change?
Changed destination of MMA banner CTA to be straight into the payment update flow (for membership only) and added some extra GA tracking which logs the product (e.g. membership) along with every mma banner related event (e.g. mma action required 'banner impression' event)

## Screenshots
nothing visual actually changed, but clicking the yellow button in the below...
![from](https://user-images.githubusercontent.com/19289579/44588899-e7ce3880-a7ae-11e8-8ca3-1c95ab78f646.png)
... will go straight here...
![to](https://user-images.githubusercontent.com/19289579/46153226-9fe97800-c26a-11e8-90f2-e8522ed439be.png)

## What is the value of this and can you measure success?
This should reduce drop off from the membership tab in manage.theguardian.com (as users who have an action required on their account will be in the place to do it)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
_**N/A** since no visual changes, but the original visual changes are in https://github.com/guardian/frontend/pull/20256_
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
