### PR TITLE
Fastly purge in CODE too, not just PROD

### DIFF
--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -18,9 +18,8 @@ object CdnPurge extends Dates with Logging {
 
   // Performs soft purge which will still serve stale if there is an error
   def soft(wsClient: WSClient, key:String, fastlyService: FastlyService)(implicit executionContext: ExecutionContext): Future[String] = {
-    // under normal circumstances we only ever want this called from PROD.
-    // Don't want too much decaching going on.
-    val result: Future[WSResponse] = if (environment.isProd ) {
+    // Fastly is in front of PROD and CODE but not locally running dev instances
+    val result: Future[WSResponse] = if (environment.isProd || environment.isCode) {
       val serviceId = fastlyService.serviceId
       wsClient.url(s"https://api.fastly.com/service/$serviceId/purge/$key")
         .withHttpHeaders(


### PR DESCRIPTION
The fact that Fastly purges don't happen in CODE makes testing certain Admin functionality (e.g. contributions banner re-deploys) very difficult, because writing new data to S3 doesn't update the data served from the endpoint

The restriction to PROD was introduced in #13052 but from discussions it seems there's no good reason for it