### PR TITLE
Tag and section based whitelisting for AMP release

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -47,8 +47,15 @@ object AMPPicker {
     logger.withRequestHeaders(request).results(msg, results, page)
   }
 
+  private[this] val sectionsWhitelist: Set[String] = Set(
 
-  private[this] val whitelist = Set(
+  )
+
+  private[this] val tagsWhitelist: Set[String] = Set(
+
+  )
+
+  private[this] val pageWhitelist: Set[String] = Set(
     "world/2018/oct/14/british-man-shot-dead-by-hunter-in-france",
     "politics/2018/oct/14/brexit-dominic-raab-rushes-to-brussels-before-eu-crunch-talks",
     "politics/2018/oct/14/eu-leaders-line-up-no-deal-emergency-brexit-summit-for-november",
@@ -102,9 +109,13 @@ object AMPPicker {
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
 
+    val isWhitelisted =
+      pageWhitelist(page.metadata.id) ||
+      page.metadata.section.exists((s) => sectionsWhitelist(s.value)) ||
+      page.item.tags.tags.exists((s)=>tagsWhitelist(s.id))
+
     val features = ampFeatureWhitelist(page, request)
     val isSupported = features.forall({ case (test, isMet) => isMet})
-    val isWhitelisted = whitelist(page.metadata.id)
     val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
     val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender


### PR DESCRIPTION
## What does this change?

Tag and section based whitelisting for AMP release

@nicl 

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
