### PR TITLE
Update US epic+banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-us-eoy.js
@@ -8,10 +8,10 @@ const abTestName = 'AcquisitionsBannerUsEoyFinal';
 
 const criticalTimesParams = {
     messageText:
-        '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
+        '<strong>In these critical times, make a year-end gift to The Guardian to help us protect independent journalism at a time when factual, trustworthy reporting is under threat.</strong> Our editorial independence means we can pursue difficult investigations, challenging the powerful and holding them to account. And our journalism is open to everyone, regardless of what they can afford. But we depend on voluntary contributions from readers. We’re in this together – please make a year-end gift today to help us deliver the independent journalism the world needs for 2019 and beyond.',
     buttonCaption: 'Support The Guardian',
     ctaText:
-        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1 and help us reach our end of year goal.</span>',
+        ' <span class="engagement-banner__highlight">Support The Guardian from as little as $1 and help us reach our goal by early January 2019.</span>',
     linkUrl: 'https://support.theguardian.com/contribute',
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
@@ -23,7 +23,7 @@ const createTemplate = (tickerPosition: TickerPosition): EpicTemplate => (
 const noteFromJohn: AcquisitionsEpicTemplateCopy = {
     heading: 'In these critical times &hellip;',
     paragraphs: [
-        '&hellip; The Guardian’s US editor John Mulholland urges you to show your support for independent journalism with a year-end gift to The Guardian. We are asking our US readers to help us raise $1 million dollars by early January 2019 to report on the most important stories in 2019.',
+        '&hellip; The Guardian’s US editor John Mulholland urges you to show your support for independent journalism with a year-end gift to The Guardian. We are asking our US readers to help us raise $1 million dollars by early January to report on the most important stories in 2019.',
         'A note from John:',
         'In normal times we might not be making this appeal. But these are not normal times. Many of the values and beliefs we hold dear at The Guardian are under threat both here in the US and around the world. Facts, science, humanity, diversity and equality are being challenged daily. As is truth. Which is why we need your help.',
         'Powerful public figures choose lies over truths, prefer supposition over science; and select hate over humanity. The US administration is foremost among them; whether in denying climate science or hating on immigrants; giving succor to racists or targeting journalists and the media. Many of these untruths and attacks find fertile ground on social media where tech platforms seem unable to cauterise lies. As a result, fake is in danger of overriding fact.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-top-ticker.js
@@ -23,7 +23,7 @@ const createTemplate = (tickerPosition: TickerPosition): EpicTemplate => (
 const noteFromJohn: AcquisitionsEpicTemplateCopy = {
     heading: 'In these critical times &hellip;',
     paragraphs: [
-        '&hellip; The Guardian’s US editor John Mulholland urges you to show your support for independent journalism with a year-end gift to The Guardian. We are asking our US readers to help us raise $1 million dollars by the new year to report on the most important stories in 2019.',
+        '&hellip; The Guardian’s US editor John Mulholland urges you to show your support for independent journalism with a year-end gift to The Guardian. We are asking our US readers to help us raise $1 million dollars by early January 2019 to report on the most important stories in 2019.',
         'A note from John:',
         'In normal times we might not be making this appeal. But these are not normal times. Many of the values and beliefs we hold dear at The Guardian are under threat both here in the US and around the world. Facts, science, humanity, diversity and equality are being challenged daily. As is truth. Which is why we need your help.',
         'Powerful public figures choose lies over truths, prefer supposition over science; and select hate over humanity. The US administration is foremost among them; whether in denying climate science or hating on immigrants; giving succor to racists or targeting journalists and the media. Many of these untruths and attacks find fertile ground on social media where tech platforms seem unable to cauterise lies. As a result, fake is in danger of overriding fact.',


### PR DESCRIPTION
## What does this change?
This makes small updates to the epic and banner copy for the US end of year campaign.

## Screenshots
<img width="441" alt="picture 6" src="https://user-images.githubusercontent.com/1513454/50598147-c3434500-0ea1-11e9-9a61-f75fa79b9710.png">
<img width="353" alt="picture 8" src="https://user-images.githubusercontent.com/1513454/50599975-88441000-0ea7-11e9-9c2a-d103567110b6.png">



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
