### PR TITLE
Convert dotcomponents abtest to switch

### DIFF
--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -1,6 +1,5 @@
 package services.dotcomponents
 
-import experiments.{ActiveExperiments, Control, DotcomponentsRendering, Excluded, Participant}
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
 import services.dotcomponents.pickers.{RenderTierPickerStrategy, SimplePagePicker, WhitelistPicker}
@@ -11,14 +10,14 @@ object RenderingTierPicker {
   val picker: RenderTierPickerStrategy = new SimplePagePicker()
   val whitelist: RenderTierPickerStrategy = new WhitelistPicker()
 
-  def logRequest(msg:String, results:List[(String, Boolean)])(implicit request: RequestHeader): Unit =
+  def logRequest(msg: String, results: List[(String, Boolean)])(implicit request: RequestHeader): Unit =
     DotcomponentsLogger().withRequestHeaders(request).results(msg, results)
 
   def getRenderTierFor(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
 
     // all requests with ?guui automatically get remotely rendered
 
-    if(request.isGuui) {
+    if (request.isGuui) {
       return RemoteRender
     }
 
@@ -38,11 +37,10 @@ object RenderingTierPicker {
 
     // We use dotcomponents if we are in the AB test, and are supported
 
-    ActiveExperiments.groupFor(DotcomponentsRendering) match {
-      case Participant if supportedAndWhitelisted => RemoteRender
-      case Participant => LocalRender
-      case Control => LocalRender
-      case Excluded => LocalRender
+    if (conf.switches.Switches.DotcomRendering.isSwitchedOn && supportedAndWhitelisted) {
+      RemoteRender
+    } else {
+      LocalRender
     }
 
   }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -4,6 +4,17 @@ import conf.switches.Expiry.never
 import org.joda.time.LocalDate
 
 trait FeatureSwitches {
+
+  val DotcomRendering = Switch(
+    SwitchGroup.Feature,
+    "dotcom-rendering",
+    "If this switch is on, we will use the dotcom rendering tier for articles which are supported by it",
+    owners = Seq(Owner.withGithub("MatthewJWalls")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     CommercialClientLogging,
     OrielParticipation,
     OldTLSSupportDeprecation,
-    DotcomponentsRendering,
     HeaderSubscribeUKTest
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -48,14 +47,6 @@ object AudioPageChange extends Experiment(
   owners = Owner.group(SwitchGroup.Journalism),
   sellByDate = new LocalDate(2018, 12, 5),
   participationGroup = Perc0B
-)
-
-object DotcomponentsRendering extends Experiment(
-  name = "dotcomponents-rendering",
-  description = "This will allow rendering of articles to use dotcomponents, if that page is supported",
-  owners = Seq(Owner.withGithub("MatthewJWalls")),
-  sellByDate = new LocalDate(2018, 12, 31),
-  participationGroup = Perc50
 )
 
 object HeaderSubscribeUKTest extends Experiment(


### PR DESCRIPTION
## What does this change?

Converts dotcom rendering to use a feature switch instead of an AB test so we can free up the 50% abtest slot. This means for the whitelisted articles, 100% of traffic will go through dotcomponents.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
