### PR TITLE
Don't spread non-iterables (e.g. HTMLCollection)

### DIFF
--- a/static/src/javascripts/bootstraps/atoms/storyquestions.js
+++ b/static/src/javascripts/bootstraps/atoms/storyquestions.js
@@ -36,7 +36,7 @@ Promise.all([
     updateHeight();
 
     // Brittle but will work
-    [...document.getElementsByClassName('user__question')]
+    Array.from(document.getElementsByClassName('user__question'))
         .slice(0, 1)
         .forEach((sq: Element) => {
             new MutationObserver(updateHeight).observe(sq, {

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -22,7 +22,9 @@ import { enhanceUpsell } from 'common/modules/identity/upsell/upsell';
 const initFormstack = (): void => {
     const attr = 'data-formstack-id';
     const forms = [...document.querySelectorAll(`[${attr}]`)];
-    const iframes = [...document.getElementsByClassName('js-formstack-iframe')];
+    const iframes = Array.from(
+        document.getElementsByClassName('js-formstack-iframe')
+    );
 
     forms.forEach(form => {
         const id = form.getAttribute(attr) || '';

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -9,7 +9,7 @@ import { initHostedCarousel } from './onward-journey-carousel';
 const getPlaceholderFromDom = (
     dom: typeof document = document
 ): Array<HTMLElement> =>
-    [...dom.getElementsByClassName('js-onward-placeholder')].slice(0, 1);
+    Array.from(dom.getElementsByClassName('js-onward-placeholder')).slice(0, 1);
 
 const generateUrlFromConfig = (
     c: {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -52,7 +52,9 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const addReferrerDataToAcquisitionLinksOnPage = (): void => {
-    const links = [...document.getElementsByClassName(ACQUISITION_LINK_CLASS)];
+    const links = Array.from(
+        document.getElementsByClassName(ACQUISITION_LINK_CLASS)
+    );
 
     links.forEach(el => {
         fastdom.read(() => el.getAttribute('href')).then(link => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -48,13 +48,13 @@ const getBlocksToInsertEpicAfter = (): Array<HTMLElement> => {
         epicsAlreadyOnPage.length ||
         !isLiveblogLongEnoughYet
     ) {
-        return [...blocksToInsertManualEpicAfter];
+        return Array.from(blocksToInsertManualEpicAfter);
     }
 
     const autoBlockNum = Math.floor(Math.random() * 3);
     const blockToInsertAutoEpicAfter = blocks[autoBlockNum];
 
-    return [...blocksToInsertManualEpicAfter].concat(
+    return Array.from(blocksToInsertManualEpicAfter).concat(
         blockToInsertAutoEpicAfter
     );
 };

--- a/static/src/javascripts/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/main.js
@@ -10,7 +10,7 @@ const initCrosswords = (): void => {
     fastdom
         .read(() => document.getElementsByClassName('js-crossword'))
         .then(elements => {
-            [...elements].forEach(element => {
+            Array.from(elements).forEach(element => {
                 const data = element.getAttribute('data-crossword-data');
 
                 if (!data) {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -78,8 +78,8 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
         },
         format
     );
-    const meta = el.getElementsByClassName('js-item__meta');
-    const containers = meta.length ? [...meta] : [el];
+    const meta = Array.from(el.getElementsByClassName('js-item__meta'));
+    const containers = meta.length ? meta : [el];
 
     return fastdom.write(() => {
         containers.forEach(container => {

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -39,11 +39,13 @@ const loadDiscussionFrontend = (
                     /* By the time discussion frontent loads, the number of comments
                    might have changed. If there are other comment counts element
                    in the page refresh their value. */
-                    const otherValues = document.getElementsByClassName(
-                        'js_commentcount_actualvalue'
+                    const otherValues = Array.from(
+                        document.getElementsByClassName(
+                            'js_commentcount_actualvalue'
+                        )
                     );
 
-                    [...otherValues].forEach(el => {
+                    otherValues.forEach(el => {
                         updateCommentCount(el, value);
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -45,7 +45,7 @@ const initUserAvatars = (): Promise<void> =>
         .read(() => document.getElementsByClassName('user-avatar'))
         .then(avatars => {
             if (avatars) {
-                [...avatars].forEach(avatarify);
+                Array.from(avatars).forEach(avatarify);
             }
         });
 

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -28,7 +28,9 @@ const addEditLink = (containerEl: HTMLElement): void => {
 
 const initUserEditLink = (): Promise<void> =>
     fastdom
-        .read(() => [...document.getElementsByClassName('user-profile__name')])
+        .read(() =>
+            Array.from(document.getElementsByClassName('user-profile__name'))
+        )
         .then(names => {
             names.forEach(addEditLink);
         });

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
@@ -248,37 +248,39 @@ class FormstackEmbedIframe {
         setTimeout(() => {
             // Remove any existing errors
             const formErrorClass = this.config.idClasses.formError;
-            const formErrors = document.getElementsByClassName(formErrorClass);
+            const formErrors = Array.from(
+                document.getElementsByClassName(formErrorClass)
+            );
 
-            [...formErrors].forEach(formError => {
+            formErrors.forEach(formError => {
                 formError.classList.remove(formErrorClass);
             });
 
             const fieldErrorClass = this.config.idClasses.fieldError;
-            const fieldErrors = document.getElementsByClassName(
-                fieldErrorClass
+            const fieldErrors = Array.from(
+                document.getElementsByClassName(fieldErrorClass)
             );
 
-            [...fieldErrors].forEach(fieldError => {
+            fieldErrors.forEach(fieldError => {
                 fieldError.classList.remove(fieldErrorClass);
             });
 
             // Handle new errors
             const fsFormErrorClass = this.config.fsSelectors.formError;
-            const fsFormErrors = this.form.getElementsByClassName(
-                fsFormErrorClass
+            const fsFormErrors = Array.from(
+                this.form.getElementsByClassName(fsFormErrorClass)
             );
 
-            [...fsFormErrors].forEach(fsFormError => {
+            fsFormErrors.forEach(fsFormError => {
                 fsFormError.classList.add(formErrorClass);
             });
 
             const fsFieldErrorClass = this.config.fsSelectors.fieldError;
-            const fsFieldErrors = this.form.getElementsByClassName(
-                fsFieldErrorClass
+            const fsFieldErrors = Array.from(
+                this.form.getElementsByClassName(fsFieldErrorClass)
             );
 
-            [...fsFieldErrors].forEach(fsFieldError => {
+            fsFieldErrors.forEach(fsFieldError => {
                 fsFieldError.classList.add(fieldErrorClass);
             });
 

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -178,37 +178,39 @@ class Formstack {
         setTimeout(() => {
             // Remove any existing errors
             const formErrorClass = this.config.idClasses.formError;
-            const formErrors = document.getElementsByClassName(formErrorClass);
+            const formErrors = Array.from(
+                document.getElementsByClassName(formErrorClass)
+            );
 
-            [...formErrors].forEach(formError => {
+            formErrors.forEach(formError => {
                 formError.classList.remove(formErrorClass);
             });
 
             const fieldErrorClass = this.config.idClasses.fieldError;
-            const fieldErrors = document.getElementsByClassName(
-                fieldErrorClass
+            const fieldErrors = Array.from(
+                document.getElementsByClassName(fieldErrorClass)
             );
 
-            [...fieldErrors].forEach(fieldError => {
+            fieldErrors.forEach(fieldError => {
                 fieldError.classList.remove(fieldErrorClass);
             });
 
             // Handle new errors
             const fsFormErrorClass = this.config.fsSelectors.formError;
-            const fsFormErrors = this.form.getElementsByClassName(
-                fsFormErrorClass
+            const fsFormErrors = Array.from(
+                this.form.getElementsByClassName(fsFormErrorClass)
             );
 
-            [...fsFormErrors].forEach(fsFormError => {
+            fsFormErrors.forEach(fsFormError => {
                 fsFormError.classList.add(formErrorClass);
             });
 
             const fsFieldErrorClass = this.config.fsSelectors.fieldError;
-            const fsFieldErrors = this.form.getElementsByClassName(
-                fsFieldErrorClass
+            const fsFieldErrors = Array.from(
+                this.form.getElementsByClassName(fsFieldErrorClass)
             );
 
-            [...fsFieldErrors].forEach(fsFieldError => {
+            fsFieldErrors.forEach(fsFieldError => {
                 fsFieldError.classList.add(fieldErrorClass);
             });
 

--- a/static/src/javascripts/projects/common/modules/identity/public-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/public-profile.js
@@ -35,9 +35,11 @@ const getActivityStream = (cb: Function): void => {
 };
 
 const selectTab = (el: HTMLElement): void => {
-    const selectedTabs = document.getElementsByClassName('tabs__tab--selected');
+    const selectedTabs = Array.from(
+        document.getElementsByClassName('tabs__tab--selected')
+    );
 
-    [...selectedTabs].forEach(selectedTab => {
+    selectedTabs.forEach(selectedTab => {
         selectedTab.classList.remove('tabs__tab--selected');
     });
 

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -436,9 +436,9 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
 };
 
 const enhanceMenuToggles = (): void => {
-    const checkboxs: Array<HTMLInputElement> = ([
-        ...document.getElementsByClassName('js-enhance-checkbox'),
-    ]: Array<any>);
+    const checkboxs: Array<HTMLInputElement> = (Array.from(
+        document.getElementsByClassName('js-enhance-checkbox')
+    ): Array<any>);
 
     checkboxs.forEach(checkbox => {
         if (!enhanced[checkbox.id] && !checkbox.checked) {

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -12,9 +12,9 @@ class Search {
 
     constructor(): void {
         fastdom
-            .read(() => [
-                ...document.getElementsByClassName('js-search-toggle'),
-            ])
+            .read(() =>
+                Array.from(document.getElementsByClassName('js-search-toggle'))
+            )
             .then(toggles => {
                 const googleSearchSwitch = config.get('switches.googleSearch');
                 const googleSearchUrl = config.get('page.googleSearchUrl');
@@ -155,9 +155,9 @@ class Search {
 
         fastdom
             .read(() => ({
-                allSearchPlaceholders: [
-                    ...document.getElementsByClassName('js-search-placeholder'),
-                ],
+                allSearchPlaceholders: Array.from(
+                    document.getElementsByClassName('js-search-placeholder')
+                ),
                 searchPlaceholder: popup.getElementsByClassName(
                     'js-search-placeholder'
                 )[0],

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -8,8 +8,8 @@ const contentCN = 'dropdown__content';
 
 const updateAria = (container: Element): void => {
     const v: boolean = container.classList.contains('dropdown--active');
-    const content = [...container.getElementsByClassName(contentCN)];
-    const button = container.getElementsByClassName(buttonCN);
+    const content = Array.from(container.getElementsByClassName(contentCN));
+    const button = Array.from(container.getElementsByClassName(buttonCN));
     content.forEach((c: Element) => {
         c.setAttribute('aria-hidden', (!v).toString());
     });

--- a/static/src/javascripts/projects/common/modules/ui/full-height.js
+++ b/static/src/javascripts/projects/common/modules/ui/full-height.js
@@ -35,9 +35,9 @@ const getState = (): Promise<{
     isMobile: boolean,
 }> =>
     fastdom.read(() => {
-        const elements = [
-            ...document.getElementsByClassName('js-is-fixed-height'),
-        ];
+        const elements = Array.from(
+            document.getElementsByClassName('js-is-fixed-height')
+        );
 
         return { elements, isMobile: getBreakpoint() === 'mobile' };
     });


### PR DESCRIPTION
## What does this change?

The [spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) allows us to transform an iterable object into an array, so we can use array methods like `map` and `filter`.

However spread is being used to transform non-iterable objects, such as the [`HTMLCollection`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection) returned by `getElementsByClassName(...)` into an array. This fails with a TypeError in Safari 10:

> Invalid attempt to spread non-iterable instance

The problem has manifested since the upgrade to Babel 7 (#20883).

This change fixes the issue by using `Array.from(...)` instead of the spread syntax. [`Array.from(...)` works](https://javascript.info/rest-parameters-spread-operator#summary) on array-like objects such as `HTMLCollection`

## What is the value of this and can you measure success?

Fixes enhancement of the header in Safari 10, which is vital for accessibility. Fixes a whole bunch of other things that are probably currently broken.

