### PR TITLE
Make minArticlesBeforeShowingBanner configurable at the test level

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -7,9 +7,10 @@ declare type Variant = {
     impression?: ListenerFunction,
     success?: ListenerFunction,
     options?: Object,
-    engagementBannerParams?: EngagementBannerParams,
+    engagementBannerParams?: EngagementBannerTestParams,
     deploymentRules?: DeploymentRules,
 };
+
 
 declare type ABTest = {
     id: string,

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -23,12 +23,23 @@ declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     pageviewId: string,
     products: OphanProduct[],
     isHardcodedFallback: boolean,
-    paypalClass?: string,
-    template?: (templateParams: EngagementBannerTemplateParams) => string,
+    template: (templateParams: EngagementBannerTemplateParams) => string,
+    minArticlesBeforeShowingBanner: number,
     bannerModifierClass?: string,
     abTest?: {
         name: string,
         variant: string
     },
-    minArticlesBeforeShowingBanner: number,
 };
+
+declare type EngagementBannerTestParams = {
+    messageText?: string,
+    ctaText?: string,
+    buttonCaption?: string,
+    linkUrl?: string,
+    hasTicker?: boolean,
+    products?: OphanProduct[],
+    template?: (templateParams: EngagementBannerTemplateParams) => string,
+    bannerModifierClass?: string,
+    minArticlesBeforeShowingBanner?: number,
+}

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -29,5 +29,6 @@ declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     abTest?: {
         name: string,
         variant: string
-    }
+    },
+    minArticlesBeforeShowingBanner: number,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -1,4 +1,7 @@
 // @flow
+import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
+
+// @flow
 import config from 'lib/config';
 import reportError from 'lib/report-error';
 import { getLocalCurrencySymbol } from 'lib/geolocation';
@@ -30,19 +33,22 @@ const getAcquisitionsBannerParams = (
         );
     }
 
+    const ctaText = `<span class="engagement-banner__highlight"> ${firstRow.ctaText.replace(
+        /%%CURRENCY_SYMBOL%%/g,
+        getLocalCurrencySymbol()
+    )}</span>`;
+
     return {
-        pageviewId: config.get('ophan.pageViewId', 'not_found'),
-        products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
-        campaignCode: 'control_banner_from_google_doc',
         messageText: firstRow.messageText,
-        ctaText: `<span class="engagement-banner__highlight"> ${firstRow.ctaText.replace(
-            /%%CURRENCY_SYMBOL%%/g,
-            getLocalCurrencySymbol()
-        )}</span>`,
+        ctaText,
         buttonCaption: firstRow.buttonCaption,
         linkUrl: firstRow.linkUrl,
         hasTicker: false,
+        campaignCode: 'control_banner_from_google_doc',
+        pageviewId: config.get('ophan.pageViewId', 'not_found'),
+        products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
         isHardcodedFallback: false,
+        template: acquisitionsBannerControlTemplate,
         minArticlesBeforeShowingBanner: 3,
     };
 };
@@ -66,15 +72,16 @@ export const getControlEngagementBannerParams = (): Promise<
             );
 
             return {
-                pageviewId: config.get('ophan.pageViewId', 'not_found'),
-                products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
-                campaignCode: 'fallback_hardcoded_banner',
                 messageText: fallbackCopy,
                 ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
                 buttonCaption: 'Support The Guardian',
                 linkUrl: supportContributeURL,
                 hasTicker: false,
+                campaignCode: 'fallback_hardcoded_banner',
+                pageviewId: config.get('ophan.pageViewId', 'not_found'),
+                products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
                 isHardcodedFallback: true,
+                template: acquisitionsBannerControlTemplate,
                 minArticlesBeforeShowingBanner: 3,
             };
         });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -43,6 +43,7 @@ const getAcquisitionsBannerParams = (
         linkUrl: firstRow.linkUrl,
         hasTicker: false,
         isHardcodedFallback: false,
+        minArticlesBeforeShowingBanner: 3,
     };
 };
 
@@ -74,5 +75,6 @@ export const getControlEngagementBannerParams = (): Promise<
                 linkUrl: supportContributeURL,
                 hasTicker: false,
                 isHardcodedFallback: true,
+                minArticlesBeforeShowingBanner: 3,
             };
         });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -61,6 +61,9 @@ jest.mock(
         ),
     })
 );
+
+jest.mock('lodash/memoize', () => f => f);
+
 jest.mock(
     'common/modules/commercial/membership-engagement-banner-block',
     () => ({

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -16,6 +16,4 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
     acquisitionsEpicAlwaysAskIfTagged,
 ];
 
-export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-
-];
+export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -16,4 +16,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
     acquisitionsEpicAlwaysAskIfTagged,
 ];
 
-export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [];
+export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+
+];

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -6,7 +6,7 @@ import {
     canShow as canShowEngagementBanner,
     hideBanner as hideEngagementBanner,
     deriveBannerParams as deriveEngagementBannerParams,
-    getBannerHtml as getEngagementBannerHtml,
+    bannerParamsToHtml as getEngagementBannerHtml,
 } from 'common/modules/commercial/membership-engagement-banner';
 import {
     track as trackFirstPvConsent,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -6,7 +6,7 @@ import {
     canShow as canShowEngagementBanner,
     hideBanner as hideEngagementBanner,
     deriveBannerParams as deriveEngagementBannerParams,
-    bannerParamsToHtml as getEngagementBannerHtml,
+    bannerParamsToHtml as engagementBannerParamsToHtml,
 } from 'common/modules/commercial/membership-engagement-banner';
 import {
     track as trackFirstPvConsent,
@@ -111,7 +111,7 @@ const show = (): Promise<boolean> => {
     trackFirstPvConsent();
     return getEngagementBannerTestToRun()
         .then(deriveEngagementBannerParams)
-        .then(getEngagementBannerHtml)
+        .then(engagementBannerParamsToHtml)
         .then(engagementBannerHtml =>
             fastdom.write(() => {
                 const html = doubleBannerHtml(engagementBannerHtml);


### PR DESCRIPTION
## What does this change?
We would like to be able to set `minArticlesBeforeShowingBanner` configurable at the test level, so that we can run tests which change this parameter.

Also, this PR creates a new type, `EngagementBannerTestParams`, used when creating Engagement Banner test variants,  which contains all the values of `EngagementBannerParams` that a test may wish to configure, set as optional. This reduces boilerplate in the test files because, for example, we may want to specify only one parameter change in a variant, so by having this extra type with all the configurable parameters optional, we don't have to recreate the whole `EngagementBannerParams` every time we write a new variant. 
