### PR TITLE
Fixes for IE 10 and 11 layout issues, minor sass-lint rule change

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -38,6 +38,7 @@ rules:
         - background
         - display
         - color
+        - left
   no-empty-rulesets: 0
   no-invalid-hex: 1
   no-mergeable-selectors: 0

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -226,6 +226,7 @@ $avatarPadding: $gs-gutter / 2;
 
 .discussion__ad-wrapper {
     .discussion__ad-slot {
+        width: $mpu-original-width;
         position: absolute;
         top: 10px;
         right: -1 * (gs-span(4) + $gs-gutter);

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -32,6 +32,8 @@
             }
 
             @include mq(desktop) {
+                // IE 10 and 11 do not recognize 'unset' so will fallback to 'auto' which luckily gives us the desired layout
+                left: auto;
                 left: unset;
                 right: $gs-column-width + 10;
                 width: $gs-column-width * 3 + 40;


### PR DESCRIPTION
## What does this change?

#### 👉 Fix for comments ad being pushed to the right in IE

The ad shifts to the right when scrolling down on comments in internet explorer, this is related to it becoming 'sticky' and how the position settings on the wrapper change.

The fix for this is to set a width on the wrapper, since it seems IE is being finicky and otherwise pushing any `absolute` positioned elements without a width too far over. Other browsers seem to happily be calculating the width based on the child elements (the ad-slot) of the ad-slot-wapper, but not IE. 😠

#### 👉 Fix for Hosted caption layout issue

This PR allows IE to fallback to a valid CSS setting since IE 10 and 11 do not currently recognise 'unset':

<img width="650" alt="screen shot 2019-01-03 at 15 07 31" src="https://user-images.githubusercontent.com/8607683/50654415-b0ee0780-0f84-11e9-8424-3914f5e3cf79.png">

#### 👉 Update sass-lint settings to allow left property to be duplicated

This allows `left` to be duplicated within a block so long as the duplicates are next to one another. We can then lean on the cascade to let browsers use a fallback when facing css they do not understand.

## What is the value of this and can you measure success?

##### BEFORE:

![image](https://user-images.githubusercontent.com/8607683/50655516-59ea3180-0f88-11e9-9182-3b4f70efc2f8.png)

❌ Above: comments slot sticky offset right going wild
❌ Below: caption text for the image is overlaying the submeta icons

<img width="700" alt="screen shot 2019-01-03 at 15 01 41" src="https://user-images.githubusercontent.com/8607683/50654489-edb9fe80-0f84-11e9-82c8-b19858cd7a46.png">

##### AFTER: 

![image](https://user-images.githubusercontent.com/8607683/50655537-68d0e400-0f88-11e9-96ac-fa8a5a3ed5d9.png)

✅ Above: intended position of the comments slot 
✅ Below: intended position of the caption text

<img width="700" alt="screen shot 2019-01-03 at 15 26 41" src="https://user-images.githubusercontent.com/8607683/50654605-4b4e4b00-0f85-11e9-97a2-0d40f56b0551.png">

The picture above was taken in Chrome. Since Chrome recognises 'unset' this overrides the 'auto'. However, IE will not recognise 'unset' as valid CSS so respects the 'auto' instead... Hooray for cascading style sheets! 


## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Affects Hosted pages @guardian/commercial-dev 

### Does this change break ad-free?

Nope

### Tested

- [ ] Locally
- [x] On CODE
