### PR TITLE
Sync the liveblog and article epic control

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -11,6 +11,7 @@ const controlCopyParagraphTwo =
 const controlCopyParagraphThree =
     'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.';
 
+// used when Google Doc control cannot be fetched
 export const articleCopy = {
     heading: 'Since you’re here &hellip;',
     paragraphs: [

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -2,20 +2,30 @@
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 import reportError from 'lib/report-error';
 
+const controlCopyParagraphOne =
+    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.';
+
+const controlCopyParagraphTwo =
+    'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.';
+
+const controlCopyParagraphThree =
+    'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.';
+
 export const articleCopy = {
     heading: 'Since you’re here &hellip;',
     paragraphs: [
-        '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-        'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.',
-        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+        controlCopyParagraphOne,
+        controlCopyParagraphTwo,
+        controlCopyParagraphThree,
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
 };
 
 export const liveblogCopy: AcquisitionsEpicTemplateCopy = {
     paragraphs: [
-        'Since you’re here &hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help.',
-        'If everyone who reads our reporting, who likes it, helps fund it, our future would be much more secure.',
+        `Since you’re here ${controlCopyParagraphOne}`,
+        controlCopyParagraphTwo,
+        controlCopyParagraphThree,
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute.`,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -3,7 +3,7 @@ import { getLocalCurrencySymbol } from 'lib/geolocation';
 import reportError from 'lib/report-error';
 
 const controlCopyParagraphOne =
-    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.';
+    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help.';
 
 const controlCopyParagraphTwo =
     'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our Editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.';


### PR DESCRIPTION
## What does this change?

. Updates the liveblog copy to the current control. 
. Updates the fallback epic copy to the current control
. Refactors it so that the liveblog copy and fallback epic copy use the same copy. 

| Liveblog with updated copy |
|-------|
|![liveblog](https://user-images.githubusercontent.com/2844554/46611782-b0211300-cb06-11e8-96e3-082eb113f82a.png)|
