### PR TITLE
Update Prebid AppNexus on page placement IDs

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -89,10 +89,10 @@ export const getAppNexusDirectPlacementId = (
             return defaultPlacementId;
         case 'T':
             if (containsMpu(sizes)) {
-                return '11600568';
+                return '4371641';
             }
             if (containsLeaderboard(sizes)) {
-                return '11600778';
+                return '4371640';
             }
             return defaultPlacementId;
         default:

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -144,7 +144,7 @@ describe('getAppNexusDirectPlacementId', () => {
         getBreakpointKey.mockReturnValue('T');
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size, false))
-        ).toEqual(['11600568', '9251752', '9251752', '11600778', '9251752']);
+        ).toEqual(['4371641', '9251752', '9251752', '4371640', '9251752']);
     });
 });
 


### PR DESCRIPTION
This corrects a bug where we were using wrong IDs for tablet breakpoint.