### PR TITLE
renamed 'Digital Pack' MMA tab (and global nav) to 'Subscriptions' following unification in manage-frontend

### DIFF
--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -39,20 +39,20 @@ object DropdownMenus {
       label = "Emails & marketing"
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/membership/edit"),
+      href = Some(s"${Configuration.id.mmaUrl}/membership"),
       linkName = Some("membership"),
       label = "Membership",
       divider = true,
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/contribution/recurring/edit"),
+      href = Some(s"${Configuration.id.mmaUrl}/contributions"),
       linkName = Some("contributions"),
       label = "Contributions",
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/digitalpack/edit"),
+      href = Some(s"${Configuration.id.mmaUrl}/subscriptions"),
       linkName = Some("subscriptions"),
-      label = "Digital Pack",
+      label = "Subscriptions",
     ),
     DropdownMenuItem(
       href = Some(s"${Configuration.id.url}/signout"),

--- a/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
+++ b/identity/app/controllers/editprofile/tabs/SupporterTabs.scala
@@ -24,6 +24,6 @@ trait SupporterTabs
   def redirectToManageContributions: Action[AnyContent] = redirectToManage("contributions")
 
   /** Redirect /digitalpack/edit to manage.theguardian.com/digitalpack */
-  def redirectToManageDigitalPack: Action[AnyContent] = redirectToManage("digitalpack")
+  def redirectToManageSubscriptions: Action[AnyContent] = redirectToManage("subscriptions")
 
 }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -81,7 +81,7 @@
 
                     @tab(3, "Membership", "/membership/edit", None, optionalClass="qa-membership-tab", disableClientSideRouting = true)
 
-                    @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab", disableClientSideRouting = true)
+                    @tab(4, "Subscriptions", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab", disableClientSideRouting = true)
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation, disableClientSideRouting = true)
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -54,7 +54,7 @@ POST        /account/edit                           controllers.editprofile.Edit
 
 GET         /membership/edit                        controllers.editprofile.EditProfileController.redirectToManageMembership
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.redirectToManageContributions
-GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.redirectToManageDigitalPack
+GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.redirectToManageSubscriptions
 
 GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/manage-frontend/pull/185 unifies Newspaper, Guardian Weekly and Digital Pack into a unified tab entitled **'Subscriptions'**, replacing the 'Digital Pack' tab. These changes replicate the tab headings and global nav to match (but for backwards compatibility retaining the `/digitalpack/edit` redirect  - now to `/subscriptions` on `manage-frontend`)

## Screenshots
| | Before | After |
| --- | --- | --- |
| Tabs | ![image](https://user-images.githubusercontent.com/19289579/51979672-ae000d00-2485-11e9-9a16-67eccbc6614d.png) | ![image](https://user-images.githubusercontent.com/19289579/51980122-008df900-2487-11e9-86d6-e0fbc2ceaa84.png) |
| Global Nav | ![image](https://user-images.githubusercontent.com/19289579/51980238-5bbfeb80-2487-11e9-9024-80132ae26ce3.png) | ![image](https://user-images.githubusercontent.com/19289579/51980203-434fd100-2487-11e9-979c-314ad02c9a74.png) |



## What is the value of this and can you measure success?
This is part of a wider product management unification process, and so the success is arguably by more traffic to the `manage-platform`, less help centre calls and confused user complaints.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
