### PR TITLE
Give the RHS slot the default background colour

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -214,6 +214,8 @@
         }
     }
 }
+
+.ad-slot--right,
 .ad-slot--inline,
 .ad-slot--container-inline {
     background-color: $brightness-97;


### PR DESCRIPTION
## What does this change?

Currently the RHS slot has no background colour, although the inline and mostpop slots do.

This PR adds the same grey background to the RHS slot.

## Screenshots

#### 👇 Here is the existing inline1 with the background showing 👇 

<img width="1237" alt="screen shot 2019-02-14 at 13 45 25" src="https://user-images.githubusercontent.com/8607683/52852047-7c3aa780-310f-11e9-9ea2-322b73496d28.png">

#### 👇 Here is the updated background on the RHS slot 👇 

<img width="1328" alt="screen shot 2019-02-15 at 10 52 29" src="https://user-images.githubusercontent.com/8607683/52853293-151ef200-3113-11e9-9558-2c6b31cf796c.png">

## What is the value of this and can you measure success?

- Consistency with other slots

- We can load other components behind the slot

The background ensures that while the advert is loading or when the advert refreshes there is no flicker of the content behind.

We can then potentially use this space for site messaging. More details in [the documentation](https://docs.google.com/document/d/1u5JxXq4JJ4yMkvCnxIEJGWJwoY-I6H1PPKOlK251Vks/edit?usp=sharing) and in this old PoC: https://github.com/guardian/frontend/pull/16567

FYI @frankie297 this will complicate adding the SkyScraper to the RHS slot.

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

### Does this change break ad-free?

😈😈

Not really! 😇😇

### Accessibility test checklist

adslots have all have `aria-hidden="true"` so screenreaders ignore them 👍 

### Tested

- [x] Locally
