### PR TITLE
add userCohort option for engagement banner tests

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -72,7 +72,7 @@ declare type DeploymentRules = 'AlwaysAsk' | MaxViews
 declare type EpicABTest = AcquisitionsABTest & {
     campaignPrefix: string,
     useLocalViewLog: boolean,
-    onlyShowToExistingSupporters: boolean,
+    userCohort: AcquisitionsComponentUserCohort,
     pageCheck: (page: Object) => boolean,
     useTargetingTool: boolean,
     insertEvent: string,
@@ -116,7 +116,7 @@ declare type InitEpicABTest = {
     campaignPrefix?: string,
     useLocalViewLog?: boolean,
     useTargetingTool?: boolean,
-    onlyShowToExistingSupporters?: boolean,
+    userCohort?: AcquisitionsComponentUserCohort,
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -18,6 +18,8 @@ declare type EngagementBannerTemplateParams = {
     hasTicker: boolean,
 };
 
+declare type AcquisitionsComponentUserCohort = 'OnlyExistingSupporters' | 'OnlyNonSupporters' | 'Everyone';
+
 declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     campaignCode: string,
     pageviewId: string,
@@ -25,7 +27,7 @@ declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     isHardcodedFallback: boolean,
     template: (templateParams: EngagementBannerTemplateParams) => string,
     minArticlesBeforeShowingBanner: number,
-    onlyShowToExistingSupporters: boolean,
+    userCohort: AcquisitionsComponentUserCohort,
     bannerModifierClass?: string,
     abTest?: {
         name: string,
@@ -43,5 +45,5 @@ declare type EngagementBannerTestParams = {
     template?: (templateParams: EngagementBannerTemplateParams) => string,
     bannerModifierClass?: string,
     minArticlesBeforeShowingBanner?: number,
-    onlyShowToExistingSupporters?: boolean,
+    userCohort?: AcquisitionsComponentUserCohort,
 }

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -25,6 +25,7 @@ declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     isHardcodedFallback: boolean,
     template: (templateParams: EngagementBannerTemplateParams) => string,
     minArticlesBeforeShowingBanner: number,
+    onlyShowToExistingSupporters: boolean,
     bannerModifierClass?: string,
     abTest?: {
         name: string,
@@ -42,4 +43,5 @@ declare type EngagementBannerTestParams = {
     template?: (templateParams: EngagementBannerTemplateParams) => string,
     bannerModifierClass?: string,
     minArticlesBeforeShowingBanner?: number,
+    onlyShowToExistingSupporters?: boolean,
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -126,8 +126,19 @@ const isCompatibleWithLiveBlogEpic = (page: Object): boolean =>
 const pageShouldHideReaderRevenue = () =>
     config.get('page.shouldHideReaderRevenue');
 
-const isCompatibleUser = (onlyShowToExistingSupporters: boolean) =>
-    onlyShowToExistingSupporters ? userIsSupporter() : !userIsSupporter();
+const userIsInCorrectCohort = (
+    userCohort: AcquisitionsComponentUserCohort
+): boolean => {
+    switch (userCohort) {
+        case 'OnlyExistingSupporters':
+            return userIsSupporter();
+        case 'OnlyNonSupporters':
+            return !userIsSupporter();
+        case 'Everyone':
+        default:
+            return true;
+    }
+};
 
 const shouldShowEpic = (test: EpicABTest): boolean => {
     const onCompatiblePage = test.pageCheck(config.get('page'));
@@ -137,7 +148,7 @@ const shouldShowEpic = (test: EpicABTest): boolean => {
     return (
         !pageShouldHideReaderRevenue() &&
         onCompatiblePage &&
-        isCompatibleUser(test.onlyShowToExistingSupporters) &&
+        userIsInCorrectCohort(test.userCohort) &&
         tagsMatch
     );
 };
@@ -391,7 +402,7 @@ const makeEpicABTest = ({
     campaignPrefix = 'gdnwb_copts_memco',
     useLocalViewLog = false,
     useTargetingTool = false,
-    onlyShowToExistingSupporters = false,
+    userCohort = 'OnlyNonSupporters',
     pageCheck = isCompatibleWithArticleEpic,
     template = controlTemplate,
 }: InitEpicABTest): EpicABTest => {
@@ -421,7 +432,7 @@ const makeEpicABTest = ({
         campaignId,
         campaignPrefix,
         useLocalViewLog,
-        onlyShowToExistingSupporters,
+        userCohort,
         pageCheck,
         useTargetingTool,
     };
@@ -480,7 +491,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                               }),
                         ...(isThankYou
                             ? {
-                                  onlyShowToExistingSupporters: true,
+                                  userCohort: 'OnlyExistingSupporters',
                                   useLocalViewLog: true,
                               }
                             : {}),
@@ -626,5 +637,5 @@ export {
     defaultButtonTemplate,
     defaultMaxViews,
     getReaderRevenueRegion,
-    isCompatibleUser,
+    userIsInCorrectCohort,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -127,10 +127,7 @@ const pageShouldHideReaderRevenue = () =>
     config.get('page.shouldHideReaderRevenue');
 
 const isCompatibleUser = (onlyShowToExistingSupporters: boolean) =>
-    onlyShowToExistingSupporters
-        ? userIsSupporter()
-        : !userIsSupporter();
-
+    onlyShowToExistingSupporters ? userIsSupporter() : !userIsSupporter();
 
 const shouldShowEpic = (test: EpicABTest): boolean => {
     const onCompatiblePage = test.pageCheck(config.get('page'));

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -126,19 +126,21 @@ const isCompatibleWithLiveBlogEpic = (page: Object): boolean =>
 const pageShouldHideReaderRevenue = () =>
     config.get('page.shouldHideReaderRevenue');
 
+const isCompatibleUser = (onlyShowToExistingSupporters: boolean) =>
+    onlyShowToExistingSupporters
+        ? userIsSupporter()
+        : !userIsSupporter();
+
+
 const shouldShowEpic = (test: EpicABTest): boolean => {
     const onCompatiblePage = test.pageCheck(config.get('page'));
 
     const tagsMatch = doTagsMatch(test);
 
-    const isCompatibleUser = test.onlyShowToExistingSupporters
-        ? userIsSupporter()
-        : !userIsSupporter();
-
     return (
         !pageShouldHideReaderRevenue() &&
         onCompatiblePage &&
-        isCompatibleUser &&
+        isCompatibleUser(test.onlyShowToExistingSupporters) &&
         tagsMatch
     );
 };
@@ -627,4 +629,5 @@ export {
     defaultButtonTemplate,
     defaultMaxViews,
     getReaderRevenueRegion,
+    isCompatibleUser,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -50,7 +50,7 @@ const getAcquisitionsBannerParams = (
         isHardcodedFallback: false,
         template: acquisitionsBannerControlTemplate,
         minArticlesBeforeShowingBanner: 3,
-        onlyShowToExistingSupporters: false,
+        userCohort: 'OnlyNonSupporters',
     };
 };
 
@@ -84,6 +84,6 @@ export const getControlEngagementBannerParams = (): Promise<
                 isHardcodedFallback: true,
                 template: acquisitionsBannerControlTemplate,
                 minArticlesBeforeShowingBanner: 3,
-                onlyShowToExistingSupporters: false,
+                userCohort: 'OnlyNonSupporters',
             };
         });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -50,6 +50,7 @@ const getAcquisitionsBannerParams = (
         isHardcodedFallback: false,
         template: acquisitionsBannerControlTemplate,
         minArticlesBeforeShowingBanner: 3,
+        onlyShowToExistingSupporters: false,
     };
 };
 
@@ -83,5 +84,6 @@ export const getControlEngagementBannerParams = (): Promise<
                 isHardcodedFallback: true,
                 template: acquisitionsBannerControlTemplate,
                 minArticlesBeforeShowingBanner: 3,
+                onlyShowToExistingSupporters: false,
             };
         });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -206,11 +206,13 @@ const canShow = (): Promise<boolean> => {
             getVisitCount() >= params.minArticlesBeforeShowingBanner;
         const userAlreadyGivesUsMoney = userIsSupporter();
         const bannerIsBlockedForEditorialReasons = pageShouldHideReaderRevenue();
+        const showBecauseUserAlreadyGivesUsMoney = userAlreadyGivesUsMoney && params.onlyShowToExistingSupporters === true;
+        const showBecauseUserDoesNotAlreadyGiveUsMoney = !userAlreadyGivesUsMoney && params.onlyShowToExistingSupporters === false;
 
         if (
             userHasSeenEnoughArticles &&
-            !userAlreadyGivesUsMoney &&
-            !bannerIsBlockedForEditorialReasons
+            !bannerIsBlockedForEditorialReasons &&
+            (showBecauseUserAlreadyGivesUsMoney || showBecauseUserDoesNotAlreadyGiveUsMoney)
         ) {
             const userLastClosedBannerAt = userPrefs.get(lastClosedAtKey);
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -9,7 +9,7 @@ import {
     type ReaderRevenueRegion,
     pageShouldHideReaderRevenue,
     getReaderRevenueRegion,
-    isCompatibleUser
+    isCompatibleUser,
 } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import bean from 'bean';

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -206,13 +206,18 @@ const canShow = (): Promise<boolean> => {
             getVisitCount() >= params.minArticlesBeforeShowingBanner;
         const userAlreadyGivesUsMoney = userIsSupporter();
         const bannerIsBlockedForEditorialReasons = pageShouldHideReaderRevenue();
-        const showBecauseUserAlreadyGivesUsMoney = userAlreadyGivesUsMoney && params.onlyShowToExistingSupporters === true;
-        const showBecauseUserDoesNotAlreadyGiveUsMoney = !userAlreadyGivesUsMoney && params.onlyShowToExistingSupporters === false;
+        const showBecauseUserAlreadyGivesUsMoney =
+            userAlreadyGivesUsMoney &&
+            params.onlyShowToExistingSupporters === true;
+        const showBecauseUserDoesNotAlreadyGiveUsMoney =
+            !userAlreadyGivesUsMoney &&
+            params.onlyShowToExistingSupporters === false;
 
         if (
             userHasSeenEnoughArticles &&
             !bannerIsBlockedForEditorialReasons &&
-            (showBecauseUserAlreadyGivesUsMoney || showBecauseUserDoesNotAlreadyGiveUsMoney)
+            (showBecauseUserAlreadyGivesUsMoney ||
+                showBecauseUserDoesNotAlreadyGiveUsMoney)
         ) {
             const userLastClosedBannerAt = userPrefs.get(lastClosedAtKey);
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -9,8 +9,8 @@ import {
     type ReaderRevenueRegion,
     pageShouldHideReaderRevenue,
     getReaderRevenueRegion,
+    isCompatibleUser
 } from 'common/modules/commercial/contributions-utilities';
-import { userIsSupporter } from 'common/modules/commercial/user-features';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import bean from 'bean';
 import fetchJson from 'lib/fetch-json';
@@ -204,20 +204,12 @@ const canShow = (): Promise<boolean> => {
     return getBannerParams().then(params => {
         const userHasSeenEnoughArticles: boolean =
             getVisitCount() >= params.minArticlesBeforeShowingBanner;
-        const userAlreadyGivesUsMoney = userIsSupporter();
         const bannerIsBlockedForEditorialReasons = pageShouldHideReaderRevenue();
-        const showBecauseUserAlreadyGivesUsMoney =
-            userAlreadyGivesUsMoney &&
-            params.onlyShowToExistingSupporters === true;
-        const showBecauseUserDoesNotAlreadyGiveUsMoney =
-            !userAlreadyGivesUsMoney &&
-            params.onlyShowToExistingSupporters === false;
 
         if (
             userHasSeenEnoughArticles &&
             !bannerIsBlockedForEditorialReasons &&
-            (showBecauseUserAlreadyGivesUsMoney ||
-                showBecauseUserDoesNotAlreadyGiveUsMoney)
+            isCompatibleUser(params.onlyShowToExistingSupporters)
         ) {
             const userLastClosedBannerAt = userPrefs.get(lastClosedAtKey);
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -9,7 +9,7 @@ import {
     type ReaderRevenueRegion,
     pageShouldHideReaderRevenue,
     getReaderRevenueRegion,
-    isCompatibleUser,
+    userIsInCorrectCohort,
 } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import bean from 'bean';
@@ -209,7 +209,7 @@ const canShow = (): Promise<boolean> => {
         if (
             userHasSeenEnoughArticles &&
             !bannerIsBlockedForEditorialReasons &&
-            isCompatibleUser(params.onlyShowToExistingSupporters)
+            userIsInCorrectCohort(params.userCohort)
         ) {
             const userLastClosedBannerAt = userPrefs.get(lastClosedAtKey);
 


### PR DESCRIPTION
## What does this change?
We want the ability to create a banner test which will only display to existing supporters. This PR adds this functionality.