### PR TITLE
Separate rendering elements from liveblog elements

### DIFF
--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -112,7 +112,7 @@ object LiveBlogHelpers {
     val textBlocks = firstPageBlocks
       .take(number)
       .collect {
-        case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
+        case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _, _) if html.trim.nonEmpty =>
           TextBlock(id, title, publishedAt, updatedAt, summary)
       }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -3,13 +3,12 @@ package model.dotcomponents
 import common.Edition
 import conf.Configuration
 import controllers.ArticlePage
-import model.{SubMetaLink, SubMetaLinks}
-import model.liveblog.BlockElement
+import model.SubMetaLinks
+import model.dotcomrendering.pageElements.PageElement
 import navigation.NavMenu
-import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
-import views.support.{GUDateTimeFormat, Format}
+import views.support.GUDateTimeFormat
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -29,7 +28,7 @@ case class Tag(
 
 case class Block(
     bodyHtml: String,
-    elements: List[BlockElement]
+    elements: List[PageElement]
 )
 
 case class Blocks(
@@ -82,7 +81,7 @@ case class DotcomponentsDataModel(
 )
 
 object Block {
-  implicit val blockElementWrites: Writes[BlockElement] = Json.writes[BlockElement]
+  implicit val blockElementWrites: Writes[PageElement] = Json.writes[PageElement]
   implicit val writes = Json.writes[Block]
 }
 
@@ -119,12 +118,12 @@ object DotcomponentsDataModel {
     val article = articlePage.article
 
     val bodyBlocks: List[Block] = article.blocks match {
-      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml, bb.elements.toList)).toList
+      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml, bb.dotcomponentsPageElements.toList)).toList
       case None => List()
     }
 
     val mainBlock: Option[Block] = article.blocks.flatMap(
-      _.main.map(bb=>Block(bb.bodyHtml, bb.elements.toList))
+      _.main.map(bb=>Block(bb.bodyHtml, bb.dotcomponentsPageElements.toList))
     )
 
     val dcBlocks = Blocks(mainBlock, bodyBlocks)

--- a/article/test/model/LiveBlogCurrentPageTest.scala
+++ b/article/test/model/LiveBlogCurrentPageTest.scala
@@ -18,6 +18,7 @@ class LiveBlogCurrentPageTest extends FlatSpec with Matchers {
     None,
     None,
     Nil,
+    Nil,
     Nil
   )
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1,0 +1,195 @@
+package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
+import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
+import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
+import play.api.libs.json._
+
+/*
+  These elements are used for the Dotcom Rendering, they are essentially the new version of the
+  model.liveblog._ elements but replaced in full here
+ */
+
+sealed trait PageElement
+case class TextBlockElement(html: Option[String]) extends PageElement
+case class TweetBlockElement(html: Option[String]) extends PageElement
+case class PullquoteBlockElement(html: Option[String]) extends PageElement
+case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean]) extends PageElement
+case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
+case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String]) extends PageElement
+case class VideoBlockElement(data: Map[String, String]) extends PageElement
+case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends PageElement
+case class ContentAtomBlockElement(atomId: String) extends PageElement
+case class InteractiveBlockElement(html: Option[String]) extends PageElement
+case class CommentBlockElement(html: Option[String]) extends PageElement
+case class TableBlockElement(html: Option[String]) extends PageElement
+case class WitnessBlockElement(html: Option[String]) extends PageElement
+case class DocumentBlockElement(html: Option[String]) extends PageElement
+case class InstagramBlockElement(html: Option[String]) extends PageElement
+case class VineBlockElement(html: Option[String]) extends PageElement
+case class MapBlockElement(html: Option[String]) extends PageElement
+case class UnknownBlockElement(html: Option[String]) extends PageElement
+
+case class MembershipBlockElement(
+  originalUrl: Option[String],
+  linkText: Option[String],
+  linkPrefix: Option[String],
+  title: Option[String],
+  venue: Option[String],
+  location: Option[String],
+  identifier: Option[String],
+  image: Option[String],
+  price: Option[String]
+) extends PageElement
+
+// these don't appear to have typeData on the capi models so we just have empty html
+case class CodeBlockElement(html: Option[String]) extends PageElement
+case class FormBlockElement(html: Option[String]) extends PageElement
+
+case class RichLinkBlockElement(
+  url: Option[String],
+  text: Option[String],
+  prefix: Option[String],
+  sponsorship: Option[Sponsorship]
+) extends PageElement
+
+case class Sponsorship (
+  sponsorName: String,
+  sponsorLogo: String,
+  sponsorLink: String,
+  sponsorshipType: SponsorshipType
+)
+
+object Sponsorship {
+  def apply(sponsorship: ApiSponsorship): Sponsorship = {
+    Sponsorship(
+      sponsorship.sponsorName,
+      sponsorship.sponsorLogo,
+      sponsorship.sponsorLink,
+      sponsorship.sponsorshipType
+    )
+  }
+}
+
+object PageElement {
+
+  def make(element: ApiBlockElement): Option[PageElement] = {
+
+    element.`type` match {
+
+      case Text => Some(TextBlockElement(element.textTypeData.flatMap(_.html)))
+
+      case Tweet => Some(TweetBlockElement(element.tweetTypeData.flatMap(_.html)))
+
+      case RichLink => Some(RichLinkBlockElement(
+        element.richLinkTypeData.flatMap(_.originalUrl),
+        element.richLinkTypeData.flatMap(_.linkText),
+        element.richLinkTypeData.flatMap(_.linkPrefix),
+        element.richLinkTypeData.flatMap(_.sponsorship).map(Sponsorship(_))
+      ))
+
+      case Image => Some(ImageBlockElement(
+        ImageMedia(element.assets.zipWithIndex.map { case (a, i) => ImageAsset.make(a, i) }),
+        imageDataFor(element),
+        element.imageTypeData.flatMap(_.displayCredit)
+      ))
+
+      case Audio => Some(AudioBlockElement(element.assets.map(AudioAsset.make)))
+
+      case Video =>
+        if (element.assets.nonEmpty) {
+          Some(GuVideoBlockElement(
+            element.assets.map(VideoAsset.make),
+            ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
+              case (a, i) => ImageAsset.make(a, i)
+            }),
+            videoDataFor(element))
+          )
+        }
+        else Some(VideoBlockElement(videoDataFor(element)))
+
+      case Membership => element.membershipTypeData.map(m => MembershipBlockElement(
+        m.originalUrl,
+        m.linkText,
+        m.linkPrefix,
+        m.title,
+        m.venue,
+        m.location,
+        m.identifier,
+        m.image,
+        m.price
+      ))
+
+      case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
+
+      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId))
+
+      case Pullquote => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html))
+      case Interactive => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html))
+      case Comment => element.commentTypeData.map(d => CommentBlockElement(d.html))
+      case Table => element.tableTypeData.map(d => TableBlockElement(d.html))
+      case Witness => element.witnessTypeData.map(d => WitnessBlockElement(d.html))
+      case Document => element.documentTypeData.map(d => DocumentBlockElement(d.html))
+      case Instagram => element.instagramTypeData.map(d => InstagramBlockElement(d.html))
+      case Vine => element.vineTypeData.map(d => VineBlockElement(d.html))
+      case ElementType.Map => element.mapTypeData.map(d => MapBlockElement(d.html))
+      case Code => Some(CodeBlockElement(None))
+      case Form => Some(FormBlockElement(None))
+
+      case EnumUnknownElementType(f) => Some(UnknownBlockElement(None))
+
+    }
+  }
+
+  private def imageDataFor(element: ApiBlockElement): Map[String, String] = {
+    element.imageTypeData.map { d => Map(
+      "copyright" -> d.copyright,
+      "alt" -> d.alt,
+      "caption" -> d.caption,
+      "credit" -> d.credit
+    ) collect { case (k, Some(v)) => (k, v) }
+    } getOrElse Map()
+  }
+
+  private def videoDataFor(element: ApiBlockElement): Map[String, String] = {
+    element.videoTypeData.map { d => Map(
+      "caption" -> d.caption,
+      "url" -> d.url
+    ) collect { case (k, Some (v) ) => (k, v) }
+    } getOrElse Map()
+  }
+
+  implicit val textBlockElementWrites: Writes[TextBlockElement] = Json.writes[TextBlockElement]
+  implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
+  implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
+  implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
+  implicit val VideoBlockElementWrites: Writes[VideoBlockElement] = Json.writes[VideoBlockElement]
+  implicit val TweetBlockElementWrites: Writes[TweetBlockElement] = Json.writes[TweetBlockElement]
+  implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
+  implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
+  implicit val PullquoteBlockElementWrites: Writes[PullquoteBlockElement] = Json.writes[PullquoteBlockElement]
+  implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
+  implicit val CommentBlockElementWrites: Writes[CommentBlockElement] = Json.writes[CommentBlockElement]
+  implicit val TableBlockElementWrites: Writes[TableBlockElement] = Json.writes[TableBlockElement]
+  implicit val WitnessBlockElementWrites: Writes[WitnessBlockElement] = Json.writes[WitnessBlockElement]
+  implicit val DocumentBlockElementWrites: Writes[DocumentBlockElement] = Json.writes[DocumentBlockElement]
+  implicit val InstagramBlockElementWrites: Writes[InstagramBlockElement] = Json.writes[InstagramBlockElement]
+  implicit val VineBlockElementWrites: Writes[VineBlockElement] = Json.writes[VineBlockElement]
+  implicit val MapBlockElementWrites: Writes[MapBlockElement] = Json.writes[MapBlockElement]
+  implicit val CodeBlockElementWrites: Writes[CodeBlockElement] = Json.writes[CodeBlockElement]
+  implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]
+  implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
+  implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
+
+  implicit val SponsorshipWrites: Writes[Sponsorship] = new Writes[Sponsorship] {
+    def writes(sponsorship: Sponsorship): JsObject = Json.obj(
+      "sponsorName" -> sponsorship.sponsorName,
+      "sponsorLogo" -> sponsorship.sponsorLogo,
+      "sponsorLink" -> sponsorship.sponsorLink,
+      "sponsorshipType" -> sponsorship.sponsorshipType.name)
+  }
+
+  implicit val RichLinkBlockElementWrites: Writes[RichLinkBlockElement] = Json.writes[RichLinkBlockElement]
+  val blockElementWrites: Writes[PageElement] = Json.writes[PageElement]
+
+}

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -3,8 +3,9 @@ package model.liveblog
 import java.util.Locale
 
 import implicits.Dates.CapiRichDateTime
