### PR TITLE
Set Podcast design test winner as default

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,8 +7,7 @@ import org.joda.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OrielParticipation,
-    OldTLSSupportDeprecation,
-    PodcastImage
+    OldTLSSupportDeprecation
   )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -28,13 +27,5 @@ object OldTLSSupportDeprecation extends Experiment(
   sellByDate = new LocalDate(2019, 1,15),
   // Custom group based on header set in Fastly
   participationGroup = TLSSupport
-)
-
-object PodcastImage extends Experiment(
-  name = "podcast-image",
-  description = "For the Fronts container for the Today in Focus podcast, show either the logo or a unique story photo",
-  owners = Owner.group(SwitchGroup.Journalism),
-  sellByDate = new LocalDate(2019, 1, 9),
-  participationGroup = Perc50
 )
 

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -8,7 +8,6 @@
 @import layout.SliceWithCards
 @import conf.audio.FlagshipFrontContainer
 @import conf.AudioFlagship
-@import experiments.{ActiveExperiments, PodcastImage}
 
 @(containerDefinition: layout.FaciaContainer, frontProperties: FrontProperties)(implicit request: RequestHeader)
 
@@ -59,27 +58,21 @@
                         <div class="fc-item--type-media">
                             <div class="fc-podcast-container__episode">
 
-                                @if(ActiveExperiments.isParticipating(PodcastImage)){
-                                    @card.displayElement match {
-                                        case Some(InlineImage(image)) => {
-                                            <div class="fc-podcast-container__episode-image-story">
-                                                @itemImage(
-                                                    image,
-                                                    inlineImage = true,
-                                                    widthsByBreakpoint = Some(card.squareImageWidthsByBreakpoint)
-                                                )
-                                            </div>
-                                        }
-                                        case _ => {
-                                            <div class="fc-podcast-container__episode-image-generic">
-                                                <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
-                                            </div>
-                                        }
+                                @card.displayElement match {
+                                    case Some(InlineImage(image)) => {
+                                        <div class="fc-podcast-container__episode-image-story">
+                                            @itemImage(
+                                                image,
+                                                inlineImage = true,
+                                                widthsByBreakpoint = Some(card.squareImageWidthsByBreakpoint)
+                                            )
+                                        </div>
                                     }
-                                } else{
-                                    <div class="fc-podcast-container__episode-image-generic">
-                                        <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
-                                    </div>
+                                    case _ => {
+                                        <div class="fc-podcast-container__episode-image-generic">
+                                            <img src="@FlagshipFrontContainer.AlbumArtUrl"/>
+                                        </div>
+                                    }
                                 }
 
                                 <div class="fc-podcast-container__episode-details">

--- a/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
@@ -93,8 +93,6 @@
     color: #ff6a56;
 }
 
-/* AB TEST WITH ACTUAL STORY IMAGE VS GENERIC */
-
 /* GENERIC IMAGE */
 .fc-podcast-container__episode-image-generic,
 .fc-podcast-container__episode-image-generic img {


### PR DESCRIPTION
## What does this change?
Removes an A/B test (https://github.com/guardian/frontend/pull/20820), leaving the winning variant the default view

## Screenshots
To follow

## What is the value of this and can you measure success?
Better engagement 🏁 ✅ 👏 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None of the above

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (but needs supporting data before it'll work, hence the Do Not Merge label)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
