### PR TITLE
Use correct quality param for email images

### DIFF
--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -206,12 +206,12 @@ object FacebookOpenGraphImage extends OverlayBase64 {
 }
 
 object EmailImage extends ImageProfile(width = Some(580), autoFormat = false) {
-  override val qualityparam = "quality=60"
+  override val qualityparam = "quality=85"
   val knownWidth = width.get
 }
 
 object EmailVideoImage extends ImageProfile(width = Some(580), autoFormat = false) with OverlayBase64 {
-  override val qualityparam = "quality=60"
+  override val qualityparam = "quality=85"
   val overlayAlignParam = "overlay-align=center"
   val overlayUrlParam = s"overlay-base64=${overlayUrlBase64("play.png")}"
 

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -222,7 +222,7 @@ object EmailVideoImage extends ImageProfile(width = Some(580), autoFormat = fals
 }
 
 object FrontEmailImage extends ImageProfile(width = Some(500), autoFormat = false) {
-  override val qualityparam = "quality=60"
+  override val qualityparam = "quality=85"
   val knownWidth = width.get
 }
 
@@ -230,7 +230,7 @@ object SmallFrontEmailImage {
   def apply(customWidth: Int): SmallFrontEmailImage = new SmallFrontEmailImage(customWidth)
 }
 class SmallFrontEmailImage(customWidth: Int) extends ImageProfile(Some(customWidth), autoFormat = false) {
-  override val qualityparam = "quality=60"
+  override val qualityparam = "quality=85"
 }
 
 // The imager/images.js base image.


### PR DESCRIPTION
## What does this change?
Increases the quality setting for email images from 60 to 85. `60` is actually the old imgix value which should have been updated when we migrated to fastly (we were rewriting it in VCL to 85). 

## Screenshots
Bad images in an email:
![screen shot 2018-12-10 at 11 29 54](https://user-images.githubusercontent.com/3606555/49730002-f44ba380-fc6e-11e8-82bd-e4b7e59c5074.png)

## What is the value of this and can you measure success?
Images will look better in emails 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
