### PR TITLE
Add RH col with ad to crossword at wide breakpoint

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -2,6 +2,8 @@
 
 @import play.api.libs.json.Json
 @import views.html.fragments.crosswords._
+@import conf.switches.Switches.CommercialSwitch
+@import views.support.Commercial.shouldShowAds
 
 <div class="l-side-margins">
     <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
@@ -36,6 +38,11 @@
                     </div>
                 </div>
             </div>
+            @if(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage)) {
+                <div class="content__secondary-column hide-until-wide" aria-hidden="true">
+                @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map("desktop" -> Seq("300,250", "300,274", "300,600", "fluid")))
+                </div>
+            }
         </div>
     </div>
     </article>

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -14,7 +14,7 @@
 .crossword__clue {
     @include fs-textSans(4);
     position: relative;
-    padding: $gs-baseline * .25 $gs-baseline;
+    padding: $gs-baseline * .25 $gs-baseline $gs-baseline * .25 0;
     margin: $gs-baseline * .25 0;
     display: block;
 
@@ -42,10 +42,6 @@
 
     .has-grouped-clues & {
         width: $gs-gutter * 2;
-
-        @include mq(leftCol) {
-            width: $gs-gutter * 3;
-        }
     }
 }
 

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -51,6 +51,10 @@
     clear: both;
     position: relative;
     margin-top: $gs-baseline;
+
+    @include mq($from: wide) {
+        margin-right: gs-span(4) + $gs-baseline;
+    }
 }
 
 .crossword__controls {

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -52,7 +52,7 @@
     position: relative;
     margin-top: $gs-baseline;
 
-    @include mq($from: wide) {
+    @include mq(wide) {
         margin-right: gs-span(4) + $gs-baseline;
     }
 }


### PR DESCRIPTION
Need to clear this change with Comms prior to merge / release, because crosswords.

## What does this change?

If ads are enabled we add a secondary-column to the crossword page that only appears at the largest breakpoint. It contains an ad slot that can fit ads up to 300px wide.

The crossword layout has been tweaked to accommodate the ad in at this breakpoint, based on the design in the ticket. The design given wasn't fully realisable so only this breakpoint works like this, happy to chat about this more in person. We can look at designing something for smaller breakpoints if this works.

## Screenshots

![crossword-ad](https://user-images.githubusercontent.com/29761/46668666-081e4f00-cbc5-11e8-9e6b-e958797f4264.png)

## What is the value of this and can you measure success?

People persist on the crossword page so a refreshing ad there (even only at the largest size) could provide real value from our free online crosswords.

## Checklist

### Does this affect other platforms?

It does not.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No, this is just a small tweak to the crossword page.

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

No change to how the crosswords work here.

### Tested

- [x] Locally
- [x] On CODE (optional)

Looks ok at all breakpoints, tested with multiple crosswords of all types. Crosswords still work, too.

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
