### PR TITLE
Fix close button in double engagement banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -88,11 +88,11 @@ class SubMessage extends Message {
                 '.js-site-message-close'
             );
             // https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
-            Array.prototype.forEach.call(closeButtons, function (button) {
+            Array.prototype.forEach.call(closeButtons, function(button) {
                 button.addEventListener('click', () => {
                     close(this);
-                })
-            })
+                });
+            });
         }
     }
 }

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -87,13 +87,12 @@ class SubMessage extends Message {
             const closeButtons = element.querySelectorAll(
                 '.js-site-message-close'
             );
-            if (closeButtons) {
-                closeButtons.forEach(button =>
-                    button.addEventListener('click', () => {
-                        close(this);
-                    })
-                );
-            }
+            // https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
+            Array.prototype.forEach.call(closeButtons, function (button) {
+                button.addEventListener('click', () => {
+                    close(this);
+                })
+            })
         }
     }
 }


### PR DESCRIPTION
## What does this change?
The `forEach` function on `NodeList` isn't supported in IE. This is a workaround 

See https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
