### PR TITLE
Flow Strict all the Commercial Page Targeting 

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -28,7 +28,7 @@ const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     onConsentSet(provider, state);
 };
 
-const getAdConsentState = (provider: AdConsent): ?boolean => {
+const getAdConsentState = (provider: AdConsent): boolean | null => {
     const cookieRaw = getCookie(provider.cookie);
     if (!cookieRaw) return null;
     const cookieParsed = cookieRaw.split('.')[0];

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -152,7 +152,6 @@ type PageTargeting = {
     co: string,
     tn: string,
     slot: string,
-    invCode: ?string,
 };
 
 const buildAppNexusTargetingObject = once(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -28,7 +28,7 @@ const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
 
 jest.mock('lib/storage');
-jest.mock('lib/config', () => ({}));
+jest.mock('lib/config');
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
 }));
@@ -94,10 +94,7 @@ describe('Build Page Targeting', () => {
             },
             isSensitive: false,
         };
-
-        config.ophan = {
-            pageViewId: 'presetOphanPageViewId',
-        };
+        config.ophan = { pageViewId: 'presetOphanPageViewId' };
 
         commercialFeatures.adFree = false;
 
@@ -206,7 +203,7 @@ describe('Build Page Targeting', () => {
 
     it('should remove empty values', () => {
         config.page = {};
-        config.ophan.pageViewId = '123456';
+        config.ophan = { pageViewId: '123456' };
         getUserSegments.mockReturnValue([]);
         getKruxSegments.mockReturnValue([]);
 
@@ -252,10 +249,6 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Referrer', () => {
-        afterEach(() => {
-            getReferrer.mockReturnValue('');
-        });
-
         it('should set ref to Facebook', () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'


### PR DESCRIPTION
## What does this change?

Flow Strict all the things and fix the new issues

- Add new type for PageTargeting to support further work
- Remove unsafe Object and any types from usage
- Warn on sketchy-null checks

Fixes include switching to `{}` from `Object` as a type annotation, since `any`, `Object` and `Function` are considered unsafe types and should be avoided as much as possible. Flow Strict now enforces this. 🎉 💎

This also resolves the warnings from our internal rule for no-direct-access-config since the preferred approach is to access properties on config using the get() method. See #17711

## Screenshots

## What is the value of this and can you measure success?

Started converting to Flow strict while working on updates to page-targeting.
Illusion of type safety 😅

## Checklist

### Does this change break ad-free?

Not to my knowledge! @JustinPinner the change is the Flow type signature of some Adfree logic.

### Tested

- [x] Locally
