### PR TITLE
[WIP] Fetch test variants from Google Doc

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -235,4 +235,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 6, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-us-from-google-doc",
+    "Tests a US-specific epic with copy from a Google Doc",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -1,3 +1,14 @@
+import {
+    addTrackingCodesToUrl,
+    submitInsertEvent,
+    submitViewEvent
+} from 'common/modules/commercial/acquisitions-ophan';
+import { supportContributeURL } from 'common/modules/commercial/support-utilities';
+import { noop } from '../../lib/noop';
+import mediator from '../../lib/mediator';
+import { defaultButtonTemplate, defaultMaxViews } from 'common/modules/commercial/contributions-utilities';
+import type { EpicTemplate } from 'common/modules/commercial/contributions-utilities';
+
 type ListenerFunction = (f: () => void) => void;
 
 declare type Variant = {
@@ -44,6 +55,35 @@ declare type EpicABTest = AcquisitionsABTest & {
     insertEvent: string,
     viewEvent: string,
 };
+
+// declare type EpicABTestOptions = {|
+//     maxViews?: {
+//         count: number,
+//         days: number,
+//         minDaysBetweenViews: number,
+//     } ,
+//     isUnlimited?: boolean,
+//     campaignCode?: string,
+//     supportURL?: stirng,
+//     subscribeURL?: string,
+//     // TODO ?
+//     template?: EpicTemplate,
+//     // TODO ?
+//     buttonTemplate?: ButtonTemplate,
+//     blockEngagementBanner?: boolean,
+//     // TODO?
+//     engagementBannerParams?: Object,
+//     isOutbrainCompliant?: boolean,
+//     usesIframe?: boolean,
+//     onInsert?: () => void,
+//     onView?: () => void,
+//     insertAtSelector?: string,
+//     insertMultiple?: false,
+//     insertAfter?: false,
+//     test?: () => void,
+//     impression?: () => void,
+//     success?: () => void,
+// |};
 
 declare type InitEpicABTestVariant = {
     id: string,

--- a/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
@@ -6,7 +6,7 @@ import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { checks } from 'common/modules/check-mediator-checks';
 import { resolveCheck, waitForCheck } from 'common/modules/check-mediator';
-import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
+import { getEpicTestToDisplay } from 'common/modules/experiments/epic-test-selector';
 
 const someCheckPassed = (results): boolean => results.includes(true);
 
@@ -26,7 +26,7 @@ const checksToDispatch = {
     },
 
     isUserInContributionsAbTest(): Promise<boolean> {
-        return Promise.resolve(!!getAcquisitionTest());
+        return Promise.resolve(!!getEpicTestToDisplay());
     },
 
     isUserNotInContributionsAbTest(): Promise<boolean> {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -51,15 +51,27 @@ export const liveblogMillionCopy: AcquisitionsEpicTemplateCopy = {
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute. Thank you.`,
 };
 
+export const copyFromGoogleDocRows = (
+    firstRow: AcquisitionsEpicTemplateCopy,
+    allRows: $ReadOnlyArray<{paragraphs: string}>,
+): AcquisitionsEpicTemplateCopy => ({
+    heading: firstRow.heading,
+    paragraphs: allRows.map(row => row.paragraphs),
+    highlightedText: firstRow.highlightedText.replace(
+        /%%CURRENCY_SYMBOL%%/g,
+        getLocalCurrencySymbol()
+    ),
+});
+
 export const getEpicParams = (
     googleDocJson: any,
     sheetName: string
 ): AcquisitionsEpicTemplateCopy => {
-    const rows =
+    const allRows =
         googleDocJson &&
         googleDocJson.sheets &&
         googleDocJson.sheets[sheetName];
-    const firstRow = rows && rows[0];
+    const firstRow = allRows && allRows[0];
 
     if (
         !(
@@ -77,7 +89,7 @@ export const getEpicParams = (
 
     return {
         heading: firstRow.heading,
-        paragraphs: rows.map(row => row.paragraphs),
+        paragraphs: allRows.map(row => row.paragraphs),
         highlightedText: firstRow.highlightedText.replace(
             /%%CURRENCY_SYMBOL%%/g,
             getLocalCurrencySymbol()

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -1,13 +1,49 @@
 // @flow
 import fetchJSON from 'lib/fetch-json';
-import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
+import { articleCopy, copyFromGoogleDocRows, getEpicParams } from 'common/modules/commercial/acquisitions-copy';
+import reportError from '../../../../lib/report-error';
 
 const epicGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 const bannerGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
 
-const getGoogleDoc = (url: string): Promise<any> =>
+export const getVariants = (googleDocJson: any): $ReadOnlyArray<Variant> => {
+    const sheets = googleDocJson && googleDocJson.sheets;
+    const variants = Object.keys(sheets).map(variantName => {
+        const rows = sheets[variantName];
+        const firstRow = rows && rows[0];
+
+        if (
+            !(
+                firstRow &&
+                firstRow.heading &&
+                firstRow.paragraphs &&
+                firstRow.highlightedText
+            )
+        ) {
+            return {
+                // Seeing impressions/conversions with this variant name
+                // should flag that something's gone wrong
+                id: 'defaulted_to_control_variant',
+                products: [],
+            };
+        } else {
+            return {
+                id: variantName,
+                products: [],
+                options: {
+                    copy: copyFromGoogleDocRows(firstRow, rows),
+                    // we can eventually add whatever options we want
+                }
+            }
+        }
+    });
+
+    return variants;
+};
+
+export const getGoogleDoc = (url: string): Promise<any> =>
     fetchJSON(url, {
         mode: 'cors',
     });

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,14 +1,12 @@
 // @flow
 import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 import { removeParticipation } from 'common/modules/experiments/utils';
-import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { commercialAdMobileWebIncrease } from 'common/modules/experiments/tests/commercial-ad-mobile-web-increase.js';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
-    getAcquisitionTest(),
     commercialPrebidSafeframe,
     commercialAdVerification,
     commercialCmpCustomise,

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -22,8 +22,15 @@ import {
     getForcedTests,
 } from 'common/modules/experiments/utils';
 
+const allocateUserToTest = test => {
+    // Only allocate the user if the test is valid and they're not already participating.
+    if (testCanBeRun(test) && !isParticipating(test)) {
+        addParticipation(test, variantIdFor(test));
+    }
+};
+
 // Finds variant in specific tests and runs it
-const runTest = (test: ABTest): void => {
+export const runTest = (test: ABTest): void => {
     if (isParticipating(test) && testCanBeRun(test)) {
         const participations = getParticipations();
         const variantId = participations[test.id].variant;
@@ -34,13 +41,6 @@ const runTest = (test: ABTest): void => {
         } else if (!isInTest(test) && test.notInTest) {
             test.notInTest();
         }
-    }
-};
-
-const allocateUserToTest = test => {
-    // Only allocate the user if the test is valid and they're not already participating.
-    if (testCanBeRun(test) && !isParticipating(test)) {
-        addParticipation(test, variantIdFor(test));
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -7,7 +7,7 @@ import config from 'lib/config';
 import overlay from 'raw-loader!common/views/experiments/overlay.html';
 import styles from 'raw-loader!common/views/experiments/styles.css';
 import { TESTS } from 'common/modules/experiments/ab-tests';
-import { acquisitionsTests } from 'common/modules/experiments/acquisition-test-selector';
+import { asyncEpicTests, getAllEpicTests, hardcodedEpicTests } from 'common/modules/experiments/epic-test-selector';
 import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 
 const getSelectedAbTests = () =>
@@ -80,12 +80,15 @@ const appendOverlay = () => {
         isSwitchedOn: config.get(`switches.ab${id}`),
         isExpired: isExpired(expiry),
     });
-    const data = {
-        tests: TESTS.map(extractData),
-        acquisitionsTests: acquisitionsTests.map(extractData),
-    };
 
-    $('body').prepend(template(overlay)(data));
+    getAllEpicTests().then(epicTests => {
+        const data = {
+            tests: TESTS.map(extractData),
+            acquisitionsTests: epicTests.map(extractData),
+        };
+
+        $('body').prepend(template(overlay)(data));
+    });
 };
 
 export const showExperiments = () => {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-from-google-doc.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-from-google-doc.js
@@ -1,0 +1,27 @@
+// @flow
+import { makeAsyncABTest } from 'common/modules/commercial/contributions-utilities';
+
+const abTestName = 'AcquisitionsEpicUsFromGoogleDoc';
+
+export const acquisitionsEpicUsFromGoogleDoc: Promise<EpicABTest> = makeAsyncABTest({
+    id: abTestName,
+    campaignId: abTestName,
+
+    start: '2018-04-17',
+    expiry: '2019-06-05',
+
+    author: 'Joseph Smith',
+    description: 'Tests an epic with custom copy in US',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Alternative copy makes more money than the control',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    // TODO: us
+    locations: ['US'],
+
+    // These come from the Google Doc instead
+    variants: [],
+}, 'https://interactive.guim.co.uk/docsdata-test/16xMIOovo3hIvV9U4KqcJc1-XTIuHM-b8yLwLbl_2AKA.json');


### PR DESCRIPTION
This allows Google Docs to determine the name & number of variants on an epic test, as well as set more parameters than just the copy.

It needs a fair bit of tidying up but it's basically working

@guardian/contributions 