### PR TITLE
Resolved content labels madness

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -11,6 +11,7 @@
         "content__labels--not-immersive" -> !item.content.isImmersive,
         "content__labels--column" -> item.content.isColumn,
         "content__labels--immersive" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || badgeFor(item).isDefined),
+        "content__labels--panel" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || item.content.isGallery),
         "content__labels--flagship"  -> (item.tags.isAudio && !ActiveExperiments.isParticipating(OldAudioPage))
     ), "content__labels")
 ">

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -889,9 +889,6 @@
 
 @mixin immersivePillarColours($pillar, $color, $color2) {
     .content--pillar-#{$pillar}.content--immersive-article:not(.paid-content) {
-        .content__labels--immersive {
-            background-color: $color2;
-        }
         .u-underline {
             color: $color2;
             border-bottom: 1px solid rgba($color2, .4);

--- a/static/src/stylesheets/module/content-garnett/_media.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_media.head.scss
@@ -46,15 +46,3 @@
         fill: #bdbdbd;
     }
 }
-
-/* Styling fix for special topic label */
-.content--media:not(.paid-content) {
-    header {
-        .content__labels.content__labels--immersive {
-            background: none;
-            .badge-slot {
-                margin-bottom: 16px;
-            }
-        }
-    }
-}

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -61,7 +61,8 @@
 
     .bullet::before,
     .content__headline-column-wrapper--column,
-    .content__labels--column {
+    .content__labels--column,
+    .content__labels--panel {
         background-color: $kickerColor;
     }
 
@@ -265,10 +266,6 @@
     .content__section-label__link,
     .youtube-media-atom__bottom-bar__duration {
         color: $mediaColor;
-    }
-
-    .content__labels--immersive {
-        background: $pillarColor;
     }
 
     .gu-media--show-controls-at-start.vjs-paused .vjs-big-play-button .vjs-control-text:before,


### PR DESCRIPTION
As referenced here [https://github.com/guardian/frontend/pull/20794/](url) certain meta areas were inheriting a distracting background colour when they shouldn't have been.

A couple of fixes were created, that work: 
https://github.com/guardian/frontend/pull/20805
https://github.com/guardian/frontend/pull/20794/

But sadly these work by creating more specificity to overrides. The problem is `content__labels--immersive` is applied to any `content__labels` area with a badge, and in some cases it won't be the immersive template. So I've attached the colour logic to a new modifying class that is only applied to the immersive template and the gallery template, which are as far as I know the only templates that require this. 

