### PR TITLE
AUDIO: Series page - actually fix css

### DIFF
--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -142,17 +142,23 @@
                     z-index: 8;
                 }
                 .artwork-holder {
-                    margin-bottom: -8px;
                     width: 100%;
                     top: 0;
-
-                    @include mq($from: desktop) {
+                    @include mq($until: mobileMedium) {
+                        margin-bottom: -$gs-baseline*4;
+                    }
+                    @include mq($from: mobileMedium, $until: mobileLandscape) {
+                        margin-bottom: -$gs-baseline*3;
+                    }
+                    @include mq($from: mobileLandscape) {
+                        margin-bottom: -$gs-baseline/2;
                     }
                     @include mq($from: phablet, $until: desktop) {
                         float: right;
                         position: relative;
                     }
                     svg {
+                        overflow: visible;
                         @include mq($until: phablet) {
                             width: 100%;
                         }
@@ -181,7 +187,7 @@
         display: block;
         margin: 0;
 
-        @include mq($from: mobile, $until: phablet) {
+        @include mq($until: phablet) {
             display: none;
         }
         .flagship-audio__subscribe-label {
@@ -223,7 +229,7 @@
     #flagship-audio__mobile-only {
         display: none;
 
-        @include mq($from: mobile, $until: phablet) {
+        @include mq($until: phablet) {
             display: block;
             padding: 0;
 


### PR DESCRIPTION
## What does this change?
🙈 
Makes the fix I intended to make in https://github.com/guardian/frontend/pull/20618
.. without breaking the other CSS. 

Basically I have removed the "inline-block" I added to span wrapping the svg, which was causing odd behaviour at wider breakpoints, and removed the `width:100%` on the svg at wider breakpoints. Which again caused some strange behaviour in Chrome. But not on Firefox. I don't know why. 

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
