### PR TITLE
Bump Prebid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#685f150",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#e03de4a",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7940,9 +7940,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#685f150":
+"prebid.js@https://github.com/guardian/Prebid.js.git#e03de4a":
   version "1.35.0"
-  resolved "https://github.com/guardian/Prebid.js.git#685f150296d2e862e1bfd4bb3a9773a2c62b52ed"
+  resolved "https://github.com/guardian/Prebid.js.git#e03de4ad4ee4741a9c137c907b45e246a8834727"
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.1"


### PR DESCRIPTION
To bring more data into analytics: https://github.com/guardian/Prebid.js/pull/73

