### PR TITLE
Extending the interactive header switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -502,7 +502,7 @@ trait FeatureSwitches {
     "If switched on, the header on all interctives will display in full.",
     owners = Seq(Owner.withName("dotcom.platform")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 11, 8),
+    sellByDate = new LocalDate(2018, 11, 9),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
We're still seeing large numbers of casuals and traffic to our midterm interactives, so we've been asked to extend this until tomorrow.
