### PR TITLE
Make Hosted video autoplay under the right conditions

### DIFF
--- a/common/app/common/commercial/hosted/HostedMetadata.scala
+++ b/common/app/common/commercial/hosted/HostedMetadata.scala
@@ -16,6 +16,7 @@ object HostedMetadata {
     val toneIds = toneTags.map(_.id).mkString(",")
     val toneNames = toneTags.map(_.webTitle).mkString(",")
     val description = item.fields.flatMap(_.trailText).getOrElse("")
+    val productionOffice = item.fields.flatMap(_.productionOffice.map(_.name)).getOrElse("")
     val owner = {
       val hostedTag = item.tags.find(_.paidContentType.contains("HostedContent"))
       val sponsorship = hostedTag.flatMap(_.activeSponsorships).map(_.head)
@@ -34,6 +35,7 @@ object HostedMetadata {
       commercial = Some(CommercialProperties.fromContent(item)),
       javascriptConfigOverrides = Map(
         "isHosted" -> JsBoolean(true),
+        "productionOffice" -> JsString(productionOffice),
         "toneIds" -> JsString(toneIds),
         "tones" -> JsString(toneNames),
         "shortUrl" -> JsString(item.fields.flatMap(_.shortUrl).getOrElse(""))

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -47,11 +47,11 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val BlockIASSwitch = Switch(
+  val HostedVideoAutoplay = Switch(
     Commercial,
-    "block-ias",
-    "Controls whether the Service Worker can filter out IAS calls",
-    owners = Seq(Owner.withGithub("regiskuckaertz")),
+    "hosted-video-autoplay",
+    "When ON, hosted video content may be allowed to autoplay",
+    owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -30,6 +30,7 @@ type Page = {
     isDev: boolean,
     contentType: string,
     host: string,
+    productionOffice: string,
 };
 
 const EVENTSFIRED = [];
@@ -41,16 +42,22 @@ const shouldAutoplay = (page: Page): boolean => {
         if (page.isDev) {
             return document.referrer.indexOf(window.location.origin) === 0;
         }
-
         return document.referrer.indexOf(page.host) === 0;
     };
 
     const flashingElementsAllowed = () => isOn('flashing-elements');
-
     const isVideoArticle = () => page.contentType.toLowerCase() === 'video';
+    const isUSContent = () => page.productionOffice.toLowerCase() === 'us';
+
+    if (!page.contentType || !page.productionOffice) {
+        return false;
+    }
 
     return (
-        isVideoArticle() && isInternalReferrer() && flashingElementsAllowed()
+        isUSContent() &&
+        isVideoArticle() &&
+        isInternalReferrer() &&
+        flashingElementsAllowed()
     );
 };
 

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -1,7 +1,7 @@
 // @flow strict
 import {
     init as initNextVideoAutoPlay,
-    canAutoplay,
+    canAutoplay as canAutoplayNextVideo,
     addCancelListener,
     triggerAutoplay,
     triggerEndSlate,
@@ -108,7 +108,7 @@ export const initHostedYoutube = (el: HTMLElement): void => {
                 if (event.data === window.YT.PlayerState.ENDED) {
                     trackYoutubeEvent('end', atomId);
                     youtubeTimer.textContent = '0:00';
-                    if (canAutoplay()) {
+                    if (canAutoplayNextVideo()) {
                         // on mobile show the next video link in the end of the currently watching video
                         if (!isDesktop()) {
                             triggerEndSlate();
@@ -142,12 +142,13 @@ export const initHostedYoutube = (el: HTMLElement): void => {
                     shouldAutoplay(
                         config.get('page', {}),
                         config.get('switches', {})
-                    )
+                    ) &&
+                    isDesktop()
                 ) {
                     event.target.playVideo();
                 }
                 initNextVideoAutoPlay().then(() => {
-                    if (canAutoplay() && isDesktop()) {
+                    if (canAutoplayNextVideo() && isDesktop()) {
                         addCancelListener();
                         triggerAutoplay(
                             event.target.getCurrentTime.bind(event.target),

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -37,7 +37,10 @@ const EVENTSFIRED = [];
 
 const isDesktop = (): boolean => isBreakpoint({ min: 'desktop' });
 
-const shouldAutoplay = (page: Page): boolean => {
+const shouldAutoplay = (
+    page: Page,
+    switches: { hostedVideoAutoplay: ?boolean }
+): boolean => {
     const isInternalReferrer = () => {
         if (page.isDev) {
             return document.referrer.indexOf(window.location.origin) === 0;
@@ -48,12 +51,14 @@ const shouldAutoplay = (page: Page): boolean => {
     const flashingElementsAllowed = () => isOn('flashing-elements');
     const isVideoArticle = () => page.contentType.toLowerCase() === 'video';
     const isUSContent = () => page.productionOffice.toLowerCase() === 'us';
+    const isSwitchedOn = switches.hostedVideoAutoplay || false;
 
     if (!page.contentType || !page.productionOffice) {
         return false;
     }
 
     return (
+        isSwitchedOn &&
         isUSContent() &&
         isVideoArticle() &&
         isInternalReferrer() &&
@@ -141,7 +146,12 @@ export const initHostedYoutube = (el: HTMLElement): void => {
                 }
             },
             onPlayerReady(event: { target: YouTubePlayer }) {
-                if (shouldAutoplay(config.get('page', {}))) {
+                if (
+                    shouldAutoplay(
+                        config.get('page', {}),
+                        config.get('switches', {})
+                    )
+                ) {
                     event.target.playVideo();
                 }
                 initNextVideoAutoPlay().then(() => {

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -41,13 +41,6 @@ const shouldAutoplay = (
     page: Page,
     switches: { hostedVideoAutoplay: ?boolean }
 ): boolean => {
-    const isInternalReferrer = () => {
-        if (page.isDev) {
-            return document.referrer.indexOf(window.location.origin) === 0;
-        }
-        return document.referrer.indexOf(page.host) === 0;
-    };
-
     const flashingElementsAllowed = () => isOn('flashing-elements');
     const isVideoArticle = () => page.contentType.toLowerCase() === 'video';
     const isUSContent = () => page.productionOffice.toLowerCase() === 'us';
@@ -61,7 +54,6 @@ const shouldAutoplay = (
         isSwitchedOn &&
         isUSContent() &&
         isVideoArticle() &&
-        isInternalReferrer() &&
         flashingElementsAllowed()
     );
 };


### PR DESCRIPTION
## What does this change?

#### 👉 Make Hosted video autoplay under the right conditions

Add a switch that will enable Hosted Videos to autoplay if:

- The user is on a desktop device (avoiding autoplay videos on mobile and tablet)
- The production office is 'US' (targeting this change to only US Labs content for now)
- The user has not updated their accessibility settings to disable flashing elements

Example article: https://www.theguardian.com/advertiser-content/we-are-still-in/driving-climate-action

N.B. the next video autoplay is still in place, therefore the next video will still start once the first ends, after the standard 10 second countdown. 

#### 👉 Use Flow Strict in the module and fix the new issues

- Add new type for PageTargeting to support further work
- Remove unsafe Object and any types from usage
- Warn on sketchy-null checks

Fixes include switching to `{}` from `Object` as a type annotation, since `any`, `Object` and `Function` are considered unsafe types and should be avoided as much as possible. Flow Strict now enforces this. 🎉 💎

Also, `?string` is allowed in strict flow, but `?string` might be `string`, `null`... or `undefined`. I therefore have a minor preference for `string || null` over `?string` in these kind of cases (where we are returning a value or null), because it makes Flow inference a bit smarter, reduces some boilerplate around refining types, and gives the reader a bit more specific typing.

## Screenshots

## What is the value of this and can you measure success?

Users are already clicking to get to the page so it makes sense to have that play start when they get there. 

More details on trello: https://trello.com/c/tnjQacXQ

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Only Hosted content from the GLabs production office

### Does this change break ad-free?

Nope

### Accessibility test checklist

- [x] Considerate autoplay 
- [x] Developer souls sacrificed 🔪💀👻

### Tested

- [x] Locally
- [x] On CODE

