### PR TITLE
Fix Outbrain compliance check

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
@@ -26,7 +26,7 @@ const checksToDispatch = {
     },
 
     isUserInContributionsAbTest(): Promise<boolean> {
-        return Promise.resolve(!!getEpicTestToRun());
+        return getEpicTestToRun().then(Boolean);
     },
 
     isUserNotInContributionsAbTest(): Promise<boolean> {


### PR DESCRIPTION
Fixes a bug introduced in #20931. Caused by changing the return type of `getEpicTestToRun()` from `?Runnable<EpicABTest>` to `Promise<?Runnable<EpicABTest>>` but not changing this bit of code.

I'd love it if there was a way to tell Flow to disallow treating as Boolean types which can only ever type-coerce to a particular value, to avoid a common class of runtime errors which it seems could easily be avoided with static checks.

Such that `!!functionWhichReturnsOptionalType` would not type check but `!!functionWhichReturnsOptionalType()` would.

And:
```javascript
if (promiseOfBoolean) {
  // something
else {
  // something else
}
```
would not type-check because you're treating a Promise (which is an object and therefore truthy) as a Boolean. And what you actually mean is:

```javascript
promiseOfBoolean.then(isTrue =>
  if (isTrue) {
    // something
  else {
    // something else
  }
)
```

@SiAdcock is there anything you're aware of that can help with this?