### PR TITLE
Bump Prebid dependency to v1.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#13498e3",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#61c75fb",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7940,9 +7940,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#13498e3":
-  version "1.32.0"
-  resolved "https://github.com/guardian/Prebid.js.git#13498e37f8eb1b7c68c85e0eb2edb1b621145210"
+"prebid.js@https://github.com/guardian/Prebid.js.git#61c75fb":
+  version "1.35.0"
+  resolved "https://github.com/guardian/Prebid.js.git#61c75fb24c82c73d4f45e8c128007aa60318bc99"
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.1"


### PR DESCRIPTION
This brings in the upstream [release 1.35.0](https://github.com/prebid/Prebid.js/releases/tag/1.35.0) and the fix to the notorious bug https://github.com/prebid/Prebid.js/pull/3300 (which we have already applied in our code). 