### PR TITLE
Remove fc-link from image anchor

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -51,7 +51,7 @@ object EmailHelpers {
   def imgFromCard(card: ContentCard, colWidth: Int = 12)(implicit requestHeader: RequestHeader): Option[Html] = {
     val width = ((colWidth.toDouble / 12.toDouble) * FrontEmailImage.knownWidth).toInt
     imageUrlFromCard(card, width).map { url => Html {
-        s"""<a class="fc-link" ${card.header.url.hrefWithRel}>${img(width)(url, Some(card.header.headline))}</a>"""
+        s"""<a ${card.header.url.hrefWithRel}>${img(width)(url, Some(card.header.headline))}</a>"""
       }
     }
   }


### PR DESCRIPTION
## What does this change?

Removes the `fc-link` class from the anchor tag wrapping images

## What is the value of this and can you measure success?

This class doesn't add styles relevant to images, so it isn't needed.

