### PR TITLE
Use sectionName as a fallback for section, improve Flow typing

### DIFF
--- a/static/src/javascripts/lib/url.js
+++ b/static/src/javascripts/lib/url.js
@@ -9,10 +9,8 @@ const supportsPushState = hasPushStateSupport();
 // Returns a map { <bidderName>: true } of bidders
 // according to the pbtest URL parameter
 
-type TestNameMap = { [string]: boolean };
-
-const pbTestNameMap: () => TestNameMap = memoize(
-    (): TestNameMap =>
+const pbTestNameMap: () => { [string]: boolean } = memoize(
+    (): { [string]: boolean } =>
         new URLSearchParams(window.location.search)
             .getAll('pbtest')
             .reduce((acc, value) => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -21,10 +21,14 @@ import type { PrebidAppNexusParams, PrebidSize } from './types';
 
 const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
     const device: string = getBreakpointKey() === 'M' ? 'M' : 'D';
-    const section: string = config.get('page.section', 'unknown');
+    // section is optional and makes it through to the config object as an empty string... OTL
+    const sectionName =
+        config.get('page.section', '') ||
+        config.get('page.sectionName', '').replace(/ /g, '-');
+
     const slotSize: PrebidSize | null = getLargestSize(sizes);
     if (slotSize) {
-        return `${device}${section.toLowerCase()}${slotSize.join('x')}`;
+        return `${device}${sectionName.toLowerCase()}${slotSize.join('x')}`;
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -53,6 +53,7 @@ const resetConfig = () => {
     config.set('ophan', { pageViewId: 'pvid' });
     config.set('page.contentType', 'Article');
     config.set('page.section', 'Magic');
+    config.set('page.sectionName', 'More Magic');
     config.set('page.edition', 'UK');
 };
 
@@ -98,6 +99,11 @@ describe('getAppNexusInvCode', () => {
             'Dmagic970x250',
             'Dmagic728x90',
         ]);
+    });
+
+    test('should use sectionName, replacing whitespace with hyphens, when section is an empty string', () => {
+        config.set('page.section', '');
+        expect(getAppNexusInvCode([[300, 250]])).toEqual('Dmore-magic300x250');
     });
 });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/price-config.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-export type PrebidPriceGranularity = {
+type PrebidPriceGranularity = {
     buckets: Array<{
         precision?: number,
         min: number,


### PR DESCRIPTION
## What does this change?

#### 👉 Use sectionName as a fallback for section when generating the invCode

Some pages, like [this one](https://www.theguardian.com/global/2018/oct/31/trump-democrats-evangelicals-pro-jesus-republicans) have no section set in the global page config... or rather, the section is `""`, an empty string. 

Section is optional and gets set to empty string, so adding the fallback to sectionName should solve the empty string issue that resulted in sending codes without the section included.

#### 👉 Removes some custom types associated with Prebid

Export types are not always needed, neither are type aliases.

Custom types that are only in use in one place add a layer of abstraction and can make type inference more difficult, or hide the type entirely in some IDEs.

## Screenshots

<img width="953" alt="screen shot 2018-11-05 at 14 29 44" src="https://user-images.githubusercontent.com/8607683/48003781-53197c80-e107-11e8-8c79-69ce32d4e558.png">

## What is the value of this and can you measure success?

Commercial BAU and Prebid optimisation: https://trello.com/c/RFz15Wr1

💰💸💰💸

## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

### Accessibility test checklist

N/A