### PR TITLE
Send tags on dotcomponents calls

### DIFF
--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -36,7 +36,10 @@ class RemoteRender(implicit context: ApplicationContext) {
 
   def render(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
 
-    val contentFieldsJson = List("contentFields" -> Json.toJson(ContentFields(article.article)))
+    val contentFieldsJson = List(
+      "contentFields" -> Json.toJson(ContentFields(article.article)),
+      "tags" -> Json.toJson(article.article.tags)
+    )
     val jsonResponse = List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
     val jsonPayload = JsonComponent.jsonFor(article, jsonResponse:_*)
 


### PR DESCRIPTION
## What does this change?

Make sure we're sending tags with dotcomponents calls, the same way we do with the .json?guui endpoint.

There's more work to do to ensure we can never have a difference between .json endpoint and the data model but that's for another PR. This gets us working now.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
