### PR TITLE
Youtube related video: Listen for events with new tracking ID (activeAtomId)

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -134,7 +134,7 @@ const handlePlay = (atomId: string, player: AtomPlayer): void => {
 
     // don't track play if resumed from a paused state
     if (paused) {
-        paused = false;
+        player.paused = false;
     } else {
         trackYoutubeEvent('play', trackingId);
     }

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -180,10 +180,15 @@ const onPlayerPlaying = (atomId: string): void => {
      */
     const latestYoutubeId = getYoutubeIdFromUrl(youtubePlayer.getVideoUrl());
 
+    console.log('compare --->', youtubeId, latestYoutubeId);
+
     if (youtubeId !== latestYoutubeId) {
         fetchJson(`/atom/youtube/${latestYoutubeId}.json`)
             .then(resp => {
                 const activeAtomId = resp.atomId;
+
+                console.log('fetch --->', resp);
+
                 if (!activeAtomId) {
                     return;
                 }

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -82,6 +82,8 @@ document.addEventListener('focusin', () => {
 const recordPlayerProgress = (atomId: string): void => {
     const player = players[atomId];
 
+    console.log('handlePlay trackingId --->', atomId, player);
+
     if (!player) {
         return;
     }
@@ -125,6 +127,8 @@ const setProgressTracker = (atomId: string): IntervalID => {
 const handlePlay = (atomId: string, player: AtomPlayer): void => {
     const { trackingId, iframe, overlay, endSlate } = player;
 
+    console.log('handlePlay trackingId --->', trackingId);
+
     killProgressTracker(atomId);
     setProgressTracker(atomId);
 
@@ -141,7 +145,7 @@ const handlePlay = (atomId: string, player: AtomPlayer): void => {
         mainMedia.classList.add('atom-playing');
     }
 
-    if (overlay && endSlate) {
+    if (overlay && endSlate && !endSlate.rendered) {
         const parentElem = overlay.parentElement;
 
         if (parentElem) {


### PR DESCRIPTION
## What does this change?

When a new `trackingID` is registered we need to call `initYoutubeEvents(trackingId)` in order for tracking events emitted with that `trackingID` to be recorded.

### Tested

- [x] Locally
- [ ] On CODE (optional)
