### PR TITLE
Added video captions to mobile breakpoint

### DIFF
--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -3,7 +3,7 @@
 @(captionText: String, mainMedia: Boolean = false)(implicit request: RequestHeader)
 <figcaption class="@RenderClasses(Map(
     "caption" -> true,
-    "caption--img" -> true,
+    "caption--video" -> true,
     "caption--main" -> mainMedia))"
 itemprop="description">
     @fragments.inlineSvg("triangle", "icon")


### PR DESCRIPTION
Captions are currently not showing beneath main-media videos at mobile breakpoints.

# Before
<img width="408" alt="screen shot 2019-01-16 at 14 26 05" src="https://user-images.githubusercontent.com/14570016/51255876-fc98ac00-199b-11e9-98f6-e843fff3e06d.png">

# After
<img width="411" alt="screen shot 2019-01-16 at 14 25 54" src="https://user-images.githubusercontent.com/14570016/51255894-09b59b00-199c-11e9-9c78-a995b4522a92.png">
