### PR TITLE
Override default h3 margin on card headlines

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -185,6 +185,7 @@ $fc-item-gutter: $gs-gutter / 4;
     padding-bottom: $gs-baseline/6;
     word-wrap: break-word;
     overflow: hidden;
+    margin-bottom: 0;
 }
 
 .fc-sublink__kicker,


### PR DESCRIPTION
## What does this change?

As of #20788 headlines on fronts cards are `<h3>` elements. However, `h3` elements have a [default `margin-bottom`](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/base/_type.scss#L75) applied in `base/_type.scss`. This is super-old code, so it's not clear what the intention was. However, deleting this margin in all cases may have undesirable consequences.

This change overrides the margin for facia card headlines specifically, removing the spacing between headline and byline on some cards.

## Screenshots

![image 1](https://user-images.githubusercontent.com/5931528/49523726-3e650b80-f8a2-11e8-9da1-1c0fe7d6ac79.png)

## What is the value of this and can you measure success?

Removes unintentional spacing

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
