### PR TITLE
Correct config of Prebid OpenX in Ozone

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -579,35 +579,13 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
         bidParams: (): PrebidOpenXParams =>
             Object.assign(
                 {},
-                (() => {
-                    switch (config.get('page.edition')) {
-                        case 'UK':
-                            return {
-                                delDomain: 'guardian-d.openx.net',
-                                unit: '539997090',
-                                customParams: buildAppNexusTargetingObject(
-                                    buildPageTargeting()
-                                ),
-                            };
-                        case 'US':
-                            return {
-                                delDomain: 'guardian-us-d.openx.net',
-                                unit: '539997087',
-                                customParams: buildAppNexusTargetingObject(
-                                    buildPageTargeting()
-                                ),
-                            };
-                        default:
-                            // AU and rest
-                            return {
-                                delDomain: 'guardian-aus-d.openx.net',
-                                unit: '539997046',
-                                customParams: buildAppNexusTargetingObject(
-                                    buildPageTargeting()
-                                ),
-                            };
-                    }
-                })(),
+                (() => ({
+                    delDomain: 'guardian-d.openx.net',
+                    unit: '539997090',
+                    customParams: buildAppNexusTargetingObject(
+                        buildPageTargeting()
+                    ),
+                }))(),
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
             ),
     };


### PR DESCRIPTION
This is to fix a bug where countries other than UK reporting incorrectly.
It seems to be because code depends on edition, and default edition for countries other than UK, US and AU is International.
And Ozone only runs in UK and ROW so don't need values for US and AU.
