### PR TITLE
Configure Amp ad slots according to geolocation

### DIFF
--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -4,14 +4,13 @@ GDPR personalised advertisement setting component inspired by
 https://support.google.com/dfp_premium/answer/7678538
 *@
 
-@*
- EEA Countries
-*@
 <amp-geo layout="nodisplay">
   <script type="application/json">
    {
        "ISOCountryGroups": {
-           "eea": [ "preset-eea" ]
+           "eea": [ "preset-eea" ],
+           "us": [ "us", "ca" ],
+           "au": [ "au", "nz" ]
        }
    }
   </script>

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -4,7 +4,6 @@ import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues, SingleValue}
 import common.Edition
 import common.commercial.AdUnitMaker
-import common.editions._
 import conf.switches.Switches.KruxSwitch
 import conf.switches.{Switch, Switches}
 import model.Article
@@ -40,7 +39,7 @@ object AmpAdRtcConfig {
   // if debug, give additional debug output in RTC responses
   def toJsonString(
     prebidServerUrl: String,
-    edition: Edition,
+    adRegion: AdRegion,
     debug: Boolean
   ): String = {
 
@@ -61,9 +60,9 @@ object AmpAdRtcConfig {
        * and https://github.com/prebid/prebid-server/blob/master/docs/endpoints/openrtb2/amp.md#query-parameters
        */
       val ampPrebidUrl = {
-        val placementId = edition match {
-          case Us => 7
-          case Au => 6
+        val placementId = adRegion match {
+          case UsAdRegion => 7
+          case AuAdRegion => 6
           case _ => 4
         }
         val url = s"$prebidServerUrl/openrtb2/amp?tag_id=$placementId&w=ATTR(width)&h=ATTR(height)" +
@@ -88,4 +87,17 @@ object AmpAdRtcConfig {
 
     rtc.toString()
   }
+}
+
+sealed trait AdRegion {
+  def cssClassSuffix: String
+}
+case object UsAdRegion extends AdRegion {
+  val cssClassSuffix = "us"
+}
+case object AuAdRegion extends AdRegion {
+  val cssClassSuffix = "au"
+}
+case object RowAdRegion extends AdRegion {
+  val cssClassSuffix = "row"
 }

--- a/common/test/views/support/AmpAdRtcConfigTest.scala
+++ b/common/test/views/support/AmpAdRtcConfigTest.scala
@@ -1,6 +1,5 @@
 package views.support
 
-import common.editions._
 import conf.switches.Switches.{KruxSwitch, ampPrebid}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import play.api.libs.json.{JsNull, Json}
@@ -26,7 +25,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
     KruxSwitch.switchOn()
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = true
+      prebidServerUrl, RowAdRegion, debug = true
     ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
@@ -38,7 +37,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   it should "hold no real-time config when both switches are off" in {
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = true
+      prebidServerUrl, RowAdRegion, debug = true
     ))
     json shouldBe JsNull
   }
@@ -46,7 +45,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   it should "hold Krux config when Krux switch is on" in {
     KruxSwitch.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = true
+      prebidServerUrl, RowAdRegion, debug = true
     ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
@@ -58,7 +57,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   it should "hold Prebid server config when Prebid server switch is on" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = true
+      prebidServerUrl, RowAdRegion, debug = true
     ))
     json shouldBe Json.obj(
       "urls" -> Json.arr(
@@ -70,7 +69,7 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   it should "hold debug param in Amp Prebid URL if debugging" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = true
+      prebidServerUrl, RowAdRegion, debug = true
     ))
     Json.stringify(json) should include("&debug=1")
   }
@@ -78,40 +77,32 @@ class AmpAdRtcConfigTest extends FlatSpec with Matchers with BeforeAndAfter {
   it should "not hold debug param in Amp Prebid URL if not debugging" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = false
+      prebidServerUrl, RowAdRegion, debug = false
     ))
     Json.stringify(json) should not include "&debug=1"
   }
 
-  it should "have correct placement ID for UK edition" in {
+  it should "have correct placement ID for ROW ad region" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Uk, debug = false
+      prebidServerUrl, RowAdRegion, debug = false
     ))
     Json.stringify(json) should include ("tag_id=4")
   }
 
-  it should "have correct placement ID for US edition" in {
+  it should "have correct placement ID for US ad region" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Us, debug = false
+      prebidServerUrl, UsAdRegion, debug = false
     ))
     Json.stringify(json) should include ("tag_id=7")
   }
 
-  it should "have correct placement ID for AU edition" in {
+  it should "have correct placement ID for AU ad region" in {
     ampPrebid.switchOn()
     val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = Au, debug = false
+      prebidServerUrl, AuAdRegion, debug = false
     ))
     Json.stringify(json) should include ("tag_id=6")
-  }
-
-  it should "have correct placement ID for International edition" in {
-    ampPrebid.switchOn()
-    val json = Json.parse(AmpAdRtcConfig.toJsonString(
-      prebidServerUrl, edition = International, debug = false
-    ))
-    Json.stringify(json) should include ("tag_id=4")
   }
 }

--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -33,3 +33,5 @@
 
 @import 'amp/_d2-comments';
 @import 'amp/_from-content-api';
+
+@import 'amp/_geo';

--- a/static/src/stylesheets/amp/_geo.scss
+++ b/static/src/stylesheets/amp/_geo.scss
@@ -1,0 +1,10 @@
+.geo-amp-ad {
+    display: none;
+}
+
+.amp-geo-group-us .geo-amp-ad--us,
+.amp-geo-group-au .geo-amp-ad--au,
+.amp-geo-group-eea .geo-amp-ad--row,
+.amp-geo-no-group .geo-amp-ad--row {
+    display: block;
+}


### PR DESCRIPTION
This allows us to switch on ad slots according to geolocation rather than edition.

This solves the problem where edition doesn't respect the geolocation of the reader in Amp pages because the pages are generally served from Google servers, and therefore generally cached in the US. 

As a result of this PR, Amp ad containers will each hold three amp-ad elements, of which only one is shown at any time corresponding to one of the three ad regions we have set up in the amp-geo element.

This is a hack suggested by Google to get around the inability to have variable substitutions in URLs being sent from ad slots.

# How it works
The amp-geo element puts countries into groups, and this has the effect of adding CSS classes for the country and for the group it falls into to the body element of the page.
Eg. for GB:
`<body class="... amp-geo-group-eea amp-iso-country-gb" ...`

Then each ad slot has a class that makes it initially hidden: `geo-amp-ad`
and another class that combined with the body class makes it visible, for one of the three ad slots in the block.  The three ad slots have the CSS class `geo-amp-ad--us`, `geo-amp-ad--au` and `geo-amp-ad--row` respectively.
Thus, in Britain, the body and the ad slot CSS classes combined give `geo-group-eea geo-amp-ad--row` which causes the ad slot for UK and the rest of world to be visible.
When the ad slot is visible the URLs in its rtc-config attribute are fired and the ad is populated.

# How to test it
To simulate being in a different country:
1. Switch on dev-channel at https://cdn.ampproject.org/experiments.html
1. Append #amp-geo=XX to URL, where XX is a country code, eg `nz`

The `amp-geo`element is documented [here](https://www.ampproject.org/docs/reference/components/amp-geo).
