### PR TITLE
Make Learn More button on FIV banner act like a close button

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
@@ -50,7 +50,7 @@ export const acquisitionsBannerFivTemplate = (
                 }">
                     ${params.buttonCaption}
                 </a>
-                <a class="button engagement-banner__button engagement-banner__button__learn-more" href="${'TODO - get url'}">
+                <a class="button engagement-banner__button engagement-banner__button__learn-more js-engagement-banner-close-button js-site-message-close" href="${'TODO - get url'}">
                     Learn more
                 </a>
             </div>

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -84,11 +84,15 @@ class SubMessage extends Message {
     bindCloseHandler(close: (banner: Message) => void): void {
         const element = document.querySelector(this.elementSelector);
         if (element) {
-            const closeButton = element.querySelector('.js-site-message-close');
-            if (closeButton) {
-                closeButton.addEventListener('click', () => {
-                    close(this);
-                });
+            const closeButtons = element.querySelectorAll(
+                '.js-site-message-close'
+            );
+            if (closeButtons) {
+                closeButtons.forEach(button =>
+                    button.addEventListener('click', () => {
+                        close(this);
+                    })
+                );
             }
         }
     }


### PR DESCRIPTION
## What does this change?
When a user clicks "Learn more" on the FIV banner, we don't want to show them the banner again. This is especially pertinent on mobile, where they would already have most of the screen blocked, then click "Learn more" and be taken to what would appear to be the same screen, giving the unfortunate effect of an infinity loop whereby the user actually learns nothing. 

This PR makes the learn more button act in the same way as the close button, in as much as prevents the banner from displaying until the next redeploy


## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
