### PR TITLE
Disable affiliate links when ad free header is set.

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -806,17 +806,16 @@ object GarnettQuoteCleaner extends HtmlCleaner {
     document
   }
 }
-
+import implicits.Requests._
 case class AffiliateLinksCleaner(
                                   pageUrl: String,
                                   sectionId: String,
                                   showAffiliateLinks: Option[Boolean],
                                   contentType: String,
                                   appendDisclaimer: Option[Boolean] = None,
-                                  tags: List[String]) extends HtmlCleaner with Logging {
-
+                                  tags: List[String])(implicit request: RequestHeader) extends HtmlCleaner with Logging {
   override def clean(document: Document): Document = {
-    if (AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(AffiliateLinks.isSwitchedOn,
+    if (AffiliateLinks.isSwitchedOn && !request.isAdFree && AffiliateLinksCleaner.shouldAddAffiliateLinks(AffiliateLinks.isSwitchedOn,
       sectionId, showAffiliateLinks, affiliateLinkSections, defaultOffTags, alwaysOffTags, tags)) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
     } else document


### PR DESCRIPTION
## What does this change?
Removes affiliate links for users with ad-free enabled.

## What is the value of this and can you measure success?
It just feels like 'the right thing to do' for our users. We don't make enough money on affiliate links to justify adding them to ad-free content. 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
