### PR TITLE
Remove button from 'thank you' epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -199,7 +199,7 @@ const makeEpicABTestVariant = (
             },
         }),
         template,
-        buttonTemplate: initVariant.buttonTemplate || defaultButtonTemplate,
+        buttonTemplate: initVariant.buttonTemplate,
         copy: initVariant.copy,
 
         locations: initVariant.locations || [],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,5 +1,8 @@
 // @flow
-import { makeEpicABTest } from 'common/modules/commercial/contributions-utilities';
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+} from 'common/modules/commercial/contributions-utilities';
 
 export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
@@ -27,6 +30,7 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             deploymentRules: 'AlwaysAsk',
+            buttonTemplate: defaultButtonTemplate,
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -1,5 +1,8 @@
 // @flow
-import { makeEpicABTest } from 'common/modules/commercial/contributions-utilities';
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+} from 'common/modules/commercial/contributions-utilities';
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
@@ -22,6 +25,7 @@ export const askFourEarning: EpicABTest = makeEpicABTest({
         {
             id: 'control',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            buttonTemplate: defaultButtonTemplate,
         },
     ],
 });


### PR DESCRIPTION
## What does this change?
[This change](https://github.com/guardian/frontend/pull/21068) accidentally added the 'Support' button to the 'thank you' epic. The buttonTemplate field is meant to be optional

## Screenshots
Back to normal:
<img width="512" alt="picture 19" src="https://user-images.githubusercontent.com/1513454/52643794-a012a900-2ed5-11e9-9567-6c3d46c6e881.png">

Other epics still have the button:
<img width="430" alt="picture 20" src="https://user-images.githubusercontent.com/1513454/52643850-bb7db400-2ed5-11e9-8e41-b4112b024888.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
