### PR TITLE
Make sure we never try and do guui on amp

### DIFF
--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -6,6 +6,7 @@ import model.liveblog.{BlockElement, ImageBlockElement, TextBlockElement}
 import play.api.mvc.RequestHeader
 import services.dotcomponents.{LocalRender, RemoteRender, RenderType}
 import views.support.Commercial
+import implicits.Requests._
 
 object PageChecks {
 
@@ -51,6 +52,8 @@ object PageChecks {
 
   def isNotAGallery(page:PageWithStoryPackage): Boolean = ! page.item.tags.isGallery
 
+  def isNotAMP(request: RequestHeader): Boolean = ! request.isAmp
+
 }
 
 class SimplePagePicker extends RenderTierPickerStrategy {
@@ -69,7 +72,8 @@ class SimplePagePicker extends RenderTierPickerStrategy {
       ("isNotImmersive", PageChecks.isNotImmersive(page)),
       ("isNotLiveBlog", PageChecks.isNotLiveBlog(page)),
       ("isNotAReview", PageChecks.isNotAReview(page)),
-      ("isNotAGallery", PageChecks.isNotAGallery(page))
+      ("isNotAGallery", PageChecks.isNotAGallery(page)),
+      ("isNotAMP", PageChecks.isNotAMP(request))
     )
 
     val success = ! results.exists{!_._2}


### PR DESCRIPTION
## What does this change?

Make sure we never try and do guui on amp pages

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
