### PR TITLE
Conditionally load Prebid for Google Web Preview

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -41,6 +41,7 @@ module.exports = {
             "plugins": [
                 "@babel/plugin-transform-runtime",
                 "@babel/plugin-proposal-class-properties",
+                "dynamic-import-node",
             ],
         },
         "internal": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
+    "babel-plugin-dynamic-import-node": "^2.2.0",
     "browser-sync": "^2.18.13",
     "bs-fullscreen-message": "^1.1.0",
     "btoa": "1.1.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -6,7 +6,7 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { queueAdvert } from 'commercial/modules/dfp/queue-advert';
 import { displayLazyAds } from 'commercial/modules/dfp/display-lazy-ads';
 import { displayAds } from 'commercial/modules/dfp/display-ads';
-import { setupPrebid } from 'commercial/modules/dfp/prepare-prebid';
+import { setupPrebidOnce } from 'commercial/modules/dfp/prepare-prebid';
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
@@ -20,7 +20,7 @@ const fillAdvertSlots = (): Promise<void> => {
     // This module has the following strict dependencies. These dependencies must be
     // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
     // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-    const dependencies: Promise<void>[] = [setupPrebid(), closeDisabledSlots()];
+    const dependencies: Promise<void>[] = [setupPrebidOnce(), closeDisabledSlots()];
 
     return Promise.all(dependencies).then(() => {
         // Quit if ad-free

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -20,7 +20,10 @@ const fillAdvertSlots = (): Promise<void> => {
     // This module has the following strict dependencies. These dependencies must be
     // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
     // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-    const dependencies: Promise<void>[] = [setupPrebidOnce(), closeDisabledSlots()];
+    const dependencies: Promise<void>[] = [
+        setupPrebidOnce(),
+        closeDisabledSlots(),
+    ];
 
     return Promise.all(dependencies).then(() => {
         // Quit if ad-free

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -15,7 +15,7 @@ const isGoogleWebPreview: () => boolean = () => {
 };
 
 if (!isGoogleWebPreview()) {
-    import('prebid.js/build/dist/prebid');
+    require('prebid.js/build/dist/prebid'); // eslint-disable-line global-require
 }
 
 export const setupPrebid: () => Promise<void> = once(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -17,7 +17,7 @@ if (!isGoogleWebPreview()) {
     import('prebid.js/build/dist/prebid');
 }
 
-export const setupPrebid: () => Promise<void> = once(() => {
+const setupPrebid: () => Promise<void> = () => {
     if (
         dfpEnv.externalDemand === 'prebid' &&
         commercialFeatures.dfpAdvertising &&
@@ -28,14 +28,17 @@ export const setupPrebid: () => Promise<void> = once(() => {
         prebid.initialise();
     }
     return Promise.resolve();
-});
+};
+
+export const setupPrebidOnce: () => Promise<void> = once(setupPrebid);
 
 export const init = (start: () => void, stop: () => void): Promise<void> => {
     start();
-    setupPrebid().then(stop);
+    setupPrebidOnce().then(stop);
     return Promise.resolve();
 };
 
 export const _ = {
     isGoogleWebPreview,
+    setupPrebid,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -14,6 +14,10 @@ const isGoogleWebPreview: () => boolean = () => {
     }
 };
 
+if (!isGoogleWebPreview()) {
+    import('prebid.js/build/dist/prebid');
+}
+
 export const setupPrebid: () => Promise<void> = once(() => {
     if (
         dfpEnv.externalDemand === 'prebid' &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -6,16 +6,15 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
-const isGoogleWebPreview: () => boolean = () => {
-    try {
-        return navigator.userAgent.indexOf('Google Web Preview') > -1;
-    } catch (exception) {
-        return false;
-    }
-};
+const isGoogleWebPreview: () => boolean = () =>
+    !!(
+        navigator &&
+        navigator.userAgent &&
+        navigator.userAgent.indexOf('Google Web Preview') > -1
+    );
 
 if (!isGoogleWebPreview()) {
-    require('prebid.js/build/dist/prebid'); // eslint-disable-line global-require
+    import('prebid.js/build/dist/prebid');
 }
 
 export const setupPrebid: () => Promise<void> = once(() => {
@@ -35,4 +34,8 @@ export const init = (start: () => void, stop: () => void): Promise<void> => {
     start();
     setupPrebid().then(stop);
     return Promise.resolve();
+};
+
+export const _ = {
+    isGoogleWebPreview,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -6,8 +6,13 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
-const isGoogleWebPreview: () => boolean = () =>
-    navigator.userAgent.indexOf('Google Web Preview') > -1;
+const isGoogleWebPreview: () => boolean = () => {
+    try {
+        return navigator.userAgent.indexOf('Google Web Preview') > -1;
+    } catch (exception) {
+        return false;
+    }
+};
 
 export const setupPrebid: () => Promise<void> = once(() => {
     if (

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -6,11 +6,15 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import { prebid } from 'commercial/modules/prebid/prebid';
 
+const isGoogleWebPreview: () => boolean = () =>
+    navigator.userAgent.indexOf('Google Web Preview') > -1;
+
 export const setupPrebid: () => Promise<void> = once(() => {
     if (
         dfpEnv.externalDemand === 'prebid' &&
         commercialFeatures.dfpAdvertising &&
-        !commercialFeatures.adFree
+        !commercialFeatures.adFree &&
+        !isGoogleWebPreview()
     ) {
         buildPageTargeting();
         prebid.initialise();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -3,9 +3,9 @@
 import { prebid } from 'commercial/modules/prebid/prebid';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { init, _ } from './prepare-prebid';
+import { _ } from './prepare-prebid';
 
-const { isGoogleWebPreview } = _;
+const { isGoogleWebPreview, setupPrebid } = _;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
@@ -33,20 +33,24 @@ const fakeUserAgent = (userAgent: string): void => {
 };
 
 describe('init', () => {
-    let mockInitialise;
+    const mockInitialise = jest.fn();
     const originalUA = navigator.userAgent;
 
     beforeEach(() => {
-        mockInitialise = jest.fn();
+        jest.resetAllMocks();
         (prebid: any).initialise = mockInitialise.bind(prebid);
         fakeUserAgent(originalUA);
+    });
+
+    afterAll(() => {
+        jest.resetAllMocks();
     });
 
     it('should initialise Prebid when external demand is Prebid and advertising is on and ad-free is off', () => {
         dfpEnv.externalDemand = 'prebid';
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).toBeCalled();
     });
 
@@ -54,31 +58,31 @@ describe('init', () => {
         dfpEnv.externalDemand = 'prebid';
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).toBeCalled();
     });
 
     it('should not initialise Prebid when useragent is Google Web Preview', () => {
         fakeUserAgent('Google Web Preview');
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).not.toBeCalled();
     });
 
     it('should not initialise Prebid when no external demand', () => {
         dfpEnv.externalDemand = 'none';
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).not.toBeCalled();
     });
 
     it('should not initialise Prebid when advertising is switched off', () => {
         commercialFeatures.dfpAdvertising = false;
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).not.toBeCalled();
     });
 
     it('should not initialise Prebid when ad-free is on', () => {
         commercialFeatures.adFree = true;
-        init(jest.fn(), jest.fn());
+        setupPrebid();
         expect(mockInitialise).not.toBeCalled();
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -26,12 +26,10 @@ jest.mock('commercial/modules/prebid/bid-config', () => ({
 }));
 
 const fakeUserAgent = (userAgent: string): void => {
-    Object.defineProperty(navigator, 'userAgent', {
-        get() {
-            return userAgent;
-        },
-        configurable: true,
-    });
+    const userAgentObject = {};
+    userAgentObject.get = () => userAgent;
+    userAgentObject.configurable = true;
+    Object.defineProperty(navigator, 'userAgent', userAgentObject);
 };
 
 describe('init', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -3,7 +3,9 @@
 import { prebid } from 'commercial/modules/prebid/prebid';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { init } from './prepare-prebid';
+import { init, _ } from './prepare-prebid';
+
+const { isGoogleWebPreview } = _;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
@@ -23,12 +25,23 @@ jest.mock('commercial/modules/prebid/bid-config', () => ({
     isInVariant: jest.fn(),
 }));
 
+const fakeUserAgent = (userAgent: string): void => {
+    Object.defineProperty(navigator, 'userAgent', {
+        get() {
+            return userAgent;
+        },
+        configurable: true,
+    });
+};
+
 describe('init', () => {
     let mockInitialise;
+    const originalUA = navigator.userAgent;
 
     beforeEach(() => {
         mockInitialise = jest.fn();
         (prebid: any).initialise = mockInitialise.bind(prebid);
+        fakeUserAgent(originalUA);
     });
 
     it('should initialise Prebid when external demand is Prebid and advertising is on and ad-free is off', () => {
@@ -37,6 +50,20 @@ describe('init', () => {
         commercialFeatures.adFree = false;
         init(jest.fn(), jest.fn());
         expect(mockInitialise).toBeCalled();
+    });
+
+    it('should initialise Prebid when useragent is not Google Web Preview', () => {
+        dfpEnv.externalDemand = 'prebid';
+        commercialFeatures.dfpAdvertising = true;
+        commercialFeatures.adFree = false;
+        init(jest.fn(), jest.fn());
+        expect(mockInitialise).toBeCalled();
+    });
+
+    it('should not initialise Prebid when useragent is Google Web Preview', () => {
+        fakeUserAgent('Google Web Preview');
+        init(jest.fn(), jest.fn());
+        expect(mockInitialise).not.toBeCalled();
     });
 
     it('should not initialise Prebid when no external demand', () => {
@@ -55,5 +82,19 @@ describe('init', () => {
         commercialFeatures.adFree = true;
         init(jest.fn(), jest.fn());
         expect(mockInitialise).not.toBeCalled();
+    });
+
+    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+        expect(isGoogleWebPreview()).toBe(false);
+    });
+
+    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+        fakeUserAgent('Firefox');
+        expect(isGoogleWebPreview()).toBe(false);
+    });
+
+    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+        fakeUserAgent('Google Web Preview');
+        expect(isGoogleWebPreview()).toBe(true);
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-import 'prebid.js/build/dist/prebid';
 import config from 'lib/config';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -2,6 +2,7 @@
 
 import config from 'lib/config';
 import { prebid } from 'commercial/modules/prebid/prebid';
+import 'prebid.js/build/dist/prebid';
 
 jest.mock('lib/raven');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,6 +1741,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
+  dependencies:
+    object.assign "^4.1.0"
+
 babel-plugin-emotion@^9.2.4:
   version "9.2.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.4.tgz#a4e54a8097f6ba06cbbc7a9063927afafe9fe73a"
@@ -4969,6 +4975,10 @@ has-symbol-support-x@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.0.tgz#442d89b1d0ac6cf5ff2f7b916ee539869b93a256"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-to-string-tag-x@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz#49d7bcde85c2409be38ac327e3e119a451657c7b"
@@ -7281,6 +7291,10 @@ object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-keys@^1.0.11:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
@@ -7302,6 +7316,15 @@ object.assign@^4.0.1:
     define-properties "^1.1.2"
     function-bind "^1.1.0"
     object-keys "^1.0.10"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
## What does this change?

See explanation in #20970 

This has been updated;
 - Use `require` instead of using `import`
 - Import `prebid` explicitly into `prebid.spec`

@guardian/commercial-dev 

### Tested

- [ ] Locally
- [x] On CODE (optional)