### PR TITLE
Make amp+article picker aware of paid-for content

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -15,6 +15,10 @@ object AMPPageChecks extends Logging {
       !page.item.isPhotoEssay
   }
 
+  def isNotPaidContent(page: PageWithStoryPackage): Boolean = {
+    ! page.article.tags.isPaidContent
+  }
+
   def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
     // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/amp/components/lib/Elements.tsx
     def supported(block: BlockElement): Boolean = block match {
@@ -114,6 +118,7 @@ object AMPPicker {
       ("isBasicArticle", AMPPageChecks.isBasicArticle(page)),
       ("hasOnlySupportedElements", AMPPageChecks.hasOnlySupportedElements(page)),
       ("isNotOpinionP", AMPPageChecks.isNotOpinion(page)),
+      ("isNotPaidContent", AMPPageChecks.isNotOpinion(page)),
     )
   }
 

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -53,6 +53,9 @@ object ArticlePageChecks {
   def isNotAMP(request: RequestHeader): Boolean = ! request.isAmp
 
   def isNotOpinion(page:PageWithStoryPackage): Boolean = ! page.item.tags.isComment
+
+  def isNotPaidContent(page: PageWithStoryPackage): Boolean = ! page.article.tags.isPaidContent
+
 }
 
 object ArticlePicker {
@@ -119,7 +122,8 @@ object ArticlePicker {
       ("isNotAReview", ArticlePageChecks.isNotAReview(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
-      ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page))
+      ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page)),
+      ("isNotPaidContent", ArticlePageChecks.isNotOpinion(page)),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Paid-for/labs content has special styling and should not be allowed under the dotcom rendering picker

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
