### PR TITLE
Prevent DMPU overlowing crossword container

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -5,46 +5,49 @@
 @import conf.switches.Switches.CommercialSwitch
 @import views.support.Commercial.shouldShowAds
 
-<div class="l-side-margins">
-    <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
-        @crosswordMetaHeader(crosswordPage)
+@defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage)) { adsEnabled =>
+    <div class="l-side-margins">
+        <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
+            @crosswordMetaHeader(crosswordPage)
 
-    <div class="content__main tonal__main tonal__main--tone-news">
-        <div class="gs-container">
-            <div class="js-content-main-column">
+            <div class="content__main tonal__main tonal__main--tone-news">
+                <div class="gs-container">
+                    <div class="js-content-main-column">
+                        <div class="@if(adsEnabled) {crossword__spacer--ad}">
+                            <div class="js-crossword @if(crosswordPage.hasGroupedClues) {has-grouped-clues}"
+                            data-crossword-data="@Json.stringify(Json.toJson(crosswordPage.crossword))">
 
-                <div class="js-crossword @if(crosswordPage.hasGroupedClues) {has-grouped-clues}"
-                data-crossword-data="@Json.stringify(Json.toJson(crosswordPage.crossword))">
+                                <div class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
+                                    @* The following is a fallback for when JavaScript is not enabled *@
+                                    <div class="crossword__container__grid-wrapper">
+                                        <noscript>@crosswordPage.svg</noscript>
+                                    </div>
 
-                    <div class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
-                        @* The following is a fallback for when JavaScript is not enabled *@
-                        <div class="crossword__container__grid-wrapper">
-                            <noscript>@crosswordPage.svg</noscript>
-                        </div>
+                                    <noscript>
+                                        <div class="crossword__clues">
+                                            <div class="crossword__clues--across">
+                                                <h3 class="crossword__clues-header">Across</h3>
+                                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "across"))
+                                            </div>
 
-                        <noscript>
-                            <div class="crossword__clues">
-                                <div class="crossword__clues--across">
-                                    <h3 class="crossword__clues-header">Across</h3>
-                                    @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "across"))
-                                </div>
-
-                                <div class="crossword__clues--down">
-                                    <h3 class="crossword__clues-header">Down</h3>
-                                    @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "down"))
+                                            <div class="crossword__clues--down">
+                                                <h3 class="crossword__clues-header">Down</h3>
+                                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == "down"))
+                                            </div>
+                                        </div>
+                                    </noscript>
                                 </div>
                             </div>
-                        </noscript>
+                        </div>
                     </div>
+                    @if(adsEnabled) {
+                        <div class="content__secondary-column hide-until-wide" aria-hidden="true">
+                        @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map("desktop" -> Seq("300,250", "300,274", "300,600", "fluid")))
+                        </div>
+                    }
                 </div>
             </div>
-            @if(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage)) {
-                <div class="content__secondary-column hide-until-wide" aria-hidden="true">
-                @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map("desktop" -> Seq("300,250", "300,274", "300,600", "fluid")))
-                </div>
-            }
-        </div>
+        </article>
+        @crosswordFooter(crosswordPage)
     </div>
-    </article>
-    @crosswordFooter(crosswordPage)
-</div>
+}

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -51,7 +51,9 @@
     clear: both;
     position: relative;
     margin-top: $gs-baseline;
+}
 
+.crossword__spacer--ad {
     @include mq(wide) {
         margin-right: gs-span(4) + $gs-baseline;
         min-height: 600px + $mpu-ad-label-height;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -54,6 +54,8 @@
 
     @include mq(wide) {
         margin-right: gs-span(4) + $gs-baseline;
+        min-height: 600px + $mpu-ad-label-height;
+        margin-bottom: $gs-baseline;
     }
 }
 


### PR DESCRIPTION
Layout bug fix!

I recommend viewing the change with the `w=1` flag to [ignore whitespace changes](https://github.com/guardian/frontend/pull/20507/files?w=1) (indentation).

## What does this change?

Quick crosswords are smaller and have fewer clues. In some cases the height of the crossword / clues is less than the hight of a DoubleMPU ad, which led to the ad overflowing its container and running over the comment ad, beneath. This PR fixes that layout issue by adding a minimum height to the crossword container at the widest size where ads are displayed. At other breakpoints we leave the layout as-is.

This also improves the layout for ad-free. The RH-space for the ad only appears if ads are enabled.

## Screenshots

### With ad, properly spaced.
![crossword-ad-fix](https://user-images.githubusercontent.com/29761/46803062-156b4300-cd57-11e8-9c42-60afad915420.png)

### Without ad, no empty space at RHside.
![crossword-ad-fix-ad-free](https://user-images.githubusercontent.com/29761/46805468-07202580-cd5d-11e8-931b-dabaa6f08fa4.png)

## What is the value of this and can you measure success?

Better crosswords layout!

### Does this change break ad-free?

It improves ad-free!

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
