### PR TITLE
 Show thank you epic/banner with reader-revenue-dev-utils

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -90,8 +90,10 @@ const changeGeolocation = (asExistingSupporter: boolean = false): void => {
     const geo = window.prompt(
         `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${geolocationGetSync()}.`
     );
-    setGeolocation(geo);
-    clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    if (geo) {
+        setGeolocation(geo);
+        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    }
 };
 
 export const init = (): void => {

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -2,7 +2,10 @@
 
 import { removeCookie } from 'lib/cookies';
 import { isUserLoggedIn } from 'common/modules/identity/api';
-import { fakeOneOffContributor, readerRevenueRelevantCookies } from 'common/modules/commercial/user-features';
+import {
+    fakeOneOffContributor,
+    readerRevenueRelevantCookies,
+} from 'common/modules/commercial/user-features';
 import { clearViewLog as clearEpicViewLog } from 'common/modules/commercial/acquisitions-view-log';
 import {
     clearBannerHistory,
@@ -17,7 +20,9 @@ import {
 import { setGeolocation, getSync as geolocationGetSync } from 'lib/geolocation';
 import { clearParticipations } from 'common/modules/experiments/ab-local-storage';
 
-const clearCommonReaderRevenueStateAndReload = (asExistingSupporter: boolean): void => {
+const clearCommonReaderRevenueStateAndReload = (
+    asExistingSupporter: boolean
+): void => {
     readerRevenueRelevantCookies.forEach(cookie => removeCookie(cookie));
 
     initMvtCookie();

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -232,6 +232,11 @@ const readerRevenueRelevantCookies = [
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 ];
 
+// For debug/test purposes
+const fakeOneOffContributor = (): void => {
+    addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, Date.now().toString());
+};
+
 const isAdFreeUser = (): boolean =>
     isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
 
@@ -248,4 +253,5 @@ export {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     readerRevenueRelevantCookies,
+    fakeOneOffContributor,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -157,7 +157,7 @@ const isPayingMember = (): boolean =>
 
 // number returned is Epoch time in milliseconds.
 // null value signifies no last contribution date.
-const getLastOneOffContributionDate = (): ?number => {
+const getLastOneOffContributionDate = (): number | null => {
     const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
 
     if (!cookie) {
@@ -185,9 +185,9 @@ const getLastOneOffContributionDate = (): ?number => {
     return null;
 };
 
-const getDaysSinceLastOneOffContribution = (): ?number => {
+const getDaysSinceLastOneOffContribution = (): number | null => {
     const lastContributionDate = getLastOneOffContributionDate();
-    if (!lastContributionDate) {
+    if (lastContributionDate === null) {
         return null;
     }
     return dateDiffDays(lastContributionDate, Date.now());
@@ -196,7 +196,7 @@ const getDaysSinceLastOneOffContribution = (): ?number => {
 // in last six months
 const isRecentOneOffContributor = (): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
-    if (!daysSinceLastContribution) {
+    if (daysSinceLastContribution === null) {
         return false;
     }
     return daysSinceLastContribution <= 180;

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -13,6 +13,7 @@ import {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
 } from './user-features.js';
+import { isRecentOneOffContributor } from 'common/modules/commercial/user-features';
 
 jest.mock('lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -397,7 +397,15 @@ describe('Storing new feature data', () => {
 const setOneOffContributionCookie = (value: any): void =>
     addCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, value);
 
+const removeOneOffContributionCookie = (): void =>
+    removeCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
+
+
 describe('getting the last one-off contribution date of a user', () => {
+    beforeEach(() => {
+        removeOneOffContributionCookie();
+    });
+
     const contributionDateTimeISO8601 = '2018-01-06T09:30:14Z';
     const contributionDateTimeEpoch = Date.parse(contributionDateTimeISO8601);
 
@@ -422,6 +430,10 @@ describe('getting the last one-off contribution date of a user', () => {
 });
 
 describe('getting the days since last contribution', () => {
+    beforeEach(() => {
+        removeOneOffContributionCookie();
+    });
+
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
     it('returns null if the last one-off contribution date is null', () => {
@@ -432,5 +444,35 @@ describe('getting the days since last contribution', () => {
         global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
         expect(getDaysSinceLastOneOffContribution()).toBe(5);
+    });
+});
+
+describe('isRecentOneOffContributor', () => {
+    beforeEach(() => {
+        removeOneOffContributionCookie();
+    });
+
+    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
+
+    it('returns false if there is no one-off contribution cookie', () => {
+        expect(isRecentOneOffContributor()).toBe(false);
+    });
+
+    it('returns true if there are 5 days between the last contribution date and now', () => {
+        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isRecentOneOffContributor()).toBe(true);
+    });
+
+    it('returns true if there are 0 days between the last contribution date and now', () => {
+        global.Date.now = jest.fn(() => Date.parse('2018-08-01T13:00:30'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isRecentOneOffContributor()).toBe(true);
+    });
+
+    it('returns false if the one-off contribution was more than 6 months ago', () => {
+        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isRecentOneOffContributor()).toBe(false);
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -12,8 +12,8 @@ import {
     isDigitalSubscriber,
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
+    isRecentOneOffContributor
 } from './user-features.js';
-import { isRecentOneOffContributor } from 'common/modules/commercial/user-features';
 
 jest.mock('lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -12,7 +12,7 @@ import {
     isDigitalSubscriber,
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
-    isRecentOneOffContributor
+    isRecentOneOffContributor,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -400,7 +400,6 @@ const setOneOffContributionCookie = (value: any): void =>
 
 const removeOneOffContributionCookie = (): void =>
     removeCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
-
 
 describe('getting the last one-off contribution date of a user', () => {
     beforeEach(() => {


### PR DESCRIPTION
By accepting an `asExistingSupporter` parameter, the functions which get called by the bookmarklets can do all their stuff (settings things up so the epic/banner **will** display on the next pageview) in such a way that on the next pageview the user will be considered an existing supporter, and therefore see "thank you" messaging instead of acquisition messaging.

It defaults to `false` so as not to break existing bookmarklets.

I also discovered a really annoying bug in the process which has meant that users don't see thank-you messaging until a day after they make a one-off contribution: https://github.com/guardian/frontend/commit/80b775681012bb34d8ed4aa94c2d74e510e1f4b9

Also fixed a little bug where entering nothing in the Geolocation dialog box and clicking OK would wipe your geolocation and therefore put you back to your actual location