### PR TITLE
Simplify the js fallback in the confirm email flow

### DIFF
--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -17,11 +17,27 @@
 
 @noJsBehaviour = @{
     pageVariant match {
-        case ConfirmEmailThankYou => views.html.emailVerified(
-            ValidationState.validated, identityRequest, identityUrlBuilder, userIsLoggedIn = true, returnUrl
-        )
+        case ConfirmEmailThankYou => "Thank you! You’re now subscribed"
     }
 }
+
+@spinnerError(id: String, text: Html, cta: Option[Html] = None, async: Boolean = false) = {
+    <div id="@{id}" class="identity-forms-loading @if(async){ identity-forms-loading--hide-text } u-identity-forms-padded">
+        <div class="identity-forms-loading__spinner is-updating"></div>
+        <div class="identity-forms-loading__text">
+            <p>@text</p>
+            @cta
+        </div>
+    </div>
+    @if(async) {
+        <script>
+            setTimeout(function(){
+                if(window.@{id}) window.@{id}.className = window.@{id}.className.replace('identity-forms-loading--hide-text','')
+            },5000);
+        </script>
+    }
+}
+
 
 @prefill = @{
     Json.toJson(Map(
@@ -33,11 +49,23 @@
     }
     ).toString()
 }
+
 <div class="identity-upsell-wrapper">
     <div class="js-identity-block-list" data-page-variant="@{pageVariant.jsName}">
         <script type="text/json" data-for-prefill="true">
             @Html(prefill)
         </script>
-        @noJsBehaviour
+        <noscript>
+            @spinnerError(
+                "noscriptError",
+                Html(noJsBehaviour),
+            )
+        </noscript>
+        @spinnerError(
+            "identityUpsellLoadingError",
+            Html(noJsBehaviour),
+            None,
+            true
+        )
     </div>
 </div>

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -50,22 +50,20 @@
     ).toString()
 }
 
-<div class="identity-upsell-wrapper">
-    <div class="js-identity-block-list" data-page-variant="@{pageVariant.jsName}">
-        <script type="text/json" data-for-prefill="true">
-            @Html(prefill)
-        </script>
-        <noscript>
-            @spinnerError(
-                "noscriptError",
-                Html(noJsBehaviour),
-            )
-        </noscript>
+<div class="js-identity-block-list" data-page-variant="@{pageVariant.jsName}">
+    <script type="text/json" data-for-prefill="true">
+        @Html(prefill)
+    </script>
+    <noscript>
         @spinnerError(
-            "identityUpsellLoadingError",
+            "noscriptError",
             Html(noJsBehaviour),
-            None,
-            true
         )
-    </div>
+    </noscript>
+    @spinnerError(
+        "identityUpsellLoadingError",
+        Html(noJsBehaviour),
+        None,
+        true
+    )
 </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -83,10 +83,12 @@ const bindBlockList = (el): void => {
                             title="Thank you!"
                             subtitle="You’re now subscribed to your content"
                         />
-                        <div className="identity-upsell-layout">
-                            {ConfirmEmailThankYou}
-                            {Optouts}
-                            <AccountCreationBlock {...prefill} />
+                        <div className="identity-upsell-wrapper">
+                            <div className="identity-upsell-layout">
+                                {ConfirmEmailThankYou}
+                                {Optouts}
+                                <AccountCreationBlock {...prefill} />
+                            </div>
                         </div>
                     </div>,
                     el


### PR DESCRIPTION
## What does this change?
Copypasted from consents, Removes the flashing old page, adds a spinner.

## Screenies

Initial spinner for all clients
![screen shot 2018-10-04 at 5 23 06 pm](https://user-images.githubusercontent.com/11539094/46488368-5bc21e80-c7fa-11e8-8d23-848b245b8841.png)

After 5 seconds of the react app not loading
![screen shot 2018-10-04 at 5 23 26 pm](https://user-images.githubusercontent.com/11539094/46488386-67154a00-c7fa-11e8-9ef1-a63c8e61fb55.png)
