### PR TITLE
Increase proportion of Prebid auctions in first look

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -115,8 +115,9 @@ export const shouldIncludePangaea = (): boolean =>
     config.get('switches.ozonePangaea', false);
 
 export const shouldIncludeXaxis = (): boolean => {
+    // 50% of UK page views
     const hasFirstLook =
-        config.get('page.isDev') || getRandomIntInclusive(1, 10) === 1;
+        config.get('page.isDev') || getRandomIntInclusive(1, 2) === 1;
     if (config.get('page.edition') === 'UK') {
         return hasFirstLook;
     }


### PR DESCRIPTION
Increasing from auctions running in 10% of UK page views to auctions running in 50% of UK page views.