### PR TITLE
Serve Teads outstream ads in a SafeFrame

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-sizes.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-sizes.js
@@ -27,7 +27,7 @@ const adSizes: Object = {
 
     // guardian proprietary ad sizes
     video: getAdSize(620, 1),
-    video2: getAdSize(620, 350),
+    outstream: getAdSize(620, 350),
     merchandisingHighAdFeature: getAdSize(88, 89),
     merchandisingHigh: getAdSize(88, 87),
     merchandising: getAdSize(88, 88),

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -15,7 +15,7 @@ const inlineDefinition = {
             adSizes.empty,
             adSizes.mpu,
             adSizes.video,
-            adSizes.video2,
+            adSizes.outstream,
             adSizes.googleCard,
             adSizes.fluid,
         ],

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -6,6 +6,7 @@ import uniqBy from 'lodash/uniqBy';
 import flatten from 'lodash/flatten';
 import once from 'lodash/once';
 import { getOutbrainComplianceTargeting } from 'commercial/modules/third-party-tags/outbrain';
+import type { Slot } from 'commercial/types';
 
 const adUnit = once(() => {
     const urlVars = getUrlVars();
@@ -76,6 +77,18 @@ const adomikClassify = (): string => {
     }
 };
 
+const isEligibleForOutstream = (slotTarget: ?string): boolean =>
+    typeof slotTarget === 'string' && slotTarget === 'inline1';
+
+const allowSafeFrameToExpand = (slot: Slot): Slot => {
+    slot.setSafeFrameConfig({
+        allowOverlayExpansion: false,
+        allowPushExpansion: true,
+        sandbox: true,
+    });
+    return slot;
+};
+
 const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
     const slotTarget = adSlotNode.getAttribute('data-name');
     const sizeOpts = getSizeOpts(sizes);
@@ -92,6 +105,9 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slot = window.googletag
             .defineSlot(adUnit(), sizeOpts.sizes, id)
             .defineSizeMapping(sizeOpts.sizeMapping);
+        if (isEligibleForOutstream(slotTarget)) {
+            allowSafeFrameToExpand(slot);
+        }
         slotReady = setHighMerchSlotTargeting(slot, slotTarget);
     }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -98,7 +98,7 @@ sizeCallbacks[adSizes.video] = (_, advert) =>
         advert.updateExtraSlotClasses('u-h');
     });
 
-sizeCallbacks[adSizes.video2] = (_, advert) =>
+sizeCallbacks[adSizes.outstream] = (_, advert) =>
     fastdom.write(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });


### PR DESCRIPTION
## What does this change?
It serves a Teads outstream correctly if the creative is set to 620x350 and is set to serve in a Safeframe.

## Screenshots
![image](https://user-images.githubusercontent.com/1722550/52352248-2cc7ed80-2a24-11e9-9482-47fb601d3db4.png)
