### PR TITLE
Fix rh side ad slot for immersive content

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -14,9 +14,8 @@ const calculateAllowedAdSlots = (availableSpace: number): string => {
         return '1,1|2,2|300,250|300,274';
     } else if (availableSpace > 250) {
         return '1,1|2,2|300,250';
-    } else {
-        return '1,1|2,2';
     }
+    return '1,1|2,2';
 };
 
 export const init = (start: () => void, stop: () => void): Promise<boolean> => {
@@ -32,7 +31,7 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
 
     const $mainCol: bonzo = $('.js-content-main-column');
     const $adSlot: bonzo = $('.js-ad-slot', $col);
-    const $immersiveEls: bonzo = $(".element--immersive", $mainCol);
+    const $immersiveEls: bonzo = $('.element--immersive', $mainCol);
 
     if (!$adSlot.length || !$mainCol.length) {
         stop();
@@ -40,11 +39,14 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
     }
 
     return fastdom
-        .read((): [number, number] => {
-            return [$mainCol.dim().height, $immersiveEls.offset().top - $mainCol.offset().top]
-        })
+        .read(
+            (): [number, number] => [
+                $mainCol.dim().height,
+                $immersiveEls.offset().top - $mainCol.offset().top,
+            ]
+        )
         .then(([mainColHeight, immersiveOffset]: [number, number]) => {
-            if (config.get("page.isImmersive") && $immersiveEls.length > 0) {
+            if (config.get('page.isImmersive') && $immersiveEls.length > 0) {
                 // filter ad slot sizes based on the available height
                 return fastdom.write(() => {
                     $adSlot.removeClass('right-sticky js-sticky-mpu is-sticky');

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -3,14 +3,21 @@ import $ from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
-
 import type { bonzo } from 'bonzo';
 
 const minArticleHeight: number = 1300;
-const minImmersiveArticleHeight: number = 600;
 
-const minContentHeight = (): number =>
-    config.page.isImmersive ? minImmersiveArticleHeight : minArticleHeight;
+const calculateAllowedAdSlots = (availableSpace: number): string => {
+    if (availableSpace > 600) {
+        return '1,1|2,2|300,250|300,274|300,600|fluid';
+    } else if (availableSpace > 274) {
+        return '1,1|2,2|300,250|300,274';
+    } else if (availableSpace > 250) {
+        return '1,1|2,2|300,250';
+    } else {
+        return '1,1|2,2';
+    }
+};
 
 export const init = (start: () => void, stop: () => void): Promise<boolean> => {
     start();
@@ -25,6 +32,7 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
 
     const $mainCol: bonzo = $('.js-content-main-column');
     const $adSlot: bonzo = $('.js-ad-slot', $col);
+    const $immersiveEls: bonzo = $(".element--immersive", $mainCol);
 
     if (!$adSlot.length || !$mainCol.length) {
         stop();
@@ -32,10 +40,23 @@ export const init = (start: () => void, stop: () => void): Promise<boolean> => {
     }
 
     return fastdom
-        .read((): number => $mainCol.dim().height)
-        .then((mainColHeight: number) => {
-            // Should switch to 'right-small' MPU for short articles
-            if (mainColHeight < minContentHeight()) {
+        .read((): [number, number] => {
+            return [$mainCol.dim().height, $immersiveEls.offset().top - $mainCol.offset().top]
+        })
+        .then(([mainColHeight, immersiveOffset]: [number, number]) => {
+            if (config.get("page.isImmersive") && $immersiveEls.length > 0) {
+                // filter ad slot sizes based on the available height
+                return fastdom.write(() => {
+                    $adSlot.removeClass('right-sticky js-sticky-mpu is-sticky');
+                    $adSlot[0].setAttribute(
+                        'data-mobile',
+                        calculateAllowedAdSlots(immersiveOffset)
+                    );
+                    return $adSlot[0];
+                });
+                // remove sticky
+            } else if (mainColHeight < minArticleHeight) {
+                // Should switch to 'right-small' MPU for short articles
                 return fastdom.write(() => {
                     $adSlot.removeClass('right-sticky js-sticky-mpu is-sticky');
                     $adSlot[0].setAttribute(

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -1,5 +1,6 @@
 // @flow
 /* eslint-disable no-new */
+import config from 'lib/config';
 import qwery from 'qwery';
 import mediator from 'lib/mediator';
 import { noop } from 'lib/noop';
@@ -12,11 +13,75 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
     },
 }));
 
-const mockMainColHeight = (height: number) => {
-    jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
+const fastdomReadSpy = jest.spyOn(fastdom, 'read');
+
+jest.mock('lib/config', () => {
+    return {
+        get: jest.fn()
+    }
+});
+const configSpy = jest.spyOn(config, 'get');
+
+const sharedBeforeEach = (domSnippet: string) => (() => {
+    jest.resetAllMocks();
+
+    if (document.body) {
+        document.body.innerHTML = domSnippet;
+    }
+
+    const pubAds = {
+        listeners: [],
+        addEventListener: jest.fn(function(eventName, callback) {
+            this.listeners[eventName] = callback;
+        }),
+        setTargeting: jest.fn(),
+        enableSingleRequest: jest.fn(),
+        collapseEmptyDivs: jest.fn(),
+        refresh: jest.fn(),
+    };
+    const sizeMapping = {
+        sizes: [],
+        addSize: jest.fn(function(width, sizes) {
+            this.sizes.unshift([width, sizes]);
+        }),
+        build: jest.fn(function() {
+            const tmp = this.sizes;
+            this.sizes = [];
+            return tmp;
+        }),
+    };
+    window.googletag = {
+        cmd: {
+            push(...args) {
+                args.forEach(command => {
+                    command();
+                });
+            },
+        },
+        pubads() {
+            return pubAds;
+        },
+        sizeMapping() {
+            return sizeMapping;
+        },
+        defineSlot: jest.fn(() => window.googletag),
+        defineOutOfPageSlot: jest.fn(() => window.googletag),
+        addService: jest.fn(() => window.googletag),
+        defineSizeMapping: jest.fn(() => window.googletag),
+        setTargeting: jest.fn(() => window.googletag),
+        enableServices: jest.fn(),
+        display: jest.fn(),
+    };
+    expect.hasAssertions();
+});
+
+const sharedAfterEach = () => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
 };
 
-describe('Article Aside Adverts', () => {
+describe('Standard Article Aside Adverts', () => {
     const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
@@ -26,64 +91,8 @@ describe('Article Aside Adverts', () => {
         </div>
     `;
 
-    beforeEach(() => {
-        jest.resetAllMocks();
-
-        if (document.body) {
-            document.body.innerHTML = domSnippet;
-        }
-
-        const pubAds = {
-            listeners: [],
-            addEventListener: jest.fn(function(eventName, callback) {
-                this.listeners[eventName] = callback;
-            }),
-            setTargeting: jest.fn(),
-            enableSingleRequest: jest.fn(),
-            collapseEmptyDivs: jest.fn(),
-            refresh: jest.fn(),
-        };
-        const sizeMapping = {
-            sizes: [],
-            addSize: jest.fn(function(width, sizes) {
-                this.sizes.unshift([width, sizes]);
-            }),
-            build: jest.fn(function() {
-                const tmp = this.sizes;
-                this.sizes = [];
-                return tmp;
-            }),
-        };
-        window.googletag = {
-            cmd: {
-                push(...args) {
-                    args.forEach(command => {
-                        command();
-                    });
-                },
-            },
-            pubads() {
-                return pubAds;
-            },
-            sizeMapping() {
-                return sizeMapping;
-            },
-            defineSlot: jest.fn(() => window.googletag),
-            defineOutOfPageSlot: jest.fn(() => window.googletag),
-            addService: jest.fn(() => window.googletag),
-            defineSizeMapping: jest.fn(() => window.googletag),
-            setTargeting: jest.fn(() => window.googletag),
-            enableServices: jest.fn(),
-            display: jest.fn(),
-        };
-        expect.hasAssertions();
-    });
-
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+    beforeEach(sharedBeforeEach(domSnippet));
+    afterEach(sharedAfterEach);
 
     it('should exist', () => {
         expect(init).toBeDefined();
@@ -91,7 +100,8 @@ describe('Article Aside Adverts', () => {
     });
 
     it('should have the correct size mappings and classes', done => {
-        mockMainColHeight(900000);
+        configSpy.mockReturnValueOnce(false);
+        fastdomReadSpy.mockReturnValue(Promise.resolve([900000, 0]));
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
@@ -103,11 +113,97 @@ describe('Article Aside Adverts', () => {
     });
 
     it('should mutate the ad slot in short articles', done => {
-        mockMainColHeight(10);
+        configSpy.mockReturnValueOnce(false);
+        fastdomReadSpy.mockReturnValue(Promise.resolve([10, 0]));
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).not.toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
                 '1,1|2,2|300,250|300,274|fluid'
+            );
+            done();
+        });
+        init(noop, noop);
+    });
+});
+
+
+describe('Immersive Article Aside Adverts', () => {
+
+    const domSnippet = `
+        <div class="js-content-main-column">
+            <figure class="element element--immersive"></figure>
+            <figure class="element element--immersive"></figure>
+        </div>
+        <div class="content__secondary-column js-secondary-column">
+            <div class="ad-slot-container">
+                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>
+            </div>
+        </div>
+    `;
+    beforeEach(sharedBeforeEach(domSnippet));
+    afterEach(sharedAfterEach);
+
+    it('should have correct test elements', () => {
+        expect(qwery('.js-content-main-column .element--immersive').length).toBe(2);
+    });
+
+    it('should remove sticky and return all slot sizes when there is enough space', done => {
+        fastdomReadSpy.mockReturnValueOnce(Promise.resolve([900001, 10000]));
+        configSpy.mockReturnValueOnce(true);
+
+        mediator.once('page:defaultcommercial:right', adSlot => {
+            expect(adSlot.classList).not.toContain('js-sticky-mpu');
+            const sizes = adSlot.getAttribute('data-mobile').split("|");
+            expect(sizes).toContain("1,1");
+            expect(sizes).toContain("2,2");
+            expect(sizes).toContain("300,250");
+            expect(sizes).toContain("300,274");
+            expect(sizes).toContain("300,600");
+            expect(sizes).toContain("fluid");
+            done();
+        });
+        init(noop, noop);
+    });
+
+    it('should remove sticky and return sizes that will fit when there is limited space', done => {
+        fastdomReadSpy.mockReturnValueOnce(Promise.resolve([900002, 260]));
+        configSpy.mockReturnValueOnce(true);
+
+        mediator.once('page:defaultcommercial:right', adSlot => {
+            expect(adSlot.classList).not.toContain('js-sticky-mpu');
+            const sizes = adSlot.getAttribute('data-mobile').split("|");
+            expect(sizes).toContain("1,1");
+            expect(sizes).toContain("2,2");
+            expect(sizes).toContain("300,250");
+            expect(sizes).not.toContain("300,274");
+            expect(sizes).not.toContain("300,600");
+            expect(sizes).not.toContain("fluid");
+            done();
+        });
+        init(noop, noop);
+    });
+});
+
+describe('Immersive Article (no immersive elements) Aside Adverts', () => {
+
+    const domSnippet = `
+        <div class="js-content-main-column"></div>
+        <div class="content__secondary-column js-secondary-column">
+            <div class="ad-slot-container">
+                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>
+            </div>
+        </div>
+    `;
+    beforeEach(sharedBeforeEach(domSnippet));
+    afterEach(sharedAfterEach);
+
+    it('should have the correct size mappings and classes (leaves it untouched)', done => {
+        configSpy.mockReturnValueOnce(true);
+        fastdomReadSpy.mockReturnValue(Promise.resolve([900000, 0]));
+        mediator.once('page:defaultcommercial:right', adSlot => {
+            expect(adSlot.classList).toContain('js-sticky-mpu');
+            expect(adSlot.getAttribute('data-mobile')).toBe(
+                '1,1|2,2|300,250|300,274|300,600|fluid'
             );
             done();
         });

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -15,14 +15,12 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 
 const fastdomReadSpy = jest.spyOn(fastdom, 'read');
 
-jest.mock('lib/config', () => {
-    return {
-        get: jest.fn()
-    }
-});
+jest.mock('lib/config', () => ({
+    get: jest.fn(),
+}));
 const configSpy = jest.spyOn(config, 'get');
 
-const sharedBeforeEach = (domSnippet: string) => (() => {
+const sharedBeforeEach = (domSnippet: string) => () => {
     jest.resetAllMocks();
 
     if (document.body) {
@@ -73,7 +71,7 @@ const sharedBeforeEach = (domSnippet: string) => (() => {
         display: jest.fn(),
     };
     expect.hasAssertions();
-});
+};
 
 const sharedAfterEach = () => {
     if (document.body) {
@@ -126,9 +124,7 @@ describe('Standard Article Aside Adverts', () => {
     });
 });
 
-
 describe('Immersive Article Aside Adverts', () => {
-
     const domSnippet = `
         <div class="js-content-main-column">
             <figure class="element element--immersive"></figure>
@@ -144,7 +140,9 @@ describe('Immersive Article Aside Adverts', () => {
     afterEach(sharedAfterEach);
 
     it('should have correct test elements', () => {
-        expect(qwery('.js-content-main-column .element--immersive').length).toBe(2);
+        expect(
+            qwery('.js-content-main-column .element--immersive').length
+        ).toBe(2);
     });
 
     it('should remove sticky and return all slot sizes when there is enough space', done => {
@@ -153,13 +151,13 @@ describe('Immersive Article Aside Adverts', () => {
 
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).not.toContain('js-sticky-mpu');
-            const sizes = adSlot.getAttribute('data-mobile').split("|");
-            expect(sizes).toContain("1,1");
-            expect(sizes).toContain("2,2");
-            expect(sizes).toContain("300,250");
-            expect(sizes).toContain("300,274");
-            expect(sizes).toContain("300,600");
-            expect(sizes).toContain("fluid");
+            const sizes = adSlot.getAttribute('data-mobile').split('|');
+            expect(sizes).toContain('1,1');
+            expect(sizes).toContain('2,2');
+            expect(sizes).toContain('300,250');
+            expect(sizes).toContain('300,274');
+            expect(sizes).toContain('300,600');
+            expect(sizes).toContain('fluid');
             done();
         });
         init(noop, noop);
@@ -171,13 +169,13 @@ describe('Immersive Article Aside Adverts', () => {
 
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).not.toContain('js-sticky-mpu');
-            const sizes = adSlot.getAttribute('data-mobile').split("|");
-            expect(sizes).toContain("1,1");
-            expect(sizes).toContain("2,2");
-            expect(sizes).toContain("300,250");
-            expect(sizes).not.toContain("300,274");
-            expect(sizes).not.toContain("300,600");
-            expect(sizes).not.toContain("fluid");
+            const sizes = adSlot.getAttribute('data-mobile').split('|');
+            expect(sizes).toContain('1,1');
+            expect(sizes).toContain('2,2');
+            expect(sizes).toContain('300,250');
+            expect(sizes).not.toContain('300,274');
+            expect(sizes).not.toContain('300,600');
+            expect(sizes).not.toContain('fluid');
             done();
         });
         init(noop, noop);
@@ -185,7 +183,6 @@ describe('Immersive Article Aside Adverts', () => {
 });
 
 describe('Immersive Article (no immersive elements) Aside Adverts', () => {
-
     const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">


### PR DESCRIPTION
## What does this change?

Adds logic to the Right Hand Side adslot code to handle immersive content. This came up from photo essays, but actually applies more broadly than that (immersive content).

If the content is "immersive" we measure the distance between the top of the article body and the first immersive element. We then change the ad sizes that are eligible for the RH-Side ad slot to ensure that there will be enough space for the ad to display.
Pixels always fit so we allow 1x1 and 2x2 ads in the slot in all cases.

We also remove `sticky` from the ad slot in immersive cases because a sticky ad might need more space. This means we don't need to do more complex calculations and adjust the sticky logic to take immersive element position into account.

Commercial ticket:
https://trello.com/c/1GKP3WUy/53-ads-overlapping-images-on-photo-essays

## Screenshots

Using the new `forceads` flag, we can see what this looks like for an example piece of immersive content in production.

![immersive-rh-ad-bug](https://user-images.githubusercontent.com/29761/51257025-a5e0a180-199e-11e9-9e3d-f761fe24833e.png)

This is what it looks like in dev with this change applied.

![immersive-rh-ad-fix](https://user-images.githubusercontent.com/29761/51256595-b3495c00-199d-11e9-89fa-0b46949d4eae.png)

## What is the value of this and can you measure success?

Up to now the only workaround has been to manually disable ads on any piece of content that is affected. This is laborious and easy to forget. More importantly, it disables ads for the entire piece of content, not just for this slot. There may well be space in the article for ads and certainly, the comments will be unaffected.

Success will be the ad revenue generated by existing pieces of immersive content once ads can be re-enabled, as well as for all future immersives. It will also be the time and effort saved for Commercial and CP dealing with ads overlapping immersive content.

## Checklist

Should probs run this by commercial people and give CP a heads-up. There may be bugs when we test it on more diverse content though.

### Does this affect other platforms?

Nope, this is a website platform change.

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
