### PR TITLE
Use reader revenue region not country

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -324,7 +324,7 @@ const makeABTestVariant = (
                 locations.some(
                     region =>
                         getReaderRevenueRegion(geolocationGetSync()) ===
-                        region.toUpperCase()
+                        region.toLowerCase()
                 );
             const matchesTags =
                 tagIds.length === 0 ||

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -128,7 +128,9 @@ const shouldShowEpic = (test: EpicABTest): boolean => {
 
     const storedGeolocation = geolocationGetSync();
     const inCompatibleLocation = test.locations.length
-        ? test.locations.some(geo => geo === getReaderRevenueRegion(storedGeolocation))
+        ? test.locations.some(
+              geo => geo === getReaderRevenueRegion(storedGeolocation)
+          )
         : true;
 
     const tagsMatch = doTagsMatch(test);
@@ -320,7 +322,9 @@ const makeABTestVariant = (
             const matchesLocations =
                 locations.length === 0 ||
                 locations.some(
-                    region => getReaderRevenueRegion(geolocationGetSync()) === region.toUpperCase()
+                    region =>
+                        getReaderRevenueRegion(geolocationGetSync()) ===
+                        region.toUpperCase()
                 );
             const matchesTags =
                 tagIds.length === 0 ||

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -128,7 +128,7 @@ const shouldShowEpic = (test: EpicABTest): boolean => {
 
     const storedGeolocation = geolocationGetSync();
     const inCompatibleLocation = test.locations.length
-        ? test.locations.some(geo => geo === storedGeolocation)
+        ? test.locations.some(geo => geo === getReaderRevenueRegion(storedGeolocation))
         : true;
 
     const tagsMatch = doTagsMatch(test);
@@ -320,7 +320,7 @@ const makeABTestVariant = (
             const matchesLocations =
                 locations.length === 0 ||
                 locations.some(
-                    region => geolocationGetSync() === region.toUpperCase()
+                    region => getReaderRevenueRegion(geolocationGetSync()) === region.toUpperCase()
                 );
             const matchesTags =
                 tagIds.length === 0 ||


### PR DESCRIPTION
We want to use these in the Google Sheet instead of individual ISO country codes (because otherwise for "rest of world" you need to put in hundreds of countries!):

```javascript
export type ReaderRevenueRegion =
    | 'united-kingdom'
    | 'united-states'
    | 'australia'
    | 'rest-of-world';
```