### PR TITLE
Add VSCode section to the getting started guide

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "flowtype.flow-for-vscode"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -202,6 +202,41 @@ Then load IntelliJ, then click Import project and import the directory as an SBT
 
 Congratulations, you are now set up to edit frontend code!  See the [Optional steps](#optional-steps) below for other things to do.
 
+## Client-side development with VSCode
+
+While IntelliJ is great for Scala, you may want another option if you are writing a lot of JS and CSS, so quite a few people choose to use VSCode.
+
+You can download VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/)
+
+The built-in linting of VSCode may start finding TypeScript errors in JavaScript files...  To resolve this open your user settings and add the following lines:
+
+``` json
+    "javascript.validate.enable": false,
+    "typescript.validate.enable": false,
+```
+
+You can use the Command Palette (shift + cmd + P) to open user or workspace settings, just type in `Preferences: Open User Settings`
+
+Along with EditorConfig, the following plugins will be helpful:
+
+- [Flow VSCode plugin](https://github.com/flowtype/flow-for-vscode)
+- [Prettier VSCode plugin](https://github.com/prettier/prettier-vscode)
+- [Eslint VSCode plugin](https://github.com/Microsoft/vscode-eslint)
+
+Tip: creating or editing `.vscode/extensions.json` to contain the following will prompt VSCode to recommend installing them into your workspace:
+
+```json
+{
+	"recommendations": [
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "flowtype.flow-for-vscode"
+	]
+}
+```
+
+The [VSCode documentation](http://go.microsoft.com/fwlink/?LinkId=827846) has more details on workspace recommendations.
 
 # Optional steps
 

--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -217,26 +217,7 @@ The built-in linting of VSCode may start finding TypeScript errors in JavaScript
 
 You can use the Command Palette (shift + cmd + P) to open user or workspace settings, just type in `Preferences: Open User Settings`
 
-Along with EditorConfig, the following plugins will be helpful:
-
-- [Flow VSCode plugin](https://github.com/flowtype/flow-for-vscode)
-- [Prettier VSCode plugin](https://github.com/prettier/prettier-vscode)
-- [Eslint VSCode plugin](https://github.com/Microsoft/vscode-eslint)
-
-Tip: creating or editing `.vscode/extensions.json` to contain the following will prompt VSCode to recommend installing them into your workspace:
-
-```json
-{
-	"recommendations": [
-        "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig",
-        "esbenp.prettier-vscode",
-        "flowtype.flow-for-vscode"
-	]
-}
-```
-
-The [VSCode documentation](http://go.microsoft.com/fwlink/?LinkId=827846) has more details on workspace recommendations.
+Recommended VSCode extensions are listed in `.vscode/extensions.json` and VSCode should prompt you to install these when you open the project. You can also find and install these by searching for `@recommended` in the extensions pane.
 
 # Optional steps
 


### PR DESCRIPTION
## What does this change?

#### EDIT: 
Decided to commit `.vscode/extensions.json` after discussion and because fewer todos and more frontend magic when getting started is always good 👍 💎 

_______

First pass at some VSCode guidance for JS development joy. This PR expands the readme to give client-side developers a bit of guidance on an IDE and how to set it up.


I was really tempted to commit the `.vscode/extensions.json` since this feature of VSCode is fantastic  🚀 ✨ 

Here is the one I use:

```json
{
	"recommendations": [
        "dbaeumer.vscode-eslint",
        "editorconfig.editorconfig",
        "esbenp.prettier-vscode",
        "flowtype.flow-for-vscode"
	],
	"unwantedRecommendations": [

	]
}
```
For now it is in the readme, following it will give you some helpful prompts when opening the project.

## Screenshots

![screen shot 2018-10-09 at 12 12 43](https://user-images.githubusercontent.com/8607683/46667401-7d882080-cbc1-11e8-8398-fbdd494c615c.png)

![screen shot 2018-10-09 at 12 12 27](https://user-images.githubusercontent.com/8607683/46667770-8c230780-cbc2-11e8-8484-1209ed159678.png)

## What is the value of this and can you measure success?

Joyful developer experience  🦄 ✨ 

## Checklist

### Does this affect other platforms?

Nope, just the readme 😄 