### PR TITLE
Fix crossword "check" feature

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -664,7 +664,7 @@ class Crossword extends Component<*, CrosswordState> {
         const cells = cellsForEntry(entry);
 
         if (entry.solution) {
-            const badCells = zip(cells, entry.solution)
+            const badCells = zip(cells, entry.solution.split(''))
                 .filter(cellAndSolution => {
                     const coords = cellAndSolution[0];
                     const cell = this.state.grid[coords.x][coords.y];


### PR DESCRIPTION
## What does this change?

The lodash upgrade (#20475) silently introduced a breaking change to the way `lodash/zip` works. In v2, if a string is passed as an argument, it is implicitly coerced into an array. In v4, non-array arguments are ignored.

This fix ensures the second argument passed to `zip()` is an array, allowing the proceeding logic to function correctly

## What is the value of this and can you measure success?

The word checker works again

## Tested

- [x] Locally