### PR TITLE
Revert "Don't deploy diagnostics with the rest of the apps"

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -23,6 +23,8 @@ deployments:
     template: frontend
   commercial:
     template: frontend
+  diagnostics:
+    template: frontend
   discussion:
     template: frontend
   facia:


### PR DESCRIPTION
Reverts guardian/frontend#20291 - diagnostics should now be deployed with the other apps. To merge on monday