### PR TITLE
Discard SC_GU_GUEST_PW_SET cookie

### DIFF
--- a/identity/app/controllers/DiscardingIdentityCookies.scala
+++ b/identity/app/controllers/DiscardingIdentityCookies.scala
@@ -7,8 +7,10 @@ import conf.Configuration
 import play.api.mvc.{Cookie, DiscardingCookie, Result}
 
 object DiscardingIdentityCookies {
-  private def discardingCookieForRootDomain(name: String): DiscardingCookie =
+
+  def discardingCookieForRootDomain(name: String): DiscardingCookie =
     DiscardingCookie(name, secure = true, domain = Some(Configuration.id.domain))
+
   def apply(result: Result): Result = result.discardingCookies(
     discardingCookieForRootDomain("SC_GU_U"),
     discardingCookieForRootDomain("GU_U"),

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -43,7 +43,7 @@
 <div class="js-identity-block-list"
     data-page-variant="@{pageVariant.jsName}"
     data-csrf-token="@{play.filters.csrf.CSRF.getToken.fold("")(_.value)}"
-    data-account-token="@{requestHeader.cookies.get(UpsellController.passwordResetCookie).getOrElse("")}"
+    data-account-token="@{requestHeader.cookies.get(UpsellController.passwordResetCookie).fold("")(_.value)}"
     data-email="@email"
     data-has-password="@{hasPassword}"
     data-has-social-links="@{hasSocialLinks}"

--- a/identity/app/views/upsell/upsellContainer.scala.html
+++ b/identity/app/views/upsell/upsellContainer.scala.html
@@ -43,7 +43,7 @@
 <div class="js-identity-block-list"
     data-page-variant="@{pageVariant.jsName}"
     data-csrf-token="@{play.filters.csrf.CSRF.getToken.fold("")(_.value)}"
-    data-account-token="@{requestHeader.cookies.get("SC_GU_GUEST_PW_SET").fold("")(_.value)}"
+    data-account-token="@{requestHeader.cookies.get(UpsellController.passwordResetCookie).getOrElse("")}"
     data-email="@email"
     data-has-password="@{hasPassword}"
     data-has-social-links="@{hasSocialLinks}"


### PR DESCRIPTION
## What does this change?

Discard the `SC_GU_GUEST_PW_SET` cookie for the new flow since it's already getting injected into the HTML, and leaving the cookie in the session can lead to confusing behaviour for the user.

## Screenshots

Guest accounts are still prompted to create a full account.

<img width="1254" alt="password" src="https://user-images.githubusercontent.com/4085817/48277491-c0e4e180-e442-11e8-891d-88d900fae755.png">

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
