### PR TITLE
Don't set display:none for links in header in print version

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -31,7 +31,6 @@
 .inline-icon,
 .element--thumbnail,
 .media-primary--showcase,
-.content__standfirst a,
 .content__standfirst br,
 figure,
 .new-header {


### PR DESCRIPTION
## What does this change?
Removes anchor tags in content__standfirst from having display: none. 

This fixes https://trello.com/c/4xzt5LqJ/441-investigate-bylines-disappearing-from-print-version-of-immersive-pages-on-firefox-48, though I suspect there was a reason for links being hidden. In the case of [this article](https://www.theguardian.com/us-news/2018/oct/21/evangelical-christians-trump-liberty-university-jerry-falwell) the byline is a link in the standfirst and so hiding links results in there being no byline in the print version.

## Screenshots
<img width="805" alt="screen shot 2018-11-02 at 16 59 54" src="https://user-images.githubusercontent.com/3606555/47929398-caa99a80-dec0-11e8-9333-2280f279d9c1.png">

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
