### PR TITLE
Freshen up Identity pages

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -59,7 +59,7 @@ object css {
 
   def head(projectOverride: Option[String])(implicit context: ApplicationContext, request: RequestHeader): String = inline(cssHead(projectOverride.getOrElse(context.applicationIdentity.name)))
   def inlineNavigation(implicit request: RequestHeader, context: ApplicationContext): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) inline("head.new-navigation") else inline("head.navigation")
-  def inlineIdentity(implicit request: RequestHeader, context: ApplicationContext): String = inline("head.identity")
+  def inlineIdentity(implicit request: RequestHeader, context: ApplicationContext): String = if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) inline("head.new-identity") else inline("head.identity")
   def inlineStoryPackageGarnett(implicit context: ApplicationContext): String = inline("story-package-garnett")
   def inlinePhotoEssayGarnett(implicit context: ApplicationContext): String = inline("article-photo-essay-garnett")
   def amp(implicit context: ApplicationContext): String = inline("head.amp")

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -19,7 +19,7 @@ object IdentityHtmlPage {
 
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
     override def criticalCssLink: Html = stacked(
-      criticalStyleLink("identity"),
+      if (conf.switches.Switches.NewNavEnabled.isSwitchedOn) criticalStyleLink("new-identity") else criticalStyleLink("identity"),
       criticalStyleLink(InlineNavigationCSSFile))
     override def criticalCssInline: Html = criticalStyleInline(
       Html(common.Assets.css.inlineIdentity),

--- a/static/src/stylesheets/head.new-identity.scss
+++ b/static/src/stylesheets/head.new-identity.scss
@@ -1,0 +1,32 @@
+@charset 'UTF-8';
+
+/* ==========================================================================
+   Common head
+   ========================================================================== */
+
+@import '_head.common';
+
+/* ==========================================================================
+   Identity core
+   ========================================================================== */
+
+@import 'pasteup/forms/styles';
+@import 'module/tabs.head';
+
+@import 'module/identity/identity';
+
+@import 'module/identity/new-header';
+@import 'module/identity/new-wrapper';
+@import 'module/identity/button';
+@import 'module/identity/forms';
+@import 'module/identity/footer';
+@import 'module/identity/manage-account-tab';
+@import 'module/identity/formstack';
+@import 'module/identity/dropdown';
+@import 'module/identity/switches';
+@import 'module/identity/ad-prefs';
+@import 'module/identity/consent';
+@import 'module/identity/upsell/_base';
+@import 'module/identity/upsell/_card';
+@import 'module/identity/upsell/_layout';
+@import 'module/identity/upsell/_account-creation';

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -113,7 +113,7 @@
         bottom: ($multiline-height - 1) * -1;
         height: $multiline-height;
         margin-bottom: -1px;
-        margin-top: $gutter;
+        margin-top: $gs-baseline/2;
         width: 100%;
     }
 }

