### PR TITLE
Allow team names to wrap

### DIFF
--- a/static/src/stylesheets/module/football/_tables.scss
+++ b/static/src/stylesheets/module/football/_tables.scss
@@ -21,7 +21,7 @@
         .team-name {
             display: inline;
             overflow: hidden;
-            white-space: nowrap;
+            white-space: normal;
             max-width: 100%;
         }
     }


### PR DESCRIPTION
Minor change to football tables to allow team names to wrap as otherwise longer names overflow on smaller breakpoints and get cut off.

![screen shot 2018-10-01 at 14 54 46](https://user-images.githubusercontent.com/858402/46293236-c53bf600-c58a-11e8-9f96-1cb43b1e0545.png)

Previously, things looked broken, like:

![screen shot 2018-10-01 at 15 00 58](https://user-images.githubusercontent.com/858402/46293257-dab12000-c58a-11e8-86cc-3a5ff6725d40.png)
