### PR TITLE
Move Pangaea out of test

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -506,7 +506,7 @@ trait PrebidSwitches {
     description = "Include Ozone Pangaea connection",
     owners = group(Commercial),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2018, 10, 24),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -499,4 +499,14 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val ozonePangaeaSwitch: Switch = Switch(
+    group = CommercialPrebid,
+    name = "ozone-pangaea",
+    description = "Include Ozone Pangaea connection",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -609,7 +609,6 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
             ),
     };
 
-    // Experimental. Only 0.01% of the PVs.
     if (
         inPbTestOr(
             config.get('switches.prebidS2sozone') && shouldIncludeOzone()
@@ -617,10 +616,11 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
     ) {
         dummyServerSideBidders.push(openxServerSideBidder);
         dummyServerSideBidders.push(appnexusServerSideBidder);
-    }
 
-    if (isPbTestOn()) {
-        dummyServerSideBidders.push(pangaeaServerSideBidder);
+        // Remove this switch after initial pangaea release
+        if (config.get('switches.ozonePangaea')) {
+            dummyServerSideBidders.push(pangaeaServerSideBidder);
+        }
     }
 
     return dummyServerSideBidders;


### PR DESCRIPTION
## What does this change?

This moves Pangaea out of the test and into all Ozone calls, which is currently at 100% of the audience.

@guardian/commercial-dev 