### PR TITLE
Fix section-front pageskin targeting

### DIFF
--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -56,11 +56,10 @@
         <li>
             <h4>Targeting a section front:</h4>
             <ul>
-                <li>The Ad Unit must be a <em>front</em>, including the final "/ng" ad unit</li>
+                <li>The Ad Unit must be a <em>front</em>, ending in "/front"</li>
                 <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
                 <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
                 <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
-                <li>The viewport must be at least 1300px wide.</li>
             </ul>
         </li>
         <li>
@@ -70,10 +69,10 @@
                 <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
                 <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
                 <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
-                <li>The viewport must be at least 1300px wide.</li>
             </ul>
         </li>
     </ol>
+    <p>For a pageskin to appear, the viewport must be at least 1300px wide.</p>
 
     <h2>Pageskinned Ad Units</h2>
     <p>Last updated: @pageSkinnedAdUnits.updatedTimeStamp</p>

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -20,14 +20,21 @@ trait PageskinAdAgent {
     edition: Edition
   ): Seq[PageSkinSponsorship] = {
 
+    val nextGenSuffix = "/ng"
+
+    def containsAdUnit(adUnits: Seq[String], adUnit: String): Boolean =
+      adUnits.map { _.stripSuffix(nextGenSuffix) }
+      .exists { adUnitPath.stripSuffix(nextGenSuffix).endsWith }
+
+    def hasMatchingAdUnit(sponsorship: PageSkinSponsorship): Boolean =
+      containsAdUnit(sponsorship.adUnits, adUnitPath)
+
     val candidates = pageSkinSponsorships filter { sponsorship =>
       sponsorship.editions.contains(edition)
     }
 
     if (PageSkin.isValidAdUnit(adUnitPath)) {
-      candidates filter { sponsorship =>
-        sponsorship.adUnits.exists(adUnitPath.endsWith)
-      }
+      candidates filter hasMatchingAdUnit
     } else {
       val targetingMap = toMap(metaData.commercial.map(_.adTargeting(edition)).getOrElse(Set.empty))
 

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -187,4 +187,24 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       )
     )
   }
+
+  it should "find section-targeted sponsorship without needing an 'ng' ad unit suffix" in {
+    NotProductionTestPageskinAdAgent.findSponsorships(
+      adUnitPath = "/123456/root/testSport/front/ng",
+      metaData = keywordPressedFrontMeta,
+      edition = Uk
+    ) shouldBe Seq(
+      PageSkinSponsorship(
+        lineItemName = "lineItemName4",
+        lineItemId = 1234567,
+        adUnits = Seq("testSport/front"),
+        editions = Seq(Uk),
+        countries = Seq("United Kingdom"),
+        targetsAdTest = true,
+        adTestValue = Some("6"),
+        keywords = Nil,
+        series = Nil
+      )
+    )
+  }
 }


### PR DESCRIPTION
Previously, the suffix of the ad unit of a page had to match exactly the suffix of the ad unit of a pageskin line item set up in Ad Manager.
This change means that the ad units will match regardless of whether one of them ends in '/ng'.
This avoids having to set up line items with a pointless 'ng' suffix, and should make troubleshooting a bit easier.