### PR TITLE
Add membership to feedback form data

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
@@ -114,7 +114,6 @@ const initForms = (): Promise<any> => {
     // insert hidden extra data into forms
 
     return getExtraDataInformation().then(extraData => {
-        console.log(extraData);
         $.forEachElement('#feedback__form input[name=extra]', elem => {
             elem.value = JSON.stringify(extraData, null, '  ');
         });

--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
@@ -4,11 +4,14 @@ import $ from 'lib/$';
 import { adblockInUse } from 'lib/detect';
 import { getParticipations as getABParticipations } from 'common/modules/experiments/utils';
 import { getCookie } from 'lib/cookies';
+import fetchJson from 'lib/fetch-json';
 
 let adblockBeingUsed = false;
 const DISABLED_ELEMENTS =
     '#feedback__form input, #feedback__form textarea, #feedback__form button';
 const MANDATORY_ELEMENTS = '#feedback__form input, #feedback__form textarea';
+const MEMBERS_DATA_API_ENDPOINT =
+    'https://members-data-api.theguardian.com/user-attributes/me';
 
 const summariseAbTests = (testParticipations: Participations): string => {
     const tests = Object.keys(testParticipations);
@@ -25,7 +28,7 @@ const summariseAbTests = (testParticipations: Participations): string => {
         .join(', ');
 };
 
-const getExtraDataInformation = (): Object => ({
+const getBaseExtraData = (): Object => ({
     browser: window.navigator.userAgent,
     referrer: document.referrer,
     page: window.location,
@@ -36,6 +39,18 @@ const getExtraDataInformation = (): Object => ({
     payingMember: getCookie('gu_paying_member'),
     abTests: summariseAbTests(getABParticipations()),
 });
+
+const getExtraDataInformation = (): Promise<Object> =>
+    fetchJson(MEMBERS_DATA_API_ENDPOINT, {
+        mode: 'cors',
+    })
+        .then(membershipData => ({
+            basicInformation: getBaseExtraData(),
+            subscriptionInformation: membershipData,
+        }))
+        .catch(() => ({
+            basicInformation: getBaseExtraData(),
+        }));
 
 const toggleFormVisibility = (evt: Event): void => {
     const evtTarget: HTMLInputElement = (evt.target: any);
@@ -60,7 +75,7 @@ const toggleFormVisibility = (evt: Event): void => {
 
 const isInputFilled = (elem: HTMLInputElement): boolean => elem.value === '';
 
-const initForms = (): void => {
+const initForms = (): Promise<any> => {
     const warning = document.getElementById('feedback__explainer');
     const feedback = document.getElementById('feedback-category');
     const onSubmitChecks = (elem: HTMLElement): void => {
@@ -97,19 +112,25 @@ const initForms = (): void => {
     }
 
     // insert hidden extra data into forms
-    $.forEachElement('#feedback__form input[name=extra]', elem => {
-        elem.value = JSON.stringify(getExtraDataInformation(), null, '  ');
+
+    return getExtraDataInformation().then(extraData => {
+        console.log(extraData);
+        $.forEachElement('#feedback__form input[name=extra]', elem => {
+            elem.value = JSON.stringify(extraData, null, '  ');
+        });
     });
 };
 
-const initTechFeedback = (): void => {
+const initTechFeedback = (): Promise<any> => {
     if (document.getElementById('feedback-category')) {
         adblockInUse.then(inUse => {
             adblockBeingUsed = inUse;
         });
 
-        initForms();
+        return initForms();
     }
+
+    return Promise.resolve();
 };
 
 export { initTechFeedback };

--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.spec.js
@@ -24,42 +24,42 @@ describe('Tech-feedback', () => {
     });
 
     it('Should place the extra information into the form', () => {
-        initTechFeedback();
+        initTechFeedback().then(() => {
+            const extra: HTMLInputElement = (document.querySelector(
+                '#feedback__form input[name=extra]'
+            ): any);
 
-        const extra: HTMLInputElement = (document.querySelector(
-            '#feedback__form input[name=extra]'
-        ): any);
-
-        expect(extra.value).toContain('browser');
+            expect(extra.value).toContain('browser');
+        });
     });
 
     it('Should start off with the inputs disabled', () => {
-        initTechFeedback();
+        initTechFeedback().then(() => {
+            const extra: HTMLInputElement = (document.querySelector(
+                '#feedback__form input[name=extra]'
+            ): any);
 
-        const extra: HTMLInputElement = (document.querySelector(
-            '#feedback__form input[name=extra]'
-        ): any);
-
-        expect(extra.disabled).toBeTruthy();
+            expect(extra.disabled).toBeTruthy();
+        });
     });
 
     it('Should enable inputs after we choose something from the category select', () => {
-        initTechFeedback();
+        initTechFeedback().then(() => {
+            const extra: HTMLInputElement = (document.querySelector(
+                '#feedback__form input[name=extra]'
+            ): any);
+            const feedback: HTMLInputElement = (document.getElementById(
+                'feedback-category'
+            ): any);
+            const testoption: HTMLElement = (document.getElementById(
+                'testoption'
+            ): any);
 
-        const extra: HTMLInputElement = (document.querySelector(
-            '#feedback__form input[name=extra]'
-        ): any);
-        const feedback: HTMLInputElement = (document.getElementById(
-            'feedback-category'
-        ): any);
-        const testoption: HTMLElement = (document.getElementById(
-            'testoption'
-        ): any);
+            testoption.setAttribute('selected', 'selected');
+            feedback.value = 'feedback-form-website';
+            feedback.dispatchEvent(new Event('change'));
 
-        testoption.setAttribute('selected', 'selected');
-        feedback.value = 'feedback-form-website';
-        feedback.dispatchEvent(new Event('change'));
-
-        expect(extra.disabled).toBeFalsy();
+            expect(extra.disabled).toBeFalsy();
+        });
     });
 });


### PR DESCRIPTION
## What does this change?

Adds membership data to extra information on feedback form

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
