### PR TITLE
Add edition Id to page data

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -54,6 +54,7 @@ case class PageData(
     seriesId: Option[String],
     isHosted: Boolean,
     beaconUrl: String,
+    editionId: String,
     edition: String,
     contentType: Option[String],
     commissioningDesks: Option[String],
@@ -155,6 +156,7 @@ object DotcomponentsDataModel {
       jsConfig("seriesId"),    // source: content.scala
       article.metadata.isHosted,
       Configuration.debug.beaconUrl,
+      Edition(request).id,
       Edition(request).displayName,
       jsConfig("contentType"),
       jsConfig("commissioningDesks"),

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -55,7 +55,7 @@ object Edition {
 
   def isEditionFront(implicit request: RequestHeader): Boolean = editionFronts.contains(request.path)
 
-  private def editionCookieValue(request: RequestHeader): String = {
+  private def editionFromRequest(request: RequestHeader): String = {
     // override for Ajax calls
     val editionFromParameter = request.getQueryString("_edition")
 
@@ -73,7 +73,7 @@ object Edition {
   }
 
   def apply(request: RequestHeader): Edition = {
-    val cookieValue = editionCookieValue(request)
+    val cookieValue = editionFromRequest(request)
     all.find(_.matchesCookie(cookieValue)).getOrElse(defaultEdition)
   }
 


### PR DESCRIPTION
## What does this change?

Add the `editionId` to the page data object sent to dotcom-rendering

## Screenshots

![screenshot 2018-11-13 at 14 06 12](https://user-images.githubusercontent.com/6035518/48418499-5804ae80-e74d-11e8-99ba-3f6eda517678.png)