### PR TITLE
Auto copy inline styles in dev mode

### DIFF
--- a/dev/watch.js
+++ b/dev/watch.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const path = require('path');
+const cpy = require('cpy');
 
 const chalk = require('chalk');
 const browserSync = require('browser-sync').create();
@@ -97,6 +98,33 @@ chokidar.watch(`${sassDir}/**/*.scss`).on('change', changedFile => {
 
     // now recompile all files that matter
     Promise.all(filesToCompile.map(compileSass))
+        .then(() => {
+            Promise.all(
+                filesToCompile
+                    .filter(file => /head.email-/.test(file))
+                    .map(file =>
+                        cpy(
+                            [`**/${file.replace('.scss', '.css')}`],
+                            path.resolve(
+                                __dirname,
+                                '../',
+                                'common',
+                                'conf',
+                                'assets',
+                                'inline-stylesheets'
+                            ),
+                            {
+                                cwd: path.resolve(
+                                    __dirname,
+                                    '../',
+                                    'static',
+                                    'target'
+                                ),
+                            }
+                        )
+                    )
+            );
+        })
         .then(() => {
             // clear any previous error messages
             browserSync.sockets.emit('fullscreen:message:clear');


### PR DESCRIPTION
## What does this change?

When styles that will be inlined are updated in dev mode, they are not copied to `common/conf/assets/inline-stylesheets`. As a result, it is not possible to see the result of changes to inline styles.

This change updates the dev server to copy inline stylesheets for emails into the `inline-stylesheets/` directory.

## What is the value of this and can you measure success?

This improves the workflow for people working on emails, and saves them having to manually run the [`compile/conf/copy`](https://github.com/guardian/frontend/blob/master/tools/__tasks__/compile/conf/copy.js) task.

## Further work

The scope of this change could check for changes to any `head.*.scss`. This might slow down the developer workflow as updating the files in the `inline-stylesheets/` directory would cause partial recompilation of the `frontend` application. Happy to hear thoughts on this.

## Tested

- [x] Locally
- [ ] On CODE (optional)
