### PR TITLE
Exclusion list for epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -84,7 +84,9 @@ const getTargets = (
 };
 
 const isCompatibleWithEpic = (page: Object): boolean =>
-    page.contentType === 'Article' && !page.isMinuteArticle && isArticleWorthAnEpicImpression(page);
+    page.contentType === 'Article' &&
+    !page.isMinuteArticle &&
+    isArticleWorthAnEpicImpression(page);
 
 const shouldShowReaderRevenue = (
     showToContributorsAndSupporters: boolean = false

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -26,7 +26,10 @@ import {
     getBannerGoogleDoc,
     googleDocEpicControl,
 } from 'common/modules/commercial/contributions-google-docs';
-import { isArticleWorthAnEpicImpression } from 'common/modules/commercial/epic/epic-exclusion-list';
+import {
+    isArticleWorthAnEpicImpression,
+    defaultExclusionRules
+} from 'common/modules/commercial/epic/epic-exclusion-rules';
 
 export type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
@@ -86,7 +89,7 @@ const getTargets = (
 const isCompatibleWithEpic = (page: Object): boolean =>
     page.contentType === 'Article' &&
     !page.isMinuteArticle &&
-    isArticleWorthAnEpicImpression(page);
+    isArticleWorthAnEpicImpression(page, defaultExclusionRules);
 
 const shouldShowReaderRevenue = (
     showToContributorsAndSupporters: boolean = false

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -28,7 +28,7 @@ import {
 } from 'common/modules/commercial/contributions-google-docs';
 import {
     isArticleWorthAnEpicImpression,
-    defaultExclusionRules
+    defaultExclusionRules,
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 
 export type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-list.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-list.js
@@ -11,34 +11,44 @@ type pagePropertiesRelevantToEpic = {|
 // Especially since that epic impression deprives us of Outbrain money.
 const pagePropertiesWhichExcludeEpic: pagePropertiesRelevantToEpic[] = [
     // e.g. https://www.theguardian.com/football/blog/2018/dec/12/spurs-fans-wallow-in-afterglow-un-spursy-ending
-    {section: 'football', toneIds: ['tone/features']},
+    { section: 'football', toneIds: ['tone/features'] },
 
     // e.g. https://www.theguardian.com/football/2018/dec/12/valencia-manchester-united-champions-league-match-report
-    {section: 'football', toneIds: ['tone/matchreports']},
+    { section: 'football', toneIds: ['tone/matchreports'] },
 
     // e.g. https://www.theguardian.com/money/2018/dec/13/slime-toys-tested-fail-meet-eu-safety-standards-hamleys-christmas
-    {section: 'money'},
+    { section: 'money' },
 
     // e.g. https://www.theguardian.com/education/2018/dec/12/female-scholars-are-marginalised-on-wikipedia-because-its-written-by-men
-    {section: 'education'},
+    { section: 'education' },
 
     // e.g. https://www.theguardian.com/games/2018/dec/13/cat-condo-is-the-stupidest-most-cynical-game-in-the-app-store-so-why-cant-i-stop-playing
-    {section: 'games'},
+    { section: 'games' },
 
     // e.g. https://www.theguardian.com/teacher-network/2018/jun/02/secret-teacher-teaching-children-without-play-soul-destroying-sats-assessment
-    {section: 'teacher-network'},
+    { section: 'teacher-network' },
 
     // e.g. https://www.theguardian.com/careers/2018/dec/06/dont-expect-a-survivor-to-tell-you-her-experience-of-undergoing-fgm
-    {section: 'careers'},
+    { section: 'careers' },
 
     // e.g. https://www.theguardian.com/guardian-masterclasses/2018/oct/25/get-healthy-and-live-your-best-life-with-dr-rangan-chatterjee-health-wellness-course
-    {keywordIds: ['guardian-masterclasses/guardian-masterclasses']},
+    { keywordIds: ['guardian-masterclasses/guardian-masterclasses'] },
 ];
 
 export const isArticleWorthAnEpicImpression = (page: Object) =>
     !pagePropertiesWhichExcludeEpic.some(propertiesToExclude => {
-        const sectionsMatch = propertiesToExclude.section ? propertiesToExclude.section === page.section : true;
-        const toneIdsMatch = propertiesToExclude.toneIds ? propertiesToExclude.toneIds.every(toneId => page.toneIds.includes(toneId)) : true;
-        const keywordIdsMatch = propertiesToExclude.keywordIds ? propertiesToExclude.keywordIds.every(keywordId => page.keywordIds.includes(keywordId)) : true;
+        const sectionsMatch = propertiesToExclude.section
+            ? propertiesToExclude.section === page.section
+            : true;
+        const toneIdsMatch = propertiesToExclude.toneIds
+            ? propertiesToExclude.toneIds.every(toneId =>
+                  page.toneIds.includes(toneId)
+              )
+            : true;
+        const keywordIdsMatch = propertiesToExclude.keywordIds
+            ? propertiesToExclude.keywordIds.every(keywordId =>
+                  page.keywordIds.includes(keywordId)
+              )
+            : true;
         return sectionsMatch && toneIdsMatch && keywordIdsMatch;
     });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-list.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-list.js
@@ -1,0 +1,44 @@
+// @flow
+
+type pagePropertiesRelevantToEpic = {|
+    section?: string,
+    toneIds?: string[],
+    keywordIds?: string[],
+|};
+
+// Data has shown that pages with these properties generate significantly
+// less money than others, so we don't want to waste an epic impression on them.
+// Especially since that epic impression deprives us of Outbrain money.
+const pagePropertiesWhichExcludeEpic: pagePropertiesRelevantToEpic[] = [
+    // e.g. https://www.theguardian.com/football/blog/2018/dec/12/spurs-fans-wallow-in-afterglow-un-spursy-ending
+    {section: 'football', toneIds: ['tone/features']},
+
+    // e.g. https://www.theguardian.com/football/2018/dec/12/valencia-manchester-united-champions-league-match-report
+    {section: 'football', toneIds: ['tone/matchreports']},
+
+    // e.g. https://www.theguardian.com/money/2018/dec/13/slime-toys-tested-fail-meet-eu-safety-standards-hamleys-christmas
+    {section: 'money'},
+
+    // e.g. https://www.theguardian.com/education/2018/dec/12/female-scholars-are-marginalised-on-wikipedia-because-its-written-by-men
+    {section: 'education'},
+
+    // e.g. https://www.theguardian.com/games/2018/dec/13/cat-condo-is-the-stupidest-most-cynical-game-in-the-app-store-so-why-cant-i-stop-playing
+    {section: 'games'},
+
+    // e.g. https://www.theguardian.com/teacher-network/2018/jun/02/secret-teacher-teaching-children-without-play-soul-destroying-sats-assessment
+    {section: 'teacher-network'},
+
+    // e.g. https://www.theguardian.com/careers/2018/dec/06/dont-expect-a-survivor-to-tell-you-her-experience-of-undergoing-fgm
+    {section: 'careers'},
+
+    // e.g. https://www.theguardian.com/guardian-masterclasses/2018/oct/25/get-healthy-and-live-your-best-life-with-dr-rangan-chatterjee-health-wellness-course
+    {keywordIds: ['guardian-masterclasses/guardian-masterclasses']},
+];
+
+export const isArticleWorthAnEpicImpression = (page: Object) =>
+    !pagePropertiesWhichExcludeEpic.some(propertiesToExclude => {
+        const sectionsMatch = propertiesToExclude.section ? propertiesToExclude.section === page.section : true;
+        const toneIdsMatch = propertiesToExclude.toneIds ? propertiesToExclude.toneIds.every(toneId => page.toneIds.includes(toneId)) : true;
+        const keywordIdsMatch = propertiesToExclude.keywordIds ? propertiesToExclude.keywordIds.every(keywordId => page.keywordIds.includes(keywordId)) : true;
+        return sectionsMatch && toneIdsMatch && keywordIdsMatch;
+    });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.js
@@ -35,7 +35,10 @@ export const defaultExclusionRules: pagePropertiesRelevantToEpic[] = [
     { keywordIds: ['guardian-masterclasses/guardian-masterclasses'] },
 ];
 
-export const isArticleWorthAnEpicImpression = (page: Object, exclusionRules: pagePropertiesRelevantToEpic[]) =>
+export const isArticleWorthAnEpicImpression = (
+    page: Object,
+    exclusionRules: pagePropertiesRelevantToEpic[]
+) =>
     !exclusionRules.some(propertiesToExclude => {
         const sectionsMatch = propertiesToExclude.section
             ? propertiesToExclude.section === page.section

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.js
@@ -9,7 +9,7 @@ type pagePropertiesRelevantToEpic = {|
 // Data has shown that pages with these properties generate significantly
 // less money than others, so we don't want to waste an epic impression on them.
 // Especially since that epic impression deprives us of Outbrain money.
-const pagePropertiesWhichExcludeEpic: pagePropertiesRelevantToEpic[] = [
+export const defaultExclusionRules: pagePropertiesRelevantToEpic[] = [
     // e.g. https://www.theguardian.com/football/blog/2018/dec/12/spurs-fans-wallow-in-afterglow-un-spursy-ending
     { section: 'football', toneIds: ['tone/features'] },
 
@@ -35,8 +35,8 @@ const pagePropertiesWhichExcludeEpic: pagePropertiesRelevantToEpic[] = [
     { keywordIds: ['guardian-masterclasses/guardian-masterclasses'] },
 ];
 
-export const isArticleWorthAnEpicImpression = (page: Object) =>
-    !pagePropertiesWhichExcludeEpic.some(propertiesToExclude => {
+export const isArticleWorthAnEpicImpression = (page: Object, exclusionRules: pagePropertiesRelevantToEpic[]) =>
+    !exclusionRules.some(propertiesToExclude => {
         const sectionsMatch = propertiesToExclude.section
             ? propertiesToExclude.section === page.section
             : true;

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
@@ -1,15 +1,13 @@
 // @flow
 
-import {
-    isArticleWorthAnEpicImpression,
-} from './epic-exclusion-rules.js';
+import { isArticleWorthAnEpicImpression } from './epic-exclusion-rules.js';
 
 describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches section but not toneIds of an exclusion rule', () => {
         it('is worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
-                [{section: 'a', toneIds: ['tone/blah']}],
+                { section: 'a', toneIds: 'tone/news', keywordIds: 'us-news' },
+                [{ section: 'a', toneIds: ['tone/blah'] }]
             );
             expect(isItWorthIt).toBe(true);
         });
@@ -18,8 +16,8 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches section but not keywordIds of an exclusion rule', () => {
         it('is worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
-                [{section: 'a', keywordIds: ['us-news', 'something-else']}],
+                { section: 'a', toneIds: 'tone/news', keywordIds: 'us-news' },
+                [{ section: 'a', keywordIds: ['us-news', 'something-else'] }]
             );
             expect(isItWorthIt).toBe(true);
         });
@@ -28,8 +26,8 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches toneIds but not section of an exclusion rule', () => {
         it('is worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
-                [{section: 'b', toneIds: ['tone/news']}],
+                { section: 'a', toneIds: 'tone/news', keywordIds: 'us-news' },
+                [{ section: 'b', toneIds: ['tone/news'] }]
             );
             expect(isItWorthIt).toBe(true);
         });
@@ -38,8 +36,18 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches section, all toneIds, but just some of the keywordIds of an exclusion rule', () => {
         it('is worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news'},
-                [{section: 'a', toneIds: ['tone/something', 'tone/whatevs'], keywordIds: ['us-news', 'clinton']}],
+                {
+                    section: 'a',
+                    toneIds: 'tone/whatevs,tone/blah,tone/something',
+                    keywordIds: 'trump,us-news',
+                },
+                [
+                    {
+                        section: 'a',
+                        toneIds: ['tone/something', 'tone/whatevs'],
+                        keywordIds: ['us-news', 'clinton'],
+                    },
+                ]
             );
             expect(isItWorthIt).toBe(true);
         });
@@ -48,8 +56,12 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches toneIds of an exclusion rule which has no section or keywordIds', () => {
         it('is not worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'us-news'},
-                [{toneIds: ['tone/blah']}],
+                {
+                    section: 'a',
+                    toneIds: 'tone/whatevs,tone/blah,tone/something',
+                    keywordIds: 'us-news',
+                },
+                [{ toneIds: ['tone/blah'] }]
             );
             expect(isItWorthIt).toBe(false);
         });
@@ -58,8 +70,12 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches keywordIds of an exclusion rule which has no section or keywordIds', () => {
         it('is not worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'us-news'},
-                [{keywordIds: ['us-news']}],
+                {
+                    section: 'a',
+                    toneIds: 'tone/whatevs,tone/blah,tone/something',
+                    keywordIds: 'us-news',
+                },
+                [{ keywordIds: ['us-news'] }]
             );
             expect(isItWorthIt).toBe(false);
         });
@@ -68,8 +84,17 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches keywordIds and toneIds of an exclusion rule which has no section', () => {
         it('is not worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news'},
-                [{toneIds: ['tone/something', 'tone/whatevs'], keywordIds: ['us-news', 'trump']}],
+                {
+                    section: 'a',
+                    toneIds: 'tone/whatevs,tone/blah,tone/something',
+                    keywordIds: 'trump,us-news',
+                },
+                [
+                    {
+                        toneIds: ['tone/something', 'tone/whatevs'],
+                        keywordIds: ['us-news', 'trump'],
+                    },
+                ]
             );
             expect(isItWorthIt).toBe(false);
         });
