### PR TITLE
Include ad-free in crossword ad eligibility check

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -3,9 +3,9 @@
 @import play.api.libs.json.Json
 @import views.html.fragments.crosswords._
 @import conf.switches.Switches.CommercialSwitch
-@import views.support.Commercial.shouldShowAds
+@import views.support.Commercial.{shouldShowAds, isAdFree}
 
-@defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage)) { adsEnabled =>
+@defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
     <div class="l-side-margins">
         <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
             @crosswordMetaHeader(crosswordPage)


### PR DESCRIPTION
## What does this change?

So, I thought adfree was included in the `shouldShowAds` check. It isn't. This fixes that.

## Screenshots

Like this again, but in ad free.

![](https://user-images.githubusercontent.com/29761/46805468-07202580-cd5d-11e8-931b-dabaa6f08fa4.png)

## What is the value of this and can you measure success?

Better layout.

## Checklist

### Does this change break ad-free?

It makes it better!

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
