### PR TITLE
fix comment appearing as text on AMP page

### DIFF
--- a/common/app/views/fragments/amp/onwardJourneys.scala.html
+++ b/common/app/views/fragments/amp/onwardJourneys.scala.html
@@ -17,7 +17,8 @@
     }
 
     @if(!content.shouldHideAdverts) {
-        @fragments.amp.outbrain(page, nonCompliant = content.tags.series.length > 1) // TODO  this logic is probably wrong
+        @* TODO  this logic is probably wrong *@
+        @fragments.amp.outbrain(page, nonCompliant = content.tags.series.length > 1)
     }
 
     @defining({


### PR DESCRIPTION
## What does this change?
Fix comment that was appearing as text on AMP page

(Fix to use Twirl comment syntax)

![img_0983](https://user-images.githubusercontent.com/1764158/51061339-dadda480-15ea-11e9-9792-0edda380f185.png)

CC @nicl @mchv 

## Screenshots

## What is the value of this and can you measure success?
Fix bug!

## Checklist
I cannot run Frontend locally so you should run the branch and verify the comment no longer appears

### Does this affect other platforms?

- [ X ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->