### PR TITLE
Augment JSON model sent to dotcom-rendering (for AMP)

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -61,7 +61,11 @@ case class PageData(
     contentType: Option[String],
     commissioningDesks: Option[String],
     subMetaLinks: SubMetaLinks,
+
+    // AMP specific
     guardianBaseURL: String,
+    webURL: String,
+    shouldHideAds: Boolean,
 )
 
 case class Config(
@@ -169,7 +173,9 @@ object DotcomponentsDataModel {
       jsConfig("contentType"),
       jsConfig("commissioningDesks"),
       article.content.submetaLinks,
-      Configuration.site.host
+      Configuration.site.host,
+      article.metadata.webUrl,
+      article.content.shouldHideAdverts,
     )
 
     val tags = article.tags.tags.map(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,6 +9,8 @@ import navigation.NavMenu
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
 import views.support.GUDateTimeFormat
+import ai.x.play.json.Jsonx
+import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -58,7 +60,8 @@ case class PageData(
     edition: String,
     contentType: Option[String],
     commissioningDesks: Option[String],
-    subMetaLinks: SubMetaLinks
+    subMetaLinks: SubMetaLinks,
+    guardianBaseURL: String,
 )
 
 case class Config(
@@ -103,7 +106,12 @@ object Tag {
 }
 
 object PageData {
-  implicit val writes = Json.writes[PageData]
+  // We use Jsonx here because PageData exceeds 22 fields and
+  // regular Play JSON is unable to serialise this. See, e.g.
+  //
+  // * https://github.com/playframework/play-json/issues/3
+  // * https://stackoverflow.com/questions/23571677/22-fields-limit-in-scala-2-11-play-framework-2-3-case-classes-and-functions/23588132#23588132
+  implicit val formats = Jsonx.formatCaseClass[PageData]
 }
 
 object Config {
@@ -160,7 +168,8 @@ object DotcomponentsDataModel {
       Edition(request).displayName,
       jsConfig("contentType"),
       jsConfig("commissioningDesks"),
-      article.content.submetaLinks
+      article.content.submetaLinks,
+      Configuration.site.host
     )
 
     val tags = article.tags.tags.map(

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ val common = library("common").settings(
     scalaUri,
     commercialShared,
     playJson,
+    playJsonExtensions,
     playJsonJoda,
     jodaForms,
     jacksonDataFormat,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -654,7 +654,7 @@ final case class SubMetaLink(
 )
 
 object SubMetaLink {
-  implicit val writes: OWrites[SubMetaLink] = Json.writes[SubMetaLink]
+  implicit val formats: OFormat[SubMetaLink] = Json.format[SubMetaLink]
 }
 
 final case class SubMetaLinks(
@@ -664,7 +664,7 @@ final case class SubMetaLinks(
 
 object SubMetaLinks {
 
-  implicit val writes: OWrites[SubMetaLinks] = Json.writes[SubMetaLinks]
+  implicit val formats: OFormat[SubMetaLinks] = Json.format[SubMetaLinks]
 
   def makeKeywordName(keywordTag: Tag, keywords: List[Tag]): String = {
     if (keywords.count(_.name == keywordTag.name) > 1){

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.6.3"
+  val playJsonExtensionsVersion = "0.10.0"
   val guBox = "com.gu" %% "box" %  "0.1.0"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.5.6"
   val apacheCommonsMath3 = "org.apache.commons" % "commons-math3" % "3.6.1"
@@ -67,6 +68,7 @@ object Dependencies {
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.12"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.2"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
+  val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
   val atomRenderer = "com.gu" %% "atom-renderer" % "0.14.6"


### PR DESCRIPTION
This is needed for AMP in Dotcomponents for upcoming work.

Note, there are some complexities here around serialising the PageData case class to JSON now as it exceeds the magical 22-field limit. The code comment links to further info.
