### PR TITLE
Email signup ID for analytics

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -39,7 +39,7 @@
 
 
 @form = {
-    <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass", data-email-list-name="@listName">
+    <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
         @helper.CSRF.formField
         <div class="email-sub__form-wrapper">
             <div class="email-sub__inline-label js-email-sub__inline-label">

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -21,7 +21,7 @@ import type { bonzo } from 'bonzo';
 
 type Analytics = {
     formType: string,
-    listId: string,
+    listName: string,
     signedIn: string,
 };
 
@@ -75,7 +75,7 @@ const removeAndRemember = (
     const currentListPrefs =
         userPrefs.get(`email-sign-up-${analytics.formType}`) || [];
 
-    currentListPrefs.push(`${analytics.listId}`);
+    currentListPrefs.push(`${analytics.listName}`);
     userPrefs.set(
         `email-sign-up-${analytics.formType}`,
         uniq(currentListPrefs)
@@ -85,7 +85,7 @@ const removeAndRemember = (
 
     trackNonClickInteraction(
         `rtrt | email form inline | ${analytics.formType} | ${
-            analytics.listId
+            analytics.listName
         } | ${analytics.signedIn} | form hidden`
     );
 };
@@ -270,7 +270,7 @@ const submitForm = (
 
             analyticsInfo = `rtrt | email form inline | ${
                 analytics.formType
-            } | ${analytics.signedIn} | %action%`;
+            } | ${analytics.listName} | ${analytics.signedIn} | %action%`;
 
             state.submitting = true;
 
@@ -344,7 +344,7 @@ const setup = (
         const $formEl = $(`.${classes.form}`, el);
         const analytics = {
             formType: $formEl.data('email-form-type'),
-            listId: $formEl.data('email-list-id'),
+            listName: $formEl.data('email-list-name'),
             signedIn: isUserLoggedIn()
                 ? 'user signed-in'
                 : 'user not signed-in',


### PR DESCRIPTION
## What does this change?

In a previous life, we added the listId to the analytics ping. This disappeared, so this PR returns the *list name* so that it can be reviewed in GA.

## Screenshots

![image](https://user-images.githubusercontent.com/638051/51909962-c6a8ee00-23c5-11e9-96d2-a7db5d4256b4.png)

## What is the value of this and can you measure success?

Better tracking of specific email list in GA.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
