### PR TITLE
Fix key bindings for gallery lightbox

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -68,7 +68,6 @@ class GalleryLightbox {
     closeBtn: HTMLElement;
     infoBtn: HTMLElement;
     $swipeContainer: bonzo;
-    handleKeyEvents: Function;
     resize: Function;
     toggleInfo: Function;
     fsm: FiniteStateMachine;
@@ -422,8 +421,10 @@ class GalleryLightbox {
         this.bodyScrollPosition = $body.scrollTop();
         $body.addClass('has-overlay');
         this.$lightboxEl.addClass('gallery-lightbox--open');
-        bean.off(document.body, 'keydown', this.handleKeyEvents); // prevent double binding
-        bean.on(document.body, 'keydown', this.handleKeyEvents);
+        bean.off(document.body, 'keydown', event =>
+            this.handleKeyEvents(event)
+        ); // prevent double binding
+        bean.on(document.body, 'keydown', event => this.handleKeyEvents(event));
     }
 
     close(): void {


### PR DESCRIPTION
## What does this change?

The key bindings were broken in #20883. Here they are fixed by wrapping the event binding in an arrow function to preserve context.

## What is the value of this and can you measure success?

Accessibility 🌐 

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
