### PR TITLE
Target all Prebid bid config by geolocation rather than edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.13.0",
+  "version": "0.1.0",
   "private": true,
   "workspaces": [
     "dev/eslint-plugin-guardian-frontend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "1.13.0",
   "private": true,
   "workspaces": [
     "dev/eslint-plugin-guardian-frontend",

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -338,33 +338,30 @@ const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
     switchName: 'prebidOpenx',
     bidParams: (): PrebidOpenXParams => {
-        switch (config.get('page.edition')) {
-            case 'US':
-                return {
-                    delDomain: 'guardian-us-d.openx.net',
-                    unit: '540279544',
-                    customParams: buildAppNexusTargetingObject(
-                        buildPageTargeting()
-                    ),
-                };
-            case 'AU':
-                return {
-                    delDomain: 'guardian-aus-d.openx.net',
-                    unit: '540279542',
-                    customParams: buildAppNexusTargetingObject(
-                        buildPageTargeting()
-                    ),
-                };
-            default:
-                // UK and ROW
-                return {
-                    delDomain: 'guardian-d.openx.net',
-                    unit: '540279541',
-                    customParams: buildAppNexusTargetingObject(
-                        buildPageTargeting()
-                    ),
-                };
+        if (isInUsRegion()) {
+            return {
+                delDomain: 'guardian-us-d.openx.net',
+                unit: '540279544',
+                customParams: buildAppNexusTargetingObject(
+                    buildPageTargeting()
+                ),
+            };
         }
+        if (isInAuRegion()) {
+            return {
+                delDomain: 'guardian-aus-d.openx.net',
+                unit: '540279542',
+                customParams: buildAppNexusTargetingObject(
+                    buildPageTargeting()
+                ),
+            };
+        }
+        // UK and ROW
+        return {
+            delDomain: 'guardian-d.openx.net',
+            unit: '540279541',
+            customParams: buildAppNexusTargetingObject(buildPageTargeting()),
+        };
     },
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -33,6 +33,8 @@ import {
     containsMpuOrDmpu,
     getBreakpointKey,
     isInAuRegion,
+    isInRowRegion,
+    isInUkRegion,
     isInUsRegion,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
@@ -156,64 +158,62 @@ const getImprovePlacementId = (sizes: PrebidSize[]): number => {
             default:
                 return -1;
         }
-    } else {
-        switch (config.get('page.edition')) {
-            case 'UK':
-                switch (getBreakpointKey()) {
-                    case 'D':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116396;
-                        }
-                        if (containsLeaderboardOrBillboard(sizes)) {
-                            return 1116397;
-                        }
-                        return -1;
-                    case 'M':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116400;
-                        }
-                        return -1;
-                    case 'T':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116398;
-                        }
-                        if (containsLeaderboardOrBillboard(sizes)) {
-                            return 1116399;
-                        }
-                        return -1;
-                    default:
-                        return -1;
+    }
+    if (isInUkRegion()) {
+        switch (getBreakpointKey()) {
+            case 'D':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116396;
                 }
-            case 'INT':
-                switch (getBreakpointKey()) {
-                    case 'D':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116420;
-                        }
-                        if (containsLeaderboardOrBillboard(sizes)) {
-                            return 1116421;
-                        }
-                        return -1;
-                    case 'M':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116424;
-                        }
-                        return -1;
-                    case 'T':
-                        if (containsMpuOrDmpu(sizes)) {
-                            return 1116422;
-                        }
-                        if (containsLeaderboardOrBillboard(sizes)) {
-                            return 1116423;
-                        }
-                        return -1;
-                    default:
-                        return -1;
+                if (containsLeaderboardOrBillboard(sizes)) {
+                    return 1116397;
                 }
+                return -1;
+            case 'M':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116400;
+                }
+                return -1;
+            case 'T':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116398;
+                }
+                if (containsLeaderboardOrBillboard(sizes)) {
+                    return 1116399;
+                }
+                return -1;
             default:
                 return -1;
         }
     }
