### PR TITLE
Fix banner close

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -87,8 +87,9 @@ class SubMessage extends Message {
             const closeButtons = element.querySelectorAll(
                 '.js-site-message-close'
             );
+
             // https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
-            Array.prototype.forEach.call(closeButtons, function(button) {
+            Array.prototype.forEach.call(closeButtons, button => {
                 button.addEventListener('click', () => {
                     close(this);
                 });


### PR DESCRIPTION
## What does this change?
[this change](https://github.com/guardian/frontend/pull/21129/files) broke closing of the banner because the scope of `this` changed

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
