### PR TITLE
Use countryGroupId for targeting epics

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -19,7 +19,7 @@ declare type Variant = {
 
 declare type EpicVariant = Variant & {
     // filters, where empty is taken to mean 'all', multiple entries are combined with OR
-    locations: string[],
+    countryGroups: string[],
     tagIds: string[],
     sections: string[],
     excludedTagIds: string[],
@@ -84,7 +84,7 @@ declare type InitEpicABTestVariant = {
     products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, abTest: ABTest) => void,
     deploymentRules?: DeploymentRules,
-    locations?: string[],
+    countryGroups?: string[],
     tagIds?: string[],
     sections?: string[],
     excludedTagIds?: string[],


### PR DESCRIPTION
## What does this change?
Currently the `locations` field in the epic google sheet is compared against the user's country.
It is more useful to use the broader countryGroup.

NOTE - update any uses of `locations` in the LIVE sheet when deploying

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
