### PR TITLE
Add reader revenue links to dotComponents data model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,7 +11,7 @@ import play.api.mvc.RequestHeader
 import views.support.{CamelCase, GUDateTimeFormat}
 import ai.x.play.json.Jsonx
 import common.Maps.RichMap
-import navigation.UrlHelpers.{Footer, Header, getReaderRevenueUrl}
+import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 
@@ -49,7 +49,8 @@ case class ReaderRevenueLink(
 
 case class ReaderRevenueLinks(
   header: ReaderRevenueLink,
-  footer: ReaderRevenueLink
+  footer: ReaderRevenueLink,
+  sideMenu: ReaderRevenueLink
 )
 
 case class PageData(
@@ -240,9 +241,16 @@ object DotcomponentsDataModel {
       getReaderRevenueUrl(Support, Footer)(request)
     )
 
+    val sideMenuReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+      getReaderRevenueUrl(SupportContribute, SideMenu)(request),
+      getReaderRevenueUrl(SupportSubscribe, SideMenu)(request),
+      getReaderRevenueUrl(Support, SideMenu)(request)
+    )
+
     val readerRevenueLinks = ReaderRevenueLinks(
       headerReaderRevenueLink,
-      footerReaderRevenueLink
+      footerReaderRevenueLink,
+      sideMenuReaderRevenueLink
     )
 
     val config = Config(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,6 +11,8 @@ import play.api.mvc.RequestHeader
 import views.support.{CamelCase, GUDateTimeFormat}
 import ai.x.play.json.Jsonx
 import common.Maps.RichMap
+import navigation.UrlHelpers.{Footer, Header, getReaderRevenueUrl}
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
@@ -37,6 +39,17 @@ case class Block(
 case class Blocks(
     main: Option[Block],
     body: List[Block]
+)
+
+case class ReaderRevenueLink(
+  contribute: String,
+  subscribe: String,
+  support: String
+)
+
+case class ReaderRevenueLinks(
+  header: ReaderRevenueLink,
+  footer: ReaderRevenueLink
 )
 
 case class PageData(
@@ -74,7 +87,8 @@ case class PageData(
 case class Config(
     isImmersive: Boolean,
     page: PageData,
-    nav: NavMenu
+    nav: NavMenu,
+    readerRevenueLinks: ReaderRevenueLinks
 )
 
 case class ContentFields(
@@ -110,6 +124,14 @@ object TagProperties {
 
 object Tag {
   implicit val writes = Json.writes[Tag]
+}
+
+object ReaderRevenueLink {
+  implicit val writes = Json.writes[ReaderRevenueLink]
+}
+
+object ReaderRevenueLinks {
+  implicit val writes = Json.writes[ReaderRevenueLinks]
 }
 
 object PageData {
@@ -206,10 +228,28 @@ object DotcomponentsDataModel {
 
     val navMenu = NavMenu(articlePage, Edition(request))
 
+    val headerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+      getReaderRevenueUrl(SupportContribute, Header)(request),
+      getReaderRevenueUrl(SupportSubscribe, Header)(request),
+      getReaderRevenueUrl(Support, Header)(request)
+    )
+
+    val footerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+      getReaderRevenueUrl(SupportContribute, Footer)(request),
+      getReaderRevenueUrl(SupportSubscribe, Footer)(request),
+      getReaderRevenueUrl(Support, Footer)(request)
+    )
+
+    val readerRevenueLinks = ReaderRevenueLinks(
+      headerReaderRevenueLink,
+      footerReaderRevenueLink
+    )
+
     val config = Config(
       article.isImmersive,
       pageData,
-      navMenu
+      navMenu,
+      readerRevenueLinks
     )
 
     DotcomponentsDataModel(


### PR DESCRIPTION
## What does this change?

This PR adds reader revenue links to the dotComponents data model passed from `frontend` to `dotcom-rendering`.

## Screenshots
![screen shot 2019-01-03 at 15 26 15](https://user-images.githubusercontent.com/1590704/50646444-f9e69180-0f6d-11e9-969b-36e3df491968.png)

## What is the value of this and can you measure success?

frontend has a handy helper function for constructing the `contribute`, `subscribe` and `support` reader revenue links that appear in both the `header` and `footer`. This helper adds various query string parameters to these URLs. Rather than duplicating the logic to build up these URLs in `dotcom-rendering` (and risking they become out of sync with frontend) we can now reuse this helper and get the correct reader revenue URLs from frontend to use in dotcom-rendering.
