### PR TITLE
Remove commercial logging message

### DIFF
--- a/common/app/common/commercial/AdUnitMaker.scala
+++ b/common/app/common/commercial/AdUnitMaker.scala
@@ -14,7 +14,6 @@ object AdUnitMaker extends Logging {
       // These situation arises when the CAPI content item has no section field.
       // It is usually because the item is part of global. It will have a sectionId set to "global", but no section object.
       // Eg. "global/2016/oct/09/zen-and-the-art-of-korean-vegan-cooking"
-      log.warn(s"Bad ad unit '/$dfpAdUnitGuRoot/$adUnitSuffix' on page '$pageId'. Using default ad unit: /$dfpAccountId/$dfpAdUnitGuRoot")
       s"/$dfpAccountId/$dfpAdUnitGuRoot"
     } else {
       adUnit


### PR DESCRIPTION
(Currently accounts for 60% of commercial logging.)

The commercial team are not planning on fixing this bug soon and are happy for the logging to be removed.

See also: https://github.com/guardian/frontend/pull/20516 for other logging stuff.