### PR TITLE
set isLiveBlog to the correct value in OnwardCollection trail

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -50,7 +50,7 @@ object OnwardCollection {
         byline = content.properties.byline,
         image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
         ageWarning = ageWarning(content),
-        isLiveBlog = false
+        isLiveBlog = content.properties.isLiveBlog
       )
     )
   }


### PR DESCRIPTION
## What does this change?

Whilst working on https://github.com/guardian/dotcom-rendering/pull/211 I found that the property `isLiveBlog` was hardcoded to always return false for trails in onward collections. This PR uses the value from `content.properties.isLiveBlog` which returns the correct boolean value. I checked usages of `isLiveBlog` for `OnwardItem` and couldn't find any so hopefully this will have no knock on affect.