### PR TITLE
Close sub-banners in a consistent way

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/first-pv-consent-plus-fiv-banner.js
@@ -6,6 +6,7 @@ import {
     canShow as canShowFivBanner,
     defaultEngagementBannerParams,
     getBannerHtml as getFivBannerHtml,
+    hideBanner as hideFivBanner,
 } from 'common/modules/commercial/fiv-banner';
 import {
     track as trackFirstPvConsent,
@@ -79,13 +80,13 @@ class SubMessage extends Message {
         this.parent.remember();
     }
 
-    bindCloseHandler(): void {
+    bindCloseHandler(close: (banner: Message) => void): void {
         const element = document.querySelector(this.elementSelector);
         if (element) {
             const closeButton = element.querySelector('.js-site-message-close');
             if (closeButton) {
                 closeButton.addEventListener('click', () => {
-                    this.acknowledge();
+                    close(this);
                 });
             }
         }
@@ -114,7 +115,7 @@ const show = (): Promise<boolean> => {
         document.body.insertAdjacentHTML('beforeend', bannerHtml);
     }
     bindFirstPvConsentClickHandlers(firstPvConsentMessage);
-    fivMessage.bindCloseHandler();
+    fivMessage.bindCloseHandler(hideFivBanner);
 
     return Promise.resolve(true);
 };
@@ -124,11 +125,7 @@ const firstPvConsentPlusFivBanner: Banner = {
     canShow: (): Promise<boolean> =>
         Promise.all([canShowFirstPvConsent(), canShowFivBanner()]).then(
             (canShowBanners: Array<boolean>) =>
-                canShowBanners.every(canShowBanner => canShowBanner === true) &&
-                !(
-                    firstPvConsentMessage.isRemembered() ||
-                    fivMessage.isRemembered()
-                )
+                canShowBanners.every(canShowBanner => canShowBanner === true)
         ),
     show,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/fiv-banner.js
@@ -22,7 +22,8 @@ const messageCode = 'fiv-banner';
 const maxArticles = 3;
 const fivImpressionsRemainingKey = 'fivImpressionsRemaining2';
 
-const hideBanner = () => {
+const hideBanner = (banner: Message) => {
+    banner.hide();
     userPrefs.set(fivImpressionsRemainingKey, 0);
 };
 
@@ -82,10 +83,9 @@ const showBanner = (params: EngagementBannerParams): void => {
         trackDisplay: true,
         cssModifierClass: 'fiv-banner',
         customJs() {
-            bean.on(document, 'click', '.js-fiv-banner-close-button', () => {
-                this.hide();
-                hideBanner();
-            });
+            bean.on(document, 'click', '.js-fiv-banner-close-button', () =>
+                hideBanner(this)
+            );
         },
     }).show(renderedBanner);
 
@@ -161,4 +161,5 @@ export {
     messageCode,
     defaultEngagementBannerParams,
     getBannerHtml,
+    hideBanner,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -264,4 +264,4 @@ const membershipEngagementBanner: Banner = {
     canShow,
 };
 
-export { membershipEngagementBanner, canShow, messageCode };
+export { membershipEngagementBanner, canShow, messageCode, hideBanner };

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -7,6 +7,7 @@ import { addTrackingCodesToUrl } from 'common/modules/commercial/acquisitions-op
 import {
     messageCode as engagementMessageCode,
     canShow as canShowEngagementBanner,
+    hideBanner as hideEngagementBanner,
 } from 'common/modules/commercial/membership-engagement-banner';
 import {
     track as trackFirstPvConsent,
@@ -93,13 +94,13 @@ class SubMessage extends Message {
         this.parent.remember();
     }
 
-    bindCloseHandler(): void {
+    bindCloseHandler(close: (banner: Message) => void): void {
         const element = document.querySelector(this.elementSelector);
         if (element) {
             const closeButton = element.querySelector('.js-site-message-close');
             if (closeButton) {
                 closeButton.addEventListener('click', () => {
-                    this.acknowledge();
+                    close(this);
                 });
             }
         }
@@ -125,7 +126,7 @@ const show = (): Promise<boolean> => {
         document.body.insertAdjacentHTML('beforeend', bannerHtml);
     }
     bindFirstPvConsentClickHandlers(firstPvConsentMessage);
-    engagementMessage.bindCloseHandler();
+    engagementMessage.bindCloseHandler(hideEngagementBanner);
 
     return Promise.resolve(true);
 };
@@ -135,11 +136,7 @@ const firstPvConsentPlusEngagementBanner: Banner = {
     canShow: (): Promise<boolean> =>
         Promise.all([canShowFirstPvConsent(), canShowEngagementBanner()]).then(
             (canShowBanners: Array<boolean>) =>
-                canShowBanners.every(canShowBanner => canShowBanner === true) &&
-                !(
-                    firstPvConsentMessage.isRemembered() ||
-                    engagementMessage.isRemembered()
-                )
+                canShowBanners.every(canShowBanner => canShowBanner === true)
         ),
     show,
 };


### PR DESCRIPTION
Fixes an issue whereby closing a banner as part of the double banner didn't register it as closed as a single banner. So you could close the fiv or engagement banner when it was on top of the cookie banner, but it would re-appear after closing the cookie banner.

This is because the code in the double banner wasn't using the same "close/hide" mechanism as the single banner. This changes things so that the same `hideBanner` function used in the individual banners is imported from the relevant banner (engagement or fiv) and used in the double banner 