### PR TITLE
Add noindex tag to future football matches, remove urls to these matches

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -196,8 +196,7 @@ class MoreOnMatchController(
         val (matchReport, minByMin, preview, stats) = fetchRelatedMatchContent(theMatch, related)
         val canonicalPage = matchReport.orElse(minByMin).orElse { if (theMatch.isFixture) preview else None }.getOrElse(stats)
 
-        if(Football.isOver3DaysAway(theMatch)) NoCache(NotFound("Match is in the future"))
-        else Cached(60)(WithoutRevalidationResult(Found(canonicalPage.url)))
+        Cached(60)(WithoutRevalidationResult(Found(canonicalPage.url)))
       }
     }.getOrElse {
       // we do not keep historical data, so just redirect old stuff to the results page (see also MatchController)

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -8,7 +8,7 @@ import football.model.FootballMatchTrail
 import implicits.{Football, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Content, ContentType, NoCache}
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, Days, LocalDate}
 import org.joda.time.format.DateTimeFormat
 import com.github.nscala_time.time.Imports
 import com.github.nscala_time.time.Imports._
@@ -194,13 +194,10 @@ class MoreOnMatchController(
     maybeMatch.map { theMatch =>
       loadMoreOn(request, theMatch).map { related =>
         val (matchReport, minByMin, preview, stats) = fetchRelatedMatchContent(theMatch, related)
-        val canonicalPage = matchReport.orElse(minByMin).orElse { if (theMatch.isFixture) preview else None }
+        val canonicalPage = matchReport.orElse(minByMin).orElse { if (theMatch.isFixture) preview else None }.getOrElse(stats)
 
-        canonicalPage match {
-          case Some(footballMatch) =>  Cached(60)(WithoutRevalidationResult(Found(footballMatch.url)))
-          case None if stats.isLive =>  Cached(60)(WithoutRevalidationResult(Found(stats.url)))
-          case _ => NoCache(NotFound("Match is in the future"))
-        }
+        if(Football.isOver3DaysAway(theMatch)) NoCache(NotFound("Match is in the future"))
+        else Cached(60)(WithoutRevalidationResult(Found(canonicalPage.url)))
       }
     }.getOrElse {
       // we do not keep historical data, so just redirect old stuff to the results page (see also MatchController)

--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -2,7 +2,7 @@ package implicits
 
 import football.model.FootballMatchTrail
 import model._
-import org.joda.time.{DateTime, Days, LocalDate}
+import org.joda.time.{DateTime, Days, Hours, LocalDate}
 import pa._
 import views.MatchStatus
 
@@ -113,10 +113,9 @@ trait Football extends Collections {
 }
 
 object Football extends Football {
-  def isOver3DaysAway(theMatch: FootballMatch): Boolean = {
-    val noDays = Days.daysBetween(DateTime.now.toLocalDate, theMatch.date.toLocalDate).getDays
-    noDays >= 3
-  }
+
+  def hoursTillMatch(theMatch: FootballMatch): Int =
+    Hours.hoursBetween(DateTime.now, theMatch.date).getHours
 
 }
 

--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -62,7 +62,7 @@ trait Football extends Collections {
 
     lazy val hasStarted = m.isLive || m.isResult
 
-    val smartUrl: String = MatchUrl.smartUrl(m)
+    val smartUrl: Option[String] = MatchUrl.smartUrl(m)
 
     def hasTeam(teamId: String): Boolean = m.homeTeam.id == teamId || m.awayTeam.id == teamId
 

--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -2,9 +2,10 @@ package implicits
 
 import football.model.FootballMatchTrail
 import model._
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, Days, LocalDate}
 import pa._
 import views.MatchStatus
+
 import scala.language.implicitConversions
 
 trait Football extends Collections {
@@ -111,5 +112,11 @@ trait Football extends Collections {
   def groupTag(competitionId: String, round: Round): Option[String] = roundLinks.get(competitionId).flatMap(_(round))
 }
 
-object Football extends Football
+object Football extends Football {
+  def isOver3DaysAway(theMatch: FootballMatch): Boolean = {
+    val noDays = Days.daysBetween(DateTime.now.toLocalDate, theMatch.date.toLocalDate).getDays
+    noDays >= 3
+  }
+
+}
 

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -150,7 +150,7 @@ object MatchUrl {
   }
 
   def smartUrl(theMatch: FootballMatch): Option[String] = {
-    if (Football.isOver3DaysAway(theMatch)) None
+    if (Football.hoursTillMatch(theMatch) > 72) None
     else Some(s"/football/match-redirect/${theMatch.id}")
   }
 }

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -4,6 +4,7 @@ import common._
 import contentapi.ContentApiClient
 import _root_.feed.Competitions
 import com.gu.Box
+import implicits.Football
 import org.joda.time.{DateTime, Days}
 import pa._
 
@@ -149,7 +150,7 @@ object MatchUrl {
   }
 
   def smartUrl(theMatch: FootballMatch): Option[String] = {
-    if (Days.daysBetween(DateTime.now.toLocalDate, theMatch.date.toLocalDate).getDays > 7) None
+    if (Football.isOver3DaysAway(theMatch)) None
     else Some(s"/football/match-redirect/${theMatch.id}")
   }
 }

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -4,6 +4,7 @@ import common._
 import contentapi.ContentApiClient
 import _root_.feed.Competitions
 import com.gu.Box
+import org.joda.time.{DateTime, Days}
 import pa._
 
 import scala.concurrent.ExecutionContext
@@ -147,7 +148,8 @@ object MatchUrl {
     }).getOrElse(s"/football/match/${theMatch.id}")
   }
 
