### PR TITLE
Allow configuration of epic test audience parameters from sheet

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -478,6 +478,12 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
 
                     const rows = sheets[name];
                     const testName = name.split('__ON')[0];
+
+                    // The sheet does not easily allow test-level params, so get audience/audienceOffset from the first variant where they are defined
+                    const rowWithAudience = rows.find(row => !(isNaN(parseFloat(row.audience)) || isNaN(parseFloat(row.audienceOffset))));
+                    const audience = rowWithAudience ? rowWithAudience.audience : 1;
+                    const audienceOffset = rowWithAudience ? rowWithAudience.audienceOffset : 0;
+
                     return makeEpicABTest({
                         id: testName,
                         campaignId: testName,
@@ -490,8 +496,8 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         successMeasure: 'AV2.0',
                         idealOutcome: 'Google Docs',
                         audienceCriteria: 'All',
-                        audience: 1,
-                        audienceOffset: 0,
+                        audience: audience,
+                        audienceOffset: audienceOffset,
                         useLocalViewLog: rows.some(row =>
                             optionalStringToBoolean(row.useLocalViewLog)
                         ),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -480,9 +480,19 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                     const testName = name.split('__ON')[0];
 
                     // The sheet does not easily allow test-level params, so get audience/audienceOffset from the first variant where they are defined
-                    const rowWithAudience = rows.find(row => !(isNaN(parseFloat(row.audience)) || isNaN(parseFloat(row.audienceOffset))));
-                    const audience = rowWithAudience ? rowWithAudience.audience : 1;
-                    const audienceOffset = rowWithAudience ? rowWithAudience.audienceOffset : 0;
+                    const rowWithAudience = rows.find(
+                        row =>
+                            !(
+                                Number.isNaN(parseFloat(row.audience)) ||
+                                Number.isNaN(parseFloat(row.audienceOffset))
+                            )
+                    );
+                    const audience = rowWithAudience
+                        ? rowWithAudience.audience
+                        : 1;
+                    const audienceOffset = rowWithAudience
+                        ? rowWithAudience.audienceOffset
+                        : 0;
 
                     return makeEpicABTest({
                         id: testName,
@@ -496,8 +506,8 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         successMeasure: 'AV2.0',
                         idealOutcome: 'Google Docs',
                         audienceCriteria: 'All',
-                        audience: audience,
-                        audienceOffset: audienceOffset,
+                        audience,
+                        audienceOffset,
                         useLocalViewLog: rows.some(row =>
                             optionalStringToBoolean(row.useLocalViewLog)
                         ),


### PR DESCRIPTION
## What does this change?
The audience + audienceOffset parameters are used to configure how much of the audience should see each test.
This PR allows us to configure this from the google sheets

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
