### PR TITLE
Enable outstream ads at mobile breakpoint

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -94,13 +94,13 @@ describe('createCommentSlots', () => {
             '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
         );
         expect(commentMpu.getAttribute('data-mobile')).toBe(
-            '1,1|2,2|300,250|300,274|fluid'
+            '1,1|2,2|300,250|300,274|620,350|fluid'
         );
         expect(commentDmpu.getAttribute('data-desktop')).toBe(
             '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
         );
         expect(commentDmpu.getAttribute('data-mobile')).toBe(
-            '1,1|2,2|300,250|300,274|fluid'
+            '1,1|2,2|300,250|300,274|620,350|fluid'
         );
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -8,6 +8,7 @@ const inlineDefinition = {
             adSizes.empty,
             adSizes.mpu,
             adSizes.googleCard,
+            adSizes.outstream,
             adSizes.fluid,
         ],
         desktop: [

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -20,7 +20,7 @@ const inline1Html = `
     data-link-name="ad slot inline1"
     data-name="inline1"
     aria-hidden="true"
-    data-mobile="1,1|2,2|300,250|300,274|fluid"
+    data-mobile="1,1|2,2|300,250|300,274|620,350|fluid"
     data-desktop="1,1|2,2|300,250|620,1|620,350|300,274|fluid">
 </div>
 `;


### PR DESCRIPTION
This adds the size identifying an outstream ad to the inline ad sizes available at the mobile breakpoint.