### PR TITLE
Banner with ticker

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -208,6 +208,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-banner-us-eoy",
+    "Serves an banner with ticker and copy for US end of year campaign",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-au-post-one-million",
     "Custom epic copy for Australia",
     owners = Seq(Owner.withGithub("joelochlann")),

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -15,14 +15,11 @@ declare type EngagementBannerTemplateParams = {
     ctaText: string,
     buttonCaption: string,
     linkUrl: string,
+    hasTicker: boolean,
 };
 
-declare type EngagementBannerParams = {
+declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     campaignCode: string,
-    buttonCaption: string,
-    linkUrl: string,
-    messageText: string,
-    ctaText: string,
     pageviewId: string,
     products: OphanProduct[],
     paypalClass?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -69,6 +69,7 @@ export const defaultEngagementBannerParams = (): EngagementBannerParams => {
         ctaText: supporterEngagementCtaCopyControl(location),
         pageviewId: config.get('ophan.pageViewId', 'not_found'),
         products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
+        hasTicker: false,
     };
 };
 
@@ -114,6 +115,7 @@ export const getAcquisitionsBannerParams = (
         ),
         buttonCaption: firstRow.buttonCaption,
         linkUrl: firstRow.linkUrl,
+        hasTicker: false,
     };
 
     return paramsFromGoogleDoc;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -24,6 +24,7 @@ import {
 } from 'common/modules/commercial/acquisitions-ophan';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import userPrefs from 'common/modules/user-prefs';
+import { initTicker } from 'common/modules/commercial/ticker';
 
 type BannerDeployLog = {
     time: string,
@@ -178,6 +179,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         ctaText,
         linkUrl,
         buttonCaption,
+        hasTicker: params.hasTicker,
     };
 
     const renderedBanner: string = params.template
@@ -219,6 +221,10 @@ const showBanner = (params: EngagementBannerParams): void => {
                     : {}),
             });
         });
+
+        if (params.hasTicker) {
+            initTicker('.js-engagement-banner-ticker');
+        }
 
         mediator.emit('membership-message:display');
     }

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -3,6 +3,7 @@ import marque36icon from 'svgs/icon/marque-36.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 import arrowWhiteRight from 'svgs/icon/arrow-white-right.svg';
 import config from 'lib/config';