@@ -77,8 +102,18 @@ describe('isArticleWorthAnEpicImpression', () => {
     describe('when an article matches keywordIds, toneIds and section of an exclusion rule', () => {
         it('is not worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news,blah'},
-                [{section: 'a', toneIds: ['tone/blah','tone/whatevs'], keywordIds: ['blah', 'trump']}],
+                {
+                    section: 'a',
+                    toneIds: 'tone/whatevs,tone/blah,tone/something',
+                    keywordIds: 'trump,us-news,blah',
+                },
+                [
+                    {
+                        section: 'a',
+                        toneIds: ['tone/blah', 'tone/whatevs'],
+                        keywordIds: ['blah', 'trump'],
+                    },
+                ]
             );
             expect(isItWorthIt).toBe(false);
         });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
@@ -1,25 +1,86 @@
 // @flow
 
 import {
-    defaultExclusionRules,
     isArticleWorthAnEpicImpression,
 } from './epic-exclusion-rules.js';
 
 describe('isArticleWorthAnEpicImpression', () => {
-    describe('dummy test', () => {
-        it('fails', () => {
-            expect(true).toBe(false);
-        });
-    });
-
     describe('when an article matches section but not toneIds of an exclusion rule', () => {
-        it('does not exclude the epic from that article', () => {
+        it('is worth an epic impression', () => {
             const isItWorthIt = isArticleWorthAnEpicImpression(
-                {section: 'a'},
+                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
                 [{section: 'a', toneIds: ['tone/blah']}],
             );
             expect(isItWorthIt).toBe(true);
         });
+    });
 
+    describe('when an article matches section but not keywordIds of an exclusion rule', () => {
+        it('is worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
+                [{section: 'a', keywordIds: ['us-news', 'something-else']}],
+            );
+            expect(isItWorthIt).toBe(true);
+        });
+    });
+
+    describe('when an article matches toneIds but not section of an exclusion rule', () => {
+        it('is worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/news', keywordIds: 'us-news'},
+                [{section: 'b', toneIds: ['tone/news']}],
+            );
+            expect(isItWorthIt).toBe(true);
+        });
+    });
+
+    describe('when an article matches section, all toneIds, but just some of the keywordIds of an exclusion rule', () => {
+        it('is worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news'},
+                [{section: 'a', toneIds: ['tone/something', 'tone/whatevs'], keywordIds: ['us-news', 'clinton']}],
+            );
+            expect(isItWorthIt).toBe(true);
+        });
+    });
+
+    describe('when an article matches toneIds of an exclusion rule which has no section or keywordIds', () => {
+        it('is not worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'us-news'},
+                [{toneIds: ['tone/blah']}],
+            );
+            expect(isItWorthIt).toBe(false);
+        });
+    });
+
+    describe('when an article matches keywordIds of an exclusion rule which has no section or keywordIds', () => {
+        it('is not worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'us-news'},
+                [{keywordIds: ['us-news']}],
+            );
+            expect(isItWorthIt).toBe(false);
+        });
+    });
+
+    describe('when an article matches keywordIds and toneIds of an exclusion rule which has no section', () => {
+        it('is not worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news'},
+                [{toneIds: ['tone/something', 'tone/whatevs'], keywordIds: ['us-news', 'trump']}],
+            );
+            expect(isItWorthIt).toBe(false);
+        });
+    });
+    describe('when an article matches keywordIds, toneIds and section of an exclusion rule', () => {
+        it('is not worth an epic impression', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a', toneIds: 'tone/whatevs,tone/blah,tone/something', keywordIds: 'trump,us-news,blah'},
+                [{section: 'a', toneIds: ['tone/blah','tone/whatevs'], keywordIds: ['blah', 'trump']}],
+            );
+            expect(isItWorthIt).toBe(false);
+        });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-exclusion-rules.spec.js
@@ -1,0 +1,25 @@
+// @flow
+
+import {
+    defaultExclusionRules,
+    isArticleWorthAnEpicImpression,
+} from './epic-exclusion-rules.js';
+
+describe('isArticleWorthAnEpicImpression', () => {
+    describe('dummy test', () => {
+        it('fails', () => {
+            expect(true).toBe(false);
+        });
+    });
+
+    describe('when an article matches section but not toneIds of an exclusion rule', () => {
+        it('does not exclude the epic from that article', () => {
+            const isItWorthIt = isArticleWorthAnEpicImpression(
+                {section: 'a'},
+                [{section: 'a', toneIds: ['tone/blah']}],
+            );
+            expect(isItWorthIt).toBe(true);
+        });
+
+    });
+});


### PR DESCRIPTION
Based on data from [this dashboard](https://tableau.ophan.co.uk/views/eCPMpersectionAVper1000Epicimpressions/eCPMofepic?iframeSizedToWindow=true&%3Aembed=y&%3AshowAppBanner=false&%3Adisplay_count=no&%3AshowVizHome=no) and analysis [here](https://docs.google.com/spreadsheets/d/1O2DQNhai61a6o2oKB7r14rlf_ZT-G2RESUhSH1nox14/edit?usp=sharing), we've identified section/tag combinations on the referring article that generate significantly less money from the epic.

Reducing epic impressions is valuable since each epic impression deprives us of money from Outbrain. Moreover, anything we can do to reduce "epic fatigue" and avoid showing it at moments when it is unlikely to lead to a contribution is a good thing.

@jessewilkins 