### PR TITLE
Provide visual indication of focus when using keyboard navigation

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-band.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-band.scss
@@ -5,6 +5,13 @@
     top: 0;
     z-index: $zindex-sticky;
 
+    .popup__toggle,
+    .popup--paidfor__link,
+    .paidfor-band__inner > a {
+        // keyboard navigation should have highly visible focus
+        outline-color: $highlight-main;
+    }
+
     .has-super-sticky-banner & {
         position: static;
     }
@@ -17,6 +24,12 @@
 
     .paidfor-meta__label {
         align-items: center;
+    }
+
+    // TODO: switch to focus-visible when browsers support it
+    .popup__toggle:focus:not(:hover) {
+        outline-style: auto;
+        outline-width: 5px;
     }
 
     .paidfor-meta__label,


### PR DESCRIPTION
## What does this change?

Makes the outline visible again for buttons in the Labs banner, and use a high contrast colour to indicate where the focus currently is within the Labs banner.

This outline only occurs when focus and hover are not both in effect, so will only be seen during keyboard navigation. 🙌

We might want to consider how and when we remove the default outline settings. This article has some good ideas: https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2

I am highly excited for `focus-visible`, however this is currently not supported in most browsers. 😞

## Screenshots

![labs-a11y](https://user-images.githubusercontent.com/8607683/49579923-8ee17500-f945-11e8-8e48-c16ad1361fc1.gif)

## What is the value of this and can you measure success?

Visual indicators for users who are navigating the page using the keyboard.

2.4.7 Focus Visible: Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible. (Level AA)

https://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-focus-visible

## Checklist

### Does this affect other platforms?

Nope


### Does this change break ad-free?

Nope

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Next Steps:

- Hopefully this matches up with the Hack Day work of @SiAdcock! 
- The Labs banner also needs some ARIA attributes added, separate PR to follow soon
