### PR TITLE
Fix AppNexus targeting objects

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -25,7 +25,7 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
-export const removeUndefinedValues = (o: {
+export const removeFalseyValues = (o: {
     [string]: string,
 }): { [string]: string } =>
     Object.keys(o).reduce((m: { [string]: string }, k: string) => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -25,6 +25,14 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
+export const removeUndefinedValues = (o: object): object =>
+    Object.keys(o).reduce((m: object, k: any) => {
+        if (o[k]) {
+            m[k] = o[k];
+        }
+        return m;
+    }, {});
+
 export const stripDfpAdPrefixFrom = (s: string): string =>
     stripPrefix(s, 'dfp-ad--');
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -25,8 +25,10 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
-export const removeUndefinedValues = (o: object): object =>
-    Object.keys(o).reduce((m: object, k: any) => {
+export const removeUndefinedValues = (o: {
+    [string]: string,
+}): { [string]: string } =>
+    Object.keys(o).reduce((m: { [string]: string }, k: string) => {
         if (o[k]) {
             m[k] = o[k];
         }

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -239,16 +239,12 @@ describe('Utils', () => {
     });
 
     test('removeUndefinedValues correctly move non-truthy values', () => {
-        const result: object = removeUndefinedValues({
-            test1: 1,
-            testUndefined: undefined,
-            testNull: null,
+        const result = removeUndefinedValues({
             testString: 'non empty string',
             testEmptyString: '',
         });
 
         expect(result).toEqual({
-            test1: 1,
             testString: 'non empty string',
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -14,6 +14,7 @@ import {
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
     stripDfpAdPrefixFrom,
+    removeUndefinedValues,
 } from './utils';
 
 const getSync: any = getSync_;
@@ -235,5 +236,20 @@ describe('Utils', () => {
         expect(shouldIncludeAdYouLike([[300, 250]])).toBe(true);
         expect(shouldIncludeAdYouLike([[300, 600], [300, 250]])).toBe(true);
         expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
+    });
+
+    test('removeUndefinedValues correctly move non-truthy values', () => {
+        const result: object = removeUndefinedValues({
+            test1: 1,
+            testUndefined: undefined,
+            testNull: null,
+            testString: 'non empty string',
+            testEmptyString: '',
+        });
+
+        expect(result).toEqual({
+            test1: 1,
+            testString: 'non empty string',
+        });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -238,7 +238,7 @@ describe('Utils', () => {
         expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
     });
 
-    test('removeFalseyValues correctly move non-truthy values', () => {
+    test('removeFalseyValues correctly remove non-truthy values', () => {
         const result = removeFalseyValues({
             testString: 'non empty string',
             testEmptyString: '',

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -14,7 +14,7 @@ import {
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
     stripDfpAdPrefixFrom,
-    removeUndefinedValues,
+    removeFalseyValues,
 } from './utils';
 
 const getSync: any = getSync_;
@@ -238,8 +238,8 @@ describe('Utils', () => {
         expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
     });
 
-    test('removeUndefinedValues correctly move non-truthy values', () => {
-        const result = removeUndefinedValues({
+    test('removeFalseyValues correctly move non-truthy values', () => {
+        const result = removeFalseyValues({
             testString: 'non empty string',
             testEmptyString: '',
         });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -167,7 +167,7 @@ const buildAppNexusTargetingObject = once(
             pt5: pageTargeting.k,
             pt6: pageTargeting.su,
             pt7: pageTargeting.bp,
-            pt8: pageTargeting.x || '', // OpenX cannot handle this being undefined
+            pt8: pageTargeting.x, // OpenX cannot handle this being undefined
             pt9: [
                 pageTargeting.gdncrm,
                 pageTargeting.pv,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -14,6 +14,7 @@ import {
 } from 'common/modules/commercial/ad-prefs.lib';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getParticipations } from 'common/modules/experiments/utils';
+import { removeUndefinedValues } from 'commercial/modules/prebid/utils';
 import flattenDeep from 'lodash/flattenDeep';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
@@ -156,24 +157,25 @@ type PageTargeting = {
 };
 
 const buildAppNexusTargetingObject = once(
-    (pageTargeting: PageTargeting): {} => ({
-        sens: pageTargeting.sens,
-        pt1: pageTargeting.url,
-        pt2: pageTargeting.edition,
-        pt3: pageTargeting.ct,
-        pt4: pageTargeting.p,
-        pt5: pageTargeting.k,
-        pt6: pageTargeting.su,
-        pt7: pageTargeting.bp,
-        pt8: pageTargeting.x || '', // OpenX cannot handle this being undefined
-        pt9: [
-            pageTargeting.gdncrm,
-            pageTargeting.pv,
-            pageTargeting.co,
-            pageTargeting.tn,
-            pageTargeting.slot,
-        ].join('|'),
-    })
+    (pageTargeting: PageTargeting): {} =>
+        removeUndefinedValues({
+            sens: pageTargeting.sens,
+            pt1: pageTargeting.url,
+            pt2: pageTargeting.edition,
+            pt3: pageTargeting.ct,
+            pt4: pageTargeting.p,
+            pt5: pageTargeting.k,
+            pt6: pageTargeting.su,
+            pt7: pageTargeting.bp,
+            pt8: pageTargeting.x || '', // OpenX cannot handle this being undefined
+            pt9: [
+                pageTargeting.gdncrm,
+                pageTargeting.pv,
+                pageTargeting.co,
+                pageTargeting.tn,
+                pageTargeting.slot,
+            ].join('|'),
+        })
 );
 
 const buildAppNexusTargeting = once(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -14,7 +14,7 @@ import {
 } from 'common/modules/commercial/ad-prefs.lib';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getParticipations } from 'common/modules/experiments/utils';
-import { removeUndefinedValues } from 'commercial/modules/prebid/utils';
+import { removeFalseyValues } from 'commercial/modules/prebid/utils';
 import flattenDeep from 'lodash/flattenDeep';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
@@ -158,7 +158,7 @@ type PageTargeting = {
 
 const buildAppNexusTargetingObject = once(
     (pageTargeting: PageTargeting): {} =>
-        removeUndefinedValues({
+        removeFalseyValues({
             sens: pageTargeting.sens,
             pt1: pageTargeting.url,
             pt2: pageTargeting.edition,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -165,7 +165,7 @@ const buildAppNexusTargetingObject = once(
         pt5: pageTargeting.k,
         pt6: pageTargeting.su,
         pt7: pageTargeting.bp,
-        pt8: pageTargeting.x,
+        pt8: pageTargeting.x || '', // OpenX cannot handle this being undefined
         pt9: [
             pageTargeting.gdncrm,
             pageTargeting.pv,


### PR DESCRIPTION
## What does this change?

This changes the function `appNexusTargetingObject` to never return an object with non-truthy values by using `removeFalseyValues`.

@guardian/commercial-dev Don't think anything like `removeFalseyValues` exists in the frontend codebase, but could be wrong?