### PR TITLE
Extra safety for epic tests

### DIFF
--- a/static/src/javascripts/lib/array-utils.js
+++ b/static/src/javascripts/lib/array-utils.js
@@ -13,3 +13,11 @@ export const appendToLastElement = (
                 ? `${element}${stringToAppend}`
                 : element
     );
+
+export const throwIfEmptyArray = (name: string, array: ?any[]): any[] => {
+    if (Array.isArray(array) && array.length > 0) {
+        return array;
+    }
+
+    throw new Error(`${name} is empty`);
+};

--- a/static/src/javascripts/lib/array-utils.js
+++ b/static/src/javascripts/lib/array-utils.js
@@ -14,7 +14,7 @@ export const appendToLastElement = (
                 : element
     );
 
-export const throwIfEmptyArray = (name: string, array: ?any[]): any[] => {
+export const throwIfEmptyArray = (name: string, array: ?(any[])): any[] => {
     if (Array.isArray(array) && array.length > 0) {
         return array;
     }

--- a/static/src/javascripts/lib/string-utils.js
+++ b/static/src/javascripts/lib/string-utils.js
@@ -15,3 +15,11 @@ export const optionalSplitAndTrim = (
 
 export const optionalStringToBoolean = (str: ?string): boolean =>
     typeof str === 'string' ? str.toLowerCase().trim() === 'true' : false;
+
+export const throwIfEmptyString = (name: string, str: ?string): string => {
+    if (typeof str === 'string' && str.trim().length > 0) {
+        return str;
+    }
+
+    throw new Error(`${name} is empty`);
+};

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -528,8 +528,14 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 ','
                             ),
                             copy: {
-                                heading: throwIfEmptyString('heading', row.heading),
-                                paragraphs: throwIfEmptyArray('paragraphs', splitAndTrim(row.paragraphs, '\n')),
+                                heading: throwIfEmptyString(
+                                    'heading',
+                                    row.heading
+                                ),
+                                paragraphs: throwIfEmptyArray(
+                                    'paragraphs',
+                                    splitAndTrim(row.paragraphs, '\n')
+                                ),
                                 highlightedText: row.highlightedText
                                     ? row.highlightedText.replace(
                                           /%%CURRENCY_SYMBOL%%/g,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -24,7 +24,9 @@ import {
     splitAndTrim,
     optionalSplitAndTrim,
     optionalStringToBoolean,
+    throwIfEmptyString,
 } from 'lib/string-utils';
+import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
@@ -526,8 +528,8 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 ','
                             ),
                             copy: {
-                                heading: row.heading,
-                                paragraphs: splitAndTrim(row.paragraphs, '\n'),
+                                heading: throwIfEmptyString('heading', row.heading),
+                                paragraphs: throwIfEmptyArray('paragraphs', splitAndTrim(row.paragraphs, '\n')),
                                 highlightedText: row.highlightedText
                                     ? row.highlightedText.replace(
                                           /%%CURRENCY_SYMBOL%%/g,


### PR DESCRIPTION
At the suggestion of @jessewilkins, let's just make sure that `heading` and `paragraphs` have something in them - to avoid accidentally displaying an empty epic

The `.catch()` in the promise will handle these and log to sentry