### PR TITLE
Make epic deployment rules configurable

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -8,7 +8,7 @@ declare type Variant = {
     success?: ListenerFunction,
     options?: Object,
     engagementBannerParams?: () => Promise<EngagementBannerParams>,
-    maxViews: MaxViews,
+    maxViews?: MaxViews,
 };
 
 declare type ABTest = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -8,7 +8,7 @@ declare type Variant = {
     success?: ListenerFunction,
     options?: Object,
     engagementBannerParams?: () => Promise<EngagementBannerParams>,
-    maxViews?: MaxViews,
+    deploymentRules?: DeploymentRules,
 };
 
 declare type ABTest = {
@@ -44,6 +44,8 @@ declare type MaxViews = {
     minDaysBetweenViews: number,
 };
 
+declare type DeploymentRules = 'AlwaysAsk' | MaxViews
+
 declare type EpicABTest = AcquisitionsABTest & {
     campaignPrefix: string,
     useLocalViewLog: boolean,
@@ -60,7 +62,7 @@ declare type InitEpicABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, abTest: ABTest) => void,
-    maxViews?: MaxViews,
+    deploymentRules?: DeploymentRules,
     options?: Object
 };
 

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -8,6 +8,7 @@ declare type Variant = {
     success?: ListenerFunction,
     options?: Object,
     engagementBannerParams?: () => Promise<EngagementBannerParams>,
+    maxViews: MaxViews,
 };
 
 declare type ABTest = {
@@ -53,13 +54,13 @@ declare type EpicABTest = AcquisitionsABTest & {
     useTargetingTool: boolean,
     insertEvent: string,
     viewEvent: string,
-    maxViews: MaxViews,
 };
 
 declare type InitEpicABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, abTest: ABTest) => void,
+    maxViews?: MaxViews,
     options?: Object
 };
 
@@ -86,7 +87,6 @@ declare type InitEpicABTest = {
     variants: $ReadOnlyArray<InitEpicABTestVariant>,
 
     // locations is a filter where empty is taken to mean 'all'
-    maxViews?: MaxViews,
     locations?: string[],
     dataLinkNames?: string,
     campaignPrefix?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -215,7 +215,7 @@ const makeABTestVariant = (
         excludedTagIds = [],
         excludedSections = [],
 
-        isUnlimited = false,    // Deprecated in favour of DeploymentRules, TODO - remove later
+        isUnlimited = false, // Deprecated in favour of DeploymentRules, TODO - remove later
         campaignCode = createTestAndVariantId(
             parentTest.campaignPrefix,
             parentTest.campaignId,
@@ -335,10 +335,14 @@ const makeABTestVariant = (
                 const enoughDaysBetweenViews =
                     viewsInPreviousDays(minViewDays, testId) === 0;
 
-                return (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;
+                return (
+                    (withinViewLimit && enoughDaysBetweenViews) || isUnlimited
+                );
             };
 
-            const meetsMaxViewsConditions = deploymentRules === 'AlwaysAsk' ? true : checkMaxViews(deploymentRules);
+            const meetsMaxViewsConditions =
+                deploymentRules === 'AlwaysAsk' ||
+                checkMaxViews(deploymentRules);
 
             const matchesLocations =
                 locations.length === 0 ||
@@ -630,17 +634,24 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                             ...(isLiveBlog
                                 ? { test: setupEpicInLiveblog }
                                 : {}),
-                            deploymentRules: (row.alwaysAsk && row.alwaysAsk.toLowerCase() === 'true') ? 'AlwaysAsk' : ({
-                                days:
-                                    parseInt(row.maxViewsDays, 10) ||
-                                    defaultMaxViews.days,
-                                count:
-                                    parseInt(row.maxViewsCount, 10) ||
-                                    defaultMaxViews.count,
-                                minDaysBetweenViews:
-                                    parseInt(row.minDaysBetweenViews, 10) ||
-                                    defaultMaxViews.minDaysBetweenViews,
-                            }: MaxViews),
+                            deploymentRules:
+                                row.alwaysAsk &&
+                                row.alwaysAsk.toLowerCase() === 'true'
+                                    ? 'AlwaysAsk'
+                                    : ({
+                                          days:
+                                              parseInt(row.maxViewsDays, 10) ||
+                                              defaultMaxViews.days,
+                                          count:
+                                              parseInt(row.maxViewsCount, 10) ||
+                                              defaultMaxViews.count,
+                                          minDaysBetweenViews:
+                                              parseInt(
+                                                  row.minDaysBetweenViews,
+                                                  10
+                                              ) ||
+                                              defaultMaxViews.minDaysBetweenViews,
+                                      }: MaxViews),
 
                             options: {
                                 buttonTemplate: isThankYou

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -24,12 +24,6 @@ export const askFourEarning: EpicABTest = makeABTest({
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
-                maxViews: {
-                    days: 30,
-                    count: 4,
-                    minDaysBetweenViews: 0,
-                },
-
                 insertAtSelector: '.submeta',
                 successOnView: true,
             },


### PR DESCRIPTION
## What does this change?
The epic is now configured from google sheets.
This PR adds the ability to configure the `maxViews` rules, something that was previously configured in code. Also, setting `alwaysAsk` overrides the `maxViews` rules.

The `isUnlimited` field in `Variant.options` is now deprecated (still being used by the `acquisitionsEpicAlwaysAskIfTagged` test), and should be removed later. The `alwaysAsk` field replaces this logic.

The `maxViews` field was previously on the `EpicABTest` model. Unfortunately it now has to go on the general `Variant` model, as we can only really allow configuration at the level of variants.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
