### PR TITLE
Extend expired switch until Friday

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -24,7 +24,7 @@ object OldTLSSupportDeprecation extends Experiment(
   name = "old-tls-support-deprecation",
   description = "This will turn on a deprecation notice to any user who is accessing our site using TLS v1.0 or v1.1",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2019, 1,15),
+  sellByDate = new LocalDate(2019, 1,18),
   // Custom group based on header set in Fastly
   participationGroup = TLSSupport
 )


### PR DESCRIPTION
## What does this change?
Extended 'old-tls-support-deprecation' switch until Friday as builds are failing. @NataliaLKB @MatthewJWalls tagging you so that you can extend for a longer term. 