### PR TITLE
Add leaderboard to crosswords at tablet breakpoints

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -44,6 +44,9 @@
                         <div class="content__secondary-column hide-until-wide" aria-hidden="true">
                         @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map("desktop" -> Seq("300,250", "300,274", "300,600", "fluid")))
                         </div>
+                        <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
+                        @fragments.commercial.standardAd("inline1", Seq("crossword-banner"), Map("tablet" -> Seq("1,1", "2,2", "728,90")))
+                        </div>
                     }
                 </div>
             </div>

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -131,7 +131,7 @@
 
                     </div>
 
-                    <div class="js-discussion__ad-slot discussion__ad-slot"></div>
+                    <div class="js-discussion__ad-slot discussion__ad-slot hide-until-desktop"></div>
 
                 </div>
             </div>

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -125,9 +125,10 @@ class PrebidService {
             return PrebidService.requestQueue;
         }
 
-        const isArticle = config.get('page.contentType') === 'Article';
-
-        const adUnits: Array<PrebidAdUnit> = slots(advert.id, isArticle)
+        const adUnits: Array<PrebidAdUnit> = slots(
+            advert.id,
+            config.get('page.contentType', '')
+        )
             .map(effectiveSlotFlatMap)
             .reduce((acc, elt) => acc.concat(elt), []) // the "flat" in "flatMap"
             .map(slot => new PrebidAdUnit(advert, slot))

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -30,7 +30,9 @@ const getMostPopularSizes = memoize((isArticle: boolean) => {
     return [[300, 250]];
 });
 
-const getSlots = (isArticle: boolean): Array<PrebidSlot> => {
+const getSlots = (contentType: string): Array<PrebidSlot> => {
+    const isArticle = contentType === 'Article';
+    const isCrossword = contentType === 'Crossword';
     const commonSlots: Array<PrebidSlot> = [
         {
             key: 'mostpop',
@@ -42,7 +44,7 @@ const getSlots = (isArticle: boolean): Array<PrebidSlot> => {
         },
         {
             key: 'inline1',
-            sizes: [[300, 250]],
+            sizes: isCrossword ? [[728, 90]] : [[300, 250]],
         },
     ];
 
@@ -93,7 +95,7 @@ const getSlots = (isArticle: boolean): Array<PrebidSlot> => {
     }
 };
 
-export const slots = (advertId: string, isArticle: boolean) =>
-    filterByAdvertId(advertId, getSlots(isArticle));
+export const slots = (advertId: string, contentType: string) =>
+    filterByAdvertId(advertId, getSlots(contentType));
 
 export const _ = { getSlots };

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -24,7 +24,7 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
-        expect(getSlots(true)).toEqual([
+        expect(getSlots('Article')).toEqual([
             {
                 key: 'mostpop',
                 sizes: [[300, 250]],
@@ -50,7 +50,7 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint T', () => {
         getBreakpointKey.mockReturnValue('T');
-        expect(getSlots(true)).toEqual([
+        expect(getSlots('Article')).toEqual([
             {
                 key: 'mostpop',
                 sizes: [[300, 250]],
@@ -76,7 +76,7 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint D on article pages', () => {
         getBreakpointKey.mockReturnValue('D');
-        const desktopSlots = getSlots(true);
+        const desktopSlots = getSlots('Article');
         expect(desktopSlots).toContainEqual({
             key: 'inline',
             sizes: [[300, 600], [300, 250]],
@@ -87,9 +87,18 @@ describe('getSlots', () => {
         });
     });
 
+    test('should return the correct slots at breakpoint T on crossword pages', () => {
+        getBreakpointKey.mockReturnValue('T');
+        const tabletSlots = getSlots('Crossword');
+        expect(tabletSlots).toContainEqual({
+            key: 'inline1',
+            sizes: [[728, 90]],
+        });
+    });
+
     test('should return the correct slots at breakpoint D on other pages', () => {
         getBreakpointKey.mockReturnValue('D');
-        const desktopSlots = getSlots(false);
+        const desktopSlots = getSlots('');
         expect(desktopSlots).toContainEqual({
             key: 'inline',
             sizes: [[300, 250]],
@@ -108,7 +117,7 @@ describe('slots', () => {
 
     test('should return the correct top-above-nav slot at breakpoint D', () => {
         getBreakpointKey.mockReturnValue('D');
-        expect(slots('top-above-nav', false)).toEqual([
+        expect(slots('top-above-nav', '')).toEqual([
             {
                 key: 'top-above-nav',
                 sizes: [[970, 250], [728, 90]],
@@ -118,7 +127,7 @@ describe('slots', () => {
 
     test('should return the correct top-above-nav slot at breakpoint T', () => {
         getBreakpointKey.mockReturnValue('T');
-        expect(slots('top-above-nav', false)).toEqual([
+        expect(slots('top-above-nav', '')).toEqual([
             {
                 key: 'top-above-nav',
                 sizes: [[728, 90]],
@@ -128,7 +137,7 @@ describe('slots', () => {
 
     test('should return the correct top-above-nav slot at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
-        expect(slots('top-above-nav', false)).toEqual([
+        expect(slots('top-above-nav', '')).toEqual([
             {
                 key: 'top-above-nav',
                 sizes: [[300, 250]],

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -106,6 +106,7 @@
     }
 }
 
+.ad-slot--crossword-banner,
 .ad-slot--top-banner-ad-desktop {
     margin: 0 auto;
     min-height: 90px;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -61,6 +61,12 @@
     }
 }
 
+.crossword-banner {
+    margin-top: $gs-baseline;
+    // 90px is the height of a leaderboard
+    height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
+}
+
 .crossword__controls {
     margin-top: $gs-baseline;
     float: left;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -62,9 +62,15 @@
 }
 
 .crossword-banner {
+    clear: both;
     margin-top: $gs-baseline;
     // 90px is the height of a leaderboard
     height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
+
+    @include mq($until: desktop) {
+        margin-left: -$gs-gutter;
+        margin-right: -$gs-gutter;
+    }
 }
 
 .crossword__controls {


### PR DESCRIPTION
## What does this change?

#### 👉 Add a leaderboard slot to crosswords pages

This PR adds an inline adslot to crossword pages that can serve an leaderboard.  The leaderboard slot appears at tablet widths and disappears at wide since we currently have the right slot (DMPU) that appears at wide breakpoints.

#### 👉 Add more magic css maths

Setting the leaderboard slot height with some magic numbers prevents a 4px page yank on adrefresh:

```css
height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
```

#### 👉 Prebid slots and getSlots functions now takes a string of contentType as a parameter

Inline slots need different sizes and behaviour according to the content type.
Crossword pages are one place, but we may also want to vary sizes on gallery pages.

#### 👉 Quick fix for comment slot layout at tablet breakpoints

The comment slot was still trying to load at smaller breakpoints (on all articles), however it should only appear on desktop or above. Loading the comments on tablet causes a broken layout:

<img width="905" alt="screen shot 2019-01-29 at 13 08 24" src="https://user-images.githubusercontent.com/8607683/51910400-fefcfc00-23c6-11e9-96c1-c64d40aa1df1.png">


The quick fix here is to hide the secondary column (that the comments slot uses) until desktop.

## Screenshots

<img width="524" alt="screen shot 2019-01-28 at 17 18 18" src="https://user-images.githubusercontent.com/8607683/51903920-4aa6aa00-23b5-11e9-9d51-c954164c7fd2.png">

<img width="980" alt="screen shot 2019-01-29 at 12 56 40" src="https://user-images.githubusercontent.com/8607683/51910433-14722600-23c7-11e9-9169-0a8f1c3a4587.png">



## What is the value of this and can you measure success? 

<img width="1308" alt="screen shot 2019-01-28 at 17 28 29" src="https://user-images.githubusercontent.com/8607683/51904313-3dd68600-23b6-11e9-9f2a-b1ce6d42a60a.png">

Crossword article body contains an adslot at smaller desktop and tablet breakpoints. Design suggested that we could insert a leaderboard slot below the grid and above the comments at these breakpoints. 

More details on the trello card: https://trello.com/c/Op6GXvYW

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? 

Nope, just crosswords.

### Does this change break ad-free?

Nope, the slot only appears if `adsEnabled` is true.

### Accessibility test checklist

New slot has `aria-hidden="true"` so will be ignored by screen readers.

### Tested

- [ ] Locally
- [ ] On CODE

