### PR TITLE
Introduce separate AMP rendering switch

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -105,7 +105,7 @@ object AMPPicker {
     val features = ampFeatureWhitelist(page, request)
     val isSupported = features.forall({ case (test, isMet) => isMet})
     val isWhitelisted = whitelist(page.metadata.id)
-    val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
+    val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
     val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -17,6 +17,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val DotcomRenderingAMP = Switch(
+    SwitchGroup.Feature,
+    "dotcom-rendering-amp",
+    "If this switch is on, we will use the dotcom rendering tier for AMP articles which are supported by it",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",


### PR DESCRIPTION
Use a separate switch for AMP dotcom rendering, as we want to decouple these features.