### PR TITLE
AppNexus UK/ROW reporting

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -349,12 +349,12 @@ const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
-const appNexusBidder: PrebidBidder = {
-    name: 'and',
+const appNexusBidder = (name: string): PrebidBidder => ({
+    name,
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
         getAppNexusBidParams(sizes),
-};
+});
 
 const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
@@ -564,7 +564,9 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         sonobiBidder,
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
-        ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
+        ...(inPbTestOr(shouldIncludeAppNexus())
+            ? [appNexusBidder(isInAuRegion() ? 'and' : 'and-uk-row')]
+            : []),
         improveDigitalBidder,
         xaxisBidder,
         pubmaticBidder,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -25,6 +25,7 @@ import {
     shouldIncludeOzone as shouldIncludeOzone_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
+    isInAuRegion as isInAuRegion_,
 } from './utils';
 
 const getLargestSize: any = getLargestSize_;
@@ -44,6 +45,7 @@ const getBreakpointKey: any = getBreakpointKey_;
 const getParticipations: any = getParticipations_;
 const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
+const isInAuRegion: any = isInAuRegion_;
 
 const {
     getAdYouLikePlacementId,
@@ -730,10 +732,24 @@ describe('bids', () => {
 
     test('should include AppNexus directly if in target geolocation', () => {
         shouldIncludeAppNexus.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(true);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
             'and',
+            'improvedigital',
+            'xhb',
+            'adyoulike',
+        ]);
+    });
+
+    test('should include AppNexus directly if in target geolocation', () => {
+        shouldIncludeAppNexus.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(false);
+        expect(bidders()).toEqual([
+            'ix',
+            'sonobi',
+            'and-uk-row',
             'improvedigital',
             'xhb',
             'adyoulike',


### PR DESCRIPTION
## What does this change?

This changes the AppNexus Direct adapter (name `and`) to be sensitive to the region it's currently in. If it is in the `AU` region then it's set to `and`, otherwise it's set to `and-uk-row`.

This means when testing it we need to set the parameter to `pbtest=and-uk-row`

Not sure how I feel about doing this this way; however, having a new adapter with a different name is going to be the exact same thing anyway; same logic in a different place with the same results as we will also generally use the same settings.

@guardian/commercial-dev Thoughts?

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
