### PR TITLE
Kk merchandising supporter: take 2

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -45,6 +45,8 @@ rules:
   no-misspelled-properties:
     - 1
     - extra-properties:
+        - mso-line-height-rule
+        - mso-hide
         - overflow-scrolling
         - osx-font-smoothing
         - grid-column-gap

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -340,7 +340,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object assets {
-    lazy val path = configuration.getMandatoryStringProperty("assets.path")
+    lazy val path = "https://vallum.serveo.net/assets/" // configuration.getMandatoryStringProperty("assets.path")
 
     // This configuration value determines if this server will load and resolve assets using the asset map.
     // Set this to true if you want to run the Play server in dev, and emulate prod mode asset-loading.

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -340,7 +340,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object assets {
-    lazy val path = "https://vallum.serveo.net/assets/" // configuration.getMandatoryStringProperty("assets.path")
+    lazy val path = configuration.getMandatoryStringProperty("assets.path")
 
     // This configuration value determines if this server will load and resolve assets using the asset map.
     // Set this to true if you want to run the Play server in dev, and emulate prod mode asset-loading.

--- a/common/app/views/fragments/email/support.scala.html
+++ b/common/app/views/fragments/email/support.scala.html
@@ -1,6 +1,6 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
-<table class="subscribe sc" border="0" cellpadding="0" cellspacing="0">
+<table class="subscribe sc">
     <tr valign="top">
         <td class="padded-divider">
             <hr>
@@ -14,7 +14,7 @@
                     <td width="65%" valign="top">
                         <![endif]-->
                         <div class="column column-left">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                            <table width="100%">
                                 <tr>
                                     <td align="left" class="sup-copy">
                                         Thank you to all of you who have generously supported The Guardian’s journalism. Support from our readers helps protect our essential editorial independence, so if you value what we do, please <span class="sup-highlight">support The Guardian</span> today. Thank&nbsp;you.
@@ -27,9 +27,9 @@
                     <td width="35%" valign="top">
                         <![endif]-->
                         <div class="column column-right">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                            <table width="100%">
                                 <tr>
-                                    <td align="center" valign="middle">
+                                    <td class="cta-pad" align="center" valign="middle">
                                         <div>
                                             <!--[if mso]>
                                             <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
@@ -39,9 +39,6 @@
                                             <![endif]--><a class="sm-btn" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&">Contribute</a>
                                         </div>
                                     </td>
-                                </tr>
-                                <tr>
-                                    <td width="100%" height="15" align="center" valign="middle">
                                 </tr>
                                 <tr>
                                     <td class="cta-pad" align="center" valign="middle">

--- a/common/app/views/fragments/email/support.scala.html
+++ b/common/app/views/fragments/email/support.scala.html
@@ -1,0 +1,67 @@
+@(page: model.Page)(implicit request: RequestHeader)
+
+<table class="subscribe sc" border="0" cellpadding="0" cellspacing="0">
+    <tr valign="top">
+        <td class="padded-divider">
+            <hr>
+        </td>
+    </tr>
+    <tr>
+        <td class="wrap-pad text-center">
+            <!--[if (gte mso 9)|(IE)]>
+            <table width="100%">
+                <tr>
+                    <td width="65%" valign="top">
+                        <![endif]-->
+                        <div class="column column-left">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="left" class="sup-copy">
+                                        Thank you to all of you who have generously supported The Guardian’s journalism. Support from our readers helps protect our essential editorial independence, so if you value what we do, please <span class="sup-highlight">support The Guardian</span> today. Thank&nbsp;you.
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <!--[if (gte mso 9)|(IE)]>
+                    </td>
+                    <td width="35%" valign="top">
+                        <![endif]-->
+                        <div class="column column-right">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="center" valign="middle">
+                                        <div>
+                                            <!--[if mso]>
+                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
+                                                <w:anchorlock></w:anchorlock>
+                                                <center style="color:#000000;font-family:Georgia,serif;font-size:16px;font-weight:bold;">Contribute</center>
+                                            </v:roundrect>
+                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&">Contribute</a>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td width="100%" height="15" align="center" valign="middle">
+                                </tr>
+                                <tr>
+                                    <td class="cta-pad" align="center" valign="middle">
+                                        <div>
+                                            <!--[if mso]>
+                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskSubscribe%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
+                                                <w:anchorlock></w:anchorlock>
+                                                <center style="color:#000000;font-family:Georgia,serif;font-size:16px;font-weight:bold;">Subscribe</center>
+                                            </v:roundrect>
+                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskSubscribe%22%7D&INTCMP=EmailED&">Subscribe</a>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <!--[if (gte mso 9)|(IE)]>
+                    </td>
+                </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+</table>

--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -15,6 +15,7 @@
                                         <tr>
                                             <td class="no-pad">
                                                 @content
+                                                @fragments.email.support(page)
                                                 @fragments.email.footer(page)
                                             </td>
                                         </tr>
@@ -28,5 +29,5 @@
         </tr>
     </table>
     <!-- prevent Gmail on iOS font size manipulation -->
-    <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+    <div class="gmailfix"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
 </body>

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -3,6 +3,7 @@ $small-width: 100%;
 
 $body-color: #eaeaea;
 $container-color: #ffffff;
+$cta-font-color: #000000;
 
 @import '_normalise';
 @import '_util';
@@ -185,6 +186,83 @@ blockquote {
     font-size: 14px;
     margin: 0;
     padding: 0;
+}
+
+// Supporter Merchandising Module
+
+.subscribe {
+    border-collapse: collapse;
+    &.sc {
+        width: 100%;
+        max-width: $max-width;
+    }
+    .padded-divider {
+        padding: 10px;
+        hr {
+            height: 0;
+            border: 1px solid $brightness-86;
+            margin: 8px 0 0;
+        }
+    }
+    .sup-copy {
+        display: block;
+        font-family: Georgia, serif;
+        font-size: 14px;
+        line-height: 20px;
+        mso-line-height-rule: exactly;
+        color: $brightness-7;
+        padding-bottom: 15px;
+        .sup-highlight {
+            color: $brightness-7;
+            font-weight: bold;
+            background-color: $highlight-main;
+            padding-bottom: 2px;
+        }
+    }
+    .sm-btn {
+        background-color: $highlight-main;
+        border-radius: 20px;
+        color: $cta-font-color;
+        display: inline-block;
+        font-family: Georgia, serif;
+        font-size: 16px;
+        line-height: 40px;
+        font-weight: bold;
+        text-align: center;
+        text-decoration: none;
+        min-width: 130px;
+        -webkit-text-size-adjust: none;
+        mso-hide: all;
+    }
+    .cta-pad {
+        padding-bottom: 15px;
+    }
+    .column {
+        width: 100%;
+        display: inline-block;
+        vertical-align: top;
+        &.column-left {
+            max-width: 364px;
+        }
+        &.column-right {
+            max-width: 196px;
+        }
+    }
+    .wrap-pad {
+        padding: 20px 10px 0;
+        &.text-center {
+            text-align: center;
+            font-size: 0;
+        }
+    }
+    a {
+        &,
+        &:visited,
+        &:hover,
+        &:active {
+            color: $cta-font-color!important;
+        }
+    }
 }
 
 @import '_media-query';

--- a/static/src/stylesheets/email/_footer.scss
+++ b/static/src/stylesheets/email/_footer.scss
@@ -1,6 +1,6 @@
 // td
 .ft__margin {
-    padding-top: 36px;
+    padding-top: 20px;
 }
 
 // table
@@ -47,4 +47,11 @@
     line-height: 14px;
     padding: 20px 12px 0;
     text-align: center;
+}
+
+.gmailfix {
+    display: none;
+    white-space: nowrap;
+    font: 15px courier;
+    line-height: 0;
 }

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -4,6 +4,7 @@ $gutter: 10px;
 
 $body-color: #ffffff;
 $container-color: #ffffff;
+$cta-font-color: #000000;
 
 @import '../_vars';
 @import '_normalise';
@@ -288,6 +289,70 @@ $email-tones: (
         // table
         .tone-external {
             border-top: 1px solid $tone-color;
+        }
+    }
+}
+
+// Supporter Merchandising Module
+
+.subscribe {
+    border-collapse: collapse;
+    &.sc {
+        width: 100%;
+        max-width: $max-width;
+    }
+    .padded-divider {
+        display: none;
+    }
+    .sup-copy {
+        display: block;
+        font-family: Georgia, serif;
+        font-size: 14px;
+        line-height: 20px;
+        mso-line-height-rule: exactly;
+        color: $brightness-7;
+        padding-bottom: 15px;
+        .sup-highlight {
+            color: $brightness-7;
+            font-weight: bold;
+            background-color: $highlight-main;
+            padding-bottom: 2px;
+        }
+    }
+    .sm-btn {
+        background-color: $highlight-main;
+        border-radius: 20px;
+        color: $cta-font-color;
+        display: inline-block;
+        font-family: Georgia, serif;
+        font-size: 16px;
+        line-height: 40px;
+        font-weight: bold;
+        text-align: center;
+        text-decoration: none;
+        min-width: 130px;
+        -webkit-text-size-adjust: none;
+        mso-hide: all;
+    }
+    .cta-pad {
+        padding-bottom: 15px;
+    }
+    .column {
+        width: 100%;
+        display: inline-block;
+        vertical-align: top;
+        &.column-left {
+            max-width: 330px;
+        }
+        &.column-right {
+            max-width: 150px;
+        }
+    }
+    .wrap-pad {
+        padding: 20px 10px 0;
+        &.text-center {
+            text-align: center;
+            font-size: 0;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
The following commit adds Merchandising Supporter component to Article and Editorial emails
## Screenshots
N/A
## What is the value of this and can you measure success?
Email templates updated
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
