### PR TITLE
Half-width view applies only to desktop

### DIFF
--- a/static/src/stylesheets/module/identity/upsell/_layout.scss
+++ b/static/src/stylesheets/module/identity/upsell/_layout.scss
@@ -103,7 +103,7 @@
         }
     }
     .identity-upsell-block--half-width {
-        @include mq(tablet) {
+        @include mq(desktop) {
             width: gs-span(5);
         }
     }


### PR DESCRIPTION
## What does this change?
Noticed that the gs-span(5) applied to tablet view and ran over halfway so have set half-width to only apply to desktop view.

## Screenshots
Before:
![screen shot 2018-11-06 at 15 47 13](https://user-images.githubusercontent.com/42539745/48076596-6c8cf800-e1dd-11e8-94e7-d9784ca1b534.png)

After:
![screen shot 2018-11-06 at 15 46 49](https://user-images.githubusercontent.com/42539745/48076605-71ea4280-e1dd-11e8-9773-5dda80d7fa9f.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
