### PR TITLE
Support Prebid in Amp ads 

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -87,11 +87,11 @@ object GuardianConfiguration extends Logging {
     if (stage == "DEVINFRA")
       ConfigFactory.parseResourcesAnySyntax("env/DEVINFRA.properties")
     else {
-      val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
-      val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
-      val frontendConfig = configFromParameterStore("/frontend")
-      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
-      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+      lazy val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
+      lazy val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
+      lazy val frontendConfig = configFromParameterStore("/frontend")
+      lazy val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
+      lazy val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
       userPrivate
         .withFallback(runtimeOnly)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -87,11 +87,11 @@ object GuardianConfiguration extends Logging {
     if (stage == "DEVINFRA")
       ConfigFactory.parseResourcesAnySyntax("env/DEVINFRA.properties")
     else {
-      lazy val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
-      lazy val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
-      lazy val frontendConfig = configFromParameterStore("/frontend")
-      lazy val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
-      lazy val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+      val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
+      val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
+      val frontendConfig = configFromParameterStore("/frontend")
+      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
+      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
       userPrivate
         .withFallback(runtimeOnly)
@@ -463,6 +463,9 @@ class GuardianConfiguration extends Logging {
 
     lazy val prebidAnalyticsStream = configuration.getMandatoryStringProperty("commercial.prebid.analytics.stream")
     lazy val pageViewAnalyticsStream = configuration.getMandatoryStringProperty("commercial.pv.analytics.stream")
+
+    lazy val prebidServerHost =
+      configuration.getStringProperty("commercial.prebid.server.host") getOrElse "http://localhost:8000"
   }
 
   object journalism {

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -370,6 +370,16 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+  val prebidServer: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-server",
+    description = "In-house Prebid server is available",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val prebidSonobi: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-sonobi",
@@ -401,7 +411,7 @@ trait PrebidSwitches {
   )
 
   val prebidOpenx: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-openx",
     description = "Include OpenX adapter in Prebid auctions",
     owners = group(Commercial),
@@ -411,7 +421,7 @@ trait PrebidSwitches {
   )
 
   val prebidPubmatic: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "prebid-pubmatic",
     description = "Include Pubmatic adapter in Prebid auctions",
     owners = group(Commercial),

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -5,6 +5,7 @@ import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValu
 import common.Edition
 import common.commercial.AdUnitMaker
 import conf.Configuration.commercial.prebidServerHost
+import conf.Configuration.environment
 import conf.switches.Switches.KruxSwitch
 import conf.switches.{Switch, Switches}
 import model.Article
@@ -55,12 +56,16 @@ object AmpAdRtcConfig {
        * See https://github.com/ampproject/amphtml/pull/14155
        * and https://github.com/prebid/prebid-server/blob/master/docs/endpoints/openrtb2/amp.md#query-parameters
        */
-      val prebidServerUrl = urlValue(
-        s"$prebidServerHost/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
-          "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT" +
-          "&adcid=ADCID&purl=HREF",
-        Switches.prebidServer
-      )
+      val prebidServerUrl = {
+        val url = s"$prebidServerHost/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+          "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)" +
+          "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT" +
+          s"&adcid=ADCID&purl=HREF"
+        urlValue(
+          if (environment.isProd) url else s"$url&debug=1",
+          Switches.prebidServer
+        )
+      }
 
       val urlValues = (kruxUrl ++ prebidServerUrl).toSeq
       if (urlValues.nonEmpty) Seq("urls" -> urlValues)

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -4,9 +4,11 @@ import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValue}
 import common.Edition
 import common.commercial.AdUnitMaker
-import common.commercial.EditionAdTargeting._
+import conf.Configuration.commercial.prebidServerHost
 import conf.switches.Switches.KruxSwitch
+import conf.switches.{Switch, Switches}
 import model.Article
+import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
 case class AmpAd(article: Article, uri: String, edition: String) {
@@ -33,16 +35,40 @@ case class AmpAdDataSlot(article: Article) {
   }
 }
 
-case class AmpAdRtcConfig() {
-  def toJsonString: String =
-    Json.obj("urls" -> (
-               Json.arr() ++
-                 (
-                   if(KruxSwitch.isSwitchedOn)
-                     // See https://trello.com/c/zBlwvOWI
-                     Json.arr("https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid")
-                   else Json.arr()
-                 )
-             )
-    ).toString()
+object AmpAdRtcConfig {
+
+  def toJsonString: String = {
+
+    val urls: Seq[(String, JsValueWrapper)] = {
+
+      def urlValue(url: String, switch: Switch): Option[String] =
+        if (switch.isSwitchedOn) Some(url)
+        else None
+
+      // See https://trello.com/c/zBlwvOWI
+      val kruxUrl = urlValue(
+        "https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid",
+        KruxSwitch
+      )
+
+      val prebidServerUrl = urlValue(
+        s"$prebidServerHost/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+          "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT" +
+          "&adcid=ADCID&purl=HREF",
+        Switches.prebidServer
+      )
+
+      val urlValues = (kruxUrl ++ prebidServerUrl).toSeq
+      if (urlValues.nonEmpty) Seq("urls" -> urlValues)
+      else Nil
+    }
+
+    val rtc = {
+      val rtcValues = urls
+      if (rtcValues.nonEmpty) Json.obj(rtcValues: _*)
+      else JsNull
+    }
+
+    rtc.toString()
+  }
 }

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -51,6 +51,10 @@ object AmpAdRtcConfig {
         KruxSwitch
       )
 
+      /*
+       * See https://github.com/ampproject/amphtml/pull/14155
+       * and https://github.com/prebid/prebid-server/blob/master/docs/endpoints/openrtb2/amp.md#query-parameters
+       */
       val prebidServerUrl = urlValue(
         s"$prebidServerHost/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
           "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT" +

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -95,7 +95,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
                    data-loading-strategy="prefer-viewability-over-views"
                    json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
                    data-slot={AmpAdDataSlot(article).toString()}
-                   rtc-config={AmpAdRtcConfig().toJsonString}
+                   rtc-config={AmpAdRtcConfig.toJsonString}
                 ></amp-ad>
 
     val ampAdString = {

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,0 +1,29 @@
+package views.support
+
+import conf.switches.Switches
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsNull, Json}
+
+class AmpAdRtcConfigTest extends FlatSpec with Matchers {
+
+  "toJsonString" should "hold Prebid server and Krux config when switches on" in {
+    Switches.KruxSwitch.switchOn()
+    Switches.prebidServer.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(Some(1)))
+    json shouldBe Json.obj(
+      "urls" -> Json.arr(
+        "https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid",
+        "http://localhost:8000/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+          "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)" +
+          "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"
+      )
+    )
+  }
+
+  it should "hold no real-time config when switches off" in {
+    Switches.KruxSwitch.switchOff()
+    Switches.prebidServer.switchOff()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(Some(1)))
+    json shouldBe JsNull
+  }
+}

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,29 +1,58 @@
 package views.support
 
 import conf.switches.Switches
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.{JsNull, Json}
 
-class AmpAdRtcConfigTest extends FlatSpec with Matchers {
+class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
 
-  "toJsonString" should "hold Prebid server and Krux config when switches on" in {
+  private val kruxUrl =
+    "https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid"
+
+  private val prebidServerUrl =
+    "http://localhost:8000/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+      "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)" +
+      "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"
+
+  before {
+    Switches.KruxSwitch.switchOff()
+    Switches.prebidServer.switchOff()
+  }
+
+  "toJsonString" should "hold Prebid server and Krux config when both switches are on" in {
     Switches.KruxSwitch.switchOn()
     Switches.prebidServer.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString)
     json shouldBe Json.obj(
       "urls" -> Json.arr(
-        "https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid",
-        "http://localhost:8000/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
-          "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)" +
-          "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"
+        kruxUrl,
+        prebidServerUrl
       )
     )
   }
 
-  it should "hold no real-time config when switches off" in {
-    Switches.KruxSwitch.switchOff()
-    Switches.prebidServer.switchOff()
+  it should "hold no real-time config when both switches are off" in {
     val json = Json.parse(AmpAdRtcConfig.toJsonString)
     json shouldBe JsNull
+  }
+
+  it should "hold Krux config when Krux switch is on" in {
+    Switches.KruxSwitch.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString)
+    json shouldBe Json.obj(
+      "urls" -> Json.arr(
+        kruxUrl
+      )
+    )
+  }
+
+  it should "hold Prebid server config when Prebid server switch is on" in {
+    Switches.prebidServer.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString)
+    json shouldBe Json.obj(
+      "urls" -> Json.arr(
+        prebidServerUrl
+      )
+    )
   }
 }

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -9,7 +9,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers {
   "toJsonString" should "hold Prebid server and Krux config when switches on" in {
     Switches.KruxSwitch.switchOn()
     Switches.prebidServer.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(Some(1)))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString)
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         "https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid",
@@ -23,7 +23,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers {
   it should "hold no real-time config when switches off" in {
     Switches.KruxSwitch.switchOff()
     Switches.prebidServer.switchOff()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(Some(1)))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString)
     json shouldBe JsNull
   }
 }

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -12,7 +12,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   private val prebidServerUrl =
     "http://localhost:8000/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
       "&oh=ATTR(data-override-height)&slot=ATTR(data-slot)" +
-      "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"
+      "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&debug=1"
 
   before {
     Switches.KruxSwitch.switchOff()


### PR DESCRIPTION
## What does this change?
This change adds some config to Amp ads so that they will make calls to Prebid before making an ad call.  The server side of this is still in development.

## What is the value of this and can you measure success?
Should make a significant improvement in ad revenue on Amp.

## Checklist

### Does this affect other platforms?
Yes - Amp.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

### Does this change break ad-free?
No.  Only enriches pre-existing ad calls.

### Tested
It works when running a Prebid server locally.
