### PR TITLE
Updates the front connected to the Universities email banner

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -284,8 +284,8 @@ case object HealthcareProfessionalsNetwork extends FrontEmailMetadata {
   override val banner = Some("healthcare-professionals-network.png")
 }
 
-case object HigherEducationNetwork extends FrontEmailMetadata {
-  val name = "Higher Education Network"
+case object GuardianUniversities extends FrontEmailMetadata {
+  val name = "Guardian Universities"
   override val banner = Some("universities.png")
 }
 
@@ -388,7 +388,7 @@ object EmailAddons {
     USMorningBriefing)
   private val frontEmails = Seq(
     SocialCareNetwork,
-    HigherEducationNetwork,
+    GuardianUniversities,
     GuardianStudents,
     HealthcareProfessionalsNetwork,
     PublicLeadersNetwork,


### PR DESCRIPTION
## What does this change?

Updates the guardian universities email banner to go with the "Guardian Universities" email front, instead of the "Higher Education Network" front.

## Screenshots

No visual change — it's an existing banner

## What is the value of this and can you measure success?

This is an editorial request

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
