### PR TITLE
Add AMP rollout switch

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -43,13 +43,25 @@ object AMPPicker {
     logger.withRequestHeaders(request).results(msg, results, page)
   }
 
-  private[this] val sectionsWhitelist: Set[String] = Set(
+  private[this] val sectionsWhitelist: Set[String] = {
+    val safeSections = Set[String]()
 
-  )
+    if (conf.switches.Switches.DotcomRenderingAMPRollout.isSwitchedOn) {
+      Set("music") ++ safeSections
+    } else {
+      safeSections
+    }
+  }
 
-  private[this] val tagsWhitelist: Set[String] = Set(
+  private[this] val tagsWhitelist: Set[String] = {
+    val safeTags = Set[String]()
 
-  )
+    if (conf.switches.Switches.DotcomRenderingAMPRollout.isSwitchedOn) {
+      Set("info/series/digital-blog") ++ safeTags
+    } else {
+      safeTags
+    }
+  }
 
   private[this] val pageWhitelist: Set[String] = Set(
     "world/2018/oct/14/british-man-shot-dead-by-hunter-in-france",

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -27,6 +27,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val DotcomRenderingAMPRollout = Switch(
+    SwitchGroup.Feature,
+    "dotcom-rendering-amp-rollout",
+    "If this switch is on, we will use the dotcom rendering tier for AMP articles in the next rollout stage",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2019, 4, 1),
+    exposeClientSide = false
+  )
+
   val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",


### PR DESCRIPTION
The intent is to allow us to stagger rollout without having to switch off the entire migration if things go wrong. As something will almost certainly go wrong but we want to keep the migration alive when it does!

Also adds the initial two section/tags:

* dev blog
* music (a relatively stable-low-traffic section)