### PR TITLE
ATOMS: Font problem, scss variables not assigned a value

### DIFF
--- a/static/src/stylesheets/atoms/vars.scss
+++ b/static/src/stylesheets/atoms/vars.scss
@@ -3,16 +3,14 @@
 /* in the CSS provided by the atom library                                  */
 /* ************************************************************************ */
 
-@import '../_vars';
-@import '../pasteup/typography/src';
+// The below code is used to give values to the CSS variables coming from Atom-Renderer.
+// They are the same as in the pasteup library below. But they cannot be added from there,
+// as the sass-loader does not import the pasteup dependency in time for the variables to have a value.
+// Please see the PR for more information
+//@import '../pasteup/typography/src';
 
 :root {
-    --f-serif-text: $f-serif-text;
-    --f-serif-headline: $f-serif-headline;
-    --f-sans-serif-text: $f-sans-serif-text;
-    --c-pillar-news: $news-main;
-    --c-pillar-arts: $culture-main;
-    --c-pillar-opinion: $opinion-main;
-    --c-pillar-lifestyle: $lifestyle-main;
-    --c-pillar-sport: $sport-main;
+    --f-serif-text: 'Guardian Text Egyptian Web', Georgia, serif;
+    --f-serif-headline: 'Guardian Egyptian Web', Georgia, serif;
+    --f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }


### PR DESCRIPTION
Okay. You're not going to like this, but.....

**The problem:**
Scss variables in Atom stylesheets were not being assigned a value. They simply turned up as a strings eg `$f-serif-headline` which the browser then ignores, reverting to default font. 

![screen shot 2019-02-05 at 17 43 50](https://user-images.githubusercontent.com/10324129/52881657-14ab4900-315d-11e9-8755-5968e9c71e9a.png)

Simon helpfully outlined the problem [in a google doc
](https://docs.google.com/document/d/1cBc2Tl3sq3uxpjamMaj830JC2TJIwZruS7BxZPMQ2Lc/edit#)

**Why I have gone for this solution**

* Changes in Atom-Renderer made no difference, the problem was very clearly in the sass-loader in the webpack config of frontend. In the `vars.scss` file below, the variables were arriving and getting prepended to the atom css files, but they were never given an actual value. 

* It wasn't directly a problem with the imports in the `vars.scss` file. Even if the value was pasted right above the CSS rules, it didn't work. 
```
 $f-serif-text: 'Guardian Text Egyptian Web', Georgia, serif;
:root {
    --f-serif-text: $f-serif-text;
}
```

* The various requires in the webpack.config are confusing, but I pasted all the webpack config in the main webpack config file, and it worked the same way. This isn't a problem with bits of webpack config getting lost. 

* The key problem that I can see is that more recent versions of `sass-loader` ( from v5.0 on) work asynchronously. You can't ask it to process synchronously. We are using v7.+.

Someone raised the exact same issue here: https://github.com/webpack-contrib/sass-loader/issues/483

The async processing means that it has appended the css code below to the top of all the atom CSS files before it has had time to import and assign the SCSS variables. 

This would explain why we're not seeing a sass error - there's no attempt to parse the variables that fails, by the time it's in a css file it's not interpreted as sass and so doesn't get parsed as a sass variable. 

More information on how we are adding environment variables to sass-loader  with the `options: { data : xxx})` configuration [can be found here](https://github.com/webpack-contrib/sass-loader#environment-variables). 

**Alternative solutions and why I didn't go for them** 
The creators of Sass-Loader came up with 3 different solutions: 

1) Add the sass variables directly to all the files that need them 
-> these are in a separate library Atom-Renderer so we can't do that

2) Write your own Css Loader that can be run in front of `sass-loader` and assign the scss variables before it gets there. 
-> this seemed like too much effort for this small font problem 

3) Import a new dependency to Frontend, [get sass vars](https://github.com/niksy/get-sass-vars) that can convert Scss variables to JSON that can then be fed into `sass-loader`.
-> I was reluctant to do this because it would add bloat to frontend, again for a very small use case. 

--> Let me know if you have different opinions on these options. 

**Reasons I made this choice**

a) easy to read
b) works 
c) doesn't add extra code /libraries 
d) when Zef changed fonts last time he did a find and replace so I imagine he would do the same again when we need to change fonts next time. 

## What is the value of this and can you measure success?

The font will be right and designers will be happy. 

## Checklist

### Tested

- [x ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
