### PR TITLE
Revert "Jdr photoessay"

### DIFF
--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -59,7 +59,7 @@
                             case None => { }
                         }
 
-                        @fragments.contentMeta(article, model, amp = false)
+                        @fragments.contentMeta(article, model, amp = amp)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />

--- a/article/app/views/fragments/photoEssayBody.scala.html
+++ b/article/app/views/fragments/photoEssayBody.scala.html
@@ -1,78 +1,41 @@
-@(amp: Boolean = false)(implicit model: ArticlePage, request: RequestHeader, context: _root_.model.ApplicationContext)
+@()(implicit model: ArticlePage, request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import common.LinkTo
 @import views.BodyCleaner
-@import views.support.RenderClasses
 @import views.support.Commercial.{isPaidContent, articleAsideOptionalSizes, shouldShowAds}
 @import views.support.TrailCssClasses.toneClass
-@import _root_.model.ContentDesignType.RichContentDesignType
 
-@defining((model.article, isPaidContent(model))) { case (article, isPaidContent) =>
-
+@defining(model.article) { article =>
+  @defining(isPaidContent(model)) { isPaidContent =>
         <article id="article" data-test-id="article-root"
-
-            class="@RenderClasses(Map(
-                "paid-content" -> isPaidContent,
-                "content--pillar-special-report" -> (toneClass(article) == "tone-special-report")
-            ),
-                "content",
-                "content--article",
-                "content--photo-essay",
-                s"content--pillar-${article.metadata.pillar.nameOrDefault}",
-                s"content--type-${article.metadata.designType.nameOrDefault}",
-                "tonal",
-                s"tonal--${toneClass(article)}",
-                s"section-${article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")}"
-            ), content content--type-immersive content--article content--immersive content--immersive-article content--immersive-garnett tonal"
-
+            class="content content--article content--immersive content--immersive-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
+            @if(isPaidContent){content--paid-content}
+            @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}"
             itemscope itemtype="@article.metadata.schemaType" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">
                 <link itemprop="sameAs" href="http://www.theguardian.com">
             </div>
-            @if(isPaidContent) {
-                @fragments.guBand()
-            }
             @fragments.headerImmersive(article)
-            @fragments.immersiveGarnettHeadline()
-            <div class="content__standfirst--wrapper">
+            <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
-                    <div class="content__main-column">
-                        @fragments.standfirst(article)
-                    </div>
-                </div>
-            </div>
-            <div class="content__main tonal__main tonal__main--@toneClass(article) content--photo-essay">
-                <div class="gs-container">
-                    <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
-                        @defining(model.article.elements.mainPicture.flatMap(_.images.masterImage)) {
-                            case Some(masterImage) => {
-                                <figcaption class="caption caption--immersive hide-from-leftcol">
-                                    Main image:
-                                    @masterImage.caption.map(Html(_))
-                                    @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
-                                        @masterImage.credit.map(Html(_))
-                                    }
-                                </figcaption>
-                            }
-                            case None => { }
-                        }
+                    <div class="content__main-column content__main-column--article js-content-main-column">
 
-                        @fragments.contentMeta(article, model, amp = amp)
+                        @fragments.contentMeta(article, model)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
                         }
 
                         <div class="content__article-body from-content-api js-article__body"
-                             itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
+                             itemprop="articleBody"
                              data-test-id="article-review-body" @langAttributes(article.content)>
-                            @BodyCleaner(article, amp = amp)
-                            @fragments.submeta(article)
-
+                            @BodyCleaner(article, amp = false)
                         </div>
+
+                        @fragments.submeta(article)
 
                         <div class="after-article js-after-article"></div>
                     </div>
@@ -83,9 +46,10 @@
 
                     </div>
                 </div>
+            </div>
         </article>
 
         @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent)
 
-    </div>
+  }
 }

--- a/article/app/views/fragments/photoEssayHeader.scala.html
+++ b/article/app/views/fragments/photoEssayHeader.scala.html
@@ -4,7 +4,7 @@
 
 <div class="@RenderClasses(Map(
     ("immersive-header-container", page.item.fields.main.nonEmpty),
-    ("immersive-header-container--photo-essay", page.item.content.isPhotoEssay))) content--photo-essay">
+    ("immersive-header-container--photo-essay", page.item.content.isPhotoEssay)))">
 
     @fragments.header()
     @fragments.photoEssay()

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -55,4 +55,52 @@
           <div class="immersive-main-media__image-overlay"></div>
         }
     </div>
+
+    @if(!page.item.elements.hasMainVideo){
+      <div class="@RenderClasses("immersive-main-media__headline-container--dark", "immersive-main-media__headline-container--gallery", "content--pillar-news", s"content--pillar-${page.metadata.pillar.nameOrDefault}")">
+          <div class="gs-container">
+            <div class="content__main-column">
+                @fragments.meta.metaInline(page.item)
+                <h1 class="@if(hasMainMedia){content__headline--immersive--with-main-media} @if(isPaidContent){content__headline--advertisement} content__headline content__headline--immersive content__headline--immersive-article">
+                    @Html(page.item.trail.headline)
+                </h1>
+
+                @defining(page.item.elements.mainPicture.flatMap(_.images.masterImage)) {
+                    case Some(masterImage) => {
+                        <figcaption class="caption caption--immersive hide-until-leftcol">
+                            @fragments.inlineSvg("triangle", "icon")
+                            @masterImage.caption.map(Html(_))
+                            @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
+                                @masterImage.credit.map(Html(_))
+                            }
+                        </figcaption>
+                    }
+                    case None => { }
+                }
+            </div>
+          </div>
+      </div>
+    }
+    @if(page.item.fields.standfirst.isDefined) {
+        <div class="content__wrapper--standfirst">
+            <div class="gs-container">
+                <div class="content__main-column">
+                    @fragments.standfirst(page.item)
+
+                    @defining(page.item.elements.mainPicture.flatMap(_.images.masterImage)) {
+                        case Some(masterImage) => {
+                            <figcaption class="caption caption--immersive hide-from-leftcol">
+                                Main image:
+                                @masterImage.caption.map(Html(_))
+                                @if(masterImage.displayCredit && !masterImage.creditEndsWithCaption) {
+                                    @masterImage.credit.map(Html(_))
+                                }
+                            </figcaption>
+                        }
+                        case None => { }
+                    }
+                </div>
+            </div>
+        </div>
+    }
 }

--- a/static/src/stylesheets/inline/article-photo-essay-garnett.scss
+++ b/static/src/stylesheets/inline/article-photo-essay-garnett.scss
@@ -1,175 +1,268 @@
 @import '../_vars';
 @import '../_mixins';
 
-.content--photo-essay {
-    h2 {
-        margin-bottom: $gs-baseline;
-    }
+.content--photo-essay .immersive-main-media__headline-container {
+    margin-top: 0;
+    bottom: 0;
 
-    .section-title {
-        background-color: rgb(0, 0, 0);
-        background: linear-gradient(transparent, rgb(0, 0, 0));
-        font-weight: 900;
-        margin-bottom: 0;
-    }
+    .content__standfirst--immersive-article {
 
-    .element--halfWidth {
-        width: 49%;
-        float: left;
-        margin-top: 0;
-        margin-bottom: 2%;
+        @include mq(desktop) {
+            padding-bottom: 1rem;
 
-        // Makes sure that elements which come after the block of images are no longer floating
-        & + p, & + blockquote, & + .element-pullquote:not(.element--halfWidth) {
-            clear: both;
-        }
-    }
-
-    .element--halfWidth.half-width-odd {
-        margin-right: 2%;
-
-        &:before {
-            content: '';
-            display: block;
-            width: 2px;
-            top: 0;
-            bottom: 0;
-            z-index: 300;
-            position: absolute;
-            background-color: #ffffff;
-       }
-    }
-
-    .element-pullquote--photo-essay {
-        &.element--inline,
-        &.element--showcase {
-            width: 100%;
-            margin: 0;
-        }
-
-        &.element--supporting {
-            width: 100%;
-            @include mq(leftCol) {
-                width: gs-span(2) + $gs-gutter;
-            }
-
-            @include mq(wide) {
-                width: gs-span(3) + $gs-gutter;
-            }
-
-            .pullquote-paragraph {
-                @include fs-headlineGarnett(1);
-                font-weight: 900;
-            }
-      }
-
-        &.element--halfWidth,
-        &.element--inline,
-        &.element--showcase {
-            .pullquote-paragraph {
-                @include fs-headlineGarnett(2);
-                font-weight: 900;
-
-                @include mq($from: desktop) {
-                    @include fs-headlineGarnett(4);
-                    font-weight: 900;
-                }
+            &:before {
+                content: '';
+                position: absolute;
+                top: 0;
+                height: 2px;
+                width: gs-span(2);
+                background-color: rgba(255, 255, 255, .2);
             }
         }
     }
+}
 
-    .photo-essay-block-quote {
+.content--article.content--immersive-article {
+    .content__article-body {
+        margin: 0;
+    }
+
+    a.u-underline.in-body-link--immersive {
+        color: $sport-dark;
+
+        &:hover {
+            border-bottom: 1px solid $sport-bright;
+        }
+    }
+
+    blockquote.photo-essay-block-quote {
+        font-family: $f-serif-headline;
         font-style: normal;
-        display: inline;
-        float: left;
+        margin: 0 0 $gs-baseline * 2;
 
-        .inline-garnett-quote.inline-icon {
-            position: relative;
-            top: $gs-gutter/2;
-            svg {
-                width: 50px;
-                height: auto;
-            }
+        &:not(.quoted) {
+            background-color: $brightness-93;
+            padding: $gs-baseline / 1.5  $gs-baseline $gs-baseline;
+        }
+
+        .inline-icon {
+            fill: $sport-dark;
         }
 
         .quoted__contents {
-            @include fs-headlineGarnett(2);
             margin: 0;
-            font-weight: 900;
+        }
 
-            @include mq($from: desktop) {
-                @include fs-headlineGarnett(4);
-                font-weight: 900;
+        h2 {
+            color: $sport-dark;
+            font-weight: 100;
+            font-size: 38px;
+            line-height: 1;
+        }
+
+        &.quoted {
+            color: $sport-dark;
+            font-size: 26px;
+            line-height: 28px;
+
+            .inline-icon {
+                fill: $sport-bright;
+                width: $gs-baseline * 2;
+                display: block;
+                margin-bottom: $gs-baseline;
+            }
+
+            .inline-icon .inline-garnett-quote__svg {
+                width: 100%;
+                height: auto;
             }
         }
     }
-
-    .element--halfWidth.element-pullquote--photo-essay {
-        width: 45%;
-        margin-right: $gs-gutter;
-        border-bottom: 0;
-        margin-top: 0;
-        clear: none;
-        margin-left: 0;
-        margin-bottom: $gs-baseline/2;
-        border-top: 1px solid $brightness-86;
-        vertical-align: top;
-    }
-
-    .element-pullquote svg {
-        width: 18px;
-    }
-
-    .element-image.element--showcase {
+    .element-image--photo-essay {
+        padding-bottom: 0;
         margin-bottom: $gs-baseline;
-    }
 
-    .from-content-api ul:not(.submeta__links):not(.social--bottom):not(.syndication--bottom) {
-        display: inline-block;
-        width: 98%;
-        margin-top: 0;
-
-        @include mq($until: mobileLandscape) {
-            margin-top: -$gs-baseline / 2;
+        //importants here to overide previously set !important
+        &.fig--no-caption.fig--has-shares {
+            padding-bottom: 0px !important;
         }
 
-        & > li {
-            @include fs-textSans(1);
-            width: 100%;
-            margin-right: 1%;
-            padding-top: $gs-baseline / 2;
-            padding-left: 0 !important; // override padding applied in from-content-api.scss, blame BEN
-            border-top: 1px solid $brightness-86;
-            color: $brightness-46;
+        .caption {
+            max-width: 100%;
+            color: $sport-dark;
 
-            @include mq($until: mobileLandscape) {
-                width: 98%;
+            .inline-information.reveal-caption-icon {
+                background-color: $sport-dark;
+            }
+        }
+
+        .section-title {
+            background-color: rgb(0, 0, 0);
+            background: linear-gradient(transparent, rgb(0, 0, 0));
+
+            &:before {
+                background-color: $sport-bright;
+                display: block;
+                content: '';
+                width: gs-span(2);
+                height: $gs-baseline;
+                margin-bottom: calc(#{$gs-gutter} / 3);
+            }
+        }
+
+        &.element--supporting {
+            .caption {
+                max-width: 100%;
+            }
+        }
+
+        &.element--halfWidth {
+            width: 49%;
+            float: left;
+            margin-top: 0;
+            margin-bottom: 2%;
+
+            .inline-expand-image {
+                display: none;
+            }
+
+            &:before {
+                content: '';
+                display: block;
+                width: 2px;
+                top: 0;
+                bottom: 0;
+                z-index: 300;
+                position: absolute;
+                background-color: #ffffff;
+            }
+
+            // Makes sure that elements which come after the block of images are no longer floating
+            & + p, & + blockquote, & + .element-pullquote:not(.element--halfWidth) {
+                clear: both;
+                padding-top: $gs-baseline / 2;
+            }
+            // changes the padding for a half width quote after directly after a half width image
+            & + .element-pullquote.element--halfWidth {
+                margin-top: 0;
+            }
+
+            & + .element-image:not(.element--halfWidth) {
+                clear: left;
+            }
+        }
+        &.element--halfWidth.half-width-odd {
+            margin-right: 2%;
+        }
+    }
+
+    .element-pullquote--photo-essay.element--supporting {
+        .pullquote-paragraph {
+            text-indent: 0;
+        }
+    }
+
+    .element-pullquote--photo-essay {
+        .pullquote-paragraph {
+            color: $sport-dark;
+            font-size: 26px;
+        }
+
+        //important because it is important elsewhere
+        .pullquote-cite {
+            color: $brightness-46 !important;
+            font-size: 26px;
+        }
+
+        &.element--halfWidth {
+            width: 45%;
+            float: left;
+            margin-right: $gs-gutter;
+            border-bottom: 0;
+            margin-top: $gs-baseline / 2;
+            clear: none;
+        }
+
+        .inline-icon {
+            fill: $sport-bright;
+            width: $gs-baseline * 2;
+            display: block;
+            margin-bottom: $gs-baseline;
+
+            .inline-garnett-quote__svg {
+                width: 100%;
+                height: auto;
             }
         }
     }
+}
 
-    //changes the style of the list item when it comes directly after an immersive or showcase element.
-    //Pulls the list item into the leftColumn on wide.
-    .element--immersive + ul:not(.submeta__links):not(.social--bottom):not(.syndication--bottom),
-    .element--showcase + ul:not(.submeta__links):not(.social--bottom):not(.syndication--bottom) {
-        width: 150px;
-        margin-left: -170px;
-        float: left;
+.content__series-label--photo-essay .content__label__link {
+    color: #ffffff;
+}
 
-        & > li {
-            width: 100%;
-        }
+.content__section-label--advertisement {
+    @include f-textSans;
+    font-size: 20px;
+    line-height: 24px;
+    font-weight: 900;
+    margin: 0;
 
-        @include mq($until: leftCol) {
-            width: 98%;
-            margin-left: 0;
-            float: none;
+    .content__section-label__link--advertisement {
+        color: $labs-main;
+    }
+}
+
+.from-content-api ul {
+    display: inline-block;
+    width: 98%;
+    margin-top: 0;
+    @include mq($until: mobileLandscape) {
+        margin-top: -$gs-baseline / 2;
+    }
+
+    & > li {
+        @include fs-textSans(3);
+        color: $brand-main;
+        font-size: 12px;
+        width: 100%;
+        margin-right: 1%;
+        line-height: 14px;
+        padding-top: $gs-baseline / 2;
+        padding-left: 0 !important; // override padding applied in from-content-api.scss
+        border-top: 1px solid $brand-main;
+
+        &::before {
+            display: none !important;
         }
 
         @include mq($until: mobileLandscape) {
             width: 98%;
-            float: none;
-            margin-left: 0;
         }
+    }
+}
+
+//changes the style of the list item when it comes directly after an immersive or showcase element.
+//Pulls the list item into the leftColumn on wide.
+
+.element--immersive + ul, .element--showcase + ul {
+    width: 150px;
+    margin-left: -170px;
+    float: left;
+
+    & > li {
+        width: 100%;
+    }
+
+    @include mq($until: leftCol) {
+        width: 98%;
+        margin-left: 0;
+        float: none;
+    }
+
+    @include mq($until: mobileLandscape) {
+        width: 98%;
+        float: none;
+        margin-left: 0;
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -14,8 +14,7 @@
     .button--secondary,
     .drop-cap,
     .element-pullquote p,
-    .u-underline,
-    .photo-essay-block-quote {
+    .u-underline {
         color: $pillarColor;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -362,7 +362,7 @@ $quote-mark: 35px;
     }
 
     // *************** Quote Styles ***************
-    .element-pullquote:not(.element-pullquote--photo-essay) {
+    .element-pullquote {
         background-color: $brightness-97;
         margin: $gs-gutter/4 0 $gs-baseline*2;
         padding: $gs-baseline/2 $gs-gutter/2 $gs-baseline;
@@ -431,7 +431,7 @@ $quote-mark: 35px;
         }
     }
     // Quote supporting
-    .element-pullquote.element--supporting:not(.element-pullquote--photo-essay) {
+    .element-pullquote.element--supporting {
         @include mq(mobileMedium) {
             clear: left;
             float: left;
@@ -464,7 +464,7 @@ $quote-mark: 35px;
         }
     }
     // Quote halfWidth
-    .element-pullquote.element--halfWidth:not(.element-pullquote--photo-essay) {
+    .element-pullquote.element--halfWidth {
         @include mq(mobileMedium) {
             clear: left;
             float: left;
@@ -484,7 +484,7 @@ $quote-mark: 35px;
         }
     }
     // Quote inline
-    .element-pullquote.element--inline:not(.element-pullquote--photo-essay) {
+    .element-pullquote.element--inline {
         width: gs-span(4);
         @include mq(mobileLandscape) {
             width: gs-span(5);
@@ -502,7 +502,7 @@ $quote-mark: 35px;
         }
     }
     // Quote showcase
-    .element-pullquote.element--showcase:not(.element-pullquote--photo-essay) {
+    .element-pullquote.element--showcase {
         @include mq(mobileLandscape) {
             margin-left: -$gs-gutter;
         }
@@ -563,7 +563,7 @@ $quote-mark: 35px;
         }
     }
 
-    .element-image.element--showcase:not(.element-image--photo-essay) {
+    .element-image.element--showcase {
         @include mq(leftCol) {
             margin-bottom: $gs-baseline * 3;
         }
@@ -1176,7 +1176,7 @@ $quote-mark: 35px;
 }
 // *************** Feature quote weight overrides ***************
 
-.content--type-article:not(.content--photo-essay) {
+.content--type-article {
     .element-pullquote.element--supporting .pullquote-cite,
     .element-pullquote.element--supporting .pullquote-paragraph {
         font-weight: 400;


### PR DESCRIPTION
Reverts guardian/frontend#20975, which has unexpectedly changed the commercial photo-essay design, breaking the design for the ~77 commercial photo essays currently being run.

Here's an example:
https://www.theguardian.com/tales-of-the-everyday-extraordinary/2018/dec/20/kele-okereke-on-masculinity-and-the-music-industry

It has switched the commercial photo essays to the immersive grey background. Coupled with commercial's use of "tiled" images with a white background this has broken the layout.

We'll roll this back for now and discuss it in more detail when we're all in the office.
