### PR TITLE
Update moment epic style

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -162,8 +162,8 @@ a[href].contributions__contribute.contributions__contribute--epic {
 
     h2 {
         @include fs-header(5);
-        font-size: 32px;
-        line-height: 34px;
+        font-size: 28px;
+        line-height: 28px;
     }
 }
 
@@ -173,8 +173,8 @@ a[href].contributions__contribute.contributions__contribute--epic {
 
     .contributions__title {
         @include fs-header(5);
-        font-size: 32px;
-        line-height: 34px;
+        font-size: 28px;
+        line-height: 28px;
         color: $contributions__epic--moment--blue;
     }
 


### PR DESCRIPTION
## What does this change?
Makes the header and footer font size slightly smaller on the epic for the latest moment

## Screenshots
<img width="426" alt="picture 4" src="https://user-images.githubusercontent.com/1513454/53089089-7a078d00-3503-11e9-8e67-64607cf17c25.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
