### PR TITLE
Fix slotId parameter sent to pubmatic to strip dfp-ad--

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -47,6 +47,7 @@ import {
     stripTrailingNumbersAbove1,
     isInUsRegion,
     isInAuRegion,
+    stripDfpAdPrefixFrom,
 } from './utils';
 
 const isInSafeframeTestVariant = (): boolean => {
@@ -397,7 +398,7 @@ const pubmaticBidder: PrebidBidder = {
             {},
             {
                 publisherId: getPubmaticPublisherId(),
-                adSlot: slotId,
+                adSlot: stripDfpAdPrefixFrom(slotId),
             }
         ),
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -20,6 +20,14 @@ const currentGeoLocation = once((): string => geolocationGetSync());
 const contains = (sizes: PrebidSize[], size: PrebidSize): boolean =>
     Boolean(sizes.find(s => s[0] === size[0] && s[1] === size[1]));
 
+const stripPrefix = (s: string, prefix: string): string => {
+    const re = new RegExp(`^${prefix}`);
+    return s.replace(re, '');
+};
+
+export const stripDfpAdPrefixFrom = (s: string): string =>
+    stripPrefix(s, 'dfp-ad--');
+
 export const isInUsRegion = (): boolean =>
     ['US', 'CA'].includes(currentGeoLocation());
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -13,6 +13,7 @@ import {
     shouldIncludeTrustX,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
+    stripDfpAdPrefixFrom,
 } from './utils';
 
 const getSync: any = getSync_;
@@ -38,6 +39,22 @@ describe('Utils', () => {
     beforeEach(() => {
         jest.resetAllMocks();
         config.switches.prebidAppnexusUkRow = undefined;
+    });
+
+    test('stripPrefix correctly strips valid cases', () => {
+        const validStrips: Array<Array<string>> = [
+            ['dfp-ad--slot', 'slot'],
+            ['slot', 'slot'],
+            ['dfp-ad--', ''],
+        ];
+
+        validStrips.forEach(([stringToStrip, result]) => {
+            expect(stripDfpAdPrefixFrom(stringToStrip)).toEqual(result);
+        });
+    });
+
+    test('stripPrefix correctly behaves in invalid case', () => {
+        expect(stripDfpAdPrefixFrom(' dfp-ad--slot')).toEqual(' dfp-ad--slot');
     });
 
     test('getBreakpointKey should find the correct key', () => {


### PR DESCRIPTION
## What does this change?

The `bidParams` function within a `PrebidBidder` receives `slotId` with the full prefix of `dfp-ad--`.

Pubmatic have already setup mappings with these without the prefix, so we will strip them before we send them.

The other alternative would be to advise them to change their mappings; although I'm not sure about it as this prefix isn't apart of the ad-slot name, depending on who you talk to. Thoughts?

@guardian/commercial-dev 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
