### PR TITLE
AUDIO: series page - improve squareness of image at small breakpoints

### DIFF
--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
@@ -42,11 +42,19 @@
             }
 
             .fc-item__media-wrapper {
-                flex-basis: 20%;
-                @include mq($from: mobile , $until: phablet) {
+                @include mq($until: phablet) {
                     margin: 0;
                 }
-
+                /*hack to maintain square images */
+                @include mq($until: tablet) {
+                    flex-basis: 15%;
+                }
+                @include mq($from: tablet, $until: desktop) {
+                    flex-basis: 30%;
+                }
+                @include mq($from: desktop) {
+                    flex-basis: 20%;
+                }
                 .u-responsive-ratio {
                     padding-bottom: 100%; /* this is horrible but it works */
                     height: 100%;
@@ -65,6 +73,7 @@
             .fc-item__content {
                 max-width: 100%;
                 justify-content: flex-start;
+                min-height: 120px; /*hack to mantain square images at smaller breakpoints */
                 @include mq($from: tablet , $until: wide) {
                     padding: 0 $gs-gutter $gs-gutter;
                 }


### PR DESCRIPTION
## What does this change?
Design want this series page to have square images in each container. By forcing the min-height of the content box `.fc-item__content` in the container, it allows the image to grow to a square size. 

At larger breakpoints where the min-height won't apply I've used the flex-basis of the image container `.fc-item__media-wrapper` to set a width for the image container allowing the image to have a natural shape. 

## Screenshots

BEFORE 
![screen shot 2018-11-02 at 17 23 07](https://user-images.githubusercontent.com/10324129/47930588-4c4ef780-dec4-11e8-8b03-0d794fa69282.png)

AFTER 
![screen shot 2018-11-02 at 17 09 20](https://user-images.githubusercontent.com/10324129/47930799-f038a300-dec4-11e8-9d69-985bbdbdc2ad.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
