### PR TITLE
remove Support Server Side Rendering switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -517,17 +517,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  // Contributions
-  val ContributionsServerSideRenderingSwitch = Switch(
-    SwitchGroup.Feature,
-    "contributions-server-side-rendering-switch",
-    "If switched on, half of links to support.theguardian.com/contribute will have ssr=on and half will have ssr=off added to the query string",
-    owners = Seq(Owner.withName("jranks123")),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 20),
-    exposeClientSide = true
-  )
-
   val SubscribeWithGoogle = Switch(
     SwitchGroup.Feature,
     "subscribe-with-google",

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,6 +1,5 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
-import { addServerSideRenderingTestParameterToLink } from 'common/modules/commercial/contributions-utilities';
 import fastdom from 'lib/fastdom-promise';
 
 // Currently the only acquisition components on the site are
@@ -61,15 +60,10 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
         fastdom.read(() => el.getAttribute('href')).then(link => {
             if (link) {
                 fastdom.write(() => {
-                    let linkWithAcquisitionData = addReferrerDataToAcquisitionLink(
-                        link
+                    el.setAttribute(
+                        'href',
+                        addReferrerDataToAcquisitionLink(link)
                     );
-                    if (link.contains('support.theguardian.com/contribute')) {
-                        linkWithAcquisitionData = addServerSideRenderingTestParameterToLink(
-                            linkWithAcquisitionData
-                        );
-                    }
-                    el.setAttribute('href', linkWithAcquisitionData);
                 });
             }
         });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -166,29 +166,6 @@ const registerIframeListener = (iframeId: string) => {
     });
 };
 
-const addServerSideRenderingTestParameterToLink = (rawUrl: string): string => {
-    const serverSideRenderingField = 'ssr';
-    const switchIsOn = config.get(
-        'switches.contributionsServerSideRenderingSwitch',
-        false
-    );
-    const randomNumber = Math.random();
-    if (!typeof randomNumber === 'number' || !switchIsOn) {
-        return rawUrl;
-    }
-    const paramValue = randomNumber >= 0.5 ? 'on' : 'off';
-    let url;
-    try {
-        url = new URL(rawUrl);
-    } catch (e) {
-        return rawUrl;
-    }
-    if (paramValue) {
-        url.searchParams.set(serverSideRenderingField, paramValue);
-    }
-    return url.toString();
-};
-
 const makeABTestVariant = (
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
@@ -204,19 +181,6 @@ const makeABTestVariant = (
     const iframeId = `${parentTest.campaignId}_iframe`;
 
     // defaults for options
-
-    const supportUrlWithTrackingCodes = (campaignCode: string) =>
-        addTrackingCodesToUrl({
-            base: `${options.supportBaseURL || supportContributeURL}`,
-            componentType: parentTest.componentType,
-            componentId,
-            campaignCode,
-            abTest: {
-                name: parentTest.id,
-                variant: id,
-            },
-        });
-
     const {
         // filters, where empty is taken to mean 'all', multiple entries are combined with OR
         locations = [],
@@ -230,9 +194,16 @@ const makeABTestVariant = (
             parentTest.campaignId,
             id
         ),
-        supportURL = addServerSideRenderingTestParameterToLink(
-            supportUrlWithTrackingCodes(campaignCode)
-        ),
+        supportURL = addTrackingCodesToUrl({
+            base: `${options.supportBaseURL || supportContributeURL}`,
+            componentType: parentTest.componentType,
+            componentId,
+            campaignCode,
+            abTest: {
+                name: parentTest.id,
+                variant: id,
+            },
+        }),
         subscribeURL = addTrackingCodesToUrl({
             base: 'https://support.theguardian.com/subscribe',
             componentType: parentTest.componentType,
@@ -664,5 +635,4 @@ export {
     getReaderRevenueRegion,
     makeGoogleDocBannerControl,
     makeGoogleDocBannerVariants,
-    addServerSideRenderingTestParameterToLink,
 };


### PR DESCRIPTION
## What does this change?
We are now doing the audience splitting on the support backend, so the switch we added in https://github.com/guardian/frontend/pull/21001 is no longer necessary


