### PR TITLE
update message for removed content

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -76,7 +76,7 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
             views.html.gone(
               gonePage,
               "Sorry - there is no content here",
-              "This could be because the content on this tag page hasn't been published yet or has expired, there was a legal issue, or for another reason.",
+              "This could be, for example, because content associated with it is not yet published, or due to legal reasons such as the expiry of our rights to publish the content.",
               ))))
         case Right(other) => RenderOtherStatus(other)
       }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -197,7 +197,7 @@ object RenderOtherStatus {
     case 410 => Cached(60)(WithoutRevalidationResult(Gone(views.html.gone(
       gonePage,
       "Sorry - this page has been removed.",
-      "This could be because the content on this tag page hasn't been published yet or has expired, there was a legal issue, or for another reason."))))
+      "This could be, for example, because content associated with it is not yet published, or due to legal reasons such as the expiry of our rights to publish the content."))))
     case _ => result
   }
 }


### PR DESCRIPTION
## What does this change?
the removed content page
## Screenshots
![image](https://user-images.githubusercontent.com/2670496/48617738-309d2400-e98f-11e8-841e-d16e7d2725ea.png)
➡
![image](https://user-images.githubusercontent.com/2670496/48618637-e8333580-e991-11e8-91e6-a71ddf5dddf6.png)

## What is the value of this and can you measure success?
copy update
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
