### PR TITLE
Transpile vendorlist.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = {
                 test: /\.js$/,
                 // TODO: @guardian/dotcom-rendering is not properly published or pre-transpiled, so we have to
                 // transpile it as part of the frontend build step for now
-                exclude: /(node_modules(?!\/@guardian\/dotcom-rendering)|vendor)/,
+                exclude: /(node_modules(?!\/@guardian\/dotcom-rendering)|vendor\/)/,
                 loader: 'babel-loader',
             },
             {


### PR DESCRIPTION
## What does this change?

Updates the regex that excludes files from transpilation. The regex that was intended to exclude vendor code is also excluding the file `vendorlist.js`, which is causing problems for older browsers.

## Screenshots

![screen shot 2018-10-31 at 14 26 52](https://user-images.githubusercontent.com/5931528/47798698-ce062000-dd20-11e8-8fb2-0780951dde79.png)

## What is the value of this and can you measure success?

Currently, `vendorlist.js` is not being transpiled, which introduces a stray `const` into our built bundles. This causes fronts to break on IE9, probably among other older browsers.
