### PR TITLE
Filtering out paid-for (not supported by) content from "More <sectionname> buttons" for Ad Free users

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -134,7 +134,8 @@ final case class PressedMetadata(
   `type`: Option[DotcomContentType],
   pillar: Option[Pillar],
   sectionId: Option[SectionId],
-  designType: DesignType
+  designType: DesignType,
+  isPaid: Option[Boolean]
 )
 final case class PressedElements(
   mainVideo: Option[VideoElement],
@@ -174,7 +175,8 @@ object PressedStory {
         metadata.contentType,
         Pillar(apiContent),
         sectionId,
-        apiContent.designType
+        apiContent.designType,
+        metadata.commercial.map(_.isPaidContent)
       ),
       PressedFields(
         fields.main,

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -134,8 +134,7 @@ final case class PressedMetadata(
   `type`: Option[DotcomContentType],
   pillar: Option[Pillar],
   sectionId: Option[SectionId],
-  designType: DesignType,
-  isPaid: Option[Boolean]
+  designType: DesignType
 )
 final case class PressedElements(
   mainVideo: Option[VideoElement],
@@ -175,8 +174,7 @@ object PressedStory {
         metadata.contentType,
         Pillar(apiContent),
         sectionId,
-        apiContent.designType,
-        metadata.commercial.map(_.isPaidContent)
+        apiContent.designType
       ),
       PressedFields(
         fields.main,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -249,9 +249,13 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
             containerLayout <- container.containerLayout
           } yield {
             val withFrom: Seq[FaciaCardAndIndex] = containerLayout.remainingCards.map(_.withFromShowMore)
-            val withFromFiltered = withFrom.filter( c => !checkIfPaid(c.item).getOrElse(false) )
+            val withFromAdapted : Seq[FaciaCardAndIndex] = if (request.isAdFree) {
+              withFrom.filter( c => !checkIfPaid(c.item).getOrElse(false) )
+            } else {
+              withFrom
+            }
             successful(Cached(CacheTime.Facia) {
-              JsonComponent(views.html.fragments.containers.facia_cards.showMore(withFromFiltered, index))
+              JsonComponent(views.html.fragments.containers.facia_cards.showMore(withFromAdapted, index))
             })
           }
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -233,7 +233,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
 
   def checkIfPaid(faciaCard: FaciaCard): Option[Boolean] = {
     faciaCard match {
-      // case c: ContentCard => c.properties.map( p => p.maybeContent.map( c => c.metadata.isPaid ) )
       case c: ContentCard => c.properties.map( pp => pp.isPaidFor )
       case _ => None
     }


### PR DESCRIPTION
## What does this change?

Correct an alignement problem experienced by Ad Free users when using the "More <sectionname> buttons". We achieve that by filtering those cards out in the backend. See screenshots for details.

This addresses: 
- https://trello.com/c/jD598OTO/308-filtering-out-paid-for-not-supported-by-content-from-more-sectionname-buttons
- (and the first part of) https://trello.com/c/kyB0NQQw/1734-investigate-ad-free-capi

## Screenshots

**Before**

![screenshot 2018-10-01 at 15 05 12](https://user-images.githubusercontent.com/6035518/46294102-f1587680-c58c-11e8-9a94-cf3e33d9ca50.png)

**After**

![screenshot 2018-10-01 at 15 08 09](https://user-images.githubusercontent.com/6035518/46294106-f5849400-c58c-11e8-8e94-134898a963f8.png)

## What is the value of this and can you measure success?

Makes the website prettier :)

### Does this change break ad-free?

It corrects it.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
