### PR TITLE
Fix qqqq analysis card styling at leftcol, wide

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-analysis.scss
@@ -33,7 +33,7 @@ $pillars: (
             .fc-slice--q-q-q-q {
                 .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
                     &.fc-item--standard-tablet {
-                        @include mq(tablet, desktop) {
+                        @include mq(tablet) {
                             @include garnett-underline($pillarColor, 20px);
                         }
                     }
@@ -44,7 +44,7 @@ $pillars: (
         .fc-slice--t-t-mpu {
             .fc-item--pillar-#{$pillar}.fc-item--type-analysis {
                 &.fc-item--third-tablet {
-                    @include mq(tablet, desktop) {
+                    @include mq(tablet) {
                         @include garnett-underline($pillarColor, 20px);
                     }
                 }


### PR DESCRIPTION
## What does this change?

For:

- four quarter-width cards (`q-q-q-q`) 
- with analysis type and 
- leftcol or wide breakpoint

the analysis underline is vertically misaligned with the text. This change fixes the issue by including these breakpoints in the `tablet` and `desktop` overrides.

## Screenshots

**Before**

![screen shot 2018-12-24 at 10 56 32](https://user-images.githubusercontent.com/5931528/50397835-f895b780-076a-11e9-8650-42817e64fdd2.png)

**After**

![screen shot 2018-12-24 at 10 56 11](https://user-images.githubusercontent.com/5931528/50397831-f0d61300-076a-11e9-89db-a50ba31dede6.png)

## What is the value of this and can you measure success?

Fixes another issue with this most expensive of card types 💸 

## Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
