### PR TITLE
Better landmarks on articles

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -492,8 +492,6 @@ import collection.JavaConverters._
         import browser._
 
         Then("I should see the main ARIA roles described")
-        $(".related").attribute("role") should be("complementary")
-        $("aside").attribute("role") should be("complementary")
         $("header").attribute("role") should be("banner")
         $(".l-footer__secondary").attribute("role") should be("contentinfo")
         $("nav").attribute("aria-label") should not be empty

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -22,7 +22,7 @@
                     <a data-link-name="section heading" href="@LinkTo {/@href}">
                         @badgeFor(containerDefinition).map { badge =>
                             <div class="badge-slot">
-                                <img class="badge-slot__img" src="@badge.imageUrl"/>
+                                <img class="badge-slot__img" src="@badge.imageUrl" alt="" />
                             </div>
                         }
                         <span class="fc-container__title__text">@Localisation(title)</span>

--- a/common/app/views/fragments/onwardPlaceholder.scala.html
+++ b/common/app/views/fragments/onwardPlaceholder.scala.html
@@ -1,7 +1,7 @@
 @(isPaidContent: Boolean)(implicit request: RequestHeader)
 <aside id="onward"
   class="onward js-onward facia-container facia-container--layout-content @if(isPaidContent){ paid-content} js-outbrain-anchor"
-  role="complementary"></aside>
+  ></aside>
 <aside id="more-in-section"
   class="more-in-section js-more-in-section facia-container facia-container--layout-content @if(isPaidContent){ paid-content}"
-  role="complementary"></aside>
+  ></aside>

--- a/common/app/views/fragments/richLinkDefault.scala.html
+++ b/common/app/views/fragments/richLinkDefault.scala.html
@@ -8,7 +8,7 @@
     <div class="rich-link__container">
 
     <div class="rich-link__header">
-        <h1 class="rich-link__title">@title</h1>
+        <h2 class="rich-link__title">@title</h2>
     </div>
 
     <div class="rich-link__read-more">

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -14,11 +14,11 @@
 
 @defining(Seq("related") ++ (if(isPaidContent) Seq("paid-content") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
-        <aside class="@classes.mkString(" ") more-on-this-story js-outbrain-anchor" role="complementary" aria-labelledby="related-content-head">
+        <aside class="@classes.mkString(" ") more-on-this-story js-outbrain-anchor" aria-labelledby="related-content-head">
             @container("more on this story", "more-on-this-story", href = None)
         </aside>
     } else {
-        <aside class="@classes.mkString(" ") js-related hide-on-childrens-books-site" role="complementary" data-test-id="related-content">
+        <aside class="@classes.mkString(" ") js-related hide-on-childrens-books-site" data-test-id="related-content">
         @*
             We are not doing progressive enhancement here. The related content query is expensive and crawlers
             were having too much fun with the links that used to be here. Also, nobody was actually reading those pages.

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -41,14 +41,14 @@
         }
 
         <div class="rich-link__header">
-            <h1 class="rich-link__title">
+            <h2 class="rich-link__title">
                 @if(content.content.cardStyle == Comment) {
                     @fragments.inlineSvg("garnett-quote", "icon")
                 }
                 <a class="rich-link__link">
                     @Html(content.trail.headline)
                 </a>
-            </h1>
+            </h2>
             @if(!content.tags.isMedia && (
                 content.content.cardStyle == Comment ||
                 (content.content.cardStyle == SpecialReport && content.content.hasTonalHeaderByline)

--- a/static/src/javascripts/projects/common/views/content/share-count.html
+++ b/static/src/javascripts/projects/common/views/content/share-count.html
@@ -1,3 +1,3 @@
-<h3 class="sharecount__heading"><%=icon%><span class="sharecount__text u-h">Shares</span></h3>
+<div class="sharecount__heading"><%=icon%><span class="sharecount__text u-h">Shares</span></div>
 <div class="sharecount__value sharecount__value--full">0</div>
 <div class="sharecount__value sharecount__value--short">0</div>


### PR DESCRIPTION
## What does this change?

Improves the document structure on articles:

- removes explicit complementary role from onward containers, as the `<aside>` tag [implies the element is complementary](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role#Description)
- makes badges presentational
- demotes rich link headers from `h1` to `h2` (Chris Moran will be happy)
- update share count tag from `h3` to `div`. Less is more

## What is the value of this and can you measure success?

These changes make it easier for screenreader users to navigate

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
