### PR TITLE
Fix async tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -227,23 +227,23 @@ describe('Membership engagement banner', () => {
             emitSpy.mockRestore();
         });
 
-        it('should show the membership engagement banner', () => {
+        it('should show the membership engagement banner', () =>
             membershipEngagementBanner
                 .show()
                 .then(() =>
                     expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1)
-                );
-        });
+                )
+        );
 
-        it('should emit a display event', () => {
+        it('should emit a display event', () =>
             membershipEngagementBanner
                 .show()
                 .then(() =>
                     expect(emitSpy).toHaveBeenCalledWith(
                         'membership-message:display'
                     )
-                );
-        });
+                )
+        );
 
         it('should record the component event in ophan with a/b test info', () =>
             membershipEngagementBanner.show().then(() =>

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -232,8 +232,7 @@ describe('Membership engagement banner', () => {
                 .show()
                 .then(() =>
                     expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1)
-                )
-        );
+                ));
 
         it('should emit a display event', () =>
             membershipEngagementBanner
@@ -242,8 +241,7 @@ describe('Membership engagement banner', () => {
                     expect(emitSpy).toHaveBeenCalledWith(
                         'membership-message:display'
                     )
-                )
-        );
+                ));
 
         it('should record the component event in ophan with a/b test info', () =>
             membershipEngagementBanner.show().then(() =>

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -61,7 +61,7 @@ export const getSynchronousTestsToRun = memoize(
     }
 );
 
-export const getAynschronousTestsToRun = (): Promise<
+export const getAsyncTestsToRun = (): Promise<
     $ReadOnlyArray<Runnable<ABTest>>
 > =>
     getEpicTestToRun().then(
@@ -106,7 +106,7 @@ export const runAndTrackAbTests = (): Promise<void> => {
         ...testExclusions,
     });
 
-    return getAynschronousTestsToRun().then(tests => {
+    return getAsyncTestsToRun().then(tests => {
         tests.forEach(test => test.variantToRun.test(test));
 
         registerImpressionEvents(tests);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -238,16 +238,20 @@ describe('A/B', () => {
                 ...expectedAsyncTestsToRun,
             };
 
-            const checkTests = (tests) =>
-                expect(
-                    runnableTestsToParticipations(tests)
-                ).toEqual(expectedTestsToRun);
+            const checkTests = tests =>
+                expect(runnableTestsToParticipations(tests)).toEqual(
+                    expectedTestsToRun
+                );
 
             return getAsyncTestsToRun()
-                .then(asyncTests => checkTests([...asyncTests, ...getSynchronousTestsToRun()]))
+                .then(asyncTests =>
+                    checkTests([...asyncTests, ...getSynchronousTestsToRun()])
+                )
                 .then(runAndTrackAbTests)
                 .then(getAsyncTestsToRun)
-                .then(asyncTests => checkTests([...asyncTests, ...getSynchronousTestsToRun()]));
+                .then(asyncTests =>
+                    checkTests([...asyncTests, ...getSynchronousTestsToRun()])
+                );
         });
     });
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -6,7 +6,7 @@ import {
 } from 'common/modules/experiments/ab-local-storage';
 import { overwriteMvtCookie } from 'common/modules/analytics/mvt-cookie';
 import {
-    getAynschronousTestsToRun,
+    getAsyncTestsToRun,
     getSynchronousTestsToRun,
     isInVariantSynchronous,
     runAndTrackAbTests,
@@ -224,50 +224,30 @@ describe('A/B', () => {
             });
             window.location.hash = '#ab-DummyTest=variant';
 
-            const expectedTestsToRun = {
-                DummyTest: { variant: 'variant' },
-                DummyTest2: { variant: 'variant' },
+            const expectedAsyncTestsToRun = {
                 EpicTest: { variant: 'control' },
             };
 
-            getAynschronousTestsToRun().then(tests => {
+            const expectedSynchronousTestsToRun = {
+                DummyTest: { variant: 'variant' },
+                DummyTest2: { variant: 'variant' },
+            };
+
+            const expectedTestsToRun = {
+                ...expectedSynchronousTestsToRun,
+                ...expectedAsyncTestsToRun,
+            };
+
+            const checkTests = (tests) =>
                 expect(
-                    runnableTestsToParticipations([
-                        ...tests,
-                        ...getSynchronousTestsToRun(),
-                    ])
+                    runnableTestsToParticipations(tests)
                 ).toEqual(expectedTestsToRun);
-            });
 
-            runAndTrackAbTests()
-                .then(() => {
-                    expect(
-                        runnableTestsToParticipations(
-                            getSynchronousTestsToRun()
-                        )
-                    ).toEqual(expectedTestsToRun);
-
-                    // In this case, the localStorage participations should be the same as the tests to run,
-                    // because there are no 'notintest' participations to preserve
-                    expect(getParticipationsFromLocalStorage()).toEqual(
-                        expectedTestsToRun
-                    );
-
-                    return runAndTrackAbTests();
-                })
-                .then(() => {
-                    expect(
-                        runnableTestsToParticipations(
-                            getSynchronousTestsToRun()
-                        )
-                    ).toEqual(expectedTestsToRun);
-
-                    // In this case, the localStorage participations should be the same as the tests to run,
-                    // because there are no 'notintest' participations to preserve
-                    expect(getParticipationsFromLocalStorage()).toEqual(
-                        expectedTestsToRun
-                    );
-                });
+            return getAsyncTestsToRun()
+                .then(asyncTests => checkTests([...asyncTests, ...getSynchronousTestsToRun()]))
+                .then(runAndTrackAbTests)
+                .then(getAsyncTestsToRun)
+                .then(asyncTests => checkTests([...asyncTests, ...getSynchronousTestsToRun()]));
         });
     });
 

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.spec.js
@@ -95,7 +95,7 @@ describe('breaking news', () => {
             const compiled = jest.fn();
 
             fakeTemplate.mockReturnValueOnce(compiled);
-            breakingNews.canShow().then(canShow => {
+            return breakingNews.canShow().then(canShow => {
                 expect(canShow).toBe(true);
             });
         });
@@ -355,7 +355,7 @@ describe('breaking news', () => {
             const compiled = jest.fn();
 
             fakeTemplate.mockReturnValueOnce(compiled);
-            breakingNews.canShow().then(canShow => {
+            return breakingNews.canShow().then(canShow => {
                 expect(canShow).toBe(true);
 
                 if (canShow) {


### PR DESCRIPTION
While working on #21014 and trying to get the tests to pass, I was getting seriously misled by some dodgy async tests. If you don't actually return the promise containing the `expect` calls, and the assertions fail, Jest will pass the test but give you warnings about unhandled Promise rejections.

It seems this is a fairly common problem, since the difference between returning a Promise and returning undefined is just a matter of adding/removing a pair of `{}`

I've fixed tests that I'm responsible for:
- `ab.spec.js` (also refactored an incomprehensible test that I myself wrote)
- `membership-engagement-banner.spec.js`

and one other that was easy (`breaking.news.spec.js`).


## Others to fix (...or delete)
There are three other tests that I think are actually failing but have dodgy async handling so they're not breaking the build.

I'll leave it up to the @guardian/dotcom-platform team to decide when & whether to do something about those ones

```
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-100%, 0);"
Received:
  "transform: translate(-100%, 0);"
(node:8760) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-200%, 0);"
Received:
  "transform: translate(-200%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-100%, 0);"
Received:
  "transform: translate(-100%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 4): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-000%, 0);"
Received:
  "transform: translate(-000%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 5): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-300%, 0);"
Received:
  "transform: translate(-300%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 6): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-100%, 0);"
Received:
  "transform: translate(-100%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 7): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-200%, 0);"
Received:
  "transform: translate(-200%, 0);"
(node:8760) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 8): Error: expect(received).toEqual(expected)
Expected value to equal:
  "-webkit-transform: translate(-000%, 0);"
Received:
  "transform: translate(-000%, 0);"
 PASS  static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js


(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'id' of undefined
(node:8758) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: Cannot read property 'id' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): TypeError: Cannot read property 'id' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 4): TypeError: Cannot read property 'id' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 5): TypeError: Cannot read property 'id' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 6): TypeError: Cannot read property 'html' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 7): TypeError: Cannot read property 'html' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 8): TypeError: Cannot read property 'id' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 9): TypeError: Cannot read property 'html' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 10): TypeError: Cannot read property 'html' of undefined
(node:8758) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 11): TypeError: Cannot read property 'html' of undefined
 PASS  static/src/javascripts/projects/facia/modules/onwards/weather.spec.js


(node:8759) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: labelEl.querySelector is not a function
(node:8759) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:8759) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 4): TypeError: labelEl.querySelector is not a function
(node:8759) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 6): TypeError: labelEl.querySelector is not a function
(node:8759) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 8): TypeError: Cannot read property 'add' of undefined
(node:8759) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 10): TypeError: Cannot read property 'add' of undefined
 PASS  static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
```