### PR TITLE
Pangaea in technology only

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -43,6 +43,7 @@ import {
     shouldIncludeOpenx,
     shouldIncludeOzone,
     shouldIncludeTrustX,
+    shouldIncludePangaea,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
     isInUsRegion,
@@ -524,7 +525,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
         dummyServerSideBidders.push(appnexusServerSideBidder);
 
         // Remove this switch after initial pangaea release
-        if (inPbTestOr(config.get('switches.ozonePangaea'))) {
+        if (inPbTestOr(shouldIncludePangaea())) {
             dummyServerSideBidders.push(pangaeaServerSideBidder);
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -124,6 +124,10 @@ export const shouldIncludeAppNexus = (): boolean =>
     ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
         !!pbTestNameMap().and);
 
+export const shouldIncludePangaea = (): boolean =>
+    config.get('switches.ozonePangaea') &&
+    config.get('page.section', '').toLowerCase() === 'technology';
+
 export const stripMobileSuffix = (s: string): string =>
     stripSuffix(s, '--mobile');
 


### PR DESCRIPTION
## What does this change?

This changes Pangaea so that it only is served on the technology section. This is a part of a wider test of rolling out bit by bit to figure out why it is under-performing.

@guardian/commercial-dev 