### PR TITLE
Flagship: reporting and support fixes

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -138,7 +138,6 @@
                 <p>The Guardian is editorially independent.
                     And we want to keep our journalism open and accessible to all.
                     But we increasingly need our readers to fund our work.
-                    Support The Guardian.
                 </p>
                 <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22today_in_focus%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=today_in_focus" class="podcast__support-link podcast__section-link">
                     Support The Guardian

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -9,6 +9,8 @@
 
 @trackingCode(target: String) = {@if(page.media.tags.isPodcast){podcast:subscribe:}@target:@page.media.metadata.webTitle}
 
+@seriesId() = {@audio.tags.tags.find(_.properties.podcast.nonEmpty).map(s => s.id.substring(s.id.lastIndexOf("/") + 1))}
+
 @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
 
 <div class="@RenderClasses(Map(
@@ -139,7 +141,7 @@
                     And we want to keep our journalism open and accessible to all.
                     But we increasingly need our readers to fund our work.
                 </p>
-                <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22today_in_focus%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=today_in_focus" class="podcast__support-link podcast__section-link">
+                <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22today_in_focus%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=@seriesId()" class="podcast__support-link podcast__section-link">
                     Support The Guardian
                     @fragments.inlineSvg("arrow-right", "icon", List("podcast-support__icon", "podcast__section-icon"))
                 </a>

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -38,7 +38,7 @@
             <figure class="podcast__player podcast__section"
                 data-component="main audio"
                 id="audio-component-container"
-                data-media-id="@audio.elements.mainAudio.map{ audioElement => @audioElement.properties.id}"
+                data-media-id="@audio.elements.mainAudio.map(_.properties.id)"
                 data-source="@audio.downloadUrl.map(Audio.acastUrl(_, false))"
                 data-download-url="@audio.downloadUrl.getOrElse("#")"
                 data-duration="@audio.duration"

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -141,7 +141,7 @@
                     And we want to keep our journalism open and accessible to all.
                     But we increasingly need our readers to fund our work.
                 </p>
-                <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22today_in_focus%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=@seriesId()" class="podcast__support-link podcast__section-link">
+                <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22@seriesId()%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=@seriesId()" class="podcast__support-link podcast__section-link">
                     Support The Guardian
                     @fragments.inlineSvg("arrow-right", "icon", List("podcast-support__icon", "podcast__section-icon"))
                 </a>

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -135,12 +135,12 @@
 
             <div class="podcast__support from-content-api podcast__section">
                 <div class="podcast__support-heading podcast__section-heading">Support The Guardian</div>
-                <p>The Guardian is editorially independent. And we want to keep our journalism,
-                    including our podcasts, open and accessible to all. But we increasingly
-                    need our readers to fund our work. You can support The Guardian from as
-                    little as £1 – and it only takes a minute.
+                <p>The Guardian is editorially independent.
+                    And we want to keep our journalism open and accessible to all.
+                    But we increasingly need our readers to fund our work.
+                    Support The Guardian.
                 </p>
-                <a href="https://support.theguardian.com/" class="podcast__support-link podcast__section-link">
+                <a href="https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22DIRECT%22%2C%22campaignCode%22%3A%22today_in_focus%22%2C%22componentId%22%3A%22episode_page%22%7D&INTCMP=today_in_focus" class="podcast__support-link podcast__section-link">
                     Support The Guardian
                     @fragments.inlineSvg("arrow-right", "icon", List("podcast-support__icon", "podcast__section-icon"))
                 </a>


### PR DESCRIPTION
Right now the media id is sent in ophan with an extra space:
```
audio: {"id":" gu-audio-5be042d3e4b02dafd12f1528","eventType":"audio:content:play"}
```
I've removed the space at the front.

And the support message is now this version sent by Paul Lamey, links to the support sites with the proper metadata.