### PR TITLE
Implement Dotcomponents awareness into HTTP asset preload 

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -12,7 +12,7 @@ import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.{CommonFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, PreloadFilters, CorsHttpErrorHandler}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
@@ -69,7 +69,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
-  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
+  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
   def actorSystem: ActorSystem

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -12,7 +12,7 @@ import conf.switches.SwitchboardLifecycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.{CommonFilters, PreloadFilters, CorsHttpErrorHandler}
+import http.{CommonFilters, CorsHttpErrorHandler}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
@@ -69,7 +69,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
-  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters
+  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
   def actorSystem: ActorSystem

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -16,8 +16,10 @@ import play.api.Logger
 import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
+import model.ApplicationContext
+import http.ResultWithPreload
 
-object `package` extends implicits.Strings with implicits.Requests with play.api.mvc.Results {
+object `package` extends implicits.Strings with implicits.Requests with play.api.mvc.Results with ResultWithPreload {
 
   def isCommercialExpiry(error: ErrorResponse): Boolean = {
     error.message == "The requested resource has expired for commercial reason."
@@ -108,8 +110,10 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
         RevalidatableResult.Ok(htmlResponse())
     }
 
-  def renderHtml(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){
-    RevalidatableResult.Ok(html)
+  def renderHtml(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = {
+    Cached(page)(RevalidatableResult.Ok(html)).withPreload(
+      Preload.config(request).getOrElse(context.applicationIdentity, Seq.empty)
+    )(context, request)
   }
 
   def renderJson(json: List[(String, Any)], page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = Cached(page){

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -128,9 +128,17 @@ object Filters {
     new Gzipper,
     new BackendHeaderFilter,
     new SurrogateKeyFilter,
-    new AmpFilter,
+    new AmpFilter
+  )
+
+  def preload(
+     implicit materializer: Materializer,
+     applicationContext: ApplicationContext,
+     executionContext: ExecutionContext
+   ): List[EssentialFilter] = List(
     new H2PreloadFilter
   )
+
 }
 
 class CommonFilters(
@@ -139,6 +147,14 @@ class CommonFilters(
   executionContext: ExecutionContext
 ) extends HttpFilters {
   val filters = Filters.common
+}
+
+class PreloadFilters(
+   implicit mat: Materializer,
+   applicationContext: ApplicationContext,
+   executionContext: ExecutionContext
+ ) extends HttpFilters {
+  val filters = Filters.preload
 }
 
 class CommonGzipFilter @Inject() (

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -11,7 +11,7 @@ import conf.CachedHealthCheckLifeCycle
 import controllers.front.{FrontJsonFapiDraft, FrontJsonFapiLive}
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import http.CommonFilters
+import http.{CommonFilters, PreloadFilters}
 import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
@@ -63,7 +63,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
     FaciaPressMetrics.FrontDownloadLatency
   )
 
-  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
+  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 
   def actorSystem: ActorSystem


### PR DESCRIPTION
## What does this change?

### Goal

Don't do http preload of assets when you're requesting an article rendered through dotcomponents, because we don't want normal frontend assets being preloaded onto dotcomponents where they won't be used.

### Problem

Our HTTP preload is curently implemented as a play *filter*, but only the *controller* knows how for sure if a request is being rendered under dotcomponents.

### Solution

Don't use http preload as a filter in article, instead give that responsibility to the controller.

### Work done

1. Take the existing HTTP preload filter out of our list of common filters, so it won't be loaded by default into the Article app.

2. Make the Fronts app specifically load the http preload filter (which it has to do now that it's not a part of our common filters)

3. Change the common/package.scala file (which contains helpers functions for rendering HTML and is *only used by article*) to directly apply the asset preload logic.

4. As an effect of #3, article will apply preload logic for normal articles, but not for dotcomponents which doesn't use the package.scala helpers

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
