### PR TITLE
Fix football snap styling

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -8,9 +8,9 @@
 
     // Generic
     &.facia-snap-embed {
-        height: auto;
-        margin: 0;
-        padding: 0 $gs-gutter/2;
+        height: 14rem;
+        margin: 0 $gs-gutter/2;
+        padding: 0;
         position: relative;
         background: #ffffff;
     }
@@ -32,6 +32,7 @@
     .c-football-matches,
     .football-embed {
         overflow: visible; // ensure height expands in container
+        height: 100%;
     }
 
     .table,

--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -112,6 +112,15 @@
         padding-left: 14px;
     }
 
+    .football-match--result {
+        .football-match__team--home {
+            padding-right: 20px;
+        }
+        .football-match__team--away {
+            padding-left: 20px;
+        }
+    }
+
 
     .football-matches__day:last-child {
         .table__caption--bottom {


### PR DESCRIPTION
## What does this change?

Should fix snap styling. Specifically the height and vertical position of the 'more' link.

See also https://github.com/guardian/frontend/pull/20604 for my previous attempt 🤦‍♂️ .

## Why?

So that sports desk can use football snaps on fronts.

## Screenshots

Before:
<img width="309" alt="screenshot 2018-11-20 at 15 55 08" src="https://user-images.githubusercontent.com/858402/48785485-b21ceb00-ecdc-11e8-872e-08d8dee45fe6.png">

After:
![screenshot 2018-11-20 at 15 20 30](https://user-images.githubusercontent.com/858402/48784928-8ea57080-ecdb-11e8-91ab-52f4331cec13.png)

