### PR TITLE
Avoid inserting MPU after first container thrasher on all fronts

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -24,7 +24,7 @@ object IndexCleaner {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
       CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.page.metadata.hasPageSkin(edition)),
-      CommercialMPUForFronts(isNetworkFront = false)
+      CommercialMPUForFronts()
     )
   }
 }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -711,11 +711,11 @@ object setSvgClasses {
   }
 }
 
-case class CommercialMPUForFronts(isNetworkFront: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends HtmlCleaner {
   override def clean(document: Document): Document = {
 
-    def isNetworkFrontWithThrasher(element: Element, index: Int): Boolean = {
-      index == 0 && isNetworkFront && element.hasClass("fc-container--thrasher")
+    def isFrontWithThrasher(element: Element, index: Int): Boolean = {
+      index == 0 && element.hasClass("fc-container--thrasher")
     }
 
     def hasAdjacentCommercialContainer(element: Element): Boolean = {
@@ -730,11 +730,12 @@ case class CommercialMPUForFronts(isNetworkFront: Boolean)(implicit val request:
 
     val containers: List[Element] = document.getElementsByClass("fc-container").asScala.toList
 
-    // On mobile, we remove the first container if it is a thrasher on a Network Front
+    // On mobile, we remove the first container if it is a thrasher
     // and remove a container if it, or the next sibling, is a commercial container
+    // we also exclude any containers that are directly before a thrasher
     // then we take every other container, up to a maximum of 10, for targeting MPU insertion
     val containersForCommercialMPUs = containers.zipWithIndex.collect {
-      case (x, i) if !isNetworkFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
+      case (x, i) if !isFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
     }.zipWithIndex.collect {
       case (x, i) if i % 2 == 0 => x
     }.take(10)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -714,7 +714,7 @@ object setSvgClasses {
 case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends HtmlCleaner {
   override def clean(document: Document): Document = {
 
-    def isFrontWithThrasher(element: Element, index: Int): Boolean = {
+    def hasFirstContainerThrasher(element: Element, index: Int): Boolean = {
       index == 0 && element.hasClass("fc-container--thrasher")
     }
 
@@ -735,7 +735,7 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
     // we also exclude any containers that are directly before a thrasher
     // then we take every other container, up to a maximum of 10, for targeting MPU insertion
     val containersForCommercialMPUs = containers.zipWithIndex.collect {
-      case (x, i) if !isFrontWithThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
+      case (x, i) if !hasFirstContainerThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
     }.zipWithIndex.collect {
       case (x, i) if i % 2 == 0 => x
     }.take(10)

--- a/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
+++ b/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
@@ -12,7 +12,7 @@ class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
     try source.mkString finally source.close()
   }
 
-  val body = getFileContent("fixtures/CommercialMPUForFronts.html").cleanWith(CommercialMPUForFronts(true)(FakeRequest()))
+  val body = getFileContent("fixtures/CommercialMPUForFronts.html").cleanWith(CommercialMPUForFronts()(FakeRequest()))
 
   it should "insert MPUs into applicable slices, and give them unique IDs" in {
     val desktopMPUs = body.getElementsByClass("fc-slice__item--mpu-candidate")
@@ -28,7 +28,7 @@ class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
     mobileMPUs.last.toString should include ("dfp-ad--inline1--mobile")
   }
 
-  it should "not count the first container, if it is a thrasher on a Network Front, when adding mobile MPUs" in {
+  it should "not count the first container, if it is a thrasher, when adding mobile MPUs" in {
     val thrasher = body.getElementsByClass("fc-container--first").first
     thrasher.id should be ("thrasher")
 

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -25,7 +25,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
       CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition)),
-      CommercialMPUForFronts(page.isNetworkFront)
+      CommercialMPUForFronts()
     )
   }
 

--- a/facia/app/views/package.scala
+++ b/facia/app/views/package.scala
@@ -12,7 +12,7 @@ object FrontsCleaner {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
       CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition)),
-      CommercialMPUForFronts(page.isNetworkFront)
+      CommercialMPUForFronts()
     )
   }
 }


### PR DESCRIPTION
## What does this change?

We currently only check for thrashers at the top of **network** fronts. However, we now want to avoid adding a MPU slot directly below any thrasher added to the top section of **any** fronts.

 🎃👻🎃

The [tone/recipes](https://www.theguardian.com/tone/recipes) front currently has a thrasher occupying the`fc-container--first` section. 

Inserting MPUs into fronts on mobile web has a fair amount of conditions:

> On mobile, we remove the first container if it is a thrasher
> and remove a container if it, or the next sibling, is a commercial container
> we also exclude any containers that are directly before a thrasher
> then we take every other container, up to a maximum of 10, for targeting MPU insertion

#### N.B. The exemption only applies to the top container!!
This change will still allow an MPU to insert directly after a thrasher if the thrasher is lower down the page. Maybe we want to avoid going either side of a thrasher, maybe not. We can tighten up the rules further and avoid inserting before or after thrashers like so:

```
    def hasAdjacentThrasher(element: Element): Boolean =
      element.hasClass("fc-container--thrasher") ||
      Option(element.nextElementSibling()).exists(_.hasClass("fc-container--thrasher"))
```

This would also prevent MPUs inserting directly after thrashers and allow us to delete the hasFirstContainerThrasher check. The tradeoff is potentially fewer MPUs on mobile web. 

## Screenshots

#### Before:

![mobile-mpu-before](https://user-images.githubusercontent.com/8607683/47801271-b54c3900-dd25-11e8-8eb4-0ec728806679.gif)

#### After:

![mobile-mpu-after](https://user-images.githubusercontent.com/8607683/47801286-bf6e3780-dd25-11e8-9df4-022d0647d802.gif)

## What is the value of this and can you measure success?

Beautiful website for mobile visitors 🌈🦄✨

Potentially fewer MPUs and ad impressions on mobile web 📉🤭💸

Link to CommDev trello card: https://trello.com/c/8niYglp2 

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] On CODE