### PR TITLE
Add dotcomponents flag to request logs

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -298,9 +298,9 @@ object DotcomponentsDataModel {
       switches,
       linkedData,
       Configuration.google.subscribeWithGoogleApiUrl,
-      Configuration.site.host,
-      article.metadata.webUrl,
-      article.content.shouldHideAdverts,
+      guardianBaseURL = Configuration.site.host,
+      webURL = article.metadata.webUrl,
+      shouldHideAds = article.content.shouldHideAdverts,
       hasStoryPackage = articlePage.related.hasStoryPackage,
       hasRelated = article.content.showInRelated,
       isCommentable = article.trail.isCommentable

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -44,7 +44,7 @@ class RemoteRenderer {
       .map(response => {
         response.status match {
           case 200 =>
-            Cached(article)(RevalidatableResult.Ok(Html(response.body)))
+            Cached(article)(RevalidatableResult.OkDotcomponents(Html(response.body)))
           case _ =>
             throw new Exception(response.body)
         }

--- a/common/app/common/Logging.scala
+++ b/common/app/common/Logging.scala
@@ -60,11 +60,14 @@ object LoggingField {
   case class LogFieldString(name: String, value: String) extends LogField
   case class LogFieldDouble(name: String, value: Double) extends LogField
   case class LogFieldLong(name: String, value: Long) extends LogField
+  case class LogFieldBoolean(name: String, value: Boolean) extends LogField
+
 
   implicit def tupleToLogFieldInt(t: (String, Int)): LogFieldInt = LogFieldInt(t._1, t._2)
   implicit def tupleToLogFieldString(t: (String, String)): LogFieldString = LogFieldString(t._1, t._2)
   implicit def tupleToLogFieldDouble(t: (String, Double)): LogFieldDouble = LogFieldDouble(t._1, t._2)
   implicit def tupleToLogFieldLong(t: (String, Long)): LogFieldLong = LogFieldLong(t._1, t._2)
+  implicit def tupleToLogFieldBoolean(t: (String, Boolean)): LogFieldBoolean = LogFieldBoolean(t._1, t._2)
 
   def customFieldMarkers(fields: List[LogField]) : LogstashMarker = {
     val fieldsMap = fields.map {
@@ -72,6 +75,7 @@ object LoggingField {
       case LogFieldString(n, v) => (n, v)
       case LogFieldDouble(n, v) => (n, v)
       case LogFieldLong(n, v) => (n, v)
+      case LogFieldBoolean(n, v) => (n, v)
     }
       .toMap
       .asJava

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -45,7 +45,8 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
 
     val responseHeaders: List[LogField] = response.map { r: Result =>
       List[LogField](
-        "resp.status" -> r.header.status
+        "resp.status" -> r.header.status,
+        "resp.dotcomponents" -> r.header.headers.get("X-GU-Dotcomponents").isDefined
       )
     }.getOrElse(Nil)
 

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -59,6 +59,10 @@ object Cached extends implicits.Dates {
     def Ok[C](content: C)(implicit writeable: Writeable[C]): RevalidatableResult = {
       apply(Results.Ok(content), content)
     }
+
+    def OkDotcomponents[C](content: C)(implicit writeable: Writeable[C]): RevalidatableResult = {
+      apply(Results.Ok(content).withHeaders("X-GU-Dotcomponents" -> "true"), content)
+    }
   }
 
 


### PR DESCRIPTION
Will make it easier to answer questions like:

* average latency of dotcomponents-responses vs normal ones
* what % of traffic is served by each
* in general, any kind of analysis of response info by platform