### PR TITLE
Add sentry config to dotComponents data model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -2,6 +2,7 @@ package model.dotcomponents
 
 import common.Edition
 import conf.Configuration
+import conf.Configuration.environment
 import controllers.ArticlePage
 import model.SubMetaLinks
 import model.dotcomrendering.pageElements.PageElement
@@ -64,6 +65,7 @@ case class PageData(
     subMetaLinks: SubMetaLinks,
     sentryHost: Option[String],
     sentryPublicApiKey: Option[String],
+    isDev: Boolean,
     // AMP specific
     guardianBaseURL: String,
     webURL: String,
@@ -182,6 +184,7 @@ object DotcomponentsDataModel {
       article.content.submetaLinks,
       jsPageData.get("sentryHost"),
       jsPageData.get("sentryPublicApiKey"),
+      !environment.isProd,
       Configuration.site.host,
       article.metadata.webUrl,
       article.content.shouldHideAdverts,

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -8,8 +8,9 @@ import model.dotcomrendering.pageElements.PageElement
 import navigation.NavMenu
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.RequestHeader
-import views.support.GUDateTimeFormat
+import views.support.{CamelCase, GUDateTimeFormat}
 import ai.x.play.json.Jsonx
+import common.Maps.RichMap
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
@@ -61,7 +62,8 @@ case class PageData(
     contentType: Option[String],
     commissioningDesks: Option[String],
     subMetaLinks: SubMetaLinks,
-
+    sentryHost: Option[String],
+    sentryPublicApiKey: Option[String],
     // AMP specific
     guardianBaseURL: String,
     webURL: String,
@@ -150,6 +152,11 @@ object DotcomponentsDataModel {
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
 
+
+    val jsPageData = Configuration.javascript.pageData mapKeys { key =>
+      CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))
+    }
+
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),
       article.metadata.id,
@@ -173,6 +180,8 @@ object DotcomponentsDataModel {
       jsConfig("contentType"),
       jsConfig("commissioningDesks"),
       article.content.submetaLinks,
+      jsPageData.get("sentryHost"),
+      jsPageData.get("sentryPublicApiKey"),
       Configuration.site.host,
       article.metadata.webUrl,
       article.content.shouldHideAdverts,

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,8 +11,7 @@ import play.api.mvc.RequestHeader
 import views.support.{CamelCase, GUDateTimeFormat}
 import ai.x.play.json.Jsonx
 import common.Maps.RichMap
-import ai.x.play.json.implicits.optionWithNull
-import conf.switches.Switch // Note, required despite Intellij saying otherwise
+import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,


### PR DESCRIPTION
## What does this change?

To enable Sentry error logging in dotComponents rendered articles we need a couple of config options to be sent in the `json` from `frontend` (`sentryHost` and `sentryPublicApiKey`) which can then be used when initialising Sentry/Raven.

I've also included a new property `isDev` as we don't want to report errors in Sentry from our dev environments, we use the same property in frontend now here https://github.com/guardian/frontend/blob/master/static/src/javascripts/lib/raven.js#L56