### PR TITLE
Fix design bug on Audio Series page

### DIFF
--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -138,7 +138,6 @@
                 @include mq($from: phablet) {
                     position: absolute;
                     right: 0;
-                    bottom: 0;
                     z-index: 8;
                 }
                 .artwork-holder {


### PR DESCRIPTION
One line change - pulls the image on the right down, improving a design problem

## What does this change?

## Screenshots

Before 
<img width="913" alt="screen shot 2018-10-25 at 08 08 22" src="https://user-images.githubusercontent.com/10324129/47482278-fe842080-d82d-11e8-9dfe-2aac3de3c5ef.png">

After 

<img width="771" alt="screen shot 2018-10-25 at 08 15 06" src="https://user-images.githubusercontent.com/10324129/47482383-528f0500-d82e-11e8-8792-b063cb90bcc7.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
