### PR TITLE
Removing G+ share option

### DIFF
--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -1071,14 +1071,6 @@
                         <a href="http://twitter.com/share" class="twitter-share-button" data-url="http://gu.com/p/3kft2/tw" data-via="guardian" data-counturl="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-related="lifeandstyle" data-text="Thanksgiving recipe swap">Tweet this</a>
                     </li>
 
-                    <li class="full-line google-plus" data-link-name="Google plus Top" >
-
-
-                        <div class="g-plusone" data-size="medium" data-callback="trackGPlusTop"></div>
-
-                    </li>
-
-
                     <li class="full-line linked-in" data-link-name="LinkedIn Top">
                         <script type="IN/Share" data-counter="right" data-showzero="true"></script>
                     </li>

--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -75,19 +75,14 @@
     <link rel="shorturl" href="http://gu.com/p/3kft2" />
 
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes"/>
-
+    <link rel="publisher" href="https://plus.google.com/113000071431138202574"/>
     <meta name="twitter:card" content="summary">
-
     <meta name="twitter:site" content="@guardian">
-
     <meta name="twitter:app:name:iphone" content="The Guardian">
     <meta name="twitter:app:id:iphone" content="409128287">
-
     <meta name="twitter:app:name:googleplay" content="The Guardian">
     <meta name="twitter:app:id:googleplay" content="com.guardian">
     <meta name="twitter:app:url:googleplay" content="guardian://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
-
-
     <meta name="p:domain_verify" content="4f4576e6bac27d86fd926c4579b97f23"/>
     <meta name="pocket-site-verification" content="be6d97bc1f6961ce6348e7ced4f1f4" />
     <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/content-wide.css" media="all" />

--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -76,16 +76,9 @@
 
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes"/>
 
-    <link rel="publisher" href="https://plus.google.com/113000071431138202574"/>
-
-
-
-
-
     <meta name="twitter:card" content="summary">
 
     <meta name="twitter:site" content="@guardian">
-
 
     <meta name="twitter:app:name:iphone" content="The Guardian">
     <meta name="twitter:app:id:iphone" content="409128287">

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -35,7 +35,6 @@
     <meta name="msapplication-TileImage" content="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/favicons/windows_tile_144_b.png">
     <link rel="shorturl" href="http://gu.com/p/3kft2">
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
-    <link rel="publisher" href="https://plus.google.com/113000071431138202574">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@guardian">
     <meta name="twitter:app:name:iphone" content="The Guardian">

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -213,8 +213,6 @@
                 <ul id="content-actions" class="share-links trackable-component" data-component="Interactive:top share tools">
                     <li class="full-line facebook"> <span class="facebook-share"> <a class="facebook-share-btn" href="https://www.facebook.com/sharer/sharer.php?u=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-href="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-link-name="Facebook Share Top"> <span class="facebook-share-icon"></span> <span class="facebook-share-label">Share</span> </a> </span> </li>
                     <li class="full-line" data-link-name="Twitter Top"> <a href="http://twitter.com/share" class="twitter-share-button" data-url="http://gu.com/p/3kft2/tw" data-via="guardian" data-counturl="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-related="lifeandstyle" data-text="Thanksgiving recipe swap">Tweet this</a> </li>
-                    <li class="full-line google-plus" data-link-name="Google plus Top">
-                        <div class="g-plusone" data-size="medium" data-callback="trackGPlusTop"></div> </li>
                     <li class="full-line linked-in" data-link-name="LinkedIn Top">  </li>
                     <li class="full-line email" data-link-name="email this story Top"> <a class="rollover send-email" href="#" title="Send to a friend"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-email.png" alt="" class="trail-icon">Email</a> </li>
                 </ul>

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -35,6 +35,7 @@
     <meta name="msapplication-TileImage" content="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/favicons/windows_tile_144_b.png">
     <link rel="shorturl" href="http://gu.com/p/3kft2">
     <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+    <link rel="publisher" href="https://plus.google.com/113000071431138202574">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@guardian">
     <meta name="twitter:app:name:iphone" content="The Guardian">

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -40,7 +40,6 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         pageShares.hidden.map(_.href) should be (List(
           "http://www.linkedin.com/shareArticle?mini=true&title=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live",
           "http://www.pinterest.com/pin/find/?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live",
-          "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_gp&amp;hl=en-GB&amp;wwc=1",
           "whatsapp://send?text=%22Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live%22%20https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_wa",
           "fb-messenger://share?link=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_me&app_id=180444840287"
         ))
@@ -84,7 +83,6 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         elementShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232",
           "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232",
