### PR TITLE
Add Prebid user-sync iframe in Amp

### DIFF
--- a/common/app/views/fragments/amp/adUserSync.scala.html
+++ b/common/app/views/fragments/amp/adUserSync.scala.html
@@ -1,0 +1,14 @@
+@()
+
+<amp-iframe
+width="1"
+title="User Sync"
+height="1"
+sandbox="allow-scripts"
+frameborder="0"
+src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie.html">
+    <amp-img
+    layout="fill"
+    src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+    placeholder></amp-img>
+</amp-iframe>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -60,5 +60,7 @@
 
             @fragments.footer(isAmp = true)
         </div>
+
+        @fragments.amp.adUserSync()
     </body>
 </html>


### PR DESCRIPTION
This fires a beacon to enable the syncing of user IDs for Prebid in Amp.

See http://prebid.org/dev-docs/show-prebid-ads-on-amp-pages.html#user-sync

This is consistent with the current GDPR policy for Amp.
