### PR TITLE
engagement banner australia campaign

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -235,4 +235,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 6, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-australia-post-one-million",
+    "Tests an engagement banner with custom copy in Australia",
+    owners = Seq(Owner.withGithub("tsop14")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 6, 6),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -4,7 +4,7 @@ import config from 'lib/config';
 import { local as storage } from 'lib/storage';
 
 const storageKey = 'gu.geolocation';
-export type geolocationString = 'GB' | 'US' | 'AU'
+export type geolocationString = 'GB' | 'US' | 'AU';
 const editionToGeolocationMap = {
     UK: 'GB',
     US: 'US',

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -4,6 +4,7 @@ import config from 'lib/config';
 import { local as storage } from 'lib/storage';
 
 const storageKey = 'gu.geolocation';
+export type geolocationString = 'GB' | 'US' | 'AU'
 const editionToGeolocationMap = {
     UK: 'GB',
     US: 'US',

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,7 +1,10 @@
 // @flow
 import { isAbTestTargeted } from 'common/modules/commercial/targeting-tool';
 import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
-import { getAcquisitionsBannerParams, defaultEngagementBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
+import {
+    getAcquisitionsBannerParams,
+    defaultEngagementBannerParams,
+} from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import {
     submitClickEvent,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,10 +1,7 @@
 // @flow
 import { isAbTestTargeted } from 'common/modules/commercial/targeting-tool';
 import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
-import {
-    getAcquisitionsBannerParams,
-    defaultEngagementBannerParams,
-} from 'common/modules/commercial/membership-engagement-banner-parameters';
+import { getAcquisitionsBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import {
     submitClickEvent,
@@ -508,11 +505,7 @@ const makeEngagementBannerVariant = (
 ): InitBannerABTestVariant => ({
     id,
     products: [],
-    engagementBannerParams: () =>
-        Promise.resolve({
-            ...defaultEngagementBannerParams,
-            ...engagementBannerParams,
-        }),
+    engagementBannerParams: () => Promise.resolve(engagementBannerParams),
 });
 
 const makeGoogleDocBannerControl = (): InitBannerABTestVariant => ({

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -499,7 +499,7 @@ const makeGoogleDocBannerVariants = (
     return variants;
 };
 
-const makeEngagementBannerVariant = (
+const makeBannerABTestVariant = (
     id: string,
     engagementBannerParams: Object
 ): InitBannerABTestVariant => ({
@@ -526,7 +526,7 @@ export {
     makeGoogleDocEpicVariants,
     makeGoogleDocBannerVariants,
     makeGoogleDocBannerControl,
-    makeEngagementBannerVariant,
+    makeBannerABTestVariant,
     defaultMaxViews,
     isEpicDisplayable,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,7 +1,7 @@
 // @flow
 import { isAbTestTargeted } from 'common/modules/commercial/targeting-tool';
 import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
-import { getAcquisitionsBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
+import { getAcquisitionsBannerParams, defaultEngagementBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import {
     submitClickEvent,
@@ -499,6 +499,19 @@ const makeGoogleDocBannerVariants = (
     return variants;
 };
 
+const makeEngagementBannerVariant = (
+    id: string,
+    engagementBannerParams: Object
+): InitBannerABTestVariant => ({
+    id,
+    products: [],
+    engagementBannerParams: () =>
+        Promise.resolve({
+            ...defaultEngagementBannerParams,
+            ...engagementBannerParams,
+        }),
+});
+
 const makeGoogleDocBannerControl = (): InitBannerABTestVariant => ({
     id: 'control',
     products: [],
@@ -517,6 +530,7 @@ export {
     makeGoogleDocEpicVariants,
     makeGoogleDocBannerVariants,
     makeGoogleDocBannerControl,
+    makeEngagementBannerVariant,
     defaultMaxViews,
     isEpicDisplayable,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
@@ -1,7 +1,7 @@
 // @flow strict
 import {
     makeBannerABTestVariants,
-    makeEngagementBannerVariant,
+    makeBannerABTestVariant,
 } from 'common/modules/commercial/contributions-utilities';
 import {
     getSync as geolocationGetSync,
@@ -32,6 +32,6 @@ export const AcquisitionsBannerAustraliaPostOneMillionTest: AcquisitionsABTest =
     canRun: () => geolocationGetSync() === ('AU': geolocationString),
 
     variants: makeBannerABTestVariants([
-        makeEngagementBannerVariant('AU2018_POST_1M_EB', variantAParams),
+        makeBannerABTestVariant('AU2018_POST_1M_EB', variantAParams),
     ]),
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
@@ -1,0 +1,35 @@
+// @flow strict
+import {
+    makeBannerABTestVariants,
+    makeGoogleDocBannerControl,
+    makeEngagementBannerVariant,
+} from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync, geolocationString } from 'lib/geolocation';
+
+const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
+const abTestName = 'AcquisitionsBannerAustraliaPostOneMillion';
+const variantAParams = {
+    messageText:
+        '<strong>With the support of one million Guardian readers, including 89,000 supporters in Australia, we remain editorially independent.</strong> Support from our readers keeps our journalism free from commercial bias and our reporting open and accessible to all. Imagine what we could continue to achieve with the support of many more of you. Together we can be a force for change.',
+};
+
+export const AcquisitionsBannerAustraliaPostOneMillionTest: AcquisitionsABTest = {
+    id: abTestName,
+    campaignId: abTestName,
+    start: '2018-12-03',
+    expiry: '2019-06-06',
+    author: 'Emma Milner',
+    description: 'Tests a banner with custom copy in Australia',
+    audience: 1,
+    audienceOffset: 0,
+    audienceCriteria: 'AU web traffic.',
+    successMeasure: 'AV 2.0',
+    idealOutcome: 'Increase in overall AV, and AV from recurring',
+    componentType,
+    showForSensitive: true,
+    canRun: () => geolocationGetSync() === ('AU': geolocationString),
+
+    variants: makeBannerABTestVariants([
+        makeEngagementBannerVariant('AU2018_POST_1M_EB', variantAParams),
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-australia-post-one-million.js
@@ -1,10 +1,12 @@
 // @flow strict
 import {
     makeBannerABTestVariants,
-    makeGoogleDocBannerControl,
     makeEngagementBannerVariant,
 } from 'common/modules/commercial/contributions-utilities';
-import { getSync as geolocationGetSync, geolocationString } from 'lib/geolocation';
+import {
+    getSync as geolocationGetSync,
+    type geolocationString,
+} from 'lib/geolocation';
 
 const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
 const abTestName = 'AcquisitionsBannerAustraliaPostOneMillion';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -6,10 +6,12 @@ import {
     AcquisitionsBannerGoogleDocTestFourVariants,
     AcquisitionsBannerGoogleDocTestFiveVariants,
 } from 'common/modules/experiments/tests/acquisitions-banner-from-google-doc';
+import { AcquisitionsBannerAustraliaPostOneMillionTest } from './acquisitions-banner-australia-post-one-million';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
 > = [
+    AcquisitionsBannerAustraliaPostOneMillionTest,
     AcquisitionsBannerGoogleDocTestOneVariant,
     AcquisitionsBannerGoogleDocTestTwoVariants,
     AcquisitionsBannerGoogleDocTestThreeVariants,


### PR DESCRIPTION
## What does this change?
Adds custom engagement banner copy for all users in Australia (those with 'Au' local storage geolocation value). There is no control. 


## Screenshots
![screen shot 2018-12-07 at 14 38 56](https://user-images.githubusercontent.com/8484757/49655635-0a6d2000-fa33-11e8-9f26-6a4b6031c2d4.jpg)
@jessewilkins 

## What is the value of this and can you measure success?
Drives traffic towards support and therefore increases contributions. This is not being tested. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
