### PR TITLE
Enforce one single import syntax across static/src/stylesheets

### DIFF
--- a/static/src/stylesheets/admin/_bootstrap.graun.scss
+++ b/static/src/stylesheets/admin/_bootstrap.graun.scss
@@ -56,7 +56,7 @@ $btn-primary-color: $brightness-7;
 $btn-primary-bg: $brand-secondary;
 $btn-primary-border: $brand-secondary;
 
-@import '../../../../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap.scss';
+@import '../../../../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap';
 
 .container--global {
     margin: 0 auto;

--- a/static/src/stylesheets/head.commercial.scss
+++ b/static/src/stylesheets/head.commercial.scss
@@ -22,7 +22,7 @@
 @import 'module/_live-pulse';
 @import 'module/content/_article-immersive';
 @import 'module/content/_article-minute';
-@import 'module/content/_gallery.head.scss';
+@import 'module/content/_gallery.head';
 @import 'module/_badging';
 
 /* ==========================================================================

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -26,7 +26,7 @@
 @import 'module/content-garnett/_article-column';
 @import 'module/content-garnett/_article-special-report';
 @import 'module/content-garnett/_article-minute';
-@import 'module/content-garnett/_gallery.head.scss';
+@import 'module/content-garnett/_gallery.head';
 @import 'module/_badging';
 
 /* ==========================================================================
@@ -52,5 +52,5 @@
     Podcasts
     ========================================================================== */
 
-@import 'module/journalism/_media.scss';
+@import 'module/journalism/_media';
 

--- a/static/src/stylesheets/head.signup.scss
+++ b/static/src/stylesheets/head.signup.scss
@@ -21,7 +21,7 @@
 @import 'module/_live-pulse';
 @import 'module/content/_article-immersive';
 @import 'module/content/_article-minute';
-@import 'module/content/_gallery.head.scss';
+@import 'module/content/_gallery.head';
 
 /* ==========================================================================
    External modules

--- a/static/src/stylesheets/head.survey.scss
+++ b/static/src/stylesheets/head.survey.scss
@@ -21,7 +21,7 @@
 @import 'module/_live-pulse';
 @import 'module/content/_article-immersive';
 @import 'module/content/_article-minute';
-@import 'module/content/_gallery.head.scss';
+@import 'module/content/_gallery.head';
 
 /* ==========================================================================
    External modules

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -2,10 +2,10 @@ $hosted-stripe: 28px;
 $hosted-video-width: 980px;
 $hosted-video-height: 551px;
 
-@import '_hosted-video.scss';
-@import '_hosted-gallery.scss';
-@import '_hosted-article.scss';
-@import '_hosted-header.scss';
+@import '_hosted-video';
+@import '_hosted-gallery';
+@import '_hosted-article';
+@import '_hosted-header';
 
 .hosted-tone--dark {
     background-color: #3e3e3e;


### PR DESCRIPTION
## What does this change?

Enforce the import syntax

```
@import 'module/_social';
```

instead of 

```
@import 'module/_social.scss';
```

across `static/src/stylesheets`
