### PR TITLE
Add outstream size to mobile top-above-nav ad slot

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { _ } from 'commercial/modules/dfp/Advert';
+import { _, Advert } from 'commercial/modules/dfp/Advert';
 
 const { filterClasses } = _;
 
@@ -31,5 +31,59 @@ describe('Filter classes', () => {
         expect(result.length).toBe(2);
         expect(result).toContain('old-class');
         expect(result).toContain('old-class-3');
+    });
+});
+
+describe('Advert', () => {
+    beforeEach(() => {
+        const sizeMapping = {
+            sizes: [],
+            build: jest.fn(() => []),
+        };
+        window.googletag = {
+            pubads() {
+                return {};
+            },
+            sizeMapping() {
+                return sizeMapping;
+            },
+            defineSlot: jest.fn(() => window.googletag),
+            addService: jest.fn(() => window.googletag),
+            defineSizeMapping: jest.fn(() => window.googletag),
+            setTargeting: jest.fn(() => window.googletag),
+            setSafeFrameConfig: jest.fn(() => window.googletag),
+        };
+    });
+
+    it('should enable safeframe to expand in the top-above-nav slot', () => {
+        const slot = document.createElement('div');
+        slot.setAttribute('data-name', 'top-above-nav');
+        const ad = new Advert(slot);
+        expect(ad).toBeDefined();
+        expect(window.googletag.setSafeFrameConfig).toBeCalledWith({
+            allowOverlayExpansion: false,
+            allowPushExpansion: true,
+            sandbox: true,
+        });
+    });
+
+    it('should enable safeframe to expand in the inline1 slot', () => {
+        const slot = document.createElement('div');
+        slot.setAttribute('data-name', 'inline1');
+        const ad = new Advert(slot);
+        expect(ad).toBeDefined();
+        expect(window.googletag.setSafeFrameConfig).toBeCalledWith({
+            allowOverlayExpansion: false,
+            allowPushExpansion: true,
+            sandbox: true,
+        });
+    });
+
+    it('should not enable safeframe to expand in a slot that cannot take outstream ads', () => {
+        const slot = document.createElement('div');
+        slot.setAttribute('data-name', 'inline2');
+        const ad = new Advert(slot);
+        expect(ad).toBeDefined();
+        expect(window.googletag.setSafeFrameConfig).not.toBeCalled();
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -78,8 +78,9 @@ const adSlotDefinitions = {
             mobile: [
                 adSizes.outOfPage,
                 adSizes.empty,
-                adSizes.mpu,
                 adSizes.fabric,
+                adSizes.outstreamMobile,
+                adSizes.mpu,
                 adSizes.fluid,
             ],
         },

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -77,4 +77,10 @@ describe('Create Ad Slot', () => {
                 .indexOf(adSizes.leaderboard.toString())
         ).toBeTruthy();
     });
+
+    it('should use correct sizes for the mobile top-above-nav slot', () => {
+        const topAboveNavSlot = bonzo(createSlots('top-above-nav')[0]);
+        const mobileSizes = topAboveNavSlot.attr('data-mobile');
+        expect(mobileSizes).toBe('1,1|2,2|88,71|300,197|300,250|fluid');
+    });
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -78,7 +78,8 @@ const adomikClassify = (): string => {
 };
 
 const isEligibleForOutstream = (slotTarget: ?string): boolean =>
-    typeof slotTarget === 'string' && slotTarget === 'inline1';
+    typeof slotTarget === 'string' &&
+    (slotTarget === 'inline1' || slotTarget === 'top-above-nav');
 
 const allowSafeFrameToExpand = (slot: Slot): Slot => {
     slot.setSafeFrameConfig({


### PR DESCRIPTION
At the mobile breakpoint, the top-above-nav slot is actually the first inline slot.  
So it corresponds to `inline1` at desktop.
This change will enable mobile outstream ads to run in the slot.