### PR TITLE
Password change endpoint refactor and new result

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -80,13 +80,12 @@ class ChangePasswordController(
   def renderPasswordConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action { implicit request =>
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
-    NoCache(DiscardingIdentityCookies(
+    NoCache(
       Ok(
         IdentityHtmlPage.html(
           views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, None)
         )(page, request, context)
-      )
-    ))
+      ))
   }
 
   def submitForm(): Action[AnyContent] = csrfCheck {

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -107,7 +107,7 @@ class ChangePasswordController(
             val update = PasswordUpdate(form.oldPassword, form.newPassword1)
             val authResponse = api.updatePassword(update, request.user.auth, idRequest.trackingData)
 
-            signInService.getCookies(authResponse, true) map {
+            signInService.getCookies(authResponse, rememberMe = true) map {
               case Left(errors) =>
                 val formWithErrors = errors.foldLeft(boundForm){ (form, error) =>
                   form.withError(error.context.getOrElse(""), error.description)

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -89,11 +89,11 @@ class IdApiClient(
     response map extract[Boolean](jsonField("passwordExists"))
   }
 
-  def updatePassword(pwdUpdate: PasswordUpdate, auth: Auth, trackingData: TrackingData ): Future[Response[Unit]] = {
+  def updatePassword(pwdUpdate: PasswordUpdate, auth: Auth, trackingData: TrackingData ): Future[Response[CookiesResponse]] = {
     val apiPath = urlJoin("user", "password")
     val body = write(pwdUpdate)
     val response = post(apiPath, Some(auth), Some(trackingData), Some(body))
-    response map extractUnit
+    response map extract(jsonField("cookies"))
   }
 
   def userForToken( token : String ): Future[Response[User]] = {

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -92,7 +92,8 @@ class IdApiClient(
   def updatePassword(pwdUpdate: PasswordUpdate, auth: Auth, trackingData: TrackingData ): Future[Response[CookiesResponse]] = {
     val apiPath = urlJoin("user", "password")
     val body = write(pwdUpdate)
-    val response = post(apiPath, Some(auth), Some(trackingData), Some(body))
+    val headers = buildHeaders(Some(auth), extra = xForwardedForHeader(trackingData))
+    val response = httpClient.POST(apiUrl(apiPath), Some(body), clientAuth.parameters, headers)
     response map extract(jsonField("cookies"))
   }
 

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -94,7 +94,7 @@ class IdApiClient(
     val body = write(pwdUpdate)
     val headers = buildHeaders(Some(auth), extra = xForwardedForHeader(trackingData))
     val response = httpClient.POST(apiUrl(apiPath), Some(body), clientAuth.parameters, headers)
-    response map extract(jsonField("cookies"))
+    response map extract[CookiesResponse](jsonField("cookies"))
   }
 
   def userForToken( token : String ): Future[Response[User]] = {


### PR DESCRIPTION
## What does this change?
- We are now returning a full login cookie on the password change endpoint in Identity. 
- This is so users are still fully logged in after password change. 
- Related Identity PR : https://github.com/guardian/identity/pull/1503

## Screenshots

## What is the value of this and can you measure success?
- Keep users logged in when they don't need to be logged out.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
