### PR TITLE
⚡️📢☁️( Adds elements and logic to separate soundcloud embeds from embeds*)

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -197,21 +197,18 @@ object PageElement {
       d <- element.audioTypeData
       html <- d.html
       mandatory = true
-      s = extractSoundcloud(html, mandatory)
     } yield {
-      s getOrElse AudioBlockElement(element.assets.map(AudioAsset.make))
+      extractSoundcloud(html, mandatory) getOrElse AudioBlockElement(element.assets.map(AudioAsset.make))
     }
   }
 
   private def extractEmbed(element: ApiBlockElement): Option[PageElement] = {
-      for {
+    for {
       d <- element.embedTypeData
       html <- d.html
       mandatory = d.isMandatory.getOrElse(false)
-      e = EmbedBlockElement(html, d.safeEmbedCode, d.alt, mandatory)
-      s = extractSoundcloud(html, mandatory)
     } yield {
-      s getOrElse e
+      extractSoundcloud(html, mandatory) getOrElse EmbedBlockElement(html, d.safeEmbedCode, d.alt, mandatory)
     }
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -26,7 +26,7 @@ case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String], role: Role) extends PageElement
 case class VideoBlockElement(data: Map[String, String], role: Role) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
-case class SoundcloudBlockElement(html: String, track: Option[String], playlist: Option[String], isMandatory: Boolean) extends PageElement
+case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
 case class InteractiveBlockElement(html: Option[String], role: Role, isMandatory: Option[Boolean]) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
@@ -221,13 +221,10 @@ object PageElement {
     doc.getElementsByTag("iframe").asScala.headOption.flatMap {
       iframe =>
         val src = iframe.attr("src")
-        val maybeTrack = AmpSoundcloud.getTrackIdFromUrl(src)
-        val maybePlaylist = AmpSoundcloud.getPlaylistIdFromUrl(src)
-        if (maybeTrack.isEmpty && maybePlaylist.isEmpty) {
-          None
-        }
-        else {
-          Some(SoundcloudBlockElement(html, maybeTrack, maybePlaylist, isMandatory))
+        (AmpSoundcloud.getTrackIdFromUrl(src), AmpSoundcloud.getPlaylistIdFromUrl(src)) match {
+          case (Some(track), _) => Some(SoundcloudBlockElement(html, track, isTrack = true, isMandatory))
+          case (_, Some(playlist)) => Some(SoundcloudBlockElement(html, playlist, isTrack = false, isMandatory))
+          case _ => None
         }
     }
   }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -6,6 +6,8 @@ import layout.ContentWidths.BodyMedia
 import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
 import play.api.libs.json._
 import org.jsoup.Jsoup
+import views.support.cleaner.AmpSoundcloud
+
 import scala.collection.JavaConverters._
 import views.support.{ImageProfile, ImageUrlSigner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
 
@@ -23,7 +25,8 @@ case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String], role: Role) extends PageElement
 case class VideoBlockElement(data: Map[String, String], role: Role) extends PageElement
-case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String], isMandatory: Option[Boolean]) extends PageElement
+case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
+case class SoundcloudBlockElement(html: String, track: Option[String], playlist: Option[String], isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
 case class InteractiveBlockElement(html: Option[String], role: Role, isMandatory: Option[Boolean]) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
@@ -129,7 +132,7 @@ object PageElement {
           imageSources
         ))
 
-      case Audio => List(AudioBlockElement(element.assets.map(AudioAsset.make)))
+      case Audio => extractAudio(element).toList
 
       case Video =>
         if (element.assets.nonEmpty) {
@@ -170,7 +173,7 @@ object PageElement {
         )
       }).toList
 
-      case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt, d.isMandatory)).toList
+      case Embed => extractEmbed(element).toList
 
       case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId)).toList
 
@@ -186,6 +189,38 @@ object PageElement {
       case Form => List(FormBlockElement(None))
       case EnumUnknownElementType(f) => List(UnknownBlockElement(None))
 
+    }
+  }
+
+  private def extractAudio(element: ApiBlockElement) = {
+    for {
+      d <- element.audioTypeData
+      html <- d.html
+      mandatory = true
+      s = extractSoundcloud(html, mandatory)
+    } yield {
+      s getOrElse AudioBlockElement(element.assets.map(AudioAsset.make))
+    }
+  }
+
+  private def extractEmbed(element: ApiBlockElement) = {
+    for {
+      d <- element.embedTypeData
+      html <- d.html
+      mandatory = d.isMandatory.getOrElse(false)
+      e = EmbedBlockElement(html, d.safeEmbedCode, d.alt, mandatory)
+      s = extractSoundcloud(html, mandatory)
+    } yield {
+      s getOrElse e
+    }
+  }
+
+  private def extractSoundcloud(html: String, isMandatory: Boolean): Option[SoundcloudBlockElement] = {
+    val doc = Jsoup.parseBodyFragment(html)
+    doc.getElementsByTag("iframe").asScala.headOption.map {
+      iframe =>
+        val src = iframe.attr("src")
+        SoundcloudBlockElement(html, AmpSoundcloud.getTrackIdFromUrl(src), AmpSoundcloud.getPlaylistIdFromUrl(src), isMandatory)
     }
   }
 
