### PR TITLE
Don't alias Raven

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "raven": "raven-js",
       "videojs": "video.js",
       "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.js",
       "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.js",

--- a/static/src/javascripts/lib/__mocks__/raven.js
+++ b/static/src/javascripts/lib/__mocks__/raven.js
@@ -1,0 +1,8 @@
+// @flow
+
+export default {
+    wrap(fn: () => mixed): () => mixed {
+        return fn;
+    },
+    captureException() {},
+};

--- a/static/src/javascripts/lib/ajax.spec.js
+++ b/static/src/javascripts/lib/ajax.spec.js
@@ -2,6 +2,7 @@
 import reqwest from 'reqwest';
 import { ajax } from 'lib/ajax';
 
+jest.mock('lib/raven');
 jest.mock('reqwest', () => jest.fn());
 jest.mock('lib/config');
 

--- a/static/src/javascripts/lib/cookies.spec.js
+++ b/static/src/javascripts/lib/cookies.spec.js
@@ -11,6 +11,8 @@ import {
 
 const { isValidCookieValue } = _;
 
+jest.mock('lib/raven');
+
 // Mock the Date constructor to always return the beginning of time
 const OriginalDate = global.Date;
 global.Date = jest.fn(() => new OriginalDate(0));

--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -1,6 +1,6 @@
 // @flow
 
-import raven from 'raven';
+import raven from 'raven-js';
 import config from 'lib/config';
 import { adblockInUse } from 'lib/detect';
 

--- a/static/src/javascripts/lib/report-error.spec.js
+++ b/static/src/javascripts/lib/report-error.spec.js
@@ -1,11 +1,18 @@
 // @flow
 
-import raven from 'raven';
 import reportError from './report-error';
 
-jest.mock('raven', () => ({
+jest.mock('raven-js', () => ({
+    config() {
+        return this;
+    },
+    install() {
+        return this;
+    },
     captureException: jest.fn(),
 }));
+
+const fakeRaven: any = require('raven-js');
 
 describe('report-error', () => {
     const error = new Error('Something broke.');
@@ -17,7 +24,7 @@ describe('report-error', () => {
             reportError(error, metaData, false);
         }).not.toThrowError(error);
 
-        expect(raven.captureException).toHaveBeenCalledWith(
+        expect(fakeRaven.captureException).toHaveBeenCalledWith(
             error,
             ravenMetaData
         );
@@ -28,7 +35,7 @@ describe('report-error', () => {
             reportError(error, metaData);
         }).toThrowError(error);
 
-        expect(raven.captureException).toHaveBeenCalledWith(
+        expect(fakeRaven.captureException).toHaveBeenCalledWith(
             error,
             ravenMetaData
         );

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -4,6 +4,7 @@ import fetchJson from 'lib/fetch-json';
 import { _, init } from './cmp';
 import { log as log_ } from './log';
 
+jest.mock('lib/raven');
 jest.mock('lib/fetch-json', () => jest.fn());
 const fetchJsonMock: JestMockFn<*, *> = (fetchJson: any);
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/cookie.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cookie.spec.js
@@ -19,6 +19,7 @@ const {
     convertVendorsToRanges,
 } = _;
 
+jest.mock('lib/raven');
 jest.mock('commercial/modules/cmp/log', () => ({
     log: {
         debug: jest.fn(),

--- a/static/src/javascripts/projects/commercial/modules/cmp/store.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/store.spec.js
@@ -10,6 +10,7 @@ const {
     generateVendorConsentResponse,
 } = _;
 
+jest.mock('lib/raven');
 jest.mock('commercial/modules/cmp/log', () => ({
     log: {
         debug: jest.fn(),

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.js
@@ -3,6 +3,7 @@ import { _ } from 'commercial/modules/dfp/Advert';
 
 const { filterClasses } = _;
 
+jest.mock('lib/raven');
 jest.mock('ophan/ng', () => null);
 
 describe('Filter classes', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -13,6 +13,7 @@ import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 
 const getBreakpoint: any = getBreakpoint_;
 
+jest.mock('lib/raven');
 jest.mock('common/modules/identity/api', () => ({
     isUserLoggedIn: () => true,
     getUserFromCookie: jest.fn(),

--- a/static/src/javascripts/projects/commercial/modules/dfp/performance-logging.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/performance-logging.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import { defer, wrap } from 'commercial/modules/dfp/performance-logging';
 
+jest.mock('lib/raven');
 jest.mock('common/modules/analytics/beacon', () => ({
     postJson: jest.fn(),
 }));

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -3,6 +3,8 @@
 import config from 'lib/config';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
+jest.mock('lib/raven');
+
 jest.mock('commercial/modules/dfp/Advert', () =>
     jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
 );

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -3,6 +3,8 @@ import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { stickyMpu, stickyCommentsMpu } from 'commercial/modules/sticky-mpu';
 
+jest.mock('lib/raven');
+
 // Workaround to fix issue where dataset is missing from jsdom, and solve the
 // 'cannot set property [...] which has only a getter' TypeError
 Object.defineProperty(HTMLElement.prototype, 'dataset', {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -4,6 +4,8 @@ import { init, _ } from './third-party-tags';
 
 const { insertScripts, loadOther } = _;
 
+jest.mock('lib/raven');
+
 beforeEach(() => {
     const firstScript = document.createElement('script');
     if (document.body && firstScript) {

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.spec.js
@@ -12,6 +12,7 @@ import interactionTracking from './interaction-tracking';
 
 jest.mock('lib/mediator');
 jest.mock('lib/storage');
+jest.mock('lib/raven');
 
 jest.mock('common/modules/analytics/google', () => ({
     trackSamePageLinkClick: jest.fn(),

--- a/static/src/javascripts/projects/common/modules/article/rich-links.spec.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.spec.js
@@ -9,6 +9,7 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 
 let mockParas: ?NodeList<HTMLParagraphElement>;
 
+jest.mock('lib/raven');
 jest.mock('lib/config');
 jest.mock('common/modules/article/space-filler', () => ({
     spaceFiller: {

--- a/static/src/javascripts/projects/common/modules/commercial/krux.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.spec.js
@@ -3,8 +3,8 @@ import { krux } from 'common/modules/commercial/krux';
 
 const { url, shouldRun } = krux;
 
+jest.mock('lib/raven');
 jest.mock('ophan/ng', () => null);
-
 jest.mock('lib/config', () => ({
     switches: { krux: false },
 }));

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -14,6 +14,7 @@ import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions
 const defaultEngagementBannerParams: any = defaultEngagementBannerParams_;
 const getUserVariantParams: any = getUserVariantParams_;
 
+jest.mock('lib/raven');
 jest.mock('lib/mediator');
 jest.mock('lib/storage', () => ({
     local: {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -14,6 +14,7 @@ import {
     getDaysSinceLastOneOffContribution,
 } from './user-features.js';
 
+jest.mock('lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({
     isUserLoggedIn: jest.fn(),
 }));

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
@@ -3,6 +3,7 @@ import { handle, closeTooltip } from 'common/modules/discussion/upvote';
 import { recommendComment as recommendComment_ } from 'common/modules/discussion/api';
 import fakeConfig from 'lib/config';
 
+jest.mock('lib/raven');
 jest.mock('common/modules/discussion/api', () => ({
     recommendComment: jest.fn(),
 }));

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.spec.js
@@ -13,13 +13,13 @@ import config from 'lib/config';
 
 import { genAbTest } from './__fixtures__/ab-test';
 
+jest.mock('lib/raven');
 jest.mock('lib/storage');
 jest.mock('lib/report-error');
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
 jest.mock('lodash/memoize', () => f => f);
 jest.mock('ophan/ng', () => null);
-jest.mock('raven-js', () => null);
 
 describe('A/B Ophan analytics', () => {
     beforeEach(() => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -15,12 +15,12 @@ import config from 'lib/config';
 
 import { genAbTest } from './__fixtures__/ab-test';
 
+jest.mock('lib/raven');
 jest.mock('lib/storage');
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
 jest.mock('lodash/memoize', () => f => f);
 jest.mock('ophan/ng', () => null);
-jest.mock('raven-js', () => null);
 
 describe('A/B tests', () => {
     beforeEach(() => {

--- a/static/src/javascripts/projects/common/modules/identity/cookierefresh.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/cookierefresh.spec.js
@@ -2,6 +2,8 @@
 
 import { shouldRefreshCookie } from './cookierefresh.js';
 
+jest.mock('lib/raven');
+
 const now = new Date().getTime();
 
 test('should return true for a user who has never refreshed cookies', () => {

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import { breakingNews } from 'common/modules/onward/breaking-news';
 
+jest.mock('lib/raven');
 jest.mock('lib/storage', () => ({
     local: {
         get: jest.fn(key => {

--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.spec.js
@@ -2,6 +2,8 @@
 
 import { initTechFeedback } from './tech-feedback';
 
+jest.mock('lib/raven');
+
 describe('Tech-feedback', () => {
     beforeEach(() => {
         if (document.body) {

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
@@ -6,6 +6,8 @@ import fetchJson_ from 'lib/fetch-json';
 import { SearchTool } from 'facia/modules/onwards/search-tool';
 import mediator from 'lib/mediator';
 
+jest.mock('lib/raven');
+
 jest.mock('lib/fetch-json', () => jest.fn());
 
 const fetchJson: JestMockFn<*, *> = (fetchJson_: any);

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.spec.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.spec.js
@@ -5,6 +5,7 @@ import fetchJson from 'lib/fetch-json';
 import userPrefs from 'common/modules/user-prefs';
 import { Weather } from 'facia/modules/onwards/weather';
 
+jest.mock('lib/raven');
 jest.mock('lib/config');
 jest.mock('common/modules/user-prefs');
 jest.mock('lib/fetch-json', () => jest.fn());

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
@@ -5,6 +5,8 @@ import qwery from 'qwery';
 
 import { _ } from 'facia/modules/ui/container-show-more';
 
+jest.mock('lib/raven');
+
 const { itemsByArticleId, dedupShowMore } = _;
 
 describe('Container Show More', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,6 @@ module.exports = {
             journalism: 'projects/journalism',
 
             // #wp-rjs weird old aliasing from requirejs
-            raven: 'raven-js',
             videojs: 'video.js',
 
             svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),


### PR DESCRIPTION
## What does this change?

In this project, we alias the `raven-js` dependency to `raven`. There is no clear reason for doing this (from what I can tell, [`raven`](https://www.npmjs.com/package/raven) is the Node client whereas [`raven-js`](https://www.npmjs.com/package/raven-js) is the web client), and it adds clutter to our Webpack and Jest configs.

This change also ensures we are mocking Raven in our tests. 

## What is the value of this and can you measure success?

- less complexity in configuration
- sensible boundaries in our tests. We rarely want to test Raven is working correctly, and by simply loading the module we invoke side effects that are better avoided.
