### PR TITLE
Make highlightedText field optional for epic tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -622,10 +622,12 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                         row.paragraphs,
                                         '\n'
                                     ),
-                                    highlightedText: row.highlightedText.replace(
-                                        /%%CURRENCY_SYMBOL%%/g,
-                                        getLocalCurrencySymbol()
-                                    ),
+                                    highlightedText: row.highlightedText
+                                        ? row.highlightedText.replace(
+                                              /%%CURRENCY_SYMBOL%%/g,
+                                              getLocalCurrencySymbol()
+                                          )
+                                        : undefined,
                                 },
                             },
                         })),


### PR DESCRIPTION
## What does this change?
Not all epics need the `highlightedText` field. This change means the column can be missing from the google sheets if not required

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
