### PR TITLE
Update Brexit Briefing email name

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -73,7 +73,7 @@ case object TheUSMinute extends ArticleEmailMetadata {
 }
 
 case object EuReferendum extends ArticleEmailMetadata {
-  val name = "EU Referendum Morning Briefing"
+  val name = "Brexit Briefing"
   override val banner = Some("brexit-briefing.png")
   def test(c: ContentPage): Boolean = c.item.tags.series.exists(_.id == "politics/series/eu-referendum-morning-briefing")
 }


### PR DESCRIPTION
## What does this change?

Updates the name of this email, so it appears correctly in the footer

## What is the value of this and can you measure success?

It's a much snappier name, don't you think?
