### PR TITLE
Callouts: Match callout data with callout location using tagnames

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.0"
   val logback = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client-play26" % "0.14.5"
+  val targetingClient = "com.gu" %% "targeting-client-play26" % "0.14.7"
   val scanamo = "com.gu" %% "scanamo" % "0.9.5"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.12"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.2"

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -5,20 +5,15 @@ export const getCampaigns = () => {
     // eslint-disable-next-line
     const isCallout = campaign => campaign.fields._type === 'callout';
     const allCampaigns = config.get('page.campaigns');
-
     const allCallouts = allCampaigns.filter(isCallout);
 
-    if (allCallouts.length) {
+    console.log('allcallouts', allCallouts);
 
-        return allCallouts.map( callout => {
-            return {
-                title: callout.fields.callout,
-                description: callout.fields.description || `<p>&nbsp;</p>`,
-                formFields: callout.fields.formFields,
-                formId: callout.fields.formId
-            }
-        });
-    }
-
-    // return empty array?
+    return allCallouts.map(callout => ({
+        name: callout.name,
+        title: callout.fields.callout,
+        description: callout.fields.description || `<p>&nbsp;</p>`,
+        formFields: callout.fields.formFields,
+        formId: callout.fields.formId,
+    }));
 };

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -19,4 +19,6 @@ export const getCampaigns = () => {
             }
         });
     }
+
+    // return empty array?
 };

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -7,13 +7,15 @@ export const getCampaigns = () => {
     const allCampaigns = config.get('page.campaigns');
     const allCallouts = allCampaigns.filter(isCallout);
 
-    console.log('allcallouts', allCallouts);
-
-    return allCallouts.map(callout => ({
-        name: callout.name,
-        title: callout.fields.callout,
-        description: callout.fields.description || `<p>&nbsp;</p>`,
-        formFields: callout.fields.formFields,
-        formId: callout.fields.formId,
-    }));
+    return allCallouts.reduce((acc, curr) => {
+        acc[curr.fields.tagName] = {
+            name: curr.name,
+            title: curr.fields.callout,
+            description: curr.fields.description || '',
+            formFields: curr.fields.formFields,
+            formId: curr.fields.formId,
+            tagName: curr.fields.tagName,
+        };
+        return acc;
+    }, {});
 };

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.js
@@ -1,27 +1,22 @@
 // @flow
 import config from 'lib/config';
 
-export const getCampaign = () => {
+export const getCampaigns = () => {
     // eslint-disable-next-line
     const isCallout = campaign => campaign.fields._type === 'callout';
     const allCampaigns = config.get('page.campaigns');
 
-    // take the last added campaign as campaign to show
     const allCallouts = allCampaigns.filter(isCallout);
-    const campaignToShow = allCallouts[allCallouts.length - 1];
 
-    if (campaignToShow) {
-        const {
-            callout,
-            description,
-            formFields,
-            formId,
-        } = campaignToShow.fields;
-        return {
-            title: callout,
-            description: description || `<p>&nbsp;</p>`,
-            formFields,
-            formId,
-        };
+    if (allCallouts.length) {
+
+        return allCallouts.map( callout => {
+            return {
+                title: callout.fields.callout,
+                description: callout.fields.description || `<p>&nbsp;</p>`,
+                formFields: callout.fields.formFields,
+                formId: callout.fields.formId
+            }
+        });
     }
 };

--- a/static/src/javascripts/projects/journalism/modules/get-campaign.spec.js
+++ b/static/src/javascripts/projects/journalism/modules/get-campaign.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getCampaign } from 'journalism/modules/get-campaign';
+import { getCampaigns } from 'journalism/modules/get-campaign';
 import config from 'lib/config';
 
 jest.mock('lib/config');
@@ -19,6 +19,7 @@ const twoCampaigns = [
             description: 'Tell us your story and upload a file',
             formFields: [],
             _type: 'callout',
+            tagName: 'callout-1',
         },
     },
     {
@@ -45,6 +46,7 @@ const twoCampaigns = [
             description: 'How far away is it?',
             formFields: [],
             _type: 'callout',
+            tagName: 'exciting-callout-tagname',
         },
     },
 ];
@@ -74,6 +76,7 @@ const oneCampaign = [
             description: 'How far away is it?',
             formFields: [],
             _type: 'callout',
+            tagName: 'exciting-callout-tagname',
         },
     },
 ];
