### PR TITLE
Make variant names lowercase

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -591,7 +591,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                               }
                             : {}),
                         variants: rows.map(row => ({
-                            id: row.name.trim(),
+                            id: row.name.toLower().trim(),
                             products: [],
                             ...(isLiveBlog
                                 ? { test: setupEpicInLiveblog }


### PR DESCRIPTION
Because the A/B test dashboard expects a variant called "control" (all lowercase)

So let's be defensive and normalise all to lowercase