### PR TITLE
Fix height of facia football snaps

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -3,6 +3,8 @@
 
     overflow: hidden;
     padding: 0;
+    display: flex;
+    flex: 1 1 auto;
 
     // Generic
     &.facia-snap-embed {
@@ -16,8 +18,7 @@
     // Matches and tables
     // =============================================================================
     .c-football-table {
-        // this works as a min-height
-        height: $gs-baseline*14;
+        min-height: $gs-baseline*14;
         overflow: visible;
         position: relative;
     }
@@ -229,10 +230,6 @@ $footballBadgeSizeDesktop: 120px;
         vertical-align: middle;
     }
 
-}
-
-.facia-snap.facia-snap--football.facia-snap-embed {
-    height: auto !important; // height is normally set on the parent snap element in Facia
 }
 
 .facia-snap--football .inline-icon {

--- a/static/src/stylesheets/module/football/_matches.scss
+++ b/static/src/stylesheets/module/football/_matches.scss
@@ -64,6 +64,8 @@
     display: inline-block;
     position: relative;
     width: 50%;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .football-match__team--home {


### PR DESCRIPTION
There is JS, in football-snaps.js, that will adjust the height correctly but this was being overridden by the 'important' styling. In addition, flex styling is needed to ensure the height grows/shrinks correctly. This is present at non-mobile breakpoints but is needed at mobile too because the 'more' link requires it to be positioned correctly in the typical case where the table is larger than container.

Before:

![picture 1213](https://user-images.githubusercontent.com/858402/47724008-aeea8e00-dc4d-11e8-84ad-f4d239e5f36c.jpg)

After:

[insert]
