### PR TITLE
Brand blue and side margins

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -67,15 +67,10 @@ $mq-breakpoints: (
 $guss-column-rule: none;
 
 
-// Legacy colours to be removed ================================================
-$guardian-brand:         #005689;
-$guardian-brand-light:   #94b1ca;
-$guardian-brand-dark:    #00456e;
-
-// Nav colours =================================================================
-$nav-blue:               #052962;
-$nav-border-colour:      rgba(#ffffff, .3);
-
+// Brand  ======================================================================
+$brand-dark:             #041f4a;
+$brand-main:             #052962;
+$brand-pastel:           #506991;
 
 // Neutrals ====================================================================
 $brightness-7:           #121212;
@@ -94,35 +89,35 @@ $highlight-main:         #ffe500;
 
 
 // Pillars =====================================================================
-// News (Red)
+// News (red)
 $news-dark:              #ab0613;
 $news-main:              #c70000;
 $news-bright:            #ff4e36;
 $news-pastel:            #ffbac8;
 $news-faded:             #fff4f2;
 
-// Opinion (Orange)
+// Opinion (orange)
 $opinion-dark:           #bd5318;
 $opinion-main:           #e05e00;
 $opinion-bright:         #ff7f0f;
 $opinion-pastel:         #f9b376;
 $opinion-faded:          #fef9f5;
 
-// Sport (Blue)
+// Sport (blue)
 $sport-dark:             #005689;
 $sport-main:             #0084c6;
 $sport-bright:           #00b2ff;
 $sport-pastel:           #90dcff;
 $sport-faded:            #f1f8fc;
 
-// Culture (Brown)
+// Culture (brown)
 $culture-dark:           #6b5840;
 $culture-main:           #a1845c;
 $culture-bright:         #eacca0;
 $culture-pastel:         #e7d4b9;
 $culture-faded:          #fbf6ef;
 
-// Lifestyle (Magenta)
+// Lifestyle (magenta)
 $lifestyle-dark:         #7d0068;
 $lifestyle-main:         #bb3b80;
 $lifestyle-bright:       #ffabdb;

--- a/static/src/stylesheets/amp/_buttons.scss
+++ b/static/src/stylesheets/amp/_buttons.scss
@@ -91,7 +91,7 @@
     line-height: $gs-row-height;
 
     &:hover {
-        background-color: $guardian-brand-dark;
+        background-color: $brand-dark;
     }
 
     .inline-plus__svg {

--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -98,7 +98,7 @@
 .from-content-api pre {
     // Unset from `.from-content-api`
     word-wrap: normal;
-    $x: lighten($guardian-brand-light, 30%);
+    $x: lighten($brand-pastel, 30%);
     background-color: $x;
     border: 1px solid darken($x, 10%);
     padding: $gs-baseline*.75 $gs-gutter*.75;

--- a/static/src/stylesheets/amp/footer.new/_colophon.scss
+++ b/static/src/stylesheets/amp/footer.new/_colophon.scss
@@ -1,5 +1,5 @@
 .colophon {
-    border-bottom: 1px solid $nav-border-colour;
+    border-bottom: 1px solid $brand-pastel;
     padding-bottom: $gs-baseline * 3;
 }
 

--- a/static/src/stylesheets/amp/footer.new/_footer.scss
+++ b/static/src/stylesheets/amp/footer.new/_footer.scss
@@ -12,7 +12,7 @@
     @include content-gutter();
     line-height: 1;
     font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
-    background: $nav-blue;
+    background: $brand-main;
     z-index: 1;
     color: $brightness-100;
 

--- a/static/src/stylesheets/amp/nav.new/_header.scss
+++ b/static/src/stylesheets/amp/nav.new/_header.scss
@@ -1,5 +1,5 @@
 .header {
-    background-color: $nav-blue;
+    background-color: $brand-main;
     position: relative;
     max-width: 600px;
     margin: 0 auto;

--- a/static/src/stylesheets/amp/nav.new/_menu-group.scss
+++ b/static/src/stylesheets/amp/nav.new/_menu-group.scss
@@ -10,7 +10,7 @@
 }
 
 .menu-group--secondary {
-    background-color: darken($nav-blue, 5%);
+    background-color: $brand-dark;
     margin-top: 0;
     padding-top: 0;
 }
@@ -21,5 +21,5 @@
 }
 
 .menu-group--editions .menu-group {
-    background-color: darken($nav-blue, 5%);
+    background-color: $brand-dark;
 }

--- a/static/src/stylesheets/amp/nav.new/_menu-item.scss
+++ b/static/src/stylesheets/amp/nav.new/_menu-item.scss
@@ -10,7 +10,7 @@
 
     .menu-group--primary > & {
         &:not(:last-child):after {
-            background-color: $nav-border-colour;
+            background-color: $brand-pastel;
             bottom: 0;
             content: '';
             display: block;

--- a/static/src/stylesheets/amp/nav.new/_menu.scss
+++ b/static/src/stylesheets/amp/nav.new/_menu.scss
@@ -1,5 +1,5 @@
 .menu {
-    background-color: $nav-blue;
+    background-color: $brand-main;
     color: $brightness-100;
     // This is the max width AMP allows
     width: 80vw;

--- a/static/src/stylesheets/amp/nav.new/_pillar-link.scss
+++ b/static/src/stylesheets/amp/nav.new/_pillar-link.scss
@@ -20,7 +20,7 @@
         left: 0;
         bottom: 0;
         position: absolute;
-        border-left: 1px solid $nav-border-colour;
+        border-left: 1px solid $brand-pastel;
         top: 0;
     }
 }

--- a/static/src/stylesheets/amp/nav.new/_pillars.scss
+++ b/static/src/stylesheets/amp/nav.new/_pillars.scss
@@ -1,5 +1,5 @@
 .pillars {
-    border-top: 1px solid $nav-border-colour;
+    border-top: 1px solid $brand-pastel;
     height: $pillar-height - $gs-baseline / 2;
     margin: 0;
     padding: 0 $gs-gutter / 2;

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -124,7 +124,7 @@
 .skip:active {
     font-size: 80%;
     display: block;
-    color: $guardian-brand-dark;
+    color: $brand-dark;
     text-decoration: none;
 
     position: static !important;

--- a/static/src/stylesheets/inline/article-photo-essay-garnett.scss
+++ b/static/src/stylesheets/inline/article-photo-essay-garnett.scss
@@ -223,14 +223,14 @@
 
     & > li {
         @include fs-textSans(3);
-        color: $guardian-brand;
+        color: $brand-main;
         font-size: 12px;
         width: 100%;
         margin-right: 1%;
         line-height: 14px;
         padding-top: $gs-baseline / 2;
         padding-left: 0 !important; // override padding applied in from-content-api.scss
-        border-top: 1px solid $guardian-brand;
+        border-top: 1px solid $brand-main;
 
         &::before {
             display: none !important;

--- a/static/src/stylesheets/layout/_side-margins.scss
+++ b/static/src/stylesheets/layout/_side-margins.scss
@@ -30,7 +30,6 @@
             content: '';
             position: absolute;
             z-index: 1;
-            background: transparent;
             top: 0;
             height: 100%;
             width: 0;
@@ -38,11 +37,11 @@
         }
         &:before {
             left: 0;
-            border-right: 1px solid $brightness-86;
+            border-right: 1px solid rgba($brightness-46, .3);
         }
         &:after {
             right: 0;
-            border-left: 1px solid $brightness-86;
+            border-left: 1px solid rgba($brightness-46, .3);
         }
         @include side-margins-position(gs-span(9));
     }

--- a/static/src/stylesheets/layout/new-footer/_back-to-top.scss
+++ b/static/src/stylesheets/layout/new-footer/_back-to-top.scss
@@ -5,7 +5,7 @@
     position: absolute;
     right: $gs-gutter / 2;
     text-align: right;
-    background-color: $nav-blue;
+    background-color: $brand-main;
     padding: 0 $gs-gutter / 4;
     transform: translateY(-50%);
 
@@ -40,7 +40,7 @@
         left: 9px;
 
         path {
-            fill: $nav-blue;
+            fill: $brand-main;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-footer/_colophon.scss
+++ b/static/src/stylesheets/layout/new-footer/_colophon.scss
@@ -1,11 +1,11 @@
 .colophon {
     @include content-gutter();
     padding-bottom: $gs-baseline * 2;
-    border-bottom: 1px solid $nav-border-colour;
+    border-bottom: 1px solid $brand-pastel;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline / 2;
-        border: 1px solid $nav-border-colour;
+        border: 1px solid $brand-pastel;
         border-top: 0;
     }
 }
@@ -87,7 +87,7 @@
         left: -$gs-gutter / 2;
         width: 1px;
         display: block;
-        background-color: $nav-border-colour;
+        background-color: $brand-pastel;
 
         @include mq(tablet) {
             bottom: $gs-baseline / 2;

--- a/static/src/stylesheets/layout/new-nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/new-nav/_cta-bar.scss
@@ -50,7 +50,7 @@
 
     @include mq($until: tablet) {
         // These changes are only visible in the footer
-        border-top: 1px solid $nav-border-colour;
+        border-top: 1px solid $brand-pastel;
         padding-top: $gs-baseline / 4;
     }
 

--- a/static/src/stylesheets/layout/new-nav/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-nav/_menu-group.scss
@@ -33,7 +33,7 @@
 }
 
 .menu-group--secondary {
-    background-color: darken($nav-blue, 5%);
+    background-color: $brand-dark;
     margin-top: 0;
     padding-top: 0;
 
@@ -54,7 +54,7 @@
     padding-bottom: 0;
 
     .menu-group {
-        background-color: darken($nav-blue, 3%);
+        background-color: $brand-dark;
     }
 }
 
@@ -86,7 +86,7 @@
             left: 0;
             top: 0;
             bottom: 0;
-            border-left: 1px solid $nav-border-colour;
+            border-left: 1px solid $brand-pastel;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-nav/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-nav/_menu-item.scss
@@ -32,7 +32,7 @@
 .menu-item-divider {
     height: 1px;
     width: 100%;
-    background: $nav-border-colour;
+    background: $brand-pastel;
     border: 0;
     margin: $gs-baseline/2 0 0 $menu-spacing-left-small;
 
@@ -96,7 +96,7 @@
     .menu-group--membership > *:first-child & {
         @include mq($until: desktop) {
             &:not([aria-expanded='true']):after {
-                background-color: $nav-border-colour;
+                background-color: $brand-pastel;
                 bottom: 0;
                 content: '';
                 display: block;

--- a/static/src/stylesheets/layout/new-nav/_menu.scss
+++ b/static/src/stylesheets/layout/new-nav/_menu.scss
@@ -1,5 +1,5 @@
 .menu {
-    background-color: $nav-blue;
+    background-color: $brand-main;
     box-sizing: border-box;
     font-size: 20px;
     left: 0;
@@ -82,8 +82,8 @@
     }
 
     @include mq(desktop) {
-        background-color: $nav-blue;
-        border: 1px solid $nav-border-colour;
+        background-color: $brand-main;
+        border: 1px solid $brand-pastel;
         border-bottom: 0;
         border-top: 0;
         box-sizing: border-box;

--- a/static/src/stylesheets/layout/new-nav/_new-header.scss
+++ b/static/src/stylesheets/layout/new-nav/_new-header.scss
@@ -13,7 +13,7 @@ from scrolling */
 }
 
 .new-header {
-    background-color: $nav-blue;
+    background-color: $brand-main;
     position: relative;
 
     &:not(.new-header--slim) {
@@ -155,7 +155,7 @@ from scrolling */
     }
 
     & path:nth-child(2) {
-        fill: $nav-blue;
+        fill: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/layout/new-nav/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-nav/_pillar-link.scss
@@ -64,7 +64,7 @@
 
     &:before {
         // Dividing lines
-        border-left: 1px solid $nav-border-colour;
+        border-left: 1px solid $brand-pastel;
         top: 0;
         z-index: 1;
 

--- a/static/src/stylesheets/layout/new-nav/_pillars.scss
+++ b/static/src/stylesheets/layout/new-nav/_pillars.scss
@@ -6,7 +6,7 @@
     .new-header:not(.new-header--slim) & {
         &:after {
             content: '';
-            border: 1px solid $nav-border-colour;
+            border: 1px solid $brand-pastel;
             border-bottom: 0;
             position: absolute;
             bottom: 0;

--- a/static/src/stylesheets/layout/new-nav/_search-dropdown.scss
+++ b/static/src/stylesheets/layout/new-nav/_search-dropdown.scss
@@ -15,7 +15,7 @@
     left: 0 !important;
 
     svg {
-        fill: $nav-blue !important;
+        fill: $brand-main !important;
         height: 20px !important;
         width: 20px !important;
     }

--- a/static/src/stylesheets/layout/new-nav/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-nav/_top-bar.scss
@@ -62,7 +62,7 @@
 }
 
 .top-bar__item__seperator {
-    border-left: 1px solid $nav-border-colour;
+    border-left: 1px solid $brand-pastel;
     position: absolute;
     left: 0;
     top: 0;

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -684,7 +684,7 @@ $avatarPadding: $gs-gutter / 2;
 .d-show-more-replies__button.button--show-more {
     padding-left: $gs-baseline * 2;
     svg {
-        fill: $guardian-brand;
+        fill: $brand-main;
         height: 14px;
         width: 14px;
         left: $gs-gutter / 2;
@@ -700,7 +700,7 @@ $avatarPadding: $gs-gutter / 2;
     margin-top: $gs-baseline / 1.5;
 
     a {
-        color: $guardian-brand-light;
+        color: $brand-pastel;
     }
 }
 
@@ -939,7 +939,7 @@ $comment-recommend-button-size: 19px;
 }
 
 .comment-share-icon {
-    fill: $guardian-brand;
+    fill: $brand-main;
 }
 
 .comment-share-icon svg {
@@ -1494,7 +1494,7 @@ $comment-recommend-button-size: 19px;
     line-height: 17px;
 
     &:hover {
-        border-color: $guardian-brand;
+        border-color: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -28,7 +28,7 @@
         text-align: left;
 
         &:focus {
-            color: $guardian-brand;
+            color: $brand-main;
         }
 
         .control {

--- a/static/src/stylesheets/module/_search-tool.scss
+++ b/static/src/stylesheets/module/_search-tool.scss
@@ -18,7 +18,7 @@
 }
 
 .search-tool__btn {
-    background-color: $guardian-brand;
+    background-color: $brand-main;
     border: 0;
     width: 28px;
     height: 28px;

--- a/static/src/stylesheets/module/atoms/_quiz.scss
+++ b/static/src/stylesheets/module/atoms/_quiz.scss
@@ -304,7 +304,7 @@
     @include fs-headline(9);
     font-size: 72px;
     line-height: 78px;
-    color: $guardian-brand;
+    color: $brand-main;
     display: block;
 }
 

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -53,7 +53,7 @@
         color: $brightness-7;
 
         .fc-container__header__link {
-            color: $guardian-brand;
+            color: $brand-main;
 
             &:hover {
                 color: $sport-bright;

--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -209,7 +209,7 @@
     }
 
     .adverts__logo {
-        color: $guardian-brand-dark;
+        color: $brand-dark;
     }
 
     .badge__help {

--- a/static/src/stylesheets/module/content-garnett/_article.scss
+++ b/static/src/stylesheets/module/content-garnett/_article.scss
@@ -10,7 +10,7 @@
     position: relative;
 
     .i-center {
-        background-color: $guardian-brand;
+        background-color: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -20,7 +20,7 @@
     position: relative;
 
     .i-center {
-        background-color: $guardian-brand;
+        background-color: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -988,10 +988,10 @@
             color: $brightness-46;
 
             a {
-                color: $guardian-brand;
+                color: $brand-main;
 
                 &:hover {
-                    border-bottom-color: $guardian-brand;
+                    border-bottom-color: $brand-main;
                 }
             }
         }

--- a/static/src/stylesheets/module/content/tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-editorial.scss
@@ -4,13 +4,13 @@
     editorial, // $tone
     $brightness-93, // $tonal__header-background
     $brightness-46, // $tonal__header-text
-    $guardian-brand, // $tonal__header-link
+    $brand-main, // $tonal__header-link
     200, // $tonal__headline-weight
     $brightness-7, // $tonal__headline-colour
-    $guardian-brand, // $tonal__headline-accent
-    $guardian-brand, // $tonal__standfirst-background
+    $brand-main, // $tonal__headline-accent
+    $brand-main, // $tonal__standfirst-background
     #ffffff, // $tonal__standfirst-text
     #ffffff, // $tonal__standfirst-link
     #ffffff, // $tonal__article-background
-    $guardian-brand // $tonal__article-link
+    $brand-main // $tonal__article-link
 );

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -118,7 +118,7 @@
 
 .email-sub__small {
     @include fs-textSans(1, $size-only: true);
-    color: $guardian-brand;
+    color: $brand-main;
     display: block;
     padding-left: $gs-baseline / 3;
     position: relative;
@@ -202,7 +202,7 @@
 .email-sub__form--footer {
     .email-sub__submit-button {
         @include fs-textSans(5);
-        color: $nav-blue;
+        color: $brand-main;
         height: 42px;
         line-height: 40px;
         background-color: $brightness-100;
@@ -234,7 +234,7 @@
     .email-sub__text-input {
         @include fs-textSans(5);
         background-color: rgba($brightness-100, .08);
-        border: 1px solid $nav-border-colour;
+        border: 1px solid $brand-pastel;
         border-radius: 99px;
         height: 42px;
         line-height: 42px;
@@ -259,7 +259,7 @@
 
 // LANDING PAGE MODS
 .email-sub--landing {
-    background-color: $guardian-brand;
+    background-color: $brand-main;
 
     .email-sub__description {
         padding: $gs-baseline $gs-gutter;
@@ -301,8 +301,8 @@
     }
 
     .email-sub__submit-button {
-        background-color: $guardian-brand;
-        border-color: $guardian-brand;
+        background-color: $brand-main;
+        border-color: $brand-main;
     }
 
     .email-sub__label,
@@ -321,7 +321,7 @@
     padding: 0;
 
     .email-sub__text-input {
-        border-color: $guardian-brand;
+        border-color: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/module/email-signup/_header.scss
+++ b/static/src/stylesheets/module/email-signup/_header.scss
@@ -3,13 +3,13 @@
 }
 
 .email-sub__heading-emph {
-    color: $guardian-brand;
+    color: $brand-main;
 }
 
 .email-sub__description {
     border-top: 3px solid $form-secondary-colour;
     color: $form-primary-colour;
-    background-color: $guardian-brand;
+    background-color: $brand-main;
 }
 
 .email-sub__description-emph {
@@ -59,7 +59,7 @@
 // PLAIN MODS
 .email-sub--plain {
     .email-sub__message__headline {
-        color: $guardian-brand;
+        color: $brand-main;
         line-height: 2rem;
     }
 

--- a/static/src/stylesheets/module/email-signup/_vars.scss
+++ b/static/src/stylesheets/module/email-signup/_vars.scss
@@ -22,12 +22,12 @@ $tones: (
 // so the colour scheme is different.
 $article-tones: (
     // tone, title, accent, text, button-text, background
-    (analysis, $guardian-brand, $sport-bright, $brightness-46, #ffffff,  #f1f1f1),
+    (analysis, $brand-main, $sport-bright, $brightness-46, #ffffff,  #f1f1f1),
     (comment, $brightness-7, $opinion-main, $brightness-7, #ffffff, $brightness-93),
     (feature, #ffffff, $lifestyle-pastel, #ffffff, $lifestyle-dark, $lifestyle-dark),
     (live, #ffffff, $lifestyle-pastel, #ffffff, $news-dark, $news-dark),
     (media, #ffffff, $highlight-main, #ffffff, $brightness-7, $brightness-20),
-    (news, #ffffff, $sport-pastel, #ffffff, $guardian-brand, $guardian-brand),
+    (news, #ffffff, $sport-pastel, #ffffff, $brand-main, $brand-main),
     (review, #ffffff, $highlight-main, #ffffff, #615b52, #615b52),
     (special-feature, #ffffff, $highlight-main, #ffffff, $brightness-46, $brightness-46)
 );

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -127,7 +127,7 @@
 .from-content-api pre {
     // Unset from `.from-content-api`
     word-wrap: normal;
-    $x: lighten($guardian-brand-light, 30%);
+    $x: lighten($brand-pastel, 30%);
     background-color: $x;
     border: 1px solid darken($x, 10%);
     padding: $gs-baseline*.75 $gs-gutter*.75;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -133,7 +133,7 @@ $header-image-size-desktop: 100px;
     position: relative;
     padding-bottom: $gs-baseline/3;
     line-height: get-line-height(header, 2);
-    color: $guardian-brand-dark;
+    color: $brand-dark;
 
     @include mq(tablet, leftCol) {
         float: left;
@@ -549,7 +549,7 @@ $header-image-size-desktop: 100px;
 
     &,
     a {
-        color: $guardian-brand-dark;
+        color: $brand-dark;
     }
 
     @include fs-header(4);

--- a/static/src/stylesheets/module/facia/_tag-meta.scss
+++ b/static/src/stylesheets/module/facia/_tag-meta.scss
@@ -26,7 +26,7 @@
         @include fs-header(4);
         padding-bottom: $gs-baseline/3;
         line-height: get-line-height(header, 2);
-        color: $guardian-brand-dark;
+        color: $brand-dark;
 
         @include mq($until: tablet) {
             padding: 0 0 $gs-baseline/3;

--- a/static/src/stylesheets/module/identity/_new-header.scss
+++ b/static/src/stylesheets/module/identity/_new-header.scss
@@ -4,7 +4,7 @@ $padding: 3px;
 
 .identity-header {
     @include clearfix;
-    background-color: $nav-blue;
+    background-color: $brand-main;
     padding: $padding 0;
     color: $brightness-100;
     overflow: visible;

--- a/static/src/stylesheets/module/identity/_new-wrapper.scss
+++ b/static/src/stylesheets/module/identity/_new-wrapper.scss
@@ -75,7 +75,7 @@
     }
 
     a.u-underline {
-        color: $nav-blue;
+        color: $brand-main;
     }
 }
 

--- a/static/src/stylesheets/module/survey/_inline-email-form.scss
+++ b/static/src/stylesheets/module/survey/_inline-email-form.scss
@@ -7,9 +7,9 @@
         @include fs-textSans(2);
         @include button-height($base-size * 5);
         @include button-colour(
-            $guardian-brand,
+            $brand-main,
             #ffffff,
-            $guardian-brand
+            $brand-main
         );
         display: inline-block;
         vertical-align: top;

--- a/static/src/stylesheets/module/survey/_survey-page.scss
+++ b/static/src/stylesheets/module/survey/_survey-page.scss
@@ -9,7 +9,7 @@
 
     h1, h2 {
         @include fs-headline(4);
-        color: $guardian-brand;
+        color: $brand-main;
     }
 
     h1 {
@@ -54,9 +54,9 @@
         @include fs-textSans(2);
         @include button-height($base-size * 5);
         @include button-colour(
-            $guardian-brand,
+            $brand-main,
             #ffffff,
-            $guardian-brand
+            $brand-main
         );
         font-size: .8125rem !important;
         display: inline-block;

--- a/static/src/stylesheets/pasteup/buttons/_styles.scss
+++ b/static/src/stylesheets/pasteup/buttons/_styles.scss
@@ -36,12 +36,12 @@
 
 .button--primary {
     @include button-colour(
-        $guardian-brand,
+        $brand-main,
         #ffffff
     );
 
     @include button-hover-colour(
-        darken($guardian-brand, 10%)
+        darken($brand-main, 10%)
     );
 }
 


### PR DESCRIPTION
Tidied up our colour palette, so we have brand colours again, that fit with the rules of the rest of the colour palette.

![screen shot 2018-11-20 at 14 38 16](https://user-images.githubusercontent.com/14570016/48786249-56ebf800-ecde-11e8-860d-128fec14239b.png)


Also side margin borders changed a to a transparency so they play a bit nicer with dark tones, and contrast with greys.

