### PR TITLE
New outbrain widget IDs and structure

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -32,7 +32,7 @@ trait ABTestSwitches {
     "Enable the outbrain new IDs (Jan 2019) AB Test",
     owners = Seq(Owner.withGithub("jeteve")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 6, 1),
+    sellByDate = new LocalDate(2019, 6, 3),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -8,6 +8,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-commercial-ad-mobile-web-increase",
+    "increase ads on mobile web",
+    owners = Seq(Owner.withGithub("frankie297")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 12, 20),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-commercial-cmp-customise",
     "change the location and format of your CMP data",
     owners = Seq(Owner.withGithub("katebee")),
@@ -18,11 +28,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-commercial-ad-mobile-web-increase",
-    "increase ads on mobile web",
-    owners = Seq(Owner.withGithub("frankie297")),
+    "ab-commercial-outbrain-newids",
+    "Enable the outbrain new IDs (Jan 2019) AB Test",
+    owners = Seq(Owner.withGithub("jeteve")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 12, 20),
+    sellByDate = new LocalDate(2019, 6, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes-new.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes-new.js
@@ -69,6 +69,8 @@ const getCode = function(args: {
         return outbrainCode('nonCompliant', normalizedBreakpoint);
     }
     // No other possibility as normalizedType can only have this set of values.
+    // note that for flow, we still need to return something
+    return outbrainCode('nonCompliant', normalizedBreakpoint);
 };
 
 export { getCode };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes-new.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes-new.js
@@ -1,0 +1,74 @@
+// @flow
+
+/*
+  Implements outbrain codes according to the new structure defined
+  here: https://trello.com/c/r1TDqVKP
+*/
+
+const normalizedTypes = {
+    defaults: 'defaults',
+    merchandising: 'nonCompliant',
+    nonCompliant: 'nonCompliant',
+};
+
+const outbrainCodes = {
+    defaults: {
+        desktop: { code: 'AR_12' },
+        tablet: { code: 'MB_6' },
+        mobile: { code: 'MB_4' },
+    },
+    epic: {
+        desktop: { code: 'AR_13' },
+        tablet: { code: 'MB_7' },
+        mobile: { code: 'MB_5' },
+    },
+    nonCompliant: {
+        desktop: { code: 'AR_14' },
+        tablet: { code: 'MB_8' },
+        mobile: { code: 'MB_10' },
+    },
+};
+
+const outbrainCode = function(
+    paramSet: string,
+    breakpoint: string
+): { code?: string, image?: string, text?: string } {
+    const byParamSet = outbrainCodes[paramSet];
+    if (!byParamSet) {
+        throw new Error(`Unknown outbrain param set  (${paramSet})`);
+    }
+    const byBreakpoint = byParamSet[breakpoint];
+    if (!byBreakpoint) {
+        throw new Error(`Unknown outbrain breakpoint (${breakpoint})`);
+    }
+    return { code: byBreakpoint.code };
+};
+
+const getCode = function(args: {
+    outbrainType: string,
+    contributionEpicVisible: boolean,
+    breakpoint: string,
+    section: string,
+}): { code?: string, image?: string, text?: string } {
+    console.log('OUTBRAIN -NEW getCode arguments', args);
+
+    const normalizedType = normalizedTypes[args.outbrainType];
+    if (!normalizedType) {
+        throw new Error(`Unknown outbrainType (${args.outbrainType})`);
+    }
+    const normalizedBreakpoint =
+        args.breakpoint === 'wide' ? 'desktop' : args.breakpoint;
+
+    if (normalizedType === 'defaults') {
+        return outbrainCode('defaults', normalizedBreakpoint);
+    }
+    if (normalizedType === 'nonCompliant') {
+        if (args.contributionEpicVisible) {
+            return outbrainCode('epic', normalizedBreakpoint);
+        }
+        return outbrainCode('nonCompliant', normalizedBreakpoint);
+    }
+    // No other possibility as normalizedType can only have this set of values.
+};
+
+export { getCode };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-codes.js
@@ -39,7 +39,7 @@ const outbrainCodes = {
             },
         },
     },
-
+    // This is the same as 'nonCompliant'
     merchandising: {
         mobile: {
             code: 'MB_10',
@@ -65,23 +65,25 @@ const outbrainCodes = {
     },
 };
 
-const getCode = function(data: {
-    slot: string,
+const getCode = function(args: {
+    outbrainType: string,
     breakpoint: string,
     section: string,
 }): { code?: string, image?: string, text?: string } {
-    if (!(data.slot in outbrainCodes) || data.slot === 'defaults') {
-        return outbrainCodes.defaults[getSection(data.section)][
-            data.breakpoint === 'wide' ? 'desktop' : data.breakpoint
+    const normalizedBreakpoint =
+        args.breakpoint === 'wide' ? 'desktop' : args.breakpoint;
+
+    if (
+        !(args.outbrainType in outbrainCodes) ||
+        args.outbrainType === 'defaults'
+    ) {
+        return outbrainCodes.defaults[getSection(args.section)][
+            normalizedBreakpoint
         ];
-    } else if (data.slot === 'nonCompliant') {
-        return outbrainCodes.nonCompliant[
-            data.breakpoint === 'wide' ? 'desktop' : data.breakpoint
-        ];
+    } else if (args.outbrainType === 'nonCompliant') {
+        return outbrainCodes.nonCompliant[normalizedBreakpoint];
     }
-    return outbrainCodes.merchandising[
-        data.breakpoint === 'wide' ? 'desktop' : data.breakpoint
-    ];
+    return outbrainCodes.merchandising[normalizedBreakpoint];
 };
 
 export { getCode };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
@@ -67,7 +67,7 @@ const load = (
     const $container = $(selectors.outbrain.container, $outbrain[0]);
     const breakpoint = getBreakpoint();
 
-    const useNewOutbrainCodes =
+    const shouldUseNewOutbrainCodes: boolean =
         getTestVariantId('CommercialOutbrainNewids') === 'variant';
 
     const widgetCodes = ((): {
@@ -75,22 +75,22 @@ const load = (
         image?: string,
         text?: string,
     } => {
-        if (useNewOutbrainCodes) {
+        if (shouldUseNewOutbrainCodes) {
             return getNewCode({
                 outbrainType,
                 contributionEpicVisible,
-                section: config.page.section,
+                section: config.get('page.section', ''),
                 breakpoint,
             });
         }
         return getCode({
             outbrainType,
-            section: config.page.section,
+            section: config.get('page.section', ''),
             breakpoint,
         });
     })();
 
-    if (useNewOutbrainCodes) {
+    if (shouldUseNewOutbrainCodes) {
         console.log('OUTBRAIN -NEW widget code is ', widgetCodes);
     }
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
@@ -6,6 +6,7 @@ import fastdom from 'lib/fastdom-promise';
 import { getBreakpoint } from 'lib/detect';
 import { loadScript } from 'lib/load-script';
 import { getCode } from './outbrain-codes';
+import { getCode as getNewCode } from './outbrain-codes-new';
 import { tracking } from './outbrain-tracking';
 
 const outbrainUrl = '//widgets.outbrain.com/outbrain.js';
@@ -35,6 +36,8 @@ const build = (
     let html = outbrainTpl({
         widgetCode: codes.code || codes.image || '',
     });
+
+    // Add another line containing text only
     if (breakpoint !== 'mobile' && codes.text) {
         html += outbrainTpl({
             widgetCode: codes.text,
@@ -43,25 +46,58 @@ const build = (
     return html;
 };
 
-const load = (target?: string): Promise<void> => {
-    const slot = target && target in selectors ? target : 'defaults';
+/*
+  Load the outbrain widget according to target and to the visibility of
+  the contribution epic
+
+  Valid values for target are 'defaults', 'merchandising', 'nonCompliant'
+  
+  When the target is nonCompliant, you are encouraged to pass the contributionEpicVisible
+  parameter as this will have an effect on the new outbrain ID mapping (as of end 2018).
+
+ */
+const load = (
+    target: string,
+    contributionEpicVisible?: boolean = false
+): Promise<void> => {
+    const outbrainType = target && target in selectors ? target : 'defaults';
     const $outbrain = $(selectors.outbrain.widget);
     const $container = $(selectors.outbrain.container, $outbrain[0]);
     const breakpoint = getBreakpoint();
 
-    const widgetCodes = getCode({
-        slot,
-        section: config.page.section,
-        breakpoint,
-    });
+    const useNewOutbrainCodes = false;
+
+    const widgetCodes = ((): {
+        code?: string,
+        image?: string,
+        text?: string,
+    } => {
+        if (useNewOutbrainCodes) {
+            return getNewCode({
+                outbrainType,
+                contributionEpicVisible,
+                section: config.page.section,
+                breakpoint,
+            });
+        }
+        return getCode({
+            outbrainType,
+            section: config.page.section,
+            breakpoint,
+        });
+    })();
+
+    if (useNewOutbrainCodes) {
+        console.log('OUTBRAIN -NEW widget code is ', widgetCodes);
+    }
 
     const widgetHtml = build(widgetCodes, breakpoint);
 
     if ($container.length) {
         return fastdom
             .write(() => {
-                if (slot === 'merchandising') {
-                    $(selectors[slot].widget).replaceWith($outbrain[0]);
+                if (outbrainType === 'merchandising') {
+                    $(selectors.merchandising.widget).replaceWith($outbrain[0]);
                 }
                 $container.append(widgetHtml);
                 $outbrain.css('display', 'block');

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.js
@@ -5,6 +5,8 @@ import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 import { getBreakpoint } from 'lib/detect';
 import { loadScript } from 'lib/load-script';
+import { getTestVariantId } from 'common/modules/experiments/utils.js';
+
 import { getCode } from './outbrain-codes';
 import { getCode as getNewCode } from './outbrain-codes-new';
 import { tracking } from './outbrain-tracking';
@@ -65,7 +67,8 @@ const load = (
     const $container = $(selectors.outbrain.container, $outbrain[0]);
     const breakpoint = getBreakpoint();
 
-    const useNewOutbrainCodes = false;
+    const useNewOutbrainCodes =
+        getTestVariantId('CommercialOutbrainNewids') === 'variant';
 
     const widgetCodes = ((): {
         code?: string,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-sections.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-sections.js
@@ -1,9 +1,18 @@
 // @flow
-const sections = ['politics', 'world', 'business', 'commentisfree'];
 
-const getSection = function(section: string): string {
-    const sectionLower = section.toLowerCase();
-    return /news/.test(sectionLower) || sections.includes(sectionLower)
+// these are considered as 'news' section for outbrain purpose.
+const newsSections = ['politics', 'world', 'business', 'commentisfree'];
+
+/* 
+   Returns the 'outbrain' section ('news' or 'default') according
+   to the given Guardian section (could be any guardian section)
+*/
+const getSection = function(guardianSection: string): string {
+    // Make things case insensitive
+    const lcGuardianSection = guardianSection.toLowerCase();
+    // Section matches regex '/news/' or is an outbrain purpose 'news section'
+    return /news/.test(lcGuardianSection) ||
+        newsSections.includes(lcGuardianSection)
         ? 'news'
         : 'defaults';
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -94,16 +94,17 @@ export const initOutbrain = (): Promise<void> =>
             return;
         }
 
+        const contributionVisible = pageConditions.contributionsTestVisible;
         const editorialTests =
-            pageConditions.contributionsTestVisible ||
+            contributionVisible ||
             pageConditions.emailTestVisible ||
             pageConditions.storyQuestionsVisible;
 
         if (pageConditions.noMerchSlotsExpected) {
             if (editorialTests) {
-                load('nonCompliant');
+                load('nonCompliant', contributionVisible);
             } else {
-                load();
+                load('defaults');
             }
         } else {
             // only wait for dfp conditions if we really have to.
@@ -115,9 +116,9 @@ export const initOutbrain = (): Promise<void> =>
                 if (dfpConditions.useMerchandiseAdSlot) {
                     load('merchandising');
                 } else if (editorialTests) {
-                    load('nonCompliant');
+                    load('nonCompliant', contributionVisible);
                 } else {
-                    load();
+                    load('defaults');
                 }
             });
         }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -135,7 +135,7 @@ describe('Outbrain', () => {
             resolveCheck('isStoryQuestionsOnPage', false);
 
             return initOutbrain().then(() => {
-                expect(load).toHaveBeenCalledWith('nonCompliant');
+                expect(load).toHaveBeenCalledWith('nonCompliant', true);
             });
         });
 
@@ -150,7 +150,7 @@ describe('Outbrain', () => {
             resolveCheck('isStoryQuestionsOnPage', true);
 
             return initOutbrain().then(() => {
-                expect(load).toHaveBeenCalledWith('nonCompliant');
+                expect(load).toHaveBeenCalledWith('nonCompliant', false);
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -50,9 +50,14 @@ export const getEpicParams = (
             firstRow.highlightedText
         )
     ) {
-        reportError(new Error('Could not fetch epic copy from Google Doc'), {
-            feature: 'epic-test',
-        });
+        reportError(
+            new Error(
+                `Could not find epic properties for sheetName=${sheetName}`
+            ),
+            {
+                feature: 'epic-test',
+            }
+        );
         return articleCopy;
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,6 +6,7 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { commercialAdMobileWebIncrease } from 'common/modules/experiments/tests/commercial-ad-mobile-web-increase.js';
+import { commercialOutbrainNewids } from 'common/modules/experiments/tests/commercial-outbrain-newids.js';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     getAcquisitionTest(),
@@ -13,6 +14,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     commercialAdVerification,
     commercialCmpCustomise,
     commercialAdMobileWebIncrease,
+    commercialOutbrainNewids,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-newids.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-newids.js
@@ -1,0 +1,26 @@
+// @flow
+
+export const commercialOutbrainNewids: ABTest = {
+    id: 'CommercialOutbrainNewids',
+    start: '2018-11-18',
+    expiry: '2019-06-01',
+    author: 'Jerome Eteve',
+    description: 'Zero size AB test to allow testing new Outbrain Ids Scheme',
+    audience: 0,
+    audienceOffset: 0,
+    successMeasure: 'n/a',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'Outbrain people are happy with our implementation',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-newids.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-newids.js
@@ -5,7 +5,8 @@ export const commercialOutbrainNewids: ABTest = {
     start: '2018-11-18',
     expiry: '2019-06-01',
     author: 'Jerome Eteve',
-    description: 'Zero size AB test to allow testing new Outbrain Ids Scheme',
+    description:
+        '0% participation AB test to allow testing new Outbrain Ids Scheme',
     audience: 0,
     audienceOffset: 0,
     successMeasure: 'n/a',


### PR DESCRIPTION
This introduces a new Outbrain widget IDs structure that sits behind a 0% participation AB test. That will allow our Outbrain friends to test their new widget on our site.

Implemented card: https://trello.com/c/r1TDqVKP

Existing logic has not been changed, although clearer naming and signatures have been introduced.

Follow up card to clean things out once outbrain is happy: https://trello.com/c/BHF6fXB0 