### PR TITLE
MMA: migrate digipack to manage platform

### DIFF
--- a/identity/app/controllers/editprofile/editprofile.scala
+++ b/identity/app/controllers/editprofile/editprofile.scala
@@ -7,7 +7,6 @@ package object editprofile {
   object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
   object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
   object EmailPrefsProfilePage extends IdentityPage("/email-prefs", "Emails")
-  object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
 
   sealed abstract class ConsentJourneyPage(id: String, val journey: AnyConsentsJourney)
       extends IdentityPage(id, "Consent", isFlow = true)

--- a/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
+++ b/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
@@ -1,5 +1,6 @@
 package controllers.editprofile.tabs
 
+import conf.Configuration
 import controllers.editprofile._
 import play.api.mvc.{Action, AnyContent}
 
@@ -10,25 +11,19 @@ trait SupporterTabs
     extends EditProfileControllerComponents
     with EditProfileFormHandling {
 
-  /** Redirect /membership/edit to manage.theguardian.com/membership */
-  def redirectToManageMembership: Action[AnyContent] = Action { implicit request =>
+  private def redirectToManage(path: String): Action[AnyContent] = Action { implicit request =>
     Redirect(
-      url = "https://manage.theguardian.com/membership",
+      url = s"${Configuration.id.mmaUrl}/${path}",
       MOVED_PERMANENTLY)
   }
+
+  /** Redirect /membership/edit to manage.theguardian.com/membership */
+  def redirectToManageMembership: Action[AnyContent] = redirectToManage("membership")
 
   /** Redirect /contribution/recurring/edit to manage.theguardian.com/contributions */
-  def redirectToManageContributions: Action[AnyContent] = Action { implicit request =>
-    Redirect(
-      url = "https://manage.theguardian.com/contributions",
-      MOVED_PERMANENTLY)
-  }
+  def redirectToManageContributions: Action[AnyContent] = redirectToManage("contributions")
 
   /** Redirect /digitalpack/edit to manage.theguardian.com/digitalpack */
-  def redirectToManageDigitalPack: Action[AnyContent] = Action { implicit request =>
-    Redirect(
-      url = "https://manage.theguardian.com/digitalpack",
-      MOVED_PERMANENTLY)
-  }
+  def redirectToManageDigitalPack: Action[AnyContent] = redirectToManage("digitalpack")
 
 }

--- a/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
+++ b/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
@@ -24,7 +24,11 @@ trait SupporterTabs
       MOVED_PERMANENTLY)
   }
 
-  /** GET /digitalpack/edit */
-  def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
+  /** Redirect /digitalpack/edit to manage.theguardian.com/digitalpack */
+  def redirectToManageDigitalPack: Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      url = "https://manage.theguardian.com/digitalpack",
+      MOVED_PERMANENTLY)
+  }
 
 }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -81,7 +81,7 @@
 
                     @tab(3, "Membership", "/membership/edit", None, optionalClass="qa-membership-tab", disableClientSideRouting = true)
 
-                    @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
+                    @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab", disableClientSideRouting = true)
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation, disableClientSideRouting = true)
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -54,7 +54,7 @@ POST        /account/edit                           controllers.editprofile.Edit
 
 GET         /membership/edit                        controllers.editprofile.EditProfileController.redirectToManageMembership
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.redirectToManageContributions
-GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.displayDigitalPackForm
+GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.redirectToManageDigitalPack
 
 GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -13,16 +13,16 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import userPrefs from 'common/modules/user-prefs';
 
+const createManageBannerLink = manageProductKeyword =>
+    `${config.get('page.mmaUrl')}/banner/${manageProductKeyword}?INTCMP=BANNER`;
+
 const accountDataUpdateLink = accountDataUpdateWarningLink => {
     switch (accountDataUpdateWarningLink) {
         case 'contribution':
-            return `${config.get(
-                'page.mmaUrl'
-            )}/banner/contributions?INTCMP=BANNER`;
+            return createManageBannerLink('contributions');
         case 'membership':
-            return `${config.get(
-                'page.mmaUrl'
-            )}/banner/membership?INTCMP=BANNER`;
+        case 'digitalpack':
+            return createManageBannerLink(accountDataUpdateWarningLink);
         default:
             return `${config.get(
                 'page.idUrl'


### PR DESCRIPTION
## What does this change?
This migrates the Digital Pack tab over to the new manage platform (the last of the three Reader Revenue tabs 🎉). This change is largely just redirects (albeit in a slightly cleaner way than before)
**There will be a follow up PR very soon to clean-up all the old reader revenue code (Membership, Contributions & Digpack tab logic and HTML templates - just the redirects will remain.**

_Note this is a similar change to migrating contributions tab back in Oct 2018 https://github.com/guardian/frontend/pull/20571_

## Screenshots
_N/A this is not a visual change_ (however the what the tab looks like can be see on https://github.com/guardian/manage-frontend/pull/178)

## What is the value of this and can you measure success?
This is more of a strategic change to move functionality off a large codebase. That said there is GA tracking in the new platform to allow for before/after comparison.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist
_N/A this change is just redirects_
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
