### PR TITLE
Update placement ID of Amp Prebid call

### DIFF
--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -4,7 +4,6 @@ import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValue}
 import common.Edition
 import common.commercial.AdUnitMaker
-import conf.Configuration.environment
 import conf.switches.Switches.KruxSwitch
 import conf.switches.{Switch, Switches}
 import model.Article
@@ -37,7 +36,8 @@ case class AmpAdDataSlot(article: Article) {
 
 object AmpAdRtcConfig {
 
-  def toJsonString(prebidServerUrl: String): String = {
+  // if debug, give additional debug output in RTC responses
+  def toJsonString(prebidServerUrl: String, debug: Boolean): String = {
 
     val urls: Seq[(String, JsValueWrapper)] = {
 
@@ -56,11 +56,12 @@ object AmpAdRtcConfig {
        * and https://github.com/prebid/prebid-server/blob/master/docs/endpoints/openrtb2/amp.md#query-parameters
        */
       val ampPrebidUrl = {
-        val url = s"$prebidServerUrl/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)" +
+        val placementId = 11016434
+        val url = s"$prebidServerUrl/openrtb2/amp?tag_id=$placementId&w=ATTR(width)&h=ATTR(height)" +
           "&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)" +
           "&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"
         urlValue(
-          if (environment.isProd) url else s"$url&debug=1",
+          if (debug) s"$url&debug=1" else url,
           Switches.ampPrebid
         )
       }

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -2,6 +2,7 @@ package views.support.cleaner
 
 import common.Edition
 import conf.Configuration.commercial.prebidServerUrl
+import conf.Configuration.environment
 import model.Article
 import org.jsoup.nodes.{Document, Element}
 import views.support.{AmpAd, AmpAdDataSlot, AmpAdRtcConfig, HtmlCleaner}
@@ -96,7 +97,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
                    data-loading-strategy="prefer-viewability-over-views"
                    json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
                    data-slot={AmpAdDataSlot(article).toString()}
-                   rtc-config={AmpAdRtcConfig.toJsonString(prebidServerUrl)}
+                   rtc-config={AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = environment.isNonProd)}
                 ></amp-ad>
 
     val ampAdString = {

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -12,7 +12,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   private val prebidServerUrl = "http://localhost:8000"
 
   private val ampPrebidUrl =
-    "http://localhost:8000/openrtb2/amp?tag_id=1&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+    "http://localhost:8000/openrtb2/amp?tag_id=11016434&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
       "&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)" +
       "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&debug=1"
 
@@ -24,7 +24,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   "toJsonString" should "hold Prebid server and Krux config when both switches are on" in {
     KruxSwitch.switchOn()
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         kruxUrl,
@@ -34,13 +34,13 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   it should "hold no real-time config when both switches are off" in {
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
     json shouldBe JsNull
   }
 
   it should "hold Krux config when Krux switch is on" in {
     KruxSwitch.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         kruxUrl
@@ -50,11 +50,23 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   it should "hold Prebid server config when Prebid server switch is on" in {
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         ampPrebidUrl
       )
     )
+  }
+
+  it should "hold debug param in Amp Prebid URL if debugging" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    Json.stringify(json) should include("&debug=1")
+  }
+
+  it should "not hold debug param in Amp Prebid URL if not debugging" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = false))
+    Json.stringify(json) should not include "&debug=1"
   }
 }


### PR DESCRIPTION
The call to Prebid from an Amp now uses the correct placement ID.