### PR TITLE
Correct vertical alignment of social share numbers

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -100,7 +100,6 @@
     text-align: right;
     float: left;
     min-width: 15px; // Min width is the width of the icons
-    padding-top: $gs-baseline / 2;
 }
 
 .meta__number + .meta__number {

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -162,7 +162,6 @@
 
     .meta__numbers {
         float: right;
-        padding-top: $gs-baseline/2;
 
         .sharecount__value,
         a {


### PR DESCRIPTION
## What does this change?

**Before**

![screenshot 2019-02-25 at 14 40 14](https://user-images.githubusercontent.com/6035518/53344802-7ca32180-390b-11e9-8d46-54cd33bb688b.png)


**After**

![screenshot 2019-02-25 at 14 40 35](https://user-images.githubusercontent.com/6035518/53344893-a0fefe00-390b-11e9-8155-e669171ad633.png)


