### PR TITLE
Gather more analytics from Prebid auctions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -97,8 +97,8 @@ class PrebidService {
 
         window.pbjs.setConfig(pbjsConfig);
 
-        // gather analytics from 20% (1 in 5) of page views
-        const inSample = getRandomIntInclusive(1, 5) === 1;
+        // gather analytics from 50% (1 in 2) of page views
+        const inSample = getRandomIntInclusive(1, 2) === 1;
         if (
             config.get('switches.prebidAnalytics', false) &&
             (inSample || config.get('page.isDev', false))


### PR DESCRIPTION
This increases the sample size from 20% to 50% of page views.  This is to give D&I more data to analyse the performance of our auctions.