### PR TITLE
extend the Ad's on mobile web A/B test expiry date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,7 +22,7 @@ trait ABTestSwitches {
     "increase ads on mobile web",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 12, 14),
+    sellByDate = new LocalDate(2018, 12, 20),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
@@ -3,7 +3,7 @@
 export const commercialAdMobileWebIncrease: ABTest = {
     id: 'CommercialAdMobileWebIncrease',
     start: '2018-11-16',
-    expiry: '2018-12-14',
+    expiry: '2018-12-20',
     author: 'Francesca Hammond',
     description: 'This test will increase ads on mobile web',
     audience: 0.1,


### PR DESCRIPTION
## What does this change?
extends the expiry date of the A/B test until we decide what to do with it
## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
