### PR TITLE
Consolidate email fonts

### DIFF
--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -11,7 +11,7 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Text';
-    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff') format('woff');
+    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff2') format('woff2'), url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -19,7 +19,7 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Text';
-    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff') format('woff');
+    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff2') format('woff2'), url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff') format('woff');
     font-weight: normal;
     font-style: italic;
     font-stretch: normal;

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -11,8 +11,7 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Text';
-    src: url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg.eot');
-    src: url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg.eot?#iefix') format('embedded-opentype'), url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg.woff') format('woff'), url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg.ttf') format('truetype'), url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg.svg#Guardian-Text-Egyp-Web-Reg') format('svg');
+    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -20,8 +19,7 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Text';
-    src: url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg-It.eot');
-    src: url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg-It.eot?#iefix') format('embedded-opentype'), url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg-It.woff') format('woff'), url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg-It.ttf') format('truetype'), url('https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Reg-It.svg#Guardian-Text-Egyp-Web-Reg-It') format('svg');
+    src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff') format('woff');
     font-weight: normal;
     font-style: italic;
     font-stretch: normal;

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -13,14 +13,14 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Web Header';
-    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff') format('woff');
+    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2') format('woff2'), url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Guardian Egyptian Web Headline';
-    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff') format('woff');
+    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2') format('woff2'), url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff') format('woff');
     font-weight: 500;
     font-style: normal;
 }

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -13,18 +13,14 @@ $container-color: #ffffff;
 
 @font-face {
     font-family: 'Guardian Egyptian Web Header';
-    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2') format('woff2'),
-    url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff') format('woff'),
-    url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.ttf') format('truetype');
+    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Guardian Egyptian Web Headline';
-    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2') format('woff2'),
-    url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff') format('woff'),
-    url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.ttf') format('truetype');
+    src: url('https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff') format('woff');
     font-weight: 500;
     font-style: normal;
 }
@@ -79,7 +75,7 @@ $container-color: #ffffff;
 
 // td
 .ct__padding {
-    font-family: 'Guardian Egyptian Web Header', 'Guardian Egyptian Web Headline', Georgia, serif;
+    font-family: 'Guardian Egyptian Web Header', Georgia, serif;
     font-size: 26px;
     color: #121212;
     padding: 4px 12px 0;


### PR DESCRIPTION
## What does this change?

- use latest fonts hosted on `interactive.guim.co.uk`
- only attempt to ship woff (the [safest font format for email](https://litmus.com/blog/the-ultimate-guide-to-web-fonts), according to Litmus)

## What is the value of this and can you measure success?

Updates the fonts used by emails to be more consistent with the website. 

**Note:** custom fonts are only supported by Apple Mail on iOS, iPad and MacOS, as well as the Android 4.4 mail app. All other clients show fallbacks (mainly Georgia)

Reduces the HTML email size by around 200 bytes, in an attempt to avoid the Gmail clipping our longer emails.

## Checklist

### Tested

- [x] Locally
- [x] On CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
