### PR TITLE
Removed clearfix to prevent 1px Safari :before

### DIFF
--- a/static/src/stylesheets/layout/new-nav/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-nav/_menu-group.scss
@@ -22,7 +22,6 @@
 }
 
 .menu-group--primary {
-    @include clearfix();
     padding-top: 0;
 
     @include mq(desktop) {


### PR DESCRIPTION
I don't know how it got there. But the clearfix wasn't needed. Removing it means in Safari the pillar columns align correctly to the pillars.