### PR TITLE
Stop pretty-printing JSON

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -298,7 +298,7 @@ object DotcomponentsDataModel {
 
 
   def toJsonString(model: DotcomponentsDataModel): String = {
-    Json.prettyPrint(toJson(model))
+    Json.stringify(toJson(model))
   }
 
 }


### PR DESCRIPTION
Pretty printing significantly increases the size of the JSON (up to double in my non-scientific tests).

What's more, JSON parsing is the largest time sink in dotcom-rendering. So anything we can do to reduce the JSON body size is worth doing.

In my own performance tests, with 80 req/sec against a t3.medium for dotcom-rendering I see an improvement in mean latency from 3s to 400ms. (Being aware, mean latency is a poor indicator - but similar improvements are seen across the upper percentiles.)

![screenshot 2019-01-07 at 17 48 40](https://user-images.githubusercontent.com/858402/50849288-757d7f80-136e-11e9-8c0f-f445bc332481.png)


## What does this change?

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
