### PR TITLE
Removed shaded margins from labs and video container

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -17,23 +17,25 @@
 // Using the string `dumathoin` gives zero chance of classname collisions, so
 // changing/rotating these classnames becomes as straightforward as possible.
 .dumathoin {
-    padding: 0 $gs-gutter / 2;
+    margin: 0 $gs-gutter / 2;
     position: relative;
 
     @include mq(tablet) {
-        padding: 0 calc(50% - 370px);
+        margin: 0 calc(50% - 370px);
     }
 
     @include mq(desktop) {
-        padding: 0 calc(50% - 490px);
+        margin: 0 calc(50% - 490px);
     }
 
-    @include mq(leftCol) {
-        padding: 0 calc(50% - 570px);
-    }
+    body:not(.has-page-skin) & {
+        @include mq(leftCol) {
+            margin: 0 calc(50% - 570px);
+        }
 
-    @include mq(wide) {
-        padding: 0 calc(50% - 650px);
+        @include mq(wide) {
+            margin: 0 calc(50% - 650px);
+        }
     }
 
     .button {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -1,7 +1,6 @@
 $video-width-desktop: 700px;
 
 .fc-container--video {
-    background-color: darken($brightness-7,  7%);
     padding-bottom: 0;
     margin-bottom: $gs-baseline;
 

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -1,7 +1,6 @@
 $video-width-desktop: 700px;
 
 .fc-container--video {
-    background-color: darken($brightness-7, 7%);
     padding-bottom: 0;
     margin-bottom: $gs-baseline;
 


### PR DESCRIPTION
This removes the shaded margins from the video container on the front and the commercial containers also. Had to change the logic to support has-page-skin.