### PR TITLE
Bump Prebid to fix positioning of user-sync iframes

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -390,6 +390,16 @@ trait PrebidSwitches {
     exposeClientSide = false
   )
 
+  val prebidUserSync: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-user-sync",
+    description = "Enable bidders to sync their user data with iframe or image beacons",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val prebidSonobi: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-sonobi",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#5d4c05b",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#31a508c",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -21,16 +21,18 @@ const consentManagement = {
     allowAuctionWithoutConsent: true,
 };
 
-const userSync = {
-    // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
-    syncsPerBidder: 999, // temporarily until above bug fixed
-    filterSettings: {
-        image: {
-            bidders: '*', // allow all bidders to sync by image beacons (iframe disabled temporarily)
-            filter: 'include',
-        },
-    },
-};
+const userSync = config.get('switches.prebidUserSync', false)
+    ? {
+          // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
+          syncsPerBidder: 999, // temporarily until above bug fixed
+          filterSettings: {
+              all: {
+                  bidders: '*', // allow all bidders to sync by iframe or image beacons
+                  filter: 'include',
+              },
+          },
+      }
+    : { syncEnabled: false };
 
 const s2sConfig = {
     accountId: '1',

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -21,19 +21,6 @@ const consentManagement = {
     allowAuctionWithoutConsent: true,
 };
 
-const userSync = config.get('switches.prebidUserSync', false)
-    ? {
-          // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
-          syncsPerBidder: 999, // temporarily until above bug fixed
-          filterSettings: {
-              all: {
-                  bidders: '*', // allow all bidders to sync by iframe or image beacons
-                  filter: 'include',
-              },
-          },
-      }
-    : { syncEnabled: false };
-
 const s2sConfig = {
     accountId: '1',
     enabled: true,
@@ -65,6 +52,19 @@ class PrebidAdUnit {
 
 class PrebidService {
     static initialise(): void {
+        const userSync = config.get('switches.prebidUserSync', false)
+            ? {
+                  // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
+                  syncsPerBidder: 999, // temporarily until above bug fixed
+                  filterSettings: {
+                      all: {
+                          bidders: '*', // allow all bidders to sync by iframe or image beacons
+                          filter: 'include',
+                      },
+                  },
+              }
+            : { syncEnabled: false };
+
         const pbjsConfig = Object.assign(
             {},
             {

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -16,6 +16,7 @@ jest.mock('commercial/modules/prebid/bid-config', () => ({
 describe('initialise', () => {
     beforeEach(() => {
         config.set('switches.enableConsentManagementService', true);
+        config.set('switches.prebidUserSync', true);
         config.set('switches.prebidAppNexus', true);
         config.set('switches.prebidS2sozone', true);
         config.set('switches.prebidSonobi', true);
@@ -49,7 +50,7 @@ describe('initialise', () => {
             _priceGranularity: 'custom',
             _publisherDomain: 'null',
             _sendAllBids: true,
-            _timoutBuffer: 200,
+            _timeoutBuffer: 400,
             bidderSequence: 'random',
             bidderTimeout: 1500,
             consentManagement: {
@@ -90,14 +91,14 @@ describe('initialise', () => {
                 syncEndpoint: 'https://elb.the-ozone-project.com/cookie_sync',
                 timeout: 1500,
             },
-            timeoutBuffer: 200,
+            timeoutBuffer: 400,
             userSync: {
                 pixelEnabled: true,
                 syncDelay: 3000,
                 syncEnabled: true,
                 syncsPerBidder: 999,
                 filterSettings: {
-                    image: {
+                    all: {
                         bidders: '*',
                         filter: 'include',
                     },
@@ -134,5 +135,11 @@ describe('initialise', () => {
         config.set('switches.prebidXaxis', false);
         prebid.initialise();
         expect(window.pbjs.bidderSettings).toEqual({});
+    });
+
+    test('should generate correct Prebid config when user-sync off', () => {
+        config.set('switches.prebidUserSync', false);
+        prebid.initialise();
+        expect(window.pbjs.getConfig().userSync.syncEnabled).toEqual(false);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7936,9 +7936,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#5d4c05b":
-  version "1.30.0"
-  resolved "https://github.com/guardian/Prebid.js.git#5d4c05b16b57ca8f42e3d3814d66b0d0aad298be"
+"prebid.js@https://github.com/guardian/Prebid.js.git#31a508c":
+  version "1.32.0"
+  resolved "https://github.com/guardian/Prebid.js.git#31a508c8be2cdc5a48948937b25d016a2969b444"
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.1"


### PR DESCRIPTION
This change:
* brings in [the fix](https://github.com/guardian/Prebid.js/pull/66) to add user-sync iframes to the bottom of the head rather than the top
* includes the latest release (v1.32.0) of the generic Prebid library
* puts a feature switch around user-syncing so that it can be disabled quickly if necessary
