### PR TITLE
Make image elements non-renderable in dotcom-rendering

### DIFF
--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -37,7 +37,6 @@ object PageChecks {
   def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
       case _: TextBlockElement => false
-      case _: ImageBlockElement => false
       case _ => true
     }
 


### PR DESCRIPTION
## What does this change?

Articles that have body images are flagged as renderable in `dotcom-rendering`. This change ensures they are not flagged as renderable

## What is the value of this and can you measure success?

Currently in dotcom-rendering, we are injecting the HTML from CAPI directly into the page HTML. This mostly superficially, however the HTML is not cleaned, therefore:

- we are sending the 1000px width image to every device, regardless of viewport width
- the image source is set to `media.guim.co.uk` instead of `i.guim.co.uk`. Therefore we are not going through Fastly's image optimisation
- ~we are not doing anything to guarantee the image appears at 5:3. If a picture editor chooses a non-standard crop, we may display an oddly-dimensioned image~ EDIT: not needed

This is a temporary fix until we support image blocks properly in dotcom-rendering.
