### PR TITLE
Don't add affiliate links to content with certain tags

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -38,7 +38,8 @@ object GalleryCaptionCleaners {
         page.gallery.content.metadata.sectionId,
         page.gallery.content.fields.showAffiliateLinks,
         "gallery",
-        appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks)))
+        appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
+        tags = page.gallery.content.tags.tags.map(_.id)))
 
     val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(caption)) { case (html, cleaner) => cleaner.clean(html) }
     Html(cleanedHtml.toString)

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -72,7 +72,7 @@ object BodyCleaner {
       TimestampCleaner(article),
       MinuteCleaner(article),
       GarnettQuoteCleaner,
-      AffiliateLinksCleaner(request.uri, article.content.metadata.sectionId, article.content.fields.showAffiliateLinks, "article")
+      AffiliateLinksCleaner(request.uri, article.content.metadata.sectionId, article.content.fields.showAffiliateLinks, "article", tags = article.content.tags.tags.map(_.id))
     ) ++
       ListIf(!amp)(VideoEmbedCleaner(article)) ++
       ListIf(amp)(AmpEmbedCleaner(article)) ++

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -251,6 +251,7 @@ class GuardianConfiguration extends Logging {
   object affiliatelinks {
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet
+    lazy val defaultOffTags: Set[String] = configuration.getStringProperty("affiliatelinks.default.off.tags").getOrElse("").split(",").toSet
   }
 
   object frontend {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -801,12 +801,17 @@ object GarnettQuoteCleaner extends HtmlCleaner {
   }
 }
 
-case class AffiliateLinksCleaner(pageUrl: String, sectionId: String, showAffiliateLinks: Option[Boolean],
-  contentType: String, appendDisclaimer: Option[Boolean] = None) extends HtmlCleaner with Logging {
+case class AffiliateLinksCleaner(
+                                  pageUrl: String,
+                                  sectionId: String,
+                                  showAffiliateLinks: Option[Boolean],
+                                  contentType: String,
+                                  appendDisclaimer: Option[Boolean] = None,
+                                  tags: List[String]) extends HtmlCleaner with Logging {
 
   override def clean(document: Document): Document = {
-    if (AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(AffiliateLinkSections.isSwitchedOn,
-      sectionId, showAffiliateLinks, affiliateLinkSections)) {
+    if (true && AffiliateLinksCleaner.shouldAddAffiliateLinks(true,
+      sectionId, showAffiliateLinks, affiliateLinkSections, defaultOffTags, tags)) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
     } else document
   }
@@ -841,11 +846,11 @@ object AffiliateLinksCleaner {
     s"http://go.theguardian.com/?id=$skimlinksId&url=$urlEncodedLink&sref=$host$pageUrl"
   }
 
-  def shouldAddAffiliateLinks(switchedOn: Boolean, section: String, showAffiliateLinks: Option[Boolean], supportedSections: Set[String]): Boolean = {
+  def shouldAddAffiliateLinks(switchedOn: Boolean, section: String, showAffiliateLinks: Option[Boolean], supportedSections: Set[String], defaultOffTags: Set[String], tagPaths: List[String]): Boolean = {
     if (showAffiliateLinks.isDefined) {
       showAffiliateLinks.contains(true)
     } else {
-      switchedOn && supportedSections.contains(section)
+      switchedOn && supportedSections.contains(section) && !tagPaths.exists(path => defaultOffTags.contains(path))
     }
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -810,7 +810,7 @@ case class AffiliateLinksCleaner(
                                   tags: List[String]) extends HtmlCleaner with Logging {
 
   override def clean(document: Document): Document = {
-    if (true && AffiliateLinksCleaner.shouldAddAffiliateLinks(true,
+    if (AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(AffiliateLinks.isSwitchedOn,
       sectionId, showAffiliateLinks, affiliateLinkSections, defaultOffTags, tags)) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
     } else document

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -11,11 +11,13 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
   }
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
-    val supportedSections = Set("film", "books")
-    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections) should be (true)
-
+    val supportedSections = Set("film", "books", "fashion")
+    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, List.empty ) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, List.empty) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections, Set.empty, List.empty) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections, Set.empty, List.empty) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("bereavement")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("tech")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), List("tech")) should be (true)
   }
 }


### PR DESCRIPTION
## What does this change?
This change stops affiliate links from being added to content with certain tags. 

## What is the value of this and can you measure success?
This is a request from editorial to stop affiliate links from being added to content concerning sensitive topics.

### Tested

- [x] Locally
- [ ] On CODE (optional)
