### PR TITLE
Stop checking adFree flag from members-data-api lookup

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -73,14 +73,13 @@ const persistResponse = (JsonResponse: () => void) => {
 
     if (
         adFreeDataIsPresent() &&
-        !JsonResponse.adFree &&
         !forcedAdFreeMode &&
         !JsonResponse.contentAccess.digitalPack
     ) {
         removeCookie(AD_FREE_USER_COOKIE);
     }
 
-    if (JsonResponse.adFree || JsonResponse.contentAccess.digitalPack) {
+    if (JsonResponse.contentAccess.digitalPack) {
         addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
     }
 };


### PR DESCRIPTION
## What does this change?
Maintaining cookies in`user-features.js` relies on the response from members-data-api's endpoint `/user-attributes/me`

We use cookies to implement ad-free for logged in digital subscribers. Before ad-free was rolled out to all our digital subscribers, we had an ad-free state stored in members-data-api's SupporterAttributes cache, and `/user-attributes/me` used to sometimes return `adFree = true` in the response. 

As of https://github.com/guardian/members-data-api/pull/353, `/user-attributes/me` will never return a value for adFree in the response. 

So, let's never check it!

## Screenshots
This shouldn't change any behaviour. Just removing a check that will never be true.

## What is the value of this and can you measure success?
Just cleaning up a little.
![image](https://user-images.githubusercontent.com/3072877/50564064-f35fdc00-0d19-11e9-9237-8733449ff54c.png)

## Checklist

### Does this affect other platforms?
Nope.
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it
- [x] Users who previously had an ad-free flag stored in the dynamo cache, but who weren't digital subscribers were ad-free. Now that ad-free is in the wild, ad-free currently means 'has a digital pack'. But this has been enforced since https://github.com/guardian/members-data-api/pull/353 , not this PR. This PR just removes a check that is never true ever since that members-data-api PR. 

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
