### PR TITLE
AUDIO: Audio style cleanups 

### DIFF
--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -75,7 +75,7 @@ object FaciaWidths {
   )
 
   private val SquareImageFronts = Map[CardType, BrowserWidth](
-    (Standard, 660.px),
+    (Standard, 368.px),
   )
 
   def mediaFromItemClasses(itemClasses: ItemClasses): WidthsByBreakpoint = {

--- a/common/app/views/fragments/items/facia_cards/audioFlagshipCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/audioFlagshipCard.scala.html
@@ -67,7 +67,7 @@ data-test-id="facia-card"
                 @itemImage(
                     images,
                     inlineImage = containerIndex == 0,
-                    widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
+                    widthsByBreakpoint = Some(item.squareImageWidthsByBreakpoint)
                 )
                 </div>
             }

--- a/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
@@ -67,13 +67,8 @@
 }
 
 .fc-podcast-container__episode-details .fc-item__header {
-    font-size: 16px;
-    line-height: 20px;
-
-    @include mq(tablet) {
-        font-size: 20px;
-        line-height: 24px;
-    }
+    font-size: 20px;
+    line-height: 24px;
 
     @include mq(desktop) {
         font-size: 24px;


### PR DESCRIPTION
## What does this change?

1) Changes the size of the headline on the audio fronts container. As requested by designer 

2) On the [today in focus series page ](https://www.theguardian.com/news/series/todayinfocus).
The images requested now go through a image size requestor specially for Square images. This is what we use for the square image on the front container. 

Also, having talked with Matteus, the maximum width needed for this square image is 368. 

That's because the box is 230 x 230, rectangular images come in at 5 by 3. So to get the height at 230px, the width needs to be 254px.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
