### PR TITLE
Updating the header links test end date

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -53,6 +53,6 @@ object HeaderSubscribeUKTest extends Experiment(
   name = "header-subscribe-uk-test",
   description = "We're changing the order and destination of the contribution and subscribe links in order to see if we can improve the subscription revenue",
   owners = Seq(Owner.withGithub("rcrphillips")),
-  sellByDate = new LocalDate(2018, 11, 30),
+  sellByDate = new LocalDate(2018, 11, 11),
   participationGroup = Perc50
 )


### PR DESCRIPTION
In order to make way for the new header, this test will come to a close on the 11th Nov.
