### PR TITLE
Extend Identity switches

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -19,19 +19,19 @@ trait IdentitySwitches {
     SwitchGroup.Identity,
     "id-email-sign-in-upsell",
     "If switched on, users coming from newsletters will get prompts to sign in.",
-    owners = Seq(Owner.withGithub("walaura")),
+    owners = Owner.group(SwitchGroup.Identity),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 10, 24),
+    sellByDate = new LocalDate(2019, 1, 31),
     exposeClientSide = true
   )
 
-  val IdentityUseFollowSwitches = Switch(
+  val IdentityEnableUpsellJourneysSwitch = Switch(
     SwitchGroup.Identity,
-    "id-use-follow-switches",
+    "id-enable-upsell-journeys",
     "If switched on, access to the new consent journeys will be enabled.",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 10, 24),
+    sellByDate = new LocalDate(2019, 1, 31),
     exposeClientSide = false
   )
 

--- a/identity/app/controllers/UpsellController.scala
+++ b/identity/app/controllers/UpsellController.scala
@@ -46,7 +46,7 @@ class UpsellController(
     with SafeLogging
     with IdentitySwitches {
 
-  def confirmEmailThankYou(returnUrl: Option[String]): Action[AnyContent] = if (IdentityUseFollowSwitches.isSwitchedOn) csrfAddToken {
+  def confirmEmailThankYou(returnUrl: Option[String]): Action[AnyContent] = if (IdentityEnableUpsellJourneysSwitch.isSwitchedOn) csrfAddToken {
     authenticatedActions.consentAuthWithIdapiUserAction.async { implicit request =>
       val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request)
       val email = request.user.primaryEmailAddress


### PR DESCRIPTION
## What does this change?
Extends, renames and changes owners of some Identity switches.  I've extend until January as we should know more by then about whether we can reprioritise some of this work (thinking of email sign in banner in particular).

## What is the value of this and can you measure success?
Avoid expired switches and makes their usage/ownership clearer!
