### PR TITLE
LOGGING: add logging to CampaignAgentrefresh

### DIFF
--- a/common/app/commercial/targeting/TargetingLifecycle.scala
+++ b/common/app/commercial/targeting/TargetingLifecycle.scala
@@ -1,15 +1,17 @@
 package commercial.targeting
 
 import app.LifecycleComponent
-import common.{JobScheduler, AkkaAsync}
+import common.LoggingField.LogFieldString
+import common.{AkkaAsync, JobScheduler, Logging}
 import play.api.inject.ApplicationLifecycle
+
 import scala.concurrent.duration._
 import scala.concurrent.{Future, ExecutionContext}
 
 class TargetingLifecycle(
                           appLifecycle: ApplicationLifecycle,
                           jobs: JobScheduler,
-                          akkaAsync: AkkaAsync)(implicit executionContext: ExecutionContext) extends LifecycleComponent {
+                          akkaAsync: AkkaAsync)(implicit executionContext: ExecutionContext) extends LifecycleComponent with Logging {
 
 
   appLifecycle.addStopHook {
@@ -20,9 +22,21 @@ class TargetingLifecycle(
 
   override def start(): Unit = {
     jobs.deschedule("TargetingCampaignRefreshJob")
+
+    logInfoWithCustomFields("CampaignAgent BEFORE refresh scheduled ",
+      customFields = List(
+        LogFieldString("campaign agent", s"$CampaignAgent")
+      )
+    )
+
     jobs.scheduleEvery("TargetingCampaignRefreshJob", 1.minutes) {
       CampaignAgent.refresh()
     }
+
+    logInfoWithCustomFields(s"CampaignAgent AFTER refresh",
+      customFields = List(
+        LogFieldString("campaign agent", s"$CampaignAgent")
+    ))
 
     akkaAsync.after1s {
       CampaignAgent.refresh()


### PR DESCRIPTION
## What does this change?
An error in Frontend Prod's connection to Targeting (the Campaigns tool) is stopping some other work. 

Somehow the connection between frontend and targeting/campaigns is behaving differently in Prod. This additional logging should provide more information.

ie: An article in CODE has campaigns in `config.page.campaigns`. An article in PROD set up with equivalent tags, doesn't have the campaigns. WHAT HAPPENED TO IT??

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
