### PR TITLE
Add config to support amp Subscribe with Google button

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -54,6 +54,16 @@ case class ReaderRevenueLinks(
   sideMenu: ReaderRevenueLink
 )
 
+case class IsPartOf(
+  `@type`: List[String] = List("CreativeWork", "Product"),
+  name: String = "The Guardian",
+  productID: String = "theguardian.com:basic"
+)
+
+object IsPartOf {
+  implicit val formats: OFormat[IsPartOf] = Json.format[IsPartOf]
+}
+
 case class NewsArticle(
   override val `@type`: String,
   override val `@context`: String,
@@ -61,6 +71,7 @@ case class NewsArticle(
   potentialAction: PotentialAction,
   publisher: Guardian = Guardian(),
   isAccessibleForFree: Boolean = true,
+  isPartOf: IsPartOf = IsPartOf(),
 ) extends LinkedData(`@type`, `@context`)
 
 object NewsArticle {

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -118,6 +118,7 @@ case class PageData(
     sentryPublicApiKey: Option[String],
     switches: Map[String,Boolean],
     linkedData: NewsArticle,
+    subscribeWithGoogleApiUrl: String,
 
     // AMP specific
     guardianBaseURL: String,
@@ -258,6 +259,7 @@ object DotcomponentsDataModel {
       jsPageData.get("sentryPublicApiKey"),
       switches,
       linkedData,
+      Configuration.google.subscribeWithGoogleApiUrl,
       Configuration.site.host,
       article.metadata.webUrl,
       article.content.shouldHideAdverts,

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -238,6 +238,10 @@ class GuardianConfiguration extends Logging {
     lazy val jsLocation = configuration.getStringProperty("googletag.js.location").getOrElse("//www.googletagservices.com/tag/js/gpt.js")
   }
 
+  object google {
+    lazy val subscribeWithGoogleApiUrl = configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
+  }
+
   object oriel {
     lazy val orielApiKey = configuration.getStringProperty("oriel.api.key")
     lazy val orielCacheTimeInMinutes: Int = if (environment.isProd) 60 else 5
@@ -471,7 +475,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object javascript {
-    // This is config that is avaliable to both Javascript and Scala
+    // This is config that is available to both Javascript and Scala
     // But does not change across environments.
     lazy val config: Map[String, String] = Map(
       ("googleSearchUrl", "//www.google.co.uk/cse/cse.js"),

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -506,4 +506,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val SubscribeWithGoogle = Switch(
+    SwitchGroup.Feature,
+    "subscribe-with-google",
+    "If switched on, a Subscribe with Google button will appear on AMP articles.",
+    owners = Seq(Owner.withName("adem.gaygusuz")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -513,7 +513,7 @@ trait FeatureSwitches {
     "If switched on, a Subscribe with Google button will appear on AMP articles.",
     owners = Seq(Owner.withName("adem.gaygusuz")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 22),
+    sellByDate = new LocalDate(2019, 3, 20),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -513,7 +513,7 @@ trait FeatureSwitches {
     "If switched on, a Subscribe with Google button will appear on AMP articles.",
     owners = Seq(Owner.withName("adem.gaygusuz")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2019, 3, 29),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -513,7 +513,7 @@ trait FeatureSwitches {
     "If switched on, a Subscribe with Google button will appear on AMP articles.",
     owners = Seq(Owner.withName("adem.gaygusuz")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 29),
+    sellByDate = new LocalDate(2019, 3, 22),
     exposeClientSide = true
   )
 }


### PR DESCRIPTION
## What does this change?
* Add `isPartOf` to `DoccomponentsDataModel` schema to support upcoming `amp-subscription-google` button.
* Add `Configuration.google.subscribeWithGoogleApiUrl`.
* Add `subscribeWithGoogle` feature switch.

## Screenshots
<img width="358" alt="screen shot 2019-01-23 at 15 34 33" src="https://user-images.githubusercontent.com/249676/51617572-6973ef00-1f24-11e9-95da-1ac5e65b5bfa.png">

## What is the value of this and can you measure success?
* Used by the Subscribe with Google amp extension to identify which product the user can subscribe/contribute to.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