@@ -91,29 +94,45 @@ describe('Finding the callouts to display ', () => {
 
     it('it shows a callout campaign if there is one present', () => {
         const callout1 = {
-            title: 'Do you have a supermarket near you?',
-            description: 'How far away is it?',
-            formFields: [],
-            formId: 3028078,
+            'exciting-callout-tagname': {
+                name: 'Exciting callout number 3',
+                title: 'Do you have a supermarket near you?',
+                description: 'How far away is it?',
+                formFields: [],
+                formId: 3028078,
+                tagName: 'exciting-callout-tagname',
+            },
         };
 
-        expect(getCampaign()).toEqual(callout1);
+        expect(getCampaigns()).toEqual(callout1);
     });
 
     // change this when new targeting rules come in
-    it('if there are two or more callout campaigns, it shows the last one', () => {
+    it('if there are two or more callouts, all of them are returned', () => {
         config.page.campaigns = twoCampaigns;
         const callout2 = {
-            title: 'Do you have a supermarket near you?',
-            description: 'How far away is it?',
-            formFields: [],
-            formId: 3028078,
+            'callout-1': {
+                description: 'Tell us your story and upload a file',
+                formFields: [],
+                formId: 2994970,
+                name: 'Callout 1',
+                tagName: 'callout-1',
+                title: 'Has this happened to you?',
+            },
+            'exciting-callout-tagname': {
+                name: 'Exciting callout number 3',
+                title: 'Do you have a supermarket near you?',
+                description: 'How far away is it?',
+                formFields: [],
+                formId: 3028078,
+                tagName: 'exciting-callout-tagname',
+            },
         };
-        expect(getCampaign()).toEqual(callout2);
+        expect(getCampaigns()).toEqual(callout2);
     });
 
     it('if there are no callout campaigns, nothing is shown', () => {
         config.page.campaigns = [];
-        expect(getCampaign()).toEqual(undefined);
+        expect(getCampaigns()).toEqual({});
     });
 });

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -2,7 +2,7 @@
 import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/template';
 import campaignForm from 'raw-loader!journalism/views/campaignForm.html';
-import { getCampaign } from 'journalism/modules/get-campaign';
+import { getCampaigns } from 'journalism/modules/get-campaign';
 import { submitForm } from 'journalism/modules/submit-form';
 
 const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
@@ -24,11 +24,20 @@ const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
 };
 
 export const initCampaign = () => {
-    const calloutData = getCampaign();
+    const calloutDatasets = getCampaigns();
+    console.log(calloutDatasets);
 
-    const fourthParagraph = document.querySelector(
-        '.content__article-body p:nth-of-type(4)'
-    );
-    if (calloutData && fourthParagraph)
-        renderCampaign(fourthParagraph, calloutData);
+    const calloutContainers = document.querySelectorAll('div[data-callout-id]');
+    console.log(calloutContainers);
+
+    // loop through containers and if id is found in a campaign data object, put that one in there
+
+    calloutContainers.forEach(container => {
+        const cId = container.getAttribute('data-callout-id');
+        calloutDatasets.forEach(callout => {
+            if (callout.id === cId) {
+                renderCampaign(container, callout);
+            }
+        });
+    });
 };

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -5,13 +5,17 @@ import campaignForm from 'raw-loader!journalism/views/campaignForm.html';
 import { getCampaigns } from 'journalism/modules/get-campaign';
 import { submitForm } from 'journalism/modules/submit-form';
 
-const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
+const renderCampaign = (calloutNode: HTMLElement, calloutData): void => {
     const campaign = template(campaignForm)({ data: calloutData });
     const campaignDiv = `<figure class="element element-campaign">${campaign}</figure>`;
 
+    console.log('render campaign happened');
+    console.log('calloutdata =====>', calloutData);
+    console.log('callout container ====>', calloutNode);
+
     fastdom
         .write(() => {
-            anchorNode.insertAdjacentHTML('afterend', campaignDiv);
+            calloutNode.innerHTML = campaignDiv;
         })
         .then(() => {
             const cForm = document.querySelector(
@@ -23,19 +27,31 @@ const renderCampaign = (anchorNode: HTMLElement, calloutData): void => {
         });
 };
 
+const getCalloutContainers = () => {
+    // callout container is a figure with data-alt property in the format: 'Callout callout-name' eg. 'Callout new-campaign-with-a-callout'
+    const allEmbeds = document.querySelectorAll('figure.element-embed');
+    return Array.from(allEmbeds).filter(el =>
+        el
+            .getAttribute('data-alt')
+            .toLowerCase()
+            .includes('callout')
+    );
+};
+
 export const initCampaign = () => {
     const calloutDatasets = getCampaigns();
-    console.log(calloutDatasets);
-
-    const calloutContainers = document.querySelectorAll('div[data-callout-id]');
-    console.log(calloutContainers);
-
-    // loop through containers and if id is found in a campaign data object, put that one in there
+    const calloutContainers = getCalloutContainers();
 
     calloutContainers.forEach(container => {
-        const cId = container.getAttribute('data-callout-id');
+        const containerDataAlt = container
+            .getAttribute('data-alt')
+            .toLowerCase();
+        console.log('container id', containerDataAlt);
+        console.log('dataset', calloutDatasets[0]);
+
         calloutDatasets.forEach(callout => {
-            if (callout.id === cId) {
+            console.log(callout.id);
+            if (containerDataAlt.includes(callout.id)) {
                 renderCampaign(container, callout);
             }
         });

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -9,10 +9,6 @@ const renderCampaign = (calloutNode: HTMLElement, calloutData): void => {
     const campaign = template(campaignForm)({ data: calloutData });
     const campaignDiv = `<figure class="element element-campaign">${campaign}</figure>`;
 
-    console.log('render campaign happened');
-    console.log('calloutdata =====>', calloutData);
-    console.log('callout container ====>', calloutNode);
-
     fastdom
         .write(() => {
             calloutNode.innerHTML = campaignDiv;
@@ -28,32 +24,34 @@ const renderCampaign = (calloutNode: HTMLElement, calloutData): void => {
 };
 
 const getCalloutContainers = () => {
-    // callout container is a figure with data-alt property in the format: 'Callout callout-name' eg. 'Callout new-campaign-with-a-callout'
-    const allEmbeds = document.querySelectorAll('figure.element-embed');
-    return Array.from(allEmbeds).filter(el =>
-        el
-            .getAttribute('data-alt')
-            .toLowerCase()
-            .includes('callout')
-    );
+    // callout container is a figure with data-alt property in the format: 'Callout callout-tag-name' eg. 'Callout new-campaign-with-a-callout'
+    const allEmbeds = document.querySelectorAll('figure[data-alt]');
+
+    return Array.from(allEmbeds).filter(el => {
+        const dataAlt = el.getAttribute('data-alt');
+        if (!dataAlt) return false;
+        return dataAlt.toLowerCase().startsWith('callout');
+    });
+};
+
+const clearEmptyCallout = calloutContainer => {
+    calloutContainer.innerHTML = '';
 };
 
 export const initCampaign = () => {
-    const calloutDatasets = getCampaigns();
+    const calloutData = getCampaigns();
     const calloutContainers = getCalloutContainers();
 
+    // put the data into the correct container by matching up tagName on the data with the tagName on the container
     calloutContainers.forEach(container => {
-        const containerDataAlt = container
-            .getAttribute('data-alt')
-            .toLowerCase();
-        console.log('container id', containerDataAlt);
-        console.log('dataset', calloutDatasets[0]);
+        const dataAlt = container.getAttribute('data-alt');
+        if (!dataAlt) return;
+        const tagName = dataAlt.toLowerCase().split(' ')[1];
 
-        calloutDatasets.forEach(callout => {
-            console.log(callout.id);
-            if (containerDataAlt.includes(callout.id)) {
-                renderCampaign(container, callout);
-            }
-        });
+        if (tagName in calloutData) {
+            renderCampaign(container, calloutData[tagName]);
+        } else {
+            clearEmptyCallout(container);
+        }
     });
 };

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
@@ -1,29 +1,81 @@
 // @flow
 
 import { initCampaign } from 'journalism/modules/render-campaign';
-import { getCampaign } from 'journalism/modules/get-campaign';
+import { getCampaigns } from 'journalism/modules/get-campaign';
 
 // hack to stop flow complaining about 'mockImplementation'
 const mock = (mockFn: any) => mockFn;
 jest.mock('journalism/modules/get-campaign');
-mock(getCampaign).mockImplementation(() => ({ title: 'A great campaign' }));
+mock(getCampaigns).mockImplementation(() => ({
+    'callout-hij': {
+        description: '<p>formatted <b>description</b></p>',
+        formFields: [],
+        formId: 2994970,
+        name: 'callout hij',
+        title: 'Callout HIJ',
+        tagName: 'callout-hij',
+    },
+    'callout-klm': {
+        description: '<p>new test<b>&nbsp;</b></p>',
+        formFields: [],
+        formId: 2994970,
+        name: 'callout klm',
+        title: 'Callout klm',
+        tagName: 'callout-klm',
+    },
+}));
 
-describe('Create a campaign element and insert into an article in the right place', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML =
-                '<div class="content__article-body"><h1>title</h1><p>one</p><p>two</p><p>three</p><p>four</p></div>';
-        }
-    });
+const articleBodyWithCalloutBoxes =
+    '<div class="content__article-body"><h1>title</h1><p>one</p><p>two</p><figure data-alt="Callout callout-hij"></figure><p>three</p><p>four</p><figure data-alt="Callout callout-klm"></figure></div>';
+const articleBody =
+    '<div className="content__article-body"><h1>title</h1><p>one</p><p>two</p><p>three</p><p>four</p></div>';
+const renderedCallout =
+    '<figure class="element element-campaign"><div></div></figure>';
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+const setUpArticle = articleType => {
+    if (document.body) {
+        document.body.innerHTML = articleType;
+    }
+};
 
-    it('adds the campaign element to the article body', () => {
+const clearUpArticle = () => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
+};
+
+describe('If a callout container and callout data are both present', () => {
+    beforeEach(() => setUpArticle(articleBodyWithCalloutBoxes));
+    afterEach(() => clearUpArticle());
+
+    // unfortunately the lodash template used in rendering can't be easily mocked so this basic comparision is all I can do
+    it('puts the callout in the right container', () => {
         initCampaign();
-        expect(document.querySelectorAll('figure').length).toBe(1);
+        expect(document.querySelectorAll('figure')[0].innerHTML).toEqual(
+            renderedCallout
+        );
+    });
+});
+
+describe('If there are no container boxes, no callout is added', () => {
+    beforeEach(() => setUpArticle(articleBody));
+    afterEach(() => clearUpArticle());
+
+    it('doesnt render a callout, even if the data is present', () => {
+        initCampaign();
+        expect(document.querySelectorAll('figure').length).toBe(0);
+    });
+});
+
+describe('If there is no data, no callout is added', () => {
+    beforeEach(() => {
+        setUpArticle(articleBodyWithCalloutBoxes);
+        mock(getCampaigns).mockImplementation(() => []);
+    });
+    afterEach(() => clearUpArticle());
+
+    it('doesnt render a callout, even if the container is present', () => {
+        initCampaign();
+        expect(document.querySelectorAll('figure')[0].innerHTML).toBe('');
     });
 });

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.spec.js
@@ -8,7 +8,7 @@ const mock = (mockFn: any) => mockFn;
 jest.mock('journalism/modules/get-campaign');
 mock(getCampaign).mockImplementation(() => ({ title: 'A great campaign' }));
 
-describe('Create a campaign element and insert into an article', () => {
+describe('Create a campaign element and insert into an article in the right place', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML =

--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -9,7 +9,7 @@
             </div>
             <div class="heading">
                 <h4 class="campaign--snippet__headline"> <%= data.title %></h4>
-                <%= data.description %>
+                <p><%= data.description %> </p>
             </div>
             <div class="success_box">
                 <p class="success-message">Thank you for your contribution</p>

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -153,6 +153,7 @@
     .campaign--kicker {
         display: flex;
         flex-direction: row;
+        min-height: 70px;
 
         > .campaign--snippet__heading-logo {
             flex: initial;


### PR DESCRIPTION
## What does this change?
The body html from Composer has callout containers, CAPI has callout content... we need to match the container to the content.  

To connect the two, I'm using the tagname that is associated with both of them. 

This PR:
1) pushes through the tagname to Frontend (by updating targeting-client) 
2) changes the rendering code to match on `tagName`
3) updates the tests to describe the new behaviour, including the ability to have more than one callout per story

To test:
1. Check that the below callout branch is deployed on code composer 
2. Create an article with a tag of type callout, and use the right click tool to place the callout somewhere in the story
3. Publish the article.
4. Point your `~/.gu/frontend.conf` file at *code* capi like:
```
devOverrides = {
     content.api.host="<code capi url>"
     targeting.campaignsUrl = "https://targeting.code.dev-gutools.co.uk/api/campaigns"
}
```
5. View the article ... the callout should appear.

Related: 
https://github.com/guardian/flexible-content/pull/3335

https://github.com/guardian/targeting/pull/121

## Screenshots
In composer... 
![screen shot 2018-11-30 at 13 28 05](https://user-images.githubusercontent.com/10324129/49292209-8d76ff00-f4a4-11e8-81fa-83b963d82f2b.png)


In frontend
![screen shot 2018-11-30 at 13 27 53](https://user-images.githubusercontent.com/10324129/49292228-97006700-f4a4-11e8-8c95-ef3b43a76c8d.png)

Now you can even have 2 callouts in a page 
![screen shot 2018-11-30 at 17 28 20](https://user-images.githubusercontent.com/10324129/49305269-c3c57600-f4c6-11e8-9463-8eb60949c806.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
