### PR TITLE
WIP - Email front flagship

### DIFF
--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -13,12 +13,12 @@ object FlagshipEmailContainer {
     "7050d39f-7e84-4894-a69d-449c359b9d54"  //CODE
   )
 
-  private val GoLiveDateTime = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm").parseDateTime("2018/11/01 04:00")
+  private val GoLiveDateTime = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm").parseDateTime("2018/11/01 03:15")
 
-  //The container should appear at 4:00 on Monday, and disappear at 4:00 on Saturday
-  private val fourHours: Long = 4.hours.toMillis
+  //The container should appear at 03:15 on Monday, and disappear at 03:15 on Saturday
+  private val threeHoursFifteenMinutes: Long = (3.hours + 15.minutes).toMillis
   private def isWeekend(dateTime: DateTime): Boolean = {
-    val day = dateTime.minus(fourHours).getDayOfWeek
+    val day = dateTime.minus(threeHoursFifteenMinutes).getDayOfWeek
     day == SATURDAY || day == SUNDAY
   }
 

--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -1,7 +1,8 @@
 package conf.audio
 import org.joda.time.DateTime
-import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY, MONDAY}
+import org.joda.time.DateTimeConstants.{MONDAY, SATURDAY, SUNDAY}
 import org.joda.time.format.DateTimeFormat
+import scala.concurrent.duration._
 import conf.switches.Switches.FlagshipEmailContainerSwitch
 import model.pressed.{ ItemKicker, TagKicker }
 import com.gu.facia.api.utils.{ TagKicker => FapiTagKicker }
@@ -14,14 +15,20 @@ object FlagshipEmailContainer {
 
   private val GoLiveDateTime = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm").parseDateTime("2018/11/01 04:00")
 
+  //The container should appear at 4:00 on Monday, and disappear at 4:00 on Saturday
+  private val fourHours: Long = 4.hours.toMillis
+  private def isWeekend(dateTime: DateTime): Boolean = {
+    val day = dateTime.minus(fourHours).getDayOfWeek
+    day == SATURDAY || day == SUNDAY
+  }
+
   def isFlagshipContainer(id: String): Boolean =
     EmailContainerIds.contains(id)
 
   def displayFlagshipContainer(now: DateTime = DateTime.now): Boolean =
     FlagshipEmailContainerSwitch.isSwitchedOn &&
       now.isAfter(GoLiveDateTime) &&
-      now.getDayOfWeek != SATURDAY && now.getDayOfWeek != SUNDAY &&
-      !(now.getDayOfWeek == MONDAY && now.getHourOfDay < 4)
+      !isWeekend(now)
 
   val AlbumArtUrl = "https://media.guim.co.uk/26bb29790c63ac3374470d116e54a036581bbeda/0_0_2000_1200/500.png"
 

--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -1,6 +1,6 @@
 package conf.audio
 import org.joda.time.DateTime
-import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
+import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY, MONDAY}
 import org.joda.time.format.DateTimeFormat
 import conf.switches.Switches.FlagshipEmailContainerSwitch
 
@@ -18,7 +18,8 @@ object FlagshipEmailContainer {
   def displayFlagshipContainer(now: DateTime = DateTime.now): Boolean =
     FlagshipEmailContainerSwitch.isSwitchedOn &&
       now.isAfter(GoLiveDateTime) &&
-      now.getDayOfWeek != SATURDAY && now.getDayOfWeek != SUNDAY
+      now.getDayOfWeek != SATURDAY && now.getDayOfWeek != SUNDAY &&
+      !(now.getDayOfWeek == MONDAY && now.getHourOfDay < 4)
 
   //TODO - update with actual art
   val AlbumArtUrl = "https://media.guim.co.uk/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/500.jpg"

--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -21,6 +21,5 @@ object FlagshipEmailContainer {
       now.getDayOfWeek != SATURDAY && now.getDayOfWeek != SUNDAY &&
       !(now.getDayOfWeek == MONDAY && now.getHourOfDay < 4)
 
-  //TODO - update with actual art
-  val AlbumArtUrl = "https://media.guim.co.uk/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/500.jpg"
+  val AlbumArtUrl = "https://media.guim.co.uk/26bb29790c63ac3374470d116e54a036581bbeda/0_0_2000_1200/500.png"
 }

--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -3,6 +3,8 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY, MONDAY}
 import org.joda.time.format.DateTimeFormat
 import conf.switches.Switches.FlagshipEmailContainerSwitch
