### PR TITLE
Update prbuilds config to work with new version

### DIFF
--- a/.prbuilds/setup.playbook.yml
+++ b/.prbuilds/setup.playbook.yml
@@ -26,23 +26,23 @@
     - name: preinstall nvm part II
       shell: . ~/.nvm/nvm.sh; nvm install
       args:
-        chdir: ~/workspace
+        chdir: ~/workspace/frontend/
         executable: /bin/bash
     
     - name: run setup.py
-      command: ~/workspace/setup.sh
+      command: ~/workspace/frontend/setup.sh
       args:
-        chdir: ~/workspace/
+        chdir: ~/workspace/frontend/
     
     - name: sbt compile
-      command: ~/workspace/sbt "project article" "compile"
+      command: ~/workspace/frontend/sbt "project article" "compile"
       args:
-        chdir: ~/workspace
+        chdir: ~/workspace/frontend/
     
     - name: run the article project
-      command: screen -S trousers-build -d -m ~/workspace/sbt "project article" "run"
+      command: screen -S trousers-build -d -m ~/workspace/frontend/sbt "project article" "run"
       args:
-        chdir: ~/workspace
+        chdir: ~/workspace/frontend/
     
     - name: wait for the application to become available
       wait_for:


### PR DESCRIPTION
## What does this change?

I had to make some changes to prbuilds to allow for properly building multiple repos, and in order to support it, the prbuilds config in here needs to change.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
