### PR TITLE
Fix the edition logic for the header links a/b test

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -40,7 +40,7 @@
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
 
                     @if(!page.metadata.hasSlimHeader) {
-                    @if( ActiveExperiments.isParticipating(HeaderSubscribeUKTest)){
+                    @if( editionId == "uk" && ActiveExperiments.isParticipating(HeaderSubscribeUKTest)){
                         <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
                             data-link-name="nav2 : supporter-cta"
                             data-edition="@{editionId}"
@@ -48,46 +48,48 @@
 
                             <span class="top-bar__item--cta--circle"></span>
                             <span class="top-bar__item--cta--text">
-                                @if(editionId == "us") {
-                                    Make a <br>contribution
-                                } else {
+                                
                                     Subscribe to The <br>Guardian
-                                }
 
                             </span>
                         </a>
                         <a class="top-bar__item hide-until-tablet js-subscribe js-acquisition-link"
-                            data-link-name="nav2 : subscribe-cta"
-                            data-edition="@{editionId}"
-                            href="@headerTestURLSupport">
+                                data-link-name="nav2 : subscribe-cta"
+                                data-edition="@{editionId}"
+                                href="@headerTestURLSupport">
 
-                            Contribute
+                                Support
                         </a>
-                } else {
-                    <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
-                        data-link-name="nav2 : supporter-cta"
-                        data-edition="@{editionId}"
-                        href="@getReaderRevenueUrl(Support, Header)">
+                    } else {
+                        <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
+                                data-link-name="nav2 : supporter-cta"
+                                data-edition="@{editionId}"
+                                href="@getReaderRevenueUrl(Support, Header)">
 
-                        <span class="top-bar__item--cta--circle"></span>
-                        <span class="top-bar__item--cta--text">
-                            @if(editionId == "us") {
-                                Make a <br>contribution
-                            } else {
-                                Support The <br>Guardian
-                            }
+                                <span class="top-bar__item--cta--circle"></span>
+                                <span class="top-bar__item--cta--text">
+                                    @if(editionId == "us") {
+                                        Make a <br>contribution
+                                    } else {
+                                        Support The <br>Guardian
+                                    }
 
-                        </span>
-                    </a>  
-                    <a class="top-bar__item hide-until-tablet js-subscribe js-acquisition-link"
-                            data-link-name="nav2 : subscribe-cta"
-                            data-edition="@{editionId}"
-                            href="@getReaderRevenueUrl(SupportSubscribe,Header)">
+                                </span>
+                            </a>
 
-                            Subscribe
-                        </a>
+                            <a class="top-bar__item hide-until-tablet js-subscribe js-acquisition-link"
+                                data-link-name="nav2 : subscribe-cta"
+                                data-edition="@{editionId}"
+                                href="@getReaderRevenueUrl(SupportSubscribe,Header)">
+
+                                Subscribe
+                            </a>
                 }
 
+
+
+
+                        
 
                         @if(editionId != "au") {
                             <a class="top-bar__item hide-until-tablet"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -84,12 +84,7 @@
 
                                 Subscribe
                             </a>
-                }
-
-
-
-
-                        
+                }           
 
                         @if(editionId != "au") {
                             <a class="top-bar__item hide-until-tablet"


### PR DESCRIPTION
## What does this change?
UK && user is in test:
Show the new links order.

Otherwise:
Show the previous link order

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
