### PR TITLE
Throw exception so kibana logs 500s from dotcomponents

### DIFF
--- a/article/app/renderers/RemoteRender.scala
+++ b/article/app/renderers/RemoteRender.scala
@@ -30,7 +30,7 @@ class RemoteRender(implicit context: ApplicationContext) {
         case 200 =>
           Cached(article)(RevalidatableResult.Ok(Html(response.body)))
         case _ =>
-          NoCache(InternalServerError("Rendering tier failed"))
+          throw new Exception(response.body)
       }
     })
 


### PR DESCRIPTION
## What does this change?

Currently when dotcomponents fails locally, in frontend you just get a 500 screen with no descriptive error.

This changes the way we generate errors in frontend when dotcomponents fails. Instead of returning an empty 500, we simply throw an exception. This bubbles up causing a normal 500 error which gives you the standard 500 error screen in production, but most importantly, it means **in development mode you get the proper error message shows to you**

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
