### PR TITLE
Add forceads flag

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -56,6 +56,7 @@ class DevParametersHttpRequestHandler(
     "adtest", // used to set ad-test cookie from admin domain
     "pbtest", // used to test Prebid adapters in isolation
     "adrefresh", // force adrefresh to be off with adrefresh=false in the URL
+    "forceads", // shows ads even if they have been disabled for this content
     "google_console", // two params for dfp console
     "googfc",
     "k", // keywords in commercial component requests

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -26,13 +26,19 @@ object Commercial {
       (!isPaidContent && (content.tags.isAudio || content.tags.isVideo))
   }
 
-  def shouldShowAds(page: Page): Boolean = page match {
-    case c: model.ContentPage if c.item.content.shouldHideAdverts => false
-    case p: model.Page if p.metadata.sectionId == "identity" => false
-    case s: model.SimplePage if s.metadata.contentType.contains(Signup) => false
-    case e: model.ContentPage if e.item.content.seriesName.contains("Newsletter sign-ups") => false
-    case _: model.CommercialExpiryPage => false
-    case _ => true
+  def shouldShowAds(page: Page)(implicit request: RequestHeader): Boolean = {
+    if (request.queryString.get("forceads").isDefined) {
+      true
+    } else {
+      page match {
+        case c: model.ContentPage if c.item.content.shouldHideAdverts => false
+        case p: model.Page if p.metadata.sectionId == "identity" => false
+        case s: model.SimplePage if s.metadata.contentType.contains(Signup) => false
+        case e: model.ContentPage if e.item.content.seriesName.contains("Newsletter sign-ups") => false
+        case _: model.CommercialExpiryPage => false
+        case _ => true
+      }
+    }
   }
 
   def articleAsideOptionalSizes(implicit request: RequestHeader): Seq[String] = Edition(request).id match {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -24,8 +24,9 @@ class CommercialFeatures {
 
     constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests
-        const noadsUrl = window.location.hash.match(/[#&]noads(&.*)?$/);
-        const forceAdFree = window.location.hash.match(/[#&]noadsaf(&.*)?$/);
+        const noadsUrl: boolean = /[#&]noads(&.*)?$/.test(window.location.hash);
+        const forceAdFree: boolean = /[#&]noadsaf(&.*)?$/.test(window.location.hash);
+        const forceAds: boolean = /[?&]forceads(&.*)?$/.test(window.location.search);
         const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
         const sensitiveContent =
             config.page.shouldHideAdverts ||
@@ -55,10 +56,11 @@ class CommercialFeatures {
         this.adFree = !!forceAdFree || isAdFreeUser();
 
         this.dfpAdvertising =
-            switches.commercial &&
-            externalAdvertising &&
-            !sensitiveContent &&
-            !isIdentityPage;
+            forceAds ||
+                switches.commercial &&
+                externalAdvertising &&
+                !sensitiveContent &&
+                !isIdentityPage;
 
         this.stickyTopBannerAd =
             !this.adFree &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -25,8 +25,12 @@ class CommercialFeatures {
     constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests
         const noadsUrl: boolean = /[#&]noads(&.*)?$/.test(window.location.hash);
-        const forceAdFree: boolean = /[#&]noadsaf(&.*)?$/.test(window.location.hash);
-        const forceAds: boolean = /[?&]forceads(&.*)?$/.test(window.location.search);
+        const forceAdFree: boolean = /[#&]noadsaf(&.*)?$/.test(
+            window.location.hash
+        );
+        const forceAds: boolean = /[?&]forceads(&.*)?$/.test(
+            window.location.search
+        );
         const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
         const sensitiveContent =
             config.page.shouldHideAdverts ||
@@ -57,10 +61,10 @@ class CommercialFeatures {
 
         this.dfpAdvertising =
             forceAds ||
-                switches.commercial &&
+            (switches.commercial &&
                 externalAdvertising &&
                 !sensitiveContent &&
-                !isIdentityPage;
+                !isIdentityPage);
 
         this.stickyTopBannerAd =
             !this.adFree &&


### PR DESCRIPTION
## What does this change?

Adds a new `forceads` flag that will make sure ads are displayed for a piece of content. This works even if ads have been explicitly disabled for that content.

**Note:** This depends on [a corresponding change to the Fastly Edge Cache](https://github.com/guardian/fastly-edge-cache/pull/842). This param needs to be visible to the backend so that ad slots get put into the pages in the Scala templates.

## Screenshots

This shows an example of what we want. Ads on immersive photo essays don't work properly, but because they don't work they have been disabled so we're unable to easily debug the problem. This `forceads` flag lets us override the fact that ads are disabled so we can reproduce (and tackle) the problem.

![force-ads-over-content](https://user-images.githubusercontent.com/29761/51124518-6424ef00-1816-11e9-8481-015f435acb77.png)

## What is the value of this and can you measure success?

This lets us debug problems with ads. It's important because when a piece of content has problems with ads, CP tend to disable ads for that content to fix the issues.

This PR has been driven by a fix to the immersive [Photo Essay RH-Side ad bug](https://trello.com/c/1GKP3WUy/53-ads-overlapping-images-on-photo-essays) (as shown above in the screenshot). That PR will follow and it would have been very difficult to do without this flag.

## Checklist

- [ ] Release Fastly Edge Cache change
- [ ] Release this
- [ ] Profit

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

No, this is a change to our platform.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
