### PR TITLE
Update audio switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -45,7 +45,7 @@ object AudioPageChange extends Experiment(
   name = "audio-page-change",
   description = "Show a different version of the audio page to certain people",
   owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2018, 10, 27),
+  sellByDate = new LocalDate(2018, 10, 26),
   participationGroup = Perc5A
 )
 


### PR DESCRIPTION
## What does this change?

Audio switch expires on a weekend, which is breaking the build. I've moved it one day forward so it expires on a Friday

## What is the value of this and can you measure success?

Build doesn't break
