### PR TITLE
Log out results of specific picker checks

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -8,7 +8,7 @@ import scala.util.Random
 
 case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
 
-  private lazy val customFields: List[LogField] = {
+  lazy val customFields: List[LogField] = {
 
     val requestHeaders: List[LogField] = request.map { r: RequestHeader =>
       List[LogField](
@@ -22,28 +22,33 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
 
   }
 
-  def toList: List[LogField] = customFields
-
 }
 
 case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
 
-  private def allFields: List[LogField] = DotcomponentsLoggerFields(request).toList
+  private def customFields: List[LogField] = DotcomponentsLoggerFields(request).customFields
+
+  def fieldsFromResults(results: List[(String, Boolean)]):List[LogField] =
+    results.map(x => LogFieldString(x._1, x._2.toString))
 
   def withRequestHeaders(rh: RequestHeader): DotcomponentsLogger = {
     copy(Some(rh))
   }
 
+  def results(message: String, results: List[(String, Boolean)]): Unit = {
+    logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results))
+  }
+
   def info(message: String): Unit = {
-    logInfoWithCustomFields(message, allFields)
+    logInfoWithCustomFields(message, customFields)
   }
 
   def warn(message: String, error: Throwable): Unit = {
-    logWarningWithCustomFields(message, error, allFields)
+    logWarningWithCustomFields(message, error, customFields)
   }
 
   def error(message: String, error: Throwable): Unit = {
-    logErrorWithCustomFields(message, error, allFields)
+    logErrorWithCustomFields(message, error, customFields)
   }
 
 }

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -8,12 +8,9 @@ import implicits.Requests._
 
 object RenderingTierPicker {
 
-  type Results = List[(String, Boolean)]
-
   val picker: RenderTierPickerStrategy = new SimplePagePicker()
 
-  // use this logger so we get all the log fields populated for free
-  def logRequest(msg:String, results:Results)(implicit request: RequestHeader): Unit =
+  def logRequest(msg:String, results:List[(String, Boolean)])(implicit request: RequestHeader): Unit =
     DotcomponentsLogger().withRequestHeaders(request).results(msg, results)
 
   def getRenderTierFor(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -8,12 +8,13 @@ import implicits.Requests._
 
 object RenderingTierPicker {
 
-  // todo: use injection for this
+  type Results = List[(String, Boolean)]
+
   val picker: RenderTierPickerStrategy = new SimplePagePicker()
 
   // use this logger so we get all the log fields populated for free
-  def logRequest(msg:String)(implicit request: RequestHeader): Unit =
-    DotcomponentsLogger().withRequestHeaders(request).info(msg)
+  def logRequest(msg:String, results:Results)(implicit request: RequestHeader): Unit =
+    DotcomponentsLogger().withRequestHeaders(request).results(msg, results)
 
   def getRenderTierFor(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
 
@@ -25,11 +26,11 @@ object RenderingTierPicker {
 
     // log out whenever we find a supported article, for metrics purposes
 
-    val isSupported = picker.getRenderTierFor(page, request)
+    val (results, isSupported) = picker.getRenderTierFor(page, request)
 
     isSupported match {
-      case RemoteRender => logRequest("Article was remotely renderable")
-      case _ =>
+      case RemoteRender => logRequest("Article was remotely renderable", results)
+      case _ => logRequest("Article was only locally renderable", results)
     }
 
     // We use dotcomponents if we are in the AB test, and are a supported article according to the picker

--- a/article/app/services/dotcomponents/pickers/RenderTierPickerStrategy.scala
+++ b/article/app/services/dotcomponents/pickers/RenderTierPickerStrategy.scala
@@ -5,5 +5,5 @@ import play.api.mvc.RequestHeader
 import services.dotcomponents.RenderType
 
 trait RenderTierPickerStrategy {
-  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType
+  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): (List[(String, Boolean)], RenderType)
 }

--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -7,30 +7,33 @@ import play.api.mvc.RequestHeader
 import services.dotcomponents.{LocalRender, RemoteRender, RenderType}
 import views.support.Commercial
 
-class SimplePagePicker extends RenderTierPickerStrategy {
+object PageChecks {
 
-  // each function should ideally only check a single value, so that
-  // we can just remove the lines over time as we support more.
+  // each function should ideally only check a single value
 
-  private def isDiscussionDisabled(page: PageWithStoryPackage): Boolean = {
+  def isAdFree(page: PageWithStoryPackage, request: RequestHeader): Boolean = {
+    page.item.content.shouldHideAdverts || Commercial.isAdFree(request)
+  }
+
+  def isDiscussionDisabled(page: PageWithStoryPackage): Boolean = {
     (! page.article.content.trail.isCommentable) && page.article.content.trail.isClosedForComments
   }
 
-  private def hasBlocks(page: PageWithStoryPackage): Boolean = {
+  def hasBlocks(page: PageWithStoryPackage): Boolean = {
     page.article.blocks match {
       case Some(b) => b.body.nonEmpty
       case None => false
     }
   }
 
-  private def isSupportedType(page: PageWithStoryPackage): Boolean = {
+  def isSupportedType(page: PageWithStoryPackage): Boolean = {
     page match {
       case a:ArticlePage => true
       case _ => false
     }
   }
 
-  private def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
+  def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
       case _: TextBlockElement => false
       case _: ImageBlockElement => false
@@ -40,37 +43,39 @@ class SimplePagePicker extends RenderTierPickerStrategy {
     !page.article.blocks.exists(_.body.exists(_.elements.exists(unsupportedElement)))
   }
 
-  private def isAdFree(page: PageWithStoryPackage, request: RequestHeader): Boolean = {
-    page.item.content.shouldHideAdverts || Commercial.isAdFree(request)
-  }
+  def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
 
-  private def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
+  def isNotLiveBlog(page:PageWithStoryPackage): Boolean = ! page.item.isLiveBlog
 
-  private def isNotLiveBlog(page:PageWithStoryPackage): Boolean = ! page.item.isLiveBlog
+  def isNotAReview(page:PageWithStoryPackage): Boolean = ! page.item.tags.isReview
 
-  private def isNotAReview(page:PageWithStoryPackage): Boolean = ! page.item.tags.isReview
+  def isNotAGallery(page:PageWithStoryPackage): Boolean = ! page.item.tags.isGallery
 
-  private def isNotAGallery(page:PageWithStoryPackage): Boolean = ! page.item.tags.isGallery
-  
-  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType = {
+}
 
-    val canRemotelyRender = isSupportedType(page) &&
-      hasBlocks(page) &&
-      hasOnlySupportedElements(page) &&
-      isDiscussionDisabled(page) &&
-      isAdFree(page, request) &&
-      isNotImmersive(page) &&
-      isNotLiveBlog(page) &&
-      isNotAReview(page) &&
-      isNotAGallery(page)
+class SimplePagePicker extends RenderTierPickerStrategy {
 
-    if(canRemotelyRender){
-      RemoteRender
-    } else {
-      LocalRender
-    }
+  type Check = (PageWithStoryPackage, RequestHeader) => Boolean
+  type Results = List[(String, Boolean)]
+
+  def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): (Results, RenderType) = {
+
+    val results: Results = List(
+      ("isSupportedType", PageChecks.isSupportedType(page)),
+      ("hasBlocks", PageChecks.hasBlocks(page)),
+      ("hasOnlySupportedElements", PageChecks.hasOnlySupportedElements(page)),
+      ("isDiscussionDisabled", PageChecks.isDiscussionDisabled(page)),
+      ("isAdFree", PageChecks.isAdFree(page, request)),
+      ("isNotImmersive", PageChecks.isNotImmersive(page)),
+      ("isNotLiveBlog", PageChecks.isNotLiveBlog(page)),
+      ("isNotAReview", PageChecks.isNotAReview(page)),
+      ("isNotAGallery", PageChecks.isNotAGallery(page))
+    )
+
+    val success = ! results.exists{!_._2}
+
+    (results, if(success) RemoteRender else LocalRender)
 
   }
 
 }
-

--- a/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
+++ b/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
@@ -7,16 +7,18 @@ class WhitelistPicker extends RenderTierPickerStrategy {
 
   // no real need for this list be config, hardcoding is fine for now
 
+  type Results = List[(String, Boolean)]
+
   val whitelist = List(
     "money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
   )
 
-  override def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): RenderType = {
+  override def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): (Results, RenderType) = {
 
     if(whitelist.contains(page.metadata.id)){
-      RemoteRender
+      List() -> RemoteRender
     } else {
-      LocalRender
+      List() -> LocalRender
     }
 
   }


### PR DESCRIPTION
## What does this change?

RenderTierPicker logs will now include the results of each of it's tests so we can better analyse what we should aim to support next.

I have not yet included information at the level of what block elements present on the article. I'll do that later on.

Fig 1. A Kibana Log with the new fields
![image](https://user-images.githubusercontent.com/1218561/46294182-1b119d80-c58d-11e8-9045-bd96447d1971.png)

Note that since we are now logging this information out for pages that are *not* renderable using dotcomponents, this is going to mean we're logging a lot more messages than we were. This should be fine.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
