### PR TITLE
Update AppNexus invCode logic and split up bid-config

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -7,7 +7,6 @@ import {
 } from 'common/modules/commercial/build-page-targeting';
 
 import {
-    isInAuRegion,
     getLargestSize,
     containsLeaderboard,
     containsLeaderboardOrBillboard,
@@ -18,11 +17,8 @@ import {
 
 import type { PrebidAppNexusParams, PrebidSize } from './types';
 
-const shouldUseInvCode = (): boolean =>
-    isInAuRegion() && config.get('switches.prebidAppnexusInvcode');
-
 const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
-    const device: string = getBreakpointKey();
+    const device: string = getBreakpointKey() === 'M' ? 'M' : 'D';
     const section: string = config.get('page.section', 'unknown');
     const slotSize: PrebidSize | null = getLargestSize(sizes);
     if (slotSize) {
@@ -104,7 +100,7 @@ export const getAppNexusDirectBidParams = (
     sizes: PrebidSize[],
     isAuRegion: boolean
 ): PrebidAppNexusParams => {
-    if (isAuRegion && shouldUseInvCode()) {
+    if (isAuRegion && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
         if (invCode) {

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -1,0 +1,140 @@
+// @flow strict
+
+import config from 'lib/config';
+import {
+    buildPageTargeting,
+    buildAppNexusTargetingObject,
+} from 'common/modules/commercial/build-page-targeting';
+
+import {
+    isInAuRegion,
+    getLargestSize,
+    containsLeaderboard,
+    containsLeaderboardOrBillboard,
+    containsMpu,
+    containsMpuOrDmpu,
+    getBreakpointKey,
+} from './utils';
+
+import type { PrebidAppNexusParams, PrebidSize } from './types';
+
+const shouldUseInvCode = (): boolean =>
+    isInAuRegion() && config.get('switches.prebidAppnexusInvcode');
+
+const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
+    const device: string = getBreakpointKey();
+    const section: string = config.get('page.section', 'unknown');
+    const slotSize: PrebidSize | null = getLargestSize(sizes);
+    if (slotSize) {
+        return `${device}${section.toLowerCase()}${slotSize.join('x')}`;
+    }
+};
+
+export const getAppNexusDirectPlacementId = (
+    sizes: PrebidSize[],
+    isAuRegion: boolean
+): string => {
+    if (isAuRegion) {
+        return '11016434';
+    }
+
+    const defaultPlacementId: string = '9251752';
+    switch (getBreakpointKey()) {
+        case 'D':
+            if (containsMpuOrDmpu(sizes)) {
+                return '9251752';
+            }
+            if (containsLeaderboardOrBillboard(sizes)) {
+                return '9926678';
+            }
+            return defaultPlacementId;
+        case 'M':
+            if (containsMpu(sizes)) {
+                return '4298191';
+            }
+            return defaultPlacementId;
+        case 'T':
+            if (containsMpu(sizes)) {
+                return '11600568';
+            }
+            if (containsLeaderboard(sizes)) {
+                return '11600778';
+            }
+            return defaultPlacementId;
+        default:
+            return defaultPlacementId;
+    }
+};
+
+export const getAppNexusDirectBidParams = (
+    sizes: PrebidSize[],
+    isAuRegion: boolean
+): PrebidAppNexusParams => {
+    if (isAuRegion && shouldUseInvCode()) {
+        const invCode = getAppNexusInvCode(sizes);
+        // flowlint sketchy-null-string:warn
+        if (invCode) {
+            return {
+                invCode,
+                member: '7012',
+                keywords: buildAppNexusTargetingObject(buildPageTargeting()),
+            };
+        }
+    }
+    return {
+        placementId: getAppNexusDirectPlacementId(sizes, isAuRegion),
+        keywords: buildAppNexusTargetingObject(buildPageTargeting()),
+    };
+};
+
+export const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
+    const defaultPlacementId: string = '13915593';
+    switch (config.get('page.edition')) {
+        case 'UK':
+            switch (getBreakpointKey()) {
+                case 'D':
+                    if (containsMpuOrDmpu(sizes)) {
+                        return '13366606';
+                    }
+                    if (containsLeaderboardOrBillboard(sizes)) {
+                        return '13366615';
+                    }
+                    return defaultPlacementId;
+                case 'M':
+                    if (containsMpu(sizes)) {
+                        return '13366904';
+                    }
+                    return defaultPlacementId;
+                case 'T':
+                    if (containsMpu(sizes)) {
+                        return '13366913';
+                    }
+                    if (containsLeaderboard(sizes)) {
+                        return '13366916';
+                    }
+                    return defaultPlacementId;
+                default:
+                    return defaultPlacementId;
+            }
+        default:
+            return defaultPlacementId;
+    }
+};
+
+export const getAppNexusServerSideBidParams = (
+    sizes: PrebidSize[]
+): PrebidAppNexusParams =>
+    Object.assign(
+        {},
+        {
+            placementId: getAppNexusPlacementId(sizes),
+            keywords: buildAppNexusTargetingObject(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+        },
+        window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
+    );
+
+export const _ = {
+    getAppNexusPlacementId,
+    getAppNexusInvCode,
+    getAppNexusDirectPlacementId,
+};

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -30,6 +30,40 @@ const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
     }
 };
 
+export const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
+    const defaultPlacementId: string = '13915593';
+    switch (config.get('page.edition')) {
+        case 'UK':
+            switch (getBreakpointKey()) {
+                case 'D':
+                    if (containsMpuOrDmpu(sizes)) {
+                        return '13366606';
+                    }
+                    if (containsLeaderboardOrBillboard(sizes)) {
+                        return '13366615';
+                    }
+                    return defaultPlacementId;
+                case 'M':
+                    if (containsMpu(sizes)) {
+                        return '13366904';
+                    }
+                    return defaultPlacementId;
+                case 'T':
+                    if (containsMpu(sizes)) {
+                        return '13366913';
+                    }
+                    if (containsLeaderboard(sizes)) {
+                        return '13366916';
+                    }
+                    return defaultPlacementId;
+                default:
+                    return defaultPlacementId;
+            }
+        default:
+            return defaultPlacementId;
+    }
+};
+
 export const getAppNexusDirectPlacementId = (
     sizes: PrebidSize[],
     isAuRegion: boolean
@@ -85,40 +119,6 @@ export const getAppNexusDirectBidParams = (
         placementId: getAppNexusDirectPlacementId(sizes, isAuRegion),
         keywords: buildAppNexusTargetingObject(buildPageTargeting()),
     };
-};
-
-export const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
-    const defaultPlacementId: string = '13915593';
-    switch (config.get('page.edition')) {
-        case 'UK':
-            switch (getBreakpointKey()) {
-                case 'D':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return '13366606';
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return '13366615';
-                    }
-                    return defaultPlacementId;
-                case 'M':
-                    if (containsMpu(sizes)) {
-                        return '13366904';
-                    }
-                    return defaultPlacementId;
-                case 'T':
-                    if (containsMpu(sizes)) {
-                        return '13366913';
-                    }
-                    if (containsLeaderboard(sizes)) {
-                        return '13366916';
-                    }
-                    return defaultPlacementId;
-                default:
-                    return defaultPlacementId;
-            }
-        default:
-            return defaultPlacementId;
-    }
 };
 
 export const getAppNexusServerSideBidParams = (

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -13,6 +13,8 @@ import {
     containsMpu,
     containsMpuOrDmpu,
     getBreakpointKey,
+    isInAuRegion,
+    isInUsRegion,
 } from './utils';
 
 import type { PrebidAppNexusParams, PrebidSize } from './types';
@@ -28,33 +30,31 @@ const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
 
 export const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
     const defaultPlacementId: string = '13915593';
-    switch (config.get('page.edition')) {
-        case 'UK':
-            switch (getBreakpointKey()) {
-                case 'D':
-                    if (containsMpuOrDmpu(sizes)) {
-                        return '13366606';
-                    }
-                    if (containsLeaderboardOrBillboard(sizes)) {
-                        return '13366615';
-                    }
-                    return defaultPlacementId;
-                case 'M':
-                    if (containsMpu(sizes)) {
-                        return '13366904';
-                    }
-                    return defaultPlacementId;
-                case 'T':
-                    if (containsMpu(sizes)) {
-                        return '13366913';
-                    }
-                    if (containsLeaderboard(sizes)) {
-                        return '13366916';
-                    }
-                    return defaultPlacementId;
-                default:
-                    return defaultPlacementId;
+    if (isInUsRegion() || isInAuRegion()) {
+        return defaultPlacementId;
+    }
+    switch (getBreakpointKey()) {
+        case 'D':
+            if (containsMpuOrDmpu(sizes)) {
+                return '13366606';
             }
+            if (containsLeaderboardOrBillboard(sizes)) {
+                return '13366615';
+            }
+            return defaultPlacementId;
+        case 'M':
+            if (containsMpu(sizes)) {
+                return '13366904';
+            }
+            return defaultPlacementId;
+        case 'T':
+            if (containsMpu(sizes)) {
+                return '13366913';
+            }
+            if (containsLeaderboard(sizes)) {
+                return '13366916';
+            }
+            return defaultPlacementId;
         default:
             return defaultPlacementId;
     }

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -1,0 +1,248 @@
+// @flow strict
+import config from 'lib/config';
+
+import {
+    _,
+    getAppNexusDirectBidParams,
+    getAppNexusServerSideBidParams,
+} from './appnexus';
+
+import type { PrebidSize } from './types';
+
+import {
+    getBreakpointKey as getBreakpointKey_,
+    isInAuRegion as isInAuRegion_,
+} from './utils';
+
+jest.mock('common/modules/commercial/build-page-targeting', () => ({
+    buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
+    buildAppNexusTargetingObject: () => 'someAppNexusTargetingObject',
+    buildPageTargeting: () => 'pageTargeting',
+}));
+
+jest.mock('./utils', () => {
+    const original = jest.requireActual('./utils');
+    return {
+        ...original,
+        getBreakpointKey: jest.fn(),
+        isInAuRegion: jest.fn(),
+    };
+});
+
+const {
+    getAppNexusPlacementId,
+    getAppNexusInvCode,
+    getAppNexusDirectPlacementId,
+} = _;
+
+const getBreakpointKey: any = getBreakpointKey_;
+const isInAuRegion: any = isInAuRegion_;
+
+/* eslint-disable guardian-frontend/no-direct-access-config */
+const resetConfig = () => {
+    config.set('switches.prebidAppnexus', true);
+    config.set('switches.prebidAppnexusInvcode', false);
+    config.set('ophan', { pageViewId: 'pvid' });
+    config.set('page.contentType', 'Article');
+    config.set('page.section', 'Magic');
+    config.set('page.edition', 'UK');
+};
+
+describe('getAppNexusInvCode', () => {
+    beforeEach(() => {
+        resetConfig();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+    });
+
+    test('should return the magic strings for mobile breakpoints', () => {
+        getBreakpointKey.mockReturnValue('M');
+        const invCodes = [
+            [[300, 250]],
+            [[300, 600]],
+            [[970, 250]],
+            [[728, 90]],
+        ].map(getAppNexusInvCode);
+
+        expect(invCodes).toEqual([
+            'Mmagic300x250',
+            'Mmagic300x600',
+            'Mmagic970x250',
+            'Mmagic728x90',
+        ]);
+    });
+
+    test('should return the magic strings for other breakpoints', () => {
+        getBreakpointKey.mockReturnValue('D');
+        const invCodes = [
+            [[300, 250]],
+            [[300, 600]],
+            [[970, 250]],
+            [[728, 90]],
+        ].map(getAppNexusInvCode);
+        expect(invCodes).toEqual([
+            'Dmagic300x250',
+            'Dmagic300x600',
+            'Dmagic970x250',
+            'Dmagic728x90',
+        ]);
+    });
+});
+
+describe('getAppNexusDirectPlacementId', () => {
+    beforeEach(() => {
+        resetConfig();
+        window.OzoneLotameData = { some: 'lotamedata' };
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+        window.OzoneLotameData = undefined;
+    });
+
+    const prebidSizes: Array<Array<PrebidSize>> = [
+        [[300, 250]],
+        [[300, 600]],
+        [[970, 250]],
+        [[728, 90]],
+        [[1, 2]],
+    ];
+
+    test('should return the expected values when in AU region and desktop device', () => {
+        expect(
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size, true))
+        ).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
+    });
+
+    test('should return the expected values for ROW when on desktop device', () => {
+        getBreakpointKey.mockReturnValue('D');
+        expect(
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size, false))
+        ).toEqual(['9251752', '9251752', '9926678', '9926678', '9251752']);
+    });
+
+    test('should return the expected values for ROW when on tablet device', () => {
+        getBreakpointKey.mockReturnValue('T');
+        expect(
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size, false))
+        ).toEqual(['11600568', '9251752', '9251752', '11600778', '9251752']);
+    });
+});
+
+describe('getAppNexusPlacementId', () => {
+    beforeEach(() => {
+        resetConfig();
+        window.OzoneLotameData = { some: 'lotamedata' };
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+    });
+
+    const generateTestIds = (): Array<string> => {
+        const prebidSizes: Array<Array<PrebidSize>> = [
+            [[300, 250]],
+            [[300, 600]],
+            [[970, 250]],
+            [[728, 90]],
+            [[1, 2]],
+        ];
+        return prebidSizes.map(getAppNexusPlacementId);
+    };
+
+    test('should return the expected values when on UK Edition and desktop device', () => {
+        getBreakpointKey.mockReturnValue('D');
+        expect(generateTestIds()).toEqual([
+            '13366606',
+            '13366606',
+            '13366615',
+            '13366615',
+            '13915593',
+        ]);
+        expect(getAppNexusPlacementId([[300, 250]])).toEqual('13366606');
+        expect(getAppNexusPlacementId([[970, 250]])).toEqual('13366615');
+        expect(getAppNexusPlacementId([[1, 2]])).toEqual('13915593');
+    });
+
+    test('should return the expected values when on UK Edition and tablet device', () => {
+        getBreakpointKey.mockReturnValue('T');
+        expect(generateTestIds()).toEqual([
+            '13366913',
+            '13915593',
+            '13915593',
+            '13366916',
+            '13915593',
+        ]);
+    });
+
+    test('should return the expected values when on UK Edition and mobile device', () => {
+        getBreakpointKey.mockReturnValue('M');
+        expect(generateTestIds()).toEqual([
+            '13366904',
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
+        ]);
+    });
+
+    test('should return the default value on all other editions', () => {
+        const editions = ['AU', 'US', 'INT'];
+        const expected = [
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
+            '13915593',
+        ];
+
+        editions.forEach(edition => {
+            config.set('page.edition', edition);
+            expect(generateTestIds()).toEqual(expected);
+        });
+    });
+});
+
+describe('getAppNexusDirectBidParams', () => {
+    beforeEach(() => {
+        resetConfig();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+    });
+
+    test('should include placementId if outside AU region', () => {
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '4298191',
+        });
+    });
+
+    test('should include placementId for AU region when invCode switch is off', () => {
+        isInAuRegion.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '11016434',
+        });
+    });
+
+    test('should exclude placementId for AU region when including member and invCode', () => {
+        config.set('switches.prebidAppnexusInvcode', true);
+        isInAuRegion.mockReturnValue(true);
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            member: '7012',
+            invCode: 'Mmagic300x250',
+        });
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow
 import config from 'lib/config';
 
 import {
@@ -21,6 +21,7 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
 }));
 
 jest.mock('./utils', () => {
+    // $FlowFixMe property requireActual is actually not missing Flow.
     const original = jest.requireActual('./utils');
     return {
         ...original,
@@ -142,6 +143,7 @@ describe('getAppNexusPlacementId', () => {
     afterEach(() => {
         jest.resetAllMocks();
         resetConfig();
+        window.OzoneLotameData = undefined;
     });
 
     const generateTestIds = (): Array<string> => {
@@ -204,6 +206,36 @@ describe('getAppNexusPlacementId', () => {
         editions.forEach(edition => {
             config.set('page.edition', edition);
             expect(generateTestIds()).toEqual(expected);
+        });
+    });
+});
+
+describe('getAppNexusServerSideBidParams', () => {
+    beforeEach(() => {
+        resetConfig();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        resetConfig();
+        window.OzoneLotameData = undefined;
+    });
+
+    test('should include OzoneLotameData if available', () => {
+        getBreakpointKey.mockReturnValue('M');
+        window.OzoneLotameData = { some: 'lotamedata' };
+        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '13366904',
+            lotame: { some: 'lotamedata' },
+        });
+    });
+
+    test('should excude lotame if data is unavailable', () => {
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '13366904',
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -9,10 +9,7 @@ import {
 
 import type { PrebidSize } from './types';
 
-import {
-    getBreakpointKey as getBreakpointKey_,
-    isInAuRegion as isInAuRegion_,
-} from './utils';
+import { getBreakpointKey as getBreakpointKey_ } from './utils';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
@@ -37,7 +34,6 @@ const {
 } = _;
 
 const getBreakpointKey: any = getBreakpointKey_;
-const isInAuRegion: any = isInAuRegion_;
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
@@ -77,7 +73,8 @@ describe('getAppNexusInvCode', () => {
     });
 
     test('should return the magic strings for other breakpoints', () => {
-        getBreakpointKey.mockReturnValue('D');
+        getBreakpointKey.mockReturnValueOnce('T');
+        getBreakpointKey.mockReturnValueOnce('D');
         const invCodes = [
             [[300, 250]],
             [[300, 600]],
@@ -251,7 +248,6 @@ describe('getAppNexusDirectBidParams', () => {
     });
 
     test('should include placementId for AU region when invCode switch is off', () => {
-        isInAuRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
             keywords: 'someAppNexusTargetingObject',
@@ -261,7 +257,6 @@ describe('getAppNexusDirectBidParams', () => {
 
     test('should exclude placementId for AU region when including member and invCode', () => {
         config.set('switches.prebidAppnexusInvcode', true);
-        isInAuRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
             keywords: 'someAppNexusTargetingObject',

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -250,14 +250,6 @@ describe('getAppNexusDirectBidParams', () => {
         resetConfig();
     });
 
-    test('should include placementId if outside AU region', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
-            placementId: '4298191',
-        });
-    });
-
     test('should include placementId for AU region when invCode switch is off', () => {
         isInAuRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
@@ -275,6 +267,15 @@ describe('getAppNexusDirectBidParams', () => {
             keywords: 'someAppNexusTargetingObject',
             member: '7012',
             invCode: 'Mmagic300x250',
+        });
+    });
+
+    test('should include placementId and not include invCode if outside AU region', () => {
+        config.set('switches.prebidAppnexusInvcode', true);
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '4298191',
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -340,12 +340,12 @@ const isPbTestOn = (): boolean => !isEmpty(pbTestNameMap());
 const inPbTestOr = (liveClause: boolean): boolean => isPbTestOn() || liveClause;
 
 /* Bidders */
-const appNexusBidder = (isInAu: boolean): PrebidBidder => ({
-    name: isInAu ? 'and' : 'and-uk-row',
+const appNexusBidder: PrebidBidder = {
+    name: 'and',
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
-        getAppNexusDirectBidParams(sizes, isInAu),
-});
+        getAppNexusDirectBidParams(sizes, isInAuRegion()),
+};
 
 const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
@@ -558,9 +558,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         sonobiBidder,
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
-        ...(inPbTestOr(shouldIncludeAppNexus())
-            ? [appNexusBidder(isInAuRegion())]
-            : []),
+        ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
         improveDigitalBidder,
         xaxisBidder,
         pubmaticBidder,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -31,7 +31,6 @@ import type {
     PrebidXaxisParams,
 } from './types';
 import {
-    getLargestSize,
     containsBillboard,
     containsDmpu,
     containsLeaderboard,
@@ -50,6 +49,7 @@ import {
     isInAuRegion,
     stripDfpAdPrefixFrom,
 } from './utils';
+import { getAppNexusPlacementId, getAppNexusDirectBidParams } from './appnexus';
 
 const isInSafeframeTestVariant = (): boolean => {
     const variant = getVariant(commercialPrebidSafeframe, 'variant');
@@ -216,100 +216,6 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
             default:
                 return -1;
         }
-    }
-};
-
-const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
-    const device: string = getBreakpointKey();
-    const section: string = config.get('page.section', 'unknown');
-    const slotSize: PrebidSize | null = getLargestSize(sizes);
-    if (slotSize) {
-        return `${device}${section.toLowerCase()}${slotSize.join('x')}`;
-    }
-};
-
-const getAppNexusDirectPlacementId = (
-    sizes: PrebidSize[],
-    isAuRegion: boolean
-): string => {
-    if (isAuRegion) {
-        return '11016434';
-    }
-
-    const defaultPlacementId: string = '9251752';
-    switch (getBreakpointKey()) {
-        case 'D':
-            if (containsMpuOrDmpu(sizes)) {
-                return '9251752';
-            }
-            if (containsLeaderboardOrBillboard(sizes)) {
-                return '9926678';
-            }
-            return defaultPlacementId;
-        case 'M':
-            if (containsMpu(sizes)) {
-                return '4298191';
-            }
-            return defaultPlacementId;
-        case 'T':
-            if (containsMpu(sizes)) {
-                return '11600568';
-            }
-            if (containsLeaderboard(sizes)) {
-                return '11600778';
-            }
-            return defaultPlacementId;
-        default:
-            return defaultPlacementId;
-    }
-};
-
-const getAppNexusDirectBidParams = (
-    sizes: PrebidSize[],
-    isAuRegion: boolean
-): PrebidAppNexusParams => {
-    if (isAuRegion && config.get('switches.prebidAppnexusInvcode', false)) {
-        return {
-            invCode: getAppNexusInvCode(sizes) || '',
-            member: '7012',
-            keywords: buildAppNexusTargetingObject(buildPageTargeting()),
-        };
-    }
-    return {
-        placementId: getAppNexusDirectPlacementId(sizes, isAuRegion),
-        keywords: buildAppNexusTargetingObject(buildPageTargeting()),
-    };
-};
-
-const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
-    const defaultPlacementId: string = '13915593';
-    if (isInUsRegion() || isInAuRegion()) {
-        return defaultPlacementId;
-    }
-    switch (getBreakpointKey()) {
-        case 'D':
-            if (containsMpuOrDmpu(sizes)) {
-                return '13366606';
-            }
-            if (containsLeaderboardOrBillboard(sizes)) {
-                return '13366615';
-            }
-            return defaultPlacementId;
-        case 'M':
-            if (containsMpu(sizes)) {
-                return '13366904';
-            }
-            return defaultPlacementId;
-        case 'T':
-            if (containsMpu(sizes)) {
-                return '13366913';
-            }
-            if (containsLeaderboard(sizes)) {
-                return '13366916';
-            }
-            return defaultPlacementId;
-        default:
-            return defaultPlacementId;
     }
 };
 
@@ -693,9 +599,6 @@ export const bids: (string, PrebidSize[]) => PrebidBid[] = (
 
 export const _ = {
     getAdYouLikePlacementId,
-    getAppNexusInvCode,
-    getAppNexusDirectBidParams,
-    getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,
     getImprovePlacementId,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -49,9 +49,6 @@ const isInAuRegion: any = isInAuRegion_;
 
 const {
     getAdYouLikePlacementId,
-    getAppNexusInvCode,
-    getAppNexusDirectBidParams,
-    getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,
     getImprovePlacementId,
@@ -91,189 +88,16 @@ const resetConfig = () => {
     config.set('page.edition', 'UK');
 };
 
-describe('getAppNexusInvCode', () => {
-    beforeEach(() => {
-        resetConfig();
-        [[300, 250], [300, 600], [970, 250], [728, 90]].map(
-            getLargestSize.mockReturnValueOnce
-        );
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
-
-    test('should return the magic strings for mobile breakpoints', () => {
-        getBreakpointKey.mockReturnValue('M');
-        const invCodes = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-        ].map(getAppNexusInvCode);
-
-        expect(invCodes).toEqual([
-            'Mmagic300x250',
-            'Mmagic300x600',
-            'Mmagic970x250',
-            'Mmagic728x90',
-        ]);
-    });
-
-    test('should return the magic strings for other breakpoints', () => {
-        getBreakpointKey.mockReturnValue('D');
-        const invCodes = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-        ].map(getAppNexusInvCode);
-        expect(invCodes).toEqual([
-            'Dmagic300x250',
-            'Dmagic300x600',
-            'Dmagic970x250',
-            'Dmagic728x90',
-        ]);
-    });
-});
-
-describe('getAppNexusDirectBidParams', () => {
-    beforeEach(() => {
-        resetConfig();
-        getLargestSize.mockReturnValueOnce([300, 250]);
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
-
-    test('should include placementId', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
-            placementId: '9251752',
-        });
-    });
-
-    test('should include placementId for AU region when invCode switch is off', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
-            placementId: '11016434',
-        });
-    });
-
-    test('should exclude placementId for AU region when including member and invCode', () => {
-        config.set('switches.prebidAppnexusInvcode', true);
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
-            member: '7012',
-            invCode: 'Mmagic300x250',
-        });
-    });
-});
-
-describe('getAppNexusPlacementId', () => {
-    beforeEach(() => {
-        resetConfig();
-        window.OzoneLotameData = { some: 'lotamedata' };
-
-        [[300, 250], [300, 600], [970, 250], [728, 90]].map(
-            getLargestSize.mockReturnValueOnce
-        );
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
-
-    const generateTestIds = (): Array<string> => {
-        const prebidSizes: Array<Array<PrebidSize>> = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-            [[1, 2]],
-        ];
-        return prebidSizes.map(getAppNexusPlacementId);
-    };
-
-    test('should return the expected values when on UK Edition and desktop device', () => {
-        getBreakpointKey.mockReturnValue('D');
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValue(false);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValue(false);
-        expect(generateTestIds()).toEqual([
-            '13366606',
-            '13366606',
-            '13366615',
-            '13366615',
-            '13915593',
-        ]);
-    });
-
-    test('should return the expected values when on UK Edition and tablet device', () => {
-        getBreakpointKey.mockReturnValue('T');
-        containsMpu.mockReturnValueOnce(true);
-        containsMpu.mockReturnValue(false);
-        containsLeaderboard.mockReturnValueOnce(false);
-        containsLeaderboard.mockReturnValueOnce(false);
-        containsLeaderboard.mockReturnValueOnce(true);
-        containsLeaderboard.mockReturnValue(false);
-        expect(generateTestIds()).toEqual([
-            '13366913',
-            '13915593',
-            '13915593',
-            '13366916',
-            '13915593',
-        ]);
-    });
-
-    test('should return the expected values when on UK Edition and mobile device', () => {
-        getBreakpointKey.mockReturnValue('M');
-        containsMpu.mockReturnValueOnce(true);
-        containsMpu.mockReturnValue(false);
-        expect(generateTestIds()).toEqual([
-            '13366904',
-            '13915593',
-            '13915593',
-            '13915593',
-            '13915593',
-        ]);
-    });
-
-    test('should return the default value on all other editions', () => {
-        const editions = ['AU', 'US', 'INT'];
-        const expected = [
-            '13915593',
-            '13915593',
-            '13915593',
-            '13915593',
-            '13915593',
-        ];
-
-        editions.forEach(edition => {
-            config.set('page.edition', edition);
-            expect(generateTestIds()).toEqual(expected);
-        });
-    });
-});
-
 describe('getDummyServerSideBidders', () => {
     beforeEach(() => {
         config.set('switches.prebidS2sozone', true);
+        window.OzoneLotameData = { some: 'lotamedata' };
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         resetConfig();
+        window.OzoneLotameData = undefined;
     });
 
     test('should return an empty array if the switch is off', () => {
@@ -677,7 +501,6 @@ describe('bids', () => {
         containsMpu.mockReturnValue(false);
         containsMpuOrDmpu.mockReturnValue(false);
         shouldIncludeAdYouLike.mockReturnValue(true);
-        shouldIncludeAppNexus.mockReturnValue(false);
         shouldIncludeAppNexus.mockReturnValue(false);
         shouldIncludeTrustX.mockReturnValue(false);
         stripMobileSuffix.mockImplementation(str => str);

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -25,6 +25,7 @@ import {
     shouldIncludeOzone as shouldIncludeOzone_,
     shouldIncludeTrustX as shouldIncludeTrustX_,
     stripMobileSuffix as stripMobileSuffix_,
+    isInAuRegion as isInAuRegion_,
 } from './utils';
 
 const getLargestSize: any = getLargestSize_;
@@ -44,11 +45,12 @@ const getBreakpointKey: any = getBreakpointKey_;
 const getParticipations: any = getParticipations_;
 const getVariant: any = getVariant_;
 const isInVariant: any = isInVariant_;
+const isInAuRegion: any = isInAuRegion_;
 
 const {
     getAdYouLikePlacementId,
     getAppNexusInvCode,
-    getAppNexusBidParams,
+    getAppNexusDirectBidParams,
     getAppNexusPlacementId,
     getDummyServerSideBidders,
     getIndexSiteId,
@@ -136,7 +138,7 @@ describe('getAppNexusInvCode', () => {
     });
 });
 
-describe('getAppNexusBidParams', () => {
+describe('getAppNexusDirectBidParams', () => {
     beforeEach(() => {
         resetConfig();
         getLargestSize.mockReturnValueOnce([300, 250]);
@@ -147,18 +149,26 @@ describe('getAppNexusBidParams', () => {
         resetConfig();
     });
 
-    test('should include placementId when invCode switch is off', () => {
+    test('should include placementId', () => {
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusBidParams([[300, 250]])).toEqual({
+        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
             keywords: 'someAppNexusTargetingObject',
             placementId: '9251752',
         });
     });
 
-    test('should exclude placementId when including member and invCode', () => {
+    test('should include placementId for AU region when invCode switch is off', () => {
+        getBreakpointKey.mockReturnValue('M');
+        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: '11016434',
+        });
+    });
+
+    test('should exclude placementId for AU region when including member and invCode', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusBidParams([[300, 250]])).toEqual({
+        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
             keywords: 'someAppNexusTargetingObject',
             member: '7012',
             invCode: 'Mmagic300x250',
@@ -730,6 +740,7 @@ describe('bids', () => {
 
     test('should include AppNexus directly if in target geolocation', () => {
         shouldIncludeAppNexus.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(true);
         expect(bidders()).toEqual([
             'ix',
             'sonobi',


### PR DESCRIPTION
## What does this change?

#### 👉 Move AppNexus related logic to a shiny new module 

Bid-config was getting out of control, so moving some logic to a new module allows us to remove 100 lines from bid-config and gives the AppNexus logic room to grow  🌱 🌻 

#### 👉 Additional targeting for Australia AppNexus

Modifications and refinements to the logic of when and how we use the AppNexus invCode along with some tests to capture the business requirements.

#### 👉 Fewer mocks of the Prebid utils

Extensive mocking of Prebid utils started risking that test logic would drift away from PROD behaviour, as well as adding a lot of boilerplate to our tests:

```js
	
        containsMpu.mockReturnValueOnce(true);	
        containsMpu.mockReturnValue(false);	
        containsLeaderboard.mockReturnValueOnce(false);	
        containsLeaderboard.mockReturnValueOnce(false);	
        containsLeaderboard.mockReturnValueOnce(true);	
        containsLeaderboard.mockReturnValue(false);
```
🔥 🔪 💀 We can then move away from using stuff like this ^^

Many of our utils functions can be tested as part of the modules that depend on them. Minor integration testing is preferable in these cases and has several benefits. Also gives us an intrersting approach to take with other modules we want to partially mock...

## Screenshots

<img width="567" alt="screen shot 2018-10-16 at 16 29 28" src="https://user-images.githubusercontent.com/8607683/47028162-b0ea2280-d160-11e8-8fbb-fb415658ad07.png">

## Checklist

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
