### PR TITLE
Add Twitter tracking script for re-targeting Jobs campaign

### DIFF
--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -28,4 +28,15 @@
     <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
     <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
 
+    <!-- Twitter universal website tag code -->
+    <script>
+    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+    a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+    // Insert Twitter Pixel ID and Standard Event data below
+    twq('init','nyl43');
+    twq('track','PageView');
+    </script>
+<!-- End Twitter universal website tag code -->
+
 }


### PR DESCRIPTION
## What does this change?
Adds a twitter tracking script to each page view. 
It comes in at 1.2kb and is towards the bottom of the html. 

## What is the value of this and can you measure success?
The marketing team will be running a campaign for jobs in January and believe that Twitter will be a valuable resource for re-targeting users.

It's going through a data privacy impact assessment at the moment and won't be merged until that is complete.

