### PR TITLE
Allow html in gallery captions

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -578,7 +578,9 @@ object GalleryCaptionCleaner extends HtmlCleaner {
   override def clean(galleryCaption: Document): Document = {
     val firstStrong = Option(galleryCaption.getElementsByTag("strong").first())
     val captionTitle = galleryCaption.createElement("h2")
-    val captionTitleText = firstStrong.map(_.text()).getOrElse("")
+    val captionTitleText = firstStrong.map(_.children().toString)
+      .getOrElse("")
+      .replaceAll("<br>", "")
 
     // <strong> is removed in place of having a <h2> element
     firstStrong.foreach(_.remove())
@@ -587,7 +589,7 @@ object GalleryCaptionCleaner extends HtmlCleaner {
     galleryCaption.getElementsByTag("br").remove()
 
     captionTitle.addClass("gallery__caption__title")
-    captionTitle.text(captionTitleText)
+    captionTitle.html(captionTitleText)
 
     galleryCaption.prependChild(captionTitle)
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -576,17 +576,17 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: B
 // This is a hack to serve the correct html
 object GalleryCaptionCleaner extends HtmlCleaner {
   override def clean(galleryCaption: Document): Document = {
+    // There is an inconsistent number of <br> tags in gallery captions.
+    // To create some consistency, re will remove them all.
+    galleryCaption.getElementsByTag("br").remove()
+
     val firstStrong = Option(galleryCaption.getElementsByTag("strong").first())
     val captionTitle = galleryCaption.createElement("h2")
     val captionTitleText = firstStrong.map(_.children().toString)
       .getOrElse("")
-      .replaceAll("<br>", "")
 
     // <strong> is removed in place of having a <h2> element
     firstStrong.foreach(_.remove())
-    // There is an inconsistent number of <br> tags in gallery captions.
-    // To create some consistency, re will remove them all.
-    galleryCaption.getElementsByTag("br").remove()
 
     captionTitle.addClass("gallery__caption__title")
     captionTitle.html(captionTitleText)


### PR DESCRIPTION
## What does this change?
Stops html getting stripped from the bold bit of captions as this prevents staff from putting bold links in gallery captions.

Following request from CP for an article to be published on monday. You can see my test gallery here https://composer.code.dev-gutools.co.uk/content/5c5c5cb3e4b006159235ea90

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
