### PR TITLE
FRONTS CONTAINER: AB test for image in today in focus

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,7 +8,8 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldAudioPage,
     OrielParticipation,
-    OldTLSSupportDeprecation
+    OldTLSSupportDeprecation,
+    PodcastImage
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -37,3 +38,12 @@ object OldAudioPage extends Experiment(
   sellByDate = new LocalDate(2018, 12, 19),
   participationGroup = Perc5A
 )
+
+object PodcastImage extends Experiment(
+  name = "podcast-image",
+  description = "For the Fronts container for the Today in Focus podcast, show either the logo or a unique story photo",
+  owners = Owner.group(SwitchGroup.Journalism),
+  sellByDate = new LocalDate(2019, 1, 9),
+  participationGroup = Perc50
+)
+

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -354,6 +354,9 @@ case class ContentCard(
   def mediaWidthsByBreakpoint(implicit requestHeader: RequestHeader) : WidthsByBreakpoint =
       GarnettFaciaWidths.mediaFromItemClasses(cardTypes)
 
+  def squareImageWidthsByBreakpoint(implicit requestHeader: RequestHeader) : WidthsByBreakpoint =
+      GarnettFaciaWidths.squareFront()
+
   def showTimestamp: Boolean = timeStampDisplay.isDefined && webPublicationDate.isDefined
 
   val analyticsPrefix = s"${cardStyle.toneString} | group-$group${if(displaySettings.isBoosted) "+" else ""}"

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -167,6 +167,10 @@ object GarnettFaciaWidths {
     (FullMedia100, 331.px)
   )
 
+  private val SquareImageFronts = Map[CardType, BrowserWidth](
+    (Standard, 660.px),
+  )
+
   def mediaFromItemClasses(itemClasses: ItemClasses): WidthsByBreakpoint = {
     val desktopClass = itemClasses.desktop.getOrElse(itemClasses.tablet)
 
@@ -174,6 +178,14 @@ object GarnettFaciaWidths {
       mobile          = MediaMobile.get(itemClasses.mobile),
       tablet          = MediaTablet.get(itemClasses.tablet),
       desktop         = MediaDesktop.get(desktopClass)
+    )
+  }
+
+  def squareFront(): WidthsByBreakpoint = {
+    WidthsByBreakpoint(
+      mobile          = SquareImageFronts.get(Standard),
+      tablet          = SquareImageFronts.get(Standard),
+      desktop         = SquareImageFronts.get(Standard)
     )
   }
 

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -8,6 +8,7 @@
 @import layout.SliceWithCards
 @import conf.audio.FlagshipFrontContainer
 @import conf.AudioFlagship
+@import experiments.{ActiveExperiments, PodcastImage}
 
 @(containerDefinition: layout.FaciaContainer, frontProperties: FrontProperties)(implicit request: RequestHeader)
 
@@ -36,7 +37,6 @@
     </div>
 }
 
-
 @containerHeader(containerDefinition, frontProperties)
 
 @for(containerLayout <- containerDefinition.containerLayout) {
@@ -57,9 +57,26 @@
                     @getLatestEpisode(allCards).map { card =>
                         <div class="fc-item--type-media">
                             <div class="fc-podcast-container__episode">
-                                <div class="fc-podcast-container__episode-image">
-                                    <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
-                                </div>
+
+                                @if(ActiveExperiments.isParticipating(PodcastImage)){
+                                    @card.displayElement match {
+                                        case Some(InlineImage(image)) => {
+                                            <div class="fc-podcast-container__episode-image-story">
+                                                @itemImage(
+                                                    image,
+                                                    inlineImage = true,
+                                                    widthsByBreakpoint = Some(card.mediaWidthsByBreakpoint)
+                                                )
+                                            </div>
+                                        }
+                                        case _ => {}
+                                    }
+                                } else{
+                                    <div class="fc-podcast-container__episode-image-generic">
+                                        <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
+                                    </div>
+                                }
+
                                 <div class="fc-podcast-container__episode-details">
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
@@ -91,8 +108,9 @@
                                 </div>
                                 @subscriptionLinks
                             </div>
-                            <a class="fc-podcast-container__track u-faux-block-link__overlay js-headline-text" @Html(card.header.url.hrefWithRel) data-link-name="article" tabindex="-1" aria-hidden="true">
-                                @RemoveOuterParaHtml(card.header.headline)
+                            <a class="fc-podcast-container__track u-faux-block-link__overlay js-headline-text"
+                                @Html(card.header.url.hrefWithRel) data-link-name="article" tabindex="-1" aria-hidden="true">
+                                @RemoveOuterParaHtml(card.header.headline)>
                             </a>
                         </div>
                     }

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -37,6 +37,7 @@
     </div>
 }
 
