### PR TITLE
Revert "No Subscribe for Int and US header + footer"

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -236,6 +236,14 @@
                                         Contribute
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
+
+                                    <a class="cta-bar__cta js-subscribe js-acquisition-link"
+                                        data-link-name="footer : subscribe-cta"
+                                        data-edition="@{editionId}"
+                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        Subscribe
+                                        @fragments.inlineSvg("arrow-right", "icon")
+                                    </a>
                                 }
                             </div>
 
@@ -399,6 +407,14 @@
                                         data-edition="@{editionId}"
                                         href="@getReaderRevenueUrl(SupportContribute, Footer)">
                                         Contribute
+                                        @fragments.inlineSvg("arrow-right", "icon")
+                                    </a>
+
+                                    <a class="cta-bar__cta js-subscribe js-acquisition-link"
+                                        data-link-name="footer : subscribe-cta"
+                                        data-edition="@{editionId}"
+                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        Subscribe
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
                                 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -45,23 +45,24 @@
                                 Support The&nbsp;Guardian
                             </div>
                         }
-                        @if(editionId == "au" || editionId == "uk") {
-                            <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
-                                data-link-name="nav2 : contribute-cta"
-                                data-edition="@{editionId}"
-                                href="@getReaderRevenueUrl(SupportContribute, Header)">
-                                Contribute
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
 
-                            <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
-                                data-link-name="nav2 : subscribe-cta"
-                                data-edition="@{editionId}"
-                                href="@getReaderRevenueUrl(SupportSubscribe,Header)">
-                                Subscribe
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
+                        <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : contribute-cta"
+                            data-edition="@{editionId}"
+                            href="@getReaderRevenueUrl(SupportContribute, Header)">
+                            Contribute
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </a>
 
+                        <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
+                            data-link-name="nav2 : subscribe-cta"
+                            data-edition="@{editionId}"
+                            href="@getReaderRevenueUrl(SupportSubscribe,Header)">
+                            Subscribe
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </a>
+
+                        @if(editionId == "uk") {
                             <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                                 data-link-name="nav2 : support-cta"
                                 data-edition="@{editionId}"
@@ -70,7 +71,7 @@
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </a>
                         } else {
-                            <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                                 data-link-name="nav2 : contribute-cta"
                                 data-edition="@{editionId}"
                                 href="@getReaderRevenueUrl(SupportContribute, Header)">


### PR DESCRIPTION
Reverts guardian/frontend#20689

I've been instructed to revert this change, as we do want the links present after all. 