### PR TITLE
Select correct showcase image width

### DIFF
--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -252,11 +252,11 @@ object ContentWidths {
     override val showcase = WidthsByBreakpoint(
       mobile =          Some(465.px),
       mobileLandscape = Some(645.px),
-      phablet =         Some(620.px),
+      phablet =         Some(660.px),
       tablet =          Some(700.px),
-      desktop =         Some(620.px),
-      leftCol =         Some(780.px),
-      wide =            Some(860.px))
+      desktop =         Some(700.px),
+      leftCol =         Some(940.px),
+      wide =            Some(1020.px))
 
     /**
      * main image is showcase on a feature article, e.g.


### PR DESCRIPTION
## What does this change?

Currently, the showcase images that we are loading are too small for the available space. They get stretched to fit, reducing the image quality.

This change requests image sizes appropriate for the available space

Example: https://www.theguardian.com/us-news/2018/sep/14/bob-woodward-interview-fear-trump-russia

## What is the value of this and can you measure success?

Better quality for showcase images
