### PR TITLE
Overflow:hidden on the ad free banner

### DIFF
--- a/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
@@ -11,6 +11,7 @@ $btn-height: ($gs-baseline*3.5);
 .site-message--ad-free-banner {
     color: $brightness-100;
     background: $sport-dark;
+    overflow: hidden;
 
     .site-message__close {
         padding-top: 0;


### PR DESCRIPTION
## What does this change?
Prevents this overscrolling from happening on mobile (the image **is** supposed to be aligned offscreen, but it's meant to not be visible)

![screen shot 2018-10-18 at 1 42 28 pm](https://user-images.githubusercontent.com/11539094/47155038-d64f6b80-d2db-11e8-8822-afe5dc3ac185.png)
