### PR TITLE
Fix email preferences tabbing

### DIFF
--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -29,7 +29,7 @@
     bypassing it.
 *@
 
-@tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "", disableClientSideRouting: Boolean = false) = {
+@tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "", disableClientSideRouting: Boolean = false, requiresValidation: Boolean = false) = {
 
     <li class="tabs__tab @if(hidden){is-hidden} @if(activeUrl == url){tabs__tab--selected tone-colour tone-accent-border} @optionalClass" role="tab" id="tabs-account-profile-@i-tab" aria-selected="@(activeUrl == url)" aria-controls="tabs-account-profile-@i">
         <a
@@ -40,6 +40,8 @@
             @{
                 if(disableClientSideRouting)
                     Html(s"href='$url' data-tabs-ignore='true'")
+                else if(requiresValidation)
+                    Html(s"href='${idUrlBuilder.buildUrl(routes.EmailVerificationController.resendEmailValidationEmail().url, ("returnUrl", idUrlBuilder.buildUrl(url)))}' data-tabs-ignore='true'")
                 else
                     Html(s"href='$url'")
             }
@@ -49,7 +51,7 @@
     </li>
 }
 
-@content(i: Int, url: String, optionalClass: String = "")(body: => Html) = {
+@content(i: Int, url: String, optionalClass: String = "", requiresValidation: Boolean = false)(body: => Html) = {
     <div id="tabs-account-profile-@i"
          class="@RenderClasses(Map(
             "u-h" -> (activeUrl != url)
@@ -59,7 +61,11 @@
          data-link-name="Public Profile"
          data-link-context="Identity/profile"
     >
-        @body
+    @(if(requiresValidation) {
+        Html("<div class='identity-forms-loading u-identity-forms-padded'><div class='identity-forms-loading__spinner is-updating'></div></div>")
+    } else {
+        body
+    })
     </div>
 }
 
@@ -79,7 +85,7 @@
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab")
 
-                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", disableClientSideRouting = true)
+                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = !user.statusFields.userEmailValidated)
                 </ol>
         </div>
     </div>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -85,7 +85,7 @@
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab")
 
-                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = !user.statusFields.userEmailValidated)
+                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = !user.statusFields.userEmailValidated.getOrElse(false))
                 </ol>
         </div>
     </div>


### PR DESCRIPTION
## What does this change?
Fixes the issue where tabbing away from /email-prefs causes 2 tabs worth of content to be shown.  It does this by re-instating a redirection in the way done previously.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
