### PR TITLE
update hardcoded TiF podcast kicker on fronts

### DIFF
--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -79,7 +79,7 @@
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
                                             <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="article">
-                                                <div class="fc-item__kicker">Today in Focus</div>
+                                                <div class="fc-item__kicker">Podcast</div>
                                                 <div class="u-faux-block-link__cta fc-item__headline">
                                                     <span class="js-headline-text">@RemoveOuterParaHtml(card.header.headline)</span>
                                                 </div>
@@ -130,7 +130,6 @@
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title">
                                             <a @Html(card.header.url.hrefWithRel) class="fc-item__link" data-link-name="series">
-                                                <span class="fc-item__kicker">Today in Focus</span>
                                                 <span class="u-faux-block-link__cta fc-item__headline">
                                                     <span class="js-headline-text">Listen to previous episodes</span>
                                                 </span>


### PR DESCRIPTION
## What does this change?
Podcast container kicker from 'Today in Focus' to 'Podcast' and removing the secondary card kicker.

## Screenshots
<img width="1353" alt="screen shot 2019-02-22 at 14 39 40" src="https://user-images.githubusercontent.com/4015129/53249457-0951a380-36b0-11e9-9406-c1a1295f37d7.png">
<img width="1350" alt="screen shot 2019-02-22 at 14 40 59" src="https://user-images.githubusercontent.com/4015129/53249461-0ce52a80-36b0-11e9-905f-f7da72ae7a5e.png">

## What is the value of this and can you measure success?
As part of the Apps team's mobile web - app parity KR
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
