### PR TITLE
Titlepiece font loaded on the engagement banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
@@ -15,11 +15,19 @@ export const acquisitionsBannerFivTemplate = (
                 ${closeCentralIcon.markup}
             </button>
         </div>
-        <div class="fiv-banner__headline">${
+        ${
             params.titles
-                ? `${params.titles[0]} THEN ${params.titles[1]}`
-                : 'NOPE'
-        }</div>
+                ? `<div class="fiv-banner__headline">
+            <div class="fiv-banner__headline1">
+    ${params.titles[0]}
+            </div>
+            <div class="fiv-banner__headline2">
+                ${params.titles[1]}
+            </div>
+        </div>`
+                : ''
+        }
+
         <div class="fiv-banner__circles">
             <div class="fiv-banner__circle fiv-banner__circle1"></div>
             <div class="fiv-banner__circle fiv-banner__circle2 fiv-banner__circle2-clear"></div>

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -1,3 +1,24 @@
+@font-face {
+    font-family: "GT Guardian Titlepiece";
+    src:
+        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2") format("woff2"),
+        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff") format("woff"),
+        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf") format("ttf");
+    font-weight: 400;
+}
+
+.fiv-banner__headline {
+    font-size: 48px;
+    line-height: 0.9;
+    font-family: "GT Guardian Titlepiece", Georgia, serif;
+}
+.fiv-banner__headline1 {
+    color: #ef7d21;
+}
+.fiv-banner__headline2 {
+    color: #0084c6;
+}
+
 .site-message--fiv-banner {
     background-color: #ece4d9;
 }

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -1,16 +1,16 @@
 @font-face {
-    font-family: "GT Guardian Titlepiece";
+    font-family: 'GT Guardian Titlepiece';
     src:
-        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2") format("woff2"),
-        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff") format("woff"),
-        url("//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf") format("ttf");
+    url('//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+    url('//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff') format('woff'),
+    url('//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf') format('ttf');
     font-weight: 400;
 }
 
 .fiv-banner__headline {
     font-size: 48px;
-    line-height: 0.9;
-    font-family: "GT Guardian Titlepiece", Georgia, serif;
+    line-height: .9;
+    font-family: 'GT Guardian Titlepiece', Georgia, serif;
 }
 .fiv-banner__headline1 {
     color: #ef7d21;


### PR DESCRIPTION
## What does this change?
This puts the font in a way that shouldn't download it for everyone as it doesn't use the standard method.  I think this is the best method after @jranks123 discussed with @paperboyo and @GHaberis (if I understood right)
I stole some stuff from @jesseyuen and @walaura  to get the result, based on @ionamckendrick pointing me at the right example in https://support.theguardian.com/uk/subscribe/paper which I think I copied correctly
## Screenshots
Colour should be ok but the wrapping isn't implemented (yet) and the diffferent size per breakpoint
![image](https://user-images.githubusercontent.com/7304387/52869358-6643db80-313d-11e9-805e-83cef4e70bc3.png)

