### PR TITLE
Check if we're validating dotComponents

### DIFF
--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -20,7 +20,7 @@ const fetch = options => {
                 const errorMessage = `Unable to fetch ${options.endpoint}`;
 
                 request(
-                    `${options.host + options.endpoint}?amp`,
+                    `${options.host + options.endpoint}`,
                     (error, resp, body) => {
                         if (error || resp.statusCode !== 200) {
                             const errorDetails = error ? error.message : '';
@@ -37,7 +37,7 @@ const fetch = options => {
                                 )
                             );
                         } else {
-                            resolve(body);
+                            resolve({ resp, body });
                         }
                     }
                 );

--- a/tools/amp-validation/top-traffic.js
+++ b/tools/amp-validation/top-traffic.js
@@ -1,7 +1,27 @@
 const { fetch, getEndpointsFromResponse } = require('./endpoints/ophan');
 const run = require('./run');
 
-const sections = ['music', 'football', 'sport'];
+const sections = [
+    'technology',
+    'lifeandstyle',
+    'money',
+    'travel',
+    'education',
+    'politics',
+    'science',
+    'media',
+    'music',
+    'football',
+    'sport',
+    'games',
+    'stage',
+    'artanddesign',
+    'film',
+    'books',
+    'business',
+    'society',
+    'environment',
+];
 const keywordTags = ['info%2Fseries%2Fdigital-blog'];
 const fetchPath = path => fetch(path).then(getEndpointsFromResponse);
 

--- a/tools/amp-validation/top-traffic.js
+++ b/tools/amp-validation/top-traffic.js
@@ -17,6 +17,7 @@ Promise.all([
         run({
             checkIfAmp: true,
             logErrors: false,
+            checkIfDotComponents: true,
         })
     )
     .catch(err => console.log(err));


### PR DESCRIPTION
## What does this change?

Checks header to make sure we only validate dotComponents AMP pages, for the moment.

## What is the value of this and can you measure success?

Less noise, more real errors.

@guardian/dotcom-platform 