### PR TITLE
Extend switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,7 +19,7 @@ object CommercialClientLogging extends Experiment(
   name = "commercial-client-logging",
   description = "A slice of the audience who will post their commercial js performance data",
   owners = Owner.group(SwitchGroup.Commercial),
-  sellByDate = new LocalDate(2018, 11, 28),
+  sellByDate = new LocalDate(2018, 12, 5),
   participationGroup = Perc1A
 )
 


### PR DESCRIPTION
There's a [PR to get rid of it altogether](https://github.com/guardian/frontend/pull/20745) but I want to add to it before merging and won't have time before Wednesday, so extending again temporarily.
