### PR TITLE
Include Pangaea in Ozone on more sections

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -243,6 +243,7 @@ const getPangaeaPlacementId = (sizes: PrebidSize[]): number => {
         mmpu: number,
         dmpu: number,
     };
+    // todo: why does culture appear twice?
     const pangaeaList: Array<PangaeaSection> = [
         {
             sections: ['business'],

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -22,6 +22,20 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
+const ozonePangaeaSectionBlacklist = [
+    'business',
+    'culture',
+    'uk',
+    'us',
+    'au',
+    'news',
+    'money',
+    'sport',
+    'lifeandstyle',
+    'environment',
+    'travel',
+];
+
 export const removeFalseyValues = (o: {
     [string]: string,
 }): { [string]: string } =>
@@ -112,9 +126,13 @@ export const shouldIncludeAppNexus = (): boolean =>
     ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
         !!pbTestNameMap().and);
 
-export const shouldIncludePangaea = (): boolean =>
-    config.get('switches.ozonePangaea') &&
-    config.get('page.section', '').toLowerCase() === 'technology';
+export const shouldIncludePangaea = (): boolean => {
+    const section = config.get('page.section', '').toLowerCase();
+    return (
+        config.get('switches.ozonePangaea', false) &&
+        !ozonePangaeaSectionBlacklist.includes(section)
+    );
+};
 
 export const shouldIncludeXaxis = (): boolean => {
     const hasFirstLook =

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -22,7 +22,7 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
-const ozonePangaeaSectionBlacklist = [
+export const ozonePangaeaSectionBlacklist = [
     'business',
     'culture',
     'uk',

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -7,6 +7,7 @@ import { getParticipations as getParticipations_ } from 'common/modules/experime
 import {
     getLargestSize,
     getBreakpointKey,
+    ozonePangaeaSectionBlacklist,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
     shouldIncludeImproveDigital,
@@ -238,8 +239,10 @@ describe('Utils', () => {
     });
 
     test('shouldIncludePangaea should return false if section is in blacklist', () => {
-        config.set('page.section', 'culture');
-        expect(shouldIncludePangaea()).toBe(false);
+        for (let i = 0; i < ozonePangaeaSectionBlacklist.length; i += 1) {
+            config.set('page.section', ozonePangaeaSectionBlacklist[i]);
+            expect(shouldIncludePangaea()).toBe(false);
+        }
     });
 
     test('shouldIncludeXaxis should always return false on INT, AU and US editions', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -237,6 +237,11 @@ describe('Utils', () => {
         expect(shouldIncludePangaea()).toBe(true);
     });
 
+    test('shouldIncludePangaea should return false if section is in blacklist', () => {
+        config.set('page.section', 'culture');
+        expect(shouldIncludePangaea()).toBe(false);
+    });
+
     test('shouldIncludeXaxis should always return false on INT, AU and US editions', () => {
         const editions = ['AU', 'INT', 'US'];
         const result = editions.map(edition => {


### PR DESCRIPTION
The technology section alone doesn't give enough traffic to test whether Pangaea is working properly in Ozone, so this expands it to other sections avoiding the most popular sections.
Ozone is a Prebid partnership with various other UK and US publishers.