-import com.gu.contentapi.client.model.v1.{Block, MembershipPlaceholder => ApiMembershipPlaceholder, BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks}
+import com.gu.contentapi.client.model.v1.{Block, BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks, MembershipPlaceholder => ApiMembershipPlaceholder}
 import model.liveblog.BodyBlock._
+import model.dotcomrendering.pageElements.PageElement
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.jsoup.Jsoup
@@ -32,6 +33,7 @@ object Blocks {
   }
 
   implicit val blocksWrites: Writes[Blocks] = Json.writes[Blocks]
+
 }
 
 case class Blocks(
@@ -58,7 +60,9 @@ object BodyBlock {
         bodyBlock.publishedDate.map(_.toJoda),
         bodyBlock.lastModifiedDate.map(_.toJoda),
         bodyBlock.contributors,
-        bodyBlock.elements.flatMap(BlockElement.make))
+        bodyBlock.elements.flatMap(BlockElement.make),
+        bodyBlock.elements.flatMap(PageElement.make)
+      )
 
 
   sealed trait EventType
@@ -68,6 +72,7 @@ object BodyBlock {
 
   implicit val dateWrites =  play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
   implicit val blockElementWrites = BlockElement.blockElementWrites
+  implicit val pageElementsWrites = PageElement.blockElementWrites
   implicit val bodyBlockWrites: Writes[BodyBlock] = Json.writes[BodyBlock]
 }
 
@@ -83,7 +88,8 @@ case class BodyBlock(
   publishedDate: Option[DateTime],
   lastModifiedDate: Option[DateTime],
   contributors: Seq[String],
-  elements: Seq[BlockElement]
+  elements: Seq[BlockElement],
+  dotcomponentsPageElements: Seq[PageElement]
 ) {
   lazy val eventType: EventType =
     if (attributes.keyEvent) KeyEvent


### PR DESCRIPTION
## What does this change?

Introduces a separate collection of dotcomponents elements that can diverge from the existing frontend ones without affecting liveblogs.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