--- a/static/src/stylesheets/module/identity/_dropdown.scss
+++ b/static/src/stylesheets/module/identity/_dropdown.scss
@@ -1,5 +1,5 @@
 .identity-dropdown {
-    @include fs-textSans(4);
+    @include fs-textSans(5);
     @include mq(desktop) {
         font-size: 15px;
         min-width: gs-span(2.5);

--- a/static/src/stylesheets/module/identity/_dropdown.scss
+++ b/static/src/stylesheets/module/identity/_dropdown.scss
@@ -1,7 +1,6 @@
 .identity-dropdown {
     @include fs-textSans(5);
     @include mq(desktop) {
-        font-size: 15px;
         min-width: gs-span(2.5);
     }
     background: #ffffff;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -16,7 +16,7 @@
     ========================================================================== */
     .manage-account-warning {
         border: 0;
-        padding: $gutter 0 0;
+        padding: $gs-baseline/2 0 0;
         height: auto;
         &:after {
             @include multiline(4, $brightness-86, top);
@@ -25,7 +25,7 @@
             height: 4px * 4; /*height of multiline (4px) times the number of lines (4)*/
             background-color: #ffffff;
             margin-bottom: -1px;
-            margin-top: $gutter;
+            margin-top: $gs-baseline/2;
             width: 100%;
         }
     }

--- a/static/src/stylesheets/module/identity/_new-header.scss
+++ b/static/src/stylesheets/module/identity/_new-header.scss
@@ -1,0 +1,129 @@
+$padding: 3px;
+
+@import '../../layout/nav/_variables';
+
+.identity-header {
+    @include clearfix;
+    background-color: $nav-blue;
+    padding: $padding 0;
+    color: $brightness-100;
+    overflow: visible;
+    position: relative;
+    z-index: $zindex-main-menu;
+
+    .identity-dropdown {
+        position: absolute;
+        display: none;
+        left: 0;
+        top: get-line-height(textSans, 3)*1.25;
+        z-index: $zindex-main-menu + 1;
+        li {
+            display: block;
+        }
+    }
+
+    .identity-dropdown.is-active,
+    .identity-header__nav-fallback:checked ~ .identity-dropdown {
+        display: block;
+    }
+
+    .identity-header__nav-name {
+        max-width: gs-span(2);
+        display: inline-flex;
+        align-items: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .identity-header__container {
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: space-between;
+        align-items: flex-start;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
+.identity-header__links {
+    float: left;
+    height: 40px;
+    display: flex;
+    align-items: center;
+}
+
+.identity-header__link {
+    float: left;
+    position: relative;
+}
+
+html body .identity-header__logo {
+    float: right;
+    order: -99;
+    z-index: 1;
+
+    .inline-the-guardian-logo {
+        display: none;
+    }
+
+    .inline-the-guardian-roundel__svg {
+        display: block;
+        height: 42px;
+        width: 42px;
+    }
+}
+
+label[for=identity-header-account-menu-fallback]:focus {
+    outline: none;
+}
+
+.identity-header__nav {
+    @include fs-textSans(5);
+    background: none;
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+    white-space: nowrap;
+    display: block;
+    transition: .25s ease-out;
+
+    .inline-icon {
+        vertical-align: middle;
+        display: inline-block;
+        line-height: 0;
+        &, & > svg {
+            height: $gs-baseline * 1.25;
+            width: $gs-baseline * 1.25;
+            * {
+                fill: currentColor;
+            }
+        }
+    }
+
+    &:after {
+        content: '';
+        display: inline-block;
+        width: 4px;
+        height: 4px;
+        transform: translateY(-2px) rotate(45deg);
+        border: 1px solid currentColor;
+        border-left: transparent;
+        border-top: transparent;
+        margin-left: 2px;
+        vertical-align: middle;
+        transition: .25s ease-out;
+    }
+
+
+    &:hover,
+    &:focus,
+    label[for=identity-header-account-menu-fallback]:focus & {
+        outline: 0;
+        color: $highlight-main;
+        &:after {
+            transform: translateY(0px) rotate(45deg);
+        }
+    }
+
+}

--- a/static/src/stylesheets/module/identity/_new-wrapper.scss
+++ b/static/src/stylesheets/module/identity/_new-wrapper.scss
@@ -1,0 +1,114 @@
+/* Header wrapper (for mma tabs)
+   ========================================================================== */
+.identity-wrapper-header {
+    border-bottom: 1px solid $brightness-86;
+    background: $brightness-97;
+    .identity-wrapper {
+        padding-bottom: 0;
+    }
+    .identity-title {
+        margin-bottom: ($gs-gutter * 1.5);
+    }
+    .tabs__container {
+        margin: 0 auto 0 -1px;
+        border-right: 1px solid $brightness-86;
+        grid-column-gap: 0;
+        padding: 0 1px;
+        overflow: visible;
+        .tabs__tab {
+            border-left: 1px solid $brightness-86;
+            border-top: 1px solid $brightness-86;
+            border-bottom: 0;
+            border-right: 0;
+            &.tabs__tab--selected {
+                @include mq(desktop) {
+                    box-shadow: 0 1px 0 0 $brightness-100;
+                }
+            }
+        }
+        .tabs__tab a {
+            background: $brightness-97;
+            font-weight: 400!important;
+            /*text can't fit otherwise*/
+        }
+        .tabs__tab--selected a {
+            background: $brightness-100;
+        }
+    }
+}
+
+
+/* Normal wrapper
+   ========================================================================== */
+
+.identity-wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: gs-span(6);
+    padding-bottom: $gs-gutter * 2;
+    padding-top: $gs-gutter / 4;
+
+    @include mq(desktop) {
+        max-width: gs-span(10);
+    }
+
+    &.identity-wrapper--mma-body {
+        .tabs__content {
+            border: 0;
+        }
+    }
+
+    &.identity-wrapper--no-padding {
+        padding: 0;
+    }
+
+    &.identity-wrapper--wide {
+        max-width: gs-span(8);
+
+        @include mq(desktop) {
+            max-width: gs-span(12);
+        }
+    }
+
+    &.identity-wrapper--stretched {
+        max-width: gs-span(16);
+    }
+
+    a.u-underline {
+        color: $nav-blue;
+    }
+}
+
+
+
+
+
+
+/* Flex wrap around the whole page (to stick the footer at the end)
+   ========================================================================== */
+.identity-wrapper-page-flex {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    align-items: stretch;
+    &.identity-wrapper-page-flex--flow {
+        background: $brightness-97;
+        .manage-account-small-divider {
+            border-color: $brightness-86;
+        }
+    }
+    & > .identity-wrapper-page-flex__content {
+        flex: 1 1 auto;
+    }
+}
+
+
+
+/* Account Edit page
+   ========================================================================== */
+
+.identity-wrapper .tabs {
+    .fieldset:first-of-type {
+        border-top: 0; // Included so as not to break tabs metaphor
+    }
+}


### PR DESCRIPTION
## What does this change?

Align identity with the visual changes coming to dotcom (#20646). The updates are under the same switch so there'll be no visual changes until it's flipped

## Screenshots
![smiling-face-with-halo_1f607](https://user-images.githubusercontent.com/11539094/48200916-830b8e80-e358-11e8-9438-444c10281ec7.png)


## What is the value of this and can you measure success?

Visual parity between `manage` and `identity`.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
