### PR TITLE
CALLOUTS: Change text and style on callout

### DIFF
--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -2,13 +2,15 @@
 
     <summary class="campaign--snippet__header">
         <div class="campaign--kicker">
-            <div class="campaign--snippet__heading-logo">
+            <div class="campaign--snippet__heading">
                 <div class="speech-bubble">
-                    <h4>Take part</h4>
+                    <h4>Share your story</h4>
+                </div>
+                <div class="title">
+                    <h4 class="campaign--snippet__headline"> <%= data.title %></h4>
                 </div>
             </div>
-            <div class="heading">
-                <h4 class="campaign--snippet__headline"> <%= data.title %></h4>
+            <div class="intro">
                 <p><%= data.description %> </p>
             </div>
             <div class="success_box">

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -152,11 +152,13 @@
 
     .campaign--kicker {
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         min-height: 70px;
 
-        > .campaign--snippet__heading-logo {
+        > .campaign--snippet__heading {
+            display: flex;
             flex: initial;
+            flex-direction: row;
             margin-right: 10px;
 
             .speech-bubble {
@@ -165,6 +167,7 @@
                 padding: 6px 10px 10px;
                 line-height: 18px;
                 min-width: 84px;
+                margin-right: 10px;
 
                 &::after {
                     color: $brightness-7;
@@ -213,6 +216,10 @@
                     }
                 }
             }
+        }
+
+        .intro {
+            padding: 5px 0  0 10px;
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Editorial prefer the words "Share your story" instead of "Take Part". Also a small style change so it fits on the page better. 

## Screenshots
OLD STYLE 
![screen shot 2019-01-31 at 11 08 58](https://user-images.githubusercontent.com/10324129/53177753-7dc10f80-35e8-11e9-9f2d-528f2fc6be3d.png)

NEW STYLE
![screen shot 2019-02-21 at 16 57 34](https://user-images.githubusercontent.com/10324129/53187031-1ca23780-35fa-11e9-9eb0-c7c8e5a11f6d.png)

![screen shot 2019-02-21 at 16 58 49](https://user-images.githubusercontent.com/10324129/53187049-26c43600-35fa-11e9-96d9-a27b69a3e193.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
