### PR TITLE
Add optional footer to epic

### DIFF
--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -7,7 +7,8 @@ declare type AcquisitionsEpicTemplateCopy = {
     heading?: string,
     paragraphs: Array<string>,
     highlightedText?: string,
-    testimonial?: AcquisitionsEpicTestimonialCopy
+    testimonial?: AcquisitionsEpicTestimonialCopy,
+    footer?: Array<string>,
 };
 
 declare type EngagementBannerTemplateParams = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -7,10 +7,10 @@ export const epicControlGoogleDocUrl: string =
 export const bannerControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
 export const epicMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
-    ? 'https://interactive.guim.co.uk/docsdata/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
+    ? 'https://interactive.guim.co.uk/docsdata-test/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
     : 'https://interactive.guim.co.uk/docsdata/1VQ6yn2thnkFzjxIKt-AfOB_gJnX8omLNodkRyX7_Qbg.json';
 export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
-    ? 'https://interactive.guim.co.uk/docsdata/19AGJYaPL8XpchykYlzqdKqNHxrHBILFktzM8vc5iShc.json'
+    ? 'https://interactive.guim.co.uk/docsdata-test/19AGJYaPL8XpchykYlzqdKqNHxrHBILFktzM8vc5iShc.json'
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';
 
 export const getGoogleDoc = (url: string): Promise<any> =>

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -534,6 +534,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                           getLocalCurrencySymbol()
                                       )
                                     : undefined,
+                                footer: optionalSplitAndTrim(row.footer, '\n'),
                             },
                             classNames: optionalSplitAndTrim(
                                 row.classNames,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -35,12 +35,12 @@ export const acquisitionsEpicControlTemplate = ({
             ${buttonTemplate || ''}
             
             ${footer ?
-                `<div class="contributions__one-million-footer">
+                `<div class="contributions__epic-footer">
                     ${
                         footer.map(line => {
                             const firstSpaceIndex = line.trim().indexOf(' ');
-                            return `<h2><span class="one-million-blue">${line.substring(0, firstSpaceIndex)}</span>${line.substring(firstSpaceIndex)}</h2>`;
-                        })
+                            return `<h2><span class="contributions__epic-footer-blue">${line.substring(0, firstSpaceIndex)}</span>${line.substring(firstSpaceIndex)}</h2>`;
+                        }).join('')
                     }
                 </div>`
             : ''}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -34,15 +34,20 @@ export const acquisitionsEpicControlTemplate = ({
     
             ${buttonTemplate || ''}
             
-            ${footer ?
-                `<div class="contributions__epic-footer">
-                    ${
-                        footer.map(line => {
+            ${
+                footer
+                    ? `<div class="contributions__epic-footer">
+                    ${footer
+                        .map(line => {
                             const firstSpaceIndex = line.trim().indexOf(' ');
-                            return `<h2><span class="contributions__epic-footer-blue">${line.substring(0, firstSpaceIndex)}</span>${line.substring(firstSpaceIndex)}</h2>`;
-                        }).join('')
-                    }
+                            return `<h2><span class="contributions__epic-footer-blue">${line.substring(
+                                0,
+                                firstSpaceIndex
+                            )}</span>${line.substring(firstSpaceIndex)}</h2>`;
+                        })
+                        .join('')}
                 </div>`
-            : ''}
+                    : ''
+            }
         </div>
     </div>`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -1,6 +1,18 @@
 // @flow
 import { appendToLastElement } from 'lib/array-utils';
 
+const buildFooter = (footer: string[]): string =>
+    `<div class="contributions__epic-footer">
+        ${footer
+            .map(line => {
+                const firstSpaceIndex = line.trim().indexOf(' ');
+                const firstWord = line.substring(0, firstSpaceIndex);
+                const remainder = line.substring(firstSpaceIndex);
+                return `<h2><span class="contributions__epic-footer-blue">${firstWord}</span>${remainder}</h2>`;
+            })
+            .join('')}
+    </div>`;
+
 export const acquisitionsEpicControlTemplate = ({
     copy: { heading = '', paragraphs, highlightedText, footer },
     componentName,
@@ -34,20 +46,6 @@ export const acquisitionsEpicControlTemplate = ({
     
             ${buttonTemplate || ''}
             
-            ${
-                footer
-                    ? `<div class="contributions__epic-footer">
-                    ${footer
-                        .map(line => {
-                            const firstSpaceIndex = line.trim().indexOf(' ');
-                            return `<h2><span class="contributions__epic-footer-blue">${line.substring(
-                                0,
-                                firstSpaceIndex
-                            )}</span>${line.substring(firstSpaceIndex)}</h2>`;
-                        })
-                        .join('')}
-                </div>`
-                    : ''
-            }
+            ${footer ? buildFooter(footer) : ''}
         </div>
     </div>`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -8,7 +8,7 @@ const buildFooter = (footer: string[]): string =>
                 const firstSpaceIndex = line.trim().indexOf(' ');
                 const firstWord = line.substring(0, firstSpaceIndex);
                 const remainder = line.substring(firstSpaceIndex);
-                return `<h2><span class="contributions__epic-footer-blue">${firstWord}</span>${remainder}</h2>`;
+                return `<h2><span class="contributions__epic-footer--blue">${firstWord}</span>${remainder}</h2>`;
             })
             .join('')}
     </div>`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -4,12 +4,7 @@ import { appendToLastElement } from 'lib/array-utils';
 const buildFooter = (footer: string[]): string =>
     `<div class="contributions__epic-footer">
         ${footer
-            .map(line => {
-                const firstSpaceIndex = line.trim().indexOf(' ');
-                const firstWord = line.substring(0, firstSpaceIndex);
-                const remainder = line.substring(firstSpaceIndex);
-                return `<h2><span class="contributions__epic-footer--blue">${firstWord}</span>${remainder}</h2>`;
-            })
+            .map(line => `<h2>${line}</h2>`)
             .join('')}
     </div>`;
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -3,9 +3,7 @@ import { appendToLastElement } from 'lib/array-utils';
 
 const buildFooter = (footer: string[]): string =>
     `<div class="contributions__epic-footer">
-        ${footer
-            .map(line => `<h2>${line}</h2>`)
-            .join('')}
+        ${footer.map(line => `<h2>${line}</h2>`).join('')}
     </div>`;
 
 export const acquisitionsEpicControlTemplate = ({

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -2,7 +2,7 @@
 import { appendToLastElement } from 'lib/array-utils';
 
 export const acquisitionsEpicControlTemplate = ({
-    copy: { heading = '', paragraphs, highlightedText },
+    copy: { heading = '', paragraphs, highlightedText, footer },
     componentName,
     epicClassNames = [],
     buttonTemplate,
@@ -33,5 +33,16 @@ export const acquisitionsEpicControlTemplate = ({
             </div>
     
             ${buttonTemplate || ''}
+            
+            ${footer ?
+                `<div class="contributions__one-million-footer">
+                    ${
+                        footer.map(line => {
+                            const firstSpaceIndex = line.trim().indexOf(' ');
+                            return `<h2><span class="one-million-blue">${line.substring(0, firstSpaceIndex)}</span>${line.substring(firstSpaceIndex)}</h2>`;
+                        })
+                    }
+                </div>`
+            : ''}
         </div>
     </div>`;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -157,4 +157,16 @@ a[href].contributions__contribute.contributions__contribute--epic {
     max-width: 620px;
 }
 
+.contributions__epic-footer {
+    margin-top: $gs-baseline;
 
+    h2 {
+        @include fs-header(5);
+        font-size: 32px;
+        line-height: 36px;
+    }
+}
+
+.contributions__epic-footer-blue {
+    color: #00b2ff
+}

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -167,6 +167,6 @@ a[href].contributions__contribute.contributions__contribute--epic {
     }
 }
 
