### PR TITLE
Update Prebid in Amp Placement IDs

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -390,16 +390,6 @@ trait PrebidSwitches {
     exposeClientSide = false
   )
 
-  val ampAppnexusAlias: Switch = Switch(
-    group = CommercialPrebid,
-    name = "amp-appnexus-alias",
-    description = "AppNexus has an alias in Amp Prebid auctions",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 1, 9),
-    exposeClientSide = false
-  )
-
   val prebidUserSync: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-user-sync",

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -5,7 +5,7 @@ import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValu
 import common.Edition
 import common.commercial.AdUnitMaker
 import common.editions._
-import conf.switches.Switches.{KruxSwitch, ampAppnexusAlias}
+import conf.switches.Switches.KruxSwitch
 import conf.switches.{Switch, Switches}
 import model.Article
 import play.api.libs.json.Json.JsValueWrapper
@@ -62,10 +62,9 @@ object AmpAdRtcConfig {
        */
       val ampPrebidUrl = {
         val placementId = edition match {
-          case Us => 14401433
-          case Au => 14400184
-          case _ if ampAppnexusAlias.isSwitchedOn => 4
-          case _ => 14351413
+          case Us => 7
+          case Au => 6
+          case _ => 4
         }
         val url = s"$prebidServerUrl/openrtb2/amp?tag_id=$placementId&w=ATTR(width)&h=ATTR(height)" +
           "&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)" +

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import common.editions._
-import conf.switches.Switches.{KruxSwitch, ampAppnexusAlias, ampPrebid}
+import conf.switches.Switches.{KruxSwitch, ampPrebid}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.{JsNull, Json}
 
@@ -13,14 +13,13 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   private val prebidServerUrl = "http://localhost:8000"
 
   private val ampPrebidUrl =
-    "http://localhost:8000/openrtb2/amp?tag_id=14351413&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
+    "http://localhost:8000/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)" +
       "&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)" +
       "&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&debug=1"
 
   before {
     KruxSwitch.switchOff()
     ampPrebid.switchOff()
-    ampAppnexusAlias.switchOff()
   }
 
   "toJsonString" should "hold Prebid server and Krux config when both switches are on" in {
@@ -89,7 +88,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
       prebidServerUrl, edition = Uk, debug = false
     ))
-    Json.stringify(json) should include ("tag_id=14351413")
+    Json.stringify(json) should include ("tag_id=4")
   }
 
   it should "have correct placement ID for US edition" in {
@@ -97,7 +96,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
       prebidServerUrl, edition = Us, debug = false
     ))
-    Json.stringify(json) should include ("tag_id=14401433")
+    Json.stringify(json) should include ("tag_id=7")
   }
 
   it should "have correct placement ID for AU edition" in {
@@ -105,22 +104,13 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
       prebidServerUrl, edition = Au, debug = false
     ))
-    Json.stringify(json) should include ("tag_id=14400184")
+    Json.stringify(json) should include ("tag_id=6")
   }
 
   it should "have correct placement ID for International edition" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
       prebidServerUrl, edition = International, debug = false
-    ))
-    Json.stringify(json) should include ("tag_id=14351413")
-  }
-
-  it should "have correct placement ID for UK edition when using alias for AppNexus" in {
-    ampPrebid.switchOn()
-    ampAppnexusAlias.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = false
     ))
     Json.stringify(json) should include ("tag_id=4")
   }


### PR DESCRIPTION
So that they use the new placements set up in [Prebid server](https://github.com/guardian/prebid-server/pull/7) with aliases for AppNexus.
