### PR TITLE
indent using 2 spaces in all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,29 +6,11 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.scala]
-indent_size = 2
-
-[*.sc]
-indent_size = 2
-
-[*.sbt]
-indent_size = 2
-
-[*.conf]
-indent_size = 2
-
-[package.json]
-indent_size = 2
-
-[riff-raff.yaml]
-indent_size = 2
 
 [makefile]
 indent_style = tab


### PR DESCRIPTION
## What does this change?
Indent using 2 spaces in all files. This is mainly because the twirl templates lean to the right sooooo much!

This will likely introduce some whitespace changes in new PRs as the templates are updated, but nothing too major.

## Screenshots
n/a

## What is the value of this and can you measure success?
Eyes move less.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
