### PR TITLE
Trim email html json

### DIFF
--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
 import conf.switches.Switches.InlineEmailStyles
-import _root_.html.{HtmlLinkUtmInsertion, HtmlTextExtractor}
+import _root_.html.{BrazeEmailFormatter, HtmlTextExtractor}
 import model.CacheTime.RecentlyUpdated
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, NoCache}
@@ -125,10 +125,10 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
 
     if (request.isEmailJson) {
-      val htmlWithUtmLinks = HtmlLinkUtmInsertion(htmlWithInlineStyles)
+      val htmlWithUtmLinks = BrazeEmailFormatter(htmlWithInlineStyles)
       Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithUtmLinks.toString)))))
     } else if (request.isEmailTxt) {
-      val htmlWithUtmLinks = HtmlLinkUtmInsertion(htmlWithInlineStyles)
+      val htmlWithUtmLinks = BrazeEmailFormatter(htmlWithInlineStyles)
       Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(HtmlTextExtractor(htmlWithUtmLinks))))))
     } else {
       Cached(page)(RevalidatableResult.Ok(htmlWithInlineStyles))

--- a/common/app/html/BrazeEmailFormatter.scala
+++ b/common/app/html/BrazeEmailFormatter.scala
@@ -9,11 +9,15 @@ import play.twirl.api.Html
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-object HtmlLinkUtmInsertion extends Logging {
+object BrazeEmailFormatter extends Logging {
 
   def apply(html: Html): Html = {
     val documentBody = Jsoup.parse(html.toString)
-    Html(setLinks(documentBody).toString)
+    Html(trimWhitespace(setLinks(documentBody).toString))
+  }
+
+  private def trimWhitespace(html: String): String = {
+    "(?m) *$".r.replaceAllIn("(?m)^ *".r.replaceAllIn(html, ""), "")
   }
 
   private def setLinks(element: Element): Element = {

--- a/common/test/html/BrazeEmailFormatterTest.scala
+++ b/common/test/html/BrazeEmailFormatterTest.scala
@@ -1,10 +1,9 @@
 package html
 
-import org.jsoup.Jsoup
 import org.scalatest.{FlatSpec, Matchers}
 import play.twirl.api.Html
 
-class HtmlLinkUtmInsertionTest extends FlatSpec with Matchers {
+class BrazeEmailFormatterTest extends FlatSpec with Matchers {
 
   "HtmlLinkUtimInsertion" should "insert utm code place holders into an HTML string" in {
     val rawHtml =
@@ -24,9 +23,10 @@ class HtmlLinkUtmInsertionTest extends FlatSpec with Matchers {
         |
         |<a href="/link/">some link</a>
         |
+        |<a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters">article link</a>
+        |
         |<table>
         |  <tr>
-        |    <a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters">article link</a>
         |    <td>The brown</td>
         |    <td>fox jumped</td>
         |    <td>over</td>
@@ -49,47 +49,42 @@ class HtmlLinkUtmInsertionTest extends FlatSpec with Matchers {
         |</html>""".stripMargin
 
     val expectedText =
-      """
-        |<!DOCTYPE html>
+      """<!doctype html>
         |<html>
         |<head></head>
         |<body>
-        |
         |<h2>Heading text</h2>
-        |
         |<p>Paragraph.</p>
-        |<br/>
+        |<br>
         |<div>
-        |  <span>My name is:</span> Bill
+        |<span>My name is:</span> Bill
         |</div>
-        |
         |<a href="/link/?##braze_utm##">some link</a>
-        |
+        |<a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters?##braze_utm##">article link</a>
         |<table>
-        |  <tr>
-        |    <a href="https://www.theguardian.com/environment/2018/sep/26/dont-post-crisp-packets-royal-mail-begs-packaging-protesters?##braze_utm##">article link</a>
-        |    <td>The brown</td>
-        |    <td>fox jumped</td>
-        |    <td>over</td>
-        |  </tr>
-        |  <tr>
-        |    <td>a</td>
-        |    <td>cat on</td>
-        |    <td>the window</td>
-        |  </tr>
-        |  <tr>
-        |    <td>next to the</td>
-        |    <td>kitchen</td>
-        |    <td>in the house <a href="https://www.theguardian.com/another/link?param&##braze_utm##">some other link</a></td>
-        |  </tr>
+        |<tbody>
+        |<tr>
+        |<td>The brown</td>
+        |<td>fox jumped</td>
+        |<td>over</td>
+        |</tr>
+        |<tr>
+        |<td>a</td>
+        |<td>cat on</td>
+        |<td>the window</td>
+        |</tr>
+        |<tr>
+        |<td>next to the</td>
+        |<td>kitchen</td>
+        |<td>in the house <a href="https://www.theguardian.com/another/link?param&amp;##braze_utm##">some other link</a></td>
+        |</tr>
+        |</tbody>
         |</table>
-        |
         |<hr>
-        |
         |</body>
         |</html>""".stripMargin
 
-    HtmlLinkUtmInsertion(Html(rawHtml)) shouldBe Html(Jsoup.parse(expectedText).toString)
+    BrazeEmailFormatter(Html(rawHtml)) shouldBe Html(expectedText)
   }
 
   it should "not affect unsubscribe url placeholder links" in {
@@ -106,18 +101,15 @@ class HtmlLinkUtmInsertionTest extends FlatSpec with Matchers {
         |</html>""".stripMargin
 
     val expectedText =
-      """
-        |<!DOCTYPE html>
+      """<!doctype html>
         |<html>
         |<head></head>
         |<body>
-        |
         |<a href="%%unsub_center_url%%">unsubscribe</a>
-        |
         |</body>
         |</html>""".stripMargin
 
-    HtmlLinkUtmInsertion(Html(rawHtml)) shouldBe Html(Jsoup.parse(expectedText).toString)
+    BrazeEmailFormatter(Html(rawHtml)) shouldBe Html(expectedText)
   }
 
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common._
-import _root_.html.{HtmlLinkUtmInsertion, HtmlTextExtractor}
+import _root_.html.{BrazeEmailFormatter, HtmlTextExtractor}
 import controllers.front._
 import layout.{CollectionEssentials, ContentCard, FaciaCard, FaciaCardAndIndex, FaciaContainer, Front}
 import model.Cached.{CacheableResult, RevalidatableResult, WithoutRevalidationResult}
@@ -167,11 +167,11 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
     val htmResponseInlined = if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse
 
     if (request.isEmailJson) {
-      val htmlWithUtmLinks = HtmlLinkUtmInsertion(htmResponseInlined)
+      val htmlWithUtmLinks = BrazeEmailFormatter(htmResponseInlined)
       val emailJson = JsObject(Map("body" -> JsString(htmlWithUtmLinks.toString)))
       RevalidatableResult.Ok(emailJson)
     } else if (request.isEmailTxt) {
-      val htmlWithUtmLinks = HtmlLinkUtmInsertion(htmResponseInlined)
+      val htmlWithUtmLinks = BrazeEmailFormatter(htmResponseInlined)
       val emailTxtJson = JsObject(Map("body" -> JsString(HtmlTextExtractor(htmlWithUtmLinks))))
       RevalidatableResult.Ok(emailTxtJson)
     } else {


### PR DESCRIPTION
## What does this change?

Remove whitespace from email html json. The email JSON html endpoints are not squashed by nginx since the HTML is wrapped by JSON

## What is the value of this and can you measure success?

Emails less likely to be clipped in email clients. The change should save around 20KB from large emails. Gmail clips at 102KB

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
