### PR TITLE
Remove height parameter from video images

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -3,7 +3,7 @@
 
 @import model.EndSlateComponents
 @import model.{VideoPlayer}
-@import views.support.Video640
+@import views.support.Item640
 @import views.{MainCleaner}
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
@@ -20,7 +20,7 @@
                         @defining(
                             VideoPlayer(
                                 video,
-                                Video640,
+                                Item640,
                                 article.trail.headline,
                                 autoPlay = false,
                                 showControlsAtStart = true,

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -3,7 +3,7 @@
 
 @import model.EndSlateComponents
 @import model.{VideoPlayer}
-@import views.support.Item640
+@import views.support.Video640
 @import views.{MainCleaner}
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
@@ -20,7 +20,7 @@
                         @defining(
                             VideoPlayer(
                                 video,
-                                Item640,
+                                Video640,
                                 article.trail.headline,
                                 autoPlay = false,
                                 showControlsAtStart = true,

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -405,7 +405,7 @@ import collection.JavaConverters._
 
         And("video meta thumbnailUrl should be set")
         $("[itemprop='associatedMedia video'] [itemprop=thumbnailUrl]").attribute("content") should
-          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?width=640&height=360&quality=85&auto=format&fit=max&s=")
+          include("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?width=640&quality=85&auto=format&fit=max&s=")
 
         And("video meta uploadDate should be set")
         $("[itemprop='associatedMedia video'] [itemprop=uploadDate]").attribute("content") should be("2014-05-16T16:09:34.000+01:00")

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -27,13 +27,12 @@ case class VideoPlayer(
 ) {
   def poster: String = profile.bestSrcFor(video.images).getOrElse(Static("images/media-holding.jpg"))
 
-  /** Width and height are always defined for video profile, so this is OK. */
+  /** Width is always defined for video profile, so this is OK. */
   def width: Int = profile.width.get
-  def height: Int = profile.width.get
 
   def showEndSlate: Boolean = width >= Video640.width.get
 
-  def isRatioHd: Boolean = overrideIsRatioHd getOrElse profile.isRatioHD
+  def isRatioHd: Boolean = overrideIsRatioHd getOrElse true
 
   def blockVideoAds: Boolean = video.videos.blockVideoAds
 }

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -79,15 +79,11 @@ object VideoProfile {
 
 case class VideoProfile(
   override val width: Some[Int],
-  override val height: Some[Int],
+  override val height: Option[Int] = None,
   override val hidpi: Boolean = false,
   override val compression: Int = 95,
   override val isPng: Boolean = false,
   override val autoFormat: Boolean = true) extends ElementProfile {
-
-  lazy val isRatioHD: Boolean = Precision.compareTo(VideoProfile.ratioHD.doubleValue, aspectRatio.doubleValue, 0.1d) == 0
-
-  private lazy val aspectRatio: Fraction = new Fraction(width.get, height.get)
 }
 
 case class SrcSet(src: String, width: Int) {
@@ -115,9 +111,9 @@ object Item620 extends ImageProfile(width = Some(620))
 object Item640 extends ImageProfile(width = Some(640))
 object Item700 extends ImageProfile(width = Some(700))
 object Item1200 extends ImageProfile(width = Some(1200))
-object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
-object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
-object Video1280 extends VideoProfile(width = Some(1280), height = Some(720)) // 16:9
+object Video640 extends VideoProfile(width = Some(640))
+object Video700 extends VideoProfile(width = Some(700))
+object Video1280 extends VideoProfile(width = Some(1280))
 object GoogleStructuredData extends ImageProfile(width = Some(300), height = Some(300)) // 1:1
 
 class ShareImage(overlayUrlParam: String, shouldIncludeOverlay: Boolean) extends ImageProfile(width = Some(1200)) {


### PR DESCRIPTION
## What does this change?
This gets rid of the enforced 16:9 aspect ratio for video images, which currently causes images to be squashed in articles such as [this one](https://www.theguardian.com/football/2019/jan/02/chelsea-christian-pulisic-borussia-dortmund). 

I don't know why this was enforced in the first place, but it seems unnecessary - it only changes images by around 5% so there's no reason to do this in fastly - we can allow the template to control it. 

## Screenshots
Before (squashed):
![screen shot 2019-01-08 at 17 17 48](https://user-images.githubusercontent.com/3606555/50847679-19186100-136a-11e9-942e-1ef38557a8a8.png)

After (cropped but not squashed):
![screen shot 2019-01-08 at 17 17 41](https://user-images.githubusercontent.com/3606555/50847668-1453ad00-136a-11e9-8c5a-5381c24c35be.png)

## What is the value of this and can you measure success?

Happy editors that their images aren't getting mangled. The downside is that it will decache all of our video images...I think this is maybe ok as they are a fairly small subset of all images on the site, and Fastly charges us for an image regardless whether it's cached or not.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE --> 
(I checked this - seems ok)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
