### PR TITLE
Refactor including Prebid auction ID in ad targeting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#31a508c",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#13498e3",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -142,26 +142,6 @@ class PrebidService {
                 () =>
                     new Promise(resolve => {
                         window.pbjs.que.push(() => {
-                            // Capture this specific auction starting
-                            // to set this slot pbaid targeting value
-                            const auctionInitHandler = (data: {
-                                auctionId: string,
-                            }) => {
-                                // Get rid of this handler now.
-                                window.pbjs.offEvent(
-                                    'auctionInit',
-                                    auctionInitHandler
-                                );
-                                advert.slot.setTargeting(
-                                    'hb_auction',
-                                    data.auctionId
-                                );
-                            };
-                            window.pbjs.onEvent(
-                                'auctionInit',
-                                auctionInitHandler
-                            );
-
                             window.pbjs.requestBids({
                                 adUnits,
                                 bidsBackHandler() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7940,9 +7940,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#31a508c":
+"prebid.js@https://github.com/guardian/Prebid.js.git#13498e3":
   version "1.32.0"
-  resolved "https://github.com/guardian/Prebid.js.git#31a508c8be2cdc5a48948937b25d016a2969b444"
+  resolved "https://github.com/guardian/Prebid.js.git#13498e37f8eb1b7c68c85e0eb2edb1b621145210"
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.1"


### PR DESCRIPTION
This includes the auction ID through the Prebid dependency rather than in the frontend code so that it's treated like a standard targeting parameter.

See https://github.com/guardian/Prebid.js/pull/69

It should have no effect other than ensuring auctions report the correct auction ID.

It follows the same approach as https://github.com/guardian/frontend/pull/20589.
