### PR TITLE
Better epic error handling

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -1,6 +1,9 @@
 // @flow
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 import reportError from 'lib/report-error';
+import {
+    getEpicControlFromGoogleDoc
+} from 'common/modules/commercial/contributions-google-docs';
 
 const controlCopyParagraphOne =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help.';
@@ -12,7 +15,7 @@ const controlCopyParagraphThree =
     'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.';
 
 // used when Google Doc control cannot be fetched
-export const articleCopy = {
+const fallbackCopy = {
     heading: 'Since you’re here &hellip;',
     paragraphs: [
         controlCopyParagraphOne,
@@ -22,25 +25,10 @@ export const articleCopy = {
     highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
 };
 
-export const liveblogCopy: AcquisitionsEpicTemplateCopy = {
-    paragraphs: [
-        'Since you’re here &hellip; we have a small favour to ask. Three years ago we set out to make The Guardian sustainable by deepening our relationship with our readers. We decided to seek an approach that would allow us to keep our journalism open and accessible to everyone, regardless of where they live or what they can afford.',
-        'More than one million readers have now supported our independent, investigative journalism through contributions, membership or subscriptions. We want to thank you for all of your support. But we have to maintain and build on that support for every year to come.',
-        'The Guardian is editorially independent – our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion.',
-        'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-    ],
-    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian – and it only takes a minute. Thank you.`,
-};
-
-export const getEpicParams = (
-    googleDocJson: any,
-    sheetName: string
+const getEpicParams = (
+    rowsFromGoogleDoc: any
 ): AcquisitionsEpicTemplateCopy => {
-    const rows =
-        googleDocJson &&
-        googleDocJson.sheets &&
-        googleDocJson.sheets[sheetName];
-    const firstRow = rows && rows[0];
+    const firstRow = rowsFromGoogleDoc && rowsFromGoogleDoc[0];
 
     if (
         !(
@@ -50,23 +38,39 @@ export const getEpicParams = (
             firstRow.highlightedText
         )
     ) {
-        reportError(
-            new Error(
-                `Could not find epic properties for sheetName=${sheetName}`
-            ),
-            {
-                feature: 'epic-test',
-            }
+        throw new Error(
+            `Required data from the Google Doc was missing. Got row: ${firstRow}`
         );
-        return articleCopy;
     }
 
     return {
         heading: firstRow.heading,
-        paragraphs: rows.map(row => row.paragraphs),
+        // TODO: make this consistent with the multiple tests spreadsheet.
+        // i.e. a single cell for all paragraphs
+        paragraphs: rowsFromGoogleDoc.map(row => row.paragraphs),
         highlightedText: firstRow.highlightedText.replace(
             /%%CURRENCY_SYMBOL%%/g,
             getLocalCurrencySymbol()
         ),
     };
 };
+
+
+export const getControlEpicCopy = (): Promise<AcquisitionsEpicTemplateCopy> =>
+    getEpicControlFromGoogleDoc()
+        .then(rows => getEpicParams(rows))
+        .catch(err => {
+            reportError(
+                new Error(
+                    `Could not fetch control epic copy from Google Doc. ${
+                        err.message
+                    }. Stack: ${err.stack}`
+                ),
+                {
+                    feature: 'epic-test',
+                },
+                false
+            );
+
+            return fallbackCopy;
+        });

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -1,9 +1,7 @@
 // @flow
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 import reportError from 'lib/report-error';
-import {
-    getEpicControlFromGoogleDoc
-} from 'common/modules/commercial/contributions-google-docs';
+import { getEpicControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 
 const controlCopyParagraphOne =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help.';
@@ -54,7 +52,6 @@ const getEpicParams = (
         ),
     };
 };
-
 
 export const getControlEpicCopy = (): Promise<AcquisitionsEpicTemplateCopy> =>
     getEpicControlFromGoogleDoc()

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -64,7 +64,7 @@ export const getControlEpicCopy = (): Promise<AcquisitionsEpicTemplateCopy> =>
                     }. Stack: ${err.stack}`
                 ),
                 {
-                    feature: 'epic-test',
+                    feature: 'epic',
                 },
                 false
             );

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -1,11 +1,10 @@
 // @flow
 import fetchJSON from 'lib/fetch-json';
 import config from 'lib/config';
-import { getEpicParams } from 'common/modules/commercial/acquisitions-copy';
 
-export const epicGoogleDocUrl: string =
+export const epicControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
-export const bannerGoogleDocUrl: string =
+export const bannerControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
 export const epicMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
@@ -15,12 +14,14 @@ export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';
 
 export const getGoogleDoc = (url: string): Promise<any> =>
-    fetchJSON(url, {
-        mode: 'cors',
-    });
+    fetchJSON(url, {mode: 'cors'});
 
-export const getBannerGoogleDoc = (): Promise<any> =>
-    getGoogleDoc(bannerGoogleDocUrl);
+const getSheetFromGoogleDoc = (url: string, sheet: string): Promise<any> =>
+    getGoogleDoc.then(json => json.sheets[sheet]);
 
-export const googleDocEpicControl = (): Promise<AcquisitionsEpicTemplateCopy> =>
-    getGoogleDoc(epicGoogleDocUrl).then(res => getEpicParams(res, 'control'));
+// It is the responsibility of any calling code to .catch() when using these promises.
+export const getEpicControlFromGoogleDoc = (): Promise<any> =>
+    getSheetFromGoogleDoc(epicControlGoogleDocUrl, 'control');
+
+export const getEngagementBannerControlFromGoogleDoc = (): Promise<any> =>
+    getSheetFromGoogleDoc(bannerControlGoogleDocUrl, 'control');

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -14,9 +14,9 @@ export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';
 
 export const getGoogleDoc = (url: string): Promise<any> =>
-    fetchJSON(url, {mode: 'cors'});
+    fetchJSON(url, { mode: 'cors' });
 
-const getSheetFromGoogleDoc = (url: string, sheet: string): Promise<any> =>
+export const getSheetFromGoogleDoc = (url: string, sheet: string): Promise<any> =>
     getGoogleDoc.then(json => json.sheets[sheet]);
 
 // It is the responsibility of any calling code to .catch() when using these promises.

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -16,8 +16,10 @@ export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
 export const getGoogleDoc = (url: string): Promise<any> =>
     fetchJSON(url, { mode: 'cors' });
 
-export const getSheetFromGoogleDoc = (url: string, sheet: string): Promise<any> =>
-    getGoogleDoc.then(json => json.sheets[sheet]);
+export const getSheetFromGoogleDoc = (
+    url: string,
+    sheet: string
+): Promise<any> => getGoogleDoc.then(json => json.sheets[sheet]);
 
 // It is the responsibility of any calling code to .catch() when using these promises.
 export const getEpicControlFromGoogleDoc = (): Promise<any> =>

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -662,7 +662,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                     }. Stack: ${err.stack}`
                 ),
                 {
-                    feature: 'epic-test',
+                    feature: 'epic',
                 },
                 false
             );
@@ -730,7 +730,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                     }. Stack: ${err.stack}`
                 ),
                 {
-                    feature: 'engagement-banner-test',
+                    feature: 'engagement-banner',
                 },
                 false
             );

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,12 +33,12 @@ import {
     bannerMultipleTestsGoogleDocUrl,
     epicMultipleTestsGoogleDocUrl,
     getGoogleDoc,
-    googleDocEpicControl,
 } from 'common/modules/commercial/contributions-google-docs';
 import {
     defaultExclusionRules,
     isArticleWorthAnEpicImpression,
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
+import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
 
 export type CtaUrls = {
     supportUrl: string,
@@ -370,7 +370,7 @@ const makeABTestVariant = (
 
             const copyPromise: Promise<AcquisitionsEpicTemplateCopy> =
                 (options.copy && Promise.resolve(options.copy)) ||
-                googleDocEpicControl();
+                getControlEpicCopy();
 
             copyPromise
                 .then((copy: AcquisitionsEpicTemplateCopy) =>

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -6,7 +6,6 @@ import { elementInView } from 'lib/element-inview';
 import reportError from 'lib/report-error';
 import mediator from 'lib/mediator';
 
-import { googleDocEpicControl } from 'common/modules/commercial/contributions-google-docs';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
@@ -24,6 +23,7 @@ import type {
     ABTestVariant,
     ComponentEventWithoutAction,
 } from 'common/modules/commercial/acquisitions-ophan';
+import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
 
 export type EpicComponent = {
     html: HTMLDivElement,
@@ -41,7 +41,7 @@ const controlEpicComponent = (
     const epicComponentType = 'ACQUISITIONS_EPIC';
     const testimonialBlock = '';
 
-    return googleDocEpicControl().then(copy => {
+    return getControlEpicCopy().then(copy => {
         const rawEpic = acquisitionsEpicControlTemplate({
             copy,
             componentName: '', // TODO: confirm data-component not needed

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -2,25 +2,14 @@
 import config from 'lib/config';
 import reportError from 'lib/report-error';
 import { getLocalCurrencySymbol } from 'lib/geolocation';
-import { supportContributeURL } from './support-utilities';
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
+import { supportContributeURL } from './support-utilities';
 
 const fallbackCopy: string = `<strong>The Guardian is editorially independent &ndash;
     our journalism is free from the influence of billionaire owners or politicians.
     No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put
     up a paywall as we want to keep our journalism open and accessible. But the revenue we get from
     advertising is falling, so we increasingly need our readers to fund our independent, investigative reporting.`;
-
-export const defaultEngagementBannerParams = (): EngagementBannerParams => ({
-    campaignCode: 'fallback_hardcoded_banner',
-    buttonCaption: 'Support The Guardian',
-    linkUrl: supportContributeURL,
-    messageText: fallbackCopy,
-    ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
-    pageviewId: config.get('ophan.pageViewId', 'not_found'),
-    products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
-    hasTicker: false,
-});
 
 const getAcquisitionsBannerParams = (
     rowsFromGoogleDoc: any
@@ -73,5 +62,17 @@ export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTem
             // The banner tests work by overriding built-in parameters.
             // So the default case is override nothing.
             // As opposed to the epic where we return default copy.
+            // TODO: but could we return defaultEngagementBannerParams here?
             return {};
         });
+
+export const defaultEngagementBannerParams = (): EngagementBannerParams => ({
+    campaignCode: 'fallback_hardcoded_banner',
+    buttonCaption: 'Support The Guardian',
+    linkUrl: supportContributeURL,
+    messageText: fallbackCopy,
+    ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
+    pageviewId: config.get('ophan.pageViewId', 'not_found'),
+    products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
+    hasTicker: false,
+});

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -54,7 +54,7 @@ export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTem
                     }. Stack: ${err.stack}`
                 ),
                 {
-                    feature: 'engagement-banner-test',
+                    feature: 'engagement-banner',
                 },
                 false
             );

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -3,9 +3,9 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 import { supportContributeURL } from './support-utilities';
-import { getBannerGoogleDoc } from './contributions-google-docs';
+import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 
-const engagementBannerControl: string = `<strong>The Guardian is editorially independent &ndash;
+const fallbackCopy: string = `<strong>The Guardian is editorially independent &ndash;
     our journalism is free from the influence of billionaire owners or politicians.
     No one edits our editor. No one steers our opinion.</strong> And unlike many others, we haven’t put
     up a paywall as we want to keep our journalism open and accessible. But the revenue we get from
@@ -15,22 +15,17 @@ export const defaultEngagementBannerParams = (): EngagementBannerParams => ({
     campaignCode: 'fallback_hardcoded_banner',
     buttonCaption: 'Support The Guardian',
     linkUrl: supportContributeURL,
-    messageText: engagementBannerControl,
+    messageText: fallbackCopy,
     ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
     pageviewId: config.get('ophan.pageViewId', 'not_found'),
     products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
     hasTicker: false,
 });
 
-export const getAcquisitionsBannerParams = (
-    googleDocJson: any,
-    sheetName: string
+const getAcquisitionsBannerParams = (
+    rowsFromGoogleDoc: any
 ): ?EngagementBannerTemplateParams => {
-    const rows =
-        googleDocJson &&
-        googleDocJson.sheets &&
-        googleDocJson.sheets[sheetName];
-    const firstRow = rows && rows[0];
+    const firstRow = rowsFromGoogleDoc && rowsFromGoogleDoc[0];
 
     if (
         !(
@@ -60,8 +55,8 @@ export const getAcquisitionsBannerParams = (
 };
 
 export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTemplateParams> =>
-    getBannerGoogleDoc()
-        .then(json => getAcquisitionsBannerParams(json, 'control'))
+    getEngagementBannerControlFromGoogleDoc()
+        .then(rows => getAcquisitionsBannerParams(rows))
         .catch(err => {
             reportError(
                 new Error(
@@ -75,5 +70,8 @@ export const getControlEngagementBannerParams = (): Promise<?EngagementBannerTem
                 false
             );
 
+            // The banner tests work by overriding built-in parameters.
+            // So the default case is override nothing.
+            // As opposed to the epic where we return default copy.
             return {};
         });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -58,9 +58,9 @@ const hasBannerBeenRedeployedSinceClosed = (
             // Capture in sentry
             reportError(
                 new Error(
-                    `Unable to get contributions banner deploy log: ${err}`
+                    `Unable to get engagement banner deploy log: ${err}`
                 ),
-                { feature: 'reader-revenue-contributions-banner' },
+                { feature: 'engagement-banner' },
                 false
             );
             return false;
@@ -181,7 +181,7 @@ const show = (): Promise<boolean> =>
                 new Error(
                     `Could not show banner. ${err.message}. Stack: ${err.stack}`
                 ),
-                { feature: 'engagement-banner-test' },
+                { feature: 'engagement-banner' },
                 false
             );
             return false;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -57,9 +57,7 @@ const hasBannerBeenRedeployedSinceClosed = (
         .catch(err => {
             // Capture in sentry
             reportError(
-                new Error(
-                    `Unable to get engagement banner deploy log: ${err}`
-                ),
+                new Error(`Unable to get engagement banner deploy log: ${err}`),
                 { feature: 'engagement-banner' },
                 false
             );


### PR DESCRIPTION
- Consistency between error handling of epic & banner from Google Docs
  - If control copy cannot be fetched from the doc, they will both fall back to hardcoded defaults but will report an error to Sentry
- Consistency in feature tags of Sentry errors