### PR TITLE
Allow custom classes on epic tests

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -29,6 +29,7 @@ declare type EpicVariant = Variant & {
     subscribeURL: string,
     componentName: string,
     template: EpicTemplate,
+    classNames: string[],
 
     buttonTemplate?: CtaUrls => string,
     copy?: AcquisitionsEpicTemplateCopy,
@@ -91,6 +92,7 @@ declare type InitEpicABTestVariant = {
     excludedSections?: string[],
     buttonTemplate?: CtaUrls => string,
     copy?: AcquisitionsEpicTemplateCopy,
+    classNames?: string[],
 };
 
 declare type InitBannerABTestVariant = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -82,6 +82,7 @@ const controlTemplate: EpicTemplate = (
                   subscribeUrl: variant.subscribeURL,
               })
             : undefined,
+        epicClassNames: variant.classNames,
     });
 
 const liveBlogTemplate: EpicTemplate = (
@@ -201,6 +202,7 @@ const makeEpicABTestVariant = (
         template,
         buttonTemplate: initVariant.buttonTemplate || defaultButtonTemplate,
         copy: initVariant.copy,
+        classNames: initVariant.classNames || [],
 
         locations: initVariant.locations || [],
         tagIds: initVariant.tagIds || [],
@@ -527,6 +529,10 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                       )
                                     : undefined,
                             },
+                            classNames: optionalSplitAndTrim(
+                                row.classNames,
+                                ','
+                            ),
                         })),
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -55,7 +55,7 @@ const controlEpicComponent = (
                 }),
             }),
             testimonialBlock,
-            epicClass: '',
+            epicClassNames: [],
             wrapperClass: '',
         });
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -10,7 +10,7 @@ export const acquisitionsEpicControlTemplate = ({
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
-    epicClassNames: [],
+    epicClassNames: string[],
     buttonTemplate?: string,
     wrapperClass?: string,
 }) =>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -4,17 +4,19 @@ import { appendToLastElement } from 'lib/array-utils';
 export const acquisitionsEpicControlTemplate = ({
     copy: { heading = '', paragraphs, highlightedText },
     componentName,
+    epicClassNames = [],
     buttonTemplate,
-    epicClass = '',
     wrapperClass = '',
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
+    epicClassNames: [],
     buttonTemplate?: string,
-    epicClass?: string,
     wrapperClass?: string,
 }) =>
-    `<div class="contributions__epic ${epicClass}" data-component="${componentName}" data-link-name="epic">
+    `<div class="contributions__epic ${epicClassNames.join(
+        ' '
+    )}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">
             <div>
                 <h2 class="contributions__title">


### PR DESCRIPTION
## What does this change?
We want the ability to add different styling to epic test variants, and to configure this from the google doc.
This change adds a `classNames` field.

### Tested
Tested by confirming the classes are added - we don't have the designs yet.
- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
