### PR TITLE
Revert "Allow html in gallery captions"

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -576,20 +576,18 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: B
 // This is a hack to serve the correct html
 object GalleryCaptionCleaner extends HtmlCleaner {
   override def clean(galleryCaption: Document): Document = {
+    val firstStrong = Option(galleryCaption.getElementsByTag("strong").first())
+    val captionTitle = galleryCaption.createElement("h2")
+    val captionTitleText = firstStrong.map(_.text()).getOrElse("")
+
+    // <strong> is removed in place of having a <h2> element
+    firstStrong.foreach(_.remove())
     // There is an inconsistent number of <br> tags in gallery captions.
     // To create some consistency, re will remove them all.
     galleryCaption.getElementsByTag("br").remove()
 
-    val firstStrong = Option(galleryCaption.getElementsByTag("strong").first())
-    val captionTitle = galleryCaption.createElement("h2")
-    val captionTitleText = firstStrong.map(_.children().toString)
-      .getOrElse("")
-
-    // <strong> is removed in place of having a <h2> element
-    firstStrong.foreach(_.remove())
-
     captionTitle.addClass("gallery__caption__title")
-    captionTitle.html(captionTitleText)
+    captionTitle.text(captionTitleText)
 
     galleryCaption.prependChild(captionTitle)
 


### PR DESCRIPTION
Reverts guardian/frontend#21036 on account of that pr removing all bold text that's not a link