### PR TITLE
Temporarily disable Prebid iframe-based user syncing

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -25,8 +25,8 @@ const userSync = {
     // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
     syncsPerBidder: 999, // temporarily until above bug fixed
     filterSettings: {
-        all: {
-            bidders: '*', // allow all bidders to sync by iframe or image beacons
+        image: {
+            bidders: '*', // allow all bidders to sync by image beacons (iframe disabled temporarily)
             filter: 'include',
         },
     },

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -97,7 +97,7 @@ describe('initialise', () => {
                 syncEnabled: true,
                 syncsPerBidder: 999,
                 filterSettings: {
-                    all: {
+                    image: {
                         bidders: '*',
                         filter: 'include',
                     },


### PR DESCRIPTION
Iframe-based user-syncing is causing iframes to be added to the start of the doc head, rather than to the end as specified here: http://prebid.org/dev-docs/publisher-api-reference.html

This change will disable the iframe option, until we find out why this is happening.

[Or at least we think this is what's happening.  Still to be proven.]
