### PR TITLE
Reduce logging

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -73,7 +73,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   // Needed as aliases for reverse routing
   def renderRootFrontRss(): Action[AnyContent] = renderFrontRss(path = "")
   def renderFrontRss(path: String): Action[AnyContent] = Action.async { implicit  request =>
-    log.info(s"Serving RSS Path: $path")
     if (shouldEditionRedirect(path))
       redirectTo(s"${Editionalise(path, Edition(request))}/rss")
     else if (!ConfigAgent.shouldServeFront(path))
@@ -86,7 +85,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
 
   def renderFrontHeadline(path: String): Action[AnyContent] = Action.async { implicit request =>
     def notFound() = {
-      log.warn(s"headline not found for $path")
       FrontHeadline.headlineNotFound
     }
 
@@ -96,7 +94,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   }
 
   def renderFront(path: String): Action[AnyContent] = Action.async { implicit request =>
-    log.info(s"Serving Path: $path")
     if (shouldEditionRedirect(path))
       redirectTo(Editionalise(path, Edition(request)))
     else if (!ConfigAgent.shouldServeFront(path) || request.getQueryString("page").isDefined)
@@ -125,7 +122,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
     val futureFaciaPage: Future[Option[PressedPage]] = frontJsonFapi.get(path, liteRequestType).flatMap {
         case Some(faciaPage: PressedPage) =>
           if(faciaPage.collections.isEmpty && liteRequestType == LiteAdFreeType) {
-            log.info(s"Nothing in the collection for ${faciaPage.id} so making a LiteType request.")
             frontJsonFapi.get(path, LiteType)
           }
           else Future.successful(Some(faciaPage))
@@ -182,13 +178,10 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   def renderFrontPress(path: String): Action[AnyContent] = Action.async { implicit request => renderFrontPressResult(path) }
 
   def renderContainer(id: String, preserveLayout: Boolean = false): Action[AnyContent] = Action.async { implicit request =>
-    log.info(s"Serving collection ID: $id")
     renderContainerView(id, preserveLayout)
   }
 
   def renderMostRelevantContainerJson(path: String): Action[AnyContent] = Action.async { implicit request =>
-    log.info(s"Serving most relevant container for $path")
-
     val canonicalId = ConfigAgent.getCanonicalIdForFront(path).orElse (
       alternativeEndpoints(path).map(ConfigAgent.getCanonicalIdForFront).headOption.flatten
     )
@@ -201,7 +194,6 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
   def alternativeEndpoints(path: String): Seq[String] = path.split("/").toList.take(2).reverse
 
   private def renderContainerView(collectionId: String, preserveLayout: Boolean = false)(implicit request: RequestHeader): Future[Result] = {
-    log.info(s"Rendering container view for collection id $collectionId")
     getPressedCollection(collectionId).map { collectionOption =>
       collectionOption.map { collection =>
 

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -58,7 +58,6 @@ class SeriesController(
 
   private def lookup(edition: Edition, seriesId: String, queryModifier: ItemQuery => ItemQuery = identity)(implicit request: RequestHeader): Future[Option[Series]] = {
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
-    log.info(s"Fetching content in series: $seriesId the ShortUrl $currentShortUrl" )
 
     def isCurrentStory(content: ApiContent) =
       content.fields.flatMap(_.shortUrl).exists(_.equals(currentShortUrl))

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -25,7 +25,6 @@ class VideoEndSlateController(
 
   private def lookupSection(edition: Edition, sectionId: String)(implicit request: RequestHeader): Future[Seq[Video]] = {
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
-    log.info(s"Fetching video content in section: $sectionId" )
 
     def isCurrentStory(content: ApiContent) = content.fields.flatMap(_.shortUrl).contains(currentShortUrl)
 

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -34,12 +34,8 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
     val maybeRegion = getEncodedHeader(RegionHeader).filter(_.nonEmpty)
     val maybeCountry = getEncodedHeader(CountryHeader).filter(_.nonEmpty)
 
-    log.info(s"What is my city request with headers $maybeCity $maybeRegion $maybeCountry")
-
     (maybeCity, maybeRegion, maybeCountry) match {
       case (Some(city), Some(region), Some(country)) =>
-        log.info(s"Received what is my city? request. Geo info: City=$city Region=$region Country=$country")
-
         CitiesLookUp.getLatitudeLongitude(CityRef(city, region, country)) match {
           case Some(latitudeLongitude) =>
             log.info(s"Matched $city, $region, $country to $latitudeLongitude")
@@ -60,7 +56,6 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
               cities.headOption.fold {
                 Cached(CacheTime.NotFound)(JsonNotFound())
               } { weatherCity =>
-                log.info(s"Resolved geo info (City=$city Region=$region Country=$country) to city $weatherCity")
                 Cached(1 hour)(JsonComponent(weatherCity))
               }
             }


### PR DESCRIPTION
We've been hitting limits in Kinesis with our logging. Of course we can increase the limits, but it seems like a good opportunity to remove redundant/noisy logging. In general, my view is that we shouldn't log things on the 'happy path' so I've removed a few of the more significant cases here.

Most of these cases simply duplicate information that already exists in access logs.

There are some other examples which I'd like to remove to, but awaiting confirmation from the relevant teams that the logging really isn't required.