### PR TITLE
Remove function adtestParams

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,6 +1,6 @@
 // @flow strict
 import config from 'lib/config';
-import { getCookie, removeCookie } from 'lib/cookies';
+import { getCookie } from 'lib/cookies';
 import { getReferrer as detectGetReferrer, getBreakpoint } from 'lib/detect';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { local } from 'lib/storage';

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -59,16 +59,6 @@ const abParam = (): Array<string> => {
     return abParams;
 };
 
-const adtestParams = (): ?string => {
-    const cookieAdtest: ?string = getCookie('adtest');
-    if (cookieAdtest) {
-        if (cookieAdtest.substring(0, 4) === 'demo') {
-            removeCookie('adtest');
-        }
-        return cookieAdtest;
-    }
-};
-
 const getVisitedValue = (): string => {
     const visitCount: number = local.get('gu.alreadyVisited') || 0;
 
@@ -199,7 +189,7 @@ const buildPageTargeting = once(
                 x: getKruxSegments(),
                 pv: config.get('ophan.pageViewId'),
                 bp: getBreakpoint(),
-                at: adtestParams(),
+                at: getCookie('adtest') || undefined,
                 si: isUserLoggedIn() ? 't' : 'f',
                 gdncrm: getUserSegments(),
                 ab: abParam(),


### PR DESCRIPTION
## What does this change?

This removes the function `adtestParams` from `build-page-targeting`. This function didn't seem to do anything other than;
 - Check if the prefix of the `adtest` string starts with `demo` and if so remove the cookie
 - convert a possible `null` value to `undefined`

I don't think there are any scenarios where we purposely have `demo` in the `adtest` string, so nothing makes use of this code; however there used to be code that did use this but it has since been removed.

See https://github.com/guardian/frontend/blame/33cc904f352be2d9208ac7f18fd2c9e16171c8f7/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js

Thanks @adamnfish for sleuthing :male_detective: 

@guardian/commercial-dev 