### PR TITLE
Introduce New Dotcomponents data model

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -14,6 +14,7 @@ import renderers.RemoteRender
 import services.CAPILookup
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import model.dotcomponents.DotcomponentsDataModel
 import services.dotcomponents.{LocalRender, RemoteRender, RenderType, RenderingTierPicker}
 
 import scala.concurrent.Future
@@ -80,9 +81,13 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
     List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
   }
 
+  private def getGuuiJson(article: ArticlePage)(implicit request: RequestHeader): String =
+    DotcomponentsDataModel.toJsonString(DotcomponentsDataModel.fromArticle(article, request))
+
   private def render(path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       request.getRequestFormat match {
+        case JsonFormat if request.isGuui => common.renderJson(getGuuiJson(article), article)
         case JsonFormat => common.renderJson(getJson(article), article)
         case EmailFormat => common.renderEmail(ArticleEmailHtmlPage.html(article), article)
         case HtmlFormat => common.renderHtml(ArticleHtmlPage.html(article), article)

--- a/article/app/model/ContentFields.scala
+++ b/article/app/model/ContentFields.scala
@@ -5,10 +5,23 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.{BodyCleaner, MainCleaner}
 
-case class ContentFields(fields: Fields, cleanedMainBlockHtml: String, cleanedBodyHtml: String)
+case class ContentFields(
+    fields: Fields,
+    cleanedMainBlockHtml: String,
+    cleanedBodyHtml: String
+)
+
 object ContentFields {
-  def apply(article: Article, isAmp: Boolean = false)(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
-    new ContentFields(article.fields, MainCleaner.apply(article, amp = isAmp).body, BodyCleaner.apply(article, amp = isAmp).body)
+
+  def apply(
+             article: Article,
+             isAmp: Boolean = false
+           )(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
+    new ContentFields(
+      article.fields,
+      MainCleaner.apply(article, amp = isAmp).body,
+      BodyCleaner.apply(article, amp = isAmp).body
+    )
 
   implicit val contentFieldsWrites: Writes[ContentFields] = Json.writes[ContentFields]
 }

--- a/article/app/model/ContentFields.scala
+++ b/article/app/model/ContentFields.scala
@@ -5,23 +5,10 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.{BodyCleaner, MainCleaner}
 
-case class ContentFields(
-    fields: Fields,
-    cleanedMainBlockHtml: String,
-    cleanedBodyHtml: String
-)
-
+case class ContentFields(fields: Fields, cleanedMainBlockHtml: String, cleanedBodyHtml: String)
 object ContentFields {
-
-  def apply(
-             article: Article,
-             isAmp: Boolean = false
-           )(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
-    new ContentFields(
-      article.fields,
-      MainCleaner.apply(article, amp = isAmp).body,
-      BodyCleaner.apply(article, amp = isAmp).body
-    )
+  def apply(article: Article, isAmp: Boolean = false)(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
+    new ContentFields(article.fields, MainCleaner.apply(article, amp = isAmp).body, BodyCleaner.apply(article, amp = isAmp).body)
 
   implicit val contentFieldsWrites: Writes[ContentFields] = Json.writes[ContentFields]
 }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -1,0 +1,135 @@
+package model.dotcomponents
+
+import common.Edition
+import conf.Configuration
+import controllers.ArticlePage
+import navigation.NavMenu
+import play.api.libs.json.{Json, Writes}
+import play.api.mvc.RequestHeader
+
+// We have introduced our own set of objects for serializing data to the DotComponents API,
+// because we don't want people changing the core frontend models and as a side effect,
+// making them incompatible with Dotcomponents. By having our own set of models, there's
+// only one reason for change.
+// The one exception to this is the Nav class, which we reuse because it's really big.
+
+case class TagProperties(id: String, tagType: String, webTitle: String, twitterHandle: Option[String])
+case class Tag(properties: TagProperties)
+case class Block(bodyHtml: String)
+case class Blocks(body: List[Block])
+case class PageData(author: String, pageId: String, pillar: String, ajaxUrl: String, webPublicationDate: Long, section: String, headline: String, webTitle: String)
+case class Config(isImmersive: Boolean, page: PageData, nav: NavMenu)
+case class ContentFields(standfirst: String, main: String, body: String, blocks: Blocks)
+case class DotcomponentsDataModel(contentFields: ContentFields, config: Config, tags: List[Tag], version: Int)
+
+object Block {
+  implicit val writes = Json.writes[Block]
+}
+
+object Blocks {
+  implicit val writes = Json.writes[Blocks]
+}
+
+object ContentFields {
+  implicit val writes = Json.writes[ContentFields]
+}
+
+object TagProperties {
+  implicit val writes = Json.writes[TagProperties]
+}
+
+object Tag {
+  implicit val writes = Json.writes[Tag]
+}
+
+object PageData {
+  implicit val writes = Json.writes[PageData]
+}
+
+object Config {
+  implicit val writes = Json.writes[Config]
+}
+
+object DotcomponentsDataModel {
+
+  val VERSION = 1
+
+  def fromArticle(articlePage: ArticlePage, request: RequestHeader): DotcomponentsDataModel = {
+
+    val article = articlePage.article
+
+    val blocks: List[Block] = article.blocks match {
+      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml)).toList
+      case None => List()
+    }
+
+    val dcBlocks = Blocks(blocks)
+
+    val contentFields = ContentFields(
+      article.fields.standfirst.getOrElse(""),
+      article.fields.main,
+      article.fields.body,
+      dcBlocks
+    )
+
+    val pageData = PageData(
+      article.tags.contributors.map(_.name).mkString(","),
+      article.metadata.id,
+      article.metadata.pillar.map(_.toString).getOrElse(""),
+      Configuration.ajax.url,
+      article.trail.webPublicationDate.getMillis,
+      article.metadata.section.map(_.value).getOrElse(""),
+      article.trail.headline,
+      article.metadata.webTitle
+    )
+
+    val tags = article.tags.tags.map(
+      t => Tag(
+        TagProperties(
+          t.id,
+          t.properties.tagType,
+          t.properties.webTitle,
+          t.properties.twitterHandle
+        )
+      )
+    )
+
+    val navMenu = NavMenu(articlePage, Edition(request))
+
+    val config = Config(
+      article.isImmersive,
+      pageData,
+      navMenu
+    )
+
+    DotcomponentsDataModel(
+      contentFields,
+      config,
+      tags,
+      VERSION
+    )
+
+  }
+
+  def toJsonString(model: DotcomponentsDataModel): String = {
+
+    // make what we have look a bit closer to what dotcomponents currently expects
+
+    implicit val DotComponentsDataModelWrites = new Writes[DotcomponentsDataModel] {
+      def writes(model: DotcomponentsDataModel) = Json.obj(
+        "config" -> model.config,
+        "contentFields" -> Json.obj(
+          "fields" -> model.contentFields
+        ),
+        "tags" -> Json.obj(
+          "tags" -> model.tags
+        ),
+        "version" -> model.version
+      )
+    }
+
+    Json.prettyPrint(Json.toJson(model))
+
+  }
+
+}

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -3,6 +3,7 @@ package model.dotcomponents
 import common.Edition
 import conf.Configuration
 import controllers.ArticlePage
+import model.liveblog.BlockElement
 import navigation.NavMenu
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.RequestHeader
@@ -11,11 +12,11 @@ import play.api.mvc.RequestHeader
 // because we don't want people changing the core frontend models and as a side effect,
 // making them incompatible with Dotcomponents. By having our own set of models, there's
 // only one reason for change.
-// The one exception to this is the Nav class, which we reuse because it's really big.
+// exceptions: we do resuse the existing Nav & BlockElement classes right now
 
 case class TagProperties(id: String, tagType: String, webTitle: String, twitterHandle: Option[String])
 case class Tag(properties: TagProperties)
-case class Block(bodyHtml: String)
+case class Block(bodyHtml: String, elements: List[BlockElement])
 case class Blocks(body: List[Block])
 case class PageData(author: String, pageId: String, pillar: String, ajaxUrl: String, webPublicationDate: Long, section: String, headline: String, webTitle: String)
 case class Config(isImmersive: Boolean, page: PageData, nav: NavMenu)
@@ -23,6 +24,7 @@ case class ContentFields(standfirst: String, main: String, body: String, blocks:
 case class DotcomponentsDataModel(contentFields: ContentFields, config: Config, tags: List[Tag], version: Int)
 
 object Block {
+  implicit val blockElementWrites: Writes[BlockElement] = Json.writes[BlockElement]
   implicit val writes = Json.writes[Block]
 }
 
@@ -59,7 +61,7 @@ object DotcomponentsDataModel {
     val article = articlePage.article
 
     val blocks: List[Block] = article.blocks match {
-      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml)).toList
+      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml, bb.elements.toList)).toList
       case None => List()
     }
 

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -121,6 +121,10 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     JsonComponent(page, json)
   }
 
+  def renderJson(json: String, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page) {
+    RevalidatableResult.Ok(json)
+  }
+
   def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = {
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
 


### PR DESCRIPTION
## What does this change?

This introduces a new set of models for passing data to the Dotcomponents render. The layout of the data looks exactly like the original, so this change should be transparent as far as the rendering tier is concerned. The new model only includes fields that the dotcomponents project is actually using as of right now.

This should be safer (people arbitrarily changing the core frontend models won't be able to affect the API), faster (less data to parse and transmit down the wire) and also clearer as it gives us a single place to see where all the data is actually being pulled from (which is all over the place).

**This PR needs to be heavily tested before it goes out to make 100% sure we're passing through the expected data.**

Also, for chrome people, the .json?guui route is now pretty printed.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