+
 @containerHeader(containerDefinition, frontProperties)
 
 @for(containerLayout <- containerDefinition.containerLayout) {
@@ -65,11 +66,15 @@
                                                 @itemImage(
                                                     image,
                                                     inlineImage = true,
-                                                    widthsByBreakpoint = Some(card.mediaWidthsByBreakpoint)
+                                                    widthsByBreakpoint = Some(card.squareImageWidthsByBreakpoint)
                                                 )
                                             </div>
                                         }
-                                        case _ => {}
+                                        case _ => {
+                                            <div class="fc-podcast-container__episode-image-generic">
+                                                <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
+                                            </div>
+                                        }
                                     }
                                 } else{
                                     <div class="fc-podcast-container__episode-image-generic">
@@ -108,9 +113,8 @@
                                 </div>
                                 @subscriptionLinks
                             </div>
-                            <a class="fc-podcast-container__track u-faux-block-link__overlay js-headline-text"
-                                @Html(card.header.url.hrefWithRel) data-link-name="article" tabindex="-1" aria-hidden="true">
-                                @RemoveOuterParaHtml(card.header.headline)>
+                            <a class="fc-podcast-container__track u-faux-block-link__overlay js-headline-text" @Html(card.header.url.hrefWithRel) data-link-name="article" tabindex="-1" aria-hidden="true">
+                                @RemoveOuterParaHtml(card.header.headline)
                             </a>
                         </div>
                     }

--- a/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
@@ -98,8 +98,11 @@
     color: #ff6a56;
 }
 
-.fc-podcast-container__episode-image,
-.fc-podcast-container__episode-image img {
+/* AB TEST WITH ACTUAL STORY IMAGE VS GENERIC */
+
+/* GENERIC IMAGE */
+.fc-podcast-container__episode-image-generic,
+.fc-podcast-container__episode-image-generic img {
     width: 119px;
     height: 119px;
 
@@ -113,6 +116,33 @@
         height: 220px;
     }
 }
+
+/* STORY IMAGE */
+.fc-podcast-container__episode-image-story {
+    .fc-item__image-container {
+        padding-bottom: 0;
+        line-height: 1; /* removes extra spacing on picture element */
+        img {
+            object-fit: cover;
+            position: static;
+            width: 119px;
+            height: 119px;
+
+            @include mq(tablet) {
+                width: 160px;
+                height: 160px;
+            }
+
+            @include mq(desktop) {
+                width: 220px;
+                height: 220px;
+            }
+        }
+    }
+}
+
+
+/*--------*/
 
 .fc-podcast-container__subscribe-small {
     padding: 5px 5px 2px;


### PR DESCRIPTION
## What does this change?
This adds an AB test to check if there are more clickthroughs on the podcast Today in Focus container when it has a story specific episode image compared to a generic logo. 

This is a 50:50 serverside test. 
That should be run for 5 days. 

Story images are naturally rectangular, but the design requires square images. So some CSS cropping is making the images square. This can have the effect of reducing image resolution. 

*Getting results of test*
If the story image is shown, the link on the story will have the data attribute: `data-link-variant: story-image`.
If the generic image is shown: `data-link-variant: generic-image`.

## Screenshots
Original - generic image 
<img width="1070" alt="screen shot 2018-12-07 at 16 49 26" src="https://user-images.githubusercontent.com/10324129/49661093-1ad7c780-fa40-11e8-8a00-db27f723201a.png">


Variant - story image 
<img width="981" alt="screen shot 2018-12-07 at 16 05 39" src="https://user-images.githubusercontent.com/10324129/49660982-db10e000-fa3f-11e8-8b07-b3f35549bcb8.png">


![screen shot 2018-12-11 at 11 15 19](https://user-images.githubusercontent.com/10324129/49797193-a26e5080-fd36-11e8-911c-e87378bdd768.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
