### PR TITLE
Add z index to standfirst

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -335,6 +335,7 @@
     @include fs-headline(2);
     margin-bottom: $gs-baseline/2;
     color: $brightness-7;
+    z-index: 1;
 
     @include mq(tablet) {
         @include font-size(18px, 22px);

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -354,6 +354,7 @@
     @include fs-headline(2);
     margin-bottom: $gs-baseline/2;
     color: $brightness-46;
+    z-index: 1;
 
     @include mq(tablet) {
         @include font-size(18px, 22px);


### PR DESCRIPTION
## What does this change?
Adds a z index to the standfirst so that links in articles such as this one https://www.theguardian.com/news/2017/nov/16/a-mission-for-journalism-in-a-time-of-crisis don't get hidden behind drop caps 
