### PR TITLE
 use thumbnail for media atom poster image when main media

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -96,7 +96,7 @@
                                             }
 
                                             @video.mediaAtom.map { mediaAtom =>
-                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None)
+                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None, posterImageOverride = None)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -26,12 +26,17 @@ object MainMediaWidths {
 
 object MainCleaner {
  def apply(article: Article, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
-      implicit val edition = Edition(request)
+      implicit val edition: Edition = Edition(request)
       withJsoup(BulletCleaner(article.fields.main))(
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
         MainFigCaptionCleaner,
-        AtomsCleaner(atoms = article.content.atoms, amp = amp, mediaWrapper = Some(MediaWrapper.MainMedia))
+        AtomsCleaner(
+          atoms = article.content.atoms,
+          amp = amp,
+          mediaWrapper = Some(MediaWrapper.MainMedia),
+          posterImageOverride = article.elements.thumbnail.map(_.images)
+        )
       )
   }
 }
@@ -39,7 +44,7 @@ object MainCleaner {
 object BodyCleaner {
 
   def cleaners(article: Article, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext): List[HtmlCleaner] = {
-    implicit val edition = Edition(request)
+    implicit val edition: Edition = Edition(request)
 
     val shouldShowAds = !article.content.shouldHideAdverts && article.metadata.sectionId != "childrens-books-site"
     def ListIf[T](condition: Boolean)(value: => T): List[T] = if(condition) List(value) else Nil

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -454,16 +454,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val YouTubePosterOverride = Switch(
-    SwitchGroup.Feature,
-    "youtube-poster-override",
-    "When ON show trail image on YouTube atom playable content cards instead of the poster image",
-    owners = Seq(Owner.withGithub("gidsg")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false
-  )
-
   val YouTubeRelatedVideos = Switch(
     SwitchGroup.Feature,
     "youtube-related-videos",

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -428,7 +428,7 @@ case class MediaAtomPage(
   override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "media"
-  override val body = views.html.fragments.atoms.media(atom, displayCaption = false, mediaWrapper = Some(MediaWrapper.EmbedPage))
+  override val body = views.html.fragments.atoms.media(atom, displayCaption = false, mediaWrapper = Some(MediaWrapper.EmbedPage), posterImageOverride = None)
   override val javascriptModule = "youtube-embed"
   override val metadata = MetaData.make(
     id = atom.id,

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,14 +1,29 @@
-@import model.content.MediaWrapper
+@import model.{ApplicationContext, ImageMedia}
+@import model.content.{Atom, MediaWrapper}
 @import com.gu.contentatom.renderer.{ArticleAtomRenderer, ArticleConfiguration}
 @import conf.switches.Switches.AtomRendererSwitch
-@(model: _root_.model.content.Atom, config: ArticleConfiguration, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@(
+    model: Atom,
+    config: ArticleConfiguration,
+    shouldFence: Boolean,
+    amp: Boolean,
+    mediaWrapper: Option[MediaWrapper],
+    posterImageOverride: Option[ImageMedia]
+)(implicit request: RequestHeader, context: ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom, CommonsDivisionAtom}
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
-        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = true, mediaWrapper = mediaWrapper)
+        case media: MediaAtom => views.html.fragments.atoms.media(
+            media = media,
+            amp = amp,
+            displayCaption = true,
+            displayEndSlate = true,
+            mediaWrapper = mediaWrapper,
+            posterImageOverride = posterImageOverride
+        )
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case storyquestions: StoryQuestionsAtom if !amp => Html(ArticleAtomRenderer.getHTML(storyquestions.atom, config))
         case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp, inApp = false)

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,14 +1,31 @@
 @import model.content.MediaAssetPlatform
 @import model.content.MediaWrapper
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, displayEndSlate: Boolean = false, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
+@import model.ImageMedia
+
+@(
+    media: model.content.MediaAtom,
+    amp: Boolean = false,
+    displayCaption: Boolean,
+    displayEndSlate: Boolean = false,
+    mediaWrapper: Option[MediaWrapper],
+    posterImageOverride: Option[ImageMedia] = None
+)(implicit request: RequestHeader)
 
 @{
     media match {
-            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
-                if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
-                else views.html.fragments.atoms.youtube(media, displayCaption, displayDuration = true, displayEndSlate, mediaWrapper = mediaWrapper)
-            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
-            case _ =>
-        }
+        case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  =>
+            views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
+        case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
+            if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
+            else views.html.fragments.atoms.youtube(
+                media,
+                displayCaption,
+                displayDuration = true,
+                displayEndSlate,
+                mediaWrapper = mediaWrapper,
+                posterImageOverride = posterImageOverride
+            )
+        case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
+        case _ =>
+    }
 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -8,7 +8,6 @@
 @import model.content.MediaWrapper._
 @import model.content.MediaWrapper
 @import model.content.MediaAsset
-@import conf.switches.Switches.YouTubePosterOverride
 @import conf.switches.Switches.YouTubeRelatedVideos
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
@@ -25,7 +24,7 @@
 
 @defining(media.activeAssets.headOption) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
-    @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
+    @defining(playable){sixteenByNine: Boolean =>
         @defining(
             if (YouTubeRelatedVideos.isSwitchedOn) {
                 media.channelId.getOrElse("")
@@ -37,7 +36,7 @@
                 ("u-responsive-ratio--hd", sixteenByNine),
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired ),
-                ("youtube-related-videos", YouTubePosterOverride.isSwitchedOn)
+                ("youtube-related-videos", YouTubeRelatedVideos.isSwitchedOn)
             ))"
             @for(endSlatePath <- media.endSlatePath if displayEndSlate && YouTubeRelatedVideos.isSwitchedOff)  {
               data-end-slate="@endSlatePath"
@@ -70,7 +69,7 @@
                 }
             }
         }
-        @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
+        @defining(posterImageOverride.filter(_ => !playable) orElse media.posterImage) { bestPosterImage =>
             @if(!bestPosterImage.isDefined && expired) {
                 <div class="youtube-media-atom__overlay">
                     @videoJsError()

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -12,7 +12,17 @@
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
+@(
+    media: model.content.MediaAtom,
+    displayCaption: Boolean,
+    displayDuration: Boolean = true,
+    displayEndSlate: Boolean = true,
+    playable: Boolean = true,
+    posterImageOverride: Option[ImageMedia] = None,
+    cardStyle: Option[CardStyle] = None,
+    mediaWrapper: Option[MediaWrapper] = None,
+    faciaHeaderProperties: Option[VideoFaciaProperties] = None
+)(implicit request: RequestHeader)
 
 @videoJsError() = @{
     <div class="vjs-error-display vjs-modal-dialog">
@@ -69,8 +79,8 @@
                 }
             }
         }
-        @defining(posterImageOverride.filter(_ => !playable) orElse media.posterImage) { bestPosterImage =>
-            @if(!bestPosterImage.isDefined && expired) {
+        @defining(posterImageOverride orElse media.posterImage) { bestPosterImage =>
+            @if(bestPosterImage.isEmpty && expired) {
                 <div class="youtube-media-atom__overlay">
                     @videoJsError()
                 </div>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -664,7 +664,13 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, mediaWrapper: Option[MediaWrapper] = None)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
+case class AtomsCleaner(
+  atoms: Option[Atoms],
+  shouldFence: Boolean = true,
+  amp: Boolean = false,
+  mediaWrapper: Option[MediaWrapper] = None,
+  posterImageOverride: Option[ImageMedia] = None
+)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -690,7 +696,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
           atomContainer.attr("data-atom-id", atomId)
           atomContainer.attr("data-atom-type", atomType)
 
-          val html = views.html.fragments.atoms.atom(atomData, Atoms.articleConfig, shouldFence, amp, mediaWrapper).toString()
+          val html = views.html.fragments.atoms.atom(atomData, Atoms.articleConfig, shouldFence, amp, mediaWrapper, posterImageOverride).toString()
           bodyElement.remove()
           atomContainer.append(html)
         }

--- a/common/app/views/support/ImmersiveMainCleaner.scala
+++ b/common/app/views/support/ImmersiveMainCleaner.scala
@@ -8,7 +8,7 @@ import play.twirl.api.Html
 
 object ImmersiveMainCleaner {
   def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext): Html = {
-    implicit val edition = Edition(request)
+    implicit val edition: Edition = Edition(request)
     withJsoup(BulletCleaner(html))(
       AtomsCleaner(article.content.atoms, shouldFence = true, amp, mediaWrapper = Some(MediaWrapper.ImmersiveMainMedia))
     )


### PR DESCRIPTION
## What does this change?
This is a request from Editorial with the following use-case:
- We have a match report video about player A vs player B and the thumbnail is A v B.
- We then have an article about player A which isn't primarily about the match.
- We want to embed the video in this article, however the thumbnail doesn't exactly match the tone of the article.
- Use the article's thumbnail image instead, which is typically more relevant

Also removes the `YouTubePosterOverride` switch. It's always on, so no longer needed.

## Screenshots
(these don't exactly match the use-case described above...)

From https://www.theguardian.com/football/2018/nov/04/kasper-schmeichel-cardiff-match-like-cup-final-leicester that's using this video - https://www.theguardian.com/football/video/2018/nov/04/leicester-city-players-attend-vichai-srivaddhanaprabhas-bangkok-funeral-video

### Before
![image](https://user-images.githubusercontent.com/836140/47990805-5cdbb980-e0e0-11e8-97aa-12a6d061c6df.png)

### After
![image](https://user-images.githubusercontent.com/836140/47990819-66652180-e0e0-11e8-9d55-555d93321446.png)

## What is the value of this and can you measure success?
Since moving to Atoms, the multimedia team have commented that they're reluctant to use videos in main media as it makes the content look stale. This is because an Atom only has 1 image.

Before Atoms, it was possible to set a different image for a video on each use. This change is bringing that functionality back.

## Checklist
- [x] Demo to Editorial
- [ ] ???
- [ ] Profit

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