+    if (isInRowRegion()) {
+        switch (getBreakpointKey()) {
+            case 'D':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116420;
+                }
+                if (containsLeaderboardOrBillboard(sizes)) {
+                    return 1116421;
+                }
+                return -1;
+            case 'M':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116424;
+                }
+                return -1;
+            case 'T':
+                if (containsMpuOrDmpu(sizes)) {
+                    return 1116422;
+                }
+                if (containsLeaderboardOrBillboard(sizes)) {
+                    return 1116423;
+                }
+                return -1;
+            default:
+                return -1;
+        }
+    }
+    return -1;
 };
 
 // Improve has to have single size as parameter if slot doesn't accept multiple sizes,

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -17,6 +17,10 @@ import {
     containsMpu as containsMpu_,
     containsMpuOrDmpu as containsMpuOrDmpu_,
     getBreakpointKey as getBreakpointKey_,
+    isInAuRegion as isInAuRegion_,
+    isInRowRegion as isInRowRegion_,
+    isInUkRegion as isInUkRegion_,
+    isInUsRegion as isInUsRegion_,
     shouldIncludeAdYouLike as shouldIncludeAdYouLike_,
     shouldIncludeAppNexus as shouldIncludeAppNexus_,
     shouldIncludeImproveDigital as shouldIncludeImproveDigital_,
@@ -46,6 +50,10 @@ const shouldIncludeSonobi: any = shouldIncludeSonobi_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
 const getVariant: any = getVariant_;
+const isInAuRegion: any = isInAuRegion_;
+const isInRowRegion: any = isInRowRegion_;
+const isInUkRegion: any = isInUkRegion_;
+const isInUsRegion: any = isInUsRegion_;
 const isInVariant: any = isInVariant_;
 
 const {
@@ -85,7 +93,6 @@ const resetConfig = () => {
     config.set('ophan', { pageViewId: 'pvid' });
     config.set('page.contentType', 'Article');
     config.set('page.section', 'Magic');
-    config.set('page.edition', 'UK');
     config.set('page.isDev', false);
 };
 
@@ -161,7 +168,8 @@ describe('getImprovePlacementId', () => {
         expect(getImprovePlacementId([[1, 2]])).toBe(-1);
     });
 
-    test('should return the expected values when on the UK Edition and desktop device', () => {
+    test('should return the expected values when geolocated in UK and on desktop device', () => {
+        isInUkRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -178,7 +186,8 @@ describe('getImprovePlacementId', () => {
         ]);
     });
 
-    test('should return the expected values when on the UK Edition and tablet device', () => {
+    test('should return the expected values when geolocated in UK and on tablet device', () => {
+        isInUkRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -195,7 +204,8 @@ describe('getImprovePlacementId', () => {
         ]);
     });
 
-    test('should return the expected values when on the UK Edition and mobile device', () => {
+    test('should return the expected values when geolocated in UK and on mobile device', () => {
+        isInUkRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -206,8 +216,8 @@ describe('getImprovePlacementId', () => {
         expect(generateTestIds()).toEqual([1116400, 1116400, -1, -1, -1]);
     });
 
-    test('should return the expected values when on the INT Edition and desktop device', () => {
-        config.set('page.edition', 'INT');
+    test('should return the expected values when geolocated in ROW region and on desktop device', () => {
+        isInRowRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -224,8 +234,8 @@ describe('getImprovePlacementId', () => {
         ]);
     });
 
-    test('should return the expected values when on the INT Edition and tablet device', () => {
-        config.set('page.edition', 'INT');
+    test('should return the expected values when not geolocated in ROW region and on tablet device', () => {
+        isInRowRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -242,8 +252,8 @@ describe('getImprovePlacementId', () => {
         ]);
     });
 
-    test('should return the expected values when on the INT Edition and mobile device', () => {
-        config.set('page.edition', 'INT');
+    test('should return the expected values when geolocated in ROW region and on mobile device', () => {
+        isInRowRegion.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -251,10 +261,10 @@ describe('getImprovePlacementId', () => {
         expect(generateTestIds()).toEqual([1116424, 1116424, -1, -1, -1]);
     });
 
-    test('should return -1 if on the US or AU Editions', () => {
-        config.set('page.edition', 'AU');
+    test('should return -1 if geolocated in US or AU regions', () => {
+        isInUsRegion.mockReturnValue(true);
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
-        config.set('page.edition', 'US');
+        isInAuRegion.mockReturnValue(true);
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -583,4 +583,48 @@ describe('bids', () => {
         setQueryString('pbtest=nonexistentbidder&pbtest=xhb');
         expect(bidders()).toEqual(['xhb']);
     });
+
+    test('should use correct parameters in OpenX bids geolocated in UK', () => {
+        shouldIncludeOpenx.mockReturnValue(true);
+        isInUkRegion.mockReturnValue(true);
+        const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
+        expect(openXBid.params).toEqual({
+            customParams: 'someAppNexusTargetingObject',
+            delDomain: 'guardian-d.openx.net',
+            unit: '540279541',
+        });
+    });
+
+    test('should use correct parameters in OpenX bids geolocated in US', () => {
+        shouldIncludeOpenx.mockReturnValue(true);
+        isInUsRegion.mockReturnValue(true);
+        const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
+        expect(openXBid.params).toEqual({
+            customParams: 'someAppNexusTargetingObject',
+            delDomain: 'guardian-us-d.openx.net',
+            unit: '540279544',
+        });
+    });
+
+    test('should use correct parameters in OpenX bids geolocated in AU', () => {
+        shouldIncludeOpenx.mockReturnValue(true);
+        isInAuRegion.mockReturnValue(true);
+        const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
+        expect(openXBid.params).toEqual({
+            customParams: 'someAppNexusTargetingObject',
+            delDomain: 'guardian-aus-d.openx.net',
+            unit: '540279542',
+        });
+    });
+
+    test('should use correct parameters in OpenX bids geolocated in FR', () => {
+        shouldIncludeOpenx.mockReturnValue(true);
+        isInRowRegion.mockReturnValue(true);
+        const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
+        expect(openXBid.params).toEqual({
+            customParams: 'someAppNexusTargetingObject',
+            delDomain: 'guardian-d.openx.net',
+            unit: '540279541',
+        });
+    });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -128,10 +128,8 @@ export const shouldIncludeXaxis = (): boolean => {
     return false;
 };
 
-export const shouldIncludeImproveDigital = (): boolean => {
-    const edition: ?string = config.get('page.edition');
-    return edition === 'UK' || edition === 'INT';
-};
+export const shouldIncludeImproveDigital = (): boolean =>
+    isInUkRegion() || isInRowRegion();
 
 export const stripMobileSuffix = (s: string): string =>
     stripSuffix(s, '--mobile');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -121,8 +121,8 @@ export const shouldIncludeAppNexus = (): boolean =>
 export const shouldIncludeXaxis = (): boolean => {
     // 50% of UK page views
     const hasFirstLook =
-        config.get('page.isDev') || getRandomIntInclusive(1, 2) === 1;
-    if (config.get('page.edition') === 'UK') {
+        config.get('page.isDev', true) || getRandomIntInclusive(1, 2) === 1;
+    if (isInUkRegion()) {
         return hasFirstLook;
     }
     return false;

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -35,11 +35,17 @@ export const removeFalseyValues = (o: {
 export const stripDfpAdPrefixFrom = (s: string): string =>
     stripPrefix(s, 'dfp-ad--');
 
+export const isInUkRegion = (): boolean =>
+    currentGeoLocation() === 'UK';
+
 export const isInUsRegion = (): boolean =>
     ['US', 'CA'].includes(currentGeoLocation());
 
 export const isInAuRegion = (): boolean =>
     ['AU', 'NZ'].includes(currentGeoLocation());
+
+export const isInRowRegion = (): boolean =>
+    !isInUkRegion() && !isInUsRegion() && !isInAuRegion();
 
 export const containsMpu = (sizes: PrebidSize[]): boolean =>
     contains(sizes, [300, 250]);

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -35,8 +35,7 @@ export const removeFalseyValues = (o: {
 export const stripDfpAdPrefixFrom = (s: string): string =>
     stripPrefix(s, 'dfp-ad--');
 
-export const isInUkRegion = (): boolean =>
-    currentGeoLocation() === 'UK';
+export const isInUkRegion = (): boolean => currentGeoLocation() === 'UK';
 
 export const isInUsRegion = (): boolean =>
     ['US', 'CA'].includes(currentGeoLocation());

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -7,6 +7,8 @@ import { getParticipations as getParticipations_ } from 'common/modules/experime
 import {
     getLargestSize,
     getBreakpointKey,
+    isInRowRegion,
+    isInUkRegion,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
     shouldIncludeImproveDigital,
@@ -297,5 +299,34 @@ describe('Utils', () => {
         expect(result).toEqual({
             testString: 'non empty string',
         });
+    });
+
+    test('isInUkRegion should return true if geolocation is UK', () => {
+        getSync.mockReturnValue('UK');
+        expect(isInUkRegion()).toBe(true);
+    });
+
+    test('isInUkRegion should return false if geolocation is not UK', () => {
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValue(testGeos[i]);
+            expect(isInUkRegion()).toBe(false);
+        }
+    });
+
+    test('isInRowRegion should return false if geolocation is UK, US, CA, AU or NZ', () => {
+        const testGeos = ['UK', 'US', 'CA', 'AU', 'NZ'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValue(testGeos[i]);
+            expect(isInRowRegion()).toBe(false);
+        }
+    });
+
+    test('isInRowRegion should return true if geolocation is not UK, US, CA, AU or NZ', () => {
+        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValue(testGeos[i]);
+            expect(isInRowRegion()).toBe(true);
+        }
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -227,17 +227,23 @@ describe('Utils', () => {
         }
     });
 
-    test('shouldIncludeImproveDigital should return true if edition is UK or INT', () => {
-        config.set('page.edition', 'UK');
-        expect(shouldIncludeImproveDigital()).toBe(true);
-        config.set('page.edition', 'INT');
+    test('shouldIncludeImproveDigital should return true if geolocation is UK', () => {
+        getSync.mockReturnValue('UK');
         expect(shouldIncludeImproveDigital()).toBe(true);
     });
 
-    test('shouldIncludeImproveDigital should return false if edition is AU or US', () => {
-        config.set('page.edition', 'AU');
+    test('shouldIncludeImproveDigital should return true if geolocation is ROW', () => {
+        getSync.mockReturnValue('FR');
+        expect(shouldIncludeImproveDigital()).toBe(true);
+    });
+
+    test('shouldIncludeImproveDigital should return false if geolocation is AU', () => {
+        getSync.mockReturnValue('AU');
         expect(shouldIncludeImproveDigital()).toBe(false);
-        config.set('page.edition', 'US');
+    });
+
+    test('shouldIncludeImproveDigital should return false if geolocation is US', () => {
+        getSync.mockReturnValue('US');
         expect(shouldIncludeImproveDigital()).toBe(false);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -247,13 +247,30 @@ describe('Utils', () => {
         expect(shouldIncludeImproveDigital()).toBe(false);
     });
 
-    test('shouldIncludeXaxis should always return false on INT, AU and US editions', () => {
-        const editions = ['AU', 'INT', 'US'];
-        const result = editions.map(edition => {
-            config.set('page.edition', edition);
-            return shouldIncludeXaxis();
-        });
-        expect(result).toEqual([false, false, false]);
+    test('shouldIncludeXaxis should be true if geolocation is UK', () => {
+        config.set('page.isDev', true);
+        getSync.mockReturnValue('UK');
+        expect(shouldIncludeXaxis()).toBe(true);
+    });
+
+    test('shouldIncludeXaxis should be false if geolocation is not UK', () => {
+        config.set('page.isDev', true);
+        const testGeos = [
+            'FK',
+            'GI',
+            'GG',
+            'IM',
+            'JE',
+            'SH',
+            'AU',
+            'US',
+            'CA',
+            'NZ',
+        ];
+        for (let i = 0; i < testGeos.length; i += 1) {
+            getSync.mockReturnValue(testGeos[i]);
+            expect(shouldIncludeXaxis()).toBe(false);
+        }
     });
 
     test('shouldIncludeSonobi should return true if geolocation is US', () => {


### PR DESCRIPTION
Ads are sold by region rather than by edition, so this updates the last remaining edition-specific settings.  Now everything is geotargeted.