### PR TITLE
Paidfor headings 

### DIFF
--- a/article/app/views/fragments/immersiveGarnettHeadline.scala.html
+++ b/article/app/views/fragments/immersiveGarnettHeadline.scala.html
@@ -18,7 +18,6 @@
     <div class="@RenderClasses(Map(
         "immersive-main-media__headline-container--dark" -> (!isTheMinuteArticle && hasMainMedia),
         "immersive-main-media__headline-container" -> hasMainMedia,
-        "immersive-main-media__headline-container--gallery" -> isPaidContent
     ))
     ">
     <div class="gs-container">

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -657,9 +657,9 @@
     .content__labels--paidgallery {
         background: $labs-main;
 
-       .content__section-label__link--advertisement {
-           color: $brightness-7;
-       }
+        .content__section-label__link--advertisement {
+            color: $brightness-7;
+        }
     }
 
     .content__label__link:not(.content__section-label__link--advertisement) {

--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -211,6 +211,8 @@
     &.content__standfirst--advertisement {
         font-family: $f-sans-serif-text;
         font-weight: 400;
+        padding-left: 0;
+        margin-left: 0;
     }
 }
 
@@ -650,6 +652,14 @@
                 width: auto;
             }
         }
+    }
+
+    .content__labels--paidgallery {
+        background: $labs-main;
+
+       .content__section-label__link--advertisement {
+           color: $brightness-7;
+       }
     }
 
     .content__label__link:not(.content__section-label__link--advertisement) {


### PR DESCRIPTION
Headlines are sneaking off the page on paid for immersive articles (because the css i telling them they're galleries)

# Before
<img width="388" alt="screen shot 2019-02-08 at 09 40 36" src="https://user-images.githubusercontent.com/14570016/52470807-12f2eb80-2b87-11e9-9f04-a8f872cf2251.png">

# After
<img width="391" alt="screen shot 2019-02-08 at 09 40 42" src="https://user-images.githubusercontent.com/14570016/52470808-12f2eb80-2b87-11e9-815f-2bc695225d97.png">
