### PR TITLE
Pull submeta tags into Scala model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -3,6 +3,7 @@ package model.dotcomponents
 import common.Edition
 import conf.Configuration
 import controllers.ArticlePage
+import model.{SubMetaLink, SubMetaLinks}
 import model.liveblog.BlockElement
 import navigation.NavMenu
 import play.api.libs.json.{JsValue, Json, Writes}
@@ -52,7 +53,8 @@ case class PageData(
     beaconUrl: String,
     edition: String,
     contentType: Option[String],
-    commissioningDesks: Option[String]
+    commissioningDesks: Option[String],
+    subMetaLinks: SubMetaLinks
 )
 
 case class Config(
@@ -147,7 +149,8 @@ object DotcomponentsDataModel {
       Configuration.debug.beaconUrl,
       Edition(request).displayName,
       jsConfig("contentType"),
-      jsConfig("commissioningDesks")
+      jsConfig("commissioningDesks"),
+      article.content.submetaLinks
     )
 
     val tags = article.tags.tags.map(

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -543,7 +543,7 @@ import collection.JavaConverters._
         import browser._
 
         Then("I should see links to keywords")
-        $(".submeta__link").size should be(7)
+        $(".submeta__link").size should be(8)
       }
     }
 

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -38,7 +38,7 @@ trait LinkTo extends Logging {
     case `url` if url.startsWith("//") => ProcessedUrl(url)
     case RssPath(path, format) => ProcessedUrl(urlFor(path, edition) + format)
     case GuardianUrl(_, path) => ProcessedUrl(urlFor(path, edition))
-    case otherUrl => ProcessedUrl(otherUrl, true)
+    case otherUrl => ProcessedUrl(otherUrl, shouldNoFollow = true)
   }
 
   private def urlFor(path: String, edition: Edition): String = {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -13,11 +13,12 @@ import conf.cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, MediaAssetPlatform, MediaAtom, Quiz}
 import model.pressed._
-import org.jsoup.Jsoup
+import org.jsoup.{Jsoup, nodes}
 import org.jsoup.safety.Whitelist
 import com.github.nscala_time.time.Imports._
 import play.api.libs.json._
 import views.support._
+
 import scala.collection.JavaConverters._
 import scala.util.Try
 import implicits.Booleans._
@@ -66,6 +67,7 @@ final case class Content(
   hasStoryPackage: Boolean,
   rawOpenGraphImage: Option[ImageAsset]
 ) {
+
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
   lazy val isSeries: Boolean = tags.series.nonEmpty
@@ -170,7 +172,7 @@ final case class Content(
     ImgSrc(openGraphImageOrFallbackUrl, image)
   }
 
-  lazy val syndicationType = {
+  lazy val syndicationType: String = {
     if(isBlog){
       "blog"
     } else if (tags.isGallery){
@@ -215,9 +217,7 @@ final case class Content(
     }
   }
 
-  lazy val blogOrSeriesTag: Option[Tag] = {
-    tags.tags.find( tag => tag.showSeriesInMeta && (tag.isBlog || tag.isSeries ))
-  }
+  lazy val blogOrSeriesTag: Option[Tag] = tags.blogOrSeriesTag
 
   lazy val seriesTag: Option[Tag] = {
     tags.blogs.find{tag => tag.id != "commentisfree/commentisfree"}.orElse(tags.series.headOption)
@@ -225,9 +225,9 @@ final case class Content(
 
   val seriesName: Option[String] = tags.series.filterNot(_.id == "commentisfree/commentisfree").headOption.map(_.name)
 
-  lazy val linkCounts = LinkTo.countLinks(fields.body) + fields.standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
+  lazy val linkCounts: LinkCounts = LinkTo.countLinks(fields.body) + fields.standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 
-  lazy val mainMediaVideo = Jsoup.parseBodyFragment(fields.main).body.getElementsByClass("element-video").asScala.headOption
+  lazy val mainMediaVideo: Option[nodes.Element] = Jsoup.parseBodyFragment(fields.main).body.getElementsByClass("element-video").asScala.headOption
 
   lazy val mainVideoCanonicalPath: Option[String] = mainMediaVideo.flatMap(video => {
     video.attr("data-canonical-url") match {
@@ -337,14 +337,14 @@ final case class Content(
     meta.flatten.toMap
   }
 
-  val opengraphProperties = Map(
+  val opengraphProperties: Map[String, String] = Map(
     "og:title" -> metadata.webTitle,
     "og:description" -> fields.trailText.map(StripHtmlTagsAndUnescapeEntities(_)).getOrElse(""),
     "og:image" -> openGraphImage
   ) ++ openGraphImageWidth.map("og:image:width" -> _.toString).toMap ++
     openGraphImageHeight.map("og:image:height" -> _.toString).toMap
 
-  val twitterProperties = Map(
+  val twitterProperties: Map[String, String] = Map(
     "twitter:app:url:googleplay" -> metadata.webUrl.replaceFirst("^[a-zA-Z]*://", "guardian://"), //replace current scheme with guardian mobile app scheme
     "twitter:image" -> twitterCardImage,
     "twitter:card" -> "summary_large_image"
@@ -353,7 +353,10 @@ final case class Content(
   val quizzes: Seq[Quiz] = atoms.map(_.quizzes).getOrElse(Nil)
   val media: Seq[MediaAtom] = atoms.map(_.media).getOrElse(Nil)
 
-  val nonCompliantOutbrainAmp = (hasStoryPackage && tags.series.nonEmpty) || (tags.series.length > 1)
+  val nonCompliantOutbrainAmp: Boolean = (hasStoryPackage && tags.series.nonEmpty) || (tags.series.length > 1)
+
+  lazy val submetaLinks: SubMetaLinks =
+    SubMetaLinks.make(isImmersive, tags, blogOrSeriesTag, isFromTheObserver, sectionLabelLink, sectionLabelName)
 }
 
 object Content {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
 import implicits.Dates.CapiRichDateTime
 import common.commercial.{AdUnitMaker, CommercialProperties}
 import common.dfp._
-import common.{Edition, ManifestData, Pagination}
+import common.{Edition, LinkTo, Localisation, ManifestData, Pagination}
 import conf.Configuration
 import conf.cricketPa.CricketTeams
 import model.content._
@@ -20,6 +20,8 @@ import play.api.libs.json._
 import play.api.libs.json.JodaWrites.JodaDateTimeWrites
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
+
+import scala.util.matching.Regex
 
 object Commercial {
 
@@ -645,6 +647,64 @@ final case class Elements(elements: Seq[Element]) {
   }
 }
 
+final case class SubMetaLink(
+  link: String,
+  text: String,
+  dataLinkName: Option[String] = None
+)
+
+final case class SubMetaLinks(
+  sectionLabels: List[SubMetaLink],
+  keywords: List[SubMetaLink]
+)
+
+object SubMetaLinks {
+
+  def makeKeywordName(keywordTag: Tag, keywords: List[Tag]): String = {
+    if (keywords.count(_.name == keywordTag.name) > 1){
+      s"${keywordTag.name} (${keywordTag.properties.sectionName})"
+    } else {
+      keywordTag.name
+    }
+  }
+
+  def make(isImmersive: Boolean, tags: Tags, blogOrSeriesTag: Option[Tag], isFromTheObserver: Boolean,
+    sectionLabelLink: String, sectionLabelName: String): SubMetaLinks = {
+    val sectionLink = if (!(isImmersive && tags.isArticle)) {
+      Some(SubMetaLink(s"/$sectionLabelLink", sectionLabelName, Some("article section")))
+    } else None
+
+    val secondaryLink = if (blogOrSeriesTag.isDefined) {
+      blogOrSeriesTag.map(t => SubMetaLink(t.id, t.name))
+    } else if (isFromTheObserver) {
+      Some(SubMetaLink("https://www.theguardian.com/observer", "The Observer"))
+    } else {
+      None
+    }
+
+    val sectionLabels = List(sectionLink, secondaryLink).flatten
+
+    val keywordSubMetaLinks = tags.keywords
+      .filterNot(_.isSectionTag)
+      .filterNot(t => blogOrSeriesTag.exists(s => s.id == t.id))
+      .take(6)
+      .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))
+
+
+    val toneTag = if (tags.isArticle && !tags.isLiveBlog) {
+      List(tags.tones.headOption.map(tone => SubMetaLink(
+        tone.metadata.url,
+        tone.name.toLowerCase,
+        Some(s"tone: ${tone.name.toLowerCase}"))))
+    } else List()
+
+    val subMetaLinks = keywordSubMetaLinks ++ toneTag.flatten
+
+    SubMetaLinks(sectionLabels, subMetaLinks)
+
+  }
+}
+
 /**
  * Tags lets you extract meaning from tags on a page.
  */
@@ -681,20 +741,20 @@ final case class Tags(
   def isNews: Boolean = !(isLiveBlog || isComment || isFeature)
 
   lazy val isLiveBlog: Boolean = tones.exists(t => Tags.liveMappings.contains(t.id))
-  lazy val isComment = tones.exists(t => Tags.commentMappings.contains(t.id))
-  lazy val isFeature = tones.exists(t => Tags.featureMappings.contains(t.id))
-  lazy val isInterview = tones.exists(t => Tags.interviewMappings.contains(t.id))
-  lazy val isReview = tones.exists(t => Tags.reviewMappings.contains(t.id))
-  lazy val isMedia = types.exists(t => Tags.mediaTypes.contains(t.id))
-  lazy val isAnalysis = tones.exists(_.id == Tags.Analysis)
-  lazy val isPodcast = isAudio && (types.exists(_.id == Tags.Podcast) || tags.exists(_.properties.podcast.isDefined))
-  lazy val isAudio = types.exists(_.id == Tags.Audio)
-  lazy val isEditorial = tones.exists(_.id == Tags.Editorial)
-  lazy val isCartoon = types.exists(_.id == Tags.Cartoon)
-  lazy val isLetters = tones.exists(_.id == Tags.Letters)
-  lazy val isCrossword = types.exists(_.id == Tags.Crossword)
-  lazy val isMatchReport = tones.exists(_.id == Tags.MatchReports)
-  lazy val isQuiz = tones.exists(_.id == Tags.quizzes)
+  lazy val isComment: Boolean = tones.exists(t => Tags.commentMappings.contains(t.id))
+  lazy val isFeature: Boolean = tones.exists(t => Tags.featureMappings.contains(t.id))
+  lazy val isInterview: Boolean = tones.exists(t => Tags.interviewMappings.contains(t.id))
+  lazy val isReview: Boolean = tones.exists(t => Tags.reviewMappings.contains(t.id))
+  lazy val isMedia: Boolean = types.exists(t => Tags.mediaTypes.contains(t.id))
+  lazy val isAnalysis: Boolean = tones.exists(_.id == Tags.Analysis)
+  lazy val isPodcast: Boolean = isAudio && (types.exists(_.id == Tags.Podcast) || tags.exists(_.properties.podcast.isDefined))
+  lazy val isAudio: Boolean = types.exists(_.id == Tags.Audio)
+  lazy val isEditorial: Boolean = tones.exists(_.id == Tags.Editorial)
+  lazy val isCartoon: Boolean = types.exists(_.id == Tags.Cartoon)
+  lazy val isLetters: Boolean = tones.exists(_.id == Tags.Letters)
+  lazy val isCrossword: Boolean = types.exists(_.id == Tags.Crossword)
+  lazy val isMatchReport: Boolean = tones.exists(_.id == Tags.MatchReports)
+  lazy val isQuiz: Boolean = tones.exists(_.id == Tags.quizzes)
 
   lazy val isArticle: Boolean = tags.exists { _.id == Tags.Article }
   lazy val isSudoku: Boolean = tags.exists { _.id == Tags.Sudoku } || tags.exists(t => t.id == "lifeandstyle/series/sudoku")
@@ -706,23 +766,27 @@ final case class Tags(
 
   lazy val hasLargeContributorImage: Boolean = tagsOfType("Contributor").exists(_.properties.contributorLargeImagePath.nonEmpty)
 
-  lazy val isCricketLiveBlog = isLiveBlog &&
+  lazy val isCricketLiveBlog: Boolean = isLiveBlog &&
     tags.map(_.id).exists(tagId => CricketTeams.teamTagIds.contains(tagId)) &&
     tags.map(_.id).contains("sport/over-by-over-reports")
 
-  lazy val isRugbyMatch = (isMatchReport || isLiveBlog) &&
+  lazy val isRugbyMatch: Boolean = (isMatchReport || isLiveBlog) &&
     tags.exists(t => t.id == "sport/rugby-union")
 
-  lazy val isClimateChangeSeries = tags.exists(t => t.id =="environment/series/keep-it-in-the-ground")
-  lazy val isTheMinuteArticle = tags.exists(t => t.id == "tone/minute")
+  lazy val isClimateChangeSeries: Boolean = tags.exists(t => t.id =="environment/series/keep-it-in-the-ground")
+  lazy val isTheMinuteArticle: Boolean = tags.exists(t => t.id == "tone/minute")
   //this is for the immersive header to access this info
-  lazy val isPaidContent = tags.exists( t => t.id == "tone/advertisement-features" )
+  lazy val isPaidContent: Boolean = tags.exists( t => t.id == "tone/advertisement-features" )
 
-  lazy val isPolitics = tags.exists(t => t.id=="politics/politics")
 
-  lazy val keywordIds = keywords.map { _.id }
+  lazy val isPolitics: Boolean = tags.exists(t => t.id=="politics/politics")
 
-  lazy val commissioningDesks = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }
+  lazy val keywordIds: List[String] = keywords.map { _.id }
+
+  lazy val commissioningDesks: List[String] = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }
+  lazy val blogOrSeriesTag: Option[Tag] = {
+    tags.find( tag => tag.showSeriesInMeta && (tag.isBlog || tag.isSeries ))
+  }
 
   def javascriptConfig: Map[String, JsValue] = Map(
     ("keywords", JsString(keywords.map { _.name }.mkString(","))),
@@ -790,7 +854,7 @@ object Tags {
     "tone/reviews"
   )
 
-  val CommissioningDesk = """tracking/commissioningdesk/(.*)""".r
+  val CommissioningDesk: Regex = """tracking/commissioningdesk/(.*)""".r
 
   def make(apiContent: contentapi.Content): Tags = {
     Tags(apiContent.tags.toList map { Tag.make(_) })

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -686,6 +686,7 @@ object SubMetaLinks {
 
     val keywordSubMetaLinks = tags.keywords
       .filterNot(_.isSectionTag)
+      .filterNot(_.name == sectionLabelName)
       .filterNot(t => blogOrSeriesTag.exists(s => s.id == t.id))
       .take(6)
       .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -653,12 +653,18 @@ final case class SubMetaLink(
   dataLinkName: Option[String] = None
 )
 
+object SubMetaLink {
+  implicit val writes: OWrites[SubMetaLink] = Json.writes[SubMetaLink]
+}
+
 final case class SubMetaLinks(
   sectionLabels: List[SubMetaLink],
   keywords: List[SubMetaLink]
 )
 
 object SubMetaLinks {
+
+  implicit val writes: OWrites[SubMetaLinks] = Json.writes[SubMetaLinks]
 
   def makeKeywordName(keywordTag: Tag, keywords: List[Tag]): String = {
     if (keywords.count(_.name == keywordTag.name) > 1){

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -24,65 +24,28 @@
         }
 
         <ul class="submeta__links">
-            @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
+            @content.content.submetaLinks.sectionLabels.map { label =>
                 <li class="submeta__link-item">
                     <a class="submeta__link"
-                        data-link-name="article section"
-                        href="@LinkTo {/@content.content.sectionLabelLink}">
-                            @Html(Localisation(content.content.sectionLabelName))
+                    data-link-name="@label.dataLinkName.getOrElse("")"
+                    href="@LinkTo {@label.link}">
+                    @Html(Localisation(label.text ))
                     </a>
                 </li>
-            }
-
-            @content.content.blogOrSeriesTag.map { series =>
-                <li class="submeta__link-item">
-                    <a class="submeta__link"
-                       href="@LinkTo {/@series.id}">
-                            @series.name
-                    </a>
-                </li>
-            }.getOrElse {
-                @if(content.content.isFromTheObserver) {
-                    <li class="submeta__link-item">
-                        <a class="submeta__link"
-                           href="https://www.theguardian.com/observer">
-                               The Observer
-                        </a>
-                    </li>
-                }
             }
         </ul>
     </div>
 
     <div class="submeta__keywords">
         <ul class="submeta__links">
-            @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
-                    @if(shownKeywords.nonEmpty) {
-                        @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                            <li class="submeta__link-item">
-                                <a class="submeta__link"
-                                    href="@LinkTo(keyword.metadata.url)"
-                                    data-link-name="keyword: @keyword.id">
-                                        @keyword.name
-                                        @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
-                                </a>
-                            </li>
-                        }
-                    }
-                }
-
-                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-                    @content.tags.tones.headOption.map { tone =>
-                        <li class="submeta__link-item">
-                            <a class="submeta__link"
-                                href="@LinkTo(tone.metadata.url)"
-                                data-link-name="tone: @tone.name">
-                                    @tone.name.toLowerCase
-                            </a>
-                        </li>
-                    }
-                }
+            @content.content.submetaLinks.keywords.map { keyword =>
+                <li class="submeta__link-item">
+                    <a class="submeta__link"
+                    href="@LinkTo(keyword.link)"
+                    data-link-name="@keyword.dataLinkName.getOrElse("")">
+                        @keyword.text
+                    </a>
+                </li>
             }
         </ul>
     </div>


### PR DESCRIPTION
## What does this change?
Adds a new property called `submetaLinks` to the `Content` class which contains the exact sections/tags that should be linked to at the foot of an article, thus enabling the logic in submeta.scala.html to be significantly simplified. 

This is part of a general nice aim of pulling logic out of templates and into our content model, which will help with dotcom-rendering as well as general cleanliness. 

As part of the restructure I've also fixed the issue discussed here https://github.com/guardian/frontend/pull/20542

## Screenshots
Before
![screen shot 2018-10-30 at 15 12 50](https://user-images.githubusercontent.com/3606555/47728464-4fdd4700-dc56-11e8-8364-494cdb50554d.png)
After
![screen shot 2018-10-30 at 15 11 10](https://user-images.githubusercontent.com/3606555/47728456-4ce25680-dc56-11e8-9d5e-a52797d676db.png)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
