### PR TITLE
Fix font-weight for standfirst on PaidContent

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -1011,6 +1011,7 @@
         }
     }
 }
+
 .paid-content {
     color: $brightness-7;
     .content__head {
@@ -1083,6 +1084,7 @@
         padding: ($gs-baseline / 4) 0 ($gs-baseline * 2);
         .content__standfirst {
             color: $brightness-7;
+            font-weight: lighter;
         }
     }
     .tone-media--item {


### PR DESCRIPTION
## What does this change?

Another skirmish in the CSS war... ⚔️ 🏹 💥 

This fixes a font-wight issue caused by the recent fonts-update

> We are aware that there might be a few places that the font weights change, this will affect the main website and probably also some of the commercial templates. Sadly we could not predict what and where!

https://github.com/guardian/frontend/pull/20466#issuecomment-427309216

## Screenshots

Before:

<img width="976" alt="screen shot 2018-10-17 at 13 33 20" src="https://user-images.githubusercontent.com/8607683/47088072-85753f80-d215-11e8-8d35-ac34e7808180.png">

After:

<img width="974" alt="screen shot 2018-10-17 at 13 33 43" src="https://user-images.githubusercontent.com/8607683/47088084-8d34e400-d215-11e8-8d9a-e448c072e92a.png">

@RobertFreeman does this look okay?

## What is the value of this and can you measure success?

Beautiful pages 🦄 ✨ 

Matching up with the Opinion and Feature standfirst overrides:

![screen shot 2018-10-17 at 14 02 59](https://user-images.githubusercontent.com/8607683/47088020-6d052500-d215-11e8-9db1-1640285c3647.png)

`lighter` is an alias for `200` 😄 

## Notes

Maybe I could delete that `&:not(.paid-content)` in the `_types.scss` file. However, then we just get into a specificity fight about the font-family 🙃 🤦‍♂️ 