### PR TITLE
Appnexus AU and UK adapters 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -349,12 +349,12 @@ const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
-const appNexusBidder: PrebidBidder = {
-    name: 'and',
+const appNexusBidder = (name: string): PrebidBidder => ({
+    name,
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
         getAppNexusBidParams(sizes),
-};
+});
 
 const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
@@ -564,7 +564,9 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         sonobiBidder,
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
-        ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
+        ...(inPbTestOr(shouldIncludeAppNexus())
+            ? [appNexusBidder(isInAuRegion() ? 'and' : 'and-uk-row')]
+            : []),
         improveDigitalBidder,
         xaxisBidder,
         pubmaticBidder,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -40,7 +40,8 @@ import {
     containsMpuOrDmpu,
     getBreakpointKey,
     shouldIncludeAdYouLike,
-    shouldIncludeAppNexus,
+    shouldIncludeAppNexusAu,
+    shouldIncludeAppNexusUkRow,
     shouldIncludeOpenx,
     shouldIncludeOzone,
     shouldIncludeTrustX,
@@ -228,11 +229,7 @@ const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
     }
 };
 
-const getAppNexusDirectPlacementId = (sizes: PrebidSize[]): string => {
-    if (isInAuRegion()) {
-        return '11016434';
-    }
-
+const getAppNexusDirectPlacementIdUkRow = (sizes: PrebidSize[]): string => {
     const defaultPlacementId: string = '9251752';
     switch (getBreakpointKey()) {
         case 'D':
@@ -261,7 +258,7 @@ const getAppNexusDirectPlacementId = (sizes: PrebidSize[]): string => {
     }
 };
 
-const getAppNexusBidParams = (sizes: PrebidSize[]): PrebidAppNexusParams => {
+const getAppNexusBidParamsAu = (sizes: PrebidSize[]): PrebidAppNexusParams => {
     if (config.get('switches.prebidAppnexusInvcode', false)) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
@@ -274,10 +271,17 @@ const getAppNexusBidParams = (sizes: PrebidSize[]): PrebidAppNexusParams => {
         }
     }
     return {
-        placementId: getAppNexusDirectPlacementId(sizes),
+        placementId: '11016434',
         keywords: buildAppNexusTargetingObject(buildPageTargeting()),
     };
 };
+
+const getAppNexusBidParamsUkRow = (
+    sizes: PrebidSize[]
+): PrebidAppNexusParams => ({
+    placementId: getAppNexusDirectPlacementIdUkRow(sizes),
+    keywords: buildAppNexusTargetingObject(buildPageTargeting()),
+});
 
 const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
     const defaultPlacementId: string = '13915593';
@@ -349,12 +353,19 @@ const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
-const appNexusBidder = (name: string): PrebidBidder => ({
-    name,
+const appNexusBidderUkRow: PrebidBidder = {
+    name: 'and-uk-row',
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
-        getAppNexusBidParams(sizes),
-});
+        getAppNexusBidParamsUkRow(sizes),
+};
+
+const appNexusBidderAu: PrebidBidder = {
+    name: 'and-au',
+    switchName: 'prebidAppnexus',
+    bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
+        getAppNexusBidParamsAu(sizes),
+};
 
 const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
@@ -564,8 +575,9 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         sonobiBidder,
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
-        ...(inPbTestOr(shouldIncludeAppNexus())
-            ? [appNexusBidder(isInAuRegion() ? 'and' : 'and-uk-row')]
+        ...(inPbTestOr(shouldIncludeAppNexusAu()) ? [appNexusBidderAu] : []),
+        ...(inPbTestOr(shouldIncludeAppNexusUkRow())
+            ? [appNexusBidderUkRow]
             : []),
         improveDigitalBidder,
         xaxisBidder,
@@ -606,7 +618,8 @@ export const bids: (string, PrebidSize[]) => PrebidBid[] = (
 export const _ = {
     getAdYouLikePlacementId,
     getAppNexusInvCode,
-    getAppNexusBidParams,
+    getAppNexusBidParamsUkRow,
+    getAppNexusBidParamsAu,
     getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -27,6 +27,7 @@ import {
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
     isInAuRegion as isInAuRegion_,
+    isInUsRegion as isInUsRegion_,
 } from './utils';
 
 const getLargestSize: any = getLargestSize_;
@@ -48,6 +49,7 @@ const getParticipations: any = getParticipations_;
 const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
 const isInAuRegion: any = isInAuRegion_;
+const isInUsRegion: any = isInUsRegion_;
 
 const {
     getAdYouLikePlacementId,
@@ -748,10 +750,8 @@ describe('bids', () => {
         ]);
     });
 
-    test('should include AppNexus directly if in target geolocation', () => {
-        shouldIncludeAppNexusUkRow.mockReturnValue(false);
-        shouldIncludeAppNexusAu.mockReturnValue(false);
-        isInAuRegion.mockReturnValue(false);
+    test('should exclude AppNexus if not in target geolocation', () => {
+        isInUsRegion.mockReturnValue(true);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -25,6 +25,7 @@ import {
     shouldIncludeOzone as shouldIncludeOzone_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
+    isInAuRegion as isInAuRegion_,
 } from './utils';
 
 const getLargestSize: any = getLargestSize_;
@@ -44,6 +45,7 @@ const getBreakpointKey: any = getBreakpointKey_;
 const getParticipations: any = getParticipations_;
 const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
+const isInAuRegion: any = isInAuRegion_;
 
 const {
     getAdYouLikePlacementId,
@@ -730,10 +732,24 @@ describe('bids', () => {
 
     test('should include AppNexus directly if in target geolocation', () => {
         shouldIncludeAppNexus.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(true);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
             'and',
+            'improvedigital',
+            'xhb',
+            'adyoulike',
+        ]);
+    });
+
+    test('should include AppNexus directly if in target geolocation', () => {
+        shouldIncludeAppNexus.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(false);
+        expect(bidders()).toEqual([
+            'ix',
+            'sonobi',
+            'and-uk-row',
             'improvedigital',
             'xhb',
             'adyoulike',

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -20,7 +20,8 @@ import {
     containsMpuOrDmpu as containsMpuOrDmpu_,
     getBreakpointKey as getBreakpointKey_,
     shouldIncludeAdYouLike as shouldIncludeAdYouLike_,
-    shouldIncludeAppNexus as shouldIncludeAppNexus_,
+    shouldIncludeAppNexusUkRow as shouldIncludeAppNexusUkRow_,
+    shouldIncludeAppNexusAu as shouldIncludeAppNexusAu_,
     shouldIncludeOpenx as shouldIncludeOpenx_,
     shouldIncludeOzone as shouldIncludeOzone_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
@@ -36,7 +37,8 @@ const containsLeaderboardOrBillboard: any = containsLeaderboardOrBillboard_;
 const containsMpu: any = containsMpu_;
 const containsMpuOrDmpu: any = containsMpuOrDmpu_;
 const shouldIncludeAdYouLike: any = shouldIncludeAdYouLike_;
-const shouldIncludeAppNexus: any = shouldIncludeAppNexus_;
+const shouldIncludeAppNexusUkRow: any = shouldIncludeAppNexusUkRow_;
+const shouldIncludeAppNexusAu: any = shouldIncludeAppNexusAu_;
 const shouldIncludeOpenx: any = shouldIncludeOpenx_;
 const shouldIncludeOzone: any = shouldIncludeOzone_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
@@ -50,7 +52,8 @@ const isInAuRegion: any = isInAuRegion_;
 const {
     getAdYouLikePlacementId,
     getAppNexusInvCode,
-    getAppNexusBidParams,
+    getAppNexusBidParamsUkRow,
+    getAppNexusBidParamsAu,
     getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,
@@ -151,7 +154,7 @@ describe('getAppNexusBidParams', () => {
 
     test('should include placementId when invCode switch is off', () => {
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusBidParams([[300, 250]])).toEqual({
+        expect(getAppNexusBidParamsUkRow([[300, 250]])).toEqual({
             keywords: 'someAppNexusTargetingObject',
             placementId: '9251752',
         });
@@ -160,7 +163,7 @@ describe('getAppNexusBidParams', () => {
     test('should exclude placementId when including member and invCode', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusBidParams([[300, 250]])).toEqual({
+        expect(getAppNexusBidParamsAu([[300, 250]])).toEqual({
             keywords: 'someAppNexusTargetingObject',
             member: '7012',
             invCode: 'Mmagic300x250',
@@ -669,8 +672,8 @@ describe('bids', () => {
         containsMpu.mockReturnValue(false);
         containsMpuOrDmpu.mockReturnValue(false);
         shouldIncludeAdYouLike.mockReturnValue(true);
-        shouldIncludeAppNexus.mockReturnValue(false);
-        shouldIncludeAppNexus.mockReturnValue(false);
+        shouldIncludeAppNexusUkRow.mockReturnValue(false);
+        shouldIncludeAppNexusAu.mockReturnValue(false);
         shouldIncludeTrustX.mockReturnValue(false);
         stripMobileSuffix.mockImplementation(str => str);
         getVariant.mockReturnValue(CommercialPrebidAdYouLike.variants[0]);
@@ -731,12 +734,14 @@ describe('bids', () => {
     });
 
     test('should include AppNexus directly if in target geolocation', () => {
-        shouldIncludeAppNexus.mockReturnValue(true);
+        shouldIncludeAppNexusAu.mockReturnValue(true);
+        shouldIncludeAppNexusUkRow.mockReturnValue(true);
         isInAuRegion.mockReturnValue(true);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
-            'and',
+            'and-au',
+            'and-uk-row',
             'improvedigital',
             'xhb',
             'adyoulike',
@@ -744,12 +749,12 @@ describe('bids', () => {
     });
 
     test('should include AppNexus directly if in target geolocation', () => {
-        shouldIncludeAppNexus.mockReturnValue(true);
+        shouldIncludeAppNexusUkRow.mockReturnValue(false);
+        shouldIncludeAppNexusAu.mockReturnValue(false);
         isInAuRegion.mockReturnValue(false);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',
-            'and-uk-row',
             'improvedigital',
             'xhb',
             'adyoulike',

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -119,10 +119,13 @@ export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean => {
 export const shouldIncludeOzone = (): boolean =>
     !isInUsRegion() && !isInAuRegion();
 
-export const shouldIncludeAppNexus = (): boolean =>
-    isInAuRegion() ||
-    ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
-        !!pbTestNameMap().and);
+export const shouldIncludeAppNexusAu = (): boolean => isInAuRegion();
+
+export const shouldIncludeAppNexusUkRow = (): boolean =>
+    (config.get('switches.prebidAppnexusUkRow') &&
+        !isInUsRegion() &&
+        !isInAuRegion()) ||
+    !!pbTestNameMap().and;
 
 export const stripMobileSuffix = (s: string): string =>
     stripSuffix(s, '--mobile');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -8,7 +8,8 @@ import {
     getLargestSize,
     getBreakpointKey,
     shouldIncludeAdYouLike,
-    shouldIncludeAppNexus,
+    shouldIncludeAppNexusUkRow,
+    shouldIncludeAppNexusAu,
     shouldIncludeOpenx,
     shouldIncludeOzone,
     shouldIncludeTrustX,
@@ -79,70 +80,94 @@ describe('Utils', () => {
         expect(results).toEqual(['M', 'M', 'T', 'D', 'D']);
     });
 
-    test('shouldIncludeAppNexus should return true if geolocation is AU', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('AU');
-        expect(shouldIncludeAppNexus()).toBe(true);
+    describe('shouldIncludeAppNexusAu', () => {
+        test('should return true if geolocation is AU', () => {
+            getSync.mockReturnValue('AU');
+            expect(shouldIncludeAppNexusAu()).toBe(true);
+        });
+
+        test('shouldIncludeAppNexusAu should return true if geolocation is NZ', () => {
+            getSync.mockReturnValue('NZ');
+            expect(shouldIncludeAppNexusAu()).toBe(true);
+        });
+
+        describe('should not be affected by Uk/Row switch', () => {
+            test('being on for AU', () => {
+                config.switches.prebidAppnexusUkRow = true;
+                getSync.mockReturnValue('AU');
+                expect(shouldIncludeAppNexusAu()).toBe(true);
+            });
+
+            test('being on for NZ', () => {
+                config.switches.prebidAppnexusUkRow = true;
+                getSync.mockReturnValue('NZ');
+                expect(shouldIncludeAppNexusAu()).toBe(true);
+            });
+
+            test('being off for AU', () => {
+                config.switches.prebidAppnexusUkRow = false;
+                getSync.mockReturnValue('AU');
+                expect(shouldIncludeAppNexusAu()).toBe(true);
+            });
+
+            test('being off for NZ', () => {
+                config.switches.prebidAppnexusUkRow = false;
+                getSync.mockReturnValue('NZ');
+                expect(shouldIncludeAppNexusAu()).toBe(true);
+            });
+        });
+
+        test('shouldIncludeAppNexusAu should return false for all other regions', () => {
+            const testGeos = ['US', 'CA', 'FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
+            for (let i = 0; i < testGeos.length; i += 1) {
+                getSync.mockReturnValue(testGeos[i]);
+                expect(shouldIncludeAppNexusAu()).toBe(false);
+            }
+        });
     });
 
-    test('shouldIncludeAppNexus should return true if geolocation is NZ', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('NZ');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
+    describe('shouldIncludeAppNexusUkRow', () => {
+        test('shouldIncludeAppNexusUkRow should return false if geolocation is US', () => {
+            config.switches.prebidAppnexusUkRow = true;
+            getSync.mockReturnValue('US');
+            expect(shouldIncludeAppNexusUkRow()).toBe(false);
+        });
 
-    test('shouldIncludeAppNexus should return false if geolocation is US', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('UK');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
+        test('shouldIncludeAppNexusUkRow should return false if geolocation is CA', () => {
+            config.switches.prebidAppnexusUkRow = true;
+            getSync.mockReturnValue('CA');
+            expect(shouldIncludeAppNexusUkRow()).toBe(false);
+        });
 
-    test('shouldIncludeAppNexus should return true if geolocation is CA', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('UK');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
+        test('shouldIncludeAppNexusUkRow should return true if geolocation is UK', () => {
+            config.switches.prebidAppnexusUkRow = true;
+            getSync.mockReturnValue('UK');
+            expect(shouldIncludeAppNexusUkRow()).toBe(true);
+        });
 
-    test('shouldIncludeAppNexus should return true if geolocation is UK', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('UK');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
+        test('shouldIncludeAppNexusUkRow should return true for all other regions', () => {
+            config.switches.prebidAppnexusUkRow = true;
+            const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
+            for (let i = 0; i < testGeos.length; i += 1) {
+                getSync.mockReturnValue(testGeos[i]);
+                expect(shouldIncludeAppNexusUkRow()).toBe(true);
+            }
+        });
 
-    test('shouldIncludeAppNexus should otherwise return false', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeAppNexus()).toBe(true);
-        }
-    });
+        test('shouldIncludeAppNexusUkRow should return false for UK region if switched off', () => {
+            config.switches.prebidAppnexusUkRow = false;
+            getSync.mockReturnValue('UK');
+            expect(shouldIncludeAppNexusUkRow()).toBe(false);
+        });
 
-    test('shouldIncludeAppNexus should return false for UK region if UK switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('UK');
-        expect(shouldIncludeAppNexus()).toBe(false);
-    });
-
-    test('shouldIncludeAppNexus should return false for UK region if UK switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeAppNexus()).toBe(false);
-        }
-    });
-
-    test('shouldIncludeAppNexus should return true for AU region if UK region is switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('AU');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true for NZ region if UK region is switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('NZ');
-        expect(shouldIncludeAppNexus()).toBe(true);
+        test('shouldIncludeAppNexusUkRow should return false for other regions if switched off', () => {
+            config.switches.prebidAppnexusUkRow = false;
+            const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
+            for (let i = 0; i < testGeos.length; i += 1) {
+                getSync.mockReturnValue(testGeos[i]);
+                expect(shouldIncludeAppNexusUkRow()).toBe(false);
+            }
+        });
     });
 
     test('shouldIncludeOpenx should return true if geolocation is UK', () => {


### PR DESCRIPTION
## What does this change?

This creates two adapters for AppNexus Direct; `Uk/Row` and `Au` so that we can report correctly.

This is the alternative to #20511.

@guardian/commercial-dev 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