-  def smartUrl(theMatch: FootballMatch): String = {
-    s"/football/match-redirect/${theMatch.id}"
+  def smartUrl(theMatch: FootballMatch): Option[String] = {
+    if (Days.daysBetween(DateTime.now.toLocalDate, theMatch.date.toLocalDate).getDays > 7) None
+    else Some(s"/football/match-redirect/${theMatch.id}")
   }
 }

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -22,7 +22,7 @@
 
     <tbody>
         @matchesList.map{ theMatch =>
-            <tr data-link-to="@theMatch.smartUrl.map(url=>LinkTo(url)).getOrElse("")"
+            <tr @(theMatch.smartUrl.map(url=>s"data-link-to=${LinkTo(url)}").getOrElse(""))
                 data-match-id="@theMatch.id"
                 data-score-home="@theMatch.homeTeam.score"
                 data-score-away="@theMatch.awayTeam.score"
@@ -47,7 +47,7 @@
                     <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{theMatch.homeTeam.id}.png" />
                 </td>
                 <td class="football-match__teams table-column--main">
-                    <a href="@theMatch.smartUrl.map(url => LinkTo(url)).getOrElse("")" class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
+                    <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
                         <div class="football-match__team football-match__team--home football-team">
                             <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.homeTeam)">
                                 <span class="team-name__long">@theMatch.homeTeam.name</span>

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -22,7 +22,7 @@
 
     <tbody>
         @matchesList.map{ theMatch =>
-            <tr data-link-to="@LinkTo{@theMatch.smartUrl}"
+            <tr data-link-to="@theMatch.smartUrl.map(url=>LinkTo(url)).getOrElse("")"
                 data-match-id="@theMatch.id"
                 data-score-home="@theMatch.homeTeam.score"
                 data-score-away="@theMatch.awayTeam.score"
@@ -47,7 +47,7 @@
                     <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{theMatch.homeTeam.id}.png" />
                 </td>
                 <td class="football-match__teams table-column--main">
-                    <a href="@LinkTo{@theMatch.smartUrl}" class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
+                    <a href="@theMatch.smartUrl.map(url => LinkTo(url)).getOrElse("")" class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
                         <div class="football-match__team football-match__team--home football-team">
                             <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.homeTeam)">
                                 <span class="team-name__long">@theMatch.homeTeam.name</span>

--- a/sport/app/football/views/matchStats/matchStatsPage.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsPage.scala.html
@@ -1,9 +1,14 @@
 @import common.LinkTo
 @import implicits.Football._
 
+@import implicits.Football
 @(page: football.controllers.MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page, Some("football")){
+    @* If this is just a placeholder page for a future match with no useful information, hide from search engines *@
+    @if(!page.hasPaStats && !page.hasLineUp && !page.matchStarted && !page.theMatch.isLive && Football.hoursTillMatch(page.theMatch) > 72 ) {
+        <meta name="robots" content="noindex">
+    }
 } {
 
 <article class="content content--football-stats">


### PR DESCRIPTION
## What does this change?
Modifies http://theguardian.com/football/fixtures so that we only link to matches that are in the next 72 hours. The motivation for this change is that we don't want empty pages such as this one https://www.theguardian.com/football/match/2019/feb/01/huesca-v-valladolid being indexed by google

This PR also adds a noindex tag for matches that have no PA data and are more than 72 hours away, to help deal with an existing issue where future matches are listed by google as being the canonical url for a match in the past. 

I've discussed this change with James Dart on the sport desk and Peter Martin
### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
