### PR TITLE
FIV moment banner AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,7 +38,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-february-moment-banner-uk",
+    "ab-february-moment-banner-uk-round-two",
     "switch on to enable the moment engagement banner in the UK",
     owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
@@ -48,7 +48,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-february-moment-banner-thank-you",
+    "ab-february-moment-banner-thank-you-round-two",
     "switch on to enable the moment thank you engagement banner worldwide",
     owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,8 +6,8 @@ import { askFourEarning } from 'common/modules/experiments/tests/contributions-e
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import {
-    februaryMomentBannerNonUk,
-    februaryMomentBannerUk,
+    februaryMomentBannerNonUkRoundTwo,
+    februaryMomentBannerUkRoundTwo,
     februaryMomentBannerThankYou,
 } from 'common/modules/experiments/tests/february-moment-banner';
 
@@ -24,7 +24,7 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    februaryMomentBannerNonUk,
-    februaryMomentBannerUk,
+    februaryMomentBannerNonUkRoundTwo,
+    februaryMomentBannerUkRoundTwo,
     februaryMomentBannerThankYou,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -42,7 +42,6 @@ const bannerShownCallback = () => {
     }
 };
 
-
 const openVariant: Variant = {
     id: 'open',
     test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
@@ -54,10 +53,7 @@ const openVariant: Variant = {
         bannerModifierClass: 'fiv-banner',
         minArticlesBeforeShowingBanner,
         userCohort: userCohortParam.onlyNonSupporters,
-        titles: [
-            "Open journalism is a choice",
-            'Will you support it?',
-        ],
+        titles: ['Open journalism is a choice', 'Will you support it?'],
         bannerShownCallback,
     },
     canRun: () =>
@@ -78,10 +74,7 @@ const differentVariant: Variant = {
         bannerModifierClass: 'fiv-banner',
         minArticlesBeforeShowingBanner,
         userCohort: userCohortParam.onlyNonSupporters,
-        titles: [
-            "We chose a different approach",
-            'Will you support it?',
-        ],
+        titles: ['We chose a different approach', 'Will you support it?'],
         bannerShownCallback,
     },
     canRun: () =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -19,9 +19,8 @@ const campaignId = 'empower_campaign';
 // These test params must be set on engagementBannerParams *and* passed into canShowBannerSync
 // TODO - we need to rethink how banner tests are selected/displayed
 const userCohortParam = {
-    februaryMomentBannerNonUk: 'OnlyNonSupporters',
-    februaryMomentBannerUk: 'OnlyNonSupporters',
-    februaryMomentBannerThankYou: 'OnlyExistingSupporters',
+    onlyNonSupporters: 'OnlyNonSupporters',
+    onlyExistingSupporters: 'OnlyExistingSupporters',
 };
 const minArticlesBeforeShowingBanner = 0;
 
@@ -43,11 +42,60 @@ const bannerShownCallback = () => {
     }
 };
 
