### PR TITLE
Don't render email signup form on Guardian foundation footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -27,7 +27,7 @@
         <div class="colophon u-cf">
 
             @defining(Edition(request)) { currentEdition =>
-                @if(EmailInlineInFooterSwitch.isSwitchedOn && !isAmp) {
+                @if(EmailInlineInFooterSwitch.isSwitchedOn && !isAmp && !page.metadata.isFoundation) {
                     <div class="footer__email-container js-footer__email-container">
                     @currentEdition match {
                         case Uk => {


### PR DESCRIPTION
## What does this change?

The email signup form that appears in the Guardian Footer should be hidden on Guardian Foundation pages as the foundation is technically a separate organisation and including the signup form in the footer could have GDPR implications. As requested by Guardian Foundation team.