### PR TITLE
Make Hosted videos from US production office autoplay on all devices

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -35,7 +35,7 @@ type Page = {
 
 const EVENTSFIRED = [];
 
-const isDesktop = (): boolean => isBreakpoint({ min: 'desktop' });
+const isDesktop: boolean = isBreakpoint({ min: 'desktop' });
 
 const shouldAutoplay = (
     page: Page,
@@ -110,7 +110,7 @@ export const initHostedYoutube = (el: HTMLElement): void => {
                     youtubeTimer.textContent = '0:00';
                     if (canAutoplayNextVideo()) {
                         // on mobile show the next video link in the end of the currently watching video
-                        if (!isDesktop()) {
+                        if (!isDesktop) {
                             triggerEndSlate();
                         }
                     }
@@ -142,13 +142,12 @@ export const initHostedYoutube = (el: HTMLElement): void => {
                     shouldAutoplay(
                         config.get('page', {}),
                         config.get('switches', {})
-                    ) &&
-                    isDesktop()
+                    )
                 ) {
                     event.target.playVideo();
                 }
                 initNextVideoAutoPlay().then(() => {
-                    if (canAutoplayNextVideo() && isDesktop()) {
+                    if (canAutoplayNextVideo() && isDesktop) {
                         addCancelListener();
                         triggerAutoplay(
                             event.target.getCurrentTime.bind(event.target),


### PR DESCRIPTION
## What does this change?

👉  Remove check for desktop device before autoplaying video

Autoplay of the next video is still dependent on the breakpoint, since the end-slate and countdown are visual elements that only trigger on desktop. Therefore making the next video autoplay would be a larger piece of work and is beyond the intended experience, since the intention is to make the first video autoplay.

See also: #20919 

👉  Change function to a const since we only need to evaluate the breakpoint once

## What is the value of this and can you measure success?

Request from the US production office who are going to monitor the impact of this change.

More details on trello: https://trello.com/c/bEokLXa1

💰🧙‍♀️✨

## Checklist

### Does this affect other platforms?

Nope - this only affects web

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Hosted content affected, but only content from the US production office.

### Does this change break ad-free?

Nope

### Accessibility test checklist

Autoplay still respects user preferences for flashing elements

### Tested

Tested on CODE
