### PR TITLE
Handle affiliate links at page element (block) level

### DIFF
--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -112,7 +112,7 @@ object LiveBlogHelpers {
     val textBlocks = firstPageBlocks
       .take(number)
       .collect {
-        case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _, _) if html.trim.nonEmpty =>
+        case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
           TextBlock(id, title, publishedAt, updatedAt, summary)
       }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -1,22 +1,24 @@
 package model.dotcomponents
 
+import ai.x.play.json.Jsonx
+import com.gu.contentapi.client.model.v1.{BlockElement => ClientBlockElement, Blocks => APIBlocks}
 import common.Edition
+import common.Maps.RichMap
+import common.commercial.CommercialProperties
 import conf.Configuration
+import conf.Configuration.affiliatelinks
+import conf.switches.Switches
 import controllers.ArticlePage
 import model.SubMetaLinks
-import model.dotcomrendering.pageElements.PageElement
+import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextBlockElement}
+import model.meta.{Guardian, LinkedData, PotentialAction}
 import navigation.NavMenu
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
+import navigation.UrlHelpers._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{CamelCase, GUDateTimeFormat, ImgSrc, Item1200}
-import ai.x.play.json.Jsonx
-import common.Maps.RichMap
-import navigation.UrlHelpers.{AmpHeader, AmpFooter}
-import common.commercial.CommercialProperties
-import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl}
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
-import model.meta.{Guardian, LinkedData, PotentialAction}
-import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
+import views.html.fragments.affiliateLinksDisclaimer
+import views.support.{AffiliateLinksCleaner, CamelCase, GUDateTimeFormat, ImgSrc, Item1200} // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -147,7 +149,6 @@ case class PageData(
     hasRelated: Boolean,
     isCommentable: Boolean,
     commercialProperties: Option[CommercialProperties],
-    hasAffiliateLinks: Boolean,
     starRating: Option[Int],
 )
 
