### PR TITLE
Warn if page has hide reader revenue set

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -18,12 +18,20 @@ import {
     incrementMvtCookie,
 } from 'common/modules/analytics/mvt-cookie';
 import { setGeolocation, getSync as geolocationGetSync } from 'lib/geolocation';
+import config from 'lib/config';
 import { clearParticipations } from 'common/modules/experiments/ab-local-storage';
 import { COOKIE_NAME as CONSENT_COOKIE_NAME } from 'commercial/modules/cmp/cmp-env';
+import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
+import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const clearCommonReaderRevenueStateAndReload = (
     asExistingSupporter: boolean
 ): void => {
+    if (pageShouldHideReaderRevenue()) {
+        alert('This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page');
+        return;
+    }
+
     readerRevenueRelevantCookies.forEach(cookie => removeCookie(cookie));
 
     initMvtCookie();
@@ -66,6 +74,16 @@ const showMeTheEpic = (asExistingSupporter: boolean = false): void => {
 };
 
 const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
+    if (!config.get('switches.membershipEngagementBanner')) {
+        alert('Membership engagement banner switch is turned off on the dotcom switchboard');
+        return;
+    }
+
+    if (isBlocked()) {
+        alert('Banner is blocked by a switch in the dotcom switchboard');
+        return;
+    }
+
     clearBannerHistory();
 
     // The banner only displays after a certain number of pageviews. So let's get there quick!

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -28,7 +28,9 @@ const clearCommonReaderRevenueStateAndReload = (
     asExistingSupporter: boolean
 ): void => {
     if (pageShouldHideReaderRevenue()) {
-        alert('This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page');
+        alert(
+            'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page'
+        );
         return;
     }
 
@@ -75,7 +77,9 @@ const showMeTheEpic = (asExistingSupporter: boolean = false): void => {
 
 const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
     if (!config.get('switches.membershipEngagementBanner')) {
-        alert('Membership engagement banner switch is turned off on the dotcom switchboard');
+        alert(
+            'Membership engagement banner switch is turned off on the dotcom switchboard'
+        );
         return;
     }
 


### PR DESCRIPTION
When using the bookmarklets, if a switch or editorial flag will prevent the thing showing on this page, tell the user, as these are not dependent on localStorage or cookie state and can't be overriden by the bookmarklets.