### PR TITLE
Remove Snyk badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Known Vulnerabilities](https://snyk.io/test/github/guardian/frontend/badge.svg)](https://snyk.io/test/github/guardian/frontend)
-
 ## We're hiring!
 Ever thought about joining us?
 https://workforus.theguardian.com/careers/digital-development/


### PR DESCRIPTION
## What does this change?

Removes the Snyk badge from the repo.

## What is the value of this and can you measure success?

The Snyk badge is great for letting the devs know they need to fix security vulnerabilities.

Also a great way to let malicious actors know about security vulnerabilities on our website. It's a public repo, so this information is still discoverable, but there's no need for us to be broadcasting potential attack vectors to all and sundry.