### PR TITLE
Add edition opt in link to AMP JSON

### DIFF
--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import common.{Edition, JsonComponent, LinkTo}
+import conf.Configuration
 import model.Cached
 import navigation.{NavLink, NavMenu, UrlHelpers}
 import play.api.libs.json.{JsValue, Json, Writes}
@@ -41,6 +42,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
         def writes(edition: Edition): JsValue = Json.obj(
           "id" -> edition.id,
           "displayName" -> edition.displayName,
+          "optInLink" -> s"${Configuration.id.url}/preference/edition/${edition.id.toLowerCase}"
         )
       }
 


### PR DESCRIPTION
This saves AMP having to know how to construct this itself. In edition, AMP mustance templates don't support operations like lowercase so we can't simply use the ID and lowercase it.

Previous PR here: https://github.com/guardian/frontend/pull/20731. In this I'd assumed we'd be able to lowercase the ID in the AMP mustache templates, but turns out that is not possible. In any case, passing the entire link is better as it makes AMP dumber/require less knowledge!