### PR TITLE
Pass argument to function

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -19,7 +19,7 @@ export const getGoogleDoc = (url: string): Promise<any> =>
 export const getSheetFromGoogleDoc = (
     url: string,
     sheet: string
-): Promise<any> => getGoogleDoc.then(json => json.sheets[sheet]);
+): Promise<any> => getGoogleDoc(url).then(json => json.sheets[sheet]);
 
 // It is the responsibility of any calling code to .catch() when using these promises.
 export const getEpicControlFromGoogleDoc = (): Promise<any> =>


### PR DESCRIPTION
There's a weakness in Flow that let this through. I've added a comment to an existing issue in Flow: https://github.com/facebook/flow/issues/106#issuecomment-462372048

Noticed because of a spike in Sentry errors: 
![picture 447](https://user-images.githubusercontent.com/5122968/52568013-8a35b300-2e05-11e9-89f8-65938f307361.png)
