### PR TITLE
Separate test for AU million campaign

### DIFF
--- a/applications/app/controllers/FakeGeolocationController.scala
+++ b/applications/app/controllers/FakeGeolocationController.scala
@@ -9,7 +9,7 @@ class FakeGeolocationController(val controllerComponents: ControllerComponents) 
   implicit val jf: Format[FakeGeolocation] = Json.format[FakeGeolocation]
 
   def geolocation: Action[AnyContent] = Action {
-    val fake = FakeGeolocation("GB")
+    val fake = FakeGeolocation("UK")
     Ok(Json.toJson(fake))
   }
 }

--- a/applications/app/controllers/FakeGeolocationController.scala
+++ b/applications/app/controllers/FakeGeolocationController.scala
@@ -9,7 +9,7 @@ class FakeGeolocationController(val controllerComponents: ControllerComponents) 
   implicit val jf: Format[FakeGeolocation] = Json.format[FakeGeolocation]
 
   def geolocation: Action[AnyContent] = Action {
-    val fake = FakeGeolocation("UK")
+    val fake = FakeGeolocation("GB")
     Ok(Json.toJson(fake))
   }
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -225,4 +225,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 11, 23),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-one-million-campaign-au",
+    "Tests an epic with custom copy and design for the One Million campaign",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 11, 23),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -20,6 +20,7 @@ import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experi
 import { acquisitionsEpicIframeTestV2 } from 'common/modules/experiments/tests/acquisitions-iframe-epic-v2';
 import { acquisitionsEpicAusFairfax } from 'common/modules/experiments/tests/acquisitions-epic-aus-fairfax';
 import { acquisitionsEpicOneMillionCampaign } from 'common/modules/experiments/tests/acquisitions-epic-one-million-campaign';
+import { acquisitionsEpicOneMillionCampaignAu } from 'common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options) return false;
@@ -49,6 +50,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
     acquisitionsEpicOneMillionCampaign,
+    acquisitionsEpicOneMillionCampaignAu,
     acquisitionsEpicAusFairfax,
     acquisitionsEpicIframeTestV2,
     acquisitionsEpicFromGoogleDocOneVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
