### PR TITLE
Remove ratio condition for Lightbox #2

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -821,7 +821,6 @@ case class GenericLightbox(
   properties: GenericLightboxProperties
 ) {
   lazy val mainFiltered = elements.mainPicture
-    .filter(_.images.largestEditorialCrop.map(_.ratioWholeNumber).getOrElse(0) > 0.7)
     .filter(_.images.largestEditorialCrop.map(_.width).getOrElse(1) > properties.lightboxableCutoffWidth).toSeq
   lazy val bodyFiltered: Seq[ImageElement] = elements.bodyImages.filter(_.images.largestEditorialCrop.map(_.width).getOrElse(1) > properties.lightboxableCutoffWidth)
 


### PR DESCRIPTION
[[second attempt](https://github.com/guardian/frontend/pull/20521), so that it can be easily tested on CODE]

This allows Lightbox to be opened irregardless of image ratio. IMHO, the condition never made much sense, was put in allegedly to prevent opening looong cartoons which would be unreadable when shrank to vh, but:
- these cartoons are often interactives anyway (so Lightbox is not available)
- one doesn’t **have to** open the Lightbox, if scrolling is preferable, one can do that
- we shrink images to vh in galleries without asking anyone (and we are right)
- the ratio in place was too broad anyway
- the condition prevents me from being able to appreciate [good photography](https://www.theguardian.com/world/picture/2014/apr/30/1)

Will fix half of https://github.com/guardian/frontend/issues/19768, undoes part of https://github.com/guardian/frontend/pull/7647.

Next: https://github.com/guardian/frontend/issues/12215

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No (only in a good way)
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
