### PR TITLE
AUDIO: Series page, add Google and Spotify links 

### DIFF
--- a/common/app/conf/AudioFlagship.scala
+++ b/common/app/conf/AudioFlagship.scala
@@ -6,6 +6,8 @@ object AudioFlagship {
   val seriesId: String = "today-in-focus"
   val description: String = "Listen to the story behind the headlines <br/> for a deeper understanding of the news. <br/> <strong>Every weekday with Anushka Asthana</strong>."
   val subscribeLinks: Map[String, String] = Map(
-    "Apple Podcasts" -> "https://itunes.apple.com/gb/podcast/today-in-focus/id1440133626?mt=2"
+    "Apple Podcasts" -> "https://itunes.apple.com/gb/podcast/today-in-focus/id1440133626?mt=2",
+    "Google Podcasts" -> "https://www.google.com/podcasts?feed=aHR0cHM6Ly93d3cudGhlZ3VhcmRpYW4uY29tL25ld3Mvc2VyaWVzL3RvZGF5aW5mb2N1cy9wb2RjYXN0LnhtbA%3D%3D",
+    "Spotify" -> "https://open.spotify.com/show/2cSQmzYnf6LyrN0Mi6E64p"
   )
 }


### PR DESCRIPTION
## What does this change?

The Google and Spotify links for the new podcast have landed. This adds them into the custom header design for the Today in Focus series 

## Screenshots

![screen shot 2018-10-29 at 11 04 35](https://user-images.githubusercontent.com/10324129/47645999-7a51d600-db6a-11e8-9c5e-6dde1c460dca.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