+import model.pressed.{ ItemKicker, TagKicker }
+import com.gu.facia.api.utils.{ TagKicker => FapiTagKicker }
 
 object FlagshipEmailContainer {
   private val EmailContainerIds = Seq(
@@ -22,4 +24,12 @@ object FlagshipEmailContainer {
       !(now.getDayOfWeek == MONDAY && now.getHourOfDay < 4)
 
   val AlbumArtUrl = "https://media.guim.co.uk/26bb29790c63ac3374470d116e54a036581bbeda/0_0_2000_1200/500.png"
+
+  object SeriesTag {
+    val title = "Today in Focus"
+    val url = "https://www.theguardian.com/news/series/todayinfocus"
+    val id = "news/series/todayinfocus"
+  }
+
+  def kicker: TagKicker = ItemKicker.makeTagKicker(FapiTagKicker(name = SeriesTag.title, url= SeriesTag.url, id = SeriesTag.id))
 }

--- a/common/app/conf/audio/FlagshipEmailContainer.scala
+++ b/common/app/conf/audio/FlagshipEmailContainer.scala
@@ -1,0 +1,25 @@
+package conf.audio
+import org.joda.time.DateTime
+import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
+import org.joda.time.format.DateTimeFormat
+import conf.switches.Switches.FlagshipEmailContainerSwitch
+
+object FlagshipEmailContainer {
+  private val EmailContainerIds = Seq(
+    "97f86ba7-4f14-43ec-bfb2-e149019b70f6", //PROD
+    "7050d39f-7e84-4894-a69d-449c359b9d54"  //CODE
+  )
+
+  private val GoLiveDateTime = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm").parseDateTime("2018/11/01 04:00")
+
+  def isFlagshipContainer(id: String): Boolean =
+    EmailContainerIds.contains(id)
+
+  def displayFlagshipContainer(now: DateTime = DateTime.now): Boolean =
+    FlagshipEmailContainerSwitch.isSwitchedOn &&
+      now.isAfter(GoLiveDateTime) &&
+      now.getDayOfWeek != SATURDAY && now.getDayOfWeek != SUNDAY
+
+  //TODO - update with actual art
+  val AlbumArtUrl = "https://media.guim.co.uk/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/500.jpg"
+}

--- a/common/app/conf/switches/JournalismSwitches.scala
+++ b/common/app/conf/switches/JournalismSwitches.scala
@@ -32,4 +32,14 @@ trait JournalismSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
+
+  val FlagshipEmailContainerSwitch = Switch(
+    SwitchGroup.Journalism,
+    "flagship-email-container",
+    "Display the Flagship podcast container in the daily emails",
+    owners = Seq(Owner.withName("journalism team")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
 }

--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -13,7 +13,7 @@ sealed trait EmailContainer
 case class LiveIntentMarquee(newsletterId: String, ids: (String, String, String, String, String)) extends EmailContainer
 case class LiveIntentMPU(newsletterId: String, ids: (String, String, String, String, String)) extends EmailContainer
 case class LiveIntentSafeRTB(newsletterId: String, ids: List[String]) extends EmailContainer
-case class EmailContentContainer(displayName: String, href: Option[String], cards: List[ContentCard], config: CollectionConfig, collectionType: String, branding: Option[ContainerBranding]) extends EmailContainer
+case class EmailContentContainer(displayName: String, href: Option[String], cards: List[ContentCard], config: CollectionConfig, collectionType: String, branding: Option[ContainerBranding], containerId: String) extends EmailContainer
 
 object EmailContentContainer {
 
@@ -37,7 +37,8 @@ object EmailContentContainer {
       cards = cards,
       config = collection.config,
       collectionType = collection.collectionType,
-      branding = collection.branding(Edition.defaultEdition)
+      branding = collection.branding(Edition.defaultEdition),
+      containerId = collection.id
     )
 
   private def contentCard(content: PressedContent, config: CollectionConfig): Option[ContentCard] = {

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -1,12 +1,14 @@
 package test
 
 import conf.CachedHealthCheckTest
+import conf.audio.FlagshipEmailContainerSpec
 import navigation.NavigationTest
 import org.scalatest.Suites
 
 class CommonTestSuite extends Suites(
   new CachedHealthCheckTest,
-  new NavigationTest
+  new NavigationTest,
+  new FlagshipEmailContainerSpec
 ) with SingleServerSuite {
   override lazy val port: Int = 19016
 }

--- a/common/test/conf/audio/FlagshipEmailContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipEmailContainerSpec.scala
@@ -1,0 +1,44 @@
+package conf.audio
+
+import conf.switches.Switches.FlagshipEmailContainerSwitch
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.DateTimeConstants._
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+
+@DoNotDiscover class FlagshipEmailContainerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val formatter = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm")
+
+  override def beforeAll {
+    FlagshipEmailContainerSwitch.switchOn()
+  }
+
+  it should "return false if before 2018/11/01" in {
+    val dateTime = formatter.parseDateTime("2018/10/01 00:00")
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
+  }
+
+  it should "return true if Tuesday" in {
+    val dateTime = formatter.parseDateTime("2018/11/06 00:00")
+    dateTime.getDayOfWeek should be(TUESDAY)
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
+  it should "return false if Saturday" in {
+    val dateTime = formatter.parseDateTime("2018/11/10 00:00")
+    dateTime.getDayOfWeek should be(SATURDAY)
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
+  }
+
+  it should "return true if Monday and after 4am" in {
+    val dateTime = formatter.parseDateTime("2018/11/05 05:00")
+    dateTime.getDayOfWeek should be(MONDAY)
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
+  it should "return false if Monday and before 4am" in {
+    val dateTime = formatter.parseDateTime("2018/11/05 03:00")
+    dateTime.getDayOfWeek should be(MONDAY)
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
+  }
+}

--- a/common/test/conf/audio/FlagshipEmailContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipEmailContainerSpec.scala
@@ -13,8 +13,9 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     FlagshipEmailContainerSwitch.switchOn()
   }
 
-  it should "return false if before 2018/11/01" in {
-    val dateTime = formatter.parseDateTime("2018/10/01 00:00")
+  it should "return false if Tuesday but before 2018/11/01" in {
+    val dateTime = formatter.parseDateTime("2018/10/02 00:00")
+    dateTime.getDayOfWeek should be(TUESDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
@@ -24,19 +25,25 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Saturday" in {
-    val dateTime = formatter.parseDateTime("2018/11/10 00:00")
+  it should "return false if Saturday and after 04:00" in {
+    val dateTime = formatter.parseDateTime("2018/11/10 04:00")
     dateTime.getDayOfWeek should be(SATURDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
-  it should "return true if Monday and after 4am" in {
-    val dateTime = formatter.parseDateTime("2018/11/05 05:00")
+  it should "return true if Saturday and before 04:00" in {
+    val dateTime = formatter.parseDateTime("2018/11/10 03:00")
+    dateTime.getDayOfWeek should be(SATURDAY)
+    FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
+  it should "return true if Monday and after 04:00" in {
+    val dateTime = formatter.parseDateTime("2018/11/05 04:00")
     dateTime.getDayOfWeek should be(MONDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Monday and before 4am" in {
+  it should "return false if Monday and before 04:00" in {
     val dateTime = formatter.parseDateTime("2018/11/05 03:00")
     dateTime.getDayOfWeek should be(MONDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)

--- a/common/test/conf/audio/FlagshipEmailContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipEmailContainerSpec.scala
@@ -25,25 +25,25 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Saturday and after 04:00" in {
-    val dateTime = formatter.parseDateTime("2018/11/10 04:00")
+  it should "return false if Saturday and after 03:15" in {
+    val dateTime = formatter.parseDateTime("2018/11/10 03:15")
     dateTime.getDayOfWeek should be(SATURDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
-  it should "return true if Saturday and before 04:00" in {
+  it should "return true if Saturday and before 03:15" in {
     val dateTime = formatter.parseDateTime("2018/11/10 03:00")
     dateTime.getDayOfWeek should be(SATURDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return true if Monday and after 04:00" in {
-    val dateTime = formatter.parseDateTime("2018/11/05 04:00")
+  it should "return true if Monday and after 03:15" in {
+    val dateTime = formatter.parseDateTime("2018/11/05 03:15")
     dateTime.getDayOfWeek should be(MONDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Monday and before 04:00" in {
+  it should "return false if Monday and before 03:15" in {
     val dateTime = formatter.parseDateTime("2018/11/05 03:00")
     dateTime.getDayOfWeek should be(MONDAY)
     FlagshipEmailContainer.displayFlagshipContainer(dateTime) should be(false)

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -12,6 +12,8 @@
 @import views.support.RemoveOuterParaHtml
 @import fragments.email._
 @import common.LinkTo
+@import org.joda.time.DateTime
+@import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
 
 
 @headline(card: ContentCard, isLarge: Boolean = false, isTrailText: Boolean = false) = {
@@ -206,6 +208,36 @@
     }
 }
 
+@renderFlagshipContainer(collection: EmailContentContainer) = {
+    @defining(DateTime.now.getDayOfWeek) { now =>
+        @if(now != SATURDAY && now != SUNDAY) {
+
+            @containerTitle(Seq("ct--not-top")) {
+                @collection.href.map { href =>
+                <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
+                }.getOrElse {
+                    @collection.displayName
+                }
+            }
+
+            @collection.cards.headOption.map { card =>
+                @faciaCard(classesForCard(card, withImage = true), collection.branding.isDefined) {
+                    @row(Seq("no-pad")){
+                        <a class="fc-link" href="@card.header.url.hrefWithRel">
+                            <img class="full-width" src="https://i.guim.co.uk/img/media/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/master/3910.jpg?width=500&amp;quality=60&amp;fit=max&amp;s=a31b2353a7f08f4417006bda4a77acf5" alt="@card.header.headline">
+                        </a>
+                    }
+                    @if(card.header.quoted) {
+                        @headlineAndTrailWithCutout(card, withImage = true)
+                    } else {
+                        @headline(card, isLarge = true, isTrailText = true)
+                    }
+                }
+            }
+        }
+    }
+}
+
 @renderMarquee(marquee: LiveIntentMarquee) = {
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="margin-left:auto; margin-right:auto;">
         <tr>
@@ -286,6 +318,7 @@
 }
 
 @layout.CollectionEmail.fromPressedPage(page).collections.zipWithIndex.map {
+    case (collection: EmailContentContainer, index) if collection.displayName == "Flagship" => { @renderFlagshipContainer(collection) }
     case (collection: EmailContentContainer, index) => { @renderContentContainer(collection, index) }
     case (marquee: LiveIntentMarquee, _) => { @renderMarquee(marquee) }
     case (mpu: LiveIntentMPU, _) => { @renderMPU(mpu) }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -214,24 +214,21 @@
 
             @containerTitle(Seq("ct--not-top")) {
                 @collection.href.map { href =>
-                <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
+                    <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
                 }.getOrElse {
                     @collection.displayName
                 }
             }
 
             @collection.cards.headOption.map { card =>
-                @faciaCard(classesForCard(card, withImage = true), collection.branding.isDefined) {
+                @faciaCard(classesForCard(card, withImage = true)) {
                     @row(Seq("no-pad")){
                         <a class="fc-link" href="@card.header.url.hrefWithRel">
                             <img class="full-width" src="https://i.guim.co.uk/img/media/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/master/3910.jpg?width=500&amp;quality=60&amp;fit=max&amp;s=a31b2353a7f08f4417006bda4a77acf5" alt="@card.header.headline">
                         </a>
                     }
-                    @if(card.header.quoted) {
-                        @headlineAndTrailWithCutout(card, withImage = true)
-                    } else {
-                        @headline(card, isLarge = true, isTrailText = true)
-                    }
+
+                    @headline(card, isLarge = true, isTrailText = true)
                 }
             }
         }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -12,8 +12,7 @@
 @import views.support.RemoveOuterParaHtml
 @import fragments.email._
 @import common.LinkTo
-@import org.joda.time.DateTime
-@import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
+@import conf.audio.FlagshipEmailContainer
 
 
 @headline(card: ContentCard, isLarge: Boolean = false, isTrailText: Boolean = false) = {
@@ -209,27 +208,24 @@
 }
 
 @renderFlagshipContainer(collection: EmailContentContainer) = {
-    @defining(DateTime.now.getDayOfWeek) { now =>
-        @if(now != SATURDAY && now != SUNDAY) {
-
-            @containerTitle(Seq("ct--not-top")) {
-                @collection.href.map { href =>
-                    <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
-                }.getOrElse {
-                    @collection.displayName
-                }
+    @if(FlagshipEmailContainer.displayFlagshipContainer()) {
+        @containerTitle(Seq("ct--not-top")) {
+            @collection.href.map { href =>
+                <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
+            }.getOrElse {
+                @collection.displayName
             }
+        }
 
-            @collection.cards.headOption.map { card =>
-                @faciaCard(classesForCard(card, withImage = true)) {
-                    @row(Seq("no-pad")){
-                        <a class="fc-link" href="@card.header.url.hrefWithRel">
-                            <img class="full-width" src="https://i.guim.co.uk/img/media/60478bdc559fa72fe4fe0ac09636f78df9f3cdb9/3_170_3910_2345/master/3910.jpg?width=500&amp;quality=60&amp;fit=max&amp;s=a31b2353a7f08f4417006bda4a77acf5" alt="@card.header.headline">
-                        </a>
-                    }
-
-                    @headline(card, isLarge = true, isTrailText = true)
+        @collection.cards.headOption.map { card =>
+            @faciaCard(classesForCard(card, withImage = true)) {
+                @row(Seq("no-pad")){
+                    <a class="fc-link" href="@card.header.url.hrefWithRel">
+                        <img class="full-width" src="@FlagshipEmailContainer.AlbumArtUrl" alt="@card.header.headline">
+                    </a>
                 }
+
+                @headline(card, isLarge = true, isTrailText = true)
             }
         }
     }
@@ -315,7 +311,7 @@
 }
 
 @layout.CollectionEmail.fromPressedPage(page).collections.zipWithIndex.map {
-    case (collection: EmailContentContainer, index) if collection.displayName == "Flagship" => { @renderFlagshipContainer(collection) }
+    case (collection: EmailContentContainer, index) if FlagshipEmailContainer.isFlagshipContainer(collection.containerId) => { @renderFlagshipContainer(collection) }
     case (collection: EmailContentContainer, index) => { @renderContentContainer(collection, index) }
     case (marquee: LiveIntentMarquee, _) => { @renderMarquee(marquee) }
     case (mpu: LiveIntentMPU, _) => { @renderMPU(mpu) }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -8,6 +8,8 @@
 @import layout.ContentCard
 @import model.EmailAddons.EmailContentType
 @import model.pressed.{ExternalLink, Feature}
+@import model.pressed.ItemKicker
+@import com.gu.facia.api.utils.TagKicker
 @import views.support.EmailHelpers.{icon, imgFromCard, imgForFront, classesForCard}
 @import views.support.RemoveOuterParaHtml
 @import fragments.email._
@@ -225,7 +227,7 @@
                     </a>
                 }
 
-                @headline(card, isLarge = true, isTrailText = true)
+                @headline(card.setKicker(Some(FlagshipEmailContainer.kicker)), isLarge = true, isTrailText = true)
             }
         }
     }


### PR DESCRIPTION
## What does this change?
The new flagship podcast will have a permanent weekday spot in the email front.
The container will be backfilled from the tag series, and the container will display a single card for the latest episode.
The image is hardcoded, not taken from the content. It otherwise looks like a normal `medium` container.

It relies on the name of the container being constant. This is brittle, but the alternative is making this configurable in the fronts tool and reflected in the model (which is a lot of work for a single special case).

## Screenshots
(with football weekly for now)
![picture 25](https://user-images.githubusercontent.com/1513454/46474964-20185c00-c7dc-11e8-8940-e742e72edec9.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
