### PR TITLE
YouTube: Wrap duration in check for 0:00

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -104,9 +104,11 @@
                     } else {
                         <div class="youtube-media-atom__play-button vjs-control-text">Play Video @fragments.inlineSvg("play", "icon")</div>
                         @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {
-                            <div class="youtube-media-atom__bottom-bar">
-                                <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
-                            </div>
+                            @if(duration != "0:00") {
+                                <div class="youtube-media-atom__bottom-bar">
+                                    <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
+                                </div>
+                            }
                         }
                     }
                 } else {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -44,14 +44,18 @@ data-test-id="facia-card"
                 case Some(InlineVideo(videoElement, _, _, _)) => {
                     <div class="fc-item__media-meta">
                         @inlineSvg("video-icon", "icon")
-                        <span class="fc-item__video-duration">@videoElement.videos.formattedDuration</span>
+                        @if(videoElement.videos.formattedDuration != "0:00") {
+                            <span class="fc-item__video-duration">@videoElement.videos.formattedDuration</span>
+                        }
                     </div>
                 }
 
                 case Some(media@InlineYouTubeMediaAtom(youTubeAtom, _)) => {
                     <div class="fc-item__media-meta">
                         @inlineSvg("video-icon", "icon")
-                        <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
+                        @if(youTubeAtom.formattedDuration.get != "0:00") {
+                            <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
+                        }
                     </div>
                 }
 


### PR DESCRIPTION
## What does this change?

Adds if statement around duration display on youtube videos to workaround issues with the metadata not being available.

## Screenshots
With
![screen shot 2019-01-24 at 09 40 10](https://user-images.githubusercontent.com/638051/51669489-81974d00-1fbc-11e9-9bd8-7b8218e1915b.jpg)

Without
![screen shot 2019-01-24 at 09 40 15](https://user-images.githubusercontent.com/638051/51669490-81974d00-1fbc-11e9-921a-c5fe72554a56.jpg)

Content card without

![screen shot 2019-01-24 at 10 06 36](https://user-images.githubusercontent.com/638051/51671013-e7390880-1fbf-11e9-95fe-13b368bca65b.jpg)

## What is the value of this and can you measure success?

Avoids displaying pointless information to the user.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
