### PR TITLE
Ensure we wrap read with fastdom to prevent forced layout/style

### DIFF
--- a/static/src/javascripts/lib/fastdom-promise.js
+++ b/static/src/javascripts/lib/fastdom-promise.js
@@ -22,4 +22,5 @@ const promisify = fdaction => (fn: Function, ctx: ?Object): Promise<any> =>
 export default {
     read: promisify(fastdom.read.bind(fastdom)),
     write: promisify(fastdom.write.bind(fastdom)),
+    defer: promisify(fastdom.defer.bind(fastdom)),
 };

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -1,7 +1,7 @@
 // @flow
 import formInlineLabels from 'lib/formInlineLabels';
 import bean from 'bean';
-import fastdom from 'fastdom';
+import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 import config from 'lib/config';
 import { getUserAgent } from 'lib/detect';
@@ -226,13 +226,14 @@ const setIframeHeight = (
     iFrameEl: HTMLIFrameElement,
     callback: () => void
 ): (() => void) => () => {
-    fastdom.write(() => {
-        iFrameEl.height = '';
-        iFrameEl.height = `${
-            iFrameEl.contentWindow.document.body.clientHeight
-        }px`;
-        callback();
-    });
+    fastdom
+        .read(() => iFrameEl.contentWindow.document.body.clientHeight)
+        .then(height =>
+            fastdom.write(() => {
+                iFrameEl.height = `${height}px`;
+            })
+        )
+        .then(callback());
 };
 
 const handleSubmit = (isSuccess: boolean, $form: bonzo): (() => void) => () => {


### PR DESCRIPTION
We are seeing forced layouts/styles because of email.js, specifically line 232. This PR aims to fix this by wrapping the read in fastdom.

![screenshot 2019-01-31 at 15 25 31](https://user-images.githubusercontent.com/858402/52065196-ec70f700-256d-11e9-93ae-a021d49e0d29.png)

(evidence of bad behaviour - note cumulative blocking time on a mobile device (here 4x CPU throttling in Chrome dev tools) can be 60ms+, which is not gigantic by any means, but still can block interactivity.