### PR TITLE
Only show apple pay logo for Safari/Mobile Safari

### DIFF
--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -220,7 +220,7 @@ const hasCrossedBreakpoint = (includeTweakpoint: boolean): Function => {
 };
 
 // https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/checking_for_apple_pay_availability
-const applePayApiAvailable = window.ApplePaySession;
+const applePayApiAvailable = !!window.ApplePaySession;
 
 const isIOS = (): boolean =>
     /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -219,14 +219,8 @@ const hasCrossedBreakpoint = (includeTweakpoint: boolean): Function => {
     };
 };
 
-// Will return true for any Safari browser (including Mobile Safari)
-// For an explanation of this solution, see https://stackoverflow.com/questions/7944460/detect-safari-browser/42189492
-const isSafari =
-    navigator.vendor &&
-    navigator.vendor.indexOf('Apple') > -1 &&
-    navigator.userAgent &&
-    navigator.userAgent.indexOf('CriOS') === -1 &&
-    navigator.userAgent.indexOf('FxiOS') === -1;
+// https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/checking_for_apple_pay_availability
+const applePayApiAvailable = window.ApplePaySession;
 
 const isIOS = (): boolean =>
     /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
@@ -362,7 +356,7 @@ export {
     getUserAgent,
     getViewport,
     isIOS,
-    isSafari,
+    applePayApiAvailable,
     isAndroid,
     isBreakpoint,
     initPageVisibility,

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -219,6 +219,13 @@ const hasCrossedBreakpoint = (includeTweakpoint: boolean): Function => {
     };
 };
 
+// Will return true for any Safari browser (including Mobile Safari)
+// For an explanation of this solution, see https://stackoverflow.com/questions/7944460/detect-safari-browser/42189492
+const isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') == -1 &&
+    navigator.userAgent.indexOf('FxiOS') == -1;
+
 const isIOS = (): boolean =>
     /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
 
@@ -353,6 +360,7 @@ export {
     getUserAgent,
     getViewport,
     isIOS,
+    isSafari,
     isAndroid,
     isBreakpoint,
     initPageVisibility,

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -221,10 +221,12 @@ const hasCrossedBreakpoint = (includeTweakpoint: boolean): Function => {
 
 // Will return true for any Safari browser (including Mobile Safari)
 // For an explanation of this solution, see https://stackoverflow.com/questions/7944460/detect-safari-browser/42189492
-const isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
+const isSafari =
+    navigator.vendor &&
+    navigator.vendor.indexOf('Apple') > -1 &&
     navigator.userAgent &&
-    navigator.userAgent.indexOf('CriOS') == -1 &&
-    navigator.userAgent.indexOf('FxiOS') == -1;
+    navigator.userAgent.indexOf('CriOS') === -1 &&
+    navigator.userAgent.indexOf('FxiOS') === -1;
 
 const isIOS = (): boolean =>
     /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -1,20 +1,18 @@
-import { isSafari } from 'lib/detect';
-
 // @flow
+
 import marque36icon from 'svgs/icon/marque-36.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 import arrowWhiteRight from 'svgs/icon/arrow-white-right.svg';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 import config from 'lib/config';
+import { isSafari } from 'lib/detect';
 import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
 
 export const acquisitionsBannerControlTemplate = (
     params: EngagementBannerTemplateParams
 ): string => {
-
     const applePayLogo = isSafari ? applyPayMark.markup : '';
-    return (
-        `
+    return `
         <div class="engagement-banner__close">
             <div class="engagement-banner__roundel">
                 ${marque36icon.markup}
@@ -31,13 +29,16 @@ export const acquisitionsBannerControlTemplate = (
             </div>
             <div class="engagement-banner__cta">
                 <button class="button engagement-banner__button" href="${
-                params.linkUrl
+                    params.linkUrl
                 }">
                     ${params.buttonCaption}${arrowWhiteRight.markup}
                 </button>
                 <div class="engagement-banner__payment-logos">
                     <img
-                        src="${config.get('images.acquisitions.paypal-and-credit-card', '')}"
+                        src="${config.get(
+                            'images.acquisitions.paypal-and-credit-card',
+                            ''
+                        )}"
                         alt="PayPal and credit card"
                     >
                     ${applePayLogo}
@@ -49,5 +50,5 @@ export const acquisitionsBannerControlTemplate = (
             target="_blank"
             href="${params.linkUrl}"
         ></a>
-    `);
-}
+    `;
+};

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -5,13 +5,13 @@ import closeCentralIcon from 'svgs/icon/close-central.svg';
 import arrowWhiteRight from 'svgs/icon/arrow-white-right.svg';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 import config from 'lib/config';
-import { isSafari } from 'lib/detect';
+import { applePayApiAvailable } from 'lib/detect';
 import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
 
 export const acquisitionsBannerControlTemplate = (
     params: EngagementBannerTemplateParams
 ): string => {
-    const applePayLogo = isSafari ? applyPayMark.markup : '';
+    const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
     return `
         <div class="engagement-banner__close">
             <div class="engagement-banner__roundel">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -1,3 +1,5 @@
+import { isSafari } from 'lib/detect';
+
 // @flow
 import marque36icon from 'svgs/icon/marque-36.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
@@ -8,43 +10,44 @@ import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/temp
 
 export const acquisitionsBannerControlTemplate = (
     params: EngagementBannerTemplateParams
-): string =>
-    `
-    <div class="engagement-banner__close">
-        <div class="engagement-banner__roundel">
-            ${marque36icon.markup}
-        </div>
-        <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
-            <span class="u-h">Close</span>
-            ${closeCentralIcon.markup}
-        </button>
-    </div>
-    <div class="engagement-banner__container">
-        <div class="engagement-banner__text">
-            ${params.messageText}${params.ctaText}
-            ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
-        </div>
-        <div class="engagement-banner__cta">
-            <button class="button engagement-banner__button" href="${
-                params.linkUrl
-            }">
-                ${params.buttonCaption}${arrowWhiteRight.markup}
+): string => {
+
+    const applePayLogo = isSafari ? applyPayMark.markup : '';
+    return (
+        `
+        <div class="engagement-banner__close">
+            <div class="engagement-banner__roundel">
+                ${marque36icon.markup}
+            </div>
+            <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close</span>
+                ${closeCentralIcon.markup}
             </button>
-            <div class="engagement-banner__payment-logos">
-                <img
-                    src="${config.get(
-                        'images.acquisitions.paypal-and-credit-card',
-                        ''
-                    )}"
-                    alt="PayPal and credit card"
-                >
-                ${applyPayMark.markup}
+        </div>
+        <div class="engagement-banner__container">
+            <div class="engagement-banner__text">
+                ${params.messageText}${params.ctaText}
+                ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
+            </div>
+            <div class="engagement-banner__cta">
+                <button class="button engagement-banner__button" href="${
+                params.linkUrl
+                }">
+                    ${params.buttonCaption}${arrowWhiteRight.markup}
+                </button>
+                <div class="engagement-banner__payment-logos">
+                    <img
+                        src="${config.get('images.acquisitions.paypal-and-credit-card', '')}"
+                        alt="PayPal and credit card"
+                    >
+                    ${applePayLogo}
+                </div>
             </div>
         </div>
-    </div>
-    <a
-        class="u-faux-block-link__overlay"
-        target="_blank"
-        href="${params.linkUrl}"
-    ></a>
-    `;
+        <a
+            class="u-faux-block-link__overlay"
+            target="_blank"
+            href="${params.linkUrl}"
+        ></a>
+    `);
+}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -5,8 +5,7 @@ import { isSafari } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
 export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
-
-    const applePayLogo = isSafari ? applyPayMark.markup: '';
+    const applePayLogo = isSafari ? applyPayMark.markup : '';
 
     const supportButtonSupport = `
         <div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -1,11 +1,11 @@
 // @flow
 import type { CtaUrls } from 'common/modules/commercial/contributions-utilities';
 import config from 'lib/config';
-import { isSafari } from 'lib/detect';
+import { applePayApiAvailable } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
 export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
-    const applePayLogo = isSafari ? applyPayMark.markup : '';
+    const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 
     const supportButtonSupport = `
         <div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -1,9 +1,13 @@
 // @flow
 import type { CtaUrls } from 'common/modules/commercial/contributions-utilities';
 import config from 'lib/config';
+import { isSafari } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
 export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
+
+    const applePayLogo = isSafari ? applyPayMark.markup: '';
+
     const supportButtonSupport = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
@@ -18,7 +22,7 @@ export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
             'images.acquisitions.paypal-and-credit-card',
             ''
         )}" alt="Paypal and credit card">
-        ${applyPayMark.markup}
+        ${applePayLogo}
     </div>`;
 
     return `


### PR DESCRIPTION
## What does this change?
We don't want to display the Apple Pay logo unless the user is on a browser that supports Apple Pay

Note: I've decided to just check for the availability of the Apple Pay API, rather than whether they have it set up. This is for 2 reasons:

- The function you can call on the `window.ApplePaySession` object to determine if they have Apple Pay set up is async, meaning that we would have to call this on the first page load and store something in the session storage, which wouldn't be guaranteed to happen in time for the initial epic display
- If someones got a device that Apple Pay can be used on but hasn't set it up yet, it can't hurt to let them know that we take it, they may get it in the future and it may even encourage them to set it up

This PR implements this

### Banner

| Safari mobile | Safari desktop|
|-------|------|
|<img width="485" alt="safari mobile" src="https://user-images.githubusercontent.com/2844554/51611604-88b84f80-1f17-11e9-9ad6-9fe88bbb851e.png">|<img width="1255" alt="safari desktop" src="https://user-images.githubusercontent.com/2844554/51611603-88b84f80-1f17-11e9-8148-e7c9f06183cb.png">|

| Chrome mobile | Chrome desktop|
|-------|------|
|<img width="389" alt="chromemobile" src="https://user-images.githubusercontent.com/2844554/51611599-881fb900-1f17-11e9-87ff-303a20c45038.png">|<img width="1256" alt="chromedesktop" src="https://user-images.githubusercontent.com/2844554/51611598-881fb900-1f17-11e9-8169-04f17734eb83.png">|


### Epic

| Safari mobile | Safari desktop|
|-------|------|
|<img width="458" alt="epicsafarimobile" src="https://user-images.githubusercontent.com/2844554/51612101-adf98d80-1f18-11e9-8cde-e0ac8c0f8b66.png">|<img width="625" alt="epicsafari" src="https://user-images.githubusercontent.com/2844554/51611602-881fb900-1f17-11e9-89c2-ceccc9a3e025.png">|


| Chrome mobile | Chrome desktop|
|-------|------|
|<img width="377" alt="epicchromemobile" src="https://user-images.githubusercontent.com/2844554/51612100-adf98d80-1f18-11e9-83d7-7ead0469c569.png">|<img width="623" alt="epicchrome" src="https://user-images.githubusercontent.com/2844554/51611600-881fb900-1f17-11e9-86d1-60d98a9f7a8b.png">|

@guardian/contributions 

@johnduffell 
@joelochlann 
@tomrf1 



