### PR TITLE
Add invc to AppNexus keywords if prebidAppNexusInvcode is switched on

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -107,7 +107,10 @@ export const getAppNexusDirectBidParams = (
             return {
                 invCode,
                 member: '7012',
-                keywords: buildAppNexusTargetingObject(buildPageTargeting()),
+                keywords: {
+                    invc: [invCode],
+                    ...buildAppNexusTargetingObject(buildPageTargeting()),
+                },
             };
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -17,7 +17,11 @@ import {
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
-    buildAppNexusTargetingObject: () => 'someAppNexusTargetingObject',
+    buildAppNexusTargetingObject: () => ({
+        url: 'gu.com',
+        sens: 'f',
+        edition: 'UK',
+    }),
     buildPageTargeting: () => 'pageTargeting',
 }));
 
@@ -221,7 +225,7 @@ describe('getAppNexusServerSideBidParams', () => {
         getBreakpointKey.mockReturnValue('M');
         window.OzoneLotameData = { some: 'lotamedata' };
         expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
-            keywords: 'someAppNexusTargetingObject',
+            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '13366904',
             lotame: { some: 'lotamedata' },
         });
@@ -230,7 +234,7 @@ describe('getAppNexusServerSideBidParams', () => {
     test('should excude lotame if data is unavailable', () => {
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
-            keywords: 'someAppNexusTargetingObject',
+            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '13366904',
         });
     });
@@ -249,7 +253,7 @@ describe('getAppNexusDirectBidParams', () => {
     test('should include placementId for AU region when invCode switch is off', () => {
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
+            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
         });
     });
@@ -258,7 +262,12 @@ describe('getAppNexusDirectBidParams', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
+            keywords: {
+                edition: 'UK',
+                sens: 'f',
+                url: 'gu.com',
+                invc: ['Mmagic300x250'],
+            },
             member: '7012',
             invCode: 'Mmagic300x250',
         });
@@ -268,7 +277,7 @@ describe('getAppNexusDirectBidParams', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
         expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
-            keywords: 'someAppNexusTargetingObject',
+            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '4298191',
         });
     });


### PR DESCRIPTION
## What does this change and what is the value of this?

#### 👉If InvCode is switched on also include the invcode string in the keywords

- Allow AppNexus to log the unmapped invcodes and identify where fallbacks are occurring 

- This effect is limited to AU geolocation and AppNexusDirect bidparams

Read more on the CommDev trello card: https://trello.com/c/ngxzjzde

#### 👉 Update the tests so that someAppNexusTargetingObject is actually an Object

- The tests can cover the new logic and ensure that the invc keyword is only included when conditions are correct

- Test data more accurately reflects PROD data

## Screenshots

<img width="549" alt="screen shot 2018-10-30 at 16 24 22" src="https://user-images.githubusercontent.com/8607683/47734713-c6804180-dc62-11e8-9996-1bd25157bead.png">


## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

