### PR TITLE
Add LinkedData to DotcomponentsDataModel for consumption by dotcom-rendering

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -6,7 +6,7 @@ import controllers.ArticlePage
 import model.SubMetaLinks
 import model.dotcomrendering.pageElements.PageElement
 import navigation.NavMenu
-import play.api.libs.json.{JsValue, Json, OFormat, Writes}
+import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, GUDateTimeFormat}
 import ai.x.play.json.Jsonx
@@ -55,13 +55,25 @@ case class ReaderRevenueLinks(
 )
 
 case class NewsArticle(
+  override val `@type`: String,
+  override val `@context`: String,
   `@id`: String,
+  potentialAction: PotentialAction,
   publisher: Guardian = Guardian(),
   isAccessibleForFree: Boolean = true,
-  potentialAction: PotentialAction
-) extends LinkedData("NewsArticle")
+) extends LinkedData(`@type`, `@context`)
 
 object NewsArticle {
+  def apply(
+   `@id`: String,
+   potentialAction: PotentialAction
+ ): NewsArticle = new NewsArticle(
+    "NewsArticle",
+    "http://schema.org",
+    `@id`,
+    potentialAction,
+  )
+
   implicit val formats: OFormat[NewsArticle] = Json.format[NewsArticle]
 }
 
@@ -203,7 +215,7 @@ object DotcomponentsDataModel {
 
     val webUrl = article.metadata.webUrl
     val potentialAction = PotentialAction(target = "android-app://com.guardian/" + webUrl.replace("://", "/"))
-    val linkedData = NewsArticle(`@id` = webUrl, potentialAction = potentialAction)
+    val linkedData = NewsArticle(webUrl, potentialAction)
 
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -65,13 +65,14 @@ case class NewsArticle(
 
 object NewsArticle {
   def apply(
-   `@id`: String,
-   potentialAction: PotentialAction
- ): NewsArticle = new NewsArticle(
+   `@id`: String
+ ): NewsArticle = NewsArticle(
     "NewsArticle",
     "http://schema.org",
     `@id`,
-    potentialAction,
+    PotentialAction(
+      target = s"android-app://com.guardian/${`@id`.replace("://", "/")}"
+    ),
   )
 
   implicit val formats: OFormat[NewsArticle] = Json.format[NewsArticle]
@@ -213,9 +214,7 @@ object DotcomponentsDataModel {
       acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
     })
 
-    val webUrl = article.metadata.webUrl
-    val potentialAction = PotentialAction(target = "android-app://com.guardian/" + webUrl.replace("://", "/"))
-    val linkedData = NewsArticle(webUrl, potentialAction)
+    val linkedData = NewsArticle(article.metadata.webUrl)
 
     val pageData = PageData(
       article.tags.contributors.map(_.name).mkString(","),
@@ -245,7 +244,7 @@ object DotcomponentsDataModel {
       switches,
       linkedData,
       Configuration.site.host,
-      webUrl,
+      article.metadata.webUrl,
       article.content.shouldHideAdverts,
       hasStoryPackage = articlePage.related.hasStoryPackage,
       hasRelated = article.content.showInRelated,

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,6 +1,7 @@
 package model.meta
 
 import conf.Static
+import play.api.libs.json.{Json, OFormat}
 
 class LinkedData(
   val `@type`: String,
@@ -27,6 +28,10 @@ case class Guardian(
   )
 ) extends LinkedData("Organization")
 
+object Guardian {
+  implicit val formats: OFormat[Guardian] = Json.format[Guardian]
+}
+
 // https://developers.google.com/app-indexing/webmasters/server#schemaorg-markup-for-viewaction
 case class WebPage(
   `@id`: String,
@@ -37,6 +42,10 @@ case class PotentialAction(
   `@type`: String = "ViewAction",
   target: String
 )
+
+object PotentialAction {
+  implicit val formats: OFormat[PotentialAction] = Json.format[PotentialAction]
+}
 
 case class ItemList(
   url: String,

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -18,8 +18,8 @@ object LinkedData {
 }
 
 case class Guardian(
-  override val `@type`: String,
-  override val `@context`: String,
+  override val `@type`: String = "Organization",
+  override val `@context`: String = "http://schema.org",
   name: String = "The Guardian",
   url: String = "http://www.theguardian.com/",
   logo: String = Static("images/favicons/152x152.png"),
@@ -31,7 +31,6 @@ case class Guardian(
 ) extends LinkedData(`@type`, `@context`)
 
 object Guardian {
-  def apply(): Guardian = new Guardian("Organization", "http://schema.org")
   implicit val formats: OFormat[Guardian] = Json.format[Guardian]
 }
 

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,7 +1,7 @@
 package model.meta
 
 import conf.Static
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json._
 
 class LinkedData(
   val `@type`: String,
@@ -18,6 +18,8 @@ object LinkedData {
 }
 
 case class Guardian(
+  override val `@type`: String,
+  override val `@context`: String,
   name: String = "The Guardian",
   url: String = "http://www.theguardian.com/",
   logo: String = Static("images/favicons/152x152.png"),
@@ -26,9 +28,10 @@ case class Guardian(
     "https://twitter.com/guardian",
     "https://www.youtube.com/user/TheGuardian"
   )
-) extends LinkedData("Organization")
+) extends LinkedData(`@type`, `@context`)
 
 object Guardian {
+  def apply(): Guardian = new Guardian("Organization", "http://schema.org")
   implicit val formats: OFormat[Guardian] = Json.format[Guardian]
 }
 


### PR DESCRIPTION
## What does this change?
* Add `NewsArticle`, which is similar to the existing `model.meta.WebPage`, but more specific to article pages.
* Add instance of `NewsArticle` under the new field `config.page.structuredData` in `DotcomponentsDataModel`.

## Screenshots
<img width="613" alt="screen shot 2019-01-22 at 11 08 22" src="https://user-images.githubusercontent.com/249676/51531701-1ae82700-1e36-11e9-8674-3d651cfd7a39.png">

## What is the value of this and can you measure success?
* To allow `dotcom-rendering` to render lined data on its article pages.
* The requirement came out of a [comment on this PR](https://github.com/guardian/dotcom-rendering/pull/378#discussion_r248969255)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
