### PR TITLE
Bump Prebid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#4c219c6",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#72fdc4e",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7847,9 +7847,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#4c219c6":
-  version "1.27.0"
-  resolved "https://github.com/guardian/Prebid.js.git#4c219c6aba93973a93fe477a9dbdeb1987570641"
+"prebid.js@https://github.com/guardian/Prebid.js.git#72fdc4e":
+  version "1.28.0"
+  resolved "https://github.com/guardian/Prebid.js.git#72fdc4ea5326c0c2daabc78b4a384817de2baeda"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
This brings in:
* https://github.com/guardian/Prebid.js/pull/59
* https://github.com/guardian/Prebid.js/pull/60
