### PR TITLE
Use different placement ID in Amp for AppNexus

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -390,6 +390,16 @@ trait PrebidSwitches {
     exposeClientSide = false
   )
 
+  val ampAppnexusAlias: Switch = Switch(
+    group = CommercialPrebid,
+    name = "amp-appnexus-alias",
+    description = "AppNexus has an alias in Amp Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 1, 9),
+    exposeClientSide = false
+  )
+
   val prebidUserSync: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-user-sync",

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -5,7 +5,7 @@ import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValu
 import common.Edition
 import common.commercial.AdUnitMaker
 import common.editions._
-import conf.switches.Switches.KruxSwitch
+import conf.switches.Switches.{KruxSwitch, ampAppnexusAlias}
 import conf.switches.{Switch, Switches}
 import model.Article
 import play.api.libs.json.Json.JsValueWrapper
@@ -64,6 +64,7 @@ object AmpAdRtcConfig {
         val placementId = edition match {
           case Us => 14401433
           case Au => 14400184
+          case _ if ampAppnexusAlias.isSwitchedOn => 4
           case _ => 14351413
         }
         val url = s"$prebidServerUrl/openrtb2/amp?tag_id=$placementId&w=ATTR(width)&h=ATTR(height)" +

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import common.editions._
-import conf.switches.Switches.{KruxSwitch, ampPrebid}
+import conf.switches.Switches.{KruxSwitch, ampAppnexusAlias, ampPrebid}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.{JsNull, Json}
 
@@ -20,6 +20,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   before {
     KruxSwitch.switchOff()
     ampPrebid.switchOff()
+    ampAppnexusAlias.switchOff()
   }
 
   "toJsonString" should "hold Prebid server and Krux config when both switches are on" in {
@@ -113,5 +114,14 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
       prebidServerUrl, edition = International, debug = false
     ))
     Json.stringify(json) should include ("tag_id=14351413")
+  }
+
+  it should "have correct placement ID for UK edition when using alias for AppNexus" in {
+    ampPrebid.switchOn()
+    ampAppnexusAlias.switchOn()
+    val json = Json.parse(AmpAdRtcConfig.toJsonString(
+      prebidServerUrl, edition = Uk, debug = false
+    ))
+    Json.stringify(json) should include ("tag_id=4")
   }
 }


### PR DESCRIPTION
This will target a new placement in the Prebid server when a switch is on.  The new placement will have an alias for AppNexus so that we can distinguish it from the Ozone adapter with the same name.

I've put this functionality behind a switch because I'm not sure whether it will work.
I'm not seeing any bids locally, but that may be for other reasons.

The new placement is set up here: https://github.com/guardian/prebid-server/pull/6.
