### PR TITLE
Log warning messages for slow fronts

### DIFF
--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -27,7 +27,7 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
   // log a warning if facia press is taking too long to pick up messages
   private def checkAndLogLatency(processTime: Long, messageId: String, creationTime: DateTime, startTime: DateTime): Unit = {
     val messageLatency = startTime.getMillis - creationTime.getMillis
-    if (messageLatency > 4 || processTime > 3500) {
+    if (messageLatency > 4000 || processTime > 3500) {
       val stopWatch = new StopWatch()
       logWarningWithCustomFields(
         s"Facia press took $messageLatency ms to pick up and $processTime time to process $messageId. Message creation time $creationTime, process start time $startTime",

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -2,8 +2,10 @@ package frontpress
 
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.gu.facia.api.models.faciapress.{Draft, FrontPath, Live, PressJob}
+import common.LoggingField.{LogFieldLong, LogFieldString}
 import common._
 import conf.Configuration
+import org.joda.time.DateTime
 import services._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,10 +24,31 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
 
   override def shouldRetryPress(message: Message[PressJob]): Boolean = false
 
+  // log a warning if facia press is taking too long to pick up messages
+  private def checkAndLogLatency(processTime: Long, messageId: String, creationTime: DateTime, startTime: DateTime): Unit = {
+    val messageLatency = startTime.getMillis - creationTime.getMillis
+    if (messageLatency > 4 || processTime > 3500) {
+      val stopWatch = new StopWatch()
+      logWarningWithCustomFields(
+        s"Facia press took $messageLatency ms to pick up and $processTime time to process $messageId. Message creation time $creationTime, process start time $startTime",
+        null,
+        customFields = List(
+          LogFieldLong("pressReceiveDelay", messageLatency),
+          LogFieldLong("pressProcessDelay", processTime),
+          LogFieldString("messageId", messageId),
+          LogFieldString("pressStartTime", startTime.toString)))
+    }
+  }
+
   override def process(message: Message[PressJob]): Future[Unit] = {
     val PressJob(FrontPath(path), pressType, creationTime, forceConfigUpdate) = message.get
 
-    log.info(s"Processing job from tool to update $path on $pressType")
+    val messageId = message.id.get
+
+    val processStartTime = DateTime.now()
+    log.info(s"Processing job from tool to update $path on $pressType at time $creationTime. MessageId: $messageId")
+
+    val stopWatch = new StopWatch
 
     lazy val pressFuture: Future[Unit] = pressType match {
       case Draft => draftFapiFrontPress.pressByPathId(path)
@@ -40,7 +63,11 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
     for {
       _ <- forceConfigUpdateFuture
       press <- pressFuture
-    } yield press
+    } yield {
+      val processTime = stopWatch.elapsed
+      checkAndLogLatency(processTime, messageId, creationTime, processStartTime)
+      press
+    }
 
   }
 }


### PR DESCRIPTION
## What does this change?
This adds some additional logging when facia-press takes more than 4s to get a message from SQS  or more than 3.5s to press a front. 

We do actually already have some cloudwatch metrics around this - e.g. [front press latency](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(view~'timeSeries~stacked~false~metrics~(~(~'Application~'front-press-latency~'ApplicationName~'facia-press~'Stage~'PROD))~region~'eu-west-1);search=facia-press;namespace=Application;dimensions=ApplicationName,Stage) but this doesn't record how long it's taking us to actually pick up press messages.

## What is the value of this and can you measure success?
To help debug why fronts sometimes take ages to update.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
