### PR TITLE
Add the AMP RR links for header and footer

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -51,7 +51,9 @@ case class ReaderRevenueLink(
 case class ReaderRevenueLinks(
   header: ReaderRevenueLink,
   footer: ReaderRevenueLink,
-  sideMenu: ReaderRevenueLink
+  sideMenu: ReaderRevenueLink,
+  ampHeader: ReaderRevenueLink,
+  ampFooter: ReaderRevenueLink
 )
 
 case class IsPartOf(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,7 +11,7 @@ import play.api.mvc.RequestHeader
 import views.support.{CamelCase, GUDateTimeFormat, ImgSrc, Item1200}
 import ai.x.play.json.Jsonx
 import common.Maps.RichMap
-import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl}
+import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl, AmpHeader, AmpFooter}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import model.meta.{Guardian, LinkedData, PotentialAction}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
@@ -338,7 +338,7 @@ object DotcomponentsDataModel {
       getReaderRevenueUrl(SupportSubscribe, SideMenu)(request),
       getReaderRevenueUrl(Support, SideMenu)(request)
     )
-    
+
     val ampHeaderReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
       getReaderRevenueUrl(SupportContribute, AmpHeader)(request),
       getReaderRevenueUrl(SupportSubscribe, AmpHeader)(request),

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -336,11 +336,25 @@ object DotcomponentsDataModel {
       getReaderRevenueUrl(SupportSubscribe, SideMenu)(request),
       getReaderRevenueUrl(Support, SideMenu)(request)
     )
+    
+    val ampHeaderReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+      getReaderRevenueUrl(SupportContribute, AmpHeader)(request),
+      getReaderRevenueUrl(SupportSubscribe, AmpHeader)(request),
+      getReaderRevenueUrl(Support, AmpHeader)(request)
+    )
+
+    val ampFooterReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+      getReaderRevenueUrl(SupportContribute, AmpFooter)(request),
+      getReaderRevenueUrl(SupportSubscribe, AmpFooter)(request),
+      getReaderRevenueUrl(Support, AmpFooter)(request)
+    )
 
     val readerRevenueLinks = ReaderRevenueLinks(
       headerReaderRevenueLink,
       footerReaderRevenueLink,
-      sideMenuReaderRevenueLink
+      sideMenuReaderRevenueLink,
+      ampHeaderReaderRevenueLink,
+      ampFooterReaderRevenueLink
     )
 
     val config = Config(

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -26,7 +26,7 @@ object UrlHelpers {
       case (Support, Header | SlimHeaderDropdown) => "header_support"
       case (Support, AmpHeader) => "amp_header_support"
       case (Support, SideMenu) => "side_menu_support"
-      case (Support, Footer) => "footer_support"
+      case (Support, Footer | AmpFooter) => "footer_support"
 
       case (SupportContribute, Header | AmpHeader | SlimHeaderDropdown) => "header_support_contribute"
       case (SupportContribute, SideMenu) => "side_menu_support_contribute"


### PR DESCRIPTION
## What does this change?

Adds the AMP RR links to the DotComponents Data model

## What is the value of this and can you measure success?

Source of truth for RR links on all web platforms.

Used in: https://github.com/guardian/dotcom-rendering/pull/389

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
