### PR TITLE
Commercial features are booleans

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -7,20 +7,20 @@ import userPrefs from 'common/modules/user-prefs';
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
-    dfpAdvertising: any;
-    stickyTopBannerAd: any;
-    articleBodyAdverts: any;
-    articleAsideAdverts: any;
-    carrotTrafficDriver: any;
-    videoPreRolls: any;
-    highMerch: any;
-    thirdPartyTags: any;
-    outbrain: any;
-    commentAdverts: any;
-    liveblogAdverts: any;
-    paidforBand: any;
-    asynchronous: any;
-    adFree: any;
+    dfpAdvertising: boolean;
+    stickyTopBannerAd: boolean;
+    articleBodyAdverts: boolean;
+    articleAsideAdverts: boolean;
+    carrotTrafficDriver: boolean;
+    videoPreRolls: boolean;
+    highMerch: boolean;
+    thirdPartyTags: boolean;
+    outbrain: boolean;
+    commentAdverts: boolean;
+    liveblogAdverts: boolean;
+    paidforBand: boolean;
+    asynchronous: boolean;
+    adFree: boolean;
 
     constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests


### PR DESCRIPTION
## What does this change?

Better types for CommericalFeatures (they were `any`, we can use `boolean` instead)

## Screenshots

![commercial-features-types-joy](https://user-images.githubusercontent.com/29761/46531731-2b2fc280-c896-11e8-87f3-46ea3331654d.png)

### Tested

Just flow types, it'll be fine says @katebee.
