### PR TITLE
GUUI JSON answer as application/json

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -85,7 +85,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   private def render(path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       request.getRequestFormat match {
-        case JsonFormat if request.isGuui => common.renderJson(getGuuiJson(article), article)
+        case JsonFormat if request.isGuui => common.renderJson(getGuuiJson(article), article).as("application/json")
         case JsonFormat => common.renderJson(getJson(article), article)
         case EmailFormat => common.renderEmail(ArticleEmailHtmlPage.html(article), article)
         case HtmlFormat => common.renderHtml(ArticleHtmlPage.html(article), article)


### PR DESCRIPTION
## What does this change?

Change the content-type of GUUI JSON answer from the currently incorrect `text/plain` to `application/json`.