### PR TITLE
Fix crossword input validation

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -374,7 +374,7 @@ class Crossword extends Component<*, CrosswordState> {
         const characterUppercase = character.toUpperCase();
         const cell = this.state.cellInFocus;
         if (
-            /[A-Za-zÀ-ÿ]/.test(characterUppercase) &&
+            /[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
             characterUppercase.length === 1 &&
             cell
         ) {

--- a/static/src/javascripts/projects/common/modules/crosswords/helpers.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/helpers.js
@@ -131,7 +131,7 @@ const cellsForEntry = (entry: Clue): Array<Position> =>
 
 const checkClueHasBeenAnswered = (grid: Grid, entry: Clue): boolean =>
     cellsForEntry(entry).every(position =>
-        /^[A-Z]$/.test(grid[position.x][position.y].value)
+        /^.$/.test(grid[position.x][position.y].value)
     );
 
 const otherDirection = (direction: Direction): Direction =>

--- a/static/src/javascripts/projects/common/modules/crosswords/helpers.spec.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/helpers.spec.js
@@ -513,7 +513,7 @@ describe('Helpers', () => {
             ['', '', '', '', '', ''].map(stubCellWithValue),
             ['', '', '', '', '', ''].map(stubCellWithValue),
             ['', '', '', '', '', ''].map(stubCellWithValue),
-            ['', '', '', '', '', ''].map(stubCellWithValue),
+            ['', 'T', '2', '0', '', ''].map(stubCellWithValue),
             ['', '', '', '', '', ''].map(stubCellWithValue),
         ];
 
@@ -523,6 +523,13 @@ describe('Helpers', () => {
             position: { x: 0, y: 0 },
             direction: 'down',
             length: 5,
+        });
+        const answeredEntryWithNumbersFixture = stubClue({
+            id: '2-down',
+            solution: 'T20',
+            position: { x: 4, y: 1 },
+            direction: 'down',
+            length: 3,
         });
         const unAnsweredEntryFixture = stubClue({
             id: '1-across',
@@ -535,6 +542,15 @@ describe('Helpers', () => {
         it('should return true when the clue has been answered', () => {
             expect(
                 checkClueHasBeenAnswered(gridFixture, answeredEntryFixture)
+            ).toBe(true);
+        });
+
+        it('should return true when a clue that contains numbers has been answered', () => {
+            expect(
+                checkClueHasBeenAnswered(
+                    gridFixture,
+                    answeredEntryWithNumbersFixture
+                )
             ).toBe(true);
         });
 


### PR DESCRIPTION
## What does this change?

This improves how accented characters and numbers are handled in crosswords by:
+ allowing numbers to be inputted
+ marking clues as answered when they contain numbers or accented characters

## What is the value of this and can you measure success?

Currently certain crosswords are uncompletable. This can be unfulfilling for anyone trying to solve them. Others have seen this too, for example, [there's a few comments about it on a recent weekend crossword](https://www.theguardian.com/crosswords/weekend/410#comment-122353358).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

I've worked on [extracting the crossword component](https://github.com/zetter/frontend) which has made it easier for me to work on these fixes independently of the rest of the frontend codebase. I've been able to run tests & linters for the isolated component and test it in browser to give me the confidence that this fixes the issue.

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

—-

I've read that certain contributions require a signed CLA as I'm an external contributor. Please let me know if this is required since I'm happy to do this.