### PR TITLE
Update US Minute email name

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -67,7 +67,7 @@ case object MorningBriefing extends ArticleEmailMetadata {
 }
 
 case object TheUSMinute extends ArticleEmailMetadata {
-  val name = "The campaign minute 2016"
+  val name = "The US Politics Minute"
   override val banner = Some("midterms-minute.png")
   def test(c: ContentPage): Boolean = c.item.tags.series.exists(_.id == "us-news/series/the-campaign-minute-2016")
 }


### PR DESCRIPTION
## What does this change?

Updates the name  of the US Politics Minute. Previously his was displaying an incorrect name in the footer

~This requires a corresponding change in the fronts tool.~ This is an email article, and doesn't have a corresponding email front

## Screenshots

![picture 588](https://user-images.githubusercontent.com/5931528/48409751-a2c5fc80-e734-11e8-9436-1703d3d314dd.png)

## What is the value of this and can you measure success?

Updated email name in the footer
