### PR TITLE
Remove comma from srcset strings

### DIFF
--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -92,7 +92,7 @@ case class VideoProfile(
 
 case class SrcSet(src: String, width: Int) {
   def asSrcSetString: String = {
-    s"$src, ${width}w"
+    s"$src ${width}w"
   }
 
 }


### PR DESCRIPTION
## What does this change?
This https://github.com/guardian/frontend/pull/20811 erroneously added a `,` to the the strings generated to fill the [`srcset HTML property`](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). This resulted in blurry looking images in [immersive content](https://www.theguardian.com/artanddesign/2018/nov/26/fringe-benefits-the-hair-extension-industry-in-ukraine-a-photo-essay)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
