### PR TITLE
Provide range of image sizes in dotcomponents model

### DIFF
--- a/commercial/app/model/capi/CapiImages.scala
+++ b/commercial/app/model/capi/CapiImages.scala
@@ -1,6 +1,6 @@
 package commercial.model.capi
 
-import views.support.ImgSrc
+import views.support.{ImgSrc, SrcSet}
 import layout.cards.{Half, Standard, Third}
 import com.gu.contentapi.client.model.v1.{Asset, AssetType}
 import layout.{FaciaWidths, ItemClasses}
@@ -36,10 +36,10 @@ object CapiImages {
       ImageSource(
         breakpointWidth.breakpoint.minWidth.getOrElse("0").toString,
         breakpointWidth.width.toString,
-        ImgSrc.srcsetForBreakpoint(breakpointWidth, breakpointWidths, None,
-          imageData, hidpi = true),
-        ImgSrc.srcsetForBreakpoint(breakpointWidth, breakpointWidths, None,
-          imageData)
+        SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, breakpointWidths, None,
+          imageData, hidpi = true)),
+        SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, breakpointWidths, None,
+          imageData))
       )
     }
 

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -211,6 +211,14 @@ object ContentWidths {
     def thumbnail: WidthsByBreakpoint = unused
     def immersive: WidthsByBreakpoint = unused
     def halfwidth: WidthsByBreakpoint = unused
+
+    def all: Map[String, WidthsByBreakpoint] = Map(
+      "inline" -> inline,
+      "supporting" -> supporting,
+      "showcase" -> showcase,
+      "thumbnail" -> thumbnail,
+      "immersive" -> immersive,
+      "halfwidth" -> halfwidth)
   }
 
   object BodyMedia extends ContentRelation {

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -1,5 +1,5 @@
 @import layout.ContentWidths.MainMedia
-@import views.support.{ImgSrc, RenderClasses}
+@import views.support.{ImgSrc, RenderClasses, SrcSet}
 
 @(
     picture: model.ImageMedia,
@@ -21,7 +21,7 @@
     @* This adds 15 src options to the srcset from 500 to the largest image width incrementing by 250px *@
     srcset="@{(500 to largestImage.width by 250)
         .toList
-        .map(width => ImgSrc.srcsetForProfile(views.support.ImageProfile(width = Some(width)), picture, hidpi))
+        .map(width => ImgSrc.srcsetForProfile(views.support.ImageProfile(width = Some(width)), picture, hidpi).asSrcSetString)
         .mkString(", ")}" />
 }
 
@@ -47,10 +47,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
+        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))" />
+        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture)))" />
     }
 
     <!--[if IE 9]></video><![endif]-->

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,6 +1,6 @@
 @import layout.WidthsByBreakpoint
 @import model.ImageMedia
-@import views.support.{ImgSrc, RenderClasses}
+@import views.support.{ImgSrc, RenderClasses, SrcSet}
 
 @(
     classes: Seq[String],
@@ -16,10 +16,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
+                srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />
+                srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -275,7 +275,7 @@ object ImgSrc extends Logging with implicits.Strings {
   }
 
   def srcset(imageContainer: ImageMedia, widths: WidthsByBreakpoint): String = {
-    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer, hidpi = false) } mkString ", "
+    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer, hidpi = false).asSrcSetString } mkString ", "
   }
 
   def srcsetForBreakpoint(

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -11,6 +11,7 @@ import model._
 import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import common.Environment.{app, awsRegion, stage}
+import play.api.libs.json.{Json, Writes}
 
 import Function.const
 
@@ -87,6 +88,20 @@ case class VideoProfile(
   lazy val isRatioHD: Boolean = Precision.compareTo(VideoProfile.ratioHD.doubleValue, aspectRatio.doubleValue, 0.1d) == 0
 
   private lazy val aspectRatio: Fraction = new Fraction(width.get, height.get)
+}
+
+case class SrcSet(src: String, width: Int) {
+  def asSrcSetString: String = {
+    s"$src, ${width}w"
+  }
+
+}
+object SrcSet {
+  implicit val srcSetWrites: Writes[SrcSet] = Json.writes[SrcSet]
+
+  def asSrcSetString(srcSets: Seq[SrcSet]): String = {
+    srcSets.map(_.asSrcSetString).mkString(", ")
+  }
 }
 
 // Configuration of our different image profiles
@@ -269,28 +284,27 @@ object ImgSrc extends Logging with implicits.Strings {
     maybePath: Option[String] = None,
     maybeImageMedia: Option[ImageMedia] = None,
     hidpi: Boolean = false
-  ): String = {
+  ): Seq[SrcSet] = {
     val isPng = maybePath.exists(path => path.toLowerCase.endsWith("png"))
     breakpointWidth.toPixels(breakpointWidths)
       .map(browserWidth => ImageProfile(width = Some(browserWidth), hidpi = hidpi, isPng = isPng))
-      .map { profile => {
+      .flatMap { profile => {
         maybePath
           .map(url => srcsetForProfile(profile, url, hidpi))
           .orElse(maybeImageMedia.map(imageContainer => srcsetForProfile(profile, imageContainer, hidpi)))
-          .getOrElse("")
       } }
-      .mkString(", ")
   }
 
   def srcsetForProfile(
     profile: ImageProfile,
     imageContainer: ImageMedia,
     hidpi: Boolean
-  ): String =
-    s"${profile.bestSrcFor(imageContainer).get} ${profile.width.get * (if (hidpi) 2 else 1)}w"
+  ): SrcSet =
+    SrcSet(profile.bestSrcFor(imageContainer).getOrElse("unknown"), profile.width.get * (if (hidpi) 2 else 1))
 
-  def srcsetForProfile(profile: ImageProfile, path: String, hidpi: Boolean): String =
-    s"${ImgSrc(path, profile)} ${profile.width.get * (if (hidpi) 2 else 1)}w"
+  // profile.width really shouldn't be None, but if it is use the inline image desktop default width
+  def srcsetForProfile(profile: ImageProfile, path: String, hidpi: Boolean): SrcSet =
+    SrcSet(ImgSrc(path, profile), profile.width.getOrElse(620) * (if (hidpi) 2 else 1))
 
   def getFallbackUrl(ImageElement: ImageMedia): Option[String] =
     Item300.bestSrcFor(ImageElement)


### PR DESCRIPTION
This reimplements https://github.com/guardian/frontend/pull/20678 without breaking the lightbox - previously the change broke the `srcset` url for lightbox images. 

Tested on CODE