### PR TITLE
Bumped up prebid version (with NO_BID events)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#d67625d",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#3d5681b93a23ace5791a9a9e210abd9157a4efda",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,9 +7983,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#d67625d":
+"prebid.js@https://github.com/guardian/Prebid.js.git#3d5681b93a23ace5791a9a9e210abd9157a4efda":
   version "1.39.0"
-  resolved "https://github.com/guardian/Prebid.js.git#d67625d704c84eb83988e6cf7a5705a6ea5bd3da"
+  resolved "https://github.com/guardian/Prebid.js.git#3d5681b93a23ace5791a9a9e210abd9157a4efda"
   dependencies:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.1"


### PR DESCRIPTION
Upgrades our Prebid.js version so now our analytics adapter sends the NO_BID event in the analytics bundle.