### PR TITLE
Audio: Series page, reposition contrib banner

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -14,11 +14,9 @@ const renderContributionsBanner = el => {
 };
 
 export const addContributionsBanner = () => {
-    const fifthEpisode = document.querySelector(
-        'section.fc-container--tag:nth-of-type(5)'
-    );
+    const allEpisodes = document.querySelectorAll('section.fc-container--tag');
 
-    if (fifthEpisode) {
-        renderContributionsBanner(fifthEpisode);
+    if (allEpisodes.length >= 5) {
+        renderContributionsBanner(allEpisodes[4]);
     }
 };


### PR DESCRIPTION
## What does this change?

I really don't understand why `nth-of-type(5)` wasn't working as expected... but it wasn't.
So in order for this banner to appear under the 5th episode on the series page, have changed the js slightly. 

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