@@ -218,18 +219,50 @@ object DotcomponentsDataModel {
 
   val VERSION = 1
 
-  def fromArticle(articlePage: ArticlePage, request: RequestHeader): DotcomponentsDataModel = {
+  def fromArticle(articlePage: ArticlePage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
 
     val article = articlePage.article
 
-    val bodyBlocks: List[Block] = article.blocks match {
-      case Some(bs) => bs.body.map(bb => Block(bb.bodyHtml, bb.dotcomponentsPageElements.toList)).toList
-      case None => List()
+    // TODO this logic is duplicated from the cleaners, can we consolidate?
+    val shouldAddAffiliateLinks = AffiliateLinksCleaner.shouldAddAffiliateLinks(
+      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
+      section = article.metadata.sectionId,
+      showAffiliateLinks =  article.content.fields.showAffiliateLinks,
+      supportedSections = affiliatelinks.affiliateLinkSections,
+      defaultOffTags = affiliatelinks.defaultOffTags,
+      alwaysOffTags = affiliatelinks.alwaysOffTags,
+      tagPaths = article.content.tags.tags.map(_.id)
+    )
+
+    def blocksToPageElements(elements: Seq[ClientBlockElement], affiliateLinks: Boolean): List[PageElement] = {
+      elements.toList.flatMap(el => PageElement.make(
+        element = el,
+        addAffiliateLinks = affiliateLinks,
+        pageUrl = request.uri
+      ))
     }
 
-    val mainBlock: Option[Block] = article.blocks.flatMap(
-      _.main.map(bb=>Block(bb.bodyHtml, bb.dotcomponentsPageElements.toList))
-    )
+    def addDisclaimer(elems: List[PageElement]): List[PageElement] = {
+      val hasLinks = elems.exists({
+        case TextBlockElement(html) => AffiliateLinksCleaner.stringContainsAffiliateableLinks(html)
+        case _ => false
+      })
+
+      if (hasLinks) {
+        elems :+ DisclaimerBlockElement(affiliateLinksDisclaimer("article").body)
+      } else {
+        elems
+      }
+    }
+
+    val bodyBlocks: List[Block] = {
+      val bodyBlocks = blocks.body.getOrElse(Nil)
+      bodyBlocks.map(block => Block(block.bodyHtml, blocksToPageElements(block.elements, shouldAddAffiliateLinks))).toList
+    }
+
+    val mainBlock: Option[Block] = {
+      blocks.main.map(block => Block(block.bodyHtml, blocksToPageElements(block.elements, shouldAddAffiliateLinks)))
+    }
 
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
 
@@ -312,7 +345,6 @@ object DotcomponentsDataModel {
       hasRelated = article.content.showInRelated,
       isCommentable = article.trail.isCommentable,
       article.metadata.commercial,
-      article.content.fields.showAffiliateLinks.getOrElse(false),
       article.content.starRating
     )
 

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -3,6 +3,7 @@ package renderers
 import com.eclipsesource.schema._
 import com.eclipsesource.schema.drafts.Version7
 import com.eclipsesource.schema.drafts.Version7._
+import com.gu.contentapi.client.model.v1.Blocks
 import com.osinka.i18n.Lang
 import conf.Configuration
 import controllers.ArticlePage
@@ -52,8 +53,8 @@ class RemoteRenderer {
   }
 
 
-  def getAMPArticle(ws: WSClient, payload: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request)
+  def getAMPArticle(ws: WSClient, payload: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {
@@ -63,8 +64,8 @@ class RemoteRenderer {
 
   }
 
-  def getArticle(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request)
+  def getArticle(ws:WSClient, path: String, article: ArticlePage,  blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -1,5 +1,6 @@
 package test
 
+import com.gu.contentapi.client.model.v1.Blocks
 import controllers.{ArticleController, ArticlePage}
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, PageWithStoryPackage}
@@ -26,7 +27,7 @@ class FakePicker extends RenderingTierPicker {
 }
 
 class FakeRemoteRender(implicit context: ApplicationContext) extends renderers.RemoteRenderer {
-  override def getArticle(ws:WSClient, path: String, article: ArticlePage)(implicit request: RequestHeader): Future[Result] = {
+  override def getArticle(ws:WSClient, path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(Cached(article)(RevalidatableResult.Ok(Html("OK"))))
   }

--- a/article/test/model/LiveBlogCurrentPageTest.scala
+++ b/article/test/model/LiveBlogCurrentPageTest.scala
@@ -18,7 +18,6 @@ class LiveBlogCurrentPageTest extends FlatSpec with Matchers {
     None,
     None,
     Nil,
-    Nil,
     Nil
   )
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -9,7 +9,7 @@ import org.jsoup.Jsoup
 import views.support.cleaner.AmpSoundcloud
 
 import scala.collection.JavaConverters._
-import views.support.{ImageProfile, ImageUrlSigner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
+import views.support.{AffiliateLinksCleaner, ImageProfile, ImageUrlSigner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
 
 /*
   These elements are used for the Dotcom Rendering, they are essentially the new version of the
@@ -37,6 +37,7 @@ case class InstagramBlockElement(url: String, html: Option[String], hasCaption: 
 case class VineBlockElement(html: Option[String]) extends PageElement
 case class MapBlockElement(html: Option[String],  role: Role, isMandatory: Option[Boolean]) extends PageElement
 case class UnknownBlockElement(html: Option[String]) extends PageElement
+case class DisclaimerBlockElement(html: String) extends PageElement
 
 case class MembershipBlockElement(
   originalUrl: Option[String],
@@ -84,7 +85,7 @@ object Sponsorship {
 object PageElement {
   val dotComponentsImageProfiles = List(Item1200, Item700, Item640, Item300, Item140, Item120)
 
-  def make(element: ApiBlockElement): List[PageElement] = {
+  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String): List[PageElement] = {
 
     element.`type` match {
 
@@ -92,7 +93,15 @@ object PageElement {
         block <- element.textTypeData.toList
         text <- block.html.toList
         element <- Cleaner.split(text)
-      } yield {TextBlockElement(element)}
+        textElement = TextBlockElement(element)
+        withLinks <- {
+          if (addAffiliateLinks) {
+            AffiliateLinksCleaner.replaceLinksInElement(textElement, pageUrl = pageUrl, contentType = "article")
+          } else {
+            List(textElement)
+          }
+        }
+      } yield withLinks
 
       case Tweet => {
         (for {
@@ -267,6 +276,7 @@ object PageElement {
   implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]
   implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
   implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
+  implicit val DiscalimerBlockElementWrites: Writes[DisclaimerBlockElement] = Json.writes[DisclaimerBlockElement]
 
   implicit val SponsorshipWrites: Writes[Sponsorship] = new Writes[Sponsorship] {
     def writes(sponsorship: Sponsorship): JsObject = Json.obj(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -94,14 +94,13 @@ object PageElement {
         text <- block.html.toList
         element <- Cleaner.split(text)
         textElement = TextBlockElement(element)
-        withLinks <- {
-          if (addAffiliateLinks) {
-            AffiliateLinksCleaner.replaceLinksInElement(textElement, pageUrl = pageUrl, contentType = "article")
-          } else {
-            List(textElement)
-          }
+      } yield {
+        if (addAffiliateLinks) {
+          AffiliateLinksCleaner.replaceLinksInElement(textElement, pageUrl = pageUrl, contentType = "article")
+        } else {
+          textElement
         }
-      } yield withLinks
+      }
 
       case Tweet => {
         (for {

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -2,10 +2,10 @@ package model.liveblog
 
 import java.util.Locale
 
+import com.gu.contentapi.client.model.v1.{Block, BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks}
 import implicits.Dates.CapiRichDateTime
-import com.gu.contentapi.client.model.v1.{Block, BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks, MembershipPlaceholder => ApiMembershipPlaceholder}
-import model.liveblog.BodyBlock._
 import model.dotcomrendering.pageElements.PageElement
+import model.liveblog.BodyBlock._
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.jsoup.Jsoup
@@ -15,9 +15,10 @@ object Blocks {
 
   def make(blocks: ApiBlocks): Blocks = {
 
-    def orderBlocks(blocks: Seq[BodyBlock]) =
-      blocks.sortBy(-_.publishedCreatedTimestamp().getOrElse(0L)) // Negate rather than reverse result: leaves
-                                                                  // order unchanged when there are no timestamps
+    def orderBlocks(blocks: Seq[BodyBlock]): Seq[BodyBlock] = {
+      // Negate rather than reverse result: leaves order unchanged when there are no timestamps
+      blocks.sortBy(-_.publishedCreatedTimestamp().getOrElse(0L))
+    }
 
     val mainBlock: Option[BodyBlock] = blocks.main.map(BodyBlock.make)
     val bodyBlocks: Seq[BodyBlock] = orderBlocks(blocks.body.toSeq.flatMap(BodyBlock.make))
@@ -45,8 +46,9 @@ case class Blocks(
 
 object BodyBlock {
 
-  def make(blocks: Seq[Block]): Seq[BodyBlock] =
+  def make(blocks: Seq[Block]): Seq[BodyBlock] = {
     blocks.map(make)
+  }
 
   def make(bodyBlock: Block): BodyBlock =
       BodyBlock(bodyBlock.id,
@@ -61,7 +63,6 @@ object BodyBlock {
         bodyBlock.lastModifiedDate.map(_.toJoda),
         bodyBlock.contributors,
         bodyBlock.elements.flatMap(BlockElement.make),
-        bodyBlock.elements.flatMap(PageElement.make)
       )
 
 
@@ -89,7 +90,6 @@ case class BodyBlock(
   lastModifiedDate: Option[DateTime],
   contributors: Seq[String],
   elements: Seq[BlockElement],
-  dotcomponentsPageElements: Seq[PageElement]
 ) {
   lazy val eventType: EventType =
     if (attributes.keyEvent) KeyEvent

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -62,7 +62,7 @@ object Fields {
       standfirst = apiContent.fields.flatMap(_.standfirst),
       main = apiContent.fields.flatMap(_.main).getOrElse(""),
       body = apiContent.fields.flatMap(_.body).getOrElse(""),
-      blocks = apiContent.blocks.map(Blocks.make),
+      blocks = apiContent.blocks.map(block => Blocks.make(block)),
       lastModified = apiContent.fields.flatMap(_.lastModified).map(_.toJoda).getOrElse(DateTime.now),
       displayHint = apiContent.fields.flatMap(_.displayHint).getOrElse(""),
       isLive = apiContent.fields.flatMap(_.liveBloggingNow).getOrElse(false),

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -13,7 +13,7 @@ import layout.ContentWidths
 import layout.ContentWidths._
 import model._
 import model.content._
-import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextBlockElement}
+import model.dotcomrendering.pageElements.{PageElement, TextBlockElement}
 import navigation.ReaderRevenueSite
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
@@ -857,18 +857,15 @@ object AffiliateLinksCleaner {
     else html
   }
 
-  def replaceLinksInElement(element: TextBlockElement, pageUrl: String, contentType: String): List[PageElement] = {
+  def replaceLinksInElement(element: TextBlockElement, pageUrl: String, contentType: String): PageElement = {
     val doc = Jsoup.parseBodyFragment(element.html)
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(doc)
     linksToReplace.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
 
     if (linksToReplace.nonEmpty) {
-      List(
-        TextBlockElement(doc.outerHtml()),
-        DisclaimerBlockElement(affiliateLinksDisclaimer(contentType: String).body)
-      )
+        TextBlockElement(doc.outerHtml())
     } else {
-      List(element)
+      element
     }
   }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -5,20 +5,20 @@ import java.util.regex.{Matcher, Pattern}
 
 import com.gu.contentatom.renderer.ArticleConfiguration
 import common.{Edition, LinkTo, Logging}
+import conf.Configuration.affiliatelinks._
+import conf.Configuration.site.host
+import conf.switches.Switches
 import conf.switches.Switches._
 import layout.ContentWidths
 import layout.ContentWidths._
 import model._
 import model.content._
+import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextBlockElement}
 import navigation.ReaderRevenueSite
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
-import play.twirl.api.HtmlFormat
 import services.SkimLinksCache
-import conf.Configuration.affiliatelinks._
-import conf.Configuration.site.host
-import conf.switches.Switches
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.Commercial.isAdFree
 
@@ -855,6 +855,21 @@ object AffiliateLinksCleaner {
     val shouldAppendDisclaimer = appendDisclaimer.getOrElse(linksToReplace.nonEmpty)
     if (shouldAppendDisclaimer) insertAffiliateDisclaimer(html, contentType)
     else html
+  }
+
+  def replaceLinksInElement(element: TextBlockElement, pageUrl: String, contentType: String): List[PageElement] = {
+    val doc = Jsoup.parseBodyFragment(element.html)
+    val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(doc)
+    linksToReplace.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
+
+    if (linksToReplace.nonEmpty) {
+      List(
+        TextBlockElement(doc.outerHtml()),
+        DisclaimerBlockElement(affiliateLinksDisclaimer(contentType: String).body)
+      )
+    } else {
+      List(element)
+    }
   }
 
   def isAffiliatable(element: Element): Boolean =


### PR DESCRIPTION
* add affiliate links to page elements (the blocks we send to DC)
* add the disclaimer if required as an additional element type

The benefits of this approach:

* can support affiliate links in DC as required
* works with our elements model, to reduce the special-casing/logic in DC around affiliate links and the disclaimer

To achieve this I've moved page elements out of the regular content model, as they are not relevant to non-DC request/responses. This has required a bit of rejigging though and also explicitly passing
the CAPI blocks around in the ArticleController.

![screenshot 2019-02-19 at 10 52 43](https://user-images.githubusercontent.com/858402/53010057-c6d06280-3434-11e9-9c8e-0b2b6e2469b5.png)
![screenshot 2019-02-19 at 10 52 48](https://user-images.githubusercontent.com/858402/53010059-c6d06280-3434-11e9-8cbc-07cb89eaaabb.png)
