### PR TITLE
Refactor epic ab tests

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -9,9 +9,11 @@ declare type EpicTemplate = (EpicVariant, AcquisitionsEpicTemplateCopy) => strin
 declare type Variant = {
     id: string,
     test: (x: Object) => void,
+    campaignCode?: string,
     canRun?: () => boolean,
     impression?: ListenerFunction,
     success?: ListenerFunction,
+    engagementBannerParams?: EngagementBannerParams,
     deploymentRules?: DeploymentRules,
 };
 
@@ -23,7 +25,6 @@ declare type EpicVariant = Variant & {
     excludedTagIds: string[],
     excludedSections: string[],
 
-    campaignCode: string,
     supportURL: string,
     subscribeURL: string,
     componentName: string,
@@ -31,10 +32,6 @@ declare type EpicVariant = Variant & {
 
     buttonTemplate?: CtaUrls => string,
     copy?: AcquisitionsEpicTemplateCopy,
-}
-
-declare type EngagementBannerVariant = Variant & {
-    engagementBannerParams: () => Promise<EngagementBannerParams>,
 }
 
 declare type ABTest = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -1,15 +1,41 @@
 type ListenerFunction = (f: () => void) => void;
 
+export type CtaUrls = {
+    supportUrl: string,
+};
+
+declare type EpicTemplate = (EpicVariant, AcquisitionsEpicTemplateCopy) => string;
+
 declare type Variant = {
     id: string,
     test: (x: Object) => void,
     canRun?: () => boolean,
     impression?: ListenerFunction,
     success?: ListenerFunction,
-    options?: Object,
-    engagementBannerParams?: EngagementBannerParams,
     deploymentRules?: DeploymentRules,
 };
+
+declare type EpicVariant = Variant & {
+    // filters, where empty is taken to mean 'all', multiple entries are combined with OR
+    locations: string[],
+    tagIds: string[],
+    sections: string[],
+    excludedTagIds: string[],
+    excludedSections: string[],
+
+    campaignCode: string,
+    supportURL: string,
+    subscribeURL: string,
+    componentName: string,
+    template: EpicTemplate,
+
+    buttonTemplate?: CtaUrls => string,
+    copy?: AcquisitionsEpicTemplateCopy,
+}
+
+declare type EngagementBannerVariant = Variant & {
+    engagementBannerParams: () => Promise<EngagementBannerParams>,
+}
 
 declare type ABTest = {
     id: string,
@@ -49,10 +75,8 @@ declare type DeploymentRules = 'AlwaysAsk' | MaxViews
 declare type EpicABTest = AcquisitionsABTest & {
     campaignPrefix: string,
     useLocalViewLog: boolean,
-    overrideCanRun: boolean,
     onlyShowToExistingSupporters: boolean,
     pageCheck: (page: Object) => boolean,
-    locations: $ReadOnlyArray<string>,
     useTargetingTool: boolean,
     insertEvent: string,
     viewEvent: string,
@@ -60,19 +84,21 @@ declare type EpicABTest = AcquisitionsABTest & {
 
 declare type InitEpicABTestVariant = {
     id: string,
-    products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, abTest: ABTest) => void,
     deploymentRules?: DeploymentRules,
-    options?: Object
+    locations?: string[],
+    tagIds?: string[],
+    sections?: string[],
+    excludedTagIds?: string[],
+    excludedSections?: string[],
+    buttonTemplate?: CtaUrls => string,
+    copy?: AcquisitionsEpicTemplateCopy,
 };
 
 declare type InitBannerABTestVariant = {
     id: string,
-    products: $ReadOnlyArray<OphanProduct>,
     engagementBannerParams: () => Promise<?EngagementBannerTemplateParams>
 };
-
-declare type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
 declare type InitEpicABTest = {
     id: string,
@@ -88,17 +114,13 @@ declare type InitEpicABTest = {
     campaignId: string,
     variants: $ReadOnlyArray<InitEpicABTestVariant>,
 
-    // locations is a filter where empty is taken to mean 'all'
-    locations?: string[],
-    dataLinkNames?: string,
     campaignPrefix?: string,
     useLocalViewLog?: boolean,
-    overrideCanRun?: boolean,
     useTargetingTool?: boolean,
     onlyShowToExistingSupporters?: boolean,
-    canRun?: (test: EpicABTest) => boolean,
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
+    deploymentRules?: DeploymentRules,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -81,6 +81,7 @@ declare type EpicABTest = AcquisitionsABTest & {
 
 declare type InitEpicABTestVariant = {
     id: string,
+    products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, abTest: ABTest) => void,
     deploymentRules?: DeploymentRules,
     locations?: string[],
@@ -94,6 +95,7 @@ declare type InitEpicABTestVariant = {
 
 declare type InitBannerABTestVariant = {
     id: string,
+    products: $ReadOnlyArray<OphanProduct>,
     engagementBannerParams: () => Promise<?EngagementBannerTemplateParams>
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -98,8 +98,7 @@ const doTagsMatch = (test: EpicABTest): boolean =>
     test.useTargetingTool ? isAbTestTargeted(test) : true;
 
 // Returns an array containing:
-// - the first element matching insertAtSelector, if isMultiple is false or not supplied
-// - all elements matching insertAtSelector, if isMultiple is true
+// - the first element matching insertAtSelector
 // - or an empty array if the selector doesn't match anything on the page
 const getTargets = (insertAtSelector: string): Array<HTMLElement> => {
     const els = Array.from(document.querySelectorAll(insertAtSelector));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -283,6 +283,7 @@ const makeEpicABTestVariant = (
                                 submitClickEvent({
                                     component: {
                                         componentType: parentTest.componentType,
+                                        products: initVariant.products,
                                         campaignCode,
                                         id: campaignCode,
                                     },
@@ -298,6 +299,7 @@ const makeEpicABTestVariant = (
 
                                 mediator.emit(parentTest.insertEvent, {
                                     componentType: parentTest.componentType,
+                                    products: initVariant.products,
                                     campaignCode,
                                 });
 
@@ -316,6 +318,7 @@ const makeEpicABTestVariant = (
                                         mediator.emit(parentTest.viewEvent, {
                                             componentType:
                                                 parentTest.componentType,
+                                            products: initVariant.products,
                                             campaignCode,
                                         });
                                         mediator.emit(
@@ -336,6 +339,7 @@ const makeEpicABTestVariant = (
                 submitInsertEvent({
                     component: {
                         componentType: parentTest.componentType,
+                        products: initVariant.products,
                         campaignCode,
                         id: campaignCode,
                     },
@@ -352,6 +356,7 @@ const makeEpicABTestVariant = (
                 submitViewEvent({
                     component: {
                         componentType: parentTest.componentType,
+                        products: initVariant.products,
                         campaignCode,
                         id: campaignCode,
                     },

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -20,7 +20,6 @@ import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
 } from 'lib/geolocation';
-import { noop } from 'lib/noop';
 import { splitAndTrim, optionalSplitAndTrim } from 'lib/string-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -199,7 +199,7 @@ const makeEpicABTestVariant = (
             },
         }),
         template,
-        buttonTemplate: initVariant.buttonTemplate,
+        buttonTemplate: initVariant.buttonTemplate || defaultButtonTemplate,
         copy: initVariant.copy,
 
         locations: initVariant.locations || [],

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -1,5 +1,4 @@
 // @flow
-import type { CtaUrls } from 'common/modules/commercial/contributions-utilities';
 import config from 'lib/config';
 import { applePayApiAvailable } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
@@ -24,8 +24,8 @@ const makeABEvent = (
         complete,
     };
 
-    if (variant.options && variant.options.campaignCodes) {
-        event.campaignCodes = variant.options.campaignCodes;
+    if (variant.campaignCode) {
+        event.campaignCodes = [variant.campaignCode];
     }
 
     return event;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -27,9 +27,6 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             deploymentRules: 'AlwaysAsk',
-            options: {
-                successOnView: true,
-            },
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,7 +1,7 @@
 // @flow
-import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { makeEpicABTest } from 'common/modules/commercial/contributions-utilities';
 
-export const acquisitionsEpicAlwaysAskIfTagged = makeABTest({
+export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
     campaignId: 'epic_always_ask_if_tagged',
 
@@ -26,8 +26,8 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeABTest({
             id: 'control',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
+            deploymentRules: 'AlwaysAsk',
             options: {
-                isUnlimited: true,
                 successOnView: true,
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -22,11 +22,6 @@ export const askFourEarning: EpicABTest = makeEpicABTest({
         {
             id: 'control',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-
-            options: {
-                insertAtSelector: '.submeta',
-                successOnView: true,
-            },
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -1,7 +1,7 @@
 // @flow
-import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { makeEpicABTest } from 'common/modules/commercial/contributions-utilities';
 
-export const askFourEarning: EpicABTest = makeABTest({
+export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
     campaignId: 'kr1_epic_ask_four_earning',
 


### PR DESCRIPTION
## What does this change?
The code for creating epic AB tests was getting a bit messy, and we're still adding more fields (for configuration via google sheets).
This PR is to make the code a bit more maintainable.

1. Introduces `EpicVariant`, which extends `Variant`
2. Removes the very vague `options` field (which had type `Object`) and replaces it with properly typed fields in `EpicVariant`
3. Removes a number of legacy fields that are not currently used:
```isOutbrainCompliant
usesIframe
onInsert
onView
insertAtSelector
insertMultiple
insertAfter
isUnlimited
```

4. Removes the `options.isUnlimited` setting, as this can now be achieved with `deploymentRules`


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
