### PR TITLE
Extend YouTube end slate switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -459,7 +459,7 @@ trait FeatureSwitches {
     "When ON show YouTube related video suggestions in YouTube media atoms",
     owners = Seq(Owner.withGithub("siadcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 11, 4),
+    sellByDate = new LocalDate(2018, 11, 6),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -459,7 +459,7 @@ trait FeatureSwitches {
     "When ON show YouTube related video suggestions in YouTube media atoms",
     owners = Seq(Owner.withGithub("siadcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 10, 2),
+    sellByDate = new LocalDate(2018, 11, 4),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the switch that determines whether to show video end slates provided by YouTube. I'll be working on the tracking code this week, so hopefully we can get a proper test started soon.

## What is the value of this and can you measure success?

Keeps the build ticking 
