### PR TITLE
Just top tickers in the US

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -228,8 +228,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-epic-us-end-of-year-round-2",
-    "Tests an epic with ticker in US",
+    "ab-acquisitions-epic-us-top-ticker",
+    "Tests an epic with top ticker in US",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 6, 6),

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -19,7 +19,7 @@ import { acquisitionsEpicFromGoogleDocFourVariants } from 'common/modules/experi
 import { acquisitionsEpicFromGoogleDocFiveVariants } from 'common/modules/experiments/tests/acquisitions-epic-from-google-doc-five-variants';
 import { acquisitionsEpicAuPostOneMillion } from 'common/modules/experiments/tests/acquisitions-epic-au-post-one-million';
 import { acquisitionsEpicUsPreEndOfYear } from 'common/modules/experiments/tests/acquisitions-epic-us-pre-end-of-year';
-import { acquisitionsEpicUsEndOfYearRound2 } from 'common/modules/experiments/tests/acquisitions-epic-us-end-of-year-round-2';
+import { acquisitionsEpicUsTopTicker } from 'common/modules/experiments/tests/acquisitions-epic-us-top-ticker';
 
 const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options) return false;
@@ -48,7 +48,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
  * acquisition tests in priority order (highest to lowest)
  */
 export const acquisitionsTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    acquisitionsEpicUsEndOfYearRound2,
+    acquisitionsEpicUsTopTicker,
     acquisitionsEpicUsPreEndOfYear,
     acquisitionsEpicAuPostOneMillion,
     acquisitionsEpicFromGoogleDocOneVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
@@ -5,7 +5,7 @@ import type { EpicTemplate } from 'common/modules/commercial/contributions-utili
 import { initTicker } from 'common/modules/commercial/ticker';
 import type { TickerPosition } from 'common/modules/commercial/templates/acquisitions-epic-us-ticker';
 
-const abTestName = 'AcquisitionsEpicUsEndOfYearRound2';
+const abTestName = 'AcquisitionsEpicUsTopTicker';
 
 const createTemplate = (tickerPosition: TickerPosition): EpicTemplate => (
     { options = {} },
@@ -46,7 +46,7 @@ const somethingYouCanDoCopy: AcquisitionsEpicTemplateCopy = {
         'By giving a year-end gift – however big or small – you are supporting The Guardian’s independence and ensuring we can keep delivering factual, trustworthy journalism for the years to come. Thank you.',
 };
 
-export const acquisitionsEpicUsEndOfYearRound2: EpicABTest = makeABTest({
+export const acquisitionsEpicUsTopTicker: EpicABTest = makeABTest({
     id: abTestName,
     campaignId: abTestName,
 
@@ -68,10 +68,6 @@ export const acquisitionsEpicUsEndOfYearRound2: EpicABTest = makeABTest({
 
     variants: [
         {
-            id: 'control',
-            products: [],
-        },
-        {
             id: 'us_eoy_critical_times_top_ticker',
             products: [],
             options: {
@@ -83,22 +79,11 @@ export const acquisitionsEpicUsEndOfYearRound2: EpicABTest = makeABTest({
             },
         },
         {
-            id: 'us_eoy_critical_times_bottom_ticker',
-            products: [],
-            options: {
-                copy: criticalTimesCopy,
-                template: createTemplate('BOTTOM'),
-                onView: () => {
-                    initTicker();
-                },
-            },
-        },
-        {
-            id: 'us_eoy_something_you_can_do_bottom_ticker',
+            id: 'us_eoy_something_you_can_do_top_ticker',
             products: [],
             options: {
                 copy: somethingYouCanDoCopy,
-                template: createTemplate('BOTTOM'),
+                template: createTemplate('TOP'),
                 onView: () => {
                     initTicker();
                 },


### PR DESCRIPTION
## What does this change?

The one variant with the top ticker is performing phenomenally well in the US. So we're switching to just variants with top tickers. The new "control" is `us_eoy_critical_times_top_ticker`, the winning one, and we're comparing now against alternative copy also with a top ticker (this copy only appeared with a bottom ticker in the previous test)

Test name is now **AcquisitionsEpicUsTopTicker**

## Screenshots

| us_eoy_critical_times_top_ticker | us_eoy_something_you_can_do_top_ticker |
| - | - |
| ![us_eoy_critical_times_top_ticker_two_variants](https://user-images.githubusercontent.com/5122968/49146002-13eedd80-f2f9-11e8-9dc2-2db06370c9d0.png) | ![us_eoy_something_you_can_do_top_ticker_two_variants](https://user-images.githubusercontent.com/5122968/49146003-13eedd80-f2f9-11e8-997a-e5b398c2f0e9.png) |

