### PR TITLE
Extend Ads on mobile test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "increase ads on mobile web",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2018, 12, 20),
+    sellByDate = new LocalDate(2019, 1, 9),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
@@ -3,7 +3,7 @@
 export const commercialAdMobileWebIncrease: ABTest = {
     id: 'CommercialAdMobileWebIncrease',
     start: '2018-11-16',
-    expiry: '2018-12-20',
+    expiry: '2019-01-09',
     author: 'Francesca Hammond',
     description: 'This test will increase ads on mobile web',
     audience: 0.1,


### PR DESCRIPTION
## What does this change?
Extends the expiry date of the AB test switch for increasing ad's on mobile web, until we decide what to do with it
