### PR TITLE
Improve tab order for edition picker

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -18,10 +18,6 @@
             role="navigation"
             aria-label="Guardian sections">
 
-            @if(!page.metadata.hasSlimHeader) {
-                @fragments.nav.editionPickerDropdown()
-            }
-
             <a href="@LinkTo{/}"
                 class="new-header__logo"
                 data-link-name="nav2 : logo">
@@ -132,6 +128,10 @@
                 >
                     <div class="js-search-placeholder"></div>
                 </div>
+            }
+
+            @if(!page.metadata.hasSlimHeader) {
+                @fragments.nav.editionPickerDropdown()
             }
 
             <ul class="pillars">

--- a/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
+++ b/static/src/stylesheets/layout/nav/_edition-picker-toggle.scss
@@ -1,6 +1,5 @@
 .edition-picker-toggle-button {
     border: 0;
-    outline: 0;
     background: none;
     text-align: left;
 }


### PR DESCRIPTION
## What does this change?

- Moves the edition picker in the DOM to better reflect its visual position.
- Adds outline on focus for consistency with other links and buttons in the header

## Screenshots

![dec-11-2018 11-23-53](https://user-images.githubusercontent.com/5931528/49797468-743d4080-fd37-11e8-8f61-029f67e4adfa.gif)

## What is the value of this and can you measure success?

Currently the tab order of the header is:

1. Skip to main content
2. Banner ad
3. Edition picker
4. Logo

This doesn't reflect the visual structure of the page, making the tab order surprising.

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
