### PR TITLE
Badges in live blogs are causing an unsightly text overlap

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -97,6 +97,15 @@
     }
 }
 
+// This solves a badging problem but in a very in-elegant way. Live blog templates need to be re-built using CCS grid
+.content__head--is-badged {
+    .content__headline {
+        @include mq(leftCol) {
+            min-height: 110px;
+        }
+    }
+}
+
 .badge--interactive {
     border-top: 1px dotted $brightness-46;
 


### PR DESCRIPTION
Ultimately this is because the template is brittle. Re-building with flex/css grid like the article template would prevent this from happening. Until then I've had to add a min height to the headline area as clearance. 

![unnamed](https://user-images.githubusercontent.com/14570016/49746879-0d1d7e80-fc9a-11e8-9206-68bce0942993.png)
