### PR TITLE
Only fetch remote config when necessary

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -87,11 +87,11 @@ object GuardianConfiguration extends Logging {
     if (stage == "DEVINFRA")
       ConfigFactory.parseResourcesAnySyntax("env/DEVINFRA.properties")
     else {
-      val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
-      val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
-      val frontendConfig = configFromParameterStore("/frontend")
-      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
-      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+      lazy val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
+      lazy val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
+      lazy val frontendConfig = configFromParameterStore("/frontend")
+      lazy val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
+      lazy val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
       userPrivate
         .withFallback(runtimeOnly)


### PR DESCRIPTION
If config settings are available on dev machine, there's no need to fetch them from AWS.