### PR TITLE
Remove switch for Pangaea in Ozone bidder

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -519,14 +519,4 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
-
-  val ozonePangaeaSwitch: Switch = Switch(
-    group = CommercialPrebid,
-    name = "ozone-pangaea",
-    description = "Include Ozone Pangaea connection",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 1, 9),
-    exposeClientSide = true
-  )
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -39,7 +39,6 @@ import {
     shouldIncludeImproveDigital,
     shouldIncludeOpenx,
     shouldIncludeOzone,
-    shouldIncludePangaea,
     shouldIncludeSonobi,
     shouldIncludeTrustX,
     shouldIncludeXaxis,
@@ -507,11 +506,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
     ) {
         dummyServerSideBidders.push(openxServerSideBidder);
         dummyServerSideBidders.push(appnexusServerSideBidder);
-
-        // Remove this switch after initial pangaea release
-        if (inPbTestOr(shouldIncludePangaea())) {
-            dummyServerSideBidders.push(pangaeaServerSideBidder);
-        }
+        dummyServerSideBidders.push(pangaeaServerSideBidder);
     }
 
     return dummyServerSideBidders;

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -82,7 +82,6 @@ const resetConfig = () => {
     config.set('switches.prebidXaxis', true);
     config.set('switches.prebidAdYouLike', true);
     config.set('switches.prebidS2sozone', true);
-    config.set('switches.ozonePangaea', true);
     config.set('ophan', { pageViewId: 'pvid' });
     config.set('page.contentType', 'Article');
     config.set('page.section', 'Magic');
@@ -115,7 +114,7 @@ describe('getDummyServerSideBidders', () => {
         const bidderNames = getDummyServerSideBidders().map(
             bidder => bidder.name
         );
-        expect(bidderNames).toEqual(['openx', 'appnexus']);
+        expect(bidderNames).toEqual(['openx', 'appnexus', 'pangaea']);
     });
 
     test('should include methods in the response that generate the correct bid params', () => {
@@ -511,6 +510,7 @@ describe('bids', () => {
             'adyoulike',
             'openx',
             'appnexus',
+            'pangaea',
         ]);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -113,9 +113,6 @@ export const shouldIncludeAppNexus = (): boolean =>
     ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
         !!pbTestNameMap().and);
 
-export const shouldIncludePangaea = (): boolean =>
-    config.get('switches.ozonePangaea', false);
-
 export const shouldIncludeXaxis = (): boolean => {
     // 50% of UK page views
     const hasFirstLook =

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -12,7 +12,6 @@ import {
     shouldIncludeImproveDigital,
     shouldIncludeOpenx,
     shouldIncludeOzone,
-    shouldIncludePangaea,
     shouldIncludeSonobi,
     shouldIncludeTrustX,
     shouldIncludeXaxis,
@@ -54,7 +53,6 @@ const resetConfig = () => {
     config.set('switches.prebidXaxis', true);
     config.set('switches.prebidAdYouLike', true);
     config.set('switches.prebidS2sozone', true);
-    config.set('switches.ozonePangaea', true);
     config.set('page.contentType', 'Article');
     config.set('page.section', 'Magic');
     config.set('page.edition', 'UK');
@@ -239,15 +237,6 @@ describe('Utils', () => {
         expect(shouldIncludeImproveDigital()).toBe(false);
         config.set('page.edition', 'US');
         expect(shouldIncludeImproveDigital()).toBe(false);
-    });
-
-    test('shouldIncludePangaea should return true if switch is on', () => {
-        expect(shouldIncludePangaea()).toBe(true);
-    });
-
-    test('shouldIncludePangaea should return false if switch is off', () => {
-        config.set('switches.ozonePangaea', false);
-        expect(shouldIncludePangaea()).toBe(false);
     });
 
     test('shouldIncludeXaxis should always return false on INT, AU and US editions', () => {


### PR DESCRIPTION
We only need a single switch to control bids made inside the Ozone wrapper.
This removes the switch that controlled bids from Pangaea in Ozone.
