### PR TITLE
Add sharpen parameter to ImageProfile for use in emails.

### DIFF
--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -45,21 +45,22 @@ sealed trait ElementProfile {
     bestFor(image).flatMap(_.altText)
 
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
-  val qualityparam = if (hidpi) {"quality=45"} else {"quality=85"}
-  val autoParam = if (autoFormat) "auto=format" else ""
+  val qualityparam: String = if (hidpi) {"quality=45"} else {"quality=85"}
+  val autoParam: String = if (autoFormat) "auto=format" else ""
   val fitParam = "fit=max"
-  val dprParam = if (hidpi) {
+  val dprParam: String = if (hidpi) {
     if (isPng) {
       "dpr=1.3"
     } else {
       "dpr=2"
     }
   } else {""}
-  val heightParam = height.map(pixels => s"height=$pixels").getOrElse("")
-  val widthParam = width.map(pixels => s"width=$pixels").getOrElse("")
+  val heightParam: String = height.map(pixels => s"height=$pixels").getOrElse("")
+  val widthParam: String = width.map(pixels => s"width=$pixels").getOrElse("")
+  val sharpenParam: String = ""
 
   def resizeString: String = {
-    val params = Seq(widthParam, heightParam, qualityparam, autoParam, fitParam, dprParam).filter(_.nonEmpty).mkString("&")
+    val params = Seq(widthParam, heightParam, qualityparam, autoParam, fitParam, dprParam, sharpenParam).filter(_.nonEmpty).mkString("&")
     s"?$params"
   }
 
@@ -207,11 +208,12 @@ object FacebookOpenGraphImage extends OverlayBase64 {
 
 object EmailImage extends ImageProfile(width = Some(580), autoFormat = false) {
   override val qualityparam = "quality=60"
-  val knownWidth = width.get
+  override val sharpenParam = "sharpen=a0.8,r1,t1"
+  val knownWidth: Int = width.get
 }
 
 object EmailVideoImage extends ImageProfile(width = Some(580), autoFormat = false) with OverlayBase64 {
-  override val qualityparam = "quality=60"
+  override val qualityparam: String = EmailImage.qualityparam
   val overlayAlignParam = "overlay-align=center"
   val overlayUrlParam = s"overlay-base64=${overlayUrlBase64("play.png")}"
 
@@ -222,15 +224,17 @@ object EmailVideoImage extends ImageProfile(width = Some(580), autoFormat = fals
 }
 
 object FrontEmailImage extends ImageProfile(width = Some(500), autoFormat = false) {
-  override val qualityparam = "quality=60"
-  val knownWidth = width.get
+  override val qualityparam: String = EmailImage.qualityparam
+  override val sharpenParam: String = EmailImage.sharpenParam
+  val knownWidth: Int = width.get
 }
 
 object SmallFrontEmailImage {
   def apply(customWidth: Int): SmallFrontEmailImage = new SmallFrontEmailImage(customWidth)
 }
 class SmallFrontEmailImage(customWidth: Int) extends ImageProfile(Some(customWidth), autoFormat = false) {
-  override val qualityparam = "quality=60"
+  override val qualityparam: String = EmailImage.qualityparam
+  override val sharpenParam: String = EmailImage.sharpenParam
 }
 
 // The imager/images.js base image.


### PR DESCRIPTION
## What does this change?
Adds a [sharpen](https://docs.fastly.com/api/imageopto/sharpen) setting to images used in emails, which makes them appear a bit less blurry. All credit to @paperboyo  for working this out

## Screenshots (good luck spotting the difference!)

Before:
![screen shot 2018-12-19 at 17 00 26](https://user-images.githubusercontent.com/3606555/50235418-c0c7f200-03af-11e9-823a-cc5c90c44366.png)
After:

![screen shot 2018-12-19 at 17 00 37](https://user-images.githubusercontent.com/3606555/50235426-c58ca600-03af-11e9-8bd2-1d64d7c491b5.png)
Before:
![screen shot 2018-12-19 at 17 00 21](https://user-images.githubusercontent.com/3606555/50235419-c0c7f200-03af-11e9-8ce5-e050d691f60e.png)
After:
![screen shot 2018-12-19 at 17 00 47](https://user-images.githubusercontent.com/3606555/50235424-c4f40f80-03af-11e9-8887-2f1357df1ea5.png)

## What is the value of this and can you measure success?
Makes images in emails look slightly less crappy without increasing  their file size. We suspect that Fastly IO just performs a bit worse than ImgIx did for small images.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
