### PR TITLE
Increase audience to 50% on mobile ads AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "increase ads on mobile web",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 1, 9),
+    sellByDate = new LocalDate(2019, 1, 18),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "increase ads on mobile web",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 1, 18),
+    sellByDate = new LocalDate(2019, 1, 22),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
@@ -3,7 +3,7 @@
 export const commercialAdMobileWebIncrease: ABTest = {
     id: 'CommercialAdMobileWebIncrease',
     start: '2018-11-16',
-    expiry: '2019-01-18',
+    expiry: '2019-01-22',
     author: 'Francesca Hammond',
     description: 'This test will increase ads on mobile web',
     audience: 0.5,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-mobile-web-increase.js
@@ -3,10 +3,10 @@
 export const commercialAdMobileWebIncrease: ABTest = {
     id: 'CommercialAdMobileWebIncrease',
     start: '2018-11-16',
-    expiry: '2019-01-09',
+    expiry: '2019-01-18',
     author: 'Francesca Hammond',
     description: 'This test will increase ads on mobile web',
-    audience: 0.1,
+    audience: 0.5,
     audienceOffset: 0.02,
     successMeasure: 'More ads on mobile web compared to AMP',
     audienceCriteria: 'n/a',


### PR DESCRIPTION
## What does this change?
Increases the audience of the AB test to 50% for a week, to enable a larger set of data to see the difference in uplift of ADs on mobile article pages.

## What is the value of this and can you measure success?
If there is a significant increase, then more ad impressions and more money.

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
