### PR TITLE
Remove SkyScraper from RHS slot, fix label and change a classname

### DIFF
--- a/article/app/views/fragments/articleAsideSlot.scala.html
+++ b/article/app/views/fragments/articleAsideSlot.scala.html
@@ -12,7 +12,7 @@
   @fragments.commercial.adSlot(
       "right",
       Seq("mpu-banner-ad"),
-      Map("mobile" -> (Seq("1,1", "2,2", "160,600", "300,250", "300,274", "300,600", "fluid") ++ articleAsideOptionalSizes)),
+      Map("mobile" -> (Seq("1,1", "2,2", "300,250", "300,274", "300,600", "fluid") ++ articleAsideOptionalSizes)),
       optClassNames = if (isSticky) Some("js-sticky-mpu") else None
       ){ }
   </div>

--- a/article/app/views/fragments/articleAsideSlot.scala.html
+++ b/article/app/views/fragments/articleAsideSlot.scala.html
@@ -8,7 +8,7 @@
 @import conf.switches.Switches.CommercialSwitch
 
 @if(CommercialSwitch.isSwitchedOn && shouldShowAds) {
-  <div class="ad-slot-container" aria-hidden="true">
+  <div class="aside-slot-container" aria-hidden="true">
   @fragments.commercial.adSlot(
       "right",
       Seq("mpu-banner-ad"),

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -225,7 +225,7 @@ import collection.JavaConverters._
 
         Then("The article-aside MPU should have the correct sizes")
           adSlotRight.id should be("dfp-ad--right")
-          adSlotRight.attribute("data-mobile") should be("1,1|2,2|160,600|300,250|300,274|300,600|fluid")
+          adSlotRight.attribute("data-mobile") should be("1,1|2,2|300,250|300,274|300,600|fluid")
       }
 
       Given("I am on an article entitled '10 of the best things to do in Tallinn'")
@@ -237,7 +237,7 @@ import collection.JavaConverters._
 
         Then("The article-aside MPU should have the correct sizes")
           adSlotRight.id should be("dfp-ad--right")
-          adSlotRight.attribute("data-mobile") should be("1,1|2,2|160,600|300,250|300,274|300,600|fluid|300,1050")
+          adSlotRight.attribute("data-mobile") should be("1,1|2,2|300,250|300,274|300,600|fluid|300,1050")
       }
 
       Given("I am on an immersive article, entitled 'Health insurance woes helped elect Trump, but his cure may be more painful'")

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -9,7 +9,7 @@ const minArticleHeight: number = 1300;
 
 const calculateAllowedAdSlots = (availableSpace: number): string => {
     if (availableSpace > 600) {
-        return '1,1|2,2|160,600|300,250|300,274|300,600|fluid';
+        return '1,1|2,2|300,250|300,274|300,600|fluid';
     } else if (availableSpace > 274) {
         return '1,1|2,2|300,250|300,274';
     } else if (availableSpace > 250) {

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -83,7 +83,7 @@ describe('Standard Article Aside Adverts', () => {
     const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
-            <div class="ad-slot-container">
+            <div class="aside-slot-container">
                 <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>
@@ -131,7 +131,7 @@ describe('Immersive Article Aside Adverts', () => {
             <figure class="element element--immersive"></figure>
         </div>
         <div class="content__secondary-column js-secondary-column">
-            <div class="ad-slot-container">
+            <div class="aside-slot-container">
                 <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>
@@ -188,7 +188,7 @@ describe('Immersive Article (no immersive elements) Aside Adverts', () => {
     const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
-            <div class="ad-slot-container">
+            <div class="aside-slot-container">
                 <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -84,7 +84,7 @@ describe('Standard Article Aside Adverts', () => {
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
             <div class="aside-slot-container">
-                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
+                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>
     `;
@@ -103,7 +103,7 @@ describe('Standard Article Aside Adverts', () => {
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
-                '1,1|2,2|160,600|300,250|300,274|300,600|fluid'
+                '1,1|2,2|300,250|300,274|300,600|fluid'
             );
             done();
         });
@@ -132,7 +132,7 @@ describe('Immersive Article Aside Adverts', () => {
         </div>
         <div class="content__secondary-column js-secondary-column">
             <div class="aside-slot-container">
-                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
+                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>
     `;
@@ -154,7 +154,6 @@ describe('Immersive Article Aside Adverts', () => {
             const sizes = adSlot.getAttribute('data-mobile').split('|');
             expect(sizes).toContain('1,1');
             expect(sizes).toContain('2,2');
-            expect(sizes).toContain('160,600');
             expect(sizes).toContain('300,250');
             expect(sizes).toContain('300,274');
             expect(sizes).toContain('300,600');
@@ -174,7 +173,6 @@ describe('Immersive Article Aside Adverts', () => {
             expect(sizes).toContain('1,1');
             expect(sizes).toContain('2,2');
             expect(sizes).toContain('300,250');
-            expect(sizes).not.toContain('160,600');
             expect(sizes).not.toContain('300,274');
             expect(sizes).not.toContain('300,600');
             expect(sizes).not.toContain('fluid');
@@ -189,7 +187,7 @@ describe('Immersive Article (no immersive elements) Aside Adverts', () => {
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
             <div class="aside-slot-container">
-                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>
+                <div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>
             </div>
         </div>
     `;
@@ -202,7 +200,7 @@ describe('Immersive Article (no immersive elements) Aside Adverts', () => {
         mediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
-                '1,1|2,2|160,600|300,250|300,274|300,600|fluid'
+                '1,1|2,2|300,250|300,274|300,600|fluid'
             );
             done();
         });

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -30,7 +30,7 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
     const commonSlots: Array<PrebidSlot> = [
         {
             key: 'right',
-            sizes: [[160, 600], [300, 600], [300, 250]],
+            sizes: [[300, 600], [300, 250]],
         },
         {
             key: 'inline1',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -32,7 +32,7 @@ describe('getSlots', () => {
         expect(getSlots('Article')).toEqual([
             {
                 key: 'right',
-                sizes: [[160, 600], [300, 600], [300, 250]],
+                sizes: [[300, 600], [300, 250]],
             },
             {
                 key: 'inline1',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -58,7 +58,7 @@ describe('getSlots', () => {
         expect(getSlots('Article')).toEqual([
             {
                 key: 'right',
-                sizes: [[160, 600], [300, 600], [300, 250]],
+                sizes: [[300, 600], [300, 250]],
             },
             {
                 key: 'inline1',

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -28,7 +28,7 @@ describe('Sticky MPU', () => {
         jest.resetAllMocks();
 
         if (document.body) {
-            document.body.innerHTML = `${domSnippet}<div class="ad-slot-container" aria-hidden="true">${adSlotRight}</div>`;
+            document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotRight}</div>`;
         }
     });
 
@@ -53,7 +53,7 @@ describe('Sticky MPU', () => {
         };
         mediator.once('page:commercial:sticky-mpu', () => {
             const container: HTMLElement = (document.querySelector(
-                '.ad-slot-container'
+                '.aside-slot-container'
             ): any);
             expect(container.style.height).toBe('8000px');
             done();
@@ -74,7 +74,7 @@ describe('Sticky Comments MPU', () => {
         jest.resetAllMocks();
 
         if (document.body) {
-            document.body.innerHTML = `${domSnippet}<div class="ad-slot-container" aria-hidden="true">${adSlotComments}</div>`;
+            document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotComments}</div>`;
         }
     });
 
@@ -99,7 +99,7 @@ describe('Sticky Comments MPU', () => {
         };
         mediator.once('page:commercial:sticky-comments-mpu', () => {
             const container: HTMLElement = (document.querySelector(
-                '.ad-slot-container'
+                '.aside-slot-container'
             ): any);
             expect(container.style.height).toBe('10000px');
             done();

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -22,7 +22,7 @@ describe('Sticky MPU', () => {
     `;
 
     const adSlotRight: string =
-        '<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right" data-name="right" data-mobile="1,1|2,2|160,600|300,250|300,274|300,600|fluid"></div>';
+        '<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
 
     beforeEach(() => {
         jest.resetAllMocks();

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -11,15 +11,17 @@
 /* Ad slots with sticky MPUs should be vertically separated from the following content, but collapse if empty.
  * Margins on children don't affect the position of elements we make sticky.
  */
-.ad-slot-container > :last-child {
+.aside-slot-container > :last-child {
     padding-bottom: 0;
     margin-bottom: $gs-baseline * 2;
 }
+
 .ad-slot--dark {
     background-color: lighten($brightness-7,  2.5%);
 }
 
-.ad-slot--right, .ad-slot--comments {
+.ad-slot--right,
+.ad-slot--comments {
     position: sticky;
     top: 0;
 
@@ -30,12 +32,6 @@
 
     &.is-sticky {
         width: 300px;
-    }
-}
-
-.ad-slot--sky {
-    &.ad-slot--comments, &.ad-slot--right {
-        width: $mpu-skyscraper-width;
     }
 }
 
@@ -55,6 +51,10 @@
         color: $brightness-86;
         border-top-color: $brightness-20;
         background-color: transparent;
+    }
+
+    .ad-slot--sky & {
+        width: $mpu-skyscraper-width;
     }
 }
 


### PR DESCRIPTION
## What does this change?

#### 👉 Remove SkyScraper from RHS slot

The resizing of this slot is behaving oddly at times, so when the slot refreshes from an MPU to a SkyScraper it can cause the SkyScraper to overlap the MostViewed container and when the slot refresher from a SkyScraper to an MPU/DMPU it can cause half the slot to be obscured.

#### 👉 Fix the width of the advert label when a SkyScraper present

This allows us to rely on a parent selector to set the width of the ad-label if the adslot loads a skyscraper. I think the sass was generating different css than we were expecting, which is why the styles were not getting applied previously.

#### 👉 Change the classname of the container surrounding the RHS slot

This is to support upcoming work with Reader Revenue. Ask `Dumathoin` and `Vergagain` for more information 😉 

## Screenshots

#### Odd width of MPU when it loads after a SkyScraper:

<img width="1321" alt="screen shot 2019-02-13 at 10 43 19" src="https://user-images.githubusercontent.com/8607683/52730583-a6775280-2fb3-11e9-8db5-08c16b145b16.png">

#### SkyScraper overlapping other elements when it loads after a MPU:

![image](https://user-images.githubusercontent.com/8607683/52730457-4da7ba00-2fb3-11e9-994c-5815fafb62cd.png)


## What is the value of this and can you measure success?

- Commercial BAU
- Bug fixes
- Reader revenue BAU

## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] On CODE
