### PR TITLE
Set label on Teads outstream ads

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -298,6 +298,12 @@
     @include mq(desktop) {
         width: 620px;
         height: $mpu-ad-label-height + 350px;
+        background: transparent;
+
+        & > div.ad-slot__label {
+            margin-left: 35px;
+            margin-right: 35px;
+        }
     }
 }
 


### PR DESCRIPTION
Teads outstream ads are slightly narrower than Unruly ones.  This change makes them look similar.

Unruly:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/1722550/52556493-a37a3780-2de4-11e9-9487-3d99c30dfec0.png">

Teads:

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1722550/52565686-725b3080-2dff-11e9-8d81-c802079d679f.png">
