### PR TITLE
Log dc elements

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -110,9 +110,9 @@ object AMPPicker {
     val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender
 
     if (tier != RemoteRender) {
-      logRequest(s"path executing in dotcomponents", features, page)
+      logRequest(s"path executing in dotcomponents AMP", features, page)
     } else {
-      logRequest(s"path executing in dotcomponents", features, page)
+      logRequest(s"path executing in dotcomponents AMP", features, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -109,10 +109,10 @@ object AMPPicker {
 
     val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender
 
-    if (tier != RemoteRender) {
+    if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents AMP", features, page)
     } else {
-      logRequest(s"path executing in dotcomponents AMP", features, page)
+      logRequest(s"path executing in web AMP", features, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -43,8 +43,8 @@ object AMPPicker {
 
   val logger = DotcomponentsLogger()
 
-  private[this] def logRequest(msg:String, results: Map[String, Boolean])(implicit request: RequestHeader): Unit = {
-    logger.withRequestHeaders(request).results(msg, results)
+  private[this] def logRequest(msg:String, results: Map[String, Boolean], page: PageWithStoryPackage)(implicit request: RequestHeader): Unit = {
+    logger.withRequestHeaders(request).results(msg, results, page)
   }
 
 
@@ -110,9 +110,9 @@ object AMPPicker {
     val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender
 
     if (tier != RemoteRender) {
-      logRequest(s"path executing in dotcomponents", features)
+      logRequest(s"path executing in dotcomponents", features, page)
     } else {
-      logRequest(s"path executing in dotcomponents", features)
+      logRequest(s"path executing in dotcomponents", features, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -59,8 +59,8 @@ object ArticlePicker {
 
   val logger = DotcomponentsLogger()
 
-  private[this] def logRequest(msg:String, results: Map[String, Boolean])(implicit request: RequestHeader): Unit = {
-    logger.withRequestHeaders(request).results(msg, results)
+  private[this] def logRequest(msg:String, results: Map[String, Boolean], page: PageWithStoryPackage)(implicit request: RequestHeader): Unit = {
+    logger.withRequestHeaders(request).results(msg, results, page)
   }
 
   private[this] val whitelist = Set(
@@ -133,9 +133,9 @@ object ArticlePicker {
     val tier = if ((isSupported && isWhitelisted && isEnabled) || request.isGuui) RemoteRender else LocalRender
 
     if (tier != RemoteRender) {
-      logRequest(s"path executing in dotcomponents", features)
+      logRequest(s"path executing in dotcomponents", features, page)
     } else {
-      logRequest(s"path executing in dotcomponents", features)
+      logRequest(s"path executing in dotcomponents", features, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -132,10 +132,10 @@ object ArticlePicker {
 
     val tier = if ((isSupported && isWhitelisted && isEnabled) || request.isGuui) RemoteRender else LocalRender
 
-    if (tier != RemoteRender) {
+    if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)
     } else {
-      logRequest(s"path executing in dotcomponents", features, page)
+      logRequest(s"path executing in web", features, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -2,6 +2,7 @@ package services.dotcomponents
 
 import common.Logging
 import common.LoggingField._
+import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
 
 import scala.util.Random
@@ -31,12 +32,25 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
   def fieldsFromResults(results: Map[String, Boolean]):List[LogField] =
     results.map({ case (k, v) => LogFieldString(k, v.toString)}).toList
 
+  def elementsLogFieldFromPage(page: PageWithStoryPackage): List[LogField] = List(
+    LogFieldString(
+      "page.elements",
+      (
+        page.article.blocks match {
+          case Some(blocks) => blocks.body.flatMap(bblock => bblock.elements) map (be => be.getClass.getSimpleName)
+          case None => Seq()
+        }
+      ).distinct.mkString(", ")
+    )
+  )
+
   def withRequestHeaders(rh: RequestHeader): DotcomponentsLogger = {
     copy(Some(rh))
   }
 
-  def results(message: String, results: Map[String, Boolean]): Unit = {
-    logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results))
+
+  def results(message: String, results: Map[String, Boolean], page: PageWithStoryPackage): Unit = {
+    logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results) ++ elementsLogFieldFromPage(page))
   }
 
   def info(message: String): Unit = {


### PR DESCRIPTION
## What does this change?

Adds a log field to kibana showing the elements that appear on a page. This will be logged out for all article requests. 

## Screenshots

## What is the value of this and can you measure success?

This is to give Rob/the team better insight into which elements to prioritise supporting under dotcomponents.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
