### PR TITLE
Fix mobile outstream square format

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -306,8 +306,7 @@
 
     @include mq(mobile) {
         width: 300px;
-        height: 221px;
-        min-height: 221px;
+        height: auto;
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
This fixes a problem where ad was overlapping following content.

Before:

![image](https://user-images.githubusercontent.com/1722550/52791502-00822180-3061-11e9-8dc4-eedced3041b7.png)

After:

![image](https://user-images.githubusercontent.com/1722550/52791567-2c9da280-3061-11e9-8782-2a965d7816ae.png)

Thanks to @katebee and @frankie297 for the solution!