+import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
 
 export const acquisitionsBannerControlTemplate = (
     params: EngagementBannerTemplateParams
@@ -20,6 +21,7 @@ export const acquisitionsBannerControlTemplate = (
     <div class="engagement-banner__container">
         <div class="engagement-banner__text">
             ${params.messageText}${params.ctaText}
+            ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
         </div>
         <div class="engagement-banner__cta">
             <button class="button engagement-banner__button" href="${

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
@@ -1,0 +1,19 @@
+// @flow
+
+export const acquisitionsBannerTickerTemplate = `
+    <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker">
+        <div class="js-ticker-so-far engagement-banner-ticker__so-far">
+            <div class="js-ticker-count engagement-banner-ticker__count">$0</div>
+            <div class="engagement-banner-ticker__count-label">contributed</div>
+        </div>
+        
+        <div class="js-ticker-goal engagement-banner-ticker__goal">
+            <div class="js-ticker-count engagement-banner-ticker__count">$0</div>
+            <div class="engagement-banner-ticker__count-label">our goal</div>
+        </div>
+        
+        <div class="engagement-banner-ticker__progress">
+            <div class="js-ticker-filled-progress engagement-banner-ticker__filled-progress"></div>
+        </div>
+    </div>
+`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -1,14 +1,16 @@
 // @flow
 
+import { getLocalCurrencySymbol } from 'lib/geolocation';
+
 export const acquisitionsEpicTickerTemplate = `
     <div id="epic-ticker" class="js-epic-ticker epic-ticker">
         <div class="js-ticker-so-far epic-ticker__so-far">
-            <div class="js-ticker-count epic-ticker__count">$0</div>
+            <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
             <div class="epic-ticker__count-label">contributed</div>
         </div>
         
         <div class="js-ticker-goal epic-ticker__goal">
-            <div class="js-ticker-count epic-ticker__count">$0</div>
+            <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
             <div class="epic-ticker__count-label">our goal</div>
         </div>
         

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -1,19 +1,19 @@
 // @flow
 
 export const acquisitionsEpicTickerTemplate = `
-    <div class="epic-ticker">
-        <div class="epic-ticker__so-far">
-            <div class="epic-ticker__count">$0</div>
+    <div id="epic-ticker" class="js-epic-ticker epic-ticker">
+        <div class="js-ticker-so-far epic-ticker__so-far">
+            <div class="js-ticker-count epic-ticker__count">$0</div>
             <div class="epic-ticker__count-label">contributed</div>
         </div>
         
-        <div class="epic-ticker__goal">
-            <div class="epic-ticker__count">$0</div>
+        <div class="js-ticker-goal epic-ticker__goal">
+            <div class="js-ticker-count epic-ticker__count">$0</div>
             <div class="epic-ticker__count-label">our goal</div>
         </div>
         
         <div class="epic-ticker__progress">
-            <div class="epic-ticker__filled-progress"></div>
+            <div class="js-ticker-filled-progress epic-ticker__filled-progress"></div>
         </div>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,5 +1,5 @@
 // @flow
-let count = {};
+const count = {};
 let showCount;
 let goal;
 let total;
@@ -22,7 +22,10 @@ const animateBar = (parentElement: HTMLElement) => {
     }
 };
 
-const increaseCounter = (parentElement: HTMLElement, parentElementSelector: string) => {
+const increaseCounter = (
+    parentElement: HTMLElement,
+    parentElementSelector: string
+) => {
     // Count is local to the parent element
     count[parentElementSelector] += Math.floor(total / 100);
     const counterElement = parentElement.querySelector(
@@ -30,11 +33,15 @@ const increaseCounter = (parentElement: HTMLElement, parentElementSelector: stri
     );
 
     if (counterElement && counterElement instanceof HTMLElement) {
-        counterElement.innerHTML = `$${count[parentElementSelector].toLocaleString()}`;
+        counterElement.innerHTML = `$${count[
+            parentElementSelector
+        ].toLocaleString()}`;
         if (count[parentElementSelector] >= total) {
             counterElement.innerHTML = `$${total.toLocaleString()}`;
         } else {
-            window.requestAnimationFrame(() => increaseCounter(parentElement, parentElementSelector));
+            window.requestAnimationFrame(() =>
+                increaseCounter(parentElement, parentElementSelector)
+            );
         }
     }
 };
@@ -56,7 +63,9 @@ const animate = (parentElementSelector: string) => {
         populateText(parentElement);
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
-            window.requestAnimationFrame(() => increaseCounter(parentElement, parentElementSelector));
+            window.requestAnimationFrame(() =>
+                increaseCounter(parentElement, parentElementSelector)
+            );
             animateBar(parentElement);
         }, 500);
     }

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,5 +1,6 @@
 // @flow
-let count = 0;
+let count = {};
+let showCount;
 let goal;
 let total;
 
@@ -11,9 +12,9 @@ const percentageTotalAsNegative = () => {
     return percentage;
 };
 
-const animateBar = () => {
-    const progressBarElement = document.querySelector(
-        '.epic-ticker__filled-progress'
+const animateBar = (parentElement: HTMLElement) => {
+    const progressBarElement = parentElement.querySelector(
+        '.js-ticker-filled-progress'
     );
 
     if (progressBarElement && progressBarElement instanceof HTMLElement) {
@@ -21,25 +22,26 @@ const animateBar = () => {
     }
 };
 
-const increaseCounter = () => {
-    count += Math.floor(total / 100);
-    const counterElement = document.querySelector(
-        '.epic-ticker__so-far .epic-ticker__count'
+const increaseCounter = (parentElement: HTMLElement, parentElementSelector: string) => {
+    // Count is local to the parent element
+    count[parentElementSelector] += Math.floor(total / 100);
+    const counterElement = parentElement.querySelector(
+        '.js-ticker-so-far .js-ticker-count'
     );
 
     if (counterElement && counterElement instanceof HTMLElement) {
-        counterElement.innerHTML = `$${count.toLocaleString()}`;
-        if (count >= total) {
+        counterElement.innerHTML = `$${count[parentElementSelector].toLocaleString()}`;
+        if (count[parentElementSelector] >= total) {
             counterElement.innerHTML = `$${total.toLocaleString()}`;
         } else {
-            window.requestAnimationFrame(increaseCounter);
+            window.requestAnimationFrame(() => increaseCounter(parentElement, parentElementSelector));
         }
     }
 };
 
-const populateText = () => {
-    const goalElement = document.querySelector(
-        '.epic-ticker__goal .epic-ticker__count'
+const populateText = (parentElement: HTMLElement) => {
+    const goalElement = parentElement.querySelector(
+        '.js-ticker-goal .js-ticker-count'
     );
 
     if (goalElement && goalElement instanceof HTMLElement) {
@@ -47,26 +49,41 @@ const populateText = () => {
     }
 };
 
-const fetchDataAndAnimate = () => {
-    fetch(
-        'https://interactive.guim.co.uk/docsdata-test/1ySn7Ol2NQLvvSw_eAnVrPuuRnaGOxUmaUs6svtu_irU.json'
-    )
-        .then(resp => resp.json())
-        .then(data => {
-            const showCount = data.sheets.Sheet1[0].showCount === 'TRUE';
-            total = parseInt(data.sheets.Sheet1[0].total, 10);
-            goal = parseInt(data.sheets.Sheet1[0].goal, 10);
+const animate = (parentElementSelector: string) => {
+    const parentElement = document.querySelector(parentElementSelector);
 
-            if (showCount) {
-                populateText();
-                window.setTimeout(() => {
-                    window.requestAnimationFrame(increaseCounter);
-                    animateBar();
-                }, 500);
-            }
-        });
+    if (parentElement && parentElement instanceof HTMLElement) {
+        populateText(parentElement);
+        window.setTimeout(() => {
+            count[parentElementSelector] = 0;
+            window.requestAnimationFrame(() => increaseCounter(parentElement, parentElementSelector));
+            animateBar(parentElement);
+        }, 500);
+    }
 };
 
-export const initTicker = () => {
-    fetchDataAndAnimate();
+const dataSuccessfullyFetched = () => total && goal && showCount;
+
+const fetchDataAndAnimate = (parentElementSelector: string) => {
+    if (dataSuccessfullyFetched()) {
+        animate(parentElementSelector);
+    } else {
+        fetch(
+            'https://interactive.guim.co.uk/docsdata-test/1ySn7Ol2NQLvvSw_eAnVrPuuRnaGOxUmaUs6svtu_irU.json'
+        )
+            .then(resp => resp.json())
+            .then(data => {
+                showCount = data.sheets.Sheet1[0].showCount === 'TRUE';
+                total = parseInt(data.sheets.Sheet1[0].total, 10);
+                goal = parseInt(data.sheets.Sheet1[0].goal, 10);
+
+                if (dataSuccessfullyFetched()) {
+                    animate(parentElementSelector);
+                }
+            });
+    }
+};
+
+export const initTicker = (parentElementSelector: string) => {
+    fetchDataAndAnimate(parentElementSelector);
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,4 +1,6 @@
 // @flow
+import { getLocalCurrencySymbol } from 'lib/geolocation';
+
 const count = {};
 let showCount;
 let goal;
@@ -33,11 +35,11 @@ const increaseCounter = (
     );
 
     if (counterElement && counterElement instanceof HTMLElement) {
-        counterElement.innerHTML = `$${count[
+        counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
             parentElementSelector
         ].toLocaleString()}`;
         if (count[parentElementSelector] >= total) {
-            counterElement.innerHTML = `$${total.toLocaleString()}`;
+            counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
         } else {
             window.requestAnimationFrame(() =>
                 increaseCounter(parentElement, parentElementSelector)
@@ -52,7 +54,7 @@ const populateText = (parentElement: HTMLElement) => {
     );
 
     if (goalElement && goalElement instanceof HTMLElement) {
-        goalElement.innerHTML = `$${goal.toLocaleString()}`;
+        goalElement.innerHTML = `${getLocalCurrencySymbol()}${goal.toLocaleString()}`;
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -1,7 +1,5 @@
 // @flow strict
-import {
-    makeBannerABTestVariants,
-} from 'common/modules/commercial/contributions-utilities';
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
@@ -9,20 +7,24 @@ const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
 const abTestName = 'AcquisitionsBannerUsEoy';
 
 const controlParams = {
-    messageText: '<strong>The Guardian is editorially independent – our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to help fund us. By contributing to The Guardian, you are helping sustain the long term future of independent, investigative journalism and ensuring it remains available to all.',
+    messageText:
+        '<strong>The Guardian is editorially independent – our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to help fund us. By contributing to The Guardian, you are helping sustain the long term future of independent, investigative journalism and ensuring it remains available to all.',
     buttonCaption: 'Support The Guardian',
-    ctaText: ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1.</span>',
+    ctaText:
+        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1.</span>',
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 
 const criticalTimesParams = {
-    messageText: '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+    messageText:
+        '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
     buttonCaption: 'Support The Guardian',
-    ctaText: 'We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+    ctaText:
+        'We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 
-export const AcquisitionsBannerUsEoy =  {
+export const AcquisitionsBannerUsEoy = {
     id: abTestName,
     campaignId: abTestName,
     start: '2018-08-06',
@@ -42,26 +44,29 @@ export const AcquisitionsBannerUsEoy =  {
         {
             id: 'control',
             products: [],
-            engagementBannerParams: () => Promise.resolve({
-                ...controlParams,
-                hasTicker: false,
-            })
+            engagementBannerParams: () =>
+                Promise.resolve({
+                    ...controlParams,
+                    hasTicker: false,
+                }),
         },
         {
             id: 'control_copy_with_ticker',
             products: [],
-            engagementBannerParams: () => Promise.resolve({
-                ...controlParams,
-                hasTicker: true,
-            })
+            engagementBannerParams: () =>
+                Promise.resolve({
+                    ...controlParams,
+                    hasTicker: true,
+                }),
         },
         {
             id: 'critical_times_with_ticker',
             products: [],
-            engagementBannerParams: () => Promise.resolve({
-                ...criticalTimesParams,
-                hasTicker: true,
-            })
-        }
+            engagementBannerParams: () =>
+                Promise.resolve({
+                    ...criticalTimesParams,
+                    hasTicker: true,
+                }),
+        },
     ]),
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -11,16 +11,16 @@ const controlParams = {
         '<strong>The Guardian is editorially independent – our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to help fund us. By contributing to The Guardian, you are helping sustain the long term future of independent, investigative journalism and ensuring it remains available to all.',
     buttonCaption: 'Support The Guardian',
     ctaText:
-        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1.</span>',
+        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1 and help us reach our end of year goal.</span>',
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 
 const criticalTimesParams = {
     messageText:
-        '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+        '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
     buttonCaption: 'Support The Guardian',
     ctaText:
-        'We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1 and help us reach our end of year goal.</span>',
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -1,0 +1,67 @@
+// @flow strict
+import {
+    makeBannerABTestVariants,
+} from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+
+const abTestName = 'AcquisitionsBannerUsEoy';
+
+const controlParams = {
+    messageText: '<strong>The Guardian is editorially independent – our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to help fund us. By contributing to The Guardian, you are helping sustain the long term future of independent, investigative journalism and ensuring it remains available to all.',
+    buttonCaption: 'Support The Guardian',
+    ctaText: ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1.</span>',
+    linkUrl: 'https://support.theguardian.com/contribute',
+};
+
+const criticalTimesParams = {
+    messageText: '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+    buttonCaption: 'Support The Guardian',
+    ctaText: 'We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+    linkUrl: 'https://support.theguardian.com/contribute',
+};
+
+export const AcquisitionsBannerUsEoy =  {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-08-06',
+    expiry: '2019-06-06',
+    author: 'Joseph Smith',
+    description: 'Tests a custom banner for US campaign',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'All web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome: 'Increase in overall AV, and AV from recurring',
+    componentType,
+    showForSensitive: true,
+    canRun: () => geolocationGetSync() === 'US',
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+            products: [],
+            engagementBannerParams: () => Promise.resolve({
+                ...controlParams,
+                hasTicker: false,
+            })
+        },
+        {
+            id: 'control_copy_with_ticker',
+            products: [],
+            engagementBannerParams: () => Promise.resolve({
+                ...controlParams,
+                hasTicker: true,
+            })
+        },
+        {
+            id: 'critical_times_with_ticker',
+            products: [],
+            engagementBannerParams: () => Promise.resolve({
+                ...criticalTimesParams,
+                hasTicker: true,
+            })
+        }
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
@@ -61,7 +61,7 @@ export const acquisitionsEpicUsTopTicker: EpicABTest = makeABTest({
                 copy: shorterCopy,
                 template: createTemplate('TOP'),
                 onView: () => {
-                    initTicker();
+                    initTicker('.js-epic-ticker');
                 },
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -6,10 +6,12 @@ import {
     AcquisitionsBannerGoogleDocTestFourVariants,
     AcquisitionsBannerGoogleDocTestFiveVariants,
 } from 'common/modules/experiments/tests/acquisitions-banner-from-google-doc';
+import { AcquisitionsBannerUsEoy } from 'common/modules/experiments/tests/acquisitions-banner-us-eoy';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
 > = [
+    AcquisitionsBannerUsEoy,
     AcquisitionsBannerGoogleDocTestOneVariant,
     AcquisitionsBannerGoogleDocTestTwoVariants,
     AcquisitionsBannerGoogleDocTestThreeVariants,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -31,6 +31,7 @@ const bannerTemplateParams: EngagementBannerTemplateParams = {
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         componentId: 'first_pv_consent_plus_support_the_guardian_banner',
     }),
+    hasTicker: false,
 };
 
 const bannerHtml = `

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -32,6 +32,7 @@
 @import 'module/_accessibility';
 @import 'module/experiments/embed';
 @import 'module/reader-revenue/epic-ticker';
+@import 'module/reader-revenue/banner-ticker';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
 @import 'module/experiments/_update-account';

--- a/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
@@ -1,0 +1,81 @@
+.engagement-banner-ticker {
+    display: none;
+
+    @include mq(desktop) {
+        display: block;
+        position: relative;
+        height: 70px;
+        margin-top: 12px;
+    }
+}
+
+.engagement-banner-ticker__count {
+    @include fs-header(5);
+    font-size: 32px;
+    font-weight: 800;
+    color: #333333;
+}
+
+.engagement-banner-ticker__count-label {
+    font-size: 17px;
+    line-height: 1.4;
+}
+
+$progress-bar-height: 10px;
+
+.engagement-banner-ticker__progress {
+    width: 100%;
+    height: $progress-bar-height;
+    overflow: hidden;
+    background-color: #ffffff;
+    position: absolute;
+    bottom: 0;
+    margin-top: 40px;
+}
+
+.engagement-banner-ticker__filled-progress {
+    background-color: #333333;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    transition: transform 3s cubic-bezier(.25, .55, .2, .85);
+}
+
+.engagement-banner-ticker__progress-labels {
+    position: relative;
+    width: 100%;
+    height: 16px;
+}
+
+.engagement-banner-ticker__label {
+    @include fs-textSans(4);
+    color: #676767;
+    position: absolute;
+    top: 5px;
+}
+
+.engagement-banner-ticker__goal {
+    position: absolute;
+    right: 0;
+    bottom: $progress-bar-height + 5px;
+    text-align: right;
+}
+
+.engagement-banner-ticker__so-far {
+    position: absolute;
+    left: 0;
+    bottom: $progress-bar-height + 5px;
+}
+
+.engagement-banner-ticker__caption {
+    @include fs-textSans(4);
+    position: absolute;
+    bottom: 6px;
+    left: 10px;
+    right: 10px;
+    color: #ffffff;
+    opacity: .7;
+}


### PR DESCRIPTION
Adds some US-specific banner variants including a ticker.

Note that the ticker only appears from the desktop breakpoint - it's not there mobile or tablet

Copy is from here: https://docs.google.com/document/d/1JvRDC8sBS_JKAh6pmPPHq77vaJfoJMsVR91JH58vUVg/edit

## ~~control~~ this variant was removed in #20821 
![picture 407](https://user-images.githubusercontent.com/5122968/49656358-11952d80-fa35-11e8-81a8-ae80e386a0ee.png)

## control_copy_with_ticker
![picture 405](https://user-images.githubusercontent.com/5122968/49656361-11952d80-fa35-11e8-824b-3c1653adc2c0.png)

## critical_times_with_ticker
![picture 406](https://user-images.githubusercontent.com/5122968/49656360-11952d80-fa35-11e8-906a-d457da9dc8ae.png)

