### PR TITLE
Remove Old Audio Page experiement

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -16,7 +16,7 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.{ContentCSSFile}
 import conf.switches.Switches.WeAreHiring
-import experiments.{ActiveExperiments, OldAudioPage, OldTLSSupportDeprecation}
+import experiments.{ActiveExperiments, OldTLSSupportDeprecation}
 import views.html.stacked
 
 object ContentHtmlPage extends HtmlPage[Page] {
@@ -36,7 +36,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
 
     def mediaOrAudioBody(page: MediaPage): Html  = {
         page.media match {
-          case audio: Audio if !ActiveExperiments.isParticipating(OldAudioPage) => audioBody(page, audio)
+          case audio: Audio => audioBody(page, audio)
           case _ => mediaBody(page, displayCaption = false)
         }
     }

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -127,6 +127,23 @@
                     </div>
                 </div>
             </article>
+
+            @if(mediaType != "video" && mediaType != "audio" && isPaidContent) {
+                <div class="fc-container fc-container--media">
+                    <div class="js-media-popular tonal--@toneClass(media)">
+                        <div class="fc-container fc-container--popular">
+                            <div class="fc-container__inner">
+                                <div class="fc-container__header">
+                                    <h2 class="fc-container__header__title">
+                                        <a class="most-viewed-no-js tone-colour" href="@LinkTo {/@mediaType/most-viewed}" data-link-name="Most viewed @mediaType">
+                                            More @mediaType</a>
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
         </div>
 
         <div class="l-side-margins">

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -2,12 +2,12 @@
 
 @import common.LinkTo
 @import conf.switches.Switches.SurveySwitch
-@import model.{Audio, AudioPlayer, Video, VideoPlayer}
+@import model.{Video, VideoPlayer}
 @import views.support.Commercial.{isPaidContent, isAdFree}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
 
-@defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
+@defining(page.media, "video") { case (media, mediaType) =>
     @defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
         <div class="l-side-margins @if(!isPaidContent) {l-side-margins--media} @if(isPaidContent) {l-side-margins--paidfor}">
 
@@ -37,26 +37,6 @@
 
                                 <div class="media-primary player">
                                 @media match {
-                                    case audio: Audio => {
-
-                                        @audio.elements.images.map{ img =>
-                                            @fragments.imageFigure(img.images)
-                                        }
-
-                                        <figure data-component="main audio">
-                                        @audio.elements.mainAudio.map { audioElement =>
-                                            @fragments.media.audio(
-                                                AudioPlayer(
-                                                    audio,
-                                                    audioElement,
-                                                    audio.trail.headline,
-                                                    autoPlay = false
-                                                ),
-                                                isAdFree
-                                            )
-                                        }
-                                        </figure>
-                                    }
                                     case video: Video => {
                                         <figure data-component="main video">
                                             <meta itemprop="name" content="@Html(video.trail.headline)"/>
@@ -130,45 +110,16 @@
                                     }
 
                                     @fragments.contentMeta(media, page)
-
-                                    @media match {
-                                        case a: Audio if a.fields.body.nonEmpty => {
-                                            <div class="from-content-api">
-                                            @Html(a.fields.body)
-                                            </div>
-                                        }
-                                        case _ => {}
-                                    }
-
                                     @fragments.submeta(media)
                                 </div>
                             </div>
                         </div>
 
                         @media match {
-                            case v: Video => {
-                                @if(!isPaidContent) {
-                                    <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
-                                    aria-hidden="true">
-                                        <div class="js-video-components-container"></div>
-                                    </div>
-                                }
-                            }
-                            case a: Audio if conf.switches.Switches.AudioOnwardJourneySwitch.isSwitchedOn => {
-                                <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
+                            case v: Video if !isPaidContent => {
+                                <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
                                 aria-hidden="true">
-                                    <div class="js-audio-components-container"></div>
-                                    @if(a.fields.body.nonEmpty) {
-                                        <br/>
-                                        @fragments.commercial.standardAd("right", Seq("dark"), Map("desktop" -> Seq("300,250", "300,274", "fluid")))
-                                    }
-                                </div>
-                            }
-
-                            case a: Audio if a.fields.body.nonEmpty => {
-                                <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
-                                aria-hidden="true">
-                                @fragments.commercial.standardAd("right", Seq("dark"), Map("desktop" -> Seq("300,250", "300,274", "fluid")))
+                                    <div class="js-video-components-container"></div>
                                 </div>
                             }
                             case _ => {}
@@ -176,23 +127,6 @@
                     </div>
                 </div>
             </article>
-
-            @if(mediaType != "video" && mediaType != "audio" && isPaidContent) {
-                <div class="fc-container fc-container--media">
-                    <div class="js-media-popular tonal--@toneClass(media)">
-                        <div class="fc-container fc-container--popular">
-                            <div class="fc-container__inner">
-                                <div class="fc-container__header">
-                                    <h2 class="fc-container__header__title">
-                                        <a class="most-viewed-no-js tone-colour" href="@LinkTo {/@mediaType/most-viewed}" data-link-name="Most viewed @mediaType">
-                                            More @mediaType</a>
-                                    </h2>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            }
         </div>
 
         <div class="l-side-margins">

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,7 +6,6 @@ import org.joda.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
-    OldAudioPage,
     OrielParticipation,
     OldTLSSupportDeprecation,
     PodcastImage
@@ -29,14 +28,6 @@ object OldTLSSupportDeprecation extends Experiment(
   sellByDate = new LocalDate(2019, 1,15),
   // Custom group based on header set in Fastly
   participationGroup = TLSSupport
-)
-
-object OldAudioPage extends Experiment(
-  name = "old-audio-page",
-  description = "Show the older version of the audio episode page",
-  owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2018, 12, 19),
-  participationGroup = Perc5A
 )
 
 object PodcastImage extends Experiment(

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -5,7 +5,6 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.{ContributorLinks, RenderClasses}
 @import views.support.TrailCssClasses.toneClass
-@import experiments.{ActiveExperiments, OldAudioPage}
 
 <header class="@RenderClasses(
         Map(
@@ -13,7 +12,7 @@
             "content__head--is-badged"  -> badgeFor(item).nonEmpty,
             badgeFor(item).flatMap(_.classModifier.map(modifier => s"content__head--$modifier")).getOrElse("")
                                         -> badgeFor(item).exists(_.classModifier.nonEmpty),
-            "content__head--flagship"   -> (item.tags.isAudio && !ActiveExperiments.isParticipating(OldAudioPage))
+            "content__head--flagship"   -> item.tags.isAudio
         ),
         "content__head",
         "tonal__head",
@@ -30,20 +29,8 @@
 
                 <h1 class="@RenderClasses(Map(
                     "content__headline"            -> true,
-                    "content__headline--flagship"  -> (item.tags.isAudio && !ActiveExperiments.isParticipating(OldAudioPage))
+                    "content__headline--flagship"  -> item.tags.isAudio
                 ))" itemprop="headline" @langAttributes(item.content)>
-                    @if(item.tags.isMedia && ActiveExperiments.isParticipating(OldAudioPage)) {
-                        @defining(
-                            item match {
-                                case video: model.Video => "video-icon"
-                                case audio: model.Audio => "volume-high"
-                                // The only other 2 media types: gallery and picture both use camera icon
-                                case _ => "camera"
-                            }
-                        ) { mediaIcon =>
-                            @fragments.inlineSvg(mediaIcon, "icon", List("inline-tone-fill", "inline-icon--media"))
-                        }
-                    }
                     @Html(item.trail.headline)
                 </h1>
 
@@ -109,7 +96,7 @@
         </div>
     </div>
 
-    @if(!item.tags.isAudio || ActiveExperiments.isParticipating(OldAudioPage)){
+    @if(!item.tags.isAudio){
     <div class="tonal__standfirst u-cf">
         @if(item.fields.standfirst.isDefined) {
             <div class="gs-container">

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -3,7 +3,6 @@
 @import common.{LinkTo, Localisation}
 @import model.Badges.badgeFor
 @import views.support.RenderClasses
-@import experiments.{ActiveExperiments, OldAudioPage}
 
 <div class="@RenderClasses(Map(
         "content__labels--gallery" -> item.content.isGallery,
@@ -12,7 +11,7 @@
         "content__labels--column" -> item.content.isColumn,
         "content__labels--immersive" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || badgeFor(item).isDefined),
         "content__labels--panel" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || item.content.isGallery),
-        "content__labels--flagship"  -> (item.tags.isAudio && !ActiveExperiments.isParticipating(OldAudioPage))
+        "content__labels--flagship"  -> item.tags.isAudio
     ), "content__labels")
 ">
     @if(!amp) {

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -5,9 +5,8 @@
 @import model.Badges.badgeFor
 @import views.support.ContentLayout.ContentLayout
 @import views.support.Seq2zipWithRowInfo
-@import experiments.{ActiveExperiments, OldAudioPage}
 
-<div class="submeta @if(content.content.tags.isAudio && !ActiveExperiments.isParticipating(OldAudioPage)){podcast-section}">
+<div class="submeta @if(content.content.tags.isAudio){podcast-section}">
     <span class="submeta__label">Topics</span>
 
     <div class="submeta__section-labels">


### PR DESCRIPTION
## What does this change?

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
