### PR TITLE
Decommission 'US midterms 2018' and reinstate 'US Politics'

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -14,7 +14,7 @@ object NavLinks {
   val indigenousAustralia = NavLink("Indigenous Australia", "/australia-news/indigenous-australians")
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = "US news")
-  val usPolitics = NavLink("US midterms 2018", "/us-news/us-midterm-elections-2018", longTitle = "US politics")
+  val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = "US politics")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")


### PR DESCRIPTION
## What does this change?

As per CP's request:

Replace the link in the US front called 'US midterms 2018'. Now says US Politics and link to /us-news/us-politics
