### PR TITLE
New whitelist items

### DIFF
--- a/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
+++ b/article/app/services/dotcomponents/pickers/WhitelistPicker.scala
@@ -43,7 +43,14 @@ class WhitelistPicker extends RenderTierPickerStrategy {
     "uk-news/2018/oct/14/met-police-damian-collins-no-investigation-leave-campaigners-data-misuse",
     "world/2018/oct/14/nine-climbers-killed-in-storm-in-himalayas-mount-gurja-nepal-south-korea",
     "help/2017/mar/15/computer-security-tips-for-whistleblowers-and-sources",
-    "uk-news/2018/oct/15/cornwall-murder-lyn-bryant-police-new-dna-evidence"
+    "uk-news/2018/oct/15/cornwall-murder-lyn-bryant-police-new-dna-evidence",
+    "uk-news/2018/oct/18/man-beaten-to-death-in-south-west-london",
+    "science/2018/oct/17/chinese-city-plans-to-launch-artificial-moon-to-replace-streetlights",
+    "uk-news/2018/oct/17/no-retrial-for-teacher-accused-of-having-sex-with-student-on-plane-eleanor-wilson",
+    "australia-news/2018/oct/18/queensland-man-charged-with-raping-young-english-woman-on-working-holiday",
+    "business/2018/oct/17/man-falls-from-top-floor-of-westfield-stratford-on-to-another-shopper",
+    "uk-news/2018/oct/17/elizabeth-isherwood-wales-death-locked-cupboard-macdonald-resorts-sued",
+    "us-news/2018/oct/17/high-school-cookies-teen-grandfather-ashes"
   )
 
   override def getRenderTierFor(page: PageWithStoryPackage, request: RequestHeader): (Results, RenderType) = {


### PR DESCRIPTION
## What does this change?

Add several new whitelisted articles to dotcomponents

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
