### PR TITLE
Bump circuit breaker timeout by 100ms.

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -127,7 +127,7 @@ final case class CircuitBreakingContentApiClient(
   private val circuitBreaker = new CircuitBreaker(
     scheduler = circuitBreakerActorSystem.scheduler,
     maxFailures = contentApi.circuitBreakerErrorThreshold,
-    callTimeout = contentApi.timeout + Duration.create(100, MILLISECONDS), // +100 to differentiate between circuit breaker and capi timeouts
+    callTimeout = contentApi.timeout + Duration.create(400, MILLISECONDS), // +400 to differentiate between circuit breaker and capi timeouts
     resetTimeout = contentApi.circuitBreakerResetTimeout
   )
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -127,16 +127,9 @@ final case class CircuitBreakingContentApiClient(
   private val circuitBreaker = new CircuitBreaker(
     scheduler = circuitBreakerActorSystem.scheduler,
     maxFailures = contentApi.circuitBreakerErrorThreshold,
-    callTimeout = contentApi.timeout,
+    callTimeout = contentApi.timeout + Duration.create(100, MILLISECONDS), // +100 to differentiate between circuit breaker and capi timeouts
     resetTimeout = contentApi.circuitBreakerResetTimeout
   )
-
-  val http: OkHttpClient = new OkHttpClient.Builder()
-    .connectTimeout(2, TimeUnit.SECONDS)
-    .readTimeout(2, TimeUnit.SECONDS)
-    .followRedirects(true)
-    .connectionPool(new ConnectionPool(10, 60, TimeUnit.SECONDS))
-    .build()
 
   circuitBreaker.onOpen(
     log.error(s"CAPI circuit breaker: reached error threshold (${contentApi.circuitBreakerErrorThreshold}). Breaker is OPEN!")


### PR DESCRIPTION
## What does this change?
Follows @AWare 's suggestion to increase the circuit breaker timeout so that we can identify whether it is capi or the circuit breaker that are causing us problems.

## What is the value of this and can you measure success?
We should see log messages for the capi client timing out rather than the circuit breaker

This also removes a redundant http client

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
