### PR TITLE
Remove word 'commercial' from data component on Guardian Labs container

### DIFF
--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -9,7 +9,7 @@
 @import views.support.Commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 @import views.support.Commercial.glabsLink
 
-<div data-id="@containerModel.id" class="fc-container" data-component="labs-commercial-container-@containerIndex">
+<div data-id="@containerModel.id" class="fc-container" data-component="labs-container-@containerIndex">
     @containerWrapper(
         Seq("legacy", "capi", "paidfor", "tone-paidfor"),
         optKicker = Some(fragments.commercial.paidForMeta(Some(containerModel.id))),


### PR DESCRIPTION
## What does this change?
The value 'labs-commercial-container' has been added to easylist, and as a result the Labs fronts containers are now being ad-blocked, despite not being ad served. We are changing the value in the code to just 'labs-container' so they are no longer blocked.

## Screenshots
![image](https://user-images.githubusercontent.com/4101937/50095249-026c6780-020d-11e9-95ae-82d9f8206145.png)
![image](https://user-images.githubusercontent.com/4101937/50095556-b5d55c00-020d-11e9-903e-231ac004ddc4.png)

## What is the value of this and can you measure success?
About 1m extra impressions per week - success will be if the container starts displaying again!
