### PR TITLE
Add AMP specific tracking to "Support us" button in AMP header

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -22,7 +22,8 @@ object UrlHelpers {
 
   def getComponentId(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): Option[String] = {
     condOpt((destination, position)) {
-      case (Support, Header | AmpHeader | SlimHeaderDropdown) => "header_support"
+      case (Support, Header | SlimHeaderDropdown) => "header_support"
+      case (Support, AmpHeader) => "amp_header_support"
       case (Support, SideMenu) => "side_menu_support"
       case (Support, Footer) => "footer_support"
 
@@ -38,7 +39,7 @@ object UrlHelpers {
     }
   }   
 
-  def readerRevenueLinks(implicit request: RequestHeader) = List(
+  def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] = List(
     NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
     NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe"))
   )

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -2,7 +2,7 @@
 
 @import common.{Edition, LinkTo}
 @import navigation.NavMenu
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Header}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, AmpHeader}
 @import navigation.ReaderRevenueSite.Support
 
 <header class="header"
@@ -13,7 +13,7 @@
             @defining(Edition(request).id.toLowerCase()) { editionId =>
                 <a class="cta-bar__cta js-acquisition-link"
                 data-link-name="amp : nav : supporter-cta"
-                href="@getReaderRevenueUrl(Support, Header)">
+                href="@getReaderRevenueUrl(Support, AmpHeader)">
                     Support us
                     @fragments.inlineSvg("arrow-right", "icon")
                 </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -51,7 +51,7 @@
                     <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
                         data-link-name="nav2 : subscribe-cta"
                         data-edition="@{editionId}"
-                        href="@getReaderRevenueUrl(SupportSubscribe,Header)">
+                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
                         Subscribe
                         @fragments.inlineSvg("arrow-right", "icon")
                     </a>

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -1,0 +1,18 @@
+package navigation.helpers
+
+import org.scalatest.{FlatSpec, Matchers}
+import test.TestRequest
+import navigation.ReaderRevenueSite.Support
+import navigation.UrlHelpers
+import navigation.UrlHelpers.{Header, AmpHeader}
+
+class UrlHelpersTest extends FlatSpec with Matchers {
+
+  "getComponentId when called with Support, Header" should "return header_support" in {
+    UrlHelpers.getComponentId(Support, Header)(TestRequest()) should be(Some("header_support"))
+  }
+
+  "getComponentId when called with Support, AmpHeader" should "return amp_header_support" in {
+    UrlHelpers.getComponentId(Support, AmpHeader)(TestRequest()) should be(Some("amp_header_support"))
+  }
+}


### PR DESCRIPTION
## What does this change?
* Update `getComponentId` to return `"amp_header_support"` for the `AmpHeader` position, it currently returns a broader `"header_support"`.
* Update the AMP `header.scala.html` to use `AmpHeader` position.

## Screenshots
<img width="687" alt="screen shot 2019-01-11 at 12 34 41" src="https://user-images.githubusercontent.com/249676/51034154-a5f73080-159d-11e9-8c43-08448e966e12.png">

## What is the value of this and can you measure success?
This change allows us to measure how many users contribute via the AMP header "Support us" button, helping the Subscribe with Google team make a decision on where to implement Subscribe with Google first.

This data can be seen in Tableau, AV by component Id: https://tableau.ophan.co.uk/views/TheAcquisitionsDimensionSlicer/AVbycomponentId

## Checklist

### Does this affect other platforms?

- [X] AMP
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
