### PR TITLE
Add inPbTestOr for pangaea

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -524,7 +524,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
         dummyServerSideBidders.push(appnexusServerSideBidder);
 
         // Remove this switch after initial pangaea release
-        if (config.get('switches.ozonePangaea')) {
+        if (inPbTestOr(config.get('switches.ozonePangaea'))) {
             dummyServerSideBidders.push(pangaeaServerSideBidder);
         }
     }


### PR DESCRIPTION
## What does this change?

This uses `inPbTestOr` around the inclusion of `pangaea` so that we can test it while it is turned off.

@guardian/commercial-dev 