### PR TITLE
Add list of tags for which affiliate links should never be addded to content

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -252,6 +252,7 @@ class GuardianConfiguration extends Logging {
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet
     lazy val defaultOffTags: Set[String] = configuration.getStringProperty("affiliatelinks.default.off.tags").getOrElse("").split(",").toSet
+    lazy val alwaysOffTags: Set[String] = configuration.getStringProperty("affiliatelinks.always.off.tags").getOrElse("").split(",").toSet
   }
 
   object frontend {

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -19,5 +19,7 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
     shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("bereavement")) should be (false)
     shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("tech")) should be (false)
     shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), List("tech")) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set("bereavement"), List("bereavement")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set("bereavement"), List("tech")) should be (true)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -12,14 +12,14 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, List.empty ) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, List.empty) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections, Set.empty, List.empty) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections, Set.empty, List.empty) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("bereavement")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), List("tech")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), List("tech")) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set("bereavement"), List("bereavement")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set("bereavement"), List("tech")) should be (true)
+    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, Set.empty, List.empty ) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, Set.empty, List.empty) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections, Set.empty, Set.empty, List.empty) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections, Set.empty, Set.empty, List.empty) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("bereavement")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("tech")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), Set.empty, List("tech")) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("bereavement")) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("tech")) should be (true)
   }
 }


### PR DESCRIPTION
## What does this change?
Adds a new config properly containing tag ids for which affiliate links will NEVER be added, regardless of what is set in composer. 

## What is the value of this and can you measure success?
Bugs in composer can result in affiliate links being erroneously enabled. This is a 'stop gap' to remove affiliate links from all content with certain tags, regardless of what composer thinks


### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
