### PR TITLE
Use preset value for EEA members

### DIFF
--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -11,9 +11,7 @@ https://support.google.com/dfp_premium/answer/7678538
   <script type="application/json">
    {
        "ISOCountryGroups": {
-           "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
-                    "gb", "uk", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu",
-                    "lv", "mt", "nl", "no", "pl", "pt", "ro", "se", "si", "sk" ]
+           "eea": [ "preset-eea" ]
        }
    }
   </script>


### PR DESCRIPTION
There seem to be a few values missing in our list, and this should avoid needing to update it.

See:
* https://www.ampproject.org/docs/reference/components/amp-geo#preset-country-groups
* https://github.com/ampproject/amphtml/blob/master/extensions/amp-geo/0.1/amp-geo-presets.js