### PR TITLE
Update thank you page copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -15,6 +15,7 @@ import {
 import { LegalTextBlock } from 'common/modules/identity/upsell/block/LegalTextBlock';
 import { AccountCreationBlock } from 'common/modules/identity/upsell/account-creation/AccountCreationBlock';
 import { Header } from 'common/modules/identity/upsell/header/Header';
+import config from 'lib/config';
 
 const ConfirmEmailThankYou = (
     <Block title="Guardian favourites:">
@@ -37,13 +38,16 @@ const ConfirmEmailThankYou = (
 );
 
 const Optouts = (
-    <Block
-        sideBySideBackwards
-        title="One more thing..."
-        subtitle="These are your privacy settings. You’re in full control of them.">
+    <Block sideBySideBackwards title="Your communication preferences">
         <LegalTextBlock>
-            You can also change these settings any time by visiting our Emails &
-            marketing section of your account.
+            You can change these preferences at any time via the&nbsp;
+            <a
+                data-link-name="upsell-optout-preferences-link"
+                className="u-underline identity-upsell-consent-card__link"
+                href={`${config.get('page.idUrl')}/email-prefs`}>
+                Emails & marketing
+            </a>
+            &nbsp;section of your account.
         </LegalTextBlock>
         <OptOutsList />
     </Block>
@@ -86,7 +90,7 @@ const bindBlockList = (el): void => {
                     <div>
                         <Header
                             title="Thank you!"
-                            subtitle="You’re now subscribed to your content"
+                            subtitle="You’re now subscribed"
                         />
                         <div className="identity-upsell-layout">
                             {ConfirmEmailThankYou}


### PR DESCRIPTION
## What does this change?
Makes some copy changes on the new thank you page, that move it closer to the design/copy agreed by data privacy.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8754692/47446838-00a99900-d7b4-11e8-9763-944dc070d508.png)
---
![image](https://user-images.githubusercontent.com/8754692/47446848-0a330100-d7b4-11e8-97b5-627d9cf6ecfe.png)

After:
![image](https://user-images.githubusercontent.com/8754692/47446867-14ed9600-d7b4-11e8-99d8-e74bf5eda07b.png)
---
![image](https://user-images.githubusercontent.com/8754692/47446881-1d45d100-d7b4-11e8-9e81-3295a90a0d5b.png)

## What is the value of this and can you measure success?
Removes placeholder wording getting us closer to release.