### PR TITLE
corrected typo in MMA banner GA event for clicking CTA

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -77,7 +77,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
                     'membership action required | banner update details clicked'
                 );
                 gaTrackClickMMA(
-                    `membership action required | banner update details clicked | ${updateLink ||
+                    `mma action required | banner update details clicked | ${updateLink ||
                         '?'}`
                 );
                 storeBannerCanBeLoadedAgainAfter();


### PR DESCRIPTION
Typo correction following https://github.com/guardian/frontend/pull/20430