### PR TITLE
Log correct YouTube ID on CAPI error

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -205,7 +205,7 @@ const onPlayerPlaying = (atomId: string): void => {
             .catch(err => {
                 reportError(
                     Error(
-                        `Failed to get atom ID for youtube ID ${youtubeId}. ${err}`
+                        `Failed to get atom ID for youtube ID ${latestYoutubeId}. ${err}`
                     ),
                     { feature: 'youtube' },
                     false


### PR DESCRIPTION
## What does this change?

Updates the ID of the YouTube vide that gets logged when the CAPI media atom ID lookup fails. Previously, we were logging the ID of the original YouTube video, but we should be logging the ID of the currently playing YouTube video. 

## What is the value of this and can you measure success?

Correct error logging

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
