### PR TITLE
Remove blacklisted sections from Pangaea in Ozone bid requests

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -243,7 +243,6 @@ const getPangaeaPlacementId = (sizes: PrebidSize[]): number => {
         mmpu: number,
         dmpu: number,
     };
-    // todo: why does culture appear twice?
     const pangaeaList: Array<PangaeaSection> = [
         {
             sections: ['business'],
@@ -282,7 +281,7 @@ const getPangaeaPlacementId = (sizes: PrebidSize[]): number => {
             dmpu: 13892373,
         },
         {
-            sections: ['lifeandstyle', 'culture'],
+            sections: ['lifeandstyle', 'fashion'],
             lb: 13892411,
             mmpu: 13892436,
             dmpu: 13892437,

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -22,20 +22,6 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
-export const ozonePangaeaSectionBlacklist = [
-    'business',
-    'culture',
-    'uk',
-    'us',
-    'au',
-    'news',
-    'money',
-    'sport',
-    'lifeandstyle',
-    'environment',
-    'travel',
-];
-
 export const removeFalseyValues = (o: {
     [string]: string,
 }): { [string]: string } =>
@@ -125,13 +111,8 @@ export const shouldIncludeAppNexus = (): boolean =>
     ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
         !!pbTestNameMap().and);
 
-export const shouldIncludePangaea = (): boolean => {
-    const section = config.get('page.section', '').toLowerCase();
-    return (
-        config.get('switches.ozonePangaea', false) &&
-        !ozonePangaeaSectionBlacklist.includes(section)
-    );
-};
+export const shouldIncludePangaea = (): boolean =>
+    config.get('switches.ozonePangaea', false);
 
 export const shouldIncludeXaxis = (): boolean => {
     const hasFirstLook =

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -7,7 +7,6 @@ import { getParticipations as getParticipations_ } from 'common/modules/experime
 import {
     getLargestSize,
     getBreakpointKey,
-    ozonePangaeaSectionBlacklist,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
     shouldIncludeImproveDigital,
@@ -241,16 +240,13 @@ describe('Utils', () => {
         expect(shouldIncludeImproveDigital()).toBe(false);
     });
 
-    test('shouldIncludePangaea should return true if section is technology', () => {
-        config.set('page.section', 'technology');
+    test('shouldIncludePangaea should return true if switch is on', () => {
         expect(shouldIncludePangaea()).toBe(true);
     });
 
-    test('shouldIncludePangaea should return false if section is in blacklist', () => {
-        for (let i = 0; i < ozonePangaeaSectionBlacklist.length; i += 1) {
-            config.set('page.section', ozonePangaeaSectionBlacklist[i]);
-            expect(shouldIncludePangaea()).toBe(false);
-        }
+    test('shouldIncludePangaea should return false if switch is off', () => {
+        config.set('switches.ozonePangaea', false);
+        expect(shouldIncludePangaea()).toBe(false);
     });
 
     test('shouldIncludeXaxis should always return false on INT, AU and US editions', () => {


### PR DESCRIPTION
This will increase the number of sections that the Prebid bidder Pangaea in Ozone can target, by removing the blacklist so that all sections are available.