### PR TITLE
More meaningful email front names

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -190,7 +190,7 @@ case object TheFlyer extends FrontEmailMetadata {
 }
 
 case object Opinion extends FrontEmailMetadata {
-  val name = "Opinion"
+  val name = "The Best of Guardian Opinion"
   override val banner = Some("opinion.png")
 }
 
@@ -245,7 +245,7 @@ case object BusinessView extends FrontEmailMetadata {
 }
 
 case object OpinionUs extends FrontEmailMetadata {
-  val name = "Opinion Us"
+  val name = "The Best of Guardian Opinion US"
   override val banner = Some("opinion.png")
 }
 
@@ -330,17 +330,17 @@ case object FilmToday extends FrontEmailMetadata {
 }
 
 case object OpinionAus extends FrontEmailMetadata {
-  val name = "Opinion Aus"
+  val name = "The Best of Guardian Opinion Australia"
   override val banner = Some("opinion.png")
 }
 
 case object PoliticsAu extends FrontEmailMetadata {
-  val name = "Politics Au"
+  val name = "Australian Politics"
   override val banner = Some("australian-politics.png")
 }
 
 case object SportAu extends FrontEmailMetadata {
-  val name = "Sport Au"
+  val name = "Guardian Australia Sport"
   override val banner = Some("australia-sports.png")
 }
 


### PR DESCRIPTION
## What does this change?

Some email fronts have cryptic names. This change updates them, although corresponding changes are needed to the email fronts metadata (via the Fronts Tools) before these changes will be reflected.

## Screenshot

**Before**

![screen shot 2018-10-11 at 17 42 43](https://user-images.githubusercontent.com/5931528/46820097-3e9eca00-cd7d-11e8-8f74-4d4f58bf348e.png)

**After**

![screen shot 2018-10-11 at 17 43 43](https://user-images.githubusercontent.com/5931528/46820096-3e9eca00-cd7d-11e8-9556-7a8868173937.png)

## What is the value of this and can you measure success?

Easier for users to understand why they are receiving a particular email
