### PR TITLE
Add TPT for Inizio and a switch to Commercial to control when it runs

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -87,6 +87,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+    val InizioSwitch = Switch(
+    Commercial,
+    "inizio",
+    "Include the Inizio script on page so that creatives can show a survey.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val AdomikSwitch = Switch(
     Commercial,
     "adomik",

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -14,6 +14,7 @@ import { simpleReach } from 'commercial/modules/third-party-tags/simple-reach';
 import { tourismAustralia } from 'commercial/modules/third-party-tags/tourism-australia';
 import { krux } from 'common/modules/commercial/krux';
 import { ias } from 'commercial/modules/third-party-tags/ias';
+import { inizio } from 'commercial/modules/third-party-tags/inizio';
 import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
 import { doubleClickAdFree } from 'commercial/modules/third-party-tags/doubleclick-ad-free';
 import { plista } from 'commercial/modules/third-party-tags/plista';
@@ -81,6 +82,7 @@ const loadOther = (): void => {
         tourismAustralia,
         krux,
         ias,
+        inizio,
         doubleClickAdFree,
     ].filter(_ => _.shouldRun);
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
@@ -1,8 +1,34 @@
 // @flow strict
 import config from 'lib/config';
 
+const onLoad = () => {
+    const handleQuerySurveyDone = (
+        surveyAvailable: boolean,
+        survey: { measurementId: string }
+    ) => {
+        if (surveyAvailable) {
+            if (window && window.googletag) {
+                window.googletag.cmd.push(() => {
+                    window.googletag.pubads().setTargeting('brandmetrics', 't');
+                });
+            }
+            console.log(`surveyAvailable: ${survey.measurementId}`);
+        }
+    };
+    // eslint-disable-next-line no-underscore-dangle
+    window._brandmetrics = window._brandmetrics || [];
+    // eslint-disable-next-line no-underscore-dangle
+    window._brandmetrics.push({
+        cmd: '_querySurvey',
+        val: {
+            callback: handleQuerySurveyDone,
+        },
+    });
+};
+
 export const inizio: ThirdPartyTag = {
     shouldRun: config.get('switches.inizio', false),
     url:
         '//cdn.brandmetrics.com/survey/script/e96d04c832084488a841a06b49b8fb2d.js',
+    onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
@@ -9,7 +9,7 @@ const onLoad = () => {
         if (surveyAvailable) {
             if (window && window.googletag) {
                 window.googletag.cmd.push(() => {
-                    window.googletag.pubads().setTargeting('brandmetrics', 't');
+                    window.googletag.pubads().setTargeting('inizio', 't');
                 });
             }
             console.log(`surveyAvailable: ${survey.measurementId}`);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
@@ -1,0 +1,8 @@
+// @flow strict
+import config from 'lib/config';
+
+export const inizio: ThirdPartyTag = {
+    shouldRun: config.get('switches.inizio', false),
+    url:
+        '//cdn.brandmetrics.com/survey/script/e96d04c832084488a841a06b49b8fb2d.js',
+};


### PR DESCRIPTION
## What does this change?

- Adds another script to Commercial tags
- Adds another switch to Commercial switches
- Conditionally edits page targeting if script is loaded and survey is available

More details can be found here: https://trello.com/c/wHffHVF1/171-integrate-and-test-inizio

## What is the value of this and can you measure success?

Adding the Inizio tag to the page will enable surveys to conditionally serve into one of our MPU slots.

The script inclusion is controlled by a switch so that we can test further parts of the integration on DEV/CODE. Keeping the switch also allows rapid response if anything goes awry, or if the integration is not required for a while.

When the switch is on, and the awesome cat creative is seen, the developer will subsequently get a survey! The script calls the IAB CMP framework to get consent, so you can see if it is querying by looking for a `getVendorConsent` request for ID 422:

<img width="1680" alt="screen shot 2018-11-21 at 12 16 12" src="https://user-images.githubusercontent.com/8607683/48846193-629af580-ed96-11e8-8669-9e08316f59ae.png">

N.B. survey is blank box due to css issue unrelated to this integration; the creative uses nested iframes and it appears one is not setting the correct height.

This integration also requires some line items and creatives in AdManager:
- Test MPU with the testing pixel included
- Survey Ad Creative
- Survey Ad LineItem

I have set up my items in AdManger to allow them to appear on the same page, this is not mandatory. The important thing is the survey creative, of which only one should be required and the targeting can be something like:

Currently targeting of the survey is restricted to an adtest and I have tested the integration by targeting another MPU at the same adtest:

<img width="857" alt="screen shot 2018-11-21 at 12 50 48" src="https://user-images.githubusercontent.com/8607683/48847109-ae4e9e80-ed98-11e8-9092-4f4087fb7df0.png">

When we go live we will want to target with the `inizio: 't'` key-value in the page-targeting and this will only exist if the inizio script loads, and if a survey is available.

## Screenshots

<img width="801" alt="screen shot 2018-11-19 at 17 27 26" src="https://user-images.githubusercontent.com/8607683/48724200-79b7d700-ec20-11e8-8547-b5cea911ff82.png">

🚀 🌟 👍 

## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] CODE

