### PR TITLE
Update thank-you page copy + design

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -159,6 +159,6 @@ class AuthenticatedActions(
     noOpActionBuilder andThen consentAuthRefiner andThen retrieveUserFromIdapiRefiner
 
   /** Enforce a validated email */
-  def consentAuthWithIdapiUserWithEmailValidation(): ActionBuilder[AuthRequest, AnyContent] =
+  def consentAuthWithIdapiUserWithEmailValidation: ActionBuilder[AuthRequest, AnyContent] =
     consentAuthWithIdapiUserAction andThen emailValidationFilter
 }

--- a/identity/app/controllers/UpsellController.scala
+++ b/identity/app/controllers/UpsellController.scala
@@ -47,7 +47,7 @@ class UpsellController(
     with IdentitySwitches {
 
   def confirmEmailThankYou(returnUrl: Option[String]): Action[AnyContent] = if (IdentityEnableUpsellJourneysSwitch.isSwitchedOn) csrfAddToken {
-    authenticatedActions.consentAuthWithIdapiUserAction.async { implicit request =>
+    authenticatedActions.consentAuthWithIdapiUserWithEmailValidation.async { implicit request =>
       val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request)
       val email = request.user.primaryEmailAddress
       val hasPassword = request.user.hasPassword.getOrElse(true)

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -19,7 +19,7 @@
 
 @noJsBehaviour = @{
     pageVariant match {
-        case ConfirmEmailThankYou => "Thank you! You’re now subscribed"
+        case ConfirmEmailThankYou => "Thank you! You’re now subscribed."
     }
 }
 

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -88,7 +88,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(None)
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
 
-      val result = actions.consentAuthWithIdapiUserWithEmailValidation().apply(failTest)(request)
+      val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(failTest)(request)
       val expectedLocation = s"/signin?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
       whenReady(result) { res =>
         res.header.status shouldBe 303
@@ -108,7 +108,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(mockFunc.apply(1)) thenReturn mock[Result]
       def callMock: AuthRequest[AnyContent] => Result = _ => mockFunc.apply(1)
 
-      val result = actions.consentAuthWithIdapiUserWithEmailValidation().apply(callMock)(request)
+      val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(callMock)(request)
       whenReady(result) { res =>
         verify(mockFunc).apply(1)
       }
@@ -126,7 +126,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(mockFunc.apply(1)) thenReturn mock[Result]
       def callMock: AuthRequest[AnyContent] => Result = _ => mockFunc.apply(1)
 
-      val result = actions.consentAuthWithIdapiUserWithEmailValidation().apply(callMock)(request)
+      val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(callMock)(request)
       whenReady(result) { res =>
         verify(mockFunc).apply(1)
       }
@@ -139,7 +139,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(notRecentlyAuthedUser))
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
 
-      val result = actions.consentAuthWithIdapiUserWithEmailValidation().apply(failTest)(request)
+      val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(failTest)(request)
       val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
       whenReady(result) { res =>
         res.header.status shouldBe 303

--- a/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
@@ -8,20 +8,19 @@ type CheckboxHtmlProps = {
 
 type CheckboxProps = {
     title: string,
-    subtitle: ?string,
+    key: string,
     checkboxHtmlProps: CheckboxHtmlProps,
 };
 
-const Checkbox = ({ title, subtitle, checkboxHtmlProps }: CheckboxProps) => (
+const Checkbox = ({ title, key, checkboxHtmlProps }: CheckboxProps) => (
     <label
-        data-link-name={`upsell-consent : checkbox : ${title} : ${
+        data-link-name={`upsell-consent : checkbox : ${key} : ${
             checkboxHtmlProps.checked ? 'untick' : 'tick'
         }`}
         className="identity-upsell-checkbox"
-        htmlFor={title}>
+        htmlFor={key}>
         <span className="identity-upsell-checkbox__title">{title}</span>
-        {subtitle && <span>{subtitle}</span>}
-        <input type="checkbox" id={title} {...checkboxHtmlProps} />
+        <input type="checkbox" id={key} {...checkboxHtmlProps} />
         <span className="identity-upsell-checkbox__checkmark">
             <span className="identity-upsell-checkbox__checkmark_tick" />
         </span>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
@@ -8,19 +8,19 @@ type CheckboxHtmlProps = {
 
 type CheckboxProps = {
     title: string,
-    key: string,
+    uniqueId: string,
     checkboxHtmlProps: CheckboxHtmlProps,
 };
 
-const Checkbox = ({ title, key, checkboxHtmlProps }: CheckboxProps) => (
+const Checkbox = ({ title, uniqueId, checkboxHtmlProps }: CheckboxProps) => (
     <label
-        data-link-name={`upsell-consent : checkbox : ${key} : ${
+        data-link-name={`upsell-consent : checkbox : ${uniqueId} : ${
             checkboxHtmlProps.checked ? 'untick' : 'tick'
         }`}
         className="identity-upsell-checkbox"
-        htmlFor={key}>
+        htmlFor={uniqueId}>
         <span className="identity-upsell-checkbox__title">{title}</span>
-        <input type="checkbox" id={key} {...checkboxHtmlProps} />
+        <input type="checkbox" id={uniqueId} {...checkboxHtmlProps} />
         <span className="identity-upsell-checkbox__checkmark">
             <span className="identity-upsell-checkbox__checkmark_tick" />
         </span>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -10,6 +10,7 @@ import {
 import type { ConsentWithState } from '../store/types';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 import { ExpanderButton } from '../button/ExpanderButton';
+import {LegalTextBlock} from "common/modules/identity/upsell/block/LegalTextBlock";
 
 const getConsents = (): Promise<ConsentWithState[]> => {
     const userConsents = getUserConsents([
@@ -151,6 +152,19 @@ class FollowCardList extends React.Component<Props, State> {
                         )}
                     </div>
                 )}
+                <LegalTextBlock>
+                    By subscribing, you confirm that you are 13 years or older. The
+                    Guardian’s newsletters may include advertising and messages about
+                    the Guardian’s other products and services, such as Jobs and
+                    Masterclasses. To find out what personal data we collect and how we
+                    use it, please visit our&nbsp;
+                    <a
+                        data-link-name="upsell-privacy-link"
+                        className="u-underline identity-upsell-consent-card__link"
+                        href={`https://www.theguardian.com/info/privacy`}>
+                        Privacy Policy.
+                    </a>
+                </LegalTextBlock>
             </div>
         );
     }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -7,10 +7,10 @@ import {
     getNewsLetterConsents,
     getUserConsents,
 } from 'common/modules/identity/upsell/store/consents';
+import { LegalTextBlock } from 'common/modules/identity/upsell/block/LegalTextBlock';
 import type { ConsentWithState } from '../store/types';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 import { ExpanderButton } from '../button/ExpanderButton';
-import {LegalTextBlock} from "common/modules/identity/upsell/block/LegalTextBlock";
 
 const getConsents = (): Promise<ConsentWithState[]> => {
     const userConsents = getUserConsents([
@@ -153,15 +153,15 @@ class FollowCardList extends React.Component<Props, State> {
                     </div>
                 )}
                 <LegalTextBlock>
-                    By subscribing, you confirm that you are 13 years or older. The
-                    Guardian’s newsletters may include advertising and messages about
-                    the Guardian’s other products and services, such as Jobs and
-                    Masterclasses. To find out what personal data we collect and how we
-                    use it, please visit our&nbsp;
+                    By subscribing, you confirm that you are 13 years or older.
+                    The Guardian’s newsletters may include advertising and
+                    messages about the Guardian’s other products and services,
+                    such as Jobs and Masterclasses. To find out what personal
+                    data we collect and how we use it, please visit our&nbsp;
                     <a
                         data-link-name="upsell-privacy-link"
                         className="u-underline identity-upsell-consent-card__link"
-                        href={`https://www.theguardian.com/info/privacy`}>
+                        href="https://www.theguardian.com/info/privacy">
                         Privacy Policy.
                     </a>
                 </LegalTextBlock>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
@@ -76,7 +76,7 @@ export class OptOutsList extends Component<
                         {consents.map(consent => (
                             <Checkbox
                                 title={consent.consent.description}
-                                key={consent.uniqueId}
+                                uniqueId={consent.uniqueId}
                                 checkboxHtmlProps={{
                                     checked: consent.hasConsented,
                                     onChange: ev => {

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
@@ -29,8 +29,7 @@ const Components = (props: Props): React.Component => {
             <NewsLetterSignUps />,
             <OptOuts />,
         ];
-    }
-    else if (!props.isUserLoggedIn) {
+    } else if (!props.isUserLoggedIn) {
         // TODO: sign in form
         components = [<NewsLetterSignUps />, <OptOuts />];
     }
@@ -39,7 +38,7 @@ const Components = (props: Props): React.Component => {
 };
 
 export const ConfirmEmailPage = (props: Props): React.Component => (
-    <div>
+    <div className="identity-upsell-wrapper">
         <Header title="Thank you!" subtitle="You’re now subscribed." />
         <Components {...props} />
     </div>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
@@ -30,7 +30,6 @@ const Components = (props: Props): React.Component => {
             <OptOuts />,
         ];
     }
-    // TODO: currently we sign them in. Need to resolve this!
     else if (!props.isUserLoggedIn) {
         // TODO: sign in form
         components = [<NewsLetterSignUps />, <OptOuts />];
@@ -41,7 +40,7 @@ const Components = (props: Props): React.Component => {
 
 export const ConfirmEmailPage = (props: Props): React.Component => (
     <div>
-        <Header title="Thank you!" subtitle="You’re now subscribed" />
+        <Header title="Thank you!" subtitle="You’re now subscribed." />
         <Components {...props} />
     </div>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -6,9 +6,7 @@ import { LegalTextBlock } from '../block/LegalTextBlock';
 import { OptOutsList } from '../opt-outs/OptOutsList';
 
 export const OptOuts = (): React.Component => (
-    <Block
-        sideBySideBackwards
-        title="Your communication preferences">
+    <Block sideBySideBackwards title="Your communication preferences">
         <LegalTextBlock>
             You can also change these settings later by visiting the Emails &
             marketing section of your account.

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -8,8 +8,7 @@ import { OptOutsList } from '../opt-outs/OptOutsList';
 export const OptOuts = (): React.Component => (
     <Block sideBySideBackwards title="Your communication preferences">
         <LegalTextBlock>
-            You can also change these settings later by visiting the Emails &
-            marketing section of your account.
+            You can always change these preferences later by visiting your account settings.
         </LegalTextBlock>
         <OptOutsList />
     </Block>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -8,7 +8,8 @@ import { OptOutsList } from '../opt-outs/OptOutsList';
 export const OptOuts = (): React.Component => (
     <Block sideBySideBackwards title="Your communication preferences">
         <LegalTextBlock>
-            You can always change these preferences later by visiting your account settings.
+            You can always change these preferences later by visiting your
+            account settings.
         </LegalTextBlock>
         <OptOutsList />
     </Block>

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -8,10 +8,9 @@ import { OptOutsList } from '../opt-outs/OptOutsList';
 export const OptOuts = (): React.Component => (
     <Block
         sideBySideBackwards
-        title="One more thing..."
-        subtitle="These are your privacy settings. You’re in full control of them.">
+        title="Your communication preferences">
         <LegalTextBlock>
-            You can also change these settings any time by visiting our Emails &
+            You can also change these settings later by visiting the Emails &
             marketing section of your account.
         </LegalTextBlock>
         <OptOutsList />

--- a/static/src/stylesheets/module/identity/upsell/_base.scss
+++ b/static/src/stylesheets/module/identity/upsell/_base.scss
@@ -28,7 +28,6 @@
 
     .identity-upsell-checkbox__title {
         @include fs-textSans(5, true);
-        font-weight: 600;
         display: block;
     }
 

--- a/static/src/stylesheets/module/identity/upsell/_card.scss
+++ b/static/src/stylesheets/module/identity/upsell/_card.scss
@@ -36,6 +36,7 @@
 
 .identity-upsell-consent-card-footer {
     margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
     display: flex;
     flex-direction: column;
     @include mq(tablet) {

--- a/static/src/stylesheets/module/identity/upsell/_layout.scss
+++ b/static/src/stylesheets/module/identity/upsell/_layout.scss
@@ -105,6 +105,9 @@
             }
         }
     }
+    a.u-underline {
+        color: $brightness-7;
+    }
 }
 
 .identity-upsell-title {
@@ -128,6 +131,6 @@
 }
 
 .identity-upsell-legal-text-block {
-    @include fs-textSans(5);
+    @include fs-textSans(4);
     color: $brightness-46;
 }


### PR DESCRIPTION
## What does this change?
This PR makes a few tweaks to the thank-you page based on feedback.  Namely:

- Removes placeholder wording from the opt-outs
- Unbolds the opt-outs
- Makes the background of the page white (in line with designs and to make cards stand out
- Adds required legal text below cards
- Adds fullstops
- Tweaks link name attributes for more sensible naming convention in ophan click events
- Stops unvalidated accounts from reaching this page (ought to double check ajax endpoints in another PR)

Sorry it got a bit big!

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/47846729-d01fbb80-ddc0-11e8-9ff1-547edac93c57.png)
![image](https://user-images.githubusercontent.com/8754692/47846735-d746c980-ddc0-11e8-8cc5-7b89653b0461.png)
