### PR TITLE
Fix gallery regressions

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -48,7 +48,7 @@
                 <div class="fc-container__inner">
                     <div class="fc-container__header">
                         <h2 class="fc-container__header__title">
-                            <a class="most-viewed-no-js tone-colour" href="@LinkTo{/gallery/most-viewed}" data-link-name="Most viewed galleries">More galleries</a>
+                            <a class="most-viewed-no-js tone-colour" href="@LinkTo{/inpictures/all}" data-link-name="Most viewed galleries">More galleries</a>
                         </h2>
                     </div>
                 </div>

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -52,7 +52,7 @@ class MostViewedGalleryController(
         1,
         Fixed(FixedContainers.fixedMediumSlowVI),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(galleries.map(_.faciaContent), Nil, Some("More galleries"), None, None, None),
+        CollectionEssentials(galleries.map(_.faciaContent), Nil, Some("More galleries"), Some("inpictures/all"), None, None),
         hasMore = false
       ).withTimeStamps,
       FrontProperties.empty

--- a/onward/app/views/mostViewedGalleries.scala.html
+++ b/onward/app/views/mostViewedGalleries.scala.html
@@ -4,7 +4,7 @@
 
 @mainLegacy(page, Some("facia")){
 }{
-    <div class="fc-container">
+    <div class="fc-container fc-container-gallery">
         <div class="l-side-margins">
             @container
         <div>

--- a/onward/app/views/mostViewedGalleries.scala.html
+++ b/onward/app/views/mostViewedGalleries.scala.html
@@ -4,7 +4,7 @@
 
 @mainLegacy(page, Some("facia")){
 }{
-    <div class="fc-container fc-container-gallery">
+    <div class="fc-container">
         <div class="l-side-margins">
             @container
         <div>

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -133,6 +133,7 @@ $header-image-size-desktop: 100px;
     line-height: get-line-height(header, 2);
     color: $brightness-7;
 
+
     @include mq(leftCol, wide) {
         @include font-size(20px, 24px);
     }
@@ -618,5 +619,18 @@ $header-image-size-desktop: 100px;
             // Unset
             display: block;
         }
+    }
+}
+
+
+.gallery__most-popular h2.fc-container__title__text {
+    color: $brightness-86;
+
+    &:hover {
+        text-decoration: underline;
+    }
+
+    &:after {
+        display: none;
     }
 }


### PR DESCRIPTION
## What does this change?
Applies correct text colour for the background and re-adds the correct link after the client-side fetching of the container.
https://trello.com/c/7iv0ESPM/471-regressions-in-galleries
## Screenshots
![screen shot 2019-02-08 at 11 38 09](https://user-images.githubusercontent.com/2051501/52476468-9f58da80-2b96-11e9-9103-37e0a01af2ce.png)
![screen shot 2019-02-08 at 11 42 54](https://user-images.githubusercontent.com/2051501/52476501-b8618b80-2b96-11e9-9812-c9e9ee8c0abd.png)



