### PR TITLE
Include footer.css in stylesheets.scala.html

### DIFF
--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -3,7 +3,7 @@
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
 @import conf.Static
-@import html.HtmlPageHelpers.ContentCSSFile
+@import html.HtmlPageHelpers.{ContentCSSFile, FooterCSSFile}
 
 @* any images in head need to go here (or they'll be relative to the page)} *@
 <style class="js-loggable">
@@ -57,6 +57,12 @@
 
     <link rel="stylesheet" id="head-css" data-reload="head@projectName.map("." + _).getOrElse(s".$ContentCSSFile")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(s".$ContentCSSFile") + ".css")" />
 
+    @if(NewNavEnabled.isSwitchedOn) {
+        <link rel="stylesheet" id="head-navigation" data-reload="head.navigation" type="text/css" href="@Static("stylesheets/head.new-navigation.css")" />
+    } else {
+        <link rel="stylesheet" id="head-navigation" data-reload="head.navigation" type="text/css" href="@Static("stylesheets/head.navigation.css")" />
+    }
+
     @if(isInteractive) {
         <link rel="stylesheet" id="head-interactive" data-reload="head.interactive" type="text/css" href="@Static("stylesheets/head.interactive.css")" />
     }
@@ -70,8 +76,9 @@
     </style>
 }
 @fragments.stylesheetLink(common.Assets.css.projectCss(projectName), isCrossword)
-<!--<![endif]-->
+@fragments.stylesheetLink(s"stylesheets/$FooterCSSFile.css")
 
+<!--<![endif]-->
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />
 
 @* placeholder <style>'s for font to go in *@


### PR DESCRIPTION
## What does this change?

Fixes a bug introduced in this PR: https://github.com/guardian/frontend/pull/20646

Some pages use the template `stylesheets.scala.html`, this template was missing the include to bring in the `footer.css`/`new-footer.css` file introduced by https://github.com/guardian/frontend/pull/20646. Also in `Dev` mode pages using this template were missing the `navigation.css`/`new-navigation.css`.

The only example of a page using this templates so far is: https://www.theguardian.com/advertiser-content/renault-car-of-the-future/design-competition-episode1 

### Tested

- [ x] Locally
- [ x] On CODE (optional)
