### PR TITLE
Fix height for football embed in liveblogs

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -244,6 +244,10 @@ $footballBadgeSizeDesktop: 120px;
     overflow: visible;
 }
 
+.content__main-column--liveblog .football-embed {
+    height: auto;
+}
+
 .football-embed.knockout-embed {
     height: auto;
 }


### PR DESCRIPTION
Minor change to fix the height of the liveblog football match embed.

I'd really like to simply modify the `football-embed` styling here, but it's very difficult to test this as the embeds are used in a range of places (and presumably the height is required somewhere), so I've simply added a nested selector.

![screen shot 2018-10-02 at 17 39 36](https://user-images.githubusercontent.com/858402/46364190-00aef100-c66d-11e8-8dbe-6bbbe91eb49f.png)

for reference, previously it looked like:

![screen_shot_2018-08-11_at_16 29 36](https://user-images.githubusercontent.com/858402/46364228-250acd80-c66d-11e8-8648-ce366011e88f.png)
