### PR TITLE
Expose editions in editionalised nav

### DIFF
--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -1,9 +1,9 @@
 package controllers
 
 import common.{Edition, JsonComponent, LinkTo}
-import navigation.{NavLink, NavMenu, UrlHelpers}
 import model.Cached
-import play.api.libs.json.{Json, Writes}
+import navigation.{NavLink, NavMenu, UrlHelpers}
+import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 class NavigationController(val controllerComponents: ControllerComponents) extends BaseController {
@@ -37,12 +37,20 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
         )
       }
 
+      implicit val editionWrites: Writes[Edition] = new Writes[Edition] {
+        def writes(edition: Edition): JsValue = Json.obj(
+          "id" -> edition.id,
+          "displayName" -> edition.displayName,
+        )
+      }
+
       JsonComponent(
         "items" -> Json.arr(
           Json.obj(
             "topLevelSections" -> menu.pillars.map( section => topLevelNavItems(section) ),
             "readerRevenueLinks" -> UrlHelpers.readerRevenueLinks.map( section => navSectionLink(section)),
-            "secondarySections" -> navSecondarySections
+            "secondarySections" -> navSecondarySections,
+            "editions" -> Edition.all
           )
         )
       )


### PR DESCRIPTION
This is needed to provide the choose edition dropdown in the AMP
sidebar.

It's needed for this:

![screenshot 2018-11-19 at 15 33 57](https://user-images.githubusercontent.com/858402/48717081-98ae6d00-ec10-11e8-894f-85d3b8ba77b9.png)

And the API response looks like:

![screenshot 2018-11-19 at 15 34 40](https://user-images.githubusercontent.com/858402/48717107-a6fc8900-ec10-11e8-861e-8986434cd7d6.png)

Note, the AMP sidebar is built using the AMP-list component (https://www.ampproject.org/docs/reference/components/amp-list) which calls out to the /editionalised-nav.json endpoint, which is what this PR changes. 
