### PR TITLE
FIX: added the 'gu_action_required_for' to the list of cookies to cleanup after signout

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -31,6 +31,7 @@ const forcedAdFreeMode: boolean = !!window.location.hash.match(
 
 const userHasData = (): boolean => {
     const cookie =
+        getCookie(ACTION_REQUIRED_FOR_COOKIE) ||
         getCookie(USER_FEATURES_EXPIRY_COOKIE) ||
         getCookie(PAYING_MEMBER_COOKIE) ||
         getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -10,6 +10,7 @@ import config from 'lib/config';
 import bean from 'bean';
 import arrowRight from 'svgs/icon/arrow-right.svg';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 import userPrefs from 'common/modules/user-prefs';
 
 const accountDataUpdateLink = accountDataUpdateWarningLink => {
@@ -111,6 +112,7 @@ const canShow: () => Promise<boolean> = () => {
     );
     return Promise.resolve(
         updateLink !== null &&
+            isUserLoggedIn() &&
             !(
                 bannerCanBeLoadedAgainAfter &&
                 new Date(bannerCanBeLoadedAgainAfter) > new Date()


### PR DESCRIPTION
## What does this change?
added the 'gu_action_required_for' to the list of cookies to cleanup after signout, as a signed-out user could have been shown the banner in error

## Screenshots
N/A _but the banner in question is the one detailed here https://github.com/guardian/frontend/pull/20256_

## What is the value of this and can you measure success?
This should prevent bad UX for signed-out users and also improve the integrity of banner impression data in the data-lake

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist
N/A _since this is just a cookie change, but the accessibility checklist for the banner in question is detailed here https://github.com/guardian/frontend/pull/20256_
<!-- for changes that affect how a page appears in the browser -->

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
