### PR TITLE
Add link from readme to Prebid on Amp doc

### DIFF
--- a/docs/01-start-here/06-testing-tips.md
+++ b/docs/01-start-here/06-testing-tips.md
@@ -107,7 +107,8 @@ This is useful for tests where the path to the page matters. For instance any te
 This is more relevant to testing on production where you might often be looking at the flow from
 google-search result to the amp page. The following will indicate you are on an amp page:
     - In prod the url starts with `amp.` instead of `www.`
-    - On code and on local, the url has the `?amp` querystring described above
+    - The code host is `amp.code.dev-theguardian.com`
+    - On local, the url has the `?amp` querystring described above
     - The styling of the nav header is different
     - The developer tools console has a message "Powered by AMP"
 2) That ads display ok.

--- a/docs/03-dev-howtos/16-working-with-amp.md
+++ b/docs/03-dev-howtos/16-working-with-amp.md
@@ -23,7 +23,8 @@ At the time of writing, Google is trialling wide roll-outs of AMP blue links in 
 ### Running AMP
 AMP content can be reached in various ways:
 * **Production** - `amp.theguardian.com/<path>`
-* **Code & local** - append an `amp` parameter to your query string e.g. `localhost:9000/an-article?amp`
+* **Code** - `amp.code.dev-theguardian.com/<path>`
+* **Local** - append an `amp` parameter to your query string e.g. `localhost:9000/an-article?amp`
 * **Beta** - `beta.amp.theguardian.com/<path>`
 
 ### Validation
@@ -60,3 +61,8 @@ in common/app/views/fragments/amp/customStyles.scala.html.
 
 When validating locally please comment out the <link> as this will always fail validation.
 This change was made to improve the experience of developing and styling amp pages. If there is a better way please suggest it!
+
+## Ads in Amp
+
+* [Prebid](https://prebid.org/) in Amp uses a Prebid server and is documented in a separate repo [here](https://github.com/guardian/prebid-server/tree/master/amp).
+* Ads are served in the `amp-ad` element, which is documented [here](https://www.ampproject.org/docs/ads/introduction_ads).


### PR DESCRIPTION
This makes it easier to find the documentation about Prebid on Amp.
It also updates the Code Amp URLs that have changed since Code was fronted by Fastly.
