### PR TITLE
Remove mentions of Guardian Witness

### DIFF
--- a/identity/app/views/profile/publicProfileForm.scala.html
+++ b/identity/app/views/profile/publicProfileForm.scala.html
@@ -15,8 +15,7 @@
 <fieldset class="fieldset">
     <div class="form__note">
         These details will be publicly visible to everyone who sees your profile in the
-        <a class="u-underline" href="https://www.theguardian.com/community-faqs">commenting</a> section
-        and the <a class="u-underline" href="https://witness.theguardian.com/faq">GuardianWitness</a>.
+        <a class="u-underline" href="https://www.theguardian.com/community-faqs">commenting</a> section.
     </div>
 </fieldset>
 

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -43,9 +43,6 @@
                         <li class="tabs__tab @if(activityType == "picks"){tabs__tab--selected}">
                             <a href="@link/picks" class="js-activity-stream-change" data-stream-type="picks" data-link-name="Profile picks tab">Featured</a>
                         </li>
-                        <li class="tabs__tab @if(activityType == "witness"){tabs__tab--selected}">
-                            <a href="@link/witness" class="js-activity-stream-change" data-stream-type="witness" data-link-name="Profile witness tab">GuardianWitness</a>
-                        </li>
                     </ol>
                 </div>
                 <form action="@link/search" class="activity-stream-search js-activity-stream-search">


### PR DESCRIPTION
## What does this change?
Removed link to information on Guardian Witness from public profile page and GuardianWitness tab from discussion page.

## Screenshots
![screen shot 2018-10-05 at 15 21 47](https://user-images.githubusercontent.com/42539745/46541492-17935480-c8b4-11e8-81d8-2fefbe51b633.png)
![screen shot 2018-10-05 at 15 31 44](https://user-images.githubusercontent.com/42539745/46541509-1feb8f80-c8b4-11e8-9eb0-17c570b7fb18.png)

## What is the value of this and can you measure success?
Guardian Witness and the information page associated with it doesn't exist anymore. 

## Checklist
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
