### PR TITLE
Increased contrast on italicised quotes

### DIFF
--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -76,7 +76,7 @@
     margin: 16px 0 28px 24px;
 
     &.quoted {
-        color: $brightness-46;
+        color: $brightness-7;
         margin-left: initial;
         overflow: auto;
 

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -374,7 +374,7 @@ $block-padding-left: gs-span(1) + $gs-gutter;
         }
 
         > blockquote {
-            color: $brightness-46;
+            color: $brightness-7;
         }
 
         /* Media

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -385,7 +385,7 @@ figure.element--thumbnail + h2 {
     cite {
         @include fs-bodyHeading(2);
         font-style: normal;
-        color: $brightness-46;
+        color: $brightness-7;
 
         a,
         a:visited {


### PR DESCRIPTION
Following user feedback we're increasing the contrast of italicised quotes in article. 

Given that they're indented, italicised and there's a quote icon, I think that there's enough to visually demarcate them as quotes. 

# Before 
<img width="623" alt="screen shot 2019-02-07 at 11 01 35" src="https://user-images.githubusercontent.com/14570016/52407430-30ad4b80-2ac8-11e9-8bbd-fd697fd0b384.png">

# After 
<img width="629" alt="screen shot 2019-02-07 at 11 01 46" src="https://user-images.githubusercontent.com/14570016/52407431-30ad4b80-2ac8-11e9-8e0a-f852623a0357.png">
