### PR TITLE
Fix link colour on AMP liveblog standfirsts

### DIFF
--- a/static/src/stylesheets/amp/_liveblog-tones.scss
+++ b/static/src/stylesheets/amp/_liveblog-tones.scss
@@ -30,7 +30,7 @@
     border-bottom-color: rgba(72, 72, 72, .3);
 }
 
-.tonal--tone-live .tonal__standfirst .u-underline {
+.tonal--tone-live .tonal__standfirst a.u-underline {
     color: #ffffff;
     border-bottom-color: rgba(255, 255, 255, .3);
 }


### PR DESCRIPTION
## What does this change?

This fixes the red-on-red links in liveblog standfirst. This is done by increasing the specificity of a CSS rule for liveblogs.

## Screenshots

**Before**
<img width=375 src=https://user-images.githubusercontent.com/4561/48551530-afca2380-e8cd-11e8-83a1-98122c058ffd.png>

**After**
<img width=375 src=https://user-images.githubusercontent.com/4561/48551531-afca2380-e8cd-11e8-8969-c68d4fd46ce0.png>


## What is the value of this and can you measure success?

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
