### PR TITLE
Converge on winning US banner variant

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -6,15 +6,6 @@ const componentType: OphanComponentType = 'ACQUISITIONS_ENGAGEMENT_BANNER';
 
 const abTestName = 'AcquisitionsBannerUsEoy';
 
-const controlParams = {
-    messageText:
-        '<strong>The Guardian is editorially independent – our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put up a paywall as we want to keep our journalism open and accessible. But the revenue we get from advertising is falling, so we increasingly need our readers to help fund us. By contributing to The Guardian, you are helping sustain the long term future of independent, investigative journalism and ensuring it remains available to all.',
-    buttonCaption: 'Support The Guardian',
-    ctaText:
-        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1 and help us reach our end of year goal.</span>',
-    linkUrl: 'https://support.theguardian.com/contribute',
-};
-
 const criticalTimesParams = {
     messageText:
         '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
@@ -24,6 +15,8 @@ const criticalTimesParams = {
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 
+// This is no longer really a test,
+// but it's the simplest way of doing region-specific banner copy.
 export const AcquisitionsBannerUsEoy = {
     id: abTestName,
     campaignId: abTestName,
@@ -41,15 +34,6 @@ export const AcquisitionsBannerUsEoy = {
     canRun: () => geolocationGetSync() === 'US',
 
     variants: makeBannerABTestVariants([
-        {
-            id: 'control_copy_with_ticker',
-            products: [],
-            engagementBannerParams: () =>
-                Promise.resolve({
-                    ...controlParams,
-                    hasTicker: true,
-                }),
-        },
         {
             id: 'critical_times_with_ticker',
             products: [],


### PR DESCRIPTION
Critical Times was 26% ahead of control. This was statistically significant