### PR TITLE
Bump version of libphonenumber and add test

### DIFF
--- a/identity/test/form/TelephoneNumberMappingTest.scala
+++ b/identity/test/form/TelephoneNumberMappingTest.scala
@@ -1,5 +1,6 @@
 package form
 
+import com.google.i18n.phonenumbers.PhoneNumberUtil
 import org.scalatest.{Matchers, WordSpec}
 
 class TelephoneNumberMappingTest extends WordSpec with Matchers {
@@ -11,6 +12,13 @@ class TelephoneNumberMappingTest extends WordSpec with Matchers {
 
     "be valid if a valid international number is provided" in {
       TelephoneNumberFormData(Some("44"), Some("020 3353 2000")).isValid shouldBe true
+    }
+
+    // This test addresses a user's complaint that this number was being determined invalid. This was fixed with
+    // libphonenumber library updates in both Identity Api and Frontend
+
+    "be valid if a Solomon Island number is used starting 71" in {
+      TelephoneNumberFormData(Some("677"), Some("7135649")).isValid shouldBe true
     }
 
     "be invalid if country code is provided and local number is not" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"
-  val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4"
+  val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.0"
   val logback = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val targetingClient = "com.gu" %% "targeting-client-play26" % "0.14.5"


### PR DESCRIPTION
## What does this change?
This bumps the library version libphonenumber to a more recent version.

## What is the value of this and can you measure success?
A user in the Solomon Islands complained about not being able to save their number as it was being determined as invalid. In fact, their number was a relatively newly registered number, not accounted for by the library version we were using. The new library version allows for these new number formats. This has also been updated in Identity API. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
