### PR TITLE
Fix edition paths

### DIFF
--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -74,7 +74,7 @@
                             @Edition.all.map { edition =>
                                 <li class="menu-item">
                                     <a data-link-name="amp : nav : edition-picker : @edition.id"
-                                    href="@{Configuration.id.url}/preference/edition/@{edition.id.toLowerCase}"
+                                    href="@{Configuration.site.host}/preference/edition/@{edition.id.toLowerCase}"
                                     class="menu-item__title">
                                         @edition.displayName
                                     </a>

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -42,7 +42,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
         def writes(edition: Edition): JsValue = Json.obj(
           "id" -> edition.id,
           "displayName" -> edition.displayName,
-          "optInLink" -> s"${Configuration.id.url}/preference/edition/${edition.id.toLowerCase}"
+          "optInLink" -> s"${Configuration.site.host}/preference/edition/${edition.id.toLowerCase}"
         )
       }
 


### PR DESCRIPTION
Our AMP edition-switching links point to an outdated link. I'll raise with Identity about a redirect but going to fix for now.

Also fixes the same for our AMP data model, which gets passed to dotcom rendering.