### PR TITLE
Fix more iterables

### DIFF
--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -34,7 +34,7 @@ Promise.all([
     new Promise(comready),
 ]).then(() => {
     updateHeight();
-    [...document.getElementsByTagName('details')]
+    Array.from(document.getElementsByTagName('details'))
         .slice(0, 1)
         .forEach(details => {
             new MutationObserver(updateHeight).observe(details, {

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -21,7 +21,7 @@ import { enhanceUpsell } from 'common/modules/identity/upsell/upsell';
 
 const initFormstack = (): void => {
     const attr = 'data-formstack-id';
-    const forms = [...document.querySelectorAll(`[${attr}]`)];
+    const forms = Array.from(document.querySelectorAll(`[${attr}]`));
     const iframes = Array.from(
         document.getElementsByClassName('js-formstack-iframe')
     );

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -131,9 +131,9 @@ const initOnwardContent = () => {
             new OnwardContent(qwery('.js-onward'));
         } else if (config.get('page.tones', '') !== '') {
             fastdom
-                .read(() => document.querySelectorAll('.js-onward'))
+                .read(() => Array.from(document.querySelectorAll('.js-onward')))
                 .then(els => {
-                    [...els].forEach(c => {
+                    els.forEach(c => {
                         new TonalComponent().fetch(c, 'html');
                     });
                 });

--- a/static/src/javascripts/bootstraps/standard/atoms.js
+++ b/static/src/javascripts/bootstraps/standard/atoms.js
@@ -5,25 +5,25 @@ import { services } from 'projects/atoms/services';
 
 const bootstrapAtom = <A>(atomMaker: AtomMaker<A>, atomType: AtomType) => {
     const atomBuilder = atomMaker[atomType].default(services);
-    [...document.querySelectorAll(`[data-atom-type='${atomType}']`)].forEach(
-        atomDom => {
-            const atom = atomBuilder(atomDom).runTry();
-            if (typeof atom === 'string') {
-                // eslint-disable-next-line no-console
-                console.log(
-                    `Failed to initialise atom [${atomType}/${atomDom.getAttribute(
-                        'data-atom-id'
-                    ) || ''}]: ${atom}`
-                );
-            } else if ('requestIdleCallback' in window) {
-                requestIdleCallback(() => {
-                    atom.start();
-                });
-            } else {
+    Array.from(
+        document.querySelectorAll(`[data-atom-type='${atomType}']`)
+    ).forEach(atomDom => {
+        const atom = atomBuilder(atomDom).runTry();
+        if (typeof atom === 'string') {
+            // eslint-disable-next-line no-console
+            console.log(
+                `Failed to initialise atom [${atomType}/${atomDom.getAttribute(
+                    'data-atom-id'
+                ) || ''}]: ${atom}`
+            );
+        } else if ('requestIdleCallback' in window) {
+            requestIdleCallback(() => {
                 atom.start();
-            }
+            });
+        } else {
+            atom.start();
         }
-    );
+    });
 };
 
 const initAtoms = () => {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -85,16 +85,18 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
         // https://github.com/guardian/iframe-messenger
         if (data.type === 'enrich-acquisition-links' && data.id) {
             data.referrerData = addReferrerData({});
-            [...document.getElementsByTagName('iframe')].forEach(iframe => {
-                iframe.contentWindow.postMessage(
-                    JSON.stringify(data),
-                    'https://interactive.guim.co.uk'
-                );
-            });
+            Array.from(document.getElementsByTagName('iframe')).forEach(
+                iframe => {
+                    iframe.contentWindow.postMessage(
+                        JSON.stringify(data),
+                        'https://interactive.guim.co.uk'
+                    );
+                }
+            );
         }
 
         if (data.type === 'acquisition-data-request') {
-            [...document.getElementsByTagName('iframe')].forEach(el => {
+            Array.from(document.getElementsByTagName('iframe')).forEach(el => {
                 const iframeSrc = el.getAttribute('src');
                 if (iframeSrc && isCurrentCampaign(iframeSrc)) {
                     el.contentWindow.postMessage(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -94,10 +94,10 @@ const getTargets = (
     insertAtSelector: string,
     isMultiple: boolean
 ): Array<HTMLElement> => {
-    const els = document.querySelectorAll(insertAtSelector);
+    const els = Array.from(document.querySelectorAll(insertAtSelector));
 
     if (isMultiple) {
-        return [...els];
+        return els;
     } else if (els.length) {
         return [els[0]];
     }

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -28,13 +28,13 @@ const getTemplate = (
 
 const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
     fastdom
-        .read(() => context.querySelectorAll(`[${ATTRIBUTE_NAME}]`))
+        .read(() => Array.from(context.querySelectorAll(`[${ATTRIBUTE_NAME}]`)))
         .then(elements => {
             if (elements.length === 0) {
                 return;
             }
 
-            return [...elements].reduce(
+            return elements.reduce(
                 (groupedVals: Object, el: HTMLElement): Object => {
                     const attrVal = el.getAttribute(ATTRIBUTE_NAME);
 

--- a/static/src/javascripts/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/account-profile.js
@@ -229,11 +229,11 @@ class AccountProfile {
      */
     bindInputs(form: ?HTMLElement) {
         if (form instanceof HTMLFormElement) {
-            const inputs: Array<HTMLInputElement> = ([
-                ...form.querySelectorAll(classes.textInput),
-            ]: Array<any>);
+            const inputs: Array<HTMLInputElement> = (Array.from(
+                form.querySelectorAll(classes.textInput)
+            ): Array<any>);
             inputs
-                .concat([...form.querySelectorAll('select')])
+                .concat(Array.from(form.querySelectorAll('select')))
                 .forEach(input => {
                     if (input.type === 'select-one') {
                         input.addEventListener('change', event =>

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -118,7 +118,7 @@ class AdPrefsWrapper extends Component<
 
 const enhanceAdPrefs = (): void => {
     fastdom
-        .read(() => [...document.querySelectorAll(rootSelector)])
+        .read(() => Array.from(document.querySelectorAll(rootSelector)))
         .then((wrapperEls: HTMLElement[]) => {
             wrapperEls.forEach(_ => {
                 fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -41,7 +41,7 @@ const buildConsentUpdatePayload = (
     fields: NodeList<any> = new NodeList()
 ): SettableConsent => {
     const consent = {};
-    [...fields].forEach((field: HTMLInputElement) => {
+    Array.from(fields).forEach((field: HTMLInputElement) => {
         switch (field.type) {
             case 'checkbox':
                 consent.consented = field.checked;

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -72,11 +72,13 @@ const unsubscribeFromAll = (buttonEl: HTMLButtonElement): Promise<void> => {
 
 const toggleInputsWithSelector = (className: string, checked: boolean) =>
     fastdom
-        .read(() => [
-            ...document.querySelectorAll(
-                `.${className} input[type="checkbox"]`
-            ),
-        ])
+        .read(() =>
+            Array.from(
+                document.querySelectorAll(
+                    `.${className} input[type="checkbox"]`
+                )
+            )
+        )
         .then(boxes =>
             boxes.forEach(b => {
                 b.checked = checked;
@@ -218,11 +220,11 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
                 fastdom.read(() => {
                     const nearestWrapperEl = labelEl.closest(selector);
                     if (!nearestWrapperEl) throw new Error(ERR_MALFORMED_HTML);
-                    return [
-                        ...nearestWrapperEl.querySelectorAll(
+                    return Array.from(
+                        nearestWrapperEl.querySelectorAll(
                             'input[type=checkbox]'
-                        ),
-                    ].filter(
+                        )
+                    ).filter(
                         $checkbox =>
                             $checkbox.closest(
                                 `.${checkAllCheckboxClassName}`

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
@@ -158,9 +158,9 @@ class FormstackEmbedIframe {
         // loop their selectors and add our own classes instead
         this.form.classList.add(this.config.idClasses.form);
 
-        const links = this.el.getElementsByTagName('link');
+        const links = Array.from(this.el.getElementsByTagName('link'));
 
-        [...links].forEach(link => {
+        links.forEach(link => {
             link.remove();
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
@@ -166,10 +166,10 @@ class FormstackEmbedIframe {
 
         Object.keys(this.config.fsSelectors).forEach(key => {
             const selector = this.config.fsSelectors[key];
-            const elems = this.form.querySelectorAll(selector);
+            const elems = Array.from(this.form.querySelectorAll(selector));
             const classNames = this.config.idClasses[key].split(' ');
 
-            [...elems].forEach(elem => {
+            elems.forEach(elem => {
                 classNames.forEach(className => {
                     elem.classList.add(className);
                 });
@@ -285,11 +285,11 @@ class FormstackEmbedIframe {
             });
 
             // Update character count absolute positions
-            const textAreas = this.el.querySelectorAll(
-                this.config.fsSelectors.textArea
+            const textAreas = Array.from(
+                this.el.querySelectorAll(this.config.fsSelectors.textArea)
             );
 
-            [...textAreas].forEach(textArea => {
+            textAreas.forEach(textArea => {
                 triggerKeyUp(textArea);
             });
 

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -112,10 +112,10 @@ class Formstack {
 
         Object.keys(this.config.fsSelectors).forEach(key => {
             const selector = this.config.fsSelectors[key];
-            const elems = this.form.querySelectorAll(selector);
+            const elems = Array.from(this.form.querySelectorAll(selector));
             const classNames = this.config.idClasses[key].split(' ');
 
-            [...elems].forEach(elem => {
+            elems.forEach(elem => {
                 classNames.forEach(className => {
                     elem.classList.add(className);
                 });

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -104,9 +104,9 @@ class Formstack {
         // loop their selectors and add our own classes instead
         this.form.classList.add(this.config.idClasses.form);
 
-        const links = this.el.getElementsByTagName('link');
+        const links = Array.from(this.el.getElementsByTagName('link'));
 
-        [...links].forEach(link => {
+        links.forEach(link => {
             link.remove();
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -215,11 +215,11 @@ class Formstack {
             });
 
             // Update character count absolute positions
-            const textAreas = this.el.querySelectorAll(
-                this.config.fsSelectors.textArea
+            const textAreas = Array.from(
+                this.el.querySelectorAll(this.config.fsSelectors.textArea)
             );
 
-            [...textAreas].forEach(textArea => {
+            textAreas.forEach(textArea => {
                 triggerKeyUp(textArea);
             });
 

--- a/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
@@ -10,7 +10,7 @@ const loadEnhancers = (loaders: Array<Array<any>>): void => {
         if (typeof classname !== 'string') throw new Error('Invalid classname');
         if (typeof action !== 'function') throw new Error('Invalid action');
         return fastdom
-            .read(() => [...document.querySelectorAll(classname)])
+            .read(() => Array.from(document.querySelectorAll(classname)))
             .then(elements =>
                 elements.forEach((element: HTMLElement) => {
                     robust.catchAndLogError(classname, () => {

--- a/static/src/javascripts/projects/common/modules/identity/modules/modal.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/modal.js
@@ -6,7 +6,9 @@ const ERR_MODAL_MALFORMED = 'Modal is malformed';
 
 const bindCloserOnce = (modalEl: HTMLElement): Promise<void[]> =>
     fastdom
-        .read(() => [...modalEl.querySelectorAll('.js-identity-modal__closer')])
+        .read(() =>
+            Array.from(modalEl.querySelectorAll('.js-identity-modal__closer'))
+        )
         .then(buttonEls =>
             buttonEls
                 .filter(buttonEl => !buttonEl.dataset.closeIsBound)

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -27,7 +27,7 @@ const getMenu = (): ?HTMLElement =>
     document.getElementsByClassName('js-main-menu')[0];
 
 const getSectionToggleMenuItem = (section: HTMLElement): ?HTMLElement => {
-    const children = [...section.children];
+    const children = Array.from(section.children);
     return children.find(child => child.classList.contains('menu-item__title'));
 };
 

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -40,7 +40,9 @@ const closeMenuSection = (section: HTMLElement): void => {
 };
 
 const closeAllMenuSections = (exclude?: Node): void => {
-    const sections = [...document.querySelectorAll('.js-navigation-item')];
+    const sections = Array.from(
+        document.querySelectorAll('.js-navigation-item')
+    );
 
     sections.forEach(section => {
         if (section !== exclude) {
@@ -112,7 +114,9 @@ const toggleMenu = (): void => {
     }
 
     const resetItemOrder = (): void => {
-        const items = [...document.querySelectorAll('.js-navigation-item')];
+        const items = Array.from(
+            document.querySelectorAll('.js-navigation-item')
+        );
 
         items.forEach(item => {
             const listItem = item;
@@ -579,9 +583,9 @@ const addEventHandler = (): void => {
 const bindCredentialsApiSignIn = (): void => {
     fastdom
         .read(() => ({
-            signInLinks: [
-                ...document.querySelectorAll('.js-navigation-sign-in'),
-            ],
+            signInLinks: Array.from(
+                document.querySelectorAll('.js-navigation-sign-in')
+            ),
         }))
         .then(({ signInLinks }) => {
             signInLinks.forEach(signInLink => {

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -31,13 +31,15 @@ const showMyAccountIfNecessary = (): void => {
 
     fastdom
         .read(() => ({
-            signIns: [...document.querySelectorAll('.js-navigation-sign-in')],
-            accountActionsLists: [
-                ...document.querySelectorAll('.js-navigation-account-actions'),
-            ],
-            commentItems: [
-                ...document.querySelectorAll('.js-show-comment-activity'),
-            ],
+            signIns: Array.from(
+                document.querySelectorAll('.js-navigation-sign-in')
+            ),
+            accountActionsLists: Array.from(
+                document.querySelectorAll('.js-navigation-account-actions')
+            ),
+            commentItems: Array.from(
+                document.querySelectorAll('.js-show-comment-activity')
+            ),
             accountTrigger: document.querySelector('.js-user-account-trigger'),
         }))
         .then(els => {

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -135,7 +135,7 @@ const related = (opts: Object): void => {
                 });
         }
     } else {
-        [...document.querySelectorAll('.js-related')].forEach(el =>
+        Array.from(document.querySelectorAll('.js-related')).forEach(el =>
             el.classList.add('u-h')
         );
     }

--- a/static/src/javascripts/projects/common/modules/social/pinterest.js
+++ b/static/src/javascripts/projects/common/modules/social/pinterest.js
@@ -8,9 +8,9 @@ const launchOverlay = (event: Event): void => {
 
     const scriptUrl = 'https://assets.pinterest.com/js/pinmarklet.js';
     const cachePurge = new Date().getTime();
-    const images = [
-        ...document.querySelectorAll('img:not(.gu-image):not(.responsive-img)'),
-    ];
+    const images = Array.from(
+        document.querySelectorAll('img:not(.gu-image):not(.responsive-img)')
+    );
 
     fastdom.write(() => {
         images.forEach(img => {
@@ -22,7 +22,9 @@ const launchOverlay = (event: Event): void => {
 };
 
 const initPinterest = (): void => {
-    const buttons = [...document.querySelectorAll('.social__item--pinterest')];
+    const buttons = Array.from(
+        document.querySelectorAll('.social__item--pinterest')
+    );
 
     fastdom.write(() => {
         buttons.forEach(el => {

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -140,9 +140,9 @@ const onInteractivesLoaded = memoize((rules: SpacefinderRules): Promise<
         rules.body
     ).filter(
         (interactive: Element): boolean => {
-            const iframe: HTMLIFrameElement[] = ([
-                ...interactive.children,
-            ].filter(isIframe): any[]);
+            const iframe: HTMLIFrameElement[] = (Array.from(
+                interactive.children
+            ).filter(isIframe): any[]);
             return !(iframe.length && isIframeLoaded(iframe[0]));
         }
     );

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -94,7 +94,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
 
         fastdom.write(() => {
             bonzo(resultHtml.children).addClass('autoupdate--hidden');
-            elementsToAdd = [...resultHtml.children];
+            elementsToAdd = Array.from(resultHtml.children);
 
             // Insert new blocks
             $liveblogBody.prepend(elementsToAdd);

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -67,15 +67,15 @@ const makeHtml = (): string => `
         .join('')}
     </div>
     <div class="site-message--first-pv-consent__actions">
-        <button 
-            data-link-name="first-pv-consent : agree" 
+        <button
+            data-link-name="first-pv-consent : agree"
             class="site-message--first-pv-consent__button site-message--first-pv-consent__button--main ${
                 bindableClassNames.agree
             }"
         >${checkIcon.markup}<span>${template.agreeButton}</span></button>
-        <a 
-            href="${template.linkToPreferences}" 
-            data-link-name="first-pv-consent : to-prefs" 
+        <a
+            href="${template.linkToPreferences}"
+            data-link-name="first-pv-consent : to-prefs"
             class="site-message--first-pv-consent__link u-underline"
         >${template.choicesButton}</a>
     </div>
@@ -116,11 +116,11 @@ const track = (): void => {
 };
 
 const bindClickHandlers = (msg: Message): void => {
-    [...document.querySelectorAll(`.${bindableClassNames.agree}`)].forEach(
-        agreeButtonEl => {
-            agreeButtonEl.addEventListener('click', () => onAgree(msg));
-        }
-    );
+    Array.from(
+        document.querySelectorAll(`.${bindableClassNames.agree}`)
+    ).forEach(agreeButtonEl => {
+        agreeButtonEl.addEventListener('click', () => onAgree(msg));
+    });
 };
 
 const show = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/ui/tabs.js
+++ b/static/src/javascripts/projects/common/modules/ui/tabs.js
@@ -42,7 +42,7 @@ const showPane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
 
 const init = (): Promise<void> => {
     const findTabs = (): Promise<Array<HTMLElement>> =>
-        fastdom.read(() => [...document.querySelectorAll('.tabs')]);
+        fastdom.read(() => Array.from(document.querySelectorAll('.tabs')));
 
     return findTabs().then(tabs => {
         tabs.forEach(tab => {

--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -7,10 +7,12 @@ class Toggles {
 
     constructor(component: ?HTMLElement = document.body): void {
         if (component) {
-            const controls = component.querySelectorAll('[data-toggle]');
+            const controls = Array.from(
+                component.querySelectorAll('[data-toggle]')
+            );
 
             this.component = component;
-            this.controls = [...controls];
+            this.controls = controls;
 
             mediator.on('module:clickstream:click', clickSpec => {
                 this.reset(clickSpec ? clickSpec.target : null);

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -77,19 +77,19 @@ const reducers = {
                     max: 'desktop',
                 })
             ) {
-                const youTubeIframes = [
-                    ...state.container.querySelectorAll(
+                const youTubeIframes = Array.from(
+                    state.container.querySelectorAll(
                         '.youtube-media-atom iframe'
-                    ),
-                ];
+                    )
+                );
                 youTubeIframes.forEach(el => {
                     el.remove();
                 });
-                const overlayLinks = [
-                    ...state.container.querySelectorAll(
+                const overlayLinks = Array.from(
+                    state.container.querySelectorAll(
                         '.video-container-overlay-link'
-                    ),
-                ];
+                    )
+                );
                 overlayLinks.forEach(el => {
                     el.classList.add('u-faux-block-link__overlay');
                     // make visible to screen readers / keyboard users
@@ -97,9 +97,9 @@ const reducers = {
                     el.removeAttribute('aria-hidden');
                 });
 
-                const atomWrapper = [
-                    ...state.container.querySelectorAll('.youtube-media-atom'),
-                ];
+                const atomWrapper = Array.from(
+                    state.container.querySelectorAll('.youtube-media-atom')
+                );
                 atomWrapper.forEach(el => {
                     el.classList.add('no-player');
                 });

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -207,11 +207,13 @@ const initInlinedSnap = (el: HTMLElement): void => {
 
 const init = (): void => {
     // First, init any existing inlined embeds already on the page.
-    const inlinedSnaps = [...document.querySelectorAll('.facia-snap-embed')];
+    const inlinedSnaps = Array.from(
+        document.querySelectorAll('.facia-snap-embed')
+    );
     inlinedSnaps.forEach(initInlinedSnap);
 
     // Second, init non-inlined embeds.
-    const snaps = [...document.querySelectorAll('.js-snappable.js-snap')]
+    const snaps = Array.from(document.querySelectorAll('.js-snappable.js-snap'))
         .filter(el => {
             const isInlinedSnap = $(el).hasClass('facia-snap-embed');
             const snapType = el.getAttribute('data-snap-type');


### PR DESCRIPTION
## What does this change?

#20887 caught a number of instances in which were trying to spread a non-iterable object. However, what is and isn't iterable depends on the browser. For instance on Chrome 49, `NodeList` isn't iterable (in later versions, it is).

This change uses the more permissive `Array.from()`, instead of the array spread operator, whenever we use a DOM API method.

## What is the value of this and can you measure success?

Less breaking things on older browsers

