### PR TITLE
Include first non-section tag in submeta tags list

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -2,9 +2,9 @@
 @(article: model.Article, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import model.EndSlateComponents
-@import model.{VideoPlayer}
+@import model.VideoPlayer
 @import views.support.Video640
-@import views.{MainCleaner}
+@import views.MainCleaner
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
     <div class="media-primary">

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -543,7 +543,7 @@ import collection.JavaConverters._
         import browser._
 
         Then("I should see links to keywords")
-        $(".submeta__link").size should be(6)
+        $(".submeta__link").size should be(8)
       }
     }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -543,7 +543,7 @@ import collection.JavaConverters._
         import browser._
 
         Then("I should see links to keywords")
-        $(".submeta__link").size should be(7)
+        $(".submeta__link").size should be(6)
       }
     }
 

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -56,7 +56,7 @@
     <div class="submeta__keywords">
         <ul class="submeta__links">
             @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
+                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(0, 6)) { shownKeywords =>
                     @if(shownKeywords.nonEmpty) {
                         @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
                             <li class="submeta__link-item">

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -46,7 +46,7 @@ class TopStoriesController(
           case picks => Some(RelatedContent(picks))
         }
       } recover { case ContentApiError(404, message, _) =>
-        log.info(s"Got a 404 while calling content api: $message")
+        log.info(s"Got a 404 while calling content api for path '/', edition $edition: $message")
         None
       }
   }


### PR DESCRIPTION
## What does this change?
Makes sure the first 6 tags rather than tags 1-7 are picked for submeta tags. This solves the issue here where Meghan's tag doesn't appear but Harry's does: https://gu.com/fashion/2018/oct/17/are-republicans-allowed-to-be-interested-in-meghan-markles-pregnancy

The first tag might be ignored for a reason though... @NataliaLKB any ideas?

#Screenshots 
<img width="294" alt="screen shot 2018-10-17 at 17 21 12" src="https://user-images.githubusercontent.com/3606555/47101100-0db50e00-d231-11e8-8bdc-7ca11cf1e76c.png">

## What is the value of this and can you measure success?
More predictable submeta tag behaviour

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
