### PR TITLE
Add edition-specific Amp Prebid placement IDs

### DIFF
--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -4,6 +4,7 @@ import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValue}
 import common.Edition
 import common.commercial.AdUnitMaker
+import common.editions._
 import conf.switches.Switches.KruxSwitch
 import conf.switches.{Switch, Switches}
 import model.Article
@@ -37,7 +38,11 @@ case class AmpAdDataSlot(article: Article) {
 object AmpAdRtcConfig {
 
   // if debug, give additional debug output in RTC responses
-  def toJsonString(prebidServerUrl: String, debug: Boolean): String = {
+  def toJsonString(
+    prebidServerUrl: String,
+    edition: Edition,
+    debug: Boolean
+  ): String = {
 
     val urls: Seq[(String, JsValueWrapper)] = {
 
@@ -56,7 +61,11 @@ object AmpAdRtcConfig {
        * and https://github.com/prebid/prebid-server/blob/master/docs/endpoints/openrtb2/amp.md#query-parameters
        */
       val ampPrebidUrl = {
-        val placementId = 14351413
+        val placementId = edition match {
+          case Us => 14401433
+          case Au => 14400184
+          case _ => 14351413
+        }
         val url = s"$prebidServerUrl/openrtb2/amp?tag_id=$placementId&w=ATTR(width)&h=ATTR(height)" +
           "&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)" +
           "&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF"

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -97,7 +97,11 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
                    data-loading-strategy="prefer-viewability-over-views"
                    json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
                    data-slot={AmpAdDataSlot(article).toString()}
-                   rtc-config={AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = environment.isNonProd)}
+                   rtc-config={AmpAdRtcConfig.toJsonString(
+                     prebidServerUrl,
+                     edition,
+                     debug = environment.isNonProd
+                   )}
                 ></amp-ad>
 
     val ampAdString = {

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import common.editions._
 import conf.switches.Switches.{KruxSwitch, ampPrebid}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.{JsNull, Json}
@@ -24,7 +25,9 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   "toJsonString" should "hold Prebid server and Krux config when both switches are on" in {
     KruxSwitch.switchOn()
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = true
+    ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         kruxUrl,
@@ -34,13 +37,17 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   it should "hold no real-time config when both switches are off" in {
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = true
+    ))
     json shouldBe JsNull
   }
 
   it should "hold Krux config when Krux switch is on" in {
     KruxSwitch.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = true
+    ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         kruxUrl
@@ -50,7 +57,9 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   it should "hold Prebid server config when Prebid server switch is on" in {
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = true
+    ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
         ampPrebidUrl
@@ -60,13 +69,49 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   it should "hold debug param in Amp Prebid URL if debugging" in {
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = true))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = true
+    ))
     Json.stringify(json) should include("&debug=1")
   }
 
   it should "not hold debug param in Amp Prebid URL if not debugging" in {
     ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(prebidServerUrl, debug = false))
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = false
+    ))
     Json.stringify(json) should not include "&debug=1"
+  }
+
+  it should "have correct placement ID for UK edition" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = false
+    ))
+    Json.stringify(json) should include ("tag_id=14351413")
+  }
+
+  it should "have correct placement ID for US edition" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Us, debug = false
+    ))
+    Json.stringify(json) should include ("tag_id=14401433")
+  }
+
+  it should "have correct placement ID for AU edition" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Au, debug = false
+    ))
+    Json.stringify(json) should include ("tag_id=14400184")
+  }
+
+  it should "have correct placement ID for International edition" in {
+    ampPrebid.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = International, debug = false
+    ))
+    Json.stringify(json) should include ("tag_id=14351413")
   }
 }


### PR DESCRIPTION
This sets the correct placement IDs for Prebid on Amp in each edition so that they can be targeted effectively.
A corresponding placement for each edition will need to be set up on the Prebid server as well.