### PR TITLE
Prevent email generation failure

### DIFF
--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -103,9 +103,7 @@ object InlineStyles {
       Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
         Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
       } match {
-        case Failure(_) => {
-          (inline, head :+ element.html)
-        }
+        case Failure(_) => (inline, head :+ element.html)
         case Success(sheet) =>
           val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
           val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -58,7 +58,6 @@ object CSSRule {
 }
 
 object InlineStyles {
-  val cssParser = new CSSOMParser(new SACParserCSS3())
 
   /**
     * Attempt to inline the rules from the <style> tags in a page.
@@ -100,19 +99,18 @@ object InlineStyles {
   def styles(document: Document): (Seq[CSSRule], Seq[String]) = {
     document.getElementsByTag("style").asScala.foldLeft((Seq.empty[CSSRule], Seq.empty[String])) { case ((inline, head), element) =>
       val source = new InputSource(new StringReader(element.html))
-      synchronized {
-        Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
-          Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
-        } match {
-          case Failure(_) => {
-            (inline, head :+ element.html)
-          }
-          case Success(sheet) =>
-            val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
-            val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
-            val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
-            (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
+      val cssParser = new CSSOMParser(new SACParserCSS3())
+      Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
+        Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
+      } match {
+        case Failure(_) => {
+          (inline, head :+ element.html)
         }
+        case Success(sheet) =>
+          val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
+          val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
+          val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
+          (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
       }
     }
   }

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -93,8 +93,6 @@ object InlineStyles {
     Html(document.toString)
   }
 
-
-
   /**
     * Convert the styles in a document's <style> tags to a pair.
     * The first item is the styles that should stay in the head, the second is everything that should be inlined.
@@ -102,18 +100,19 @@ object InlineStyles {
   def styles(document: Document): (Seq[CSSRule], Seq[String]) = {
     document.getElementsByTag("style").asScala.foldLeft((Seq.empty[CSSRule], Seq.empty[String])) { case ((inline, head), element) =>
       val source = new InputSource(new StringReader(element.html))
-
-      Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
-        Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
-      } match {
-        case Failure(_) =>
-          (inline, head :+ element.html)
-        case Success(sheet) =>
-          val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
-          val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
-          val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
-
-          (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
+      synchronized {
+        Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
+          Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
+        } match {
+          case Failure(_) => {
+            (inline, head :+ element.html)
+          }
+          case Success(sheet) =>
+            val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
+            val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
+            val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
+            (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
+        }
       }
     }
   }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -126,7 +126,6 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
 
   def renderEmail(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = {
     val htmlWithInlineStyles = if (InlineEmailStyles.isSwitchedOn) InlineStyles(html) else html
-
     if (request.isEmailJson) {
       val htmlWithUtmLinks = BrazeEmailFormatter(htmlWithInlineStyles)
       Cached(RecentlyUpdated)(RevalidatableResult.Ok(JsObject(Map("body" -> JsString(htmlWithUtmLinks.toString)))))


### PR DESCRIPTION
## What does this change?

We have problem by which, in some circumstances, emails are generated without their embedded styles. When this happens, an endpoint like this one

https://www.theguardian.com/politics/2018/jul/16/theresa-may-ready-cave-in-hardline-brexiters-customs-demands/email

Present an HTML document without the embedded styles

![screenshot 2018-12-14 at 11 51 29-cut](https://user-images.githubusercontent.com/6035518/50002441-0b083800-ff98-11e8-8f4c-7a5d5e4ba494.png)

Investigation revealed that the problem was caused by a CSS Parser that is not thread safe. 

When that library was first used, we knew there was a problem ( https://github.com/guardian/frontend/pull/15720 ), but it was not handled the best way and a `Retry` was used to mitigate it. Today's refactoring prevent the same object from being reused between requests.

It is not impossible that a follow up PR will come to get rid of the Retry all together (more investigation is required to make sure it is not needed). 

### Tested

- [x] Locally
- [ ] On CODE (optional)
