### PR TITLE
Name webpack preact bundle

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -18,7 +18,7 @@ __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 
 // Debug preact in DEV
 if (process.env.NODE_ENV !== 'production') {
-    import('preact/debug');
+    import(/* webpackChunkName: "preact-debug" */ 'preact/debug');
 }
 
 // kick off the app


### PR DESCRIPTION
We seem to be shipping some form of preact at the moment. I'm not altogether sure this is the cause (still digging), but in any case we should name the bundle.