### PR TITLE
Add guardian weekly links to nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -159,6 +159,7 @@ object NavLinks {
       NavLink("Observer Magazine", "/theobserver/magazine")
     )
   )
+  val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")
   val digitalNewspaperArchive = NavLink("Digital Archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink("Crosswords", "/crosswords",
     children = List(
@@ -459,6 +460,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     observer,
+    weekly,
     NavLink("Professional networks", "/guardian-professional"),
     crosswords,
     guardianMasterClasses
@@ -470,6 +472,7 @@ object NavLinks {
     pictures,
     newsletters,
     insideTheGuardian,
+    weekly,
     crosswords
   )
   val usOtherLinks = List(
@@ -479,6 +482,7 @@ object NavLinks {
     pictures,
     newsletters,
     insideTheGuardian,
+    weekly,
     crosswords
   )
   val intOtherLinks = List(
@@ -490,6 +494,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     observer,
+    weekly,
     crosswords
   )
 

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -460,7 +460,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     observer,
-    weekly,
+    weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     NavLink("Professional networks", "/guardian-professional"),
     crosswords,
     guardianMasterClasses
@@ -472,7 +472,7 @@ object NavLinks {
     pictures,
     newsletters,
     insideTheGuardian,
-    weekly,
+    weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Aus"),
     crosswords
   )
   val usOtherLinks = List(
@@ -482,7 +482,7 @@ object NavLinks {
     pictures,
     newsletters,
     insideTheGuardian,
-    weekly,
+    weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_US"),
     crosswords
   )
   val intOtherLinks = List(
@@ -494,7 +494,7 @@ object NavLinks {
     todaysPaper,
     insideTheGuardian,
     observer,
-    weekly,
+    weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_Int"),
     crosswords
   )
 


### PR DESCRIPTION
## What does this change?
Adds weekly to the nav https://trello.com/c/ArYhZFTm/416-add-guardian-weekly-to-the-nav
## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

Does not change ad free logic.

### Accessibility test checklist

Does not change presentational logic.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
