### PR TITLE
Ensure CAPI data populated for JSON endpoint

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -43,7 +43,6 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
           case RemoteRender => remoteRenderer.getArticle(ws, path, article)
           case RemoteRenderAMP => remoteRenderer.getAMPArticle(ws, path, article)
           case LocalRender => render(path, article)
-          case _ => render(path, article)
         }
       })
     }

--- a/onward/app/controllers/StoryPackageController.scala
+++ b/onward/app/controllers/StoryPackageController.scala
@@ -17,7 +17,8 @@ class StoryPackageController(val contentApiClient: ContentApiClient, val control
     with ImplicitControllerExecutionContext {
 
   def render(path: String): Action[AnyContent] = Action.async { implicit request =>
-    val query = contentApiClient.item(path).showPackages(true)
+    val fields = "headline,standfirst,shortUrl,webUrl,byline,trailText,liveBloggingNow,commentCloseDate,commentable"
+    val query = contentApiClient.item(path).showPackages(true).showFields(fields)
     val resp = contentApiClient.getResponse(query)
 
     for {


### PR DESCRIPTION
Ensure we populate the required JSON fields for the story package API endpoint (used for AMP onwards).

To prevent this sadness:

<img width="754" alt="screenshot 2019-01-17 at 13 49 13" src="https://user-images.githubusercontent.com/858402/51323097-1ea73280-1a5f-11e9-8102-65effe968469.png">
