### PR TITLE
Add Prebid to Amp live blogs

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -6,7 +6,25 @@
 @import common.Edition
 @import conf.Configuration
 @import org.joda.time.DateTimeZone
-@import views.support.{AmpAd, AmpAdDataSlot, AmpAdRtcConfig, RowAdRegion}
+@import views.support.{AdRegion, AmpAd, AmpAdDataSlot, AmpAdRtcConfig, AuAdRegion, RowAdRegion, UsAdRegion}
+
+@ad(article:Article, adRegion: AdRegion) = {
+    <amp-ad
+        class="geo-amp-ad liveblog-geo-amp-ad--@{adRegion.cssClassSuffix}"
+        width="300"
+        height="250"
+        type="doubleclick"
+        data-loading-strategy="prefer-viewability-over-views"
+        data-npa-on-unknown-consent="true"
+        json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
+        data-slot=@AmpAdDataSlot(article).toString()
+        rtc-config=@AmpAdRtcConfig.toJsonString(
+            Configuration.commercial.prebidServerUrl,
+            adRegion,
+            debug = Configuration.environment.isNonProd
+        )>
+    </amp-ad>
+}
 
 @liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
     @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
@@ -15,20 +33,10 @@
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
         @if(shouldShowAds(model) && blockGroup.length == 5 && index < 8) {
             <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
-                <amp-ad
-                    width="300"
-                    height="250"
-                    type="doubleclick"
-                    data-loading-strategy="prefer-viewability-over-views"
-                    data-npa-on-unknown-consent="true"
-                    json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
-                    data-slot=@AmpAdDataSlot(article).toString()
-                    rtc-config=@AmpAdRtcConfig.toJsonString(
-                        Configuration.commercial.prebidServerUrl,
-                        RowAdRegion,
-                        debug = Configuration.environment.isNonProd
-                    )>
-                </amp-ad>
+                @* An ad per ad region in template but only one will be active at runtime *@
+                @ad(article, RowAdRegion)
+                @ad(article, UsAdRegion)
+                @ad(article, AuAdRegion)
             </div>
         }
     }

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -1,11 +1,12 @@
-@import model.{Article, LiveBlogPage, LatestBlock}
-@import views.support.Commercial.{shouldShowAds}
+@import model.{Article, LatestBlock, LiveBlogPage}
+@import views.support.Commercial.shouldShowAds
 
 @(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.Edition
-@import views.support.{AmpAd, AmpAdDataSlot}
+@import conf.Configuration
 @import org.joda.time.DateTimeZone
+@import views.support.{AmpAd, AmpAdDataSlot, AmpAdRtcConfig, RowAdRegion}
 
 @liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
     @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
@@ -14,10 +15,19 @@
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
         @if(shouldShowAds(model) && blockGroup.length == 5 && index < 8) {
             <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
-                <amp-ad width="300" height="250" type="doubleclick"
-                data-loading-strategy="prefer-viewability-over-views"
+                <amp-ad
+                    width="300"
+                    height="250"
+                    type="doubleclick"
+                    data-loading-strategy="prefer-viewability-over-views"
+                    data-npa-on-unknown-consent="true"
                     json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
-                    data-slot=@AmpAdDataSlot(article).toString()>
+                    data-slot=@AmpAdDataSlot(article).toString()
+                    rtc-config=@AmpAdRtcConfig.toJsonString(
+                        Configuration.commercial.prebidServerUrl,
+                        RowAdRegion,
+                        debug = Configuration.environment.isNonProd
+                    )>
                 </amp-ad>
             </div>
         }

--- a/static/src/stylesheets/amp/_geo.scss
+++ b/static/src/stylesheets/amp/_geo.scss
@@ -8,3 +8,10 @@
 .amp-geo-no-group .geo-amp-ad--row {
     display: block;
 }
+
+.amp-geo-group-us .liveblog-geo-amp-ad--us,
+.amp-geo-group-au .liveblog-geo-amp-ad--au,
+.amp-geo-group-eea .liveblog-geo-amp-ad--row,
+.amp-geo-no-group .liveblog-geo-amp-ad--row {
+    display: inline-block;
+}


### PR DESCRIPTION
This should increase the value of ads in Amp live blog pages.
It has the same effect as what has already been done in Amp articles.

It just:

1. Adds an `rtc-config` attribute to all ad slots, which will make the slot call out to a Prebid server before updating ad targeting sent to the ad server.
1. Does the same trick as #20840 to make ads specific to particular ad regions: US, Australia and all others.
