### PR TITLE
Changing jobs text in header and footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -65,7 +65,7 @@
                     case Uk => {
                         <ul class="colophon__list">
                             <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
-                                jobs</a>
+                                search jobs</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
                                 dating</a>
@@ -142,7 +142,7 @@
                     case Us => {
                         <ul class="colophon__list">
                             <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
-                                jobs</a>
+                                search jobs</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : contribute" class="js-acquisition-link" href="@getReaderRevenueUrl(SupportContribute, Footer)">
                                 make a contribution</a>
@@ -222,7 +222,7 @@
                                 subscribe</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
-                                UK jobs</a>
+                                search UK jobs</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://www.theguardian.com/info/2015/aug/04/guardian-australia-job-vacancies">
                                 vacancies</a>
@@ -298,6 +298,9 @@
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : membership" class="js-acquisition-link" href="@getReaderRevenueUrl(SupportSubscribe, Footer)">
                                 subscribe</a>
+                            </li>
+                            <li class="colophon__item"><a data-link-name="int : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_INT_GU_JOBS">
+                                search UK jobs</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
                                 securedrop</a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -92,7 +92,7 @@
                             data-edition="@{editionId}"
                             href="@getJobUrl(editionId)">
 
-                                <span class="hide-until-tablet">Find a job</span>
+                                <span class="hide-until-tablet">Search jobs</span>
                                 <span class="hide-from-tablet">Jobs</span>
                             </a>
                         }


### PR DESCRIPTION
## What does this change?
The link text for most jobs links in header and footer as well as adding it to the international footer.
## Screenshots
<img width="576" alt="screen shot 2018-10-26 at 14 09 00" src="https://user-images.githubusercontent.com/2051501/47568365-d2999580-d928-11e8-9c9a-e7f7d7af423e.png">
<img width="647" alt="screen shot 2018-10-26 at 14 09 38" src="https://user-images.githubusercontent.com/2051501/47568366-d2999580-d928-11e8-9ac8-d96af520d3d2.png">


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

## Tested
- [x] Locally
- [ ] On CODE (optional)


