### PR TITLE
Add in some missing fields

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -49,7 +49,10 @@ case class PageData(
     toneIds: Option[String],
     seriesId: Option[String],
     isHosted: Boolean,
-    beaconUrl: String
+    beaconUrl: String,
+    edition: String,
+    contentType: Option[String],
+    commissioningDesks: Option[String]
 )
 
 case class Config(
@@ -61,7 +64,7 @@ case class Config(
 case class ContentFields(
     standfirst: Option[String],
     main: String,
-    body: String, 
+    body: String,
     blocks: Blocks
 )
 
@@ -141,7 +144,10 @@ object DotcomponentsDataModel {
       jsConfig("toneIds"),     // source: meta.scala
       jsConfig("seriesId"),    // source: content.scala
       article.metadata.isHosted,
-      Configuration.debug.beaconUrl
+      Configuration.debug.beaconUrl,
+      Edition(request).displayName,
+      jsConfig("contentType"),
+      jsConfig("commissioningDesks")
     )
 
     val tags = article.tags.tags.map(


### PR DESCRIPTION
## What does this change?

Adds some fields I missed for GA from the dotcomponents datamodel

## Screenshots

![image](https://user-images.githubusercontent.com/1218561/47160553-17e61380-d2e8-11e8-8367-56a22bf73ac9.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
