### PR TITLE
Conditionally load Prebid around Google Web Preview

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -14,6 +14,10 @@ const isGoogleWebPreview: () => boolean = () => {
     }
 };
 
+if (!isGoogleWebPreview()) {
+    import('prebid.js/build/dist/prebid');
+}
+
 export const setupPrebid: () => Promise<void> = once(() => {
     if (
         dfpEnv.externalDemand === 'prebid' &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -6,8 +6,13 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
-const isGoogleWebPreview: () => boolean = () =>
-    navigator.userAgent.indexOf('Google Web Preview') > -1;
+const isGoogleWebPreview: () => boolean = () => {
+    try {
+        return navigator.userAgent.indexOf('Google Web Preview') > -1;
+    } catch (exception) {
+        return false;
+    }
+};
 
 export const setupPrebid: () => Promise<void> = once(() => {
     if (

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -6,11 +6,15 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
+const isGoogleWebPreview: () => boolean = () =>
+    navigator.userAgent.indexOf('Google Web Preview') > -1;
+
 export const setupPrebid: () => Promise<void> = once(() => {
     if (
         dfpEnv.externalDemand === 'prebid' &&
         commercialFeatures.dfpAdvertising &&
-        !commercialFeatures.adFree
+        !commercialFeatures.adFree &&
+        !isGoogleWebPreview()
     ) {
         buildPageTargeting();
         prebid.initialise();

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-import 'prebid.js/build/dist/prebid';
 import config from 'lib/config';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';


### PR DESCRIPTION
## What does this change?

This changes the way the `Prebid` module loads, making it conditional on whether or not the UserAgent has `Google Web Preview` in it;
 - Don't call `PrebidService.initialise` when it's the `Google Web Preview` UA
 - Move to `prepare-prebid` to make use of `isGoogleWebPreview` and don't load it when it's `Google Web Preview`.

I thought calling `isGoogleWebPreview` made more sense in `prepare-prebid` over doing it inside the `prebid` module as this is the place where initialise is called. I prefer wrapping `initialise` over polluting `initialise` more.

@guardian/commercial-dev @kelvin-chappell 

### Tested

- [x] Locally
- [ ] On CODE (optional)