### PR TITLE
A/B test the liveblog million epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -2,7 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { liveblogMillionCopy } from 'common/modules/commercial/acquisitions-copy';
+import { liveblogCopy, liveblogMillionCopy } from 'common/modules/commercial/acquisitions-copy';
 
 export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     id: 'AcquisitionsEpicLiveblog',
@@ -28,6 +28,27 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     variants: [
         {
             id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+
+            options: {
+                isUnlimited: true,
+
+                template(variant) {
+                    return epicLiveBlogTemplate({
+                        copy: liveblogCopy,
+                        componentName: variant.options.componentName,
+                        supportURL: variant.options.supportURL,
+                    });
+                },
+
+                test(renderFn, variant, test) {
+                    const epicHtml = variant.options.template(variant);
+                    setupEpicInLiveblog(epicHtml, test);
+                },
+            },
+        },
+        {
+            id: 'million',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -2,7 +2,10 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { liveblogCopy, liveblogMillionCopy } from 'common/modules/commercial/acquisitions-copy';
+import {
+    liveblogCopy,
+    liveblogMillionCopy,
+} from 'common/modules/commercial/acquisitions-copy';
 
 export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     id: 'AcquisitionsEpicLiveblog',


### PR DESCRIPTION
## What does this change?
So that we can compare performance against the control

## Screenshots
See https://github.com/guardian/frontend/pull/20722

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
