### PR TITLE
Emails: stop adding redundant style attributes

### DIFF
--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -86,8 +86,7 @@ object InlineStyles {
     // Outlook ignores styles with !important so we need to strip that out.
     // So this doesn't change which styles take effect, we also sort styles
     // so that all important styles appear to the right of all non-important styles.
-    document.getAllElements.asScala.filter(el => el.attr("style") != "")
-      .foreach { el =>
+    document.getAllElements.asScala.filter(el => el.attr("style") != "").foreach { el =>
       el.attr("style", sortStyles(el.attr("style")).replace(" !important", ""))
     }
 

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -86,7 +86,8 @@ object InlineStyles {
     // Outlook ignores styles with !important so we need to strip that out.
     // So this doesn't change which styles take effect, we also sort styles
     // so that all important styles appear to the right of all non-important styles.
-    document.getAllElements.asScala.foreach { el =>
+    document.getAllElements.asScala.filter(el => el.attr("style") != "")
+      .foreach { el =>
       el.attr("style", sortStyles(el.attr("style")).replace(" !important", ""))
     }
 


### PR DESCRIPTION
## What does this change?

In our email HTML, every element receives a `style` attribute, even if it is empty. These `style` attributes are added unintentionally by the logic that re-orders `!important` style attributes.

This change filters unstyled elements out of this logic, to ensure they don't receive unneeded attributes.

## Screenshots

![screen shot 2018-10-30 at 12 32 27](https://user-images.githubusercontent.com/5931528/47718270-e7836b00-dc3f-11e8-9ca6-148c48e0e77b.png)

## What is the value of this and can you measure success?

Reduces the weight of the emails (~300 bytes for articles), which makes them less likely to be clipped by Outlook.com and Gmail

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (please specify)

Only emails

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE - I will test on CODE to give us a sense of how many bytes are saved

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
