### PR TITLE
Less fastdom for liveblog epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -22,8 +22,7 @@ const getLiveblogEntryTimeData = (el: Element): ?TimeData => {
 
     if (timeEl && absoluteTimeEl) {
         const link = timeEl.parentNode;
-        const blockHref =
-            link instanceof HTMLAnchorElement ? link.href : '';
+        const blockHref = link instanceof HTMLAnchorElement ? link.href : '';
 
         return {
             datetime: timeEl.getAttribute('datetime') || '',
@@ -93,9 +92,10 @@ const setupViewTracking = (el: HTMLElement, test: EpicABTest): void => {
 };
 
 const addEpicToBlocks = (epicHtml: string, test: EpicABTest): Promise<void> => {
-    const elementsWithTimeData = getBlocksToInsertEpicAfter().map(el =>
-        [el, getLiveblogEntryTimeData(el)]
-    );
+    const elementsWithTimeData = getBlocksToInsertEpicAfter().map(el => [
+        el,
+        getLiveblogEntryTimeData(el),
+    ]);
 
     return fastdom.write(() => {
         elementsWithTimeData.forEach(([el, timeData]) => {
@@ -110,7 +110,7 @@ const addEpicToBlocks = (epicHtml: string, test: EpicABTest): Promise<void> => {
             setEpicLiveblogEntryTimeData($epic[0], timeData);
             setupViewTracking(el, test);
         });
-    })
+    });
 };
 
 export const setupEpicInLiveblog = (


### PR DESCRIPTION
We don't actually need all those fastdom reads because none of those operations [trigger layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a).

This makes the execution order clearer by making more things synchronous. It also consolidates to a single `fastdom.write` call rather than calling it in a loop.

Since we keep getting reports from journalists of seeing multiple liveblog epics, this may make it easier to debug the problem properly in future. There's also a chance this will actually resolve the problem (since we never fully understood the race condition involved)