### PR TITLE
Support older versions of Safari

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -58,6 +58,7 @@
                             "last 1 Safari version",
                             "last 2 Firefox versions",
                             "last 2 Edge versions",
+                            "iOS 8"
                         ],
                     }
                 }],

--- a/.babelrc
+++ b/.babelrc
@@ -58,7 +58,6 @@
                             "last 1 Safari version",
                             "last 2 Firefox versions",
                             "last 2 Edge versions",
-                            "iOS 8"
                         ],
                     }
                 }],

--- a/tools/compile-css.js
+++ b/tools/compile-css.js
@@ -33,10 +33,10 @@ const SASS_SETTINGS = {
 const BROWSERS_LIST = [
     'Firefox >= 45',
     'Explorer >= 10',
-    'Safari >= 9',
+    'Safari >= 7',
     'Chrome >= 50',
 
-    'iOS >= 9',
+    'iOS >= 7',
     'Android >= 5',
     'BlackBerry >= 10',
     'ExplorerMobile >= 10',


### PR DESCRIPTION
## What does this change?

Adds iOS/Safari 7 to our CSS supported browser list.

This results in the following size increases in kb
![image](https://user-images.githubusercontent.com/2670496/47801990-41129500-dd27-11e8-84dd-e3d93a500bf6.png)
https://docs.google.com/spreadsheets/d/1rQPieWoDquxURmFQdfW5QCKQeCYNRwNj5AwLBn-UYic/edit?usp=sharing

## Screenshots
From:
![image](https://user-images.githubusercontent.com/2670496/47849152-8b981e00-ddc8-11e8-83d3-946ee6293bd8.png)

To:
![image](https://user-images.githubusercontent.com/2670496/47849089-58ee2580-ddc8-11e8-853b-b2f687336a00.png)



## What is the value of this and can you measure success?
Fixes fronts for Safari 7/8
## Checklist

This changes a build parameter, so should not affect any of this. 

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
