### PR TITLE
updated colour of ad-free and cookie banners

### DIFF
--- a/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
@@ -10,7 +10,7 @@ $btn-height: ($gs-baseline*3.5);
 
 .site-message--ad-free-banner {
     color: $brightness-100;
-    background: $sport-dark;
+    background: $lifestyle-dark;
     overflow: hidden;
 
     .site-message__close {
@@ -32,13 +32,13 @@ $btn-height: ($gs-baseline*3.5);
         .inline-icon {
             fill: $brightness-100;
             path:last-child {
-                fill: $brightness-7;
+                fill: $lifestyle-dark;
             }
         }
 
         svg {
-            width: 32px;
-            height: 32px;
+            width: 36px;
+            height: 36px;
             display: block;
         }
 
@@ -62,6 +62,9 @@ $btn-height: ($gs-baseline*3.5);
         position: absolute;
         top: $gs-baseline;
         right: $gs-baseline;
+
+        height: 36px;
+        width: 36px;
 
         .inline-icon {
             fill: $brightness-100;
@@ -107,7 +110,7 @@ $btn-height: ($gs-baseline*3.5);
         }
         font-weight: bold;
         padding-bottom: $gs-baseline;
-        color: $highlight-main;
+        color: $brightness-100;
         padding-right: $gs-gutter * 2;
     }
 

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -2,7 +2,7 @@ $btn-height: ($gs-baseline*3.5);
 
 .site-message--first-pv-consent {
     padding: ($gs-baseline / 2) 0 $gs-baseline * 2;
-    background: $sport-dark;
+    background: $brightness-20;
 
     a {
         color: currentColor;
@@ -28,7 +28,32 @@ $btn-height: ($gs-baseline*3.5);
     }
 
     .site-message__roundel {
+        position: absolute;
+        padding: 0;
+        width: auto;
+        height: auto;
         display: none;
+
+        .inline-icon {
+            fill: $brightness-100;
+            path:last-child {
+                fill: $brightness-20;
+            }
+        }
+
+        svg {
+            width: 36px;
+            height: 36px;
+            display: block;
+        }
+
+        @include mq(leftCol) {
+            top: $gs-baseline;
+            left: $gs-gutter;
+            right: auto;
+            bottom: auto;
+            display: block;
+        }
     }
     .site-message__inner {
         padding: 0;
@@ -123,7 +148,7 @@ $btn-height: ($gs-baseline*3.5);
         }
         font-weight: bold;
         padding-bottom: $gs-baseline;
-        color: $highlight-main;
+        color: $brightness-100;
 
         .site-message--double-banner & {
             display: none;
@@ -150,9 +175,10 @@ $btn-height: ($gs-baseline*3.5);
 }
 
 .site-message--first-pv-consent__actions {
-    @include fs-textSans(3);
+    @include fs-textSans(5);
     margin-top: $gs-baseline * 2;
-
+    font-weight: bold;
+    
     .site-message--double-banner & {
         margin-top: $gs-baseline;
 


### PR DESCRIPTION
## What does this change?
In line with the blue header etc, it made sense to change the colours of the ad-free banner and cookie banner. This PR does just that, as per design from @zeftilldeath.

## Screenshots
### Ad-free Banner
![image](https://user-images.githubusercontent.com/19289579/48346398-ec4e1300-e672-11e8-93ff-244247a9bd10.png)
![image](https://user-images.githubusercontent.com/19289579/48346307-9da07900-e672-11e8-9630-a8ab84f4b3fe.png)
### Cookie Banner
![image](https://user-images.githubusercontent.com/19289579/48346678-cffea600-e673-11e8-819f-1751f25fb6f1.png)
![image](https://user-images.githubusercontent.com/19289579/48346682-d725b400-e673-11e8-90a0-afcc28b62b18.png)


## What is the value of this and can you measure success?
N/A just for nice contrast with new header.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
