### PR TITLE
Added a loading state to newsletter consents

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -33,6 +33,7 @@ class FollowCardList extends Component<
             consents: [],
             errors: [],
             isExpanded: false,
+            isLoading: true,
         });
     }
 
@@ -40,8 +41,9 @@ class FollowCardList extends Component<
         Promise.all(this.props.consents).then(consents => {
             this.setState({
                 consents,
+                isLoading: false,
             });
-        });
+        })
     }
 
     updateConsentState(consent: ConsentWithState) {
@@ -81,7 +83,7 @@ class FollowCardList extends Component<
     };
 
     render() {
-        const { consents, isExpanded, errors } = this.state;
+        const { consents, isExpanded, errors, isLoading } = this.state;
         const { cutoff } = this.props;
 
         const displayables = isExpanded
@@ -90,6 +92,11 @@ class FollowCardList extends Component<
 
         return (
             <div>
+                {isLoading && <div
+                    className="identity-forms-loading @if(async){ identity-forms-loading--hide-text } u-identity-forms-padded">
+                    <div className="identity-forms-loading__spinner is-updating"></div>
+                    <div className="identity-forms-loading__text"></div>
+                </div> }
                 <ErrorBar errors={errors} />
                 <div className="identity-upsell-consent-card-grid">
                     {displayables.map(consent => (

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -93,9 +93,8 @@ class FollowCardList extends Component<
         return (
             <div>
                 {isLoading && (
-                    <div className="identity-forms-loading @if(async){ identity-forms-loading--hide-text } u-identity-forms-padded">
+                    <div className="identity-forms-loading u-identity-forms-padded">
                         <div className="identity-forms-loading__spinner is-updating" />
-                        <div className="identity-forms-loading__text" />
                     </div>
                 )}
                 <ErrorBar errors={errors} />

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -43,7 +43,7 @@ class FollowCardList extends Component<
                 consents,
                 isLoading: false,
             });
-        })
+        });
     }
 
     updateConsentState(consent: ConsentWithState) {
@@ -92,11 +92,12 @@ class FollowCardList extends Component<
 
         return (
             <div>
-                {isLoading && <div
-                    className="identity-forms-loading @if(async){ identity-forms-loading--hide-text } u-identity-forms-padded">
-                    <div className="identity-forms-loading__spinner is-updating"></div>
-                    <div className="identity-forms-loading__text"></div>
-                </div> }
+                {isLoading && (
+                    <div className="identity-forms-loading @if(async){ identity-forms-loading--hide-text } u-identity-forms-padded">
+                        <div className="identity-forms-loading__spinner is-updating" />
+                        <div className="identity-forms-loading__text" />
+                    </div>
+                )}
                 <ErrorBar errors={errors} />
                 <div className="identity-upsell-consent-card-grid">
                     {displayables.map(consent => (


### PR DESCRIPTION
## What does this change?
Adds a spinner to the new thank you page when the newsletter consents are loading. 

## Screenshots
![screen shot 2018-10-16 at 09 56 30](https://user-images.githubusercontent.com/42539745/47005133-099ec880-d12b-11e8-8871-473555f1e5c3.png)

## What is the value of this and can you measure success?
Improve user experience to show them that there is more content loading when the page hasn't fully loaded.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
