### PR TITLE
CALLOUTS: Allow for more than one callout per page

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -14,7 +14,7 @@ const renderCampaign = (calloutNode: HTMLElement, calloutData): void => {
             calloutNode.innerHTML = campaignDiv;
         })
         .then(() => {
-            const cForm = document.querySelector(
+            const cForm = calloutNode.querySelector(
                 '.element-campaign .campaign .campaign--snippet__body'
             );
             if (cForm) {

--- a/static/src/javascripts/projects/journalism/modules/submit-form.js
+++ b/static/src/javascripts/projects/journalism/modules/submit-form.js
@@ -9,17 +9,17 @@ const disableButton = button => {
     button.disabled = true;
 };
 
-const enableButton = form => {
-    const button = form.querySelector('button');
+const enableButton = cForm => {
+    const button = cForm.querySelector('button');
     button.disabled = false;
     button.textContent = 'Share with the Guardian';
 };
 
-const showConfirmation = () => {
-    const callout = document.querySelector('.element-campaign');
-    if (callout) {
+const showConfirmation = cForm => {
+    const calloutWrapper = cForm.closest('.element-campaign');
+    if (calloutWrapper) {
         fastdom.write(() => {
-            callout.classList.add('success');
+            calloutWrapper.classList.add('success');
         });
     }
 };
@@ -76,7 +76,7 @@ export const submitForm = (e: any) => {
         },
     }).then(res => {
         if (res.ok) {
-            showConfirmation();
+            showConfirmation(cForm);
         } else {
             showError(cForm);
         }


### PR DESCRIPTION
## What does this change?
Previously only one callout was expected on a given page. Now two or more are possible. Some of the Js code needed to change to reflect that. 

In the previous configuration, only the first campaign element was given the 'submit' event and success state. Now it should happen to both. 

## Screenshots

Both should now work: 

![screen shot 2018-12-18 at 15 28 40](https://user-images.githubusercontent.com/10324129/50164081-ad4a5780-02d9-11e9-990c-1c0578feb35e.png)

---------------------------------------------------
And they do... locally 

![screen shot 2018-12-18 at 15 29 51](https://user-images.githubusercontent.com/10324129/50164147-d10d9d80-02d9-11e9-81aa-f9394cd0ba35.png)



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
