### PR TITLE
updated MMA action required banner colours to RED

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -98,15 +98,19 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
     });
 
     newMessage.show(
-        `<span class="site-message__copy-text">
-            An action is needed on your Guardian account. 
-            Please review and update your details as soon as you can. Thank you.
-        </span>
-        <a class="button site-message__copy-button js-mma-update-details-button" href="${accountDataUpdateLink(
-            accountDataUpdateWarningLink
-        )}">
-            Update details ${arrowRight.markup}
-        </a>`
+        `<div class="site-message__copy-heading">
+            An action is needed on your Guardian&nbsp;account
+        </div>
+        <div class="site-message__copy-text">
+            Please review and update your details as&nbsp;soon&nbsp;as&nbsp;you&nbsp;can. Thank&nbsp;you.
+        </div>
+        <div class="site-message__copy-text">
+            <a class="button site-message__copy-button js-mma-update-details-button" href="${accountDataUpdateLink(
+                accountDataUpdateWarningLink
+            )}">
+                Update details ${arrowRight.markup}
+            </a>
+        </div>`
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -99,7 +99,7 @@ const showAccountDataUpdateWarningMessage = accountDataUpdateWarningLink => {
 
     newMessage.show(
         `<div class="site-message__copy-heading">
-            An action is needed on your Guardian&nbsp;account
+            Action is needed on your Guardian account
         </div>
         <div class="site-message__copy-text">
             Please review and update your details as&nbsp;soon&nbsp;as&nbsp;you&nbsp;can. Thank&nbsp;you.

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -8,7 +8,7 @@
 
 .site-message--membership-action-required {
     color: $brightness-100;
-    background: $sport-dark;
+    background: $news-dark;
 
     .site-message__inner {
         width: auto;
@@ -29,23 +29,21 @@
         .inline-icon {
             fill: $brightness-100;
             path:last-child {
-                fill: $brightness-7;
+                fill: $news-dark;
             }
         }
 
         display: block;
-        bottom: $gs-baseline;
-        right: $gs-baseline;
+        top: $gs-baseline/2;
+        right: $gs-baseline + 36px;
         svg {
-            width: 32px;
-            height: 32px;
+            width: 36px;
+            height: 36px;
         }
 
         @include mq(desktop) {
-            top: $gs-baseline;
             left: $gs-gutter;
             right: auto;
-            bottom: auto;
             svg {
                 width: inherit;
                 height: inherit;
@@ -53,16 +51,18 @@
         }
 
         @include mq(tablet) {
-            right: $gs-gutter;
+            right: $gs-gutter + 36px;
         }
 
     }
 
     .site-message__close-btn {
         position: absolute;
-        top: $gs-baseline;
+        top: $gs-baseline/2;
         right: $gs-baseline;
-
+        height: 36px;
+        width: 36px;
+        
         .inline-icon {
             fill: $brightness-100;
         }
@@ -75,8 +75,8 @@
 
     .site-message__copy {
         @include padding;
+        padding-top: $gs-baseline/4 !important;
         @include mq(desktop) {
-            display: flex;
             margin-left: gs-span(1);
         }
         @include mq(leftCol) {
@@ -84,46 +84,54 @@
         }
     }
 
-    .site-message__copy-text {
+    .site-message__copy-text, .site-message__copy-heading {
         @include banner-copy-alignment;
         display: block;
-        margin-bottom: 12px;
         margin-right: 24px;
-        font-size: 16px;
-        line-height: 20px;
+        font-size: 17px;
+        line-height: 22px;
         @include mq(phablet) {
-            font-size: 18px;
-            line-height: 24px;
             width: auto;
             margin-right: gs-span(1);
         }
         @include mq(desktop) {
-            flex-basis: gs-span(6) + $gs-gutter*3;
             margin-right: gs-span(2);
+            padding-left: 36px + $gs-gutter
         }
         @include mq(leftCol) {
-            margin-bottom: 0;
             margin-right: gs-span(3);
-            flex-basis: gs-span(6) + $gs-gutter*2;
+            padding-left: 0;
         }
+    }
+
+    .site-message__copy-heading {
+        font-size: 24px;
+        line-height: 28px;
+        font-weight: bold;
+        margin-bottom: 5px;
+        margin-right: 72px;
     }
 
     .site-message__copy-button {
         color: $brightness-7;
         background-color: $highlight-main;
         border-color: $highlight-main;
-        font-size: 14px;
-        line-height: 36px;
-        height: 36px;
+        font-size: 16px;
+        line-height: 40px;
+        height: 42px;
+        font-weight: bold;
         vertical-align: middle;
         padding-right: 0;
         text-decoration: none;
+        margin-top: 10px;
+        padding-left: 1rem;
         svg {
             fill: $brightness-7;
             float: right;
             margin-left: 36px;
-            padding-top: 3px;
-}
+            height: 2.5rem;
+            width: 2.5rem;
+        }
 
         &:hover, &:focus {
             border-color: mix($highlight-main, $brightness-7, 80%);


### PR DESCRIPTION
## What does this change?
This changes the main colour of the MMA action required banner to RED following updated designs from @zeftilldeath 

_Related PRs : **https://github.com/guardian/frontend/pull/20256**, https://github.com/guardian/frontend/pull/20430, https://github.com/guardian/frontend/pull/20560, https://github.com/guardian/frontend/pull/20438_
## Screenshots

| Mobile     | Narrow | Wide |
|------------|--------|------|
| ![image](https://user-images.githubusercontent.com/19289579/48149042-1a1e0b00-e2b3-11e8-9b1e-eff477812cd0.png)   |   ![image](https://user-images.githubusercontent.com/19289579/48148813-9401c480-e2b2-11e8-8bc5-32dff3c78e61.png) |    ![image](https://user-images.githubusercontent.com/19289579/48148862-b09dfc80-e2b2-11e8-8d02-e117df099ba5.png) |





## What is the value of this and can you measure success?
This should drive more people to update payment details and reduce churn through payment failure.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