@@ -215,6 +250,7 @@ object PageElement {
   implicit val VideoBlockElementWrites: Writes[VideoBlockElement] = Json.writes[VideoBlockElement]
   implicit val TweetBlockElementWrites: Writes[TweetBlockElement] = Json.writes[TweetBlockElement]
   implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
+  implicit val SoundCloudBlockElementWrites: Writes[SoundcloudBlockElement] = Json.writes[SoundcloudBlockElement]
   implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
   implicit val PullquoteBlockElementWrites: Writes[PullquoteBlockElement] = Json.writes[PullquoteBlockElement]
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -96,32 +96,6 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner with Logging {
   }
 
 
-  // There are two element types that have been found to contain Soundcloud embeds.
-  // These are: element-audio and element-embed
-  object AmpSoundcloud {
-    def createElement(document: Document, trackId: String): Element = {
-      val soundcloud = document.createElement("amp-soundcloud")
-      soundcloud.attr("data-trackid", trackId)
-      soundcloud.attr("data-visual", "true")
-      soundcloud.attr("height", "300") // height is necessary if data-visual == true
-    }
-
-    def getTrackIdFromUrl(soundcloudUrl: String): Option[String] = {
-      val pattern = ".*api.soundcloud.com/tracks/(\\d+).*".r
-      URLDecoder.decode(soundcloudUrl,"UTF-8") match {
-        case pattern(trackId) => {
-          Some(trackId)}
-        case _ => None
-      }
-    }
-
-    def getSoundCloudElement(document: Document, iframeElement: Element): Option[Element] = {
-      val trackId = AmpSoundcloud.getTrackIdFromUrl(iframeElement.attr("src"))
-      trackId.map(id => AmpSoundcloud.createElement(document, id))
-    }
-
-  }
-
 
   def logAmpRemoval: String => Unit = {message =>
     if (Switches.LogRemovedAmpElements.isSwitchedOn)

--- a/common/app/views/support/cleaner/AmpSoundcloud.scala
+++ b/common/app/views/support/cleaner/AmpSoundcloud.scala
@@ -1,0 +1,54 @@
+package views.support.cleaner
+
+import java.net.URLDecoder
+
+import org.jsoup.nodes.{Document, Element}
+
+
+// There are two element types that have been found to contain Soundcloud embeds.
+// These are: element-audio and element-embed
+object AmpSoundcloud {
+  def createElementFromTrack(document: Document, trackId: String): Element = {
+    val soundcloud = document.createElement("amp-soundcloud")
+    soundcloud.attr("data-trackid", trackId)
+    soundcloud.attr("data-visual", "true")
+    soundcloud.attr("height", "300") // height is necessary if data-visual == true
+  }
+
+  def createElementFromPlaylist(document: Document, playlistId: String): Element = {
+    val soundcloud = document.createElement("amp-soundcloud")
+    soundcloud.attr("data-playlistid", playlistId)
+    soundcloud.attr("data-visual", "true")
+    soundcloud.attr("height", "300") // height is necessary if data-visual == true
+  }
+
+  def getTrackIdFromUrl(soundcloudUrl: String): Option[String] = {
+    val pattern = ".*api.soundcloud.com/tracks/(\\d+).*".r
+    URLDecoder.decode(soundcloudUrl,"UTF-8") match {
+      case pattern(trackId) => {
+        Some(trackId)}
+      case _ => None
+    }
+  }
+
+  def getPlaylistIdFromUrl(soundcloudUrl: String): Option[String] = {
+    val pattern = ".*api.soundcloud.com/playlists/(\\d+).*".r
+    URLDecoder.decode(soundcloudUrl,"UTF-8") match {
+      case pattern(playlistId) => {
+        Some(playlistId)}
+      case _ => None
+    }
+  }
+
+  def getSoundCloudElement(document: Document, iframeElement: Element): Option[Element] = {
+    val trackId = AmpSoundcloud.getTrackIdFromUrl(iframeElement.attr("src"))
+    val playlistId = AmpSoundcloud.getPlaylistIdFromUrl(iframeElement.attr("src"))
+
+    (trackId, playlistId) match {
+      case (Some(id),_) => Some(AmpSoundcloud.createElementFromTrack(document, id))
+      case (_,Some(id)) => Some(AmpSoundcloud.createElementFromPlaylist(document, id))
+      case _ => None
+    }
+  }
+
+}


### PR DESCRIPTION
## What does this change?
Adds elements and logic to seperate soundcloud *embeds* from embeds*

*This logic will need repeating for audio elements.

## What is the value of this and can you measure success?

dcr amp 

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
