### PR TITLE
Pad scores for live matches on facia snaps

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -112,6 +112,15 @@
         padding-left: 14px;
     }
 
+    .football-match--live {
+        .football-match__team--home {
+            padding-right: 18px;
+        }
+        .football-match__team--away {
+            padding-left: 18px;
+        }
+    }
+
     .football-match--result {
         .football-match__team--home {
             padding-right: 20px;


### PR DESCRIPTION
## What does this change?

Adds padding around scores on live matches in football snaps.

## Screenshots

Before:
![screenshot 2018-12-19 at 13 39 07](https://user-images.githubusercontent.com/858402/50223558-7a649a00-0393-11e9-972b-46f83374c41d.png)

After:
![screenshot 2018-12-19 at 13 37 57](https://user-images.githubusercontent.com/858402/50223536-6a4cba80-0393-11e9-8c71-38b43e74e2af.png)

## What is the value of this and can you measure success?

It's a small visual bug fix, which allows us to use football snaps again on fronts.

