### PR TITLE
Show really big comment counts with a k

### DIFF
--- a/static/src/javascripts/lib/formatters.js
+++ b/static/src/javascripts/lib/formatters.js
@@ -10,7 +10,7 @@ const integerCommas = (
     }
 
     if (!!truncate && num > 9999) {
-        const thousands = ~~(num/1000)
+        const thousands = Math.floor(num / 1000);
         return `${thousands.toLocaleString()}k`;
     }
 

--- a/static/src/javascripts/lib/formatters.js
+++ b/static/src/javascripts/lib/formatters.js
@@ -10,7 +10,8 @@ const integerCommas = (
     }
 
     if (!!truncate && num > 9999) {
-        return `${num.toString().slice(0, -3)}k`;
+        const thousands = ~~(num/1000)
+        return `${thousands.toLocaleString()}k`;
     }
 
     return num.toLocaleString();

--- a/static/src/javascripts/lib/formatters.js
+++ b/static/src/javascripts/lib/formatters.js
@@ -1,21 +1,19 @@
 // @flow
-const integerCommas = (val: string | number): string | void => {
+const integerCommas = (
+    val: string | number,
+    truncate?: boolean
+): string | void => {
     // commafy integers. see formatters.spec.js for expected input/output
     const num = parseInt(val, 10);
-
-    let digits;
-    let i;
-    let len;
-    if (!Number.isNaN(num)) {
-        digits = num.toFixed(0).split('');
-        len = digits.length;
-        for (i = digits.length - 1; i >= 1; i -= 1) {
-            if ((len - i) % 3 === 0) {
-                digits.splice(i, 0, ',');
-            }
-        }
-        return digits.join('');
+    if (Number.isNaN(num)) {
+        return;
     }
+
+    if (!!truncate && num > 9999) {
+        return `${num.toString().slice(0, -3)}k`;
+    }
+
+    return num.toLocaleString();
 };
 
 export { integerCommas };

--- a/static/src/javascripts/lib/formatters.spec.js
+++ b/static/src/javascripts/lib/formatters.spec.js
@@ -21,3 +21,24 @@ describe('integerCommas', () => {
         }
     });
 });
+
+describe('integerCommas', () => {
+    it('should correctly add a comma for >=4 digit numbers', () => {
+        const tests = [
+            [1, '1'],
+            [12, '12'],
+            [123, '123'],
+            [1234, '1,234'],
+            [12345, '12k'],
+            [123456, '123k'],
+            [1234567, '1,234k'],
+            [12345678, '12,345k'],
+            [123456789, '123,456k'],
+            [1234567890, '1,234,567k'],
+        ];
+
+        for (let i = 0; i < tests.length; i += 1) {
+            expect(integerCommas(tests[i][0], true)).toBe(tests[i][1]);
+        }
+    });
+});

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -74,7 +74,7 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
         {
             url,
             icon: inlineSvg('commentCount16icon', ['inline-tone-fill']),
-            count: integerCommas(count) || '',
+            count: integerCommas(count, true) || '',
         },
         format
     );


### PR DESCRIPTION
## What does this change?
Truncates long numbers and swaps some handwritten code for a browser API. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
## Screenshots
tk
## What is the value of this and can you measure success?
Doesn't overflow.
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
