### PR TITLE
Dynamic Wording for Payment Failure Journey

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -82,7 +82,7 @@ class ChangePasswordController(
     NoCache(DiscardingIdentityCookies(
       Ok(
         IdentityHtmlPage.html(
-          views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl)
+          views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, None)
         )(page, request, context)
       )
     ))

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -32,6 +32,8 @@ class ResetPasswordController(
 
   private val page = IdentityPage("/reset-password", "Reset Password", isFlow = true)
 
+  private val paymentFailureJourneys = Set("PF", "PF1", "PF2", "PF3", "PF4", "CCX")
+
   private val requestPasswordResetForm = Form(
     Forms.single(
       "email-address" -> Forms.text
@@ -71,13 +73,12 @@ class ResetPasswordController(
   }
 
   def renderResetPassword(token: String, returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
-
     val isPaymentFailure = (for {
       url <- returnUrl
       parsedUrl <- Try(Uri.parse(url)).toOption
       intcmp <- parsedUrl.query.param("INTCMP")
     } yield {
-      intcmp.contains("PF") || intcmp.contains("CCX")
+      paymentFailureJourneys.contains(intcmp)
     }).getOrElse(false)
 
     val idRequest = idRequestParser(request)

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -3,7 +3,7 @@
 @import services.{IdentityRequest, IdentityUrlBuilder}
 @import views.html.fragments.registrationFooter
 
-@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String], isPaymentFailure: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 
 <div class="identity-wrapper monocolumn-wrapper">
@@ -29,6 +29,7 @@
                     <p><a class="manage-account__button--icon manage-account__button manage-account__button--main" href="@url" data-link-name="Continue">
                         @(url match {
                             case url if url.contains("support.") => "Back to my contribution"
+                            case url if isPaymentFailure.isDefined => "Update your payment method"
                             case _ => "Continue"
                         })
                         @fragments.inlineSvg("arrow-right", "icon")

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String, Option[String])], token : String, returnUrl: String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String, Option[String])], token : String, returnUrl: String, isPaymentFailure: Boolean)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField
@@ -28,7 +28,7 @@
 
                         <li class="form-field">
                             <button type="submit" class="manage-account__button--icon manage-account__button manage-account__button--main" data-link-name="Save password" data-test-id="reset-pwd">
-                                Save password
+                                @if(isPaymentFailure) { Continue to update payment method } else { Save password }
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </button>
                         </li>

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -28,7 +28,7 @@
 
                         <li class="form-field">
                             <button type="submit" class="manage-account__button--icon manage-account__button manage-account__button--main" data-link-name="Save password" data-test-id="reset-pwd">
-                                @if(isPaymentFailure) { Continue to update payment method } else { Save password }
+                                @if(isPaymentFailure) { Update your payment method } else { Save password }
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </button>
                         </li>

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String, Option[String])], token : String, returnUrl: String, isPaymentFailure: Boolean)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String, Option[String])], token : String, returnUrl: String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField
@@ -28,7 +28,7 @@
 
                         <li class="form-field">
                             <button type="submit" class="manage-account__button--icon manage-account__button manage-account__button--main" data-link-name="Save password" data-test-id="reset-pwd">
-                                @if(isPaymentFailure) { Update your payment method } else { Save password }
+                                Save password
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </button>
                         </li>


### PR DESCRIPTION
## What does this change?
This checks for the INTCMP=PF/CCX parameter in the returnUrl on /password/reset-confirmation page to determine if it is a part of the payment failure journey. If it is, the wording on the "Continue" button reads "Update your payment method".

## Screenshots

With Payment Failure
![screen shot 2018-11-16 at 11 14 27](https://user-images.githubusercontent.com/42539745/48618371-1a906300-e991-11e8-8d72-ce387e321559.png)

Without Payment Failure
![screen shot 2018-11-16 at 11 14 43](https://user-images.githubusercontent.com/42539745/48618392-2714bb80-e991-11e8-86fa-d9243b2e221f.png)

Mobile view
![screen shot 2018-11-16 at 11 16 24](https://user-images.githubusercontent.com/42539745/48622133-b3c57680-e99d-11e8-84aa-276ef3d1d6fc.png)

## What is the value of this and can you measure success?
Ensure user retains context when resetting or setting password in payment failure journey

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
