### PR TITLE
Allow GUUI opt-out

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -112,7 +112,7 @@ object AMPPicker {
     val isSupported = features.forall({ case (test, isMet) => isMet})
     val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
-    val tier = if ((isSupported && isEnabled && isWhitelisted) || request.isGuui) RemoteRenderAMP else LocalRender
+    val tier = if ((isSupported && isEnabled && isWhitelisted && !request.guuiOptOut) || request.isGuui) RemoteRenderAMP else LocalRender
 
     tier match {
       case RemoteRenderAMP => logRequest(s"path executing in dotcomponents AMP", features, page)

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -130,7 +130,7 @@ object ArticlePicker {
     val isWhitelisted = whitelist(page.metadata.id)
     val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
 
-    val tier = if ((isSupported && isWhitelisted && isEnabled) || request.isGuui) RemoteRender else LocalRender
+    val tier = if ((isSupported && isWhitelisted && isEnabled && !request.guuiOptOut) || request.isGuui) RemoteRender else LocalRender
 
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -37,7 +37,9 @@ trait Requests {
     // parameters for moon/guui new rendering layer project.
     lazy val isGuuiJson: Boolean = isJson && isGuui
 
-    lazy val isGuui: Boolean = r.getQueryString("guui").isDefined
+    lazy val isGuui: Boolean = r.getQueryString("guui").isDefined && !r.getQueryString("guui").contains("false")
+
+    lazy val guuiOptOut: Boolean = r.getQueryString("guui").contains("false")
 
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 


### PR DESCRIPTION
by setting the guui parameter to false like so: `guui=false`.

Useful for debugging in production when GUUI is live but doesn't look quite right.
