### PR TITLE
[wip] Add reCAPTCHA for email signups (under a switch)

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -15,6 +15,16 @@ trait IdentitySwitches {
     exposeClientSide = true
   )
 
+  val IdentityNewsletterRecaptchaSwitch = Switch(
+    SwitchGroup.Identity,
+    "id-newsletter-recaptcha",
+    "If switched on, newsletter widgets will trigger a recaptcha.",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val IdentityEmailSignInUpsellSwitch = Switch(
     SwitchGroup.Identity,
     "id-email-sign-in-upsell",

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -20,6 +20,9 @@ import { loadScript } from 'lib/load-script';
 import type { IdentityUser } from 'common/modules/identity/api';
 import type { bonzo } from 'bonzo';
 
+const recaptchaJsLib = 'https://www.google.com/recaptcha/api.js';
+const recaptchaApiKey = '6LfvU3MUAAAAAFMDYT2sgAUSYn8dDnjB65w8jAmn';
+
 type Analytics = {
     formType: string,
     listId: string,
@@ -268,12 +271,12 @@ const submitForm = (
     let captchaRendere
 
     const onCaptchaSolved = () => new Promise((accept, reject)=>{
-        loadScript('https://www.google.com/recaptcha/api.js', { async: true }).then(
+        loadScript(recaptchaJsLib, { async: true }).then(
             () => {
                 grecaptcha.ready(()=>{
                     if(!state.captchaRendered) {
                         grecaptcha.render(recaptchaHolder, {
-                            'sitekey': '6LfvU3MUAAAAAFMDYT2sgAUSYn8dDnjB65w8jAmn',
+                            'sitekey': recaptchaApiKey,
                             'size': 'invisible',
                             'errorCallback': reject,
                             'callback': accept,

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -267,9 +267,7 @@ const submitForm = (
     let analyticsInfo;
 
     event.preventDefault();
-
-    let captchaRendere
-
+    
     const onCaptchaSolved = () => new Promise((accept, reject)=>{
         loadScript(recaptchaJsLib, { async: true }).then(
             () => {
@@ -353,6 +351,9 @@ const submitForm = (
 const bindSubmit = ($form: bonzo, iframeEl?: HTMLIFrameElement, analytics: Analytics): void => {
     const url = '/email';
 
+    bean.on($form[0], 'mouseover', () => {
+        loadScript(recaptchaJsLib)
+    });
     bean.on($form[0], 'submit', (ev) => {submitForm(ev, $form, iframeEl, url, analytics)});
 };
 

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -290,9 +290,7 @@ const submitForm = (
     })
 
     if (!state.submitting && validate(emailAddress)) {
-        onCaptchaSolved().catch(e=>{
-            debugger;
-        }).then(()=> {
+        onCaptchaSolved().then((captchaToken)=> {
             const formData = $form.data('formData');
             const data = `email=${encodeURIComponent(
                 emailAddress
@@ -300,7 +298,7 @@ const submitForm = (
                 formData.campaignCode
                 }&referrer=${formData.referrer}&csrfToken=${encodeURIComponent(
                 csrfToken
-            )}&listName=${listName.val()}`;
+            )}&g-recaptcha-response=${encodeURIComponent(captchaToken)}&listName=${listName.val()}`;
 
             analyticsInfo = `rtrt | email form inline | ${
                 analytics.formType

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -30,6 +30,12 @@ body {
     &:active {
         outline: 0;
     }
+
+    &[disabled] {
+        opacity: .5;
+        pointer-events: none;
+    }
+
 }
 
 /**


### PR DESCRIPTION
## What does this change?
Adds a switch and captcha for email signups, on widgets the purpose of this is to be able to protect the widgets when under attack.

## Screenshots
tbd
