### PR TITLE
GUDateTimeFormat

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
@@ -1,5 +1,5 @@
 @(crosswordPage: crosswords.CrosswordPageWithContent)(implicit requestHeader: RequestHeader)
-@import views.support.AuFriendlyFormat
+@import views.support.GUDateTimeSuffixFormat
 
 <div class="crossword__meta">
     @crosswordPage.crossword.creator.map { creator =>
@@ -15,7 +15,7 @@
     <div class="content__dateline content__dateline-crossword">
         <time itemprop="datePublished" datetime="@crosswordPage.crossword.date.toString("yyyy-MM-dd'T'HH:mm:ssZ"))"
         data-timestamp="@crosswordPage.crossword.date.getMillis" class="content__dateline-wpd js-wpd">
-            @crosswordPage.crossword.date.toString("E d MMM yyyy") <span class="content__dateline-time">@AuFriendlyFormat(crosswordPage.crossword.date)</span>
+            @crosswordPage.crossword.date.toString("E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(crosswordPage.crossword.date)</span>
         </time>
     </div>
 </div>

--- a/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
@@ -1,5 +1,5 @@
 @(crosswordPage: crosswords.CrosswordPageWithContent)(implicit requestHeader: RequestHeader)
-@import views.support.GUDateTimeSuffixFormat
+@import views.support.GUDateTimeFormat
 
 <div class="crossword__meta">
     @crosswordPage.crossword.creator.map { creator =>
@@ -15,7 +15,7 @@
     <div class="content__dateline content__dateline-crossword">
         <time itemprop="datePublished" datetime="@crosswordPage.crossword.date.toString("yyyy-MM-dd'T'HH:mm:ssZ"))"
         data-timestamp="@crosswordPage.crossword.date.getMillis" class="content__dateline-wpd js-wpd">
-            @crosswordPage.crossword.date.toString("E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(crosswordPage.crossword.date)</span>
+            @GUDateTimeFormat.formatDateForDisplay(crosswordPage.crossword.date, requestHeader) <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(crosswordPage.crossword.date, requestHeader)</span>
         </time>
     </div>
 </div>

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,7 +9,7 @@ import navigation.NavMenu
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
-import views.support.{GUDateTimeSuffixFormat, Format}
+import views.support.{GUDateTimeFormat, Format}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -138,15 +138,13 @@ object DotcomponentsDataModel {
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
 
-    val webPublicationDateTimeDisplay: String = s"${Format(article.trail.webPublicationDate, Edition(request), "E d MMM yyyy", None)} ${GUDateTimeSuffixFormat.getDateDisplaySuffix(article.trail.webPublicationDate, request)}"
-
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),
       article.metadata.id,
       article.metadata.pillar.map(_.toString),
       Configuration.ajax.url,
       article.trail.webPublicationDate.getMillis,
-      webPublicationDateTimeDisplay,
+      GUDateTimeFormat.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
       article.metadata.section.map(_.value),
       article.trail.headline,
       article.metadata.webTitle,

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,7 +9,7 @@ import navigation.NavMenu
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
-import views.support.{AuFriendlyFormat, Format}
+import views.support.{GUDateTimeSuffixFormat, Format}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -138,7 +138,7 @@ object DotcomponentsDataModel {
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
 
-    val webPublicationDateTimeDisplay: String = s"${Format(article.trail.webPublicationDate, Edition(request), "E d MMM yyyy", None)} ${AuFriendlyFormat.getDateDisplaySuffix(article.trail.webPublicationDate, request)}"
+    val webPublicationDateTimeDisplay: String = s"${Format(article.trail.webPublicationDate, Edition(request), "E d MMM yyyy", None)} ${GUDateTimeSuffixFormat.getDateDisplaySuffix(article.trail.webPublicationDate, request)}"
 
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,6 +1,5 @@
-@import common.RichRequestHeader
 @import org.joda.time.DateTime
-@import views.support.{GUDateTimeSuffixFormat, Format}
+@import views.support.{GUDateTimeFormat, Format}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
@@ -10,7 +9,7 @@
         @if(isMinute) {
             <span class="content__dateline-time">@Format(webPublicationDate, "E d MMM yyyy")</span>
         } else {
-            @Format(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(webPublicationDate)</span>
+            @Format(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(webPublicationDate, request)</span>
         }
     </time>
     @if(isLiveBlog) {
@@ -22,7 +21,7 @@
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
         >
-            @label @Format(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(date)</span>
+            @label @Format(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(date, request)</span>
         </time>
     }
 

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,6 +1,6 @@
 @import common.RichRequestHeader
 @import org.joda.time.DateTime
-@import views.support.{AuFriendlyFormat, Format}
+@import views.support.{GUDateTimeSuffixFormat, Format}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
@@ -10,7 +10,7 @@
         @if(isMinute) {
             <span class="content__dateline-time">@Format(webPublicationDate, "E d MMM yyyy")</span>
         } else {
-            @Format(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
+            @Format(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(webPublicationDate)</span>
         }
     </time>
     @if(isLiveBlog) {
@@ -22,7 +22,7 @@
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
         >
-            @label @Format(date, "E d MMM yyyy") <span class="content__dateline-time">@AuFriendlyFormat(date)</span>
+            @label @Format(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeSuffixFormat(date)</span>
         </time>
     }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -114,16 +114,14 @@ object `package` {
   }
 }
 
-object GUDateTimeSuffixFormat {
-  def apply(date: DateTime)(implicit request: RequestHeader): String = {
-    val edition = Edition(request)
-    val timezone = edition.timezone
-    edition.id match {
-      case "AU" => date.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
-      case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
-    }
+object GUDateTimeFormat {
+  def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
+    s"${formatDateForDisplay(date, request)} ${formatTimeForDisplay(date, request)}"
   }
-  def getDateDisplaySuffix(date: DateTime, request: RequestHeader): String = {
+  def formatDateForDisplay(date: DateTime, request: RequestHeader): String = {
+    date.toString("E d MMM yyyy")
+  }
+  def formatTimeForDisplay(date: DateTime, request: RequestHeader): String = {
     val edition = Edition(request)
     val timezone = edition.timezone
     edition.id match {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -114,7 +114,7 @@ object `package` {
   }
 }
 
-object AuFriendlyFormat {
+object GUDateTimeSuffixFormat {
   def apply(date: DateTime)(implicit request: RequestHeader): String = {
     val edition = Edition(request)
     val timezone = edition.timezone


### PR DESCRIPTION
## What does this change?

This change introduce the object `GUDateTimeFormat` to replace the previous `AuFriendlyFormat`.  This is a refactoring to have a more logical handling of the way we compute datetime strings.

### Tested

- [x] Locally
- [x] On CODE (optional)
