### PR TITLE
Design fix: special topic badge on media pages

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_media.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.head.scss
@@ -48,7 +48,7 @@
 }
 
 /* Styling fix for special topic label */
-.content--media {
+.content--media:not(.paid-content) {
     header {
         .content__labels.content__labels--immersive {
             background: none;
@@ -57,5 +57,4 @@
             }
         }
     }
-
 }


### PR DESCRIPTION
## What does this change?
The new header must have changed the specificity so that the special topic badge broke on podcast pages. 

## Screenshots
Before 
![screen shot 2018-12-05 at 12 58 18](https://user-images.githubusercontent.com/10324129/49514963-79a90f80-f88d-11e8-9fb3-f284b62cd7a9.png)


After 
![screen shot 2018-12-05 at 12 55 00](https://user-images.githubusercontent.com/10324129/49514932-66963f80-f88d-11e8-8c36-c2a488156693.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
