### PR TITLE
Add structured bylineElements

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -1,3 +1,4 @@
+@import model.Content
 @(gallery: model.GalleryPage)(implicit request: RequestHeader)
 
 @import views.support.TrailCssClasses.toneClass
@@ -20,7 +21,7 @@
 
             <div class="content__meta-container gallery__meta-container">
                 @if(!gallery.item.content.hasTonalHeaderByline) {
-                    @fragments.meta.byline(gallery.item.trail.byline, gallery.item.tags)
+                    @fragments.meta.byline(gallery.item.trail.bylineWithTags)
                 }
 
                 @if(gallery.item.content.tags.contributors.length == 1) {

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -3,7 +3,7 @@ package model.dotcomponents
 import common.Edition
 import conf.Configuration
 import controllers.ArticlePage
-import model.SubMetaLinks
+import model.{BylineElement, Content, SubMetaLinks}
 import model.dotcomrendering.pageElements.PageElement
 import navigation.NavMenu
 import play.api.libs.json.{JsValue, Json, Writes}
@@ -47,6 +47,7 @@ case class PageData(
     headline: String,
     webTitle: String,
     byline: String,
+    bylineElements: List[BylineElement],
     contentId: Option[String],
     authorIds: Option[String],
     keywordIds: Option[String],
@@ -136,6 +137,7 @@ object DotcomponentsDataModel {
     )
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
+    val byline = article.trail.byline
 
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),
@@ -147,7 +149,8 @@ object DotcomponentsDataModel {
       article.metadata.section.map(_.value),
       article.trail.headline,
       article.metadata.webTitle,
-      article.trail.byline.getOrElse(""),
+      byline.getOrElse(""),
+      Content.getStructuredByline(byline, article.tags.contributors),
       jsConfig("contentId"),   // source: content.scala
       jsConfig("authorIds"),   // source: meta.scala
       jsConfig("keywordIds"),  // source: tags.scala and meta.scala

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -431,10 +431,13 @@ object Content {
   // into List(BylineElement('Cedric Diggory', Some(<Tag>)), BylineElement(' and ', None), BylineElement('Lucius Malfoy', Some(<Tag>)).....
   // so that it can be correctly rendered with the correct bits linked to contributor pages
   def getStructuredByline(byline: Option[String], contributors: List[Tag]): List[BylineElement] = {
-    val contributorRegex = if (contributors.nonEmpty) s"(${contributors.map(c => s"${c.name}").mkString("|")})" else ""
+    val contributorRegex = if (contributors.nonEmpty) s"(${contributors.map(c => s"${c.name}").mkString("|")})".r else "".r
 
     byline.map(stripHtml).map { byline =>
-      val split = byline.replaceAll(contributorRegex, "-###-$1-###-")
+      val split = contributorRegex.replaceAllIn(byline, _ match {
+        case contributorRegex(contributor) => s"-###-$contributor-###-"
+        case _ => ""
+      })
         split.split("-###-").filter(_ != "").map(token => {
           val tag = contributors.find(_.name == token)
           BylineElement(token, tag.map(t => BylineTagData(t.id, t.name)))

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -441,6 +441,9 @@ object Content {
 }
 
 case class BylineElement(text: String, tag: Option[Tag])
+object BylineElement {
+  implicit val bylineElementWrites: Writes[BylineElement] = Json.writes[BylineElement]
+}
 
 object ArticleSchemas {
   val NewsArticle = "http://schema.org/NewsArticle"

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -435,12 +435,19 @@ object Content {
 
     byline.map(stripHtml).map { byline =>
       val split = byline.replaceAll(contributorRegex, "-###-$1-###-")
-        split.split("-###-").map(token => BylineElement(token, contributors.find(_.name == token))).toList
+        split.split("-###-").filter(_ != "").map(token => {
+          val tag = contributors.find(_.name == token)
+          BylineElement(token, tag.map(t => BylineTagData(t.id, t.name)))
+        }).toList
     }.getOrElse(List())
   }
 }
 
-case class BylineElement(text: String, tag: Option[Tag])
+case class BylineTagData(id: String, name: String)
+object BylineTagData {
+  implicit val bylineTagDataWrites: Writes[BylineTagData] = Json.writes[BylineTagData]
+}
+case class BylineElement(text: String, tag: Option[BylineTagData])
 object BylineElement {
   implicit val bylineElementWrites: Writes[BylineElement] = Json.writes[BylineElement]
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -52,6 +52,8 @@ object Trail {
     metadata: MetaData,
     apiContent: contentapi.Content): Trail = {
 
+    val byline: Option[String] = apiContent.fields.flatMap(_.byline)
+
     Trail(
       webPublicationDate = apiContent.webPublicationDate.map(_.toJoda).getOrElse(DateTime.now),
       headline = apiContent.fields.flatMap(_.headline).getOrElse(""),
@@ -59,7 +61,8 @@ object Trail {
       thumbnailPath = apiContent.fields.flatMap(_.thumbnail).map(ImgSrc(_, Naked)),
       isCommentable = apiContent.fields.flatMap(_.commentable).exists(b => b),
       isClosedForComments = !apiContent.fields.flatMap(_.commentCloseDate).map(_.toJoda).exists(_.isAfterNow),
-      byline = apiContent.fields.flatMap(_.byline).map(stripHtml),
+      byline = byline.map(stripHtml),
+      bylineWithTags = Content.getStructuredByline(byline, tags.contributors),
       trailPicture = findTrailImages(elements),
       tags = tags,
       commercial = commercial,
@@ -79,6 +82,7 @@ final case class Trail (
   webPublicationDate: DateTime,
   headline: String,
   byline: Option[String],
+  bylineWithTags: List[BylineElement],
   sectionName: String,
   trailPicture: Option[ImageMedia],
   thumbnailPath: Option[String] = None,

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -8,8 +8,8 @@
 
 @byline() = {
     @item match {
-        case v: Video   => { @fragments.meta.byline(v.bylineWithSource, v.tags) }
-        case c          => { @fragments.meta.byline(c.trail.byline, c.tags) }
+        case v: Video   => { @fragments.meta.byline(Content.getStructuredByline(v.bylineWithSource, v.tags.contributors)) }
+        case c          => { @fragments.meta.byline(c.trail.bylineWithTags) }
     }
 }
 

--- a/common/app/views/fragments/meta/byline.scala.html
+++ b/common/app/views/fragments/meta/byline.scala.html
@@ -10,7 +10,7 @@
         @element.tag.map{ tag =>
         <span itemscope="" itemtype="http://schema.org/Person" itemprop="author">
             <a rel="author" class="tone-colour" itemprop="sameAs" data-link-name="auto tag link"
-            href="@LinkTo(tag.id)"><span itemprop="name">@tag.name</span></a></span>
+            href="@LinkTo(s"/${tag.id}")"><span itemprop="name">@tag.name</span></a></span>
       }.getOrElse(element.text)
     }</p>
 }

--- a/common/app/views/fragments/meta/byline.scala.html
+++ b/common/app/views/fragments/meta/byline.scala.html
@@ -1,8 +1,16 @@
 @import model.Tags
 @import views.support.ContributorLinks
 
-@(byline: Option[String], tags: Tags)(implicit request: RequestHeader)
+@import model.BylineElement
+@import common.LinkTo
+@(bylineElements: List[BylineElement])(implicit request: RequestHeader)
 
-@byline.map { text =>
-    <p class="byline" data-link-name="byline" data-component="meta-byline">@ContributorLinks(text, tags.contributors)</p>
+@if(bylineElements.nonEmpty) {
+    <p class="byline" data-link-name="byline" data-component="meta-byline">@bylineElements.map{element =>
+        @element.tag.map{ tag =>
+        <span itemscope="" itemtype="http://schema.org/Person" itemprop="author">
+            <a rel="author" class="tone-colour" itemprop="sameAs" data-link-name="auto tag link"
+            href="@LinkTo(tag.id)"><span itemprop="name">@tag.name</span></a></span>
+      }.getOrElse(element.text)
+    }</p>
 }

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -302,9 +302,9 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
     )
 
     val structuredByline: Seq[BylineElement] = Content.getStructuredByline(Some(byline), tags)
-    structuredByline.length should be (5)
-    structuredByline(1).tag.get.name should be ("Bellatrix Lestrange")
-    structuredByline(2).text should be (" and ")
+    structuredByline.length should be (4)
+    structuredByline.head.tag.get.name should be ("Bellatrix Lestrange")
+    structuredByline(1).text should be (" and ")
 
   }
 }

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -301,11 +301,10 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
       getTag("Boris Johnson")
     )
 
-    val sb = Content.getStructuredByline(Some(byline), tags)
-    println(sb)
-    sb.length should be (5)
-    sb(1).tag.get.name should be ("Bellatrix Lestrange")
-    sb(2).text should be (" and ")
+    val structuredByline: Seq[BylineElement] = Content.getStructuredByline(Some(byline), tags)
+    structuredByline.length should be (5)
+    structuredByline(1).tag.get.name should be ("Bellatrix Lestrange")
+    structuredByline(2).text should be (" and ")
 
   }
 }

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -13,6 +13,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import views.support.JavaScriptPage
 import common.Edition
 import play.api.libs.json.JsBoolean
+import model.{Tag => ContentTag}
 
 
 class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with implicits.Dates with MockitoSugar with BeforeAndAfter {
@@ -269,5 +270,42 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
     Video(contentWithByline, None, mediaAtomWithNoSource).bylineWithSource should be (byline)
     Video(contentWithByline, None, mediaAtomWithEmptySource).bylineWithSource should be (byline)
     Video(contentWithByline, Some("guardian.co.uk"), None).bylineWithSource should be (Some(s"${byline.get}, theguardian.com"))
+  }
+
+
+  "getStructuredByline" should "return a structured byline" in {
+
+    def getTag(name: String): ContentTag = ContentTag(TagProperties(
+      id = "",
+      url = "",
+      tagType = "",
+      sectionId = "",
+      sectionName = "",
+      webTitle = name,
+      webUrl = "",
+      twitterHandle = None,
+      bio = None,
+      description = None,
+      emailAddress = None,
+      contributorLargeImagePath = None,
+      bylineImageUrl = None,
+      podcast = None,
+      references = Seq(),
+      paidContentType = None,
+      commercial = None
+    ), pagination = None, richLinkId = None)
+
+    val byline = "Bellatrix Lestrange and Boris Johnson in the Hunger Games"
+    val tags = List(
+      getTag("Bellatrix Lestrange"),
+      getTag("Boris Johnson")
+    )
+
+    val sb = Content.getStructuredByline(Some(byline), tags)
+    println(sb)
+    sb.length should be (5)
+    sb(1).tag.get.name should be ("Bellatrix Lestrange")
+    sb(2).text should be (" and ")
+
   }
 }


### PR DESCRIPTION
## What does this change?
Adds a thing called bylineElements that looks like this:
![screen shot 2018-11-14 at 17 07 12](https://user-images.githubusercontent.com/3606555/48499438-5cee5e80-e830-11e8-93e4-2e1953323a91.png)

Which should significantly simplify the logic in dotcom rendering for rendering the byline. I've not been able to remove the existing crazy `ContributorLinks` logic as it's used all over the place in dotcom  - not just `byline.scala.html` - and there doesn't seem  much point as eventually the templates it's used in will be replaced by dotcom rendering.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