@@ -1,0 +1,55 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { acquisitionsEpicOneMillionCampaignTemplate } from 'common/modules/commercial/templates/acquisitions-epic-one-million-campaign';
+import { oneMillionCampaignButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-one-million-campaign-buttons';
+import type { EpicTemplate } from 'common/modules/commercial/contributions-utilities';
+import {
+    getSync as geolocationGetSync,
+    getLocalCurrencySymbol,
+} from 'lib/geolocation';
+
+const abTestName = 'AcquisitionsEpicOneMillionCampaignAu';
+
+const australiaCopy = {
+    heading: 'We’ve got some news &hellip;',
+    paragraphs: [
+        '… three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. The same technologies that connected us with a global audience had also shifted advertising revenues away from news publishers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.',
+        'And now for the good news. Thanks to the one million readers who have supported our independent, investigative journalism through contributions, membership or subscriptions, The Guardian has overcome a perilous financial situation globally. And Guardian Australia has made its first profit with the help of 89,000 Australian supporters. But we have to maintain and build on that support for every year to come.',
+        'Sustained support from our readers enables us to continue pursuing difficult stories in challenging times of political upheaval, when factual reporting has never been more critical. The Guardian is editorially independent - our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. Readers’ support means we can continue bringing The Guardian’s independent journalism to the world, and to Australia.',
+        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+    ],
+    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support The Guardian – and it only takes a minute. Thank you.`,
+};
+
+const campaignCode = 'onemillion';
+
+export const acquisitionsEpicOneMillionCampaignAu: EpicABTest = makeABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-04-17',
+    expiry: '2019-06-05',
+
+    author: 'Joseph Smith',
+    description: 'Test copy fetched from a Google Doc',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Alternative copy makes more money than the control',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    canRun: () => geolocationGetSync() === 'AU',
+
+    variants: [
+        {
+            id: 'copy',
+            products: [],
+            options: {
+                copy: australiaCopy,
+                buttonTemplate: oneMillionCampaignButtonsTemplate,
+                campaignCode,
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
@@ -1,8 +1,6 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
-import { acquisitionsEpicOneMillionCampaignTemplate } from 'common/modules/commercial/templates/acquisitions-epic-one-million-campaign';
 import { oneMillionCampaignButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-one-million-campaign-buttons';
-import type { EpicTemplate } from 'common/modules/commercial/contributions-utilities';
 import {
     getSync as geolocationGetSync,
     getLocalCurrencySymbol,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign-au.js
@@ -25,6 +25,8 @@ export const acquisitionsEpicOneMillionCampaignAu: EpicABTest = makeABTest({
     id: abTestName,
     campaignId: abTestName,
 
+    useLocalViewLog: true,
+
     start: '2018-04-17',
     expiry: '2019-06-05',
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign.js
@@ -10,17 +10,6 @@ import {
 
 const abTestName = 'AcquisitionsEpicOneMillionCampaign';
 
-const australiaCopy = {
-    heading: 'We’ve got some news &hellip;',
-    paragraphs: [
-        '… three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. The same technologies that connected us with a global audience had also shifted advertising revenues away from news publishers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.',
-        'And now for the good news. Thanks to the one million readers who have supported our independent, investigative journalism through contributions, membership or subscriptions, The Guardian has overcome a perilous financial situation globally. And Guardian Australia has made its first profit with the help of 100,000 Australian supporters. But we have to maintain and build on that support for every year to come.',
-        'Sustained support from our readers enables us to continue pursuing difficult stories in challenging times of political upheaval, when factual reporting has never been more critical. The Guardian is editorially independent - our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. Readers’ support means we can continue bringing The Guardian’s independent journalism to the world, and to Australia.',
-        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-    ],
-    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support The Guardian – and it only takes a minute. Thank you.`,
-};
-
 const everywhereExceptAustraliaCopy = {
     heading: 'We have some news &hellip;',
     paragraphs: [
@@ -31,11 +20,6 @@ const everywhereExceptAustraliaCopy = {
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support The Guardian – and it only takes a minute. Thank you.`,
 };
-
-const oneMillionCampaignCopy = (): AcquisitionsEpicTemplateCopy =>
-    geolocationGetSync() === 'AU'
-        ? australiaCopy
-        : everywhereExceptAustraliaCopy;
 
 const oneMillionCampaignTemplate: EpicTemplate = (
     { options = {} },
@@ -68,6 +52,8 @@ export const acquisitionsEpicOneMillionCampaign: EpicABTest = makeABTest({
     audience: 1,
     audienceOffset: 0,
 
+    canRun: () => geolocationGetSync() !== 'AU',
+
     variants: [
         {
             id: 'control',
@@ -81,7 +67,7 @@ export const acquisitionsEpicOneMillionCampaign: EpicABTest = makeABTest({
             id: 'just_copy',
             products: [],
             options: {
-                copy: oneMillionCampaignCopy,
+                copy: everywhereExceptAustraliaCopy,
                 buttonTemplate: oneMillionCampaignButtonsTemplate,
                 campaignCode,
             },
@@ -91,7 +77,7 @@ export const acquisitionsEpicOneMillionCampaign: EpicABTest = makeABTest({
             products: [],
             options: {
                 template: oneMillionCampaignTemplate,
-                copy: oneMillionCampaignCopy,
+                copy: everywhereExceptAustraliaCopy,
                 buttonTemplate: oneMillionCampaignButtonsTemplate,
                 campaignCode,
             },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-one-million-campaign.js
@@ -40,6 +40,8 @@ export const acquisitionsEpicOneMillionCampaign: EpicABTest = makeABTest({
     id: abTestName,
     campaignId: abTestName,
 
+    useLocalViewLog: true,
+
     start: '2018-04-17',
     expiry: '2019-06-05',
 


### PR DESCRIPTION
## What does this change?
We do not want to show the control, or the new design, to AU users.

For AU users, show the new heading "We've got some news", the AU-specific copy, and the 2 buttons.

## Screenshots
![picture 13](https://user-images.githubusercontent.com/1513454/48346822-384d8780-e674-11e8-8c51-64ad0d50c91c.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
