### PR TITLE
Remove football scores from left col in football live blogs

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -77,7 +77,7 @@
     }
 }
 
-<div class="content__meta-container js-content-meta js-football-meta u-cf
+<div class="content__meta-container js-content-meta u-cf
     @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
     @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
     @if(item.elements.hasShowcaseMainElement && !item.content.isImmersive){ content__meta-container--showcase}


### PR DESCRIPTION
Embeds are already used for this and we don't want to duplicate the information. The situation is particularly bad on mobile as the two containers simply stack vertically. 

In addition, the left col is currently broken.

Before:
![screen shot 2018-10-03 at 11 00 03](https://user-images.githubusercontent.com/858402/46405539-7748fe80-c700-11e8-965b-57afedbba532.png)

(although note broken on the left)

Now:
![screen shot 2018-10-03 at 11 35 23](https://user-images.githubusercontent.com/858402/46405561-8760de00-c700-11e8-9720-0f1079517a9d.png)

