### PR TITLE
Liveblog copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -11,15 +11,6 @@ const controlCopyParagraphTwo =
 const controlCopyParagraphThree =
     'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.';
 
-const liveblogMillionParagraphOne =
-    '… three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. The same technologies that connected us with a global audience had also shifted advertising revenues away from news publishers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.';
-
-const liveblogMillionParagraphTwo =
-    'And now for the good news. Thanks to the one million readers who have supported our independent, investigative journalism through contributions, membership or subscriptions, The Guardian has overcome a perilous financial situation globally. But we have to maintain and build on that support for every year to come.';
-
-const liveBlogMillionParagraphThree =
-    'Sustained support from our readers enables us to continue pursuing difficult stories in challenging times of political upheaval, when factual reporting has never been more critical. The Guardian is editorially independent – our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important because it enables us to give a voice to the voiceless, challenge the powerful and hold them to account. Readers’ support means we can continue bringing The Guardian’s independent journalism to the world.';
-
 // used when Google Doc control cannot be fetched
 export const articleCopy = {
     heading: 'Since you’re here &hellip;',
@@ -33,20 +24,10 @@ export const articleCopy = {
 
 export const liveblogCopy: AcquisitionsEpicTemplateCopy = {
     paragraphs: [
-        `Since you’re here ${controlCopyParagraphOne}`,
-        controlCopyParagraphTwo,
-        controlCopyParagraphThree,
-    ],
-    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute.`,
-};
-
-export const liveblogMillionCopy: AcquisitionsEpicTemplateCopy = {
-    paragraphs: [
-        'We have some news…',
-        liveblogMillionParagraphOne,
-        liveblogMillionParagraphTwo,
-        liveBlogMillionParagraphThree,
-        controlCopyParagraphThree,
+        'Since you’re here &hellip; we have a small favour to ask. Three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.',
+        'More than one million readers have now supported our independent, investigative journalism through contributions, membership or subscriptions. We want to thank you for all of your support. But we have to maintain and build on that support for every year to come.',
+        'The Guardian is editorially independent – our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion.' +
+        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute. Thank you.`,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -27,7 +27,7 @@ export const liveblogCopy: AcquisitionsEpicTemplateCopy = {
         'Since you’re here &hellip; we have a small favour to ask. Three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.',
         'More than one million readers have now supported our independent, investigative journalism through contributions, membership or subscriptions. We want to thank you for all of your support. But we have to maintain and build on that support for every year to come.',
         'The Guardian is editorially independent – our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion.' +
-        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+            'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
     ],
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute. Thank you.`,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -1,7 +1,7 @@
 // @flow
 const lastSentenceTemplate = (highlightedText: string, supportURL: string) =>
     `<span class="contributions__highlight">${highlightedText}</span>
-    <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a>. - The Guardian`;
+    <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a> - The Guardian`;
 
 export const epicLiveBlogTemplate = ({
     copy,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -20,7 +20,12 @@ export const epicLiveBlogTemplate = ({
             </a>
         </p>
         <div class="block-elements block-elements--no-byline">
-            ${copy.paragraphs.map(paragraph => `<p><em>${paragraph}</em></p>`).join('')}
-            <p><em>${lastSentenceTemplate(copy.highlightedText, supportURL)}</em></p>
+            ${copy.paragraphs
+                .map(paragraph => `<p><em>${paragraph}</em></p>`)
+                .join('')}
+            <p><em>${lastSentenceTemplate(
+                copy.highlightedText,
+                supportURL
+            )}</em></p>
         </div>
     </div>`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -1,6 +1,4 @@
 // @flow
-import { appendToLastElement } from 'lib/array-utils';
-
 const lastSentenceTemplate = (highlightedText: string, supportURL: string) =>
     `<span class="contributions__highlight">${highlightedText}</span>
     <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a>. - The Guardian`;
@@ -22,11 +20,7 @@ export const epicLiveBlogTemplate = ({
             </a>
         </p>
         <div class="block-elements block-elements--no-byline">
-            ${appendToLastElement(
-                copy.paragraphs,
-                ` ${lastSentenceTemplate(copy.highlightedText, supportURL)}`
-            )
-                .map(paragraph => `<p><em>${paragraph}</em></p>`)
-                .join('')}
+            ${copy.paragraphs.map(paragraph => `<p><em>${paragraph}</em></p>`).join('')}
+            <p><em>${lastSentenceTemplate(copy.highlightedText, supportURL)}</em></p>
         </div>
     </div>`;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -22,7 +22,9 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     audienceOffset: 0,
 
     pageCheck(page) {
-        return page.contentType === 'LiveBlog';
+        return page.contentType === 'LiveBlog'
+            && page.section !== 'sport'
+            && page.section !== 'football';
     },
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -22,9 +22,11 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     audienceOffset: 0,
 
     pageCheck(page) {
-        return page.contentType === 'LiveBlog'
-            && page.section !== 'sport'
-            && page.section !== 'football';
+        return (
+            page.contentType === 'LiveBlog' &&
+            page.section !== 'sport' &&
+            page.section !== 'football'
+        );
     },
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -2,7 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { liveblogMillionCopy } from 'common/modules/commercial/acquisitions-copy';
+import { liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
 
 export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     id: 'AcquisitionsEpicLiveblog',
@@ -35,7 +35,7 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
 
                 template(variant) {
                     return epicLiveBlogTemplate({
-                        copy: liveblogMillionCopy,
+                        copy: liveblogCopy,
                         componentName: variant.options.componentName,
                         supportURL: variant.options.supportURL,
                     });


### PR DESCRIPTION
- Switch from One Million copy on liveblog to new liveblog-tailored control copy
- Don't show liveblog epic on sport or football blogs, because their conversion rate is so low (and the context doesn't feel right for an epic)

## before
![picture 400](https://user-images.githubusercontent.com/5122968/49586355-d8878b00-f958-11e8-9f76-1fea6701b63e.png)

## after
![picture 399](https://user-images.githubusercontent.com/5122968/49586367-dde4d580-f958-11e8-8271-463f40721ff2.png)

