### PR TITLE
Fix story package boolean

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -218,7 +218,7 @@ object DotcomponentsDataModel {
       Configuration.site.host,
       article.metadata.webUrl,
       article.content.shouldHideAdverts,
-      hasStoryPackage = article.content.hasStoryPackage,
+      hasStoryPackage = articlePage.related.hasStoryPackage,
       hasRelated = article.content.showInRelated,
     )
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -64,7 +64,6 @@ final case class Content(
   javascriptReferences: Seq[JsObject],
   wordCount: Int,
   showByline: Boolean,
-  hasStoryPackage: Boolean,
   rawOpenGraphImage: Option[ImageAsset]
 ) {
 
@@ -249,7 +248,6 @@ final case class Content(
     ("contentId", JsString(metadata.id)),
     ("publication", JsString(publication)),
     ("hasShowcaseMainElement", JsBoolean(elements.hasShowcaseMainElement)),
-    ("hasStoryPackage", JsBoolean(hasStoryPackage)),
     ("pageCode", JsString(internalPageCode)),
     ("isContent", JsBoolean(true)),
     ("wordCount", JsNumber(wordCount)),
@@ -353,8 +351,6 @@ final case class Content(
   val quizzes: Seq[Quiz] = atoms.map(_.quizzes).getOrElse(Nil)
   val media: Seq[MediaAtom] = atoms.map(_.media).getOrElse(Nil)
 
-  val nonCompliantOutbrainAmp: Boolean = (hasStoryPackage && tags.series.nonEmpty) || (tags.series.length > 1)
-
   lazy val submetaLinks: SubMetaLinks =
     SubMetaLinks.make(isImmersive, tags, blogOrSeriesTag, isFromTheObserver, sectionLabelLink, sectionLabelName)
 }
@@ -417,7 +413,6 @@ object Content {
       javascriptReferences = apiContent.references.map(ref => Reference.toJavaScript(ref.id)),
       wordCount = Jsoup.clean(fields.body, Whitelist.none()).split("\\s+").length,
       showByline = fapiutils.ResolvedMetaData.fromContentAndTrailMetaData(apiContent, TrailMetaData.empty, cardStyle).showByline,
-      hasStoryPackage = apifields.flatMap(_.hasStoryPackage).getOrElse(false),
       rawOpenGraphImage =
         FacebookShareUseTrailPicFirstSwitch.isSwitchedOn
           .toOption(trail.trailPicture.flatMap(_.largestImage))

--- a/common/app/views/fragments/amp/onwardJourneys.scala.html
+++ b/common/app/views/fragments/amp/onwardJourneys.scala.html
@@ -17,7 +17,7 @@
     }
 
     @if(!content.shouldHideAdverts) {
-        @fragments.amp.outbrain(page, nonCompliant = content.nonCompliantOutbrainAmp)
+        @fragments.amp.outbrain(page, nonCompliant = content.tags.series.length > 1) // TODO  this logic is probably wrong
     }
 
     @defining({


### PR DESCRIPTION
It turns out that the hasStoryPackage property on content is unrelated to the newer concept of 'packages' and is always set to 'false' :( .

For original context on this field see: https://github.com/guardian/frontend/pull/20886