### PR TITLE
Better landmarks on fronts

### DIFF
--- a/common/app/views/fragments/commercial/containerWrapper.scala.html
+++ b/common/app/views/fragments/commercial/containerWrapper.scala.html
@@ -9,7 +9,7 @@
   optBadge: Option[Html] = None
  )(title: Html)(innards: Html)
 
-<aside class="dumathoin @classNames.map(c => s"dumathoin--$c").mkString(" ")"
+<section class="dumathoin @classNames.map(c => s"dumathoin--$c").mkString(" ")"
     @for(dln <- dataLinkName){data-link-name="@dln"}
     >
     <header class="dumathoin__header">
@@ -28,4 +28,4 @@
             @for(badge        <- optBadge)   {<div class="badge">@badge</div>}
         }
     </div>
-</aside>
+</section>

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -5,7 +5,7 @@
 @import layout.{DescriptionMetaHeader, LoneDateHeadline, MetaDataHeader}
 
 @containerDefinition.customHeader.map { customHeader =>
-    <div class="fc-container__header js-container__header">
+    <header class="fc-container__header js-container__header">
         @customHeader match {
             case metaDataHeader: MetaDataHeader => {
                 @dateHeadline(metaDataHeader.dateHeadline, containerDefinition.dateLink)
@@ -19,7 +19,7 @@
                 @descriptionHeadline(containerDefinition, frontProperties, descriptionHeader.description)
             }
         }
-    </div>
+    </header>
 }.getOrElse {
     @standardHeaderMeta(containerDefinition, frontProperties)
 }

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -7,7 +7,7 @@
 @import model.Badges.badgeFor
 
 @defining((containerDefinition.displayName, containerDefinition.href)) { case (title, href) =>
-    <div class="fc-container__header
+    <header class="fc-container__header
                 @if(containerDefinition.customHeader.isEmpty) {js-container__header}
                 @badgeFor(containerDefinition).map { badge => fc-container__header--is-badged
 	                @badge.classModifier.map(modifier => s"fc-container__header--$modifier")
@@ -25,10 +25,10 @@
                                 <img class="badge-slot__img" src="@badge.imageUrl" alt="" />
                             </div>
                         }
-                        <span class="fc-container__title__text">@Localisation(title)</span>
+                        <h2 class="fc-container__title__text">@Localisation(title)</h2>
                     </a>
                     }.getOrElse {
-                        <span tabindex="0">@Localisation(title)</span>
+                        <h2 tabindex="0">@Localisation(title)</h2>
                     }
 
                     @if(containerDefinition.showDateHeader) {
@@ -61,5 +61,5 @@
                 }
             }
         }
-    </div>
+    </header>
 }

--- a/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
@@ -7,9 +7,5 @@
     "fc-item__title" -> true,
     "fc-item__title--quoted" -> showQuote
 ))) { case (innerHtml, classes) =>
-    @if(isFirstItemOnPage) {
-        <h1 class="@classes">@innerHtml</h1>
-    } else {
-        <h2 class="@classes">@innerHtml</h2>
-    }
+    <h3 class="@classes">@innerHtml</h3>
 }

--- a/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
@@ -8,7 +8,7 @@
 
 @articleLink(html: Html) = {<a href="@sublink.url.get(request)" class="fc-sublink__link" data-link-name="article">@html</a>}
 
-<h3 class="fc-sublink__title">
+<h4 class="fc-sublink__title">
     @(sublink.kicker, sublink.kicker.flatMap(_.link)) match {
         case (Some(kicker), Some(link)) => {<a href="@LinkTo(link)" data-link-name="kicker" class="@kicker.sublinkClasses.mkString(" ")">@Html(kicker.kickerHtml)</a> @articleLink{@headline()}}
 
@@ -16,4 +16,4 @@
 
         case _ => {@articleLink{@headline()}}
     }
-</h3>
+</h4>

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -2,7 +2,7 @@
 
 @import views.support.Format
 
-<aside class="fc-item__meta js-item__meta">
+<div class="fc-item__meta js-item__meta">
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {
         <time class="fc-item__timestamp@if(timeStampDisplay.javaScriptUpdate){ js-item__timestamp}"
         datetime="@publishedAt.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
@@ -14,4 +14,4 @@
         </span>
         </time>
     }
-</aside>
+</div>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -21,6 +21,8 @@
             data-link-name="Front | @request.path"
             role="main">
 
+            <h1 class="u-h">@faciaPage.metadata.title</h1>
+
             @if(isPaid){
                 @fragments.guBand()
             }

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -39,7 +39,7 @@
         }
 
         & > span,
-        span.fc-container__title__text {
+        h2.fc-container__title__text {
             background: #fff132;
             background: -moz-linear-gradient(top, #ffe500 0%,  #ffe500 50%, #ffe500 100%);
             background: -webkit-linear-gradient(top, #ffe500 0%, #ffe500 50%, #ffe500 100%);

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -122,6 +122,8 @@ $header-image-size-desktop: 100px;
 }
 
 .fc-container__header__title,
+.fc-container__header__title > h2,
+.fc-container__title__text,
 .fc-container__header__title--sticky,
 .container__title {
     @include fs-header(4);


### PR DESCRIPTION
## What does this change?

- reduces complementary landmarks (the meta section on every card was previously an `<aside>`)
- ensures there will be only one `<h1>` tag on each front, but it is not be visible to sighted users. It is only be visible to screenreaders and crawlers. It contains the title of the front (e.g. "Opinion", "Sport", or for the network front "News, sport and opinion from the Guardian's UK edition")
- each section heading is now a `<h2>` tag (e.g. "Headlines", "Podcast", "Spotlight"). They are currently just `<spans>`
- headlines in cards (including the YouTube video carousel) are now `<h3>` tags
- sublinks are `<h4>` tags

## Screenshots

![screen shot 2018-12-03 at 10 02 10](https://user-images.githubusercontent.com/5931528/49366942-89d0bb80-f6e2-11e8-89f3-e8177852fccb.png)

## What is the value of this and can you measure success?

Having fewer complementary landmarks makes it easier for screenreader users to navigate the page.

A more intuitive header hierarchy that reflects the structure of the document improves navigability for screen reader users and may potentially improve SEO.

I have run these changes by Peter Martin and Seán Clarke (SEO) as well as Chris Moran. Siamak Amini in D&I will be monitoring our search performance to ensure the SEO impact is at least not negative.

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
