### PR TITLE
Fix commentcount flake

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -61,7 +61,6 @@ const getContentUrl = (el: HTMLElement): string => {
 };
 
 const updateElement = (el: HTMLElement, count: number): Promise<void> => {
-
     const url = el.dataset.discussionUrl || getContentUrl(el);
 
     if (el.dataset.discussionClosed === 'true' && count === 0) {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -57,11 +57,11 @@ const getContentIds = (indexedElements: IndexedElements): string =>
 
 const getContentUrl = (el: HTMLElement): string => {
     const a = el.getElementsByTagName('a')[0];
-
     return `${a ? a.pathname : ''}#comments`;
 };
 
 const updateElement = (el: HTMLElement, count: number): Promise<void> => {
+
     const url = el.dataset.discussionUrl || getContentUrl(el);
 
     if (el.dataset.discussionClosed === 'true' && count === 0) {
@@ -78,6 +78,7 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
         },
         format
     );
+
     const meta = el.getElementsByClassName('js-item__meta');
     const containers = meta.length ? [...meta] : [el];
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -5,7 +5,7 @@ import { integerCommas } from 'lib/formatters';
 import mediator from 'lib/mediator';
 import { inlineSvg } from 'common/views/svgs';
 
-type IndexedElements = { string: Array<HTMLElement> };
+type IndexedElements = { [id: string]: Array<HTMLElement> };
 
 const ATTRIBUTE_NAME: string = 'data-discussion-id';
 const COUNT_URL: string = '/discussion/comment-counts.json?shortUrls=';
@@ -26,7 +26,7 @@ const getTemplate = (
     return `<a class="fc-trail__count fc-trail__count--commentcount" href="${url}" data-link-name="Comment count" aria-label="${count} comments">${icon} ${count}</a>`;
 };
 
-const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
+export const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
     fastdom
         .read(() => context.querySelectorAll(`[${ATTRIBUTE_NAME}]`))
         .then(elements => {
@@ -50,17 +50,20 @@ const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
             );
         });
 
-const getContentIds = (indexedElements: IndexedElements): string =>
+export const getContentIds = (indexedElements: IndexedElements): string =>
     Object.keys(indexedElements)
         .sort()
         .join(',');
 
-const getContentUrl = (el: HTMLElement): string => {
+export const getContentUrl = (el: HTMLElement): string => {
     const a = el.getElementsByTagName('a')[0];
     return `${a ? a.pathname : ''}#comments`;
 };
 
-const updateElement = (el: HTMLElement, count: number): Promise<void> => {
+export const updateElement = (
+    el: HTMLElement,
+    count: number
+): Promise<void> => {
     const url = el.dataset.discussionUrl || getContentUrl(el);
 
     if (el.dataset.discussionClosed === 'true' && count === 0) {
@@ -90,7 +93,7 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
     });
 };
 
-const renderCounts = (
+export const renderCounts = (
     counts: Array<{ id: string, count: number }>,
     indexedElements: IndexedElements
 ): Promise<any> => {
@@ -101,7 +104,7 @@ const renderCounts = (
     return Promise.all(elementUpdates);
 };
 
-const getCommentCounts = (context?: HTMLElement): Promise<void> => {
+export const getCommentCounts = (context?: HTMLElement): Promise<void> => {
     const queryContext: ?HTMLElement = context || document.body;
 
     if (queryContext) {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -21,7 +21,8 @@ jest.mock('lib/fetch-json', () =>
 const fetchJsonSpy: any = fetchJson;
 
 // TODO: Investigate why these sometimes fails and re-enable
-describe.skip('Comment Count', () => {
+describe('Comment Count', () => {
+
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `<div class="comment-trails">

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -1,6 +1,11 @@
 // @flow
 import fetchJson from 'lib/fetch-json';
-import { initCommentCount } from './comment-count';
+import {
+    getCommentCounts,
+    getElementsIndexedById,
+    getContentIds,
+    updateElement,
+} from './comment-count';
 
 jest.mock('lib/fastdom-promise');
 
@@ -20,54 +25,120 @@ jest.mock('lib/fetch-json', () =>
 
 const fetchJsonSpy: any = fetchJson;
 
+const getMockCommentElement = () => {
+    const el = document.createElement('div');
+
+    el.innerHTML = `<div class="comment-trails">
+        <div class="trail" data-discussion-closed="true" data-discussion-id="/p/3ghkT"><a href="/article/1">1</a></div>
+        <div class="trail" data-discussion-id="/p/3ghv5"><a href="/article/1">1</a></div>
+        <div class="trail" data-discussion-id="/p/3ghx3"><a href="/article/2">1</a></div>
+        <div class="trail" data-discussion-id="/p/3gh4n"><a href="/article/3">1</a></div>
+        <div class="trail" data-discussion-id="/p/3ghv5"><a href="/article/4">4</a></div>
+        <div class="trail" data-commentcount-format="content" data-discussion-id="/p/3ghNp"><a href="/article/3">1</a></div>
+    </div>`;
+
+    return el;
+};
+
 // TODO: Investigate why these sometimes fails and re-enable
 describe('Comment Count', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `<div class="comment-trails">
-                <div class="trail" data-discussion-closed="true" data-discussion-id="/p/3ghkT"><a href="/article/1">1</a></div>
-                <div class="trail" data-discussion-id="/p/3ghv5"><a href="/article/1">1</a></div>
-                <div class="trail" data-discussion-id="/p/3ghx3"><a href="/article/2">1</a></div>
-                <div class="trail" data-discussion-id="/p/3gh4n"><a href="/article/3">1</a></div>
-                <div class="trail" data-discussion-id="/p/3ghv5"><a href="/article/4">4</a></div>
-                <div class="trail" data-commentcount-format="content" data-discussion-id="/p/3ghNp"><a href="/article/3">1</a></div>
-            </div>`;
-        }
+    test('getElementsIndexedById returns a map of id to list of elements', () =>
+        getElementsIndexedById(getMockCommentElement()).then(
+            indexedElements => {
+                expect(indexedElements).toBeDefined();
+                expect(Object.keys(indexedElements).length).toBe(5);
+                expect(indexedElements['/p/3gh4n'].length).toBe(1);
+                expect(indexedElements['/p/3ghv5'].length).toBe(2);
+            }
+        ));
+
+    test('getContentIds returns a CSV string of ids', () => {
+        const ids = getContentIds({
+            '/p/alpha': [],
+            '/p/beta': [],
+        });
+
+        expect(ids).toBe('/p/alpha,/p/beta');
     });
 
-    afterEach(() => {
-        expect(fetchJsonSpy).toHaveBeenCalled();
-        expect(fetchJsonSpy).toHaveBeenCalledWith(
-            '/discussion/comment-counts.json?shortUrls=/p/3gh4n,/p/3ghNp,/p/3ghkT,/p/3ghv5,/p/3ghx3',
-            { mode: 'cors' }
-        );
-    });
+    test('updateElement for non-content format', () =>
+        getElementsIndexedById(getMockCommentElement()).then(
+            indexedElements => {
+                expect(indexedElements['/p/3gh4n'].length).toBe(1);
+                updateElement(indexedElements['/p/3gh4n'][0], 77).then(() => {
+                    expect(indexedElements['/p/3gh4n'][0].innerHTML).toContain(
+                        '77 comments'
+                    );
+                    expect(
+                        indexedElements['/p/3gh4n'][0].innerHTML
+                    ).not.toContain('commentcount2');
+                });
+            }
+        ));
 
-    test('should append comment counts to DOM for open discussions only', () =>
-        initCommentCount().then(() => {
+    test('updateElement for content format', () =>
+        getElementsIndexedById(getMockCommentElement()).then(
+            indexedElements => {
+                expect(indexedElements['/p/3ghNp'].length).toBe(1);
+                updateElement(indexedElements['/p/3ghNp'][0], 88).then(() => {
+                    expect(indexedElements['/p/3ghNp'][0].innerHTML).toContain(
+                        '88 comments'
+                    );
+                    expect(indexedElements['/p/3ghNp'][0].innerHTML).toContain(
+                        'commentcount2'
+                    );
+                });
+            }
+        ));
+
+    test('should append comment counts to DOM for open discussions only', () => {
+        const el = getMockCommentElement();
+
+        getCommentCounts(el).then(() => {
             expect(
-                document.querySelectorAll(
+                el.querySelectorAll(
                     '.fc-trail__count--commentcount, .commentcount2'
                 ).length
             ).toBe(5);
-        }));
+            expect(fetchJsonSpy).toHaveBeenCalled();
+            expect(fetchJsonSpy).toHaveBeenCalledWith(
+                '/discussion/comment-counts.json?shortUrls=/p/3gh4n,/p/3ghNp,/p/3ghkT,/p/3ghv5,/p/3ghx3',
+                { mode: 'cors' }
+            );
+        });
+    });
 
-    test('should append "default" format comment counts to DOM', () =>
-        initCommentCount().then(() => {
+    test('should append "default" format comment counts to DOM', () => {
+        const el = getMockCommentElement();
+
+        getCommentCounts(el).then(() => {
             expect(
-                document.getElementsByClassName('fc-trail__count--commentcount')
+                el.getElementsByClassName('fc-trail__count--commentcount')
                     .length
             ).toBe(4);
-        }));
+            expect(fetchJsonSpy).toHaveBeenCalled();
+            expect(fetchJsonSpy).toHaveBeenCalledWith(
+                '/discussion/comment-counts.json?shortUrls=/p/3gh4n,/p/3ghNp,/p/3ghkT,/p/3ghv5,/p/3ghx3',
+                { mode: 'cors' }
+            );
+        });
+    });
 
-    test('should append "content" format comment counts to DOM', () =>
-        initCommentCount().then(() => {
-            const contentCommentCounts = document.getElementsByClassName(
+    test('should append "content" format comment counts to DOM', () => {
+        const el = getMockCommentElement();
+
+        getCommentCounts(el).then(() => {
+            const contentCommentCounts = el.getElementsByClassName(
                 'commentcount2__value'
             );
 
             expect(contentCommentCounts.length).toBe(1);
-
             expect(contentCommentCounts[0].innerHTML).toBe('400');
-        }));
+            expect(fetchJsonSpy).toHaveBeenCalled();
+            expect(fetchJsonSpy).toHaveBeenCalledWith(
+                '/discussion/comment-counts.json?shortUrls=/p/3gh4n,/p/3ghNp,/p/3ghkT,/p/3ghv5,/p/3ghx3',
+                { mode: 'cors' }
+            );
+        });
+    });
 });

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.spec.js
@@ -22,7 +22,6 @@ const fetchJsonSpy: any = fetchJson;
 
 // TODO: Investigate why these sometimes fails and re-enable
 describe('Comment Count', () => {
-
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `<div class="comment-trails">


### PR DESCRIPTION
## What does this change?

* Stops skipping the comment-count tests
* Added more specific tests for the comment counts so we have a better chance of catching it flaking out in the future (this has meant I've exported a bunch more functions, sorry!)
* Switched to call getCommentCounts directly and passing in the html element instead of using document.body
* Fixed an error with the typing on IndexedElements that was present in the original code.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