-export const februaryMomentBannerNonUk: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerNonUk',
+
+const openVariant: Variant = {
+    id: 'open',
+    test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
+    engagementBannerParams: {
+        leadSentence: defaultBold,
+        messageText: defaultCopy,
+        // buttonCaption?: string, TO be decided with non engineers
+        template: acquisitionsBannerFivTemplate,
+        bannerModifierClass: 'fiv-banner',
+        minArticlesBeforeShowingBanner,
+        userCohort: userCohortParam.onlyNonSupporters,
+        titles: [
+            "Open journalism is a choice",
+            'Will you support it?',
+        ],
+        bannerShownCallback,
+    },
+    canRun: () =>
+        canShowBannerSync(
+            minArticlesBeforeShowingBanner,
+            userCohortParam.onlyNonSupporters
+        ),
+};
+
+const differentVariant: Variant = {
+    id: 'different',
+    test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
+    engagementBannerParams: {
+        leadSentence: defaultBold,
+        messageText: defaultCopy,
+        // buttonCaption?: string, TO be decided with non engineers
+        template: acquisitionsBannerFivTemplate,
+        bannerModifierClass: 'fiv-banner',
+        minArticlesBeforeShowingBanner,
+        userCohort: userCohortParam.onlyNonSupporters,
+        titles: [
+            "We chose a different approach",
+            'Will you support it?',
+        ],
+        bannerShownCallback,
+    },
+    canRun: () =>
+        canShowBannerSync(
+            minArticlesBeforeShowingBanner,
+            userCohortParam.onlyNonSupporters
+        ),
+};
+
+export const februaryMomentBannerNonUkRoundTwo: AcquisitionsABTest = {
+    id: 'FebruaryMomentBannerNonUkRoundTwo',
     start: '2019-01-01',
     expiry: '2019-09-30',
-    author: 'John Duffell',
+    author: 'Jonathan Rankin',
     description: 'test copy on engagement banner outside UK for the feb moment',
     audience: 1,
     audienceOffset: 0,
@@ -69,7 +117,7 @@ export const februaryMomentBannerNonUk: AcquisitionsABTest = {
                 template: acquisitionsBannerFivTemplate,
                 bannerModifierClass: 'fiv-banner',
                 minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.februaryMomentBannerNonUk,
+                userCohort: userCohortParam.onlyNonSupporters,
                 titles: [
                     "Free for those who can't afford it",
                     'Supported by those who can',
@@ -79,17 +127,19 @@ export const februaryMomentBannerNonUk: AcquisitionsABTest = {
             canRun: () =>
                 canShowBannerSync(
                     minArticlesBeforeShowingBanner,
-                    userCohortParam.februaryMomentBannerNonUk
+                    userCohortParam.onlyNonSupporters
                 ),
         },
+        openVariant,
+        differentVariant,
     ],
 };
 
-export const februaryMomentBannerUk: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerUk',
+export const februaryMomentBannerUkRoundTwo: AcquisitionsABTest = {
+    id: 'FebruaryMomentBannerUkRoundTwo',
     start: '2019-01-01',
     expiry: '2019-09-30',
-    author: 'John Duffell',
+    author: 'Jonathan Rankin',
     description: 'enable engagement banner in UK for the feb moment',
     audience: 1,
     audienceOffset: 0,
@@ -110,7 +160,7 @@ export const februaryMomentBannerUk: AcquisitionsABTest = {
                 template: acquisitionsBannerFivTemplate,
                 bannerModifierClass: 'fiv-banner',
                 minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.februaryMomentBannerUk,
+                userCohort: userCohortParam.onlyNonSupporters,
                 titles: [
                     "We're available for everyone",
                     'Funded by our\xa0readers',
@@ -120,9 +170,11 @@ export const februaryMomentBannerUk: AcquisitionsABTest = {
             canRun: () =>
                 canShowBannerSync(
                     minArticlesBeforeShowingBanner,
-                    userCohortParam.februaryMomentBannerUk
+                    userCohortParam.onlyNonSupporters
                 ),
         },
+        openVariant,
+        differentVariant,
     ],
 };
 
@@ -151,7 +203,7 @@ export const februaryMomentBannerThankYou: AcquisitionsABTest = {
                 template: acquisitionsBannerFivTemplate,
                 bannerModifierClass: 'fiv-banner fiv-banner-thank-you',
                 minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.februaryMomentBannerThankYou,
+                userCohort: userCohortParam.onlyExistingSupporters,
                 titles: [
                     'Thanks to your support',
                     "We're available to everyone",
@@ -161,7 +213,7 @@ export const februaryMomentBannerThankYou: AcquisitionsABTest = {
             canRun: () =>
                 canShowBannerSync(
                     minArticlesBeforeShowingBanner,
-                    userCohortParam.februaryMomentBannerThankYou
+                    userCohortParam.onlyExistingSupporters
                 ),
         },
     ],


### PR DESCRIPTION
## What does this change?

We want to run some copy tests on the FIV banner. 

Both the UK and non-UK are retaining their current control, which will be facing  the same two variants.

![image](https://user-images.githubusercontent.com/2844554/53345118-1cf94600-390c-11e9-85b2-2546891b90c6.png)


![image](https://user-images.githubusercontent.com/2844554/53345030-ee7b6b00-390b-11e9-8d9a-bba7263b2a7e.png)



## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
