### PR TITLE
Fixes for GLabs Paid Video Page

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -1,10 +1,11 @@
 @(content: model.ContentType, page: model.Page)(implicit request: RequestHeader)
 @import common.Edition
 @import views.html.fragments.commercial.pageLogo
+@import views.support.Commercial.{isPaidContent, onDarkBackground}
 
 @for(commercial <- page.metadata.commercial; branding <- commercial.branding(Edition(request))) {
     @pageLogo(branding,
               content.tags.isInteractive,
-              onDarkBackground = content.tags.isAudio || content.tags.isVideo || content.tags.isGallery
+              onDarkBackground(content) && !isPaidContent(page)
     )
 }

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -1,11 +1,11 @@
 @(content: model.ContentType, page: model.Page)(implicit request: RequestHeader)
 @import common.Edition
 @import views.html.fragments.commercial.pageLogo
-@import views.support.Commercial.{isPaidContent, onDarkBackground}
+@import views.support.Commercial.{isPaidContent, isOnDarkBackground}
 
 @for(commercial <- page.metadata.commercial; branding <- commercial.branding(Edition(request))) {
     @pageLogo(branding,
               content.tags.isInteractive,
-              onDarkBackground(content) && !isPaidContent(page)
+              isOnDarkBackground(content) && !isPaidContent(page)
     )
 }

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -6,6 +6,6 @@
 @for(commercial <- page.metadata.commercial; branding <- commercial.branding(Edition(request))) {
     @pageLogo(branding,
               content.tags.isInteractive,
-              isOnDarkBackground(content) && !isPaidContent(page)
+              isOnDarkBackground(content, isPaidContent(page))
     )
 }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -5,7 +5,7 @@ import common.Edition
 import common.commercial._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer, PaidCard}
 import model.DotcomContentType.Signup
-import model.{Page, PressedPage}
+import model.{Page, PressedPage, ContentType}
 import org.apache.commons.lang.StringEscapeUtils._
 import play.api.libs.json.JsBoolean
 import play.api.mvc.RequestHeader
@@ -19,6 +19,10 @@ object Commercial {
     } catch {
        case e: Exception => false   // in case the cookie value can't be converted toInt
     }
+  }
+
+  def onDarkBackground(content: ContentType): Boolean = {
+    content.tags.isAudio || content.tags.isVideo || content.tags.isGallery
   }
 
   def shouldShowAds(page: Page): Boolean = page match {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -21,7 +21,7 @@ object Commercial {
     }
   }
 
-  def onDarkBackground(content: ContentType): Boolean = {
+  def isOnDarkBackground(content: ContentType): Boolean = {
     content.tags.isAudio || content.tags.isVideo || content.tags.isGallery
   }
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -5,7 +5,7 @@ import common.Edition
 import common.commercial._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer, PaidCard}
 import model.DotcomContentType.Signup
-import model.{Page, PressedPage, ContentType}
+import model.{ContentType, Page, PressedPage}
 import org.apache.commons.lang.StringEscapeUtils._
 import play.api.libs.json.JsBoolean
 import play.api.mvc.RequestHeader
@@ -21,8 +21,9 @@ object Commercial {
     }
   }
 
-  def isOnDarkBackground(content: ContentType): Boolean = {
-    content.tags.isAudio || content.tags.isVideo || content.tags.isGallery
+  def isOnDarkBackground(content: ContentType, isPaidContent: Boolean): Boolean = {
+    content.tags.isGallery ||
+      (!isPaidContent && (content.tags.isAudio || content.tags.isVideo))
   }
 
   def shouldShowAds(page: Page): Boolean = page match {

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -366,7 +366,7 @@
     @include footerPalette($sport-main);
 }
 
-.content--media.content--pillar-news,
+.content--media:not(.paid-content).content--pillar-news,
 .immersive-main-media__headline-container.content--pillar-news,
 .immersive-main-media__headline-container--gallery.content--pillar-news {
     @include mediaPalatte($news-bright, $news-main, news);


### PR DESCRIPTION
## What does this change?

#### 👉 GLabs video pages use standard logo rather than high-contrast logo

Labs video pages are using the high-contrast logo in the content meta area but should not, since the background is grey. 

The related content section contains other videos which have a black background card, so these are using the high-contrast logo correctly.

#### 👉 GLabs video pages have a black tag page name rather than a white one

Since the page background is light grey, the tag page name should be black not white

## Screenshots

##### BEFORE: 

<img width="991" alt="screen shot 2018-11-30 at 18 21 50" src="https://user-images.githubusercontent.com/8607683/49366304-e9c66280-f6e0-11e8-8bef-24bbcf935c72.png">

##### AFTER: 

<img width="996" alt="screen shot 2018-11-30 at 18 22 43" src="https://user-images.githubusercontent.com/8607683/49366325-f8147e80-f6e0-11e8-950a-97951a52a8cd.png">

https://www.theguardian.com/discover-cool-canada/video/2018/oct/05/five-canadian-cultural-highlights-video

## What is the value of this and can you measure success?

🌈🦄✨Beautiful websites

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Yep

### Tested

- [x] Locally
- [ ] On CODE
