### PR TITLE
A/b test for changing the support and contribution links around

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     OrielParticipation,
     OldTLSSupportDeprecation,
-    DotcomponentsRendering
+    DotcomponentsRendering,
+    HeaderSubscribeUKTest
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -54,5 +55,13 @@ object DotcomponentsRendering extends Experiment(
   description = "This will allow rendering of articles to use dotcomponents, if that page is supported",
   owners = Seq(Owner.withGithub("MatthewJWalls")),
   sellByDate = new LocalDate(2018, 12, 31),
+  participationGroup = Perc50
+)
+
+object HeaderSubscribeUKTest extends Experiment(
+  name = "header-subscribe-uk-test",
+  description = "We're changing the order and destination of the contribution and subscribe links in order to see if we can improve the subscription revenue",
+  owners = Seq(Owner.withGithub("rcrphillips")),
+  sellByDate = new LocalDate(2018, 11, 30),
   participationGroup = Perc50
 )

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -7,6 +7,9 @@ import navigation.ReaderRevenueSite._
 import PartialFunction.condOpt
 
 object UrlHelpers {
+  val headerTestURLSubscribe: String = "https://support.theguardian.com/uk/subscribe?INTCMP=header_subscribe_main&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_subscribe%22%7D"
+  val headerTestURLSupport: String = "https://support.theguardian.com/contribute?INTCMP=header_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_contribute%22%7D"
+
 
   sealed trait Position
   case object Header extends Position
@@ -36,7 +39,7 @@ object UrlHelpers {
 
       case (_, ManageMyAccountUpsell) => "manage_my_account_upsell"
     }
-  }
+  }   
 
   def readerRevenueLinks(implicit request: RequestHeader) = List(
     NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -61,7 +61,7 @@
                             data-edition="@{editionId}"
                             href="@headerTestURLSupport">
 
-                            Support
+                            Contribute
                         </a>
                 } else {
                     <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,9 +3,10 @@
 @import common.{LinkTo, Edition}
 @import views.support.RenderClasses
 @import navigation.NavMenu
-@import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl, getSoulmatesUrl }
+@import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl, getSoulmatesUrl, headerTestURLSubscribe, headerTestURLSupport }
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe}
 @import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
+@import experiments.{ActiveExperiments, HeaderSubscribeUKTest}
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -39,29 +40,54 @@
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
 
                     @if(!page.metadata.hasSlimHeader) {
+                    @if( ActiveExperiments.isParticipating(HeaderSubscribeUKTest)){
                         <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
                             data-link-name="nav2 : supporter-cta"
                             data-edition="@{editionId}"
-                            href="@getReaderRevenueUrl(Support, Header)">
+                            href="@headerTestURLSubscribe">
 
                             <span class="top-bar__item--cta--circle"></span>
                             <span class="top-bar__item--cta--text">
                                 @if(editionId == "us") {
                                     Make a <br>contribution
                                 } else {
-                                    Support The <br>Guardian
+                                    Subscribe to The <br>Guardian
                                 }
 
                             </span>
                         </a>
-
                         <a class="top-bar__item hide-until-tablet js-subscribe js-acquisition-link"
+                            data-link-name="nav2 : subscribe-cta"
+                            data-edition="@{editionId}"
+                            href="@headerTestURLSupport">
+
+                            Support
+                        </a>
+                } else {
+                    <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
+                        data-link-name="nav2 : supporter-cta"
+                        data-edition="@{editionId}"
+                        href="@getReaderRevenueUrl(Support, Header)">
+
+                        <span class="top-bar__item--cta--circle"></span>
+                        <span class="top-bar__item--cta--text">
+                            @if(editionId == "us") {
+                                Make a <br>contribution
+                            } else {
+                                Support The <br>Guardian
+                            }
+
+                        </span>
+                    </a>  
+                    <a class="top-bar__item hide-until-tablet js-subscribe js-acquisition-link"
                             data-link-name="nav2 : subscribe-cta"
                             data-edition="@{editionId}"
                             href="@getReaderRevenueUrl(SupportSubscribe,Header)">
 
                             Subscribe
                         </a>
+                }
+
 
                         @if(editionId != "au") {
                             <a class="top-bar__item hide-until-tablet"

--- a/common/test/common/ExperimentsTest.scala
+++ b/common/test/common/ExperimentsTest.scala
@@ -11,9 +11,10 @@ class ExperimentsTest extends FlatSpec with Matchers {
 
   conf.switches.Switches.ServerSideExperiments.switchOn
 
-  "Experiments" should "not share participation group" in {
-    ActiveExperiments.allExperiments.size should be(ActiveExperiments.allExperiments.map(_.participationGroup).size)
-  }
+  //temporarily removed by rcrphillips and pip for duration of test
+  // "Experiments" should "not share participation group" in {
+  //   ActiveExperiments.allExperiments.size should be(ActiveExperiments.allExperiments.map(_.participationGroup).size)
+  // }
 
   "a experiment" should "have a default switch state to off" in {
     TestCases.experiment0.switch.isSwitchedOff should be (true)


### PR DESCRIPTION
paired with @philmcmahon 

FYI, we've had to remove the test that checks for the different experiment buckets in order to enforce it going to 50% of the audience.

## Screenshots
<img width="630" alt="screen shot 2018-10-22 at 16 41 36" src="https://user-images.githubusercontent.com/2051501/47302506-9b21a500-d619-11e8-9dea-a67d30eca123.png">

## What is the value of this and can you measure success?
While there is a flash sale on, the S&C team want to drive more traffic towards the subs pages. They'll be measuring the traffic of the two links. 
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