-.contributions__epic-footer-blue {
+.contributions__epic-footer--blue {
     color: #00b2ff
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -165,11 +165,24 @@ a[href].contributions__contribute.contributions__contribute--epic {
         font-size: 32px;
         line-height: 36px;
     }
+}
 
-    h2:nth-of-type(odd) {
-        color: #ff7f0f;
+.contributions__epic--feb {
+    $contributions__epic--feb--orange: #ff7f0f;
+    $contributions__epic--feb--blue: #041f4a;
+
+    .contributions__title {
+        color: $contributions__epic--feb--blue;
     }
-    h2:nth-of-type(even) {
-        color: #041f4a;
+
+    border-top: 1px solid $contributions__epic--feb--orange;
+
+    .contributions__epic-footer {
+        h2:nth-of-type(odd) {
+            color: $contributions__epic--feb--orange;
+        }
+        h2:nth-of-type(even) {
+            color: $contributions__epic--feb--blue;
+        }
     }
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -165,8 +165,11 @@ a[href].contributions__contribute.contributions__contribute--epic {
         font-size: 32px;
         line-height: 36px;
     }
-}
 
-.contributions__epic-footer--blue {
-    color: #00b2ff
+    h2:nth-of-type(odd) {
+        color: #ff7f0f;
+    }
+    h2:nth-of-type(even) {
+        color: #041f4a;
+    }
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -172,6 +172,9 @@ a[href].contributions__contribute.contributions__contribute--epic {
     $contributions__epic--feb--blue: #041f4a;
 
     .contributions__title {
+        @include fs-header(5);
+        font-size: 32px;
+        line-height: 36px;
         color: $contributions__epic--feb--blue;
     }
 

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -168,24 +168,24 @@ a[href].contributions__contribute.contributions__contribute--epic {
 }
 
 .contributions__epic--moment {
-    $contributions__epic--feb--orange: #ff7f0f;
-    $contributions__epic--feb--blue: #041f4a;
+    $contributions__epic--moment--orange: #ff7f0f;
+    $contributions__epic--moment--blue: #041f4a;
 
     .contributions__title {
         @include fs-header(5);
         font-size: 32px;
         line-height: 36px;
-        color: $contributions__epic--feb--blue;
+        color: $contributions__epic--moment--blue;
     }
 
-    border-top: 1px solid $contributions__epic--feb--orange;
+    border-top: 1px solid $contributions__epic--moment--orange;
 
     .contributions__epic-footer {
         h2:nth-of-type(odd) {
-            color: $contributions__epic--feb--orange;
+            color: $contributions__epic--moment--orange;
         }
         h2:nth-of-type(even) {
-            color: $contributions__epic--feb--blue;
+            color: $contributions__epic--moment--blue;
         }
     }
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -167,7 +167,7 @@ a[href].contributions__contribute.contributions__contribute--epic {
     }
 }
 
-.contributions__epic--feb {
+.contributions__epic--moment {
     $contributions__epic--feb--orange: #ff7f0f;
     $contributions__epic--feb--blue: #041f4a;
 


### PR DESCRIPTION
## What does this change?
Adds the ability to set a multi-line footer in the epic. This is set from the google doc.

Also adds a new css class for the Feb campaign, which is added to the test from the google sheet

## Screenshots
<img width="363" alt="picture 25" src="https://user-images.githubusercontent.com/1513454/52781893-97d97b80-3045-11e9-9082-07d4e15d12fa.png">




### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
