### PR TITLE
ALT: Move Lotame stub into non-blocking JS, and exclude from identity pages

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -248,10 +248,6 @@ class GuardianConfiguration extends Logging {
     lazy val orielCacheTimeInMinutes: Int = if (environment.isProd) 60 else 5
   }
 
-  object lotame {
-    val lotameScriptUrl: String = "//tags.crwdcntrl.net/c/12666/cc.js"
-  }
-
   object affiliatelinks {
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -1,6 +1,6 @@
 @import conf.Static
 @import conf.Configuration
-@import conf.switches.Switches.{PolyfillIO, LotameSwitch}
+@import conf.switches.Switches.PolyfillIO
 
 @(bootModule: String = "standard")(implicit request: RequestHeader)
 
@@ -26,18 +26,6 @@ function guardianPolyfilled() {
     } catch (e) {};
 }
 
-function shouldServeLotame() {
-    try {    
-        var geo = JSON.parse(window.localStorage.getItem("gu.geolocation")).value;
-        if (geo === 'US' || geo === 'CA' || geo === 'AU' || geo === 'NZ') {
-            return false;
-        }
-        return true;
-    }
-    catch(e) {};
-    return false;
-}
-
 // Load the app and try to patch the env with polyfill.io
 // Adapted from https://www.html5rocks.com/en/tutorials/speed/script-loading/#toc-aggressive-optimisation
 (function (document, window) {
@@ -51,20 +39,10 @@ function shouldServeLotame() {
     } else {
       Static("javascripts/vendor/polyfillio.fallback.js")
     }) { polyfillioUrl =>
-        @if(LotameSwitch.isSwitchedOn) {
-            var scripts = [
-                '@polyfillioUrl'                
-            ];
-            if (shouldServeLotame() === true) {
-                scripts.push('@Configuration.lotame.lotameScriptUrl');
-            }
-            scripts.push('@Static(s"javascripts/graun.$bootModule.js")');
-        } else {
-            var scripts = [
-                '@polyfillioUrl',
-                '@Static(s"javascripts/graun.$bootModule.js")'
-            ];
-        }
+        var scripts = [
+            '@polyfillioUrl',
+            '@Static(s"javascripts/graun.$bootModule.js")'
+        ];
     }
 
     function stateChange() {

--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -8,7 +8,7 @@
 // to es5 but we do not provide any polyfills for missing methods.
 // for that, we use polyfill.io.
 //
-// since that's a possbile point of failure, we have a checked-in copy of
+// since that's a possible point of failure, we have a checked-in copy of
 // the pf.io response for *all* polyfills that we may serve to everyone
 // as a worst-case back up. This fallback will be loaded if the PolyfillIO
 // switch is off.

--- a/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js
@@ -16,7 +16,6 @@ try {
             return false;
         }
         if (shouldServeLotame()) {
-            // could we host the lotame tag instead? or maybe use a queue?
             var script = document.createElement('script');
             script.src = "https://tags.crwdcntrl.net/c/12666/cc.js";
             document.body.appendChild(script);

--- a/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js
@@ -1,0 +1,29 @@
+@import play.api.Mode.Dev
+
+@()(implicit context: model.ApplicationContext)
+
+try {
+    (function(document, window) {
+        function shouldServeLotame() {
+            try {
+                var geo = JSON.parse(window.localStorage.getItem("gu.geolocation")).value;
+                if (geo === 'US' || geo === 'CA' || geo === 'AU' || geo === 'NZ') {
+                    return false;
+                }
+                return true;
+            }
+            catch(e) {};
+            return false;
+        }
+        if (shouldServeLotame()) {
+            // could we host the lotame tag instead? or maybe use a queue?
+            var script = document.createElement('script');
+            script.src = "https://tags.crwdcntrl.net/c/12666/cc.js";
+            document.body.appendChild(script);
+        }
+    })(document, window);
+} catch (e) {
+    @if(context.environment.mode == Dev) {throw (e)}
+}
+
+

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -23,16 +23,15 @@
     @InlineJs(showUserName().body, "showUserName.js")
 }
 
+// ************* COMMERCIAL *************
+
 @if(enableConsentManagementService.isSwitchedOn) {
-    // add CMP stub and attach main script to the head
     @InlineJs(prepareCmp().body, "prepareCmp.js")
 }
 
-@if(LotameSwitch.isSwitchedOn) {
-    // add Lotame
+@if(LotameSwitch.isSwitchedOn && !page.metadata.contentType.contains(DotcomContentType.Identity)) {
     @InlineJs(prepareLotame().body, "prepareLotame.js")
 }
-
 
 // ************* ANALYTICS *************
 

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -1,5 +1,5 @@
 @import common.InlineJs
-@import conf.switches.Switches.{IdentityProfileNavigationSwitch, enableConsentManagementService}
+@import conf.switches.Switches.{IdentityProfileNavigationSwitch, enableConsentManagementService, LotameSwitch}
 @import conf.Configuration
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._
@@ -27,6 +27,12 @@
     // add CMP stub and attach main script to the head
     @InlineJs(prepareCmp().body, "prepareCmp.js")
 }
+
+@if(LotameSwitch.isSwitchedOn) {
+    // add Lotame
+    @InlineJs(prepareLotame().body, "prepareLotame.js")
+}
+
 
 // ************* ANALYTICS *************
 

--- a/common/app/views/fragments/page/head/lotameScriptTag.scala.html
+++ b/common/app/views/fragments/page/head/lotameScriptTag.scala.html
@@ -1,3 +1,0 @@
-@()(implicit request: RequestHeader)
-@* The advanced lotame tag (see https://trello.com/c/uRWUiBRX ) *@
-<script src="//tags.crwdcntrl.net/c/12666/cc.js"></script>

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -133,9 +133,13 @@ Secrets.
 
 [Puts the user's username](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js) into the header (increases perceived rendering speed as their username is there before the app.js has to download and parse).
 
-#### editionaliseMenu
+#### prepareCmp
 
-The [editonaliseMenu JS](https://github.com/guardian/frontend/blob/d4bc1349f981cdc8f2508b3f0df61b00420ca219/common/app/templates/inlineJS/nonBlocking/editionaliseMenu.scala.js) updates the menu to show and hide the sub-menus in the current edition.
+The [prepareCmp JS](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/prepareCmp.scala.js) is a stub that will be enhanced by the cmp module loaded in the Commercial bootstrap. Importantly, prepareCmp will create a command queue so that calls to the CMP can be processed once it is fully loaded. it will also define the stub postMessage handler for cross-origin iframe requests.
+
+#### prepareLotame
+
+The [prepareLotame JS](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js) is depended upon by modules within the commercial bootstrap and they are not happy when it is missing, so it needs to load and run ASAP.
 
 #### Ophan config
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lotame-cmp.js
@@ -1,5 +1,6 @@
-// @flow
+// @flow strict
 import { local } from 'lib/storage';
+import type { VendorConsentResponse } from './types';
 
 type LotameError = {
     error: number,
@@ -46,20 +47,21 @@ const lotameCallback = (isConsenting: boolean) => (
     }
 };
 
-const isConsentingData = (consentData): boolean => {
-    try {
+const isConsentingData = (
+    consentData: VendorConsentResponse | null
+): boolean => {
+    if (consentData) {
         const vendorConsents = consentData.vendorConsents;
         const purposeConsents = consentData.purposeConsents;
         return (
             Object.keys(vendorConsents).every(k => vendorConsents[k]) &&
             Object.keys(purposeConsents).every(k => purposeConsents[k])
         );
-    } catch (e) {
-        return false;
     }
+    return false;
 };
 
-const getLotameAdConsentFromCmp = (): Promise<any> =>
+const getLotameAdConsentFromCmp = (): Promise<VendorConsentResponse | null> =>
     new Promise((resolve, reject) => {
         if ('__cmp' in window) {
             /*eslint-disable */

--- a/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
+++ b/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
@@ -1,47 +1,41 @@
-// @flow
+// @flow strict
 import { loadScript } from 'lib/load-script';
 import config from 'lib/config';
+
+const shouldLoadLotame = (): boolean => {
+    const edition = config.get('page.edition');
+
+    return (
+        config.get('switches.lotame', false) &&
+        (edition === 'UK' || edition === 'INT')
+    );
+};
 
 // Fetches Lotame Data for the Ozone project
 // and stores in in window.OzoneLotameData
 const init = (start: () => void): Promise<void> => {
     start();
-    const isLotameOn = config.get('switches.lotame');
-    const edition = config.get('page.edition');
-
-    if (!isLotameOn) {
+    if (!shouldLoadLotame) {
         return Promise.resolve();
     }
-
-    const promiseArray = [
-        // This will inject OzoneLotameData in the window object
-        // to be used by Ozone bid adapters.
-        ...(edition === 'UK' || edition === 'INT'
-            ? [
-                  loadScript(
-                      `//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData`,
-                      { async: true }
-                  ),
-              ]
-            : []),
-        new Promise((resolve, reject) => {
-            if ('LOTCC' in window && 'bcp' in window.LOTCC) {
-                resolve(window.LOTCC.bcp());
-            } else {
-                reject(Error('No LOTCC in window'));
-            }
-        }),
-    ];
-    return promiseArray
-        .reduce((current, next) => current.then(() => next), Promise.resolve())
-        .then(
-            () => {},
-            error => {
+    return new Promise((resolve, reject) => {
+        loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')
+            .then(() => {
+                setTimeout(resolve, 1000);
+            })
+            .then(() => {
+                if ('LOTCC' in window && 'bcp' in window.LOTCC) {
+                    resolve(window.LOTCC.bcp());
+                } else {
+                    reject(Error('No LOTCC in window'));
+                }
+            })
+            .catch(error => {
                 // Lotame fails to load 0.04% of the time. We dont
                 // want to pollute our sentry
                 console.log('Failed to extract lotame data:', error);
-            }
-        );
+            });
+    });
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
+++ b/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
@@ -2,6 +2,12 @@
 import { loadScript } from 'lib/load-script';
 import config from 'lib/config';
 
+const errorHandler = (error: Error) => {
+    // Lotame fails to load 0.04% of the time. We dont
+    // want to pollute our sentry
+    console.log('Failed to extract lotame data:', error);
+};
+
 const shouldLoadLotame = (): boolean => {
     const edition = config.get('page.edition');
 
@@ -18,23 +24,19 @@ const init = (start: () => void): Promise<void> => {
     if (!shouldLoadLotame) {
         return Promise.resolve();
     }
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
         loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')
             .then(() => {
                 setTimeout(resolve, 1000);
             })
             .then(() => {
                 if ('LOTCC' in window && 'bcp' in window.LOTCC) {
-                    resolve(window.LOTCC.bcp());
+                    Promise.resolve(window.LOTCC.bcp());
                 } else {
-                    reject(Error('No LOTCC in window'));
+                    return Promise.reject(Error('No LOTCC in window'));
                 }
             })
-            .catch(error => {
-                // Lotame fails to load 0.04% of the time. We dont
-                // want to pollute our sentry
-                console.log('Failed to extract lotame data:', error);
-            });
+            .catch(errorHandler);
     });
 };
 

--- a/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
+++ b/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
@@ -24,20 +24,15 @@ const init = (start: () => void): Promise<void> => {
     if (!shouldLoadLotame) {
         return Promise.resolve();
     }
-    return new Promise(resolve => {
-        loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')
-            .then(() => {
-                setTimeout(resolve, 1000);
-            })
-            .then(() => {
-                if ('LOTCC' in window && 'bcp' in window.LOTCC) {
-                    Promise.resolve(window.LOTCC.bcp());
-                } else {
-                    return Promise.reject(Error('No LOTCC in window'));
-                }
-            })
-            .catch(errorHandler);
-    });
+    return loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')
+        .then(() => {
+            if ('LOTCC' in window && 'bcp' in window.LOTCC) {
+                Promise.resolve(window.LOTCC.bcp());
+            } else {
+                return Promise.reject(Error('No LOTCC in window'));
+            }
+        })
+        .catch(errorHandler);
 };
 
 export { init };

--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -10,8 +10,8 @@
 }
 
 // What on earth is dumathoin?
-// This class used to be `adverts` which is curently a hugely overloaded word in
-// frontend, without even counting the seperate `advert` class and derivatives.
+// This class used to be `adverts` which is currently a hugely overloaded word in
+// frontend, without even counting the separate `advert` class and derivatives.
 // Also, these styles apply to the glabs containers and content, NOT adverts.
 // However, codewords are cool, and `labs` and `paidfor` are fairly generic.
 // Using the string `dumathoin` gives zero chance of classname collisions, so


### PR DESCRIPTION
## What does this change?

An alternative to #20768 with better promise chaining and catching.

@SiAdcock suggestions included. Still not 100% certain that we need the setTimeout, but it might help! 

As I understand, `12666/cc.js` is responsible for adding the LOTCC to the window, and this will now run in non-blocking. `c=13271/pe=y/var=OzoneLotameData` is responsible for updating lotame, and is not depended on for our subsequent JS. @jeteve may be able to confirm?

We may also get some of these errors since `shouldServeLotame()` and `shouldLoadLotame()` are not identical... This PR retains the current logic for each but maybe we want to make them identical?

#### 👉Move Lotame stub into non-blocking JS

There have been concerns raised about the performance of pages that include the Lotame tag. We may need to take a longer look at how it affects pageload/render, however, as a first step we can move it into the non-blocking JS.

Discussion here: https://github.com/guardian/frontend/pull/20319#issuecomment-423111146

#### 👉Exclude Lotame from identity pages

Commercial modules are not required on Identity pages.

#### 👉Spelling fixes

Found some spelling mistakes in my travels around the codebase so fixing them here.

## Screenshots

#### Before: 

<img width="1336" alt="screen shot 2018-11-26 at 16 21 37" src="https://user-images.githubusercontent.com/8607683/49027158-75973680-f197-11e8-87ed-886353303ffa.png">

#### After: 

<img width="1329" alt="screen shot 2018-11-26 at 16 21 09" src="https://user-images.githubusercontent.com/8607683/49027189-8ba4f700-f197-11e8-935b-a390218d6eb6.png">

## What is the value of this and can you measure success?

CommDev Trello cards:
https://trello.com/c/ysOPU1U1
https://trello.com/c/U7NUQM5t

Dotcom and @rcrphillips:
https://trello.com/c/hPfiDqke

## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] On CODE
