### PR TITLE
Content in CiF/Education should always appear as such in navigation

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -537,7 +537,7 @@ object NavLinks {
      // these first two tags are section tags- they are  here to ensure that content in education and CiF always 
      // appear as such in the navigation even if they also have a tag from this list
     "commentisfree/commentisfree",
-    "education/education"
+    "education/education",
     // -------------------
     "us-news/us-politics",
     "australia-news/australian-politics",

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -531,7 +531,14 @@ object NavLinks {
   // NOTE: content with tags from this list will have the navigation set to the tag in this list, rather than its
   // section tag. e.g. Content in technology section with world/europe-news will appear in the world section in
   // the navigation. The workaround for this is to add the section to this list,as has been done with CiF and education
+  // this list exists for awkward editorial reasons, as well as legacy reasons, and has been hard to untangle despite
+  // a reasonable amount of dicussion between the audience team and dotcom in 2016 when the nav was last redone
   val tagPages = List(
+     // these first two tags are section tags- they are  here to ensure that content in education and CiF always 
+     // appear as such in the navigation even if they also have a tag from this list
+    "commentisfree/commentisfree",
+    "education/education"
+    // -------------------
     "us-news/us-politics",
     "australia-news/australian-politics",
     "australia-news/australian-immigration-and-asylum",
@@ -621,10 +628,6 @@ object NavLinks {
     "crosswords/series/everyman",
     "crosswords/series/azed",
     "fashion/beauty",
-    "technology/motoring",
-    // these last two are here to ensure that content in education and CiF always appear as such in the navigation
-    // even if they also have a tag from this list
-    "commentisfree/commentisfree",
-    "education/education"
+    "technology/motoring"
   )
 }


### PR DESCRIPTION
## What does this change?
Moves the section tags in the NavLinks 'overrides' list to the top, to ensure that when they are present content appears in these sections on the site - the order matters because we just take [the head of the list of matching tags](https://github.com/guardian/frontend/blob/master/common/app/navigation/Navigation.scala#L167).

This follows an issue with https://www.theguardian.com/commentisfree/2019/jan/11/aliens-radio-signals-space-brexit-trump where it was not possible to add the climate change tag without showing the environment navigation instead of the opinion one

## What is the value of this and can you measure success?
This actually fixes a bug previously introduced by some fool called Phil in [this pr](https://github.com/guardian/frontend/pull/20500)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
