### PR TITLE
Change contributions ticker after goal is reached

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -28,6 +28,7 @@ jest.mock('lib/url', () => ({
 }));
 jest.mock('lib/geolocation', () => ({
     getSync: jest.fn(() => 'GB'),
+    getLocalCurrencySymbol: () => '£',
 }));
 jest.mock('common/modules/experiments/acquisition-test-selector', () => ({
     getTest: jest.fn(() => ({

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
@@ -1,19 +1,39 @@
 // @flow
 
+import { getLocalCurrencySymbol } from 'lib/geolocation';
+
 export const acquisitionsBannerTickerTemplate = `
-    <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker">
-        <div class="js-ticker-so-far engagement-banner-ticker__so-far">
-            <div class="js-ticker-count engagement-banner-ticker__count">$0</div>
-            <div class="engagement-banner-ticker__count-label">contributed</div>
+    <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker is-hidden">
+        
+        <div class="js-ticker-under-goal is-hidden">
+            <div class="js-ticker-so-far engagement-banner-ticker__so-far">
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="engagement-banner-ticker__count-label">contributed</div>
+            </div>
+            
+            <div class="js-ticker-goal engagement-banner-ticker__goal">
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="engagement-banner-ticker__count-label">our goal</div>
+            </div>
         </div>
         
-        <div class="js-ticker-goal engagement-banner-ticker__goal">
-            <div class="js-ticker-count engagement-banner-ticker__count">$0</div>
-            <div class="engagement-banner-ticker__count-label">our goal</div>
+        <div class="js-ticker-over-goal is-hidden">
+            <div class="engagement-banner-ticker__thankyou">
+                <div>Help us beat our goal - thank you</div>
+                <div>Please keep contributing into the new year</div>
+            </div>
+            
+            <div class="js-ticker-exceeded engagement-banner-ticker__exceeded">
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="engagement-banner-ticker__count-label">contributed</div>
+            </div>
         </div>
         
-        <div class="engagement-banner-ticker__progress">
-            <div class="js-ticker-filled-progress engagement-banner-ticker__filled-progress"></div>
+        <div class="engagement-banner-ticker__progress-container">
+            <div class="engagement-banner-ticker__progress">
+                <div class="js-ticker-filled-progress engagement-banner-ticker__filled-progress ticker__filled-progress-under"></div>
+            </div>
+            <div class="js-ticker-goal-marker engagement-banner-ticker__goal-marker is-hidden"></div>
         </div>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -3,19 +3,37 @@
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 
 export const acquisitionsEpicTickerTemplate = `
-    <div id="epic-ticker" class="js-epic-ticker epic-ticker">
-        <div class="js-ticker-so-far epic-ticker__so-far">
-            <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
-            <div class="epic-ticker__count-label">contributed</div>
+    <div id="epic-ticker" class="js-epic-ticker epic-ticker is-hidden">
+    
+        <div class="js-ticker-under-goal is-hidden">
+            <div class="js-ticker-so-far epic-ticker__so-far">
+                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="epic-ticker__count-label">contributed</div>
+            </div>
+            
+            <div class="js-ticker-goal epic-ticker__goal">
+                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="epic-ticker__count-label">our goal</div>
+            </div>
         </div>
         
-        <div class="js-ticker-goal epic-ticker__goal">
-            <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
-            <div class="epic-ticker__count-label">our goal</div>
+        <div class="js-ticker-over-goal is-hidden">
+            <div class="epic-ticker__thankyou">
+                <div>Help us beat our goal - thank you</div>
+                <div>Please keep contributing into the new year</div>
+            </div>
+            
+            <div class="js-ticker-exceeded epic-ticker__exceeded">
+                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="epic-ticker__count-label">contributed</div>
+            </div>
         </div>
         
-        <div class="epic-ticker__progress">
-            <div class="js-ticker-filled-progress epic-ticker__filled-progress"></div>
+        <div class="epic-ticker__progress-container">
+            <div class="epic-ticker__progress">
+                <div class="js-ticker-filled-progress epic-ticker__filled-progress ticker__filled-progress-under"></div>
+            </div>
+            <div class="js-ticker-goal-marker epic-ticker__goal-marker is-hidden"></div>
         </div>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -6,8 +6,8 @@ const count = {};
 let goal;
 let total;
 
-const percentageTotalAsNegative = () => {
-    let percentage = (total / goal) * 100 - 100;
+const percentageTotalAsNegative = (end: number) => {
+    let percentage = (total / end) * 100 - 100;
     if (percentage > 0) {
         percentage = 0;
     }
@@ -15,23 +15,46 @@ const percentageTotalAsNegative = () => {
 };
 
 const animateBar = (parentElement: HTMLElement) => {
+    // If we've exceeded the goal then extend the bar 20% beyond the total
+    const end = total > goal ? total + total * 0.2 : goal;
+
     const progressBarElement = parentElement.querySelector(
         '.js-ticker-filled-progress'
     );
 
     if (progressBarElement && progressBarElement instanceof HTMLElement) {
-        progressBarElement.style.transform = `translateX(${percentageTotalAsNegative()}%)`;
+        const barTranslate = percentageTotalAsNegative(end);
+        progressBarElement.style.transform = `translateX(${barTranslate}%)`;
+
+        if (end !== goal) {
+            progressBarElement.classList.add('ticker__filled-progress-over');
+            progressBarElement.classList.remove(
+                'ticker__filled-progress-under'
+            );
+
+            // Show a marker for the goal that has been exceeded
+            const marker = parentElement.querySelector(
+                '.js-ticker-goal-marker'
+            );
+            if (marker) {
+                marker.classList.remove('is-hidden');
+                const markerTranslate = (goal / end) * 100 - 100;
+                marker.style.transform = `translateX(${markerTranslate}%)`;
+            }
+        }
     }
 };
 
 const increaseCounter = (
     parentElement: HTMLElement,
-    parentElementSelector: string
+    parentElementSelector: string,
+    tickerElementSelector: string
 ) => {
     // Count is local to the parent element
     count[parentElementSelector] += Math.floor(total / 100);
+
     const counterElement = parentElement.querySelector(
-        '.js-ticker-so-far .js-ticker-count'
+        `${tickerElementSelector} .js-ticker-count`
     );
 
     if (counterElement && counterElement instanceof HTMLElement) {
@@ -42,13 +65,17 @@ const increaseCounter = (
             counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
         } else {
             window.requestAnimationFrame(() =>
-                increaseCounter(parentElement, parentElementSelector)
+                increaseCounter(
+                    parentElement,
+                    parentElementSelector,
+                    tickerElementSelector
+                )
             );
         }
     }
 };
 
-const populateText = (parentElement: HTMLElement) => {
+const populateGoal = (parentElement: HTMLElement) => {
     const goalElement = parentElement.querySelector(
         '.js-ticker-goal .js-ticker-count'
     );
@@ -61,15 +88,34 @@ const populateText = (parentElement: HTMLElement) => {
 const animate = (parentElementSelector: string) => {
     const parentElement = document.querySelector(parentElementSelector);
 
+    const tickerElementSelector =
+        total > goal ? '.js-ticker-over-goal' : '.js-ticker-under-goal';
+
     if (parentElement && parentElement instanceof HTMLElement) {
-        populateText(parentElement);
+        if (total < goal) {
+            populateGoal(parentElement);
+        }
+
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
             window.requestAnimationFrame(() =>
-                increaseCounter(parentElement, parentElementSelector)
+                increaseCounter(
+                    parentElement,
+                    parentElementSelector,
+                    tickerElementSelector
+                )
             );
             animateBar(parentElement);
         }, 500);
+
+        parentElement.classList.remove('is-hidden');
+
+        const tickerElement = parentElement.querySelector(
+            tickerElementSelector
+        );
+        if (tickerElement) {
+            tickerElement.classList.remove('is-hidden');
+        }
     }
 };
 

--- a/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
@@ -23,14 +23,21 @@
 
 $progress-bar-height: 10px;
 
-.engagement-banner-ticker__progress {
+.engagement-banner-ticker__progress-container {
     width: 100%;
     height: $progress-bar-height;
-    overflow: hidden;
-    background-color: #ffffff;
     position: absolute;
     bottom: 0;
     margin-top: 40px;
+}
+
+.engagement-banner-ticker__progress {
+    overflow: hidden;
+    width: 100%;
+    height: $progress-bar-height;
+    background-color: #ffffff;
+    position: absolute;
+    bottom: 0;
 }
 
 .engagement-banner-ticker__filled-progress {
@@ -42,6 +49,14 @@ $progress-bar-height: 10px;
     bottom: 0;
     transform: translateX(-100%);
     transition: transform 3s cubic-bezier(.25, .55, .2, .85);
+}
+
+.engagement-banner-ticker__goal-marker {
+    border-right: 3px solid #121212;
+    content: ' ';
+    display: block;
+    height: 17px;
+    margin-top: -7px;
 }
 
 .engagement-banner-ticker__progress-labels {
@@ -57,17 +72,38 @@ $progress-bar-height: 10px;
     top: 5px;
 }
 
-.engagement-banner-ticker__goal {
+.engagement-banner-ticker__goal, .engagement-banner-ticker__exceeded {
     position: absolute;
     right: 0;
     bottom: $progress-bar-height + 5px;
     text-align: right;
 }
 
-.engagement-banner-ticker__so-far {
+.engagement-banner-ticker__so-far, .engagement-banner-ticker__thankyou {
     position: absolute;
     left: 0;
     bottom: $progress-bar-height + 5px;
+}
+
+.engagement-banner-ticker__thankyou {
+    >:first-child {
+        @include fs-header(5);
+        font-weight: 800;
+        color: #333333;
+    }
+
+    >:last-child {
+        font-style: italic;
+    }
+}
+
+.engagement-banner-ticker__exceeded .engagement-banner-ticker__count {
+    font-size: 17px;
+    line-height: 1.4;
+}
+
+.engagement-banner-ticker__exceeded .engagement-banner-ticker__count-label {
+    font-style: italic;
 }
 
 .engagement-banner-ticker__caption {

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -47,18 +47,23 @@
 
 $progress-bar-height: 10px;
 
-.epic-ticker__progress {
+.epic-ticker__progress-container {
     width: 100%;
     height: $progress-bar-height;
-    overflow: hidden;
     background-color: #dcdcdc;
     position: absolute;
     bottom: 0;
     margin-top: 40px;
 }
 
+.epic-ticker__progress {
+    overflow: hidden;
+    width: 100%;
+    height: $progress-bar-height;
+    position: absolute;
+}
+
 .epic-ticker__filled-progress {
-    background-color: #ffe500;
     position: absolute;
     top: 0;
     left: 0;
@@ -66,6 +71,22 @@ $progress-bar-height: 10px;
     bottom: 0;
     transform: translateX(-100%);
     transition: transform 3s cubic-bezier(.25, .55, .2, .85);
+}
+
+.epic-ticker__progress .ticker__filled-progress-under {
+    background-color: #ffe500;
+}
+
+.epic-ticker__progress .ticker__filled-progress-over {
+    background-color: #ff7f0f;
+}
+
+.epic-ticker__goal-marker {
+    border-right: 3px solid #121212;
+    content: ' ';
+    display: block;
+    height: 17px;
+    margin-top: -7px;
 }
 
 .epic-ticker__progress-labels {
@@ -81,18 +102,44 @@ $progress-bar-height: 10px;
     top: 5px;
 }
 
-.epic-ticker__goal {
+.epic-ticker__goal, .epic-ticker__exceeded {
     position: absolute;
     right: 0;
     bottom: $progress-bar-height + 5px;
     text-align: right;
 }
 
-.epic-ticker__so-far {
+.epic-ticker__so-far, .epic-ticker__thankyou {
     position: absolute;
     left: 0;
     bottom: $progress-bar-height + 5px;
 }
+
+.epic-ticker__thankyou {
+    >:first-child {
+        @include fs-header(5);
+        font-weight: 800;
+        color: #333333;
+    }
+
+    >:last-child {
+        font-style: italic;
+    }
+}
+
+.epic-ticker__exceeded .epic-ticker__count {
+    font-size: 17px;
+    line-height: 1.4;
+}
+
+.epic-ticker__exceeded .epic-ticker__count-label {
+    font-style: italic;
+}
+
+.epic-ticker__hidden {
+    display: none;
+}
+
 
 .epic-ticker__caption {
     @include fs-textSans(4);


### PR DESCRIPTION
## What does this change?
This change optimistically introduces a change of design for the US contributions ticker (on epic and banner) when it reaches our goal.

The `epic-ticker` div is now hidden on page load, and only becomes visible once the ticker value has been received and the user scrolls into view. This is because we don't know which of the 2 designs to display until the value is available.

After the goal is reached, the length of the grey bar is always 20% higher than the current amount. This means the goal marker will gradually shift left as the amount increases

## Screenshots

### Epic
**Before we reach the goal (no change here):**
<img width="462" alt="picture 13" src="https://user-images.githubusercontent.com/1513454/50345660-c6e0de80-0527-11e9-8c55-22d1e600cdc3.png">


**After we reach the goal:**
<img width="442" alt="picture 12" src="https://user-images.githubusercontent.com/1513454/50345666-c9433880-0527-11e9-9dd9-a40d3766b82f.png">



### Banner
**Before we reach the goal (no change here):**
<img width="403" alt="picture 1" src="https://user-images.githubusercontent.com/1513454/50345677-d95b1800-0527-11e9-954d-a95d9fa60890.png">


**After we reach the goal:**
<img width="443" alt="picture 2" src="https://user-images.githubusercontent.com/1513454/50345694-e6780700-0527-11e9-9632-bcccc3e260db.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
