### PR TITLE
Facebook pixel consent

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -357,6 +357,16 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val facebookTrackingPixel: Switch = Switch(
+    group = Commercial,
+    name = "facebook-tracking-pixel",
+    description = "Facebook's PageView tracking to improve ad targeting",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }
 
 trait PrebidSwitches {

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -3,7 +3,7 @@
 @import conf.Static
 @import conf.Configuration
 @import play.api.libs.json.Json
-@import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount}
+@import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount, FBPixel}
 @import conf.Configuration.environment
 @import navigation.NavMenu
 
@@ -59,7 +59,8 @@
         },
         "libs": {
             "googletag": "@{Configuration.javascript.config("googletagJsUrl")}",
-            "cmp": { "fullVendorDataUrl": "@Static("data/vendor/cmp_vendorlist.json")" }
+            "cmp": { "fullVendorDataUrl": "@Static("data/vendor/cmp_vendorlist.json")" },
+            "facebookAccountId": "@FBPixel.account"
         }
     }
 }

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -26,7 +26,6 @@
     </noscript>
 
     <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
-    <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
 
     <!-- Twitter universal website tag code -->
     <script>

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -18,6 +18,7 @@ import { inizio } from 'commercial/modules/third-party-tags/inizio';
 import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
 import { doubleClickAdFree } from 'commercial/modules/third-party-tags/doubleclick-ad-free';
 import { plista } from 'commercial/modules/third-party-tags/plista';
+import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
 
 const loadExternalContentWidget = (): void => {
     const externalTpl = template(externalContentContainerStr);
@@ -84,6 +85,7 @@ const loadOther = (): void => {
         ias,
         inizio,
         doubleClickAdFree,
+        fbPixel(),
     ].filter(_ => _.shouldRun);
 
     if (services.length) {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -1,0 +1,23 @@
+// @flow
+import config from 'lib/config';
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
+
+export const fbPixel: () => ThirdPartyTag = () =>
+    // console.log(
+    //     // config.get('switches.facebookTrackingPixel'),
+    //     config.switches,
+    //     getAdConsentState(thirdPartyTrackingAdConsent),
+    //     // config.switches.facebookTrackingPixel && getAdConsentState(thirdPartyTrackingAdConsent)
+    // );
+    ({
+        shouldRun:
+            config.switches.facebookTrackingPixel &&
+            !!getAdConsentState(thirdPartyTrackingAdConsent),
+        url: `https://www.facebook.com/tr?id=${
+            config.libs.facebookAccountId
+        }&ev=PageView&noscript=1`,
+        useImage: true,
+    });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -5,12 +5,15 @@ import {
     thirdPartyTrackingAdConsent,
 } from 'common/modules/commercial/ad-prefs.lib';
 
-export const fbPixel: () => ThirdPartyTag = () => ({
-    shouldRun:
-        config.switches.facebookTrackingPixel &&
-        !!getAdConsentState(thirdPartyTrackingAdConsent),
-    url: `https://www.facebook.com/tr?id=${
-        config.libs.facebookAccountId
-    }&ev=PageView&noscript=1`,
-    useImage: true,
-});
+export const fbPixel: () => ThirdPartyTag = () => {
+    const consent = getAdConsentState(thirdPartyTrackingAdConsent);
+    return {
+        shouldRun:
+            config.switches.facebookTrackingPixel &&
+            (consent == null || consent),
+        url: `https://www.facebook.com/tr?id=${
+            config.libs.facebookAccountId
+        }&ev=PageView&noscript=1`,
+        useImage: true,
+    };
+};

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -5,19 +5,12 @@ import {
     thirdPartyTrackingAdConsent,
 } from 'common/modules/commercial/ad-prefs.lib';
 
-export const fbPixel: () => ThirdPartyTag = () =>
-    // console.log(
-    //     // config.get('switches.facebookTrackingPixel'),
-    //     config.switches,
-    //     getAdConsentState(thirdPartyTrackingAdConsent),
-    //     // config.switches.facebookTrackingPixel && getAdConsentState(thirdPartyTrackingAdConsent)
-    // );
-    ({
-        shouldRun:
-            config.switches.facebookTrackingPixel &&
-            !!getAdConsentState(thirdPartyTrackingAdConsent),
-        url: `https://www.facebook.com/tr?id=${
-            config.libs.facebookAccountId
-        }&ev=PageView&noscript=1`,
-        useImage: true,
-    });
+export const fbPixel: () => ThirdPartyTag = () => ({
+    shouldRun:
+        config.switches.facebookTrackingPixel &&
+        !!getAdConsentState(thirdPartyTrackingAdConsent),
+    url: `https://www.facebook.com/tr?id=${
+        config.libs.facebookAccountId
+    }&ev=PageView&noscript=1`,
+    useImage: true,
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -1,13 +1,14 @@
 // @flow
-import * as adPrefs from 'common/modules/commercial/ad-prefs.lib';
+import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 import config from 'lib/config';
 
 import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
 
+const getAdConsentState: any = _getAdConsentState;
+
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
     getAdConsentState: jest.fn(),
 }));
-const consentSpy = jest.spyOn(adPrefs, 'getAdConsentState');
 
 type SetupParams = {
     consent: boolean | null,
@@ -21,7 +22,7 @@ describe('Facebook tracking pixel', () => {
     });
 
     const setup = (params: SetupParams) => {
-        consentSpy.mockReturnValueOnce(params.consent);
+        getAdConsentState.mockReturnValueOnce(params.consent);
         config.switches = { facebookTrackingPixel: params.switchedOn };
     };
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -44,10 +44,10 @@ describe('Facebook tracking pixel', () => {
         expect(result.shouldRun).toBe(true);
     });
 
-    it('if the switch is enabled and consent is null, do not load', () => {
+    it('if the switch is enabled and consent is null, treat consent as true', () => {
         setup({ consent: null, switchedOn: true });
         const result = fbPixel();
-        expect(result.shouldRun).toBe(false);
+        expect(result.shouldRun).toBe(true);
     });
 
     it('should send correct "netid" param', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -1,0 +1,69 @@
+// @flow
+import * as adPrefs from 'common/modules/commercial/ad-prefs.lib';
+import config from 'lib/config';
+
+import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
+
+jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
+    getAdConsentState: jest.fn(),
+}));
+const consentSpy = jest.spyOn(adPrefs, 'getAdConsentState');
+
+type SetupParams = {
+    consent: boolean | null,
+    switchedOn: boolean,
+};
+
+describe('Facebook tracking pixel', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        config.libs.facebookAccountId = 'test-account-id';
+    });
+
+    const setup = (params: SetupParams) => {
+        consentSpy.mockReturnValueOnce(params.consent);
+        config.switches = { facebookTrackingPixel: params.switchedOn };
+    };
+
+    it('should not load if switch is off', () => {
+        setup({ consent: true, switchedOn: false });
+        const result = fbPixel();
+        expect(result.shouldRun).toBe(false);
+    });
+
+    it('should not load if consent has been denied', () => {
+        setup({ consent: false, switchedOn: true });
+        const result = fbPixel();
+        expect(result.shouldRun).toBe(false);
+    });
+
+    it('should load if consent is available and the switch enabled', () => {
+        setup({ consent: true, switchedOn: true });
+        const result = fbPixel();
+        expect(result.shouldRun).toBe(true);
+    });
+
+    it('if the switch is enabled and consent is null, do not load', () => {
+        setup({ consent: null, switchedOn: true });
+        const result = fbPixel();
+        expect(result.shouldRun).toBe(false);
+    });
+
+    it('should send correct "netid" param', () => {
+        setup({ consent: true, switchedOn: true });
+        const result = fbPixel();
+        expect(result.url).toBe(
+            'https://www.facebook.com/tr?id=test-account-id&ev=PageView&noscript=1'
+        );
+    });
+
+    it('should use images', () => {
+        setup({ consent: true, switchedOn: true });
+        const result = fbPixel();
+        expect(result.useImage).toBe(true);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+});


### PR DESCRIPTION
## What does this change?

Puts the Facebook tracking Pixel behind our consent check and a switch. This means users are able to opt out of Facebook's pageview tracking using our existing Consent check.

It migrates the tracker from the Scala template over to the Commercial third-party-scripts functionality, which brings it in line with other third party modules.

**Important notes:**

This change takes `null` consent (i.e. no choice yet made) as **false**, so this pixel will only appear for users that have explicitly opted-in.

The Facebook pixel is currently also pulled in via Krux. This duplication should be addressed! We should choose one place for the Facebook tag to be included from. While considering that, we should also have a think more broadly about what factors should influence the decision of "where to put third party tags".

## Screenshots

n/a

## What is the value of this and can you measure success?

The Facebook Pixel was unconditionally pulled in from the base scala template. Following this change 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
