### PR TITLE
migrate contributions MMA tab to manage platform

### DIFF
--- a/identity/app/controllers/editprofile/editprofile.scala
+++ b/identity/app/controllers/editprofile/editprofile.scala
@@ -7,7 +7,6 @@ package object editprofile {
   object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
   object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
   object EmailPrefsProfilePage extends IdentityPage("/email-prefs", "Emails")
-  object recurringContributionPage extends IdentityPage("/contribution/recurring/edit", "Contributions")
   object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
 
   sealed abstract class ConsentJourneyPage(id: String, val journey: AnyConsentsJourney)

--- a/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
+++ b/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
@@ -17,8 +17,12 @@ trait SupporterTabs
       MOVED_PERMANENTLY)
   }
 
-  /** GET /contribution/recurring/edit */
-  def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)
+  /** Redirect /contribution/recurring/edit to manage.theguardian.com/contributions */
+  def redirectToManageContributions: Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      url = "https://manage.theguardian.com/contributions",
+      MOVED_PERMANENTLY)
+  }
 
   /** GET /digitalpack/edit */
   def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -83,7 +83,7 @@
 
                     @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
 
-                    @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation)
+                    @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation, disableClientSideRouting = true)
 
                     @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = requiresValidation)
                 </ol>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -53,7 +53,7 @@ GET         /account/edit                           controllers.editprofile.Edit
 POST        /account/edit                           controllers.editprofile.EditProfileController.submitAccountForm
 
 GET         /membership/edit                        controllers.editprofile.EditProfileController.redirectToManageMembership
-GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.displayRecurringContributionForm
+GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.redirectToManageContributions
 GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.displayDigitalPackForm
 
 GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -16,9 +16,9 @@ import userPrefs from 'common/modules/user-prefs';
 const accountDataUpdateLink = accountDataUpdateWarningLink => {
     switch (accountDataUpdateWarningLink) {
         case 'contribution':
-            return `${config.get('page.idUrl')}/contribution/recurring/edit`;
+            return `${config.get('page.mmaUrl')}/banner/contributions?INTCMP=BANNER`;
         case 'membership':
-            return `${config.get('page.mmaUrl')}/banner/membership`;
+            return `${config.get('page.mmaUrl')}/banner/membership?INTCMP=BANNER`;
         default:
             return `${config.get(
                 'page.idUrl'

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -16,9 +16,13 @@ import userPrefs from 'common/modules/user-prefs';
 const accountDataUpdateLink = accountDataUpdateWarningLink => {
     switch (accountDataUpdateWarningLink) {
         case 'contribution':
-            return `${config.get('page.mmaUrl')}/banner/contributions?INTCMP=BANNER`;
+            return `${config.get(
+                'page.mmaUrl'
+            )}/banner/contributions?INTCMP=BANNER`;
         case 'membership':
-            return `${config.get('page.mmaUrl')}/banner/membership?INTCMP=BANNER`;
+            return `${config.get(
+                'page.mmaUrl'
+            )}/banner/membership?INTCMP=BANNER`;
         default:
             return `${config.get(
                 'page.idUrl'


### PR DESCRIPTION
## What does this change?
This migrates the Contributions tab over to the new manage platform. This change is largely just redirects. (Note cleanup of the old code will happen in few weeks once everything has been working nicely - wanted to keep this change small)

## Screenshots
_N/A this is not a visual change_

## What is the value of this and can you measure success?
This is more of a strategic change to move functionality off a large codebase. That said there is GA tracking in the new platform to allow for before/after comparison. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
_N/A this change is just redirects_
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