-          "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_gp%26page%3Dwith%3A2%232&amp;hl=en-GB&amp;wwc=1"
         ))
       }
     }

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -31,7 +31,7 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         val pageShares = model.Content(apiContent).sharelinks.pageShares
 
         pageShares.visible.map(_.text) should be (List("Facebook", "Twitter", "Email"))
-        pageShares.hidden.map(_.text) should be (List("LinkedIn", "Pinterest", "Google plus", "WhatsApp", "Messenger"))
+        pageShares.hidden.map(_.text) should be (List("LinkedIn", "Pinterest", "WhatsApp", "Messenger"))
         pageShares.visible.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb",
           "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw",
@@ -80,7 +80,7 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         val liveblog = model.Content(apiContent)
         val elementShares = liveblog.sharelinks.elementShares("2", None)
 
-        elementShares.map(_.text) should be (List("Facebook", "Twitter", "Google plus"))
+        elementShares.map(_.text) should be (List("Facebook", "Twitter"))
         elementShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232",
           "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232",

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -82,7 +82,7 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         elementShares.map(_.text) should be (List("Facebook", "Twitter"))
         elementShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232",
-          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232",
+          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232"
         ))
       }
     }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -470,14 +470,12 @@ import collection.JavaConverters._
         val mailShareUrl = "mailto:?subject=Mark%20Kermode's%20DVD%20round-up&body=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_link"
         val fbShareUrl = "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_fb"
         val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark%20Kermode's%20DVD%20round-up&url=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_tw"
-        val gplusShareUrl = "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_gp&amp;hl=en-GB&amp;wwc=1"
 
         Then("I should see buttons for my favourite social network")
 
         $(".social__item[data-link-name=email] .social__action").attribute("href") should be(mailShareUrl)
         $(".social__item[data-link-name=facebook] .social__action").attribute("href") should be(fbShareUrl)
         $(".social__item[data-link-name=twitter] .social__action").attribute("href") should be(twitterShareUrl)
-        $(".social__item[data-link-name=gplus] .social__action").attribute("href") should be(gplusShareUrl)
       }
     }
 

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -44,12 +44,6 @@ object Messenger extends SharePlatform {
   override val userMessage = "Share on Messenger"
 }
 
-object GooglePlus extends SharePlatform {
-  override val campaign = Some("sgp")
-  override val text = "Google plus"
-  override val css =  "gplus"
-  override val userMessage = "Share on Google+"
-}
 object Email extends SharePlatform {
   override val campaign = Some("sbl")
   override val text = "Email"
@@ -109,7 +103,6 @@ object ShareLinks {
     lazy val twitterText = title.replace("Leave.EU", "Leave. EU").encodeURIComponent
 
     val fullLink = platform match {
-      case GooglePlus => s"https://plus.google.com/share?url=$encodedHref&amp;hl=en-GB&amp;wwc=1"
       case WhatsApp => s"""whatsapp://send?text=${("\"" + title + "\" " + href).encodeURIComponent}"""
       case PinterestBlock => s"http://www.pinterest.com/pin/create/button/?description=${title.urlEncoded}&url=$encodedHref&media=${fullMediaPath.getOrElse("").urlEncoded}"
       case PinterestPage => s"http://www.pinterest.com/pin/find/?url=$encodedHref"
@@ -149,7 +142,7 @@ final case class ShareLinks(
 ) {
 
   private val elementShareOrder: List[SharePlatform] = if (tags.isLiveBlog) {
-    List(Facebook, Twitter, GooglePlus)
+    List(Facebook, Twitter)
   } else {
     List(Facebook, Twitter, PinterestBlock)
   }
@@ -178,6 +171,6 @@ final case class ShareLinks(
 
   val pageShares: ShareLinkMeta = ShareLinkMeta(
       sharesToLinks(List(Facebook, Twitter, Email)),
-      sharesToLinks(List(LinkedIn, PinterestPage, GooglePlus, WhatsApp, Messenger))
+      sharesToLinks(List(LinkedIn, PinterestPage, WhatsApp, Messenger))
     )
 }

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -23,7 +23,6 @@ case class Guardian(
   sameAs: List[String] = List(
     "https://www.facebook.com/theguardian",
     "https://twitter.com/guardian",
-    "https://plus.google.com/+theGuardian",
     "https://www.youtube.com/user/TheGuardian"
   )
 ) extends LinkedData("Organization")

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -27,7 +27,7 @@ object MetaDataMatcher extends Matchers  {
 
     val socialNetworks = (organisation \ "sameAs").as[List[String]]
 
-    socialNetworks.size should be(4)
+    socialNetworks.size should be(3)
   }
 
   def ensureWebPage(result: Future[Result], articleUrl: String) {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -101,10 +101,6 @@ const getReferrer = (): ?string => {
             match: 't.co/',
         }, // added (/) because without slash it is picking up reddit.com too
         {
-            id: 'googleplus',
-            match: 'plus.url.google',
-        },
-        {
             id: 'reddit',
             match: 'reddit.com',
         },

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -263,13 +263,6 @@ describe('Build Page Targeting', () => {
             expect(buildPageTargeting().ref).toEqual('twitter');
         });
 
-        it('should set ref to Googleplus', () => {
-            getReferrer.mockReturnValue(
-                'https://plus.url.google.com/always-pass-on-what-you-have-learned'
-            );
-            expect(buildPageTargeting().ref).toEqual('googleplus');
-        });
-
         it('should set ref to reddit', () => {
             getReferrer.mockReturnValue(
                 'https://www.reddit.com/its-not-my-fault'

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -32,7 +32,6 @@ import shareTwitter from 'svgs/icon/share-twitter.svg';
 import shareEmail from 'svgs/icon/share-email.svg';
 import shareFacebook from 'svgs/icon/share-facebook.svg';
 import sharePinterest from 'svgs/icon/share-pinterest.svg';
-import shareGPlus from 'svgs/icon/share-gplus.svg';
 import externalLink from 'svgs/icon/external-link.svg';
 import tick from 'svgs/icon/tick.svg';
 import glabsLogoSmall from 'svgs/logo/glabs-logo-small.svg';
@@ -69,7 +68,6 @@ const svgs = {
     shareEmail,
     shareFacebook,
     sharePinterest,
-    shareGPlus,
     externalLink,
     tick,
     glabsLogoSmall,

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -143,7 +143,6 @@ $special-report-dark:    #3f464a;
 // Social icons ================================================================
 $social-facebook:        #3067a3;
 $social-twitter:         #03b3ee;
-$social-gplus:           #4285f4;
 $social-whatsapp:        #59cb3f;
 $social-linkedin:        #0071a1;
 $social-pinterest:       #b9252c;

--- a/static/src/stylesheets/module/_social-icons.scss
+++ b/static/src/stylesheets/module/_social-icons.scss
@@ -9,10 +9,6 @@
     @include social-icon($social-facebook);
 }
 
-.social-icon--gplus {
-    @include social-icon($social-gplus);
-}
-
 .social-icon--whatsapp {
     @include social-icon($social-whatsapp);
 }

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -27,14 +27,6 @@ category: Common
             <span class="social-icon"><i class="i-share-twitter--white i"></i></span>
         </a>
     </li>
-    <li class="social__item">
-        <a class="social__action social-icon-wrapper" href="#">
-            <span class="social-icon">
-                <i class="i-share-gplus--white i"></i>
-                <span class="social-icon__label">Share on Google+</span>
-            </span>
-        </a>
-    </li>
 </ul>
 ```
 */

--- a/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
@@ -50,21 +50,6 @@
     }
 }
 
-.block-share__item--gplus {
-    border-color: $social-gplus;
-    color: $social-gplus;
-    .inline-icon {
-        fill: $social-gplus;
-    }
-
-    &:hover {
-        border-color: darken($social-gplus, 15%);
-        .inline-icon {
-            fill: darken($social-gplus, 15%);
-        }
-    }
-}
-
 .block-share__item--linkedin {
     border-color: $social-linkedin;
     color: $social-linkedin;

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -50,21 +50,6 @@
     }
 }
 
-.block-share__item--gplus {
-    border-color: $social-gplus;
-    color: $social-gplus;
-    .inline-icon {
-        fill: $social-gplus;
-    }
-
-    &:hover {
-        border-color: darken($social-gplus, 15%);
-        .inline-icon {
-            fill: darken($social-gplus, 15%);
-        }
-    }
-}
-
 .block-share__item--linkedin {
     border-color: $social-linkedin;
     color: $social-linkedin;
@@ -115,15 +100,6 @@
 
     &:hover {
         background-color: darken($social-twitter, 15%);
-    }
-}
-
-.share-modal__item--gplus {
-    background-color: $social-gplus;
-    color: #ffffff;
-
-    &:hover {
-        background-color: darken($social-gplus, 15%);
     }
 }
 


### PR DESCRIPTION
## What does this change?
Google plus is being killed in March, so we need to scrub it from frontend. Hopefully this does it!

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
