### PR TITLE
Don't crop feature showcase images

### DIFF
--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -28,8 +28,7 @@
 @if(!isImmersiveMainMedia) {
     @picture.largestImage.map{ largestImage =>
         <div
-        class="u-responsive-ratio"
-            @if(isFeatureAndShowcase) {} else {style="padding-bottom: @{"%.2f".format(100 * largestImage.height.toDouble / largestImage.width)}%"}
+            @if(!isFeatureAndShowcase) {class="u-responsive-ratio" style="padding-bottom: @{"%.2f".format(100 * largestImage.height.toDouble / largestImage.width)}%"}
         >
     }
 }


### PR DESCRIPTION
## What does this change?

We currently crop feature showcase images to 5:3 aspect ratio, but really we shouldn't. We crop the bottom of the image, which means if an editor wants to use a picture of a work of art for instance, the bottom of the image would be cropped. 

We should therefore allow editors to use whatever aspect ratio they desire. Most of the time, they use 5:3 anyway, so there should be no noticeable difference. On the odd occasion they need to use a freeform crop, we should support this.

## Screenshots

**Before**

![screen shot 2018-10-01 at 17 24 05](https://user-images.githubusercontent.com/5931528/46301674-ee668180-c59e-11e8-9115-52429ed39678.png)

**After**

![screen shot 2018-10-01 at 17 24 32](https://user-images.githubusercontent.com/5931528/46301682-f2929f00-c59e-11e8-9908-9ffc2eb25e32.png)

**Before**

![screen shot 2018-10-03 at 09 53 47](https://user-images.githubusercontent.com/5931528/46400479-7610d500-c6f2-11e8-9d99-ef5113372d88.png)

**After**

![screen shot 2018-10-03 at 09 54 05](https://user-images.githubusercontent.com/5931528/46400482-78732f00-c6f2-11e8-91a7-1b1d2cdfb897.png)

## What is the value of this and can you measure success?

More flexibility for editors to choose free form crops

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
