### PR TITLE
Update liveblog epic for million campaign

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -11,6 +11,15 @@ const controlCopyParagraphTwo =
 const controlCopyParagraphThree =
     'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.';
 
+const liveblogMillionParagraphOne =
+    '… three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. The same technologies that connected us with a global audience had also shifted advertising revenues away from news publishers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.';
+
+const liveblogMillionParagraphTwo =
+    'And now for the good news. Thanks to the one million readers who have supported our independent, investigative journalism through contributions, membership or subscriptions, The Guardian has overcome a perilous financial situation globally. But we have to maintain and build on that support for every year to come.';
+
+const liveBlogMillionParagraphThree =
+    'Sustained support from our readers enables us to continue pursuing difficult stories in challenging times of political upheaval, when factual reporting has never been more critical. The Guardian is editorially independent – our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. Readers’ support means we can continue bringing The Guardian’s independent journalism to the world.';
+
 // used when Google Doc control cannot be fetched
 export const articleCopy = {
     heading: 'Since you’re here &hellip;',
@@ -29,6 +38,17 @@ export const liveblogCopy: AcquisitionsEpicTemplateCopy = {
         controlCopyParagraphThree,
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute.`,
+};
+
+export const liveblogMillionCopy: AcquisitionsEpicTemplateCopy = {
+    paragraphs: [
+        'We have some news…',
+        liveblogMillionParagraphOne,
+        liveblogMillionParagraphTwo,
+        liveBlogMillionParagraphThree,
+        controlCopyParagraphThree,
+    ],
+    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute. Thank you.`,
 };
 
 export const getEpicParams = (

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -54,7 +54,7 @@ const getBlocksToInsertEpicAfter = (): Promise<Array<HTMLElement>> =>
             return [...blocksToInsertManualEpicAfter];
         }
 
-        const autoBlockNum = Math.floor(Math.random() * 3) + 1;
+        const autoBlockNum = Math.floor(Math.random() * 3);
         const blockToInsertAutoEpicAfter = blocks[autoBlockNum];
 
         return [...blocksToInsertManualEpicAfter].concat(

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -3,7 +3,7 @@ import { appendToLastElement } from 'lib/array-utils';
 
 const lastSentenceTemplate = (highlightedText: string, supportURL: string) =>
     `<span class="contributions__highlight">${highlightedText}</span>
-    <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a>. - Guardian HQ`;
+    <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a>. - The Guardian`;
 
 export const epicLiveBlogTemplate = ({
     copy,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -2,7 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
+import { liveblogMillionCopy } from 'common/modules/commercial/acquisitions-copy';
 
 export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     id: 'AcquisitionsEpicLiveblog',
@@ -35,7 +35,7 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
 
                 template(variant) {
                     return epicLiveBlogTemplate({
-                        copy: liveblogCopy,
+                        copy: liveblogMillionCopy,
                         componentName: variant.options.componentName,
                         supportURL: variant.options.supportURL,
                     });


### PR DESCRIPTION
## What does this change?
Uses the same million campaign copy in the liveblog

## Screenshots
![picture 23](https://user-images.githubusercontent.com/1513454/48550156-d7b78800-e8c9-11e8-9851-138df7e23ecd.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
