### PR TITLE
Add AMP specific tracking to Contribute & Subscribe buttons in AMP footer

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -17,6 +17,7 @@ object UrlHelpers {
   case object SideMenu extends Position
   case object AmpHeader extends Position
   case object Footer extends Position
+  case object AmpFooter extends Position
   case object ManageMyAccountUpsell extends Position
   case object ManageMyAccountCancel extends Position
 
@@ -30,14 +31,22 @@ object UrlHelpers {
       case (SupportContribute, Header | AmpHeader | SlimHeaderDropdown) => "header_support_contribute"
       case (SupportContribute, SideMenu) => "side_menu_support_contribute"
       case (SupportContribute, Footer) => "footer_support_contribute"
+      case (SupportContribute, AmpFooter) => "amp_footer_support_contribute"
 
       case (SupportSubscribe, Header | AmpHeader | SlimHeaderDropdown) => "header_support_subscribe"
       case (SupportSubscribe, SideMenu) => "side_menu_support_subscribe"
       case (SupportSubscribe, Footer) => "footer_support_subscribe"
+      case (SupportSubscribe, AmpFooter) => "amp_footer_support_subscribe"
 
       case (_, ManageMyAccountUpsell) => "manage_my_account_upsell"
     }
-  }   
+  }
+
+  def getComponentType(position: Position): String = position match {
+    case Header | AmpHeader | SideMenu | SlimHeaderDropdown => "ACQUISITIONS_HEADER"
+    case ManageMyAccountUpsell | ManageMyAccountCancel => "ACQUISITIONS_MANAGE_MY_ACCOUNT"
+    case Footer | AmpFooter => "ACQUISITIONS_FOOTER"
+  }
 
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] = List(
     NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
@@ -46,6 +55,7 @@ object UrlHelpers {
 
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): String = {
     val componentId = getComponentId(destination, position)
+    val componentType = getComponentType(position)
 
     val acquisitionData = Json.obj(
       // GUARDIAN_WEB corresponds to a value in the Thrift enum
@@ -53,11 +63,7 @@ object UrlHelpers {
       // ACQUISITIONS_HEADER and ACQUISITIONS_FOOTER correspond to values in the Thrift enum
       // https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Enum_ComponentType
       "source" -> "GUARDIAN_WEB",
-      "componentType" -> (position match {
-        case Header | AmpHeader | SideMenu | SlimHeaderDropdown => "ACQUISITIONS_HEADER"
-        case ManageMyAccountUpsell | ManageMyAccountCancel => "ACQUISITIONS_MANAGE_MY_ACCOUNT"
-        case Footer => "ACQUISITIONS_FOOTER"
-      })
+      "componentType" -> componentType
     ) ++ componentId.fold(Json.obj())(c => Json.obj(
       "componentId" -> c
     ))

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,5 +1,3 @@
-@import navigation.UrlHelpers.AmpFooter
-@import navigation.UrlHelpers
 @(showNav: Boolean = true, isAmp: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 @import org.joda.time.DateTime

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,3 +1,5 @@
+@import navigation.UrlHelpers.AmpFooter
+@import navigation.UrlHelpers
 @(showNav: Boolean = true, isAmp: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 @import org.joda.time.DateTime
@@ -5,7 +7,7 @@
 @import common.LinkTo
 @import navigation.NavMenu
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Footer}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, AmpFooter}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
 @import conf.switches.Switches.{ EmailInlineInFooterSwitch }
@@ -129,7 +131,7 @@
                                     <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"
                                         data-link-name="footer : contribute-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportContribute, Footer)">
+                                        href="@getReaderRevenueUrl(SupportContribute, if (isAmp) AmpFooter else Footer)">
                                         Contribute
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -137,7 +139,7 @@
                                     <a class="cta-bar__cta js-subscribe js-acquisition-link"
                                         data-link-name="footer : subscribe-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        href="@getReaderRevenueUrl(SupportSubscribe, if (isAmp) AmpFooter else Footer)">
                                         Subscribe
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -217,7 +219,7 @@
                                     <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"
                                         data-link-name="footer : contribute-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportContribute, Footer)">
+                                        href="@getReaderRevenueUrl(SupportContribute, if (isAmp) AmpFooter else Footer)">
                                         Contribute
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -225,7 +227,7 @@
                                     <a class="cta-bar__cta js-subscribe js-acquisition-link"
                                         data-link-name="footer : subscribe-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        href="@getReaderRevenueUrl(SupportSubscribe, if (isAmp) AmpFooter else Footer)">
                                         Subscribe
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -310,7 +312,7 @@
                                     <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"
                                         data-link-name="footer : contribute-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportContribute, Footer)">
+                                        href="@getReaderRevenueUrl(SupportContribute, if (isAmp) AmpFooter else Footer)">
                                         Contribute
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -318,7 +320,7 @@
                                     <a class="cta-bar__cta js-subscribe js-acquisition-link"
                                         data-link-name="footer : subscribe-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        href="@getReaderRevenueUrl(SupportSubscribe, if (isAmp) AmpFooter else Footer)">
                                         Subscribe
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -390,7 +392,7 @@
                                     <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"
                                         data-link-name="footer : contribute-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportContribute, Footer)">
+                                        href="@getReaderRevenueUrl(SupportContribute, if (isAmp) AmpFooter else Footer)">
                                         Contribute
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>
@@ -398,7 +400,7 @@
                                     <a class="cta-bar__cta js-subscribe js-acquisition-link"
                                         data-link-name="footer : subscribe-cta"
                                         data-edition="@{editionId}"
-                                        href="@getReaderRevenueUrl(SupportSubscribe,Footer)">
+                                        href="@getReaderRevenueUrl(SupportSubscribe, if (isAmp) AmpFooter else Footer)">
                                         Subscribe
                                         @fragments.inlineSvg("arrow-right", "icon")
                                     </a>

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -1,18 +1,56 @@
 package navigation.helpers
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{WordSpec  , Matchers}
 import test.TestRequest
-import navigation.ReaderRevenueSite.Support
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers
-import navigation.UrlHelpers.{Header, AmpHeader}
+import navigation.UrlHelpers.{AmpFooter, AmpHeader, Footer, Header}
 
-class UrlHelpersTest extends FlatSpec with Matchers {
+class UrlHelpersTest extends WordSpec with Matchers {
 
-  "getComponentId when called with Support, Header" should "return header_support" in {
-    UrlHelpers.getComponentId(Support, Header)(TestRequest()) should be(Some("header_support"))
-  }
+  "UrlHelpers" can {
+    "getComponentId" should {
+      "return header_support when called with Support, Header" in {
+        UrlHelpers.getComponentId(Support, Header)(TestRequest()) should be(Some("header_support"))
+      }
 
-  "getComponentId when called with Support, AmpHeader" should "return amp_header_support" in {
-    UrlHelpers.getComponentId(Support, AmpHeader)(TestRequest()) should be(Some("amp_header_support"))
+      "return amp_header_support when called with Support, AmpHeader" in {
+        UrlHelpers.getComponentId(Support, AmpHeader)(TestRequest()) should be(Some("amp_header_support"))
+      }
+
+      "return footer_support_contribute when called with SupportContribute, Footer" in {
+        UrlHelpers.getComponentId(SupportContribute, Footer)(TestRequest()) should be(Some("footer_support_contribute"))
+      }
+
+      "return amp_footer_support_contribute when called with SupportContribute, AmpFooter" in {
+        UrlHelpers.getComponentId(SupportContribute, AmpFooter)(TestRequest()) should be(Some("amp_footer_support_contribute"))
+      }
+
+      "return footer_support_subscribe when called with SupportSubscribe, Footer" in {
+        UrlHelpers.getComponentId(SupportSubscribe, Footer)(TestRequest()) should be(Some("footer_support_subscribe"))
+      }
+
+      "return amp_footer_support_subscribe when called with SupportSubscribe, AmpFooter" in {
+        UrlHelpers.getComponentId(SupportSubscribe, AmpFooter)(TestRequest()) should be(Some("amp_footer_support_subscribe"))
+      }
+    }
+
+    "getComponentType" should {
+      "return ACQUISITIONS_HEADER when called with Header" in {
+        UrlHelpers.getComponentType(Header) should be("ACQUISITIONS_HEADER")
+      }
+
+      "return ACQUISITIONS_HEADER when called with AmpHeader" in {
+        UrlHelpers.getComponentType(AmpHeader) should be("ACQUISITIONS_HEADER")
+      }
+
+      "return ACQUISITIONS_FOOTER when called with Footer" in {
+        UrlHelpers.getComponentType(Footer) should be("ACQUISITIONS_FOOTER")
+      }
+
+      "return ACQUISITIONS_FOOTER when called with AmpFooter" in {
+        UrlHelpers.getComponentType(AmpFooter) should be("ACQUISITIONS_FOOTER")
+      }
+    }
   }
 }

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -1,6 +1,6 @@
 package navigation.helpers
 
-import org.scalatest.{WordSpec  , Matchers}
+import org.scalatest.{WordSpec, Matchers}
 import test.TestRequest
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers


### PR DESCRIPTION
## What does this change?
* Update getComponentId to return amp specific string for the AmpFooter position
* Conditionally set AmpFooter in footer.scala.html
* Extract logic to getComponentType
* Add AmpFooter pattern to getComponentType

## Screenshots
<img width="576" alt="screen shot 2019-01-17 at 11 38 15" src="https://user-images.githubusercontent.com/249676/51316523-d7b04180-1a4c-11e9-8d98-d3dc1e83b230.png">

## What is the value of this and can you measure success?
This change allows us to measure how many users contribute via the AMP footer support buttons, helping the Subscribe with Google team make a decision on where to implement Subscribe with Google first.

This data can be seen in Tableau, AV by component Id: https://tableau.ophan.co.uk/views/TheAcquisitionsDimensionSlicer/AVbycomponentId

It has previously been applied to the header https://github.com/guardian/frontend/pull/20914

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
