### PR TITLE
Hide sport byline dots on galleries

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -607,7 +607,7 @@ $quote-mark: 35px;
 /**** sport overrides ****/
 .content--pillar-sport:not(.content--interactive):not(.content--type-comment),
 .content--pillar-sport.content--type-feature {
-    .content__meta-container {
+    .content__meta-container:not(.gallery__meta-container) {
         background-image: url('data:image/svg+xml,%3Csvg%20width%3D%229%22%20height%3D%2212%22%20viewBox%3D%220%200%209%2012%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22%23DFDFDF%22%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%221.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%224.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%221.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%224.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%227.5%22%20r%3D%221%22/%3E%3Ccircle%20cx%3D%227.5%22%20cy%3D%2210.5%22%20r%3D%221%22/%3E%3C/g%3E%3C/svg%3E');
         background-repeat: repeat-x;
         //this makes sure that the lines join up


### PR DESCRIPTION
## What does this change?

The dots above the byline on sports articles clash with the byline. This change removes the dots on galleries

## Screenshots

**Before**
![screen shot 2018-10-01 at 16 53 25](https://user-images.githubusercontent.com/5931528/46300002-8ca41880-c59a-11e8-9ef8-cc6c3e9d864b.png)

**After**
![screen shot 2018-10-01 at 16 53 07](https://user-images.githubusercontent.com/5931528/46300021-9c236180-c59a-11e8-86e5-495e773f372f.png)

## What is the value of this and can you measure success?

Legible byline
