### PR TITLE
Show 'Support The Guardian' if user has adblocker

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -301,7 +301,7 @@ trait CommercialSwitches {
   val AdblockAsk = Switch(
     Commercial,
     "ab-adblock-ask",
-    "blah",
+    "Places a contributions ask underneath the right-hand ad slot on articles.",
     owners = group(Membership),
     safeState = On,
     sellByDate = never,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -2,7 +2,7 @@ package conf.switches
 
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
-import conf.switches.SwitchGroup.{Commercial, CommercialPrebid}
+import conf.switches.SwitchGroup.{Commercial, CommercialPrebid, Membership}
 import org.joda.time.LocalDate
 
 trait CommercialSwitches {
@@ -294,6 +294,16 @@ trait CommercialSwitches {
     "If this switch is turned on, the engagement banner will NOT show up on AU fronts for readers in AU",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val AdblockAsk = Switch(
+    Commercial,
+    "ab-adblock-ask",
+    "blah",
+    owners = group(Membership),
+    safeState = On,
     sellByDate = never,
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,6 +4,7 @@ import { commercialAdVerification } from 'common/modules/experiments/tests/comme
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
+import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import {
     februaryMomentBannerNonUk,
     februaryMomentBannerUk,
@@ -14,6 +15,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialAdVerification,
     commercialCmpCustomise,
+    adblockTest,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,0 +1,55 @@
+// @flow
+//import askHtml from 'raw-loader!journalism/views/podcastContainerA.html';
+
+const askHtml = `
+<div class="contributions__adblock--moment">
+    <div class="contributions__adblock--moment-header">
+        <h2 class="contributions__adblock--moment-header--blue">Support</h2>
+        <h2 class="contributions__adblock--moment-header--blue">The Guardian's</h2>
+        <h2 class="contributions__adblock--moment-header--orange">model for open, independent journalism</h2>
+    </div>
+    <div class="contributions__adblock--moment-sub">
+        We're available for everyone, supported by our readers
+    </div>
+    <div class="contributions__adblock--moment-button">
+        <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+          href="https://support.theguardian.com/contribute"
+          target="_blank">
+          Support The Guardian
+        </a>
+    </div>
+</div>
+`;
+
+export const adblockTest: ABTest = {
+    id: 'AdblockAsk',
+    start: '2019-02-20',
+    expiry: '2020-02-20',
+    author: 'Tom Forbes',
+    description: 'Add a contributions message under adverts, for users with adblocker enabled',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: '???',
+    audienceCriteria: '',
+    showForSensitive: true,
+    canRun() {
+        console.log("RUNNING")
+        return true;
+    },
+
+    variants: [
+        {
+            id: "control",
+            test: (): void => {
+                console.log("test?")
+                const slot = document.querySelector('.aside-slot-container');
+                console.log("slot", slot)
+                if (slot) {
+                    console.log("found slot")
+                    // slot.innerHTML = askHtml;
+                    slot.insertAdjacentHTML('afterend', askHtml)
+                }
+            }
+        }
+    ]
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,22 +1,26 @@
 // @flow
-//import askHtml from 'raw-loader!journalism/views/podcastContainerA.html';
+
+const supportUrl =
+    'https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019';
 
 const askHtml = `
 <div class="contributions__adblock--moment">
-    <div class="contributions__adblock--moment-header">
-        <h2 class="contributions__adblock--moment-header--blue">Support</h2>
-        <h2 class="contributions__adblock--moment-header--blue">The Guardian's</h2>
-        <h2 class="contributions__adblock--moment-header--orange">model for open, independent journalism</h2>
-    </div>
-    <div class="contributions__adblock--moment-sub">
-        We're available for everyone, supported by our readers
-    </div>
-    <div class="contributions__adblock--moment-button">
-        <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-          href="https://support.theguardian.com/contribute"
-          target="_blank">
-          Support The Guardian
-        </a>
+    <div class="contributions__adblock--moment-content">
+        <div class="contributions__adblock--moment-header">
+            <h2 class="contributions__adblock--moment-header--blue">Support</h2>
+            <h2 class="contributions__adblock--moment-header--blue">The Guardian’s</h2>
+            <h2 class="contributions__adblock--moment-header--orange">model for open, independent journalism</h2>
+        </div>
+        <div class="contributions__adblock--moment-sub">
+            We’re available for everyone, supported by our readers
+        </div>
+        <div class="contributions__adblock--moment-button">
+            <a class="contributions__option-button contributions__contribute "
+              href="${supportUrl}"
+              target="_blank">
+              Support The Guardian
+            </a>
+        </div>
     </div>
 </div>
 `;
@@ -26,30 +30,26 @@ export const adblockTest: ABTest = {
     start: '2019-02-20',
     expiry: '2020-02-20',
     author: 'Tom Forbes',
-    description: 'Add a contributions message under adverts, for users with adblocker enabled',
+    description:
+        'Add a contributions message under adverts, for users with adblocker enabled',
     audience: 1,
     audienceOffset: 0,
-    successMeasure: '???',
+    successMeasure: '',
     audienceCriteria: '',
     showForSensitive: true,
     canRun() {
-        console.log("RUNNING")
         return true;
     },
 
     variants: [
         {
-            id: "control",
+            id: 'control',
             test: (): void => {
-                console.log("test?")
                 const slot = document.querySelector('.aside-slot-container');
-                console.log("slot", slot)
                 if (slot) {
-                    console.log("found slot")
-                    // slot.innerHTML = askHtml;
-                    slot.insertAdjacentHTML('afterend', askHtml)
+                    slot.insertAdjacentHTML('afterend', askHtml);
                 }
-            }
-        }
-    ]
+            },
+        },
+    ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -31,7 +31,7 @@ export const adblockTest: ABTest = {
     expiry: '2020-02-20',
     author: 'Tom Forbes',
     description:
-        'Add a contributions message under adverts, for users with adblocker enabled',
+        'Places a contributions ask underneath the right-hand ad slot on articles.',
     audience: 1,
     audienceOffset: 0,
     successMeasure: '',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,4 +1,6 @@
 // @flow
+import { userIsSupporter } from 'common/modules/commercial/user-features';
+import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 
 const supportUrl =
     'https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019';
@@ -38,7 +40,7 @@ export const adblockTest: ABTest = {
     audienceCriteria: '',
     showForSensitive: true,
     canRun() {
-        return true;
+        return !userIsSupporter() && !pageShouldHideReaderRevenue();
     },
 
     variants: [

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -194,7 +194,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
 .contributions__adblock--moment {
     position: absolute;
     top: 0;
-    padding-top: 6px;
+    padding-top: $gs-baseline/2;
 
     .contributions__adblock--moment-content {
         border-top: 5px solid #052962;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -111,7 +111,8 @@
 }
 
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
-a[href].contributions__contribute.contributions__contribute--epic {
+a[href].contributions__contribute.contributions__contribute--epic,
+a[href].contributions__option-button {
     margin-top: 0;
     background-color: $highlight-main;
     color: $brightness-7;
@@ -193,8 +194,12 @@ a[href].contributions__contribute.contributions__contribute--epic {
 .contributions__adblock--moment {
     position: absolute;
     top: 0;
-    //TODO - can we make this less fragile?
     padding-top: 6px;
+
+    .contributions__adblock--moment-content {
+        border-top: 5px solid #052962;
+        background-color: #f6f6f6;
+    }
 
     .contributions__adblock--moment-header {
         padding-left: 13px;
@@ -222,5 +227,10 @@ a[href].contributions__contribute.contributions__contribute--epic {
 
     .contributions__adblock--moment-button {
         padding-left: 5px;
+        padding-bottom: 13px;
+        a {
+            color: #052962;
+            margin: $gs-baseline/3 $gs-gutter/2 $gs-baseline/3 0;
+        }
     }
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -189,3 +189,38 @@ a[href].contributions__contribute.contributions__contribute--epic {
         }
     }
 }
+
+.contributions__adblock--moment {
+    position: absolute;
+    top: 0;
+    //TODO - can we make this less fragile?
+    padding-top: 6px;
+
+    .contributions__adblock--moment-header {
+        padding-left: 13px;
+
+        h2 {
+            @include fs-header(5);
+            font-size: 32px;
+            line-height: 32px;
+        }
+
+        .contributions__adblock--moment-header--blue {
+            color: #0084c6;
+        }
+        .contributions__adblock--moment-header--orange {
+            color: #ff7f0f;
+        }
+    }
+
+    .contributions__adblock--moment-sub {
+        color: #052962;
+        font-size: 16px;
+        line-height: 20px;
+        padding: 10px 0 8px 13px;
+    }
+
+    .contributions__adblock--moment-button {
+        padding-left: 5px;
+    }
+}

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -112,7 +112,7 @@
 
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic,
-a[href].contributions__option-button {
+.contributions__adblock--moment-button a {
     margin-top: 0;
     background-color: $highlight-main;
     color: $brightness-7;


### PR DESCRIPTION
## What does this change?
Places a contributions ask underneath the right-hand ad slot on articles.
If the user has an adblocker then it will become visible.

[This PR](https://github.com/guardian/frontend/pull/21105) ensured that there will be no flickering if an ad is loading.

## Screenshots
here's a very slow gif
![shadypie](https://user-images.githubusercontent.com/1513454/53172228-bb1fa000-35dc-11e9-9658-7464c843e0a0.gif)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
