### PR TITLE
Include OpenX in AU in Prebid bids

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -110,8 +110,7 @@ export const getRandomIntInclusive = (
     return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
-export const shouldIncludeOpenx = (): boolean =>
-    !isInUsRegion() && !isInAuRegion();
+export const shouldIncludeOpenx = (): boolean => !isInUsRegion();
 
 export const shouldIncludeTrustX = (): boolean => isInUsRegion();
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -182,11 +182,19 @@ describe('Utils', () => {
         }
     });
 
-    test('shouldIncludeOpenx should return false if within AU/US region', () => {
-        const testGeos = ['NZ', 'CA', 'US', 'AU'];
+    test('shouldIncludeOpenx should return false if within US region', () => {
+        const testGeos = ['CA', 'US'];
         for (let i = 0; i < testGeos.length; i += 1) {
             getSync.mockReturnValue(testGeos[i]);
             expect(shouldIncludeOpenx()).toBe(false);
+        }
+    });
+
+    test('shouldIncludeOpenx should return true if within AU region', () => {
+        const testGeos = ['NZ', 'AU'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValue(testGeos[i]);
+            expect(shouldIncludeOpenx()).toBe(true);
         }
     });
 


### PR DESCRIPTION
This extends OpenX to include AU and NZ Prebid auctions.