### PR TITLE
Add skyscraper size to inline slots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -112,7 +112,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minBelow: 600,
             },
         },
-        filter: filterNearbyCandidates(adSizes.halfPage.height),
+        filter: (candidate: SpacefinderItem) => {
+            filterNearbyCandidates(adSizes.halfPage.height)(candidate) && filterNearbyCandidates(adSizes.skyscraper.height)(candidate)
+        },
     };
 
     const rules = isInline1 ? defaultRules : relaxedRules;
@@ -128,7 +130,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                     `inline${inlineId}`,
                     'inline',
                     `inline${isInline1 ? '' : ' offset-right'}`,
-                    isInline1 ? null : { desktop: [adSizes.halfPage] }
+                    isInline1 ? null : { desktop: [adSizes.halfPage, adSizes.skyscraper] }
                 );
             });
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -128,7 +128,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                     `inline${inlineId}`,
                     'inline',
                     `inline${isInline1 ? '' : ' offset-right'}`,
-                    isInline1 ? null : { desktop: [adSizes.halfPage, adSizes.skyscraper] }
+                    isInline1
+                        ? null
+                        : { desktop: [adSizes.halfPage, adSizes.skyscraper] }
                 );
             });
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -112,9 +112,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minBelow: 600,
             },
         },
-        filter: (candidate: SpacefinderItem) => {
-            filterNearbyCandidates(adSizes.halfPage.height)(candidate) && filterNearbyCandidates(adSizes.skyscraper.height)(candidate)
-        },
+        filter: filterNearbyCandidates(adSizes.halfPage.height),
     };
 
     const rules = isInline1 ? defaultRules : relaxedRules;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -499,6 +499,10 @@
     @include mq(wide) {
         margin-right: -400px;
     }
+    &.ad-slot--sky {
+        width: $mpu-skyscraper-width;
+        min-width: $mpu-skyscraper-width;
+    }
 }
 
 .ad-slot--survey {


### PR DESCRIPTION
## What does this change?
Add's the skyscraper size to all right hand inline slots (not inline 1)
## Screenshots
![picture 247](https://user-images.githubusercontent.com/19835654/52795916-b867fc80-306a-11e9-9805-0433e0a3394a.png)
## What is the value of this and can you measure success?
BAU
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
