### PR TITLE
Reduce cache time for Braze email front endpoints

### DIFF
--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -196,6 +196,8 @@ import scala.concurrent.Await
     val (key, html) = jsonResponse.as[Map[String,String]].head
     key shouldBe "body"
     html should include ("<!DOCTYPE html")
+    val responseHeaders = headers(emailJsonResponse)
+    responseHeaders("Surrogate-Control") should include("max-age=60")
   }
 
   it should "render txt email fronts" in {
@@ -207,6 +209,8 @@ import scala.concurrent.Await
     key shouldBe "body"
     text should not include "<!DOCTYPE html"
     text should include ("The Guardian Today | The Guardian")
+    val responseHeaders = headers(emailJsonResponse)
+    responseHeaders("Surrogate-Control") should include("max-age=60")
   }
 
   it should "render email fronts" in {
@@ -216,6 +220,8 @@ import scala.concurrent.Await
     assertThrows[JsonParseException](contentAsJson(emailJsonResponse))
     contentAsString(emailJsonResponse)
     contentAsString(emailJsonResponse) should include ("<!DOCTYPE html")
+    val responseHeaders = headers(emailJsonResponse)
+    responseHeaders("Surrogate-Control") should include("max-age=900")
   }
 
 }


### PR DESCRIPTION
## What does this change?

Reduce cache time for Braze email front non-HTML endpoints.

## What is the value of this and can you measure success?

Updates to email fronts propogate more quickly in Braze. The alternative would be to use the fastly cache purger lambda for these non-html endpoints. This might be considered an over optimisation for these endpoints.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
