### PR TITLE
Log out entire front when pressing/rendering on CODE.

### DIFF
--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -43,10 +43,10 @@ class Application(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFrontPress: D
       )
   }
 
-  private def handlePressRequest(path: String, liveOrDraft: String)(f: (String) => Future[_]): Future[Result] =
+  private def handlePressRequest(path: String, liveOrDraft: String)(f: (String, String) => Future[_]): Future[Result] =
     if (FaciaPressOnDemand.isSwitchedOn) {
       val stage = Configuration.facia.stage.toUpperCase
-      f(path)
+      f(path, "manualPress")
         .map(_ => NoCache(Ok(s"Successfully pressed $path on $liveOrDraft for $stage")))
         .recover { case t => NoCache(InternalServerError(t.getMessage))}}
     else {

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -38,7 +38,7 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorke
     if (FrontPressJobSwitch.isSwitchedOn) {
       log.info(s"Cron pressing path $path")
       val pressFuture = liveFapiFrontPress
-        .pressByPathId(path)
+        .pressByPathId(path, message.id.get)
         .map(Function.const(()))
 
       pressFuture.foreach {


### PR DESCRIPTION
## What does this change?
Sets facia and facia-press up to log out the entire contents of a front when it's being served/pressed. This will help us debug why sometimes fronts seem to revert back to their previous state. Due to the high volume of logging this will produce it's only switched on on CODE

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
