### PR TITLE
Remove control without ticker

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -42,15 +42,6 @@ export const AcquisitionsBannerUsEoy = {
 
     variants: makeBannerABTestVariants([
         {
-            id: 'control',
-            products: [],
-            engagementBannerParams: () =>
-                Promise.resolve({
-                    ...controlParams,
-                    hasTicker: false,
-                }),
-        },
-        {
             id: 'control_copy_with_ticker',
             products: [],
             engagementBannerParams: () =>


### PR DESCRIPTION
Apparently we don't want any variants without the ticker, since the ticker performed well on the epic