### PR TITLE
Change newsletter link

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -111,8 +111,8 @@ class FollowCardList extends Component<
                                 <a
                                     className="u-underline identity-upsell-consent-card__link"
                                     href={`${config.get(
-                                        'page.host'
-                                    )}/email-newsletters`}>
+                                        'page.idUrl'
+                                    )}/email-prefs`}>
                                     View all Guardian newsletters
                                 </a>
                             </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -109,6 +109,7 @@ class FollowCardList extends Component<
                         {isExpanded && (
                             <div>
                                 <a
+                                    data-link-name="upsell-newsletter-link"
                                     className="u-underline identity-upsell-consent-card__link"
                                     href={`${config.get(
                                         'page.idUrl'


### PR DESCRIPTION
## What does this change?
Change newsletter link to go to /email-prefs page rather than /email-newsletters

## What is the value of this and can you measure success?
Prompts user to sign in and links to a better, clearer consents page

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
