### PR TITLE
AUDIO: Series page - make contributions banner fancy

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -1,11 +1,15 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
+import template from 'lodash/template';
 import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContributions.html';
+import { supportContributeURL } from '../../common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
+    const banner = template(audioContribBanner)({ supportContributeURL });
+
     fastdom.write(() => {
-        el.insertAdjacentHTML('afterend', audioContribBanner);
+        el.insertAdjacentHTML('afterend', banner);
     });
 };
 

--- a/static/src/javascripts/projects/journalism/views/audioSeriesContributions.html
+++ b/static/src/javascripts/projects/journalism/views/audioSeriesContributions.html
@@ -1,11 +1,20 @@
 <section class="flagship-audio__contributions-banner fc-container">
     <div class="fc-container__inner">
         <div class="fc-container__header"> </div>
-        <div class="fc-container--rolled-up-hide fc-container__body">
-            <h2>Support The Guardian</h2>
-            <p>Help us deliver the independent
-                <br> journalism the world needs</p>
-            <a class="contributions__contribute contributions__option-button" data-link-name="audio-series-contributions">Support the Guardian</a>
+        <div class="fc-container--rolled-up-hide fc-container__body flagship-audio__contributions-banner-holder">
+            <div class="flagship-audio__contributions-banner-text">
+                <h2>Support The Guardian</h2>
+                <p>Help us deliver the independent
+                    <br> journalism the world needs</p>
+                <a class="contributions__contribute contributions__option-button"
+                   data-link-name="audio-series-contributions"
+                   href="<%= supportContributeURL %>">
+                    Support the Guardian
+                </a>
+            </div>
+            <div class="flagship-audio__contributions-banner-image">
+                <svg xmlns="http://www.w3.org/2000/svg" width="300" height="107"><path d="M0 83.118h12.148v23.824H0zm16.901-36h12.148v59.824H16.901zm16.902-21.177h12.148v81H33.803zm16.901 21.177h12.148v59.824H50.704zM67.606 18h12.148v88.941H67.606zm16.901 41.824h12.148v47.118H84.507zm16.901-12.706h12.148v59.824h-12.148zm16.902-8.471h12.148v68.294H118.31zM135.211 0h12.148v106.941h-12.148zm16.902 49.765h12.148v57.176h-12.148zm16.901-28.059h12.148v85.235h-12.148zm16.901 8.47h12.148v76.765h-12.148zM202.817 0h12.148v106.941h-12.148zm16.901 47.118h12.148v59.824h-12.148zm16.902-21.177h12.148v81H236.62zm16.901-17.47h12.148v98.471h-12.148zm16.902 41.294h12.148v57.176h-12.148zm16.901 33.882h12.148v23.294h-12.148z" fill="#FF6A56"/></svg>
+            </div>
         </div>
     </div>
 </section>

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
@@ -95,17 +95,20 @@
         }
     }
 
-    /* ---------------- CONTRIBUTIONS ------------------- */
+    /* ---------------- CONTRIBUTIONS BANNER ------------------- */
 
     .flagship-audio__contributions-banner {
-        background-color: #333333;
-        color: $brightness-100;
+        background-color: #f0dbbc;
+        padding-bottom: 0;
 
-        .fc-container__body {
+        .flagship-audio__contributions-banner-holder {
+            display: flex;
+            flex-direction: row;
 
             h2 {
                 font-size: 26px;
                 line-height: 28px;
+                color: #ff6a56;
             }
             p {
                 font-size: 18px;
@@ -113,6 +116,41 @@
             }
             a {
                 background-color: #121212;
+                max-width: 170px;
+            }
+            .flagship-audio__contributions-banner-text {
+                display: flex;
+                flex-direction: column;
+                flex: 0 0 300px;
+                z-index: 10;
+            }
+            .flagship-audio__contributions-banner-image {
+                flex: 1 1 auto;
+                display: flex;
+                justify-content: center;
+                z-index: 5;
+                svg {
+                    justify-content: center;
+                    position: absolute;
+                    bottom: 0;
+                    height: auto;
+                    width: auto;
+                    @include mq($until: phablet) {
+                        height: 60%;
+                        width: 60%;
+                    }
+                }
+            }
+        }
+
+        /* override height and color of line separating fc-container__header & fc-container__body  */
+        .fc-container__inner {
+            .fc-container__header {
+                &::after {
+                    background-color: rgba(0, 0, 0, .1);
+                    height: 300px;
+                }
+
             }
         }
     }


### PR DESCRIPTION
## What does this change?
Currently this is just a black box with text. This adds some colour, an svg and a border thing. 

*To preview* - this only visible after 5 episodes have gone up. The best way to check it is on a series with more than 5 episodes. Go to 
[AudioFlagship.scala](https://github.com/guardian/frontend/blob/master/common/app/conf/AudioFlagship.scala) and change the `tagName` to `books/series/books`


## Screenshots

BEFORE 
<img width="1010" alt="screen shot 2018-10-30 at 13 51 43" src="https://user-images.githubusercontent.com/10324129/47722801-1bb05900-dc4b-11e8-9c18-160381d6246d.png">


AFTER
<img width="773" alt="screen shot 2018-10-30 at 13 16 48" src="https://user-images.githubusercontent.com/10324129/47721695-9a57c700-dc48-11e8-9c9f-d67a1ff6e36c.png">

<img width="375" alt="screen shot 2018-10-30 at 13 17 12" src="https://user-images.githubusercontent.com/10324129/47721675-8e6c0500-dc48-11e8-898b-4f1c3a8157e3.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
