### PR TITLE
Support a new mobile outstream ad format

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-sizes.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-sizes.js
@@ -27,7 +27,8 @@ const adSizes: Object = {
 
     // guardian proprietary ad sizes
     video: getAdSize(620, 1),
-    outstream: getAdSize(620, 350),
+    outstreamDesktop: getAdSize(620, 350),
+    outstreamMobile: getAdSize(300, 197),
     merchandisingHighAdFeature: getAdSize(88, 89),
     merchandisingHigh: getAdSize(88, 87),
     merchandising: getAdSize(88, 88),

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -94,13 +94,13 @@ describe('createCommentSlots', () => {
             '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
         );
         expect(commentMpu.getAttribute('data-mobile')).toBe(
-            '1,1|2,2|300,250|300,274|fluid'
+            '1,1|2,2|300,197|300,250|300,274|fluid'
         );
         expect(commentDmpu.getAttribute('data-desktop')).toBe(
             '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600'
         );
         expect(commentDmpu.getAttribute('data-mobile')).toBe(
-            '1,1|2,2|300,250|300,274|fluid'
+            '1,1|2,2|300,197|300,250|300,274|fluid'
         );
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -6,6 +6,7 @@ const inlineDefinition = {
         mobile: [
             adSizes.outOfPage,
             adSizes.empty,
+            adSizes.outstreamMobile,
             adSizes.mpu,
             adSizes.googleCard,
             adSizes.fluid,
@@ -15,7 +16,7 @@ const inlineDefinition = {
             adSizes.empty,
             adSizes.mpu,
             adSizes.video,
-            adSizes.outstream,
+            adSizes.outstreamDesktop,
             adSizes.googleCard,
             adSizes.fluid,
         ],

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -20,7 +20,7 @@ const inline1Html = `
     data-link-name="ad slot inline1"
     data-name="inline1"
     aria-hidden="true"
-    data-mobile="1,1|2,2|300,250|300,274|fluid"
+    data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
     data-desktop="1,1|2,2|300,250|620,1|620,350|300,274|fluid">
 </div>
 `;

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -47,6 +47,11 @@ const reportEmptyResponse = (
     }
 };
 
+const outstreamSizes = [
+    adSizes.outstreamDesktop.toString(),
+    adSizes.outstreamMobile.toString(),
+];
+
 export const onSlotRender = (event: SlotRenderEndedEvent): void => {
     recordFirstAdRendered();
 
@@ -76,7 +81,7 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
         // Set refresh field based on the outcome of the slot render.
         const sizeString = advert.size && advert.size.toString();
         const isNotFluid = sizeString !== '0,0';
-        const isOutstream = sizeString === adSizes.outstream.toString();
+        const isOutstream = outstreamSizes.includes(sizeString);
         const isNonRefreshableLineItem =
             event.lineItemId &&
             config

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -98,7 +98,10 @@ sizeCallbacks[adSizes.video] = (_, advert) =>
         advert.updateExtraSlotClasses('u-h');
     });
 
-sizeCallbacks[adSizes.outstream] = (_, advert) =>
+sizeCallbacks[(adSizes.outstreamDesktop, adSizes.outstreamMobile)] = (
+    _,
+    advert
+) =>
     fastdom.write(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -295,10 +295,18 @@
 }
 
 .ad-slot--outstream {
+
+    background: transparent;
+
+    @include mq(mobile) {
+        width: 300px;
+        height: 221px;
+        min-height: 221px;
+    }
+
     @include mq(desktop) {
         width: 620px;
         height: $mpu-ad-label-height + 350px;
-        background: transparent;
 
         & > div.ad-slot__label {
             margin-left: 35px;


### PR DESCRIPTION
This is one of two new formats for mobile.  It has a new custom size: 300x197.

It looks like this:

![image](https://user-images.githubusercontent.com/1722550/52636220-e65f0c80-2ec3-11e9-9544-c7ca6333f50b.png)
