### PR TITLE
Add if statement for carousel/js youtube videos to hide 0:00 and use getOrElse

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -71,9 +71,11 @@
                         }
 
                     </div>
-                        <span class="video-overlay__duration">
-                            @media.formattedDuration
-                        </span>
+                        @if(media.formattedDuration.get != "0:00") {
+                            <span class="video-overlay__duration">
+                                @media.formattedDuration
+                            </span>
+                        }
                     </div>
                     <a href="@f.header.url.get(request)" class="video-container-overlay-link" tabindex="-1" aria-hidden="true"></a>
                 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -71,7 +71,7 @@
                         }
 
                     </div>
-                        @if(media.formattedDuration.get != "0:00") {
+                        @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
                             <span class="video-overlay__duration">
                                 @media.formattedDuration
                             </span>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -51,13 +51,9 @@ data-test-id="facia-card"
                 case Some(media@InlineYouTubeMediaAtom(youTubeAtom, _)) => {
                     <div class="fc-item__media-meta">
                         @inlineSvg("video-icon", "icon")
-<<<<<<< HEAD
-                        <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
-=======
                         @if(youTubeAtom.formattedDuration.getOrElse("0:00") != "0:00") {
                             <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
                         }
->>>>>>> Add getOrElse instead of just get
                     </div>
                 }
 

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -51,7 +51,13 @@ data-test-id="facia-card"
                 case Some(media@InlineYouTubeMediaAtom(youTubeAtom, _)) => {
                     <div class="fc-item__media-meta">
                         @inlineSvg("video-icon", "icon")
+<<<<<<< HEAD
                         <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
+=======
+                        @if(youTubeAtom.formattedDuration.getOrElse("0:00") != "0:00") {
+                            <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
+                        }
+>>>>>>> Add getOrElse instead of just get
                     </div>
                 }
 


### PR DESCRIPTION
## What does this change?

I missed one in https://github.com/guardian/frontend/pull/20962 and broke some fronts as I used `.get` instead of `.getOrElse`

## Screenshots

![image](https://user-images.githubusercontent.com/638051/51674449-8e21a280-1fc8-11e9-8526-1df0ed6f7b11.png)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
