### PR TITLE
Prioritise education section over other navigation tag pages.

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -521,6 +521,9 @@ object NavLinks {
   )
 
   // Tertiary Navigation
+  // NOTE: content with tags from this list will have the navigation set to the tag in this list, rather than its
+  // section tag. e.g. Content in technology section with world/europe-news will appear in the world section in
+  // the navigation. The workaround for this is to add the section to this list,as has been done with CiF and education
   val tagPages = List(
     "us-news/us-politics",
     "australia-news/australian-politics",
@@ -599,7 +602,6 @@ object NavLinks {
     "football/competitions",
     "football/results",
     "football/fixtures",
-    "education",
     "crosswords/crossword-blog",
     "crosswords/series/crossword-editor-update",
     "crosswords/series/quick",
@@ -612,6 +614,10 @@ object NavLinks {
     "crosswords/series/everyman",
     "crosswords/series/azed",
     "fashion/beauty",
-    "technology/motoring"
+    "technology/motoring",
+    // these last two are here to ensure that content in education and CiF always appear as such in the navigation
+    // even if they also have a tag from this list
+    "commentisfree/commentisfree",
+    "education/education"
   )
 }

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -159,9 +159,7 @@ object NavMenu {
     val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && tagPages.contains(page.metadata.id)
     val isArticleInTagPageSection = commonKeywords.nonEmpty
 
-    val id = if (page.metadata.sectionId == "commentisfree") {
-      page.metadata.sectionId
-    } else if (networkFronts.contains(page.metadata.sectionId)) {
+    val id = if (networkFronts.contains(page.metadata.sectionId)) {
       ""
     } else if (isTagPage) {
       page.metadata.id
@@ -173,7 +171,13 @@ object NavMenu {
       page.metadata.sectionId
     }
 
-    s"/$id"
+    // if id is a section tag, e.g. education/education, convert it to just /education, so it can be succesfully
+    // found up in the navigation (see findDescendantByUrl)
+    val idParts = id.split("/")
+    if (idParts.length == 2 && idParts(0) == idParts(1)) {
+      s"/${idParts(0)}"
+    } else s"/$id"
+
   }
 
   private[navigation] def getSubnav(


### PR DESCRIPTION
## What does this change?
Ensures that e.g. when the 'Europe' tag is added to articles such as [this](https://www.theguardian.com/education/2018/aug/21/no-other-european-country-tests-at-16-scrap-gcses) one they don't end up appearing as if they are in the world news section in the navigation

## What is the value of this and can you measure success?
This will enable editorial to properly tag content without worrying about nav location

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
