### PR TITLE
Navigation Switch

### DIFF
--- a/admin/app/views/football/main.scala.html
+++ b/admin/app/views/football/main.scala.html
@@ -4,7 +4,7 @@
 @import controllers.admin.routes.UncachedWebAssets
 @import play.api.Mode.Dev
 @import conf.Static
-@import html.HtmlPageHelpers.ContentCSSFile
+@import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -20,6 +20,7 @@
             <!--[if (gt IE 9)|(IEMobile)]><!-->
         @if(context.environment.mode == Dev) {
             <link rel="stylesheet" type="text/css" href="@Static(s"stylesheets/head.$ContentCSSFile.css")" />
+            <link rel="stylesheet" type="text/css" href="@Static(s"stylesheets/head.$FooterCSSFile.css")" />
         } else {
             <style>
             @Html(common.Assets.css.head(None))

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -17,12 +17,17 @@ import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.ContentCSSFile
 import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, AudioPageChange, OldTLSSupportDeprecation}
+import views.html.stacked
 
 object ContentHtmlPage extends HtmlPage[Page] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
+      override def criticalCssLink: Html = stacked(
+        criticalStyleLink(ContentCSSFile),
+        criticalStyleLink(InlineNavigationCSSFile))
+      override def criticalCssInline: Html = criticalStyleInline(
+        Html(common.Assets.css.head(None)),
+        Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -14,7 +14,7 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, orielScriptTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import conf.switches.Switches.WeAreHiring
 import experiments.{ActiveExperiments, AudioPageChange, OldTLSSupportDeprecation}
 import views.html.stacked
@@ -29,6 +29,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         Html(common.Assets.css.head(None)),
         Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -32,7 +32,10 @@ object ContentHtmlPage extends HtmlPage[Page] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -22,12 +22,12 @@ import views.html.stacked
 object ContentHtmlPage extends HtmlPage[Page] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-      override def criticalCssLink: Html = stacked(
-        criticalStyleLink(ContentCSSFile),
-        criticalStyleLink(InlineNavigationCSSFile))
-      override def criticalCssInline: Html = criticalStyleInline(
-        Html(common.Assets.css.head(None)),
-        Html(common.Assets.css.inlineNavigation))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(None)),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -32,7 +32,10 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css", true)
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css", true)
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css", true)
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css", true)
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css", true)
   }
 

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -17,12 +17,17 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(None)),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css", true)
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css", true)
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css", true)

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -16,7 +16,7 @@ import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, sk
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
@@ -29,6 +29,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
       Html(common.Assets.css.head(None)),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css", true)
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css", true)
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css", true)
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css", true)
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css", true)

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -30,7 +30,10 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -14,7 +14,7 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object GalleryHtmlPage extends HtmlPage[GalleryPage] {
@@ -27,6 +27,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
       Html(common.Assets.css.head(None)),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -15,12 +15,17 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object GalleryHtmlPage extends HtmlPage[GalleryPage] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(None)),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -18,12 +18,17 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object IndexHtml {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(FaciaCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(Some("facia"))))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(Some("facia"))),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$FaciaCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -33,7 +33,10 @@ object IndexHtml {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$FaciaCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$FaciaCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -17,7 +17,7 @@ import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, sk
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object IndexHtml {
@@ -30,6 +30,7 @@ object IndexHtml {
       Html(common.Assets.css.head(Some("facia"))),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$FaciaCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$FaciaCSSFile.css")

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -23,11 +23,13 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
     override def criticalCssLink: Html = stacked(
       criticalStyleLink(ContentCSSFile),
-      criticalStyleLink("interactive")
+      criticalStyleLink("interactive"),
+      criticalStyleLink(InlineNavigationCSSFile)
     )
     override def criticalCssInline: Html = criticalStyleInline(
       Html(common.Assets.css.head(None)),
-      Html(common.Assets.css.interactive)
+      Html(common.Assets.css.interactive),
+      Html(common.Assets.css.inlineNavigation)
     )
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -16,7 +16,7 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
 import views.html.stacked
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 
 object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
 
@@ -32,6 +32,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       Html(common.Assets.css.inlineNavigation)
     )
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -35,7 +35,10 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -15,7 +15,7 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
-import html.HtmlPageHelpers.{ContentCSSFile, SignUpCSSFile}
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object NewsletterHtmlPage extends HtmlPage[SimplePage] {
@@ -28,6 +28,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
       Html(common.Assets.css.head(Some("signup"))),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -16,12 +16,17 @@ import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, 
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.{ContentCSSFile, SignUpCSSFile}
+import views.html.stacked
 
 object NewsletterHtmlPage extends HtmlPage[SimplePage] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(SignUpCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(Some("signup"))))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(Some("signup"))),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -31,7 +31,10 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -16,12 +16,17 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink("index")
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(Some("index"))))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink("index"),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(Some("index"))),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink("stylesheets/old-ie.head.index.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -31,7 +31,10 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink("stylesheets/old-ie.head.index.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink("stylesheets/ie9.head.index.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.index.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -15,7 +15,7 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
@@ -28,6 +28,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
       Html(common.Assets.css.head(Some("index"))),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink("stylesheets/old-ie.head.index.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink("stylesheets/ie9.head.index.css")

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -15,12 +15,17 @@ import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object StoryHtmlPage {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(ContentCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(None)),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -30,7 +30,10 @@ object StoryHtmlPage {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -14,7 +14,7 @@ import views.html.fragments.page._
 import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object StoryHtmlPage {
@@ -27,6 +27,7 @@ object StoryHtmlPage {
       Html(common.Assets.css.head(None)),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/article/test/SectionsNavigationFeatureTest.scala
+++ b/article/test/SectionsNavigationFeatureTest.scala
@@ -40,20 +40,20 @@ import conf.Configuration
       Given("I am on any guardian.co.uk page")
       US("/world/2012/aug/23/australia-mining-boom-end") { browser =>
 
-        Then("I should see a link to the contributors section")
-        val contributors = browser.find(".l-footer li a", withText().contains("contributors"))
+        Then("I should see a link to the contributors section!!")
+        val contributors = browser.find("[data-link-name='us : footer : all contributors']")
         contributors.asScala.length should be > 0
 
         And("a link to the contact us page")
-        val contact = browser.find(".l-footer li a", withText().contains("contact"))
+        val contact = browser.find("[data-link-name='us : footer : contact us']")
         contact.asScala.length should be > 0
 
         And("a link to the about us page")
-        val info = browser.find(".l-footer li a", withText().contains("about us"))
+        val info = browser.find("[data-link-name='us : footer : about us']")
         info.asScala.length should be > 0
 
         And("a link to the complaints and corrections")
-        val complaints = browser.find(".l-footer li a", withText().contains("complaints & corrections"))
+        val complaints = browser.find("[data-link-name='complaints']")
         complaints.asScala.length should be > 0
       }
     }
@@ -64,15 +64,12 @@ import conf.Configuration
 
         Then("I should see a link to the terms & Conditions in the page footer")
 
-        val terms = browser.find(".l-footer li a", withText().contains("terms"))
+        val terms = browser.find("[data-link-name='terms']")
         terms.asScala.length should be > 0
 
         And("a link to the privacy policy page")
-        val privacy = browser.find(".l-footer li a", withText().contains("privacy"))
-
-        privacy.asScala.length should be > 0
-
+        val privacy = browser.find("[data-link-name='privacy']")
+        privacy.asScala.length should be > 0}
       }
     }
-  }
 }

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -58,6 +58,7 @@ object css {
   private val memoizedCss: ConcurrentMap[String, Try[String]] = TrieMap()
 
   def head(projectOverride: Option[String])(implicit context: ApplicationContext, request: RequestHeader): String = inline(cssHead(projectOverride.getOrElse(context.applicationIdentity.name)))
+  def inlineNavigation(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "head.new-navigation" else "head.navigation"
   def inlineIdentity(implicit request: RequestHeader, context: ApplicationContext): String = inline("head.identity")
   def inlineStoryPackageGarnett(implicit context: ApplicationContext): String = inline("story-package-garnett")
   def inlinePhotoEssayGarnett(implicit context: ApplicationContext): String = inline("article-photo-essay-garnett")

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -58,7 +58,7 @@ object css {
   private val memoizedCss: ConcurrentMap[String, Try[String]] = TrieMap()
 
   def head(projectOverride: Option[String])(implicit context: ApplicationContext, request: RequestHeader): String = inline(cssHead(projectOverride.getOrElse(context.applicationIdentity.name)))
-  def inlineNavigation(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "head.new-navigation" else "head.navigation"
+  def inlineNavigation(implicit request: RequestHeader, context: ApplicationContext): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) inline("head.new-navigation") else inline("head.navigation")
   def inlineIdentity(implicit request: RequestHeader, context: ApplicationContext): String = inline("head.identity")
   def inlineStoryPackageGarnett(implicit context: ApplicationContext): String = inline("story-package-garnett")
   def inlinePhotoEssayGarnett(implicit context: ApplicationContext): String = inline("article-photo-essay-garnett")

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -494,4 +494,13 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val NewNavEnabled = Switch(
+    SwitchGroup.Feature,
+    "new-nav-enabled",
+    "If this is switched on then the new navigation will be enabled",
+    owners = Seq(Owner.withGithub("GHaberis")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
 }

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -35,7 +35,8 @@ object HtmlPageHelpers {
     Map(
       ("has-page-skin", page.metadata.hasPageSkin(edition)),
       ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
-      ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"))
+      ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
+      ("has-new-navigation", conf.switches.Switches.NewNavEnabled.isSwitchedOn));
   }
 
   def FaciaCSSFile(implicit request: RequestHeader): String = "facia.garnett"
@@ -43,6 +44,4 @@ object HtmlPageHelpers {
   def RichLinksCSSFile(implicit request: RequestHeader): String = "rich-links.garnett"
   def SignUpCSSFile(implicit request: RequestHeader): String = "signup"
   def InlineNavigationCSSFile(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "new.navigation" else "navigation"
-}
-
 }

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -42,4 +42,7 @@ object HtmlPageHelpers {
   def ContentCSSFile(implicit request: RequestHeader): String = "content.garnett"
   def RichLinksCSSFile(implicit request: RequestHeader): String = "rich-links.garnett"
   def SignUpCSSFile(implicit request: RequestHeader): String = "signup"
+  def InlineNavigationCSSFile(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "new.navigation" else "navigation"
+}
+
 }

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -43,5 +43,6 @@ object HtmlPageHelpers {
   def ContentCSSFile(implicit request: RequestHeader): String = "content.garnett"
   def RichLinksCSSFile(implicit request: RequestHeader): String = "rich-links.garnett"
   def SignUpCSSFile(implicit request: RequestHeader): String = "signup"
-  def InlineNavigationCSSFile(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "new.navigation" else "navigation"
+  def InlineNavigationCSSFile(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "new-navigation" else "navigation"
+  def FooterCSSFile(implicit request: RequestHeader): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) "new-footer" else "footer"
 }

--- a/common/app/html/Styles.scala
+++ b/common/app/html/Styles.scala
@@ -7,6 +7,7 @@ trait Styles {
   def criticalCssLink: Html
   def criticalCssInline: Html
   def linkCss: Html
+  def footerCss: Html
   def oldIECriticalCss: Html
   def oldIELinkCss: Html
   def IE9CriticalCss: Html

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -8,7 +8,7 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, Footer}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
-@import conf.switches.Switches.{ EmailInlineInFooterSwitch }
+@import conf.switches.Switches.{ EmailInlineInFooterSwitch, NewNavEnabled  }
 @import com.gu.identity.model.EmailNewsletters
 @import model.NoCache
 

--- a/common/app/views/fragments/page/head/stylesheets/styles.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/styles.scala.html
@@ -33,6 +33,7 @@
 <!--[if (lt IE 9)&(!IEMobile)]>
 @styles.oldIECriticalCss
 @styles.oldIELinkCss
+@styles.footerCss
 <![endif]-->
 
 @*
@@ -42,6 +43,7 @@
 <!--[if (IE 9)&(!IEMobile)]>
 @styles.IE9CriticalCss
 @styles.IE9LinkCss
+@styles.footerCss
 <![endif]-->
 
 @*

--- a/common/app/views/fragments/page/head/stylesheets/styles.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/styles.scala.html
@@ -52,6 +52,7 @@
 <!--[if (gt IE 9)|(IEMobile)]><!-->
 @styles.criticalCss
 @styles.linkCss
+@styles.footerCss
 <!--<![endif]-->
 
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -63,6 +63,7 @@
 } else {
     <style class="js-loggable">
         @Html(common.Assets.css.head(projectName))
+        @Html(common.Assets.css.inlineNavigation)
         @if(isInteractive) {
             @Html(common.Assets.css.interactive)
         }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -30,8 +30,12 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
   }
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink(FaciaCSSFile)
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(Some("facia"))))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink(FaciaCSSFile),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(Some("facia"))),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$FaciaCSSFile.css")
 
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -15,6 +15,7 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.stacked
+import html.HtmlPageHelpers.{ContentCSSFile, FaciaCSSFile, FooterCSSFile}
 
 object FrontHtmlPage extends HtmlPage[PressedPage] {
 
@@ -37,7 +38,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       Html(common.Assets.css.head(Some("facia"))),
       Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = stylesheetLink(s"stylesheets/$FaciaCSSFile.css")
-
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
 

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -41,8 +41,10 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$FaciaCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$FaciaCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$FaciaCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -31,7 +31,10 @@ object IdentityHtmlPage {
     override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
-    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stacked(
+      stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css"),
+      stylesheetLink(s"stylesheets/head.$InlineNavigationCSSFile.css")
+    )
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -13,12 +13,17 @@ import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import html.HtmlPageHelpers.ContentCSSFile
+import views.html.stacked
 
 object IdentityHtmlPage {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
-    override def criticalCssLink: Html = criticalStyleLink("identity")
-    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.inlineIdentity))
+    override def criticalCssLink: Html = stacked(
+      criticalStyleLink("identity"),
+      criticalStyleLink(InlineNavigationCSSFile))
+    override def criticalCssInline: Html = criticalStyleInline(
+      Html(common.Assets.css.head(None)),
+      Html(common.Assets.css.inlineNavigation))
     override def linkCss: Html = HtmlFormat.fill(List(
       stylesheetLink(s"stylesheets/$ContentCSSFile.css"),
       stylesheetLink(s"stylesheets/membership-icons.css")

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -12,7 +12,7 @@ import views.html.fragments.page._
 import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
-import html.HtmlPageHelpers.ContentCSSFile
+import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 import views.html.stacked
 
 object IdentityHtmlPage {
@@ -28,6 +28,7 @@ object IdentityHtmlPage {
       stylesheetLink(s"stylesheets/$ContentCSSFile.css"),
       stylesheetLink(s"stylesheets/membership-icons.css")
     ))
+    override def footerCss: Html = stylesheetLink(s"stylesheets/$FooterCSSFile.css")
     override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
     override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
     override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -20,7 +20,8 @@
 @import 'module/facia/_facia-show-more';
 @import 'module/_tag-list';
 @import 'module/_submeta';
-@import 'layout/_footer';
+// TODO: uncomment this line after new-navigation switch removed
+// @import 'layout/_footer';
 @import 'module/content-garnett/_media-player';
 @import 'module/atoms/_youtube';
 @import 'module/atoms/_media';

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -33,6 +33,7 @@
 
 @include grid-system;
 @import 'layout/_ab-new-header-test-variant';
+// TODO: uncomment this line after new-navigation switch removed
 // @import 'layout/_navigation';
 @import 'layout/_helpers';
 @import 'layout/_side-margins';

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -33,7 +33,7 @@
 
 @include grid-system;
 @import 'layout/_ab-new-header-test-variant';
-@import 'layout/_navigation';
+// @import 'layout/_navigation';
 @import 'layout/_helpers';
 @import 'layout/_side-margins';
 @import 'pasteup/layout/styles';

--- a/static/src/stylesheets/footer.scss
+++ b/static/src/stylesheets/footer.scss
@@ -1,0 +1,12 @@
+@import '_vars';
+@import '_mixins';
+@include grid-system;
+
+@import 'layout/nav/_variables';
+@import 'layout/footer/_variables';
+
+@import 'layout/footer/_footer';
+@import 'layout/footer/_back-to-top';
+@import 'layout/footer/_colophon';
+@import 'layout/footer/_copywrite';
+@import 'layout/footer/_email-container';

--- a/static/src/stylesheets/head.navigation.scss
+++ b/static/src/stylesheets/head.navigation.scss
@@ -1,0 +1,32 @@
+@import '_vars';
+@import '_mixins';
+@include grid-system;
+
+@import 'layout/nav/_variables';
+
+@import 'layout/nav/_new-header';
+
+@import 'layout/nav/_menu';
+@import 'layout/nav/_menu-group';
+@import 'layout/nav/_menu-item';
+@import 'layout/nav/_menu-search';
+
+@import 'layout/nav/_pillars';
+@import 'layout/nav/_pillar-link';
+
+@import 'layout/nav/_cta-bar';
+@import 'layout/nav/_top-bar';
+@import 'layout/nav/_top-bar-dropdown';
+@import 'layout/nav/_search-dropdown';
+
+@import 'layout/nav/_subnav';
+@import 'layout/nav/_subnav-link';
+
+@import 'layout/nav/_veggie-burger';
+@import 'layout/nav/_veggie-burger-fallback';
+
+@import 'layout/nav/_main-menu-toggle';
+@import 'layout/nav/_edition-picker-toggle';
+@import 'layout/nav/_my-account';
+
+@import 'layout/nav/_colours';

--- a/static/src/stylesheets/head.new-navigation.scss
+++ b/static/src/stylesheets/head.new-navigation.scss
@@ -1,0 +1,32 @@
+@import '_vars';
+@import '_mixins';
+@include grid-system;
+
+@import 'layout/nav/_variables';
+
+@import 'layout/nav/_new-header';
+
+@import 'layout/nav/_menu';
+@import 'layout/nav/_menu-group';
+@import 'layout/nav/_menu-item';
+@import 'layout/nav/_menu-search';
+
+@import 'layout/nav/_pillars';
+@import 'layout/nav/_pillar-link';
+
+@import 'layout/nav/_cta-bar';
+@import 'layout/nav/_top-bar';
+@import 'layout/nav/_top-bar-dropdown';
+@import 'layout/nav/_search-dropdown';
+
+@import 'layout/nav/_subnav';
+@import 'layout/nav/_subnav-link';
+
+@import 'layout/nav/_veggie-burger';
+@import 'layout/nav/_veggie-burger-fallback';
+
+@import 'layout/nav/_main-menu-toggle';
+@import 'layout/nav/_edition-picker-toggle';
+@import 'layout/nav/_my-account';
+
+@import 'layout/nav/_colours';

--- a/static/src/stylesheets/new-footer.scss
+++ b/static/src/stylesheets/new-footer.scss
@@ -1,0 +1,12 @@
+@import '_vars';
+@import '_mixins';
+@include grid-system;
+
+@import 'layout/nav/_variables';
+@import 'layout/footer/_variables';
+
+@import 'layout/footer/_footer';
+@import 'layout/footer/_back-to-top';
+@import 'layout/footer/_colophon';
+@import 'layout/footer/_copywrite';
+@import 'layout/footer/_email-container';


### PR DESCRIPTION
This PR will be merged into @zeftilldeath's branch.

### What does this change?

- Creates new feature switch `NewNavEnabled` in `FeatureSwitches.scala`

- Stops inlining current navigation styles by commenting `@import 'layout/_navigation'` in `_head.common.scss`. Doing this stops the existing nav's styles from implicitly being inlined in the `<head>`.

- In all `HtmlPage.scala` files we now explicitly include `common.Assets.css.inlineNavigation` in the styles inlined in the `<head>`.  The value of `common.Assets.css.inlineNavigation` will either point to `head.new-naviagtion` (if the switch is on) OR `head.navigation` (If the switch is off)

- Stops bundling current footer styles by commenting out `@import 'layout/_footer';` from `_common.garnett.scss`. Instead we will download a seperate new css bundles `new-footer.scss` (if switch on) and `footer.scss` (if switch off)

Once merged into @zeftilldeath's branch we'll need to do the following:

- Point `head.new-naviagtion.scss` and `new-footer.scss` to the new styles
- Point `head.naviagtion.scss` and `footer.scss` to the old (current) styles
- Wrap any template changes with the switch