### PR TITLE
Refactor ad slot logic

### DIFF
--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -16,7 +16,7 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   private def clean(document: Document): Document = {
     val children = document.body().children().asScala.toList
-    val adsAfterAndEnd = AmpAdCleaner.findElementsNeedingAdsAfter(children)
+    val adsAfterAndEnd = AmpAdCleaner.findAdSlots(children.toVector)
     adsAfterAndEnd.foreach(adAfter) // side effects =(
     document
   }
@@ -41,8 +41,8 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   "AmpAdCleaner" should "not have changed ad intervals without someone checking the tests are still valid" in {
     AmpAdCleaner.AD_LIMIT should be(8)
-    AmpAdCleaner.CHARS_BETWEEN_ADS should be(700)
-    AmpAdCleaner.DONT_INTERLEAVE_SMALL_PARA should be(50)
+    AmpAdCleaner.MIN_CHAR_BUFFER should be(700)
+    AmpAdCleaner.SMALL_PARA_CHARS should be(50)
 
   }
 


### PR DESCRIPTION
An attempt to tidy up the code to improve readability, mainly by:

* clearer naming
* documenting the logic
* using a simpler, imperative, approach

--

@philmcmahon @johnduffell I did this mainly as an exercise in understanding the behaviour here better, but what are your thoughts on merging it in? (Albeit the code will be short-lived as we'll re-implement ad behaviour for AMP in dotcomponents very soon.)

I did find the existing code a bit hard to understand - though probably just some comments would have helped a lot here!

Also note, the diff isn't that clear here - you probably want to view the versions separately.