### PR TITLE
Use flagship subscription urls inn front container

### DIFF
--- a/common/app/conf/audio/FlagshipFrontContainer.scala
+++ b/common/app/conf/audio/FlagshipFrontContainer.scala
@@ -11,11 +11,4 @@ object FlagshipFrontContainer extends FlagshipContainer {
   override val switch = FlagshipFrontContainerSwitch
 
   val AlbumArtUrl = "https://media.guim.co.uk/e1c686325e7a35c618126d749807a75450f6011e/0_0_800_800/500.png"
-
-  object SubscriptionUrls {
-    //TODO - update
-    val apple: Option[String] = Some("https://itunes.apple.com/gb/podcast/today-in-focus/id1440133626?mt=2")
-    val google: Option[String] = None
-    val spotify: Option[String] = None
-  }
 }

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -7,6 +7,7 @@
 @import model.InlineImage
 @import layout.SliceWithCards
 @import conf.audio.FlagshipFrontContainer
+@import conf.AudioFlagship
 
 @(containerDefinition: layout.FaciaContainer, frontProperties: FrontProperties)(implicit request: RequestHeader)
 
@@ -29,9 +30,9 @@
 @subscriptionLinks = {
     <div class="fc-podcast-container__subscribe-links">
     <span>Subscribe:</span>
-    @FlagshipFrontContainer.SubscriptionUrls.apple.map { url => <span><a data-link-name="apple" href="@url">Apple Podcasts</a></span> }
-    @FlagshipFrontContainer.SubscriptionUrls.google.map { url => <span><a data-link-name="google" href="@url">Google Podcasts</a></span> }
-    @FlagshipFrontContainer.SubscriptionUrls.spotify.map { url => <span><a data-link-name="spotify" href="@url">Spotify</a></span> }
+    @for((name: String, url: String) <- AudioFlagship.subscribeLinks) {
+        <span><a data-link-name="@{name.split(" ").headOption.map(_.toLowerCase)}" href="@url">@name</a></span>
+    }
     </div>
 }
 


### PR DESCRIPTION
## What does this change?
Uses all podcast subscription urls for the new flagship front container
Switches to using the common urls in `conf.AudioFlagship`

## Screenshots
<img width="371" alt="picture 3" src="https://user-images.githubusercontent.com/1513454/47667384-b9e5e580-db9d-11e8-98e3-ff578cf70a06.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
