### PR TITLE
Render tier picker is now main-element aware

### DIFF
--- a/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
+++ b/article/app/services/dotcomponents/pickers/SimplePagePicker.scala
@@ -34,13 +34,26 @@ object PageChecks {
     }
   }
 
-  def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
+  def hasOnlySupportedMainElement(page: PageWithStoryPackage): Boolean = {
+
+    def unsupportedElement(blockElement: BlockElement) = blockElement match {
+      case _: ImageBlockElement => false
+      case _ => true
+    }
+
+    !page.article.blocks.exists(_.main.exists(_.elements.exists(unsupportedElement)))
+
+  }
+
+  def hasOnlySupportedBodyElements(page: PageWithStoryPackage): Boolean = {
+
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
       case _: TextBlockElement => false
       case _ => true
     }
 
     !page.article.blocks.exists(_.body.exists(_.elements.exists(unsupportedElement)))
+
   }
 
   def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
@@ -67,7 +80,8 @@ class SimplePagePicker extends RenderTierPickerStrategy {
     val results: Results = List(
       ("isSupportedType", PageChecks.isSupportedType(page)),
       ("hasBlocks", PageChecks.hasBlocks(page)),
-      ("hasOnlySupportedElements", PageChecks.hasOnlySupportedElements(page)),
+      ("hasOnlySupportedBodyElements", PageChecks.hasOnlySupportedBodyElements(page)),
+      ("hasOnlySupportedMainElement", PageChecks.hasOnlySupportedMainElement(page)),
       ("isDiscussionDisabled", PageChecks.isDiscussionDisabled(page)),
       ("isAdFree", PageChecks.isAdFree(page, request)),
       ("isNotImmersive", PageChecks.isNotImmersive(page)),


### PR DESCRIPTION
## What does this change?

Articles that have a main element other than image/text are now rejected by the picker.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
