### PR TITLE
Update blue in console.log hiring msg

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -58,7 +58,7 @@ const showHiringMessage = (): void => {
                     '%cWe are hiring – ever thought about joining us? \n' +
                     '%chttps://workforus.theguardian.com/careers/digital-development%c \n' +
                     '\n',
-                'font-family: Georgia, serif; font-size: 32px; color: #005689',
+                'font-family: Georgia, serif; font-size: 32px; color: #052962',
                 'font-family: Georgia, serif; font-size: 16px; color: #767676',
                 'font-family: Helvetica Neue, sans-serif; font-size: 11px; text-decoration: underline; line-height: 1.2rem; color: #767676',
                 ''


### PR DESCRIPTION
## What does this change?
What is a sick day without getting 1 petty gripe sorted out from bed

## Screenshots
This is the old one:
<img width="382" alt="screenshot 2018-11-28 at 10 03 12 am" src="https://user-images.githubusercontent.com/11539094/49144279-e869f400-f2f4-11e8-9361-d1e29ef3dbb6.png">

## What is the value of this and can you measure success?
Some engineer who cares way too much about branding might feel more compelled to join graun now that this egregious mismatch is corrected!