### PR TITLE
Log capi path in timeout errors, don't log commercial prebid endpoint.

### DIFF
--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -61,7 +61,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
 
   /*
     NOTE: The htmlResponse & jsonResponse are () => Html functions so that you do not do all the rendering twice.
-          Only the once you actually render is used
+          Only the one you actually render is used
    */
 
   def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, page: model.Page)(implicit request: RequestHeader): Result =


### PR DESCRIPTION
## What does this change?
Adds some extra data to our logging around content api errors which should help decipher logs that looks like [this](https://logs.gutools.co.uk/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2018-10-30T10:30:47.281Z',mode:absolute,to:'2018-10-30T10:43:34.608Z'))&_a=(columns:!(_source),index:afa91900-5e8b-11e8-ba01-2b66550a44f2,interval:auto,query:(language:lucene,query:'%22circuit%20breaker%22%20AND%20app:applications'),sort:!('@timestamp',desc))).

It also adds some rather nasty logic inside the request logging filter to stop request logs for the commercial `/commercial/api/hb` endpoint as this currently makes up a large proportion of frontend logging (see screenshot below). Is this ok with you @kelvin-chappell ?

## Screenshots
![screen shot 2018-10-30 at 13 43 04](https://user-images.githubusercontent.com/3606555/47722241-d9d2e300-dc49-11e8-9ef5-e6c46e72634b.png)


## What is the value of this and can you measure success?
Easier to debug error spikes, 60% reduction in volume of logs for dotcom. 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
