### PR TITLE
Remove GarnettFaciaWidths object.

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -352,10 +352,10 @@ case class ContentCard(
   def showStandfirst: Boolean = cardTypes.allTypes.exists(_.showStandfirst)
 
   def mediaWidthsByBreakpoint(implicit requestHeader: RequestHeader) : WidthsByBreakpoint =
-      GarnettFaciaWidths.mediaFromItemClasses(cardTypes)
+      FaciaWidths.mediaFromItemClasses(cardTypes)
 
   def squareImageWidthsByBreakpoint(implicit requestHeader: RequestHeader) : WidthsByBreakpoint =
-      GarnettFaciaWidths.squareFront()
+      FaciaWidths.squareFront()
 
   def showTimestamp: Boolean = timeStampDisplay.isDefined && webPublicationDate.isDefined
 

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -74,99 +74,6 @@ object FaciaWidths {
     (FullMedia100, 331.px)
   )
 
-  def mediaFromItemClasses(itemClasses: ItemClasses): WidthsByBreakpoint = {
-    val desktopClass = itemClasses.desktop.getOrElse(itemClasses.tablet)
-
-    WidthsByBreakpoint(
-      mobile          = MediaMobile.get(itemClasses.mobile),
-      tablet          = MediaTablet.get(itemClasses.tablet),
-      desktop         = MediaDesktop.get(desktopClass)
-    )
-  }
-
-  def cutOutFromItemClasses(itemClasses: ItemClasses): WidthsByBreakpoint = {
-    val desktopClass = itemClasses.desktop.getOrElse(itemClasses.tablet)
-
-    WidthsByBreakpoint(
-      mobile  = CutOutMobile.get(itemClasses.mobile),
-      tablet  = CutOutTablet.get(itemClasses.tablet),
-      desktop = CutOutDesktop.get(desktopClass)
-    )
-  }
-}
-
-
-//TODO: We should only have one facia widths object. Consolidate this garnett one with the one above.
-object GarnettFaciaWidths {
-  private val MediaMobile = Map[CardType, BrowserWidth](
-    (MediaList, 127.px),
-    (Standard, 95.vw)
-  )
-
-  val ExtraPixelWidthsForMediaMobile: Seq[PixelWidth] = List(
-    445.px, // largest width for mobile breakpoint
-    605.px  // largest width for mobile landscape breakpoint
-  )
-
-  private val CutOutMobile = Map[CardType, BrowserWidth](
-    (MediaList, 115.px),
-    (Standard, 130.px)
-  )
-
-  private val MediaTablet = Map[CardType, BrowserWidth](
-    (MediaList, 140.px),
-    (Fluid, 140.px),
-    (Standard, 160.px),
-    (Third, 220.px),
-    (Half, 340.px),
-    (ThreeQuarters, 340.px),
-    (ThreeQuartersRight, 340.px),
-    (ThreeQuartersTall, 520.px),
-    (FullMedia50, 350.px),
-    (FullMedia75, 520.px),
-    (FullMedia100, 700.px)
-  )
-
-  private val CutOutTablet = Map[CardType, BrowserWidth](
-    (MediaList, 115.px),
-    (Standard, 216.px),
-    (Third, 187.px),
-    (Half, 331.px),
-    (ThreeQuarters, 331.px),
-    (ThreeQuartersRight, 331.px),
-    (ThreeQuartersTall, 331.px),
-    (FullMedia50, 331.px),
-    (FullMedia75, 331.px),
-    (FullMedia100, 331.px)
-  )
-
-  private val MediaDesktop = Map[CardType, BrowserWidth](
-    (MediaList, 140.px),
-    (Fluid, 188.px),
-    (Standard, 500.px),
-    (Third, 300.px),
-    (Half, 600.px),
-    (ThreeQuarters, 600.px),
-    (ThreeQuartersRight, 600.px),
-    (ThreeQuartersTall, 700.px),
-    (FullMedia50, 470.px),
-    (FullMedia75, 700.px),
-    (FullMedia100, 940.px)
-  )
-
-  private val CutOutDesktop = Map[CardType, BrowserWidth](
-    (MediaList, 115.px),
-    (Standard, 216.px),
-    (Third, 216.px),
-    (Half, 331.px),
-    (ThreeQuarters, 389.px),
-    (ThreeQuartersRight, 389.px),
-    (ThreeQuartersTall, 331.px),
-    (FullMedia50, 331.px),
-    (FullMedia75, 331.px),
-    (FullMedia100, 331.px)
-  )
-
   private val SquareImageFronts = Map[CardType, BrowserWidth](
     (Standard, 660.px),
   )
@@ -199,6 +106,7 @@ object GarnettFaciaWidths {
     )
   }
 }
+
 
 object ContentWidths {
 


### PR DESCRIPTION
## What does this change?
Removes unnecessary GarnettFaciaWidths object - this was used during the transition period to Garnett. At the time it was necessary as some new sizes were introduced, and the 'highlight' cards which are no longer used. 

## What is the value of this and can you measure success?
This should save us $$$ as we are currently serving 600px width images in containers that are  460px wide. It also reduces a fair amount of duplicated code.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
