### PR TITLE
Treats Bold🡒Regular

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_treats.scss
+++ b/static/src/stylesheets/module/facia-garnett/_treats.scss
@@ -39,7 +39,7 @@
     box-sizing: border-box;
     display: inline-block;
     vertical-align: top;
-    font-weight: 700;
+    font-weight: 400;
     border-width: 1px;
     border-style: solid;
     border-right-style: none;

--- a/static/src/stylesheets/module/facia/_treats.scss
+++ b/static/src/stylesheets/module/facia/_treats.scss
@@ -42,7 +42,7 @@
     display: inline-block;
     vertical-align: top;
     width: auto;
-    font-weight: 700;
+    font-weight: 400;
     border-width: 1px;
     border-style: solid;
     text-decoration: none;


### PR DESCRIPTION
In @zeftilldeath’s wise words:

> Bold at that size looks horrible.

No idea why (if?) twice, so if it’s wrong, kill it. Kill me.