### PR TITLE
Use automated contributions ticker file 

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -3,7 +3,6 @@ import { getLocalCurrencySymbol } from 'lib/geolocation';
 import fetchJSON from 'lib/fetch-json';
 
 const count = {};
-let showCount;
 let goal;
 let total;
 
@@ -74,14 +73,14 @@ const animate = (parentElementSelector: string) => {
     }
 };
 
-const dataSuccessfullyFetched = () => total && goal && showCount;
+const dataSuccessfullyFetched = () => total && goal;
 
 const fetchDataAndAnimate = (parentElementSelector: string) => {
     if (dataSuccessfullyFetched()) {
         animate(parentElementSelector);
     } else {
         fetchJSON(
-            'https://interactive.guim.co.uk/docsdata-test/1ySn7Ol2NQLvvSw_eAnVrPuuRnaGOxUmaUs6svtu_irU.json',
+            'https://support.theguardian.com/ticker.json',
             {
                 headers: {
                     'Content-Type': 'application/json',
@@ -89,9 +88,8 @@ const fetchDataAndAnimate = (parentElementSelector: string) => {
                 mode: 'cors',
             }
         ).then(data => {
-            showCount = data.sheets.Sheet1[0].showCount === 'TRUE';
-            total = parseInt(data.sheets.Sheet1[0].total, 10);
-            goal = parseInt(data.sheets.Sheet1[0].goal, 10);
+            total = parseInt(data.total, 10);
+            goal = parseInt(data.goal, 10);
 
             if (dataSuccessfullyFetched()) {
                 animate(parentElementSelector);

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -79,15 +79,12 @@ const fetchDataAndAnimate = (parentElementSelector: string) => {
     if (dataSuccessfullyFetched()) {
         animate(parentElementSelector);
     } else {
-        fetchJSON(
-            'https://support.theguardian.com/ticker.json',
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                mode: 'cors',
-            }
-        ).then(data => {
+        fetchJSON('https://support.theguardian.com/ticker.json', {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            mode: 'cors',
+        }).then(data => {
             total = parseInt(data.total, 10);
             goal = parseInt(data.goal, 10);
 


### PR DESCRIPTION
## What does this change?
The contributions ticker for the US campaign is currently being manually updated via google docs.
There is now an automated ticker at a new location

## Screenshots
<img width="430" alt="picture 9" src="https://user-images.githubusercontent.com/1513454/50165178-48443100-02dc-11e9-97f3-2217b6eac93c.png">


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
