### PR TITLE
Require validation for access to contributions tab

### DIFF
--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -1,6 +1,4 @@
-@import conf.Static
 @import views.support.RenderClasses
-@import model.{ApplicationContext, IdentityPage}
 @import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import controllers.editprofile.ProfileForms
@@ -51,7 +49,7 @@
     </li>
 }
 
-@content(i: Int, url: String, optionalClass: String = "", requiresValidation: Boolean = false)(body: => Html) = {
+@content(i: Int, url: String, requiresValidation: Boolean = false)(body: => Html) = {
     <div id="tabs-account-profile-@i"
          class="@RenderClasses(Map(
             "u-h" -> (activeUrl != url)
@@ -69,6 +67,8 @@
     </div>
 }
 
+@requiresValidation = @{!user.statusFields.userEmailValidated.getOrElse(false)}
+
 <div class="tabs">
 
     <div class="identity-wrapper-header">
@@ -83,9 +83,9 @@
 
                     @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
 
-                    @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab")
+                    @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation)
 
-                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = !user.statusFields.userEmailValidated.getOrElse(false))
+                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = requiresValidation)
                 </ol>
         </div>
     </div>
@@ -102,9 +102,9 @@
 
                         @content(4, "/digitalpack/edit")(profile.digitalPackDetailsForm(idUrlBuilder, idRequest, user))
 
-                        @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
+                        @content(5, "/contribution/recurring/edit", requiresValidation)(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
-                        @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated, consentHint))
+                        @content(6, "/email-prefs", requiresValidation)(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated, consentHint))
                     </div>
                 </div>
     </div>


### PR DESCRIPTION
## What does this change?
Adds email validation as a requirement for access to the contributions tab.

## Screenshots


## What is the value of this and can you measure success?
To better protect recurring contribution details that are added to an account without requiring sign-in.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
