### PR TITLE
Add fiv logic

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -248,6 +248,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val FivModeBanner = Switch(
+    Commercial,
+    "fiv-mode-banner",
+    "If ON, switch the membership engagement banner to FIV mode (different styling and rules plus thank you banner is on)",
+    owners = Seq(Owner.withGithub("johnduffell")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 5, 18),
+    exposeClientSide = true
+  )
+
   val EpicTestsFromGoogleDocs = Switch(
     Commercial,
     "epic-tests-from-google-docs",

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -24,7 +24,6 @@ declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     products: OphanProduct[],
     isHardcodedFallback: boolean,
     paypalClass?: string,
-    template?: (templateParams: EngagementBannerTemplateParams) => string,
     bannerModifierClass?: string,
     abTest?: {
         name: string,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -31,7 +31,9 @@ type BannerDeployLog = {
 };
 
 // this switches the thank you banner on, changes the styling and min articles rule.
-const fivMode = config.get('switches.fivModeBanner') || window.location.hash.match(/[#&]fiv(&.*)?$/);
+const fivMode =
+    config.get('switches.fivModeBanner') ||
+    window.location.hash.match(/[#&]fiv(&.*)?$/);
 
 const messageCode = 'engagement-banner';
 const minArticlesBeforeShowingBanner = fivMode ? 0 : 3;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
@@ -1,0 +1,55 @@
+// @flow
+
+import marque36icon from 'svgs/icon/marque-36.svg';
+import closeCentralIcon from 'svgs/icon/close-central.svg';
+import arrowWhiteRight from 'svgs/icon/arrow-white-right.svg';
+import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
+import config from 'lib/config';
+import { applePayApiAvailable } from 'lib/detect';
+import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
+
+export const acquisitionsBannerFivTemplate = (thankThem: boolean) => (
+    params: EngagementBannerTemplateParams
+): string => {
+    const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
+    return `
+        <div class="engagement-banner__close">
+            <div class="engagement-banner__roundel">
+                ${marque36icon.markup}
+            </div>
+            <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close</span>
+                ${closeCentralIcon.markup}
+            </button>
+        </div>
+        <div class="engagement-banner__container">
+            <div class="engagement-banner__text">
+            THIS IS THE FIV: thank you = ${thankThem ? 'thank you' : 'normal'}
+                ${params.messageText}${params.ctaText}
+                ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
+            </div>
+            <div class="engagement-banner__cta">
+                <button class="button engagement-banner__button" href="${
+                    params.linkUrl
+                }">
+                    ${params.buttonCaption}${arrowWhiteRight.markup}
+                </button>
+                <div class="engagement-banner__payment-logos">
+                    <img
+                        src="${config.get(
+                            'images.acquisitions.paypal-and-credit-card',
+                            ''
+                        )}"
+                        alt="PayPal and credit card"
+                    >
+                    ${applePayLogo}
+                </div>
+            </div>
+        </div>
+        <a
+            class="u-faux-block-link__overlay"
+            target="_blank"
+            href="${params.linkUrl}"
+        ></a>
+    `;
+};


### PR DESCRIPTION
## What does this change?
This adds the basic logic for the FIV banner to be used in the upcoming campaign.

So far there is nothing useful, just if you add #fiv to a URL you will see the banner pop up.
Depending if you have an existing financial relationship you will either see the thank you or the normal one.  The template is separated out so that we can write the new styling.

This is ready to ship but not ready to be turned on.  The primary purpose is to keep the PRs small and get reviews early.

## Screenshots
This is the placeholder to prove that it used the copy rather than the original
![image](https://user-images.githubusercontent.com/7304387/52634019-fbd13800-2ebd-11e9-875c-d1445ca1b885.png)

### Tested

- Locally - YES!
- On CODE no

@joelochlann @jranks123 