### PR TITLE
FIV + cookies banner

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.3

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -42,6 +42,7 @@ import { init as initTabs } from 'common/modules/ui/tabs';
 import { Toggles } from 'common/modules/ui/toggles';
 import { initPinterest } from 'common/modules/social/pinterest';
 import { fivBanner } from 'common/modules/commercial/fiv-banner';
+import { firstPvConsentPlusFivBanner } from 'common/modules/commercial/first-pv-consent-plus-fiv-banner';
 import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { initEmail } from 'common/modules/email/email';
 import { init as initEmailArticle } from 'common/modules/email/email-article';
@@ -270,6 +271,7 @@ const initialiseEmail = (): void => {
 const initialiseBanner = (): void => {
     // ordered by priority
     const bannerList = [
+        firstPvConsentPlusFivBanner,
         firstPvConsentPlusEngagementBanner,
         firstPvConsentBanner,
         breakingNews,

--- a/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
@@ -1,0 +1,137 @@
+// @flow
+import { Message } from 'common/modules/ui/message';
+import type { Banner } from 'common/modules/ui/bannerPicker';
+import { acquisitionsBannerFivTemplate } from 'common/modules/commercial/templates/acquisitions-banner-fiv';
+import {
+    messageCode as fivMessageCode,
+    canShow as canShowFivBanner,
+    defaultEngagementBannerParams,
+    getBannerHtml as getFivBannerHtml,
+} from 'common/modules/commercial/fiv-banner';
+import {
+    track as trackFirstPvConsent,
+    bindClickHandlers as bindFirstPvConsentClickHandlers,
+    canShow as canShowFirstPvConsent,
+    messageCode as firstPvConsentMessageCode,
+    makeHtml as makeFirstPvConsentHtml,
+} from 'common/modules/ui/first-pv-consent-banner';
+import marque36icon from 'svgs/icon/marque-36.svg';
+
+const messageCode: string = 'first-pv-consent-plus-fiv-banner';
+
+const bannerParams: EngagementBannerParams = defaultEngagementBannerParams();
+
+const getBannerHtml = (params: EngagementBannerParams) => {
+    return `<div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner" tabindex="-1" role="dialog" aria-label="welcome" aria-describedby="site-message__message" data-component="AcquisitionsEngagementBannerStylingTweaks_control">
+        <div class="js-fiv-banner-site-message site-message--engagement-banner site-message--fiv-banner">
+            <div class="gs-container">
+                <div class="site-message__inner js-site-message-inner">
+                    <div class="site-message__roundel">
+                        ${marque36icon.markup}
+                    </div>
+                    <div class="site-message__copy js-site-message-copy u-cf">
+                        ${acquisitionsBannerFivTemplate(params)}
+                    </div>
+                </div>
+            </div>
+        </div>
+    
+        <div class="js-first-pv-consent-site-message site-message--first-pv-consent" tabindex="-1" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
+            <div class="gs-container">
+                <div class="site-message__inner js-site-message-inner">
+                    <div class="site-message__roundel">
+                        ${marque36icon.markup}
+                    </div>
+                    <div class="site-message__copy js-site-message-copy u-cf">
+                        ${makeFirstPvConsentHtml()}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>`
+}
+
+class SubMessage extends Message {
+    elementSelector: string;
+    parent: Message;
+
+    constructor(
+        id: string,
+        elementSelector: string,
+        parent: Message,
+        options?: Object
+    ) {
+        super(id, options);
+        this.elementSelector = elementSelector;
+        this.parent = parent;
+    }
+
+    hide(): void {
+        const element = document.querySelector(this.elementSelector);
+        if (element) {
+            const parentElement = element.parentElement;
+            element.remove();
+            if (parentElement && parentElement.childElementCount === 0) {
+                parentElement.remove();
+            }
+        }
+
+        // Don't display parent again if any sub-message has been hidden
+        this.parent.remember();
+    }
+
+    bindCloseHandler(): void {
+        const element = document.querySelector(this.elementSelector);
+        if (element) {
+            const closeButton = element.querySelector('.js-site-message-close');
+            if (closeButton) {
+                closeButton.addEventListener('click', () => {
+                    this.acknowledge();
+                });
+            }
+        }
+    }
+}
+
+const firstPvFivPlusfivMessage = new Message(messageCode);
+
+const firstPvConsentMessage = new SubMessage(
+    firstPvConsentMessageCode,
+    '.js-first-pv-consent-site-message',
+    firstPvFivPlusfivMessage
+);
+const fivMessage = new SubMessage(
+    fivMessageCode,
+    '.js-fiv-banner-site-message',
+    firstPvFivPlusfivMessage,
+);
+
+const show = (): Promise<boolean> => {
+    const fivBannerHtml = getFivBannerHtml(bannerParams);
+    const bannerHtml = getBannerHtml(fivBannerHtml);
+
+    trackFirstPvConsent();
+    if (document.body) {
+        document.body.insertAdjacentHTML('beforeend', bannerHtml);
+    }
+    bindFirstPvConsentClickHandlers(firstPvConsentMessage);
+    fivMessage.bindCloseHandler();
+
+    return Promise.resolve(true);
+};
+
+const firstPvConsentPlusFivBanner: Banner = {
+    id: messageCode,
+    canShow: (): Promise<boolean> =>
+        Promise.all([canShowFirstPvConsent(), canShowFivBanner()]).then(
+            (canShowBanners: Array<boolean>) =>
+                canShowBanners.every(canShowBanner => canShowBanner === true) &&
+                !(
+                    firstPvConsentMessage.isRemembered() ||
+                    fivMessage.isRemembered()
+                )
+        ),
+    show,
+};
+
+export { firstPvConsentPlusFivBanner };

--- a/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
@@ -1,7 +1,6 @@
 // @flow
 import { Message } from 'common/modules/ui/message';
 import type { Banner } from 'common/modules/ui/bannerPicker';
-import { acquisitionsBannerFivTemplate } from 'common/modules/commercial/templates/acquisitions-banner-fiv';
 import {
     messageCode as fivMessageCode,
     canShow as canShowFivBanner,
@@ -21,8 +20,8 @@ const messageCode: string = 'first-pv-consent-plus-fiv-banner';
 
 const bannerParams: EngagementBannerParams = defaultEngagementBannerParams();
 
-const getBannerHtml = (params: EngagementBannerParams) => {
-    return `<div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner" tabindex="-1" role="dialog" aria-label="welcome" aria-describedby="site-message__message" data-component="AcquisitionsEngagementBannerStylingTweaks_control">
+const getBannerHtml = (acquisitionsBannerFivHtml: string) => `
+    <div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner" tabindex="-1" role="dialog" aria-label="welcome" aria-describedby="site-message__message" data-component="AcquisitionsEngagementBannerStylingTweaks_control">
         <div class="js-fiv-banner-site-message site-message--engagement-banner site-message--fiv-banner">
             <div class="gs-container">
                 <div class="site-message__inner js-site-message-inner">
@@ -30,7 +29,7 @@ const getBannerHtml = (params: EngagementBannerParams) => {
                         ${marque36icon.markup}
                     </div>
                     <div class="site-message__copy js-site-message-copy u-cf">
-                        ${acquisitionsBannerFivTemplate(params)}
+                        ${acquisitionsBannerFivHtml}
                     </div>
                 </div>
             </div>
@@ -48,8 +47,8 @@ const getBannerHtml = (params: EngagementBannerParams) => {
                 </div>
             </div>
         </div>
-    </div>`
-}
+    </div>
+`;
 
 class SubMessage extends Message {
     elementSelector: string;
@@ -103,7 +102,7 @@ const firstPvConsentMessage = new SubMessage(
 const fivMessage = new SubMessage(
     fivMessageCode,
     '.js-fiv-banner-site-message',
-    firstPvFivPlusfivMessage,
+    firstPvFivPlusfivMessage
 );
 
 const show = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
@@ -147,4 +147,10 @@ const fivBanner: Banner = {
     canShow,
 };
 
-export { fivBanner, canShow, messageCode, defaultEngagementBannerParams, getBannerHtml };
+export {
+    fivBanner,
+    canShow,
+    messageCode,
+    defaultEngagementBannerParams,
+    getBannerHtml,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
@@ -37,7 +37,7 @@ const defaultEngagementBannerParams = () => ({
     messageText: 'n/a',
 });
 
-const showBanner = (params: EngagementBannerParams): void => {
+const getBannerHtml = (params: EngagementBannerParams) => {
     const linkUrl = addTrackingCodesToUrl({
         base: params.linkUrl,
         componentType: 'ACQUISITIONS_FIV_BANNER',
@@ -52,11 +52,16 @@ const showBanner = (params: EngagementBannerParams): void => {
     });
 
     const location = getGeoLocation();
-    const renderedBanner: string = acquisitionsBannerFivTemplate(
+    return acquisitionsBannerFivTemplate(
         location,
         linkUrl,
         subscribeUrl
     );
+};
+
+const showBanner = (params: EngagementBannerParams): void => {
+    const renderedBanner = getBannerHtml(params);
+
     const messageShown = new Message(messageCode, {
         siteMessageLinkName: 'membership message',
         siteMessageCloseBtn: 'hide',
@@ -142,4 +147,4 @@ const fivBanner: Banner = {
     canShow,
 };
 
-export { fivBanner, canShow, messageCode };
+export { fivBanner, canShow, messageCode, defaultEngagementBannerParams, getBannerHtml };

--- a/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
@@ -52,11 +52,7 @@ const getBannerHtml = (params: EngagementBannerParams) => {
     });
 
     const location = getGeoLocation();
-    return acquisitionsBannerFivTemplate(
-        location,
-        linkUrl,
-        subscribeUrl
-    );
+    return acquisitionsBannerFivTemplate(location, linkUrl, subscribeUrl);
 };
 
 const showBanner = (params: EngagementBannerParams): void => {


### PR DESCRIPTION
## What does this change?
A combined banner for cookies and FIV

## Screenshots
(FIV banner is still WIP)
![picture 12](https://user-images.githubusercontent.com/1513454/48266395-20cd8f00-e427-11e8-96c4-713268208210.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
