### PR TITLE
Remove lifestyle collection from feature stories

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/tonal.js
+++ b/static/src/javascripts/projects/common/modules/onward/tonal.js
@@ -6,19 +6,15 @@ import { Component } from 'common/modules/component';
 
 const tones = {
     uk: {
-        features: 'uk-alpha/features/feature-stories',
         comment: 'uk-alpha/contributors/feature-stories',
     },
     us: {
-        features: 'us-alpha/features/feature-stories',
         comment: 'us-alpha/contributors/feature-stories',
     },
     au: {
-        features: 'au-alpha/features/feature-stories',
         comment: 'au-alpha/contributors/feature-stories',
     },
     int: {
-        features: '22167321-f8cf-4f4a-b646-165e5b1e9a30',
         comment: 'ee3386bb-9430-4a6d-8bca-b99d65790f3b',
     },
 };


### PR DESCRIPTION
Specifically, the uk-alpha/features/feature-stories collection, which is hardcoded to appear on feature articles.

This was presumably useful in the past but the collection is no longer relevant to these pages. The collection is used on the UK front so we can't simply modify it. It is definitely possible to hardcode in another collection, though, because this behaviour is non-obvious and editorial don't have strong opinions, my preference is simply to remove this special case.