### PR TITLE
Add preconnect instructions to the HTML <head>

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -28,8 +28,6 @@
 
     <link rel="preconnect" href="@Configuration.assets.path" />
     <link rel="preconnect" href="@Configuration.images.host" />
-    <link rel="preconnect" href="//j.ophan.co.uk" />
-    <link rel="preconnect" href="//ophan.theguardian.com" />
     <link rel="preconnect" href="//www.google-analytics.com" />
 
     @if(ComscoreSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -28,7 +28,9 @@
 
     <link rel="preconnect" href="@Configuration.assets.path" />
     <link rel="preconnect" href="@Configuration.images.host" />
+    <link rel="preconnect" href="//interactive.guim.co.uk" />
     <link rel="preconnect" href="//www.google-analytics.com" />
+
 
     @if(ComscoreSwitch.isSwitchedOn) {
         <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -26,6 +26,12 @@
     <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
     <link rel="dns-prefetch" href="//www.google-analytics.com" />
 
+    <link rel="preconnect" href="@Configuration.assets.path" />
+    <link rel="preconnect" href="@Configuration.images.host" />
+    <link rel="preconnect" href="//j.ophan.co.uk" />
+    <link rel="preconnect" href="//ophan.theguardian.com" />
+    <link rel="preconnect" href="//www.google-analytics.com" />
+
     @if(ComscoreSwitch.isSwitchedOn) {
         <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />
     }


### PR DESCRIPTION
## What does this change?

This adds 5 `preconnect` instructions to the HTML <head> of non AMP pages

Before:

```
<link rel="dns-prefetch" href="https://assets.guim.co.uk/"/>
<link rel="dns-prefetch" href="https://i.guim.co.uk"/>
<link rel="dns-prefetch" href="https://api.nextgen.guardianapps.co.uk"/>
<link rel="dns-prefetch" href="https://hits-secure.theguardian.com"/>
<link rel="dns-prefetch" href="//j.ophan.co.uk"/>
<link rel="dns-prefetch" href="//ophan.theguardian.com"/>
<link rel="dns-prefetch" href="//phar.gu-web.net"/>
<link rel="dns-prefetch" href="//www.google-analytics.com"/>
<link rel="dns-prefetch" href="//sb.scorecardresearch.com"/>
```

After:

```
<link rel="dns-prefetch" href="https://assets-code.guim.co.uk/"/>
<link rel="dns-prefetch" href="https://i.guim.co.uk"/>
<link rel="dns-prefetch" href="https://code.api.nextgen.guardianapps.co.uk"/>
<link rel="dns-prefetch" href="https://hits-secure.theguardian.com"/>
<link rel="dns-prefetch" href="//j.ophan.co.uk"/>
<link rel="dns-prefetch" href="//ophan.theguardian.com"/>
<link rel="dns-prefetch" href="//phar.gu-web.net"/>
<link rel="dns-prefetch" href="//www.google-analytics.com"/>
<link rel="dns-prefetch" href="//sb.scorecardresearch.com"/>

<link rel="preconnect" href="https://assets-code.guim.co.uk/"/>
<link rel="preconnect" href="https://i.guim.co.uk"/>
<link rel="preconnect" href="//interactive.guim.co.uk"/>
<link rel="preconnect" href="//www.google-analytics.com"/>
```

### Tested

- [x] Locally
- [x] On CODE (optional)