### PR TITLE
Add chart atom

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -31,8 +31,9 @@ final case class Atoms(
   timelines: Seq[TimelineAtom],
   commonsdivisions: Seq[CommonsDivisionAtom],
   audios: Seq[AudioAtom],
+  charts: Seq[ChartAtom]
 ) {
-  val all: Seq[Atom] = quizzes ++ media ++ interactives ++ recipes ++ reviews ++ storyquestions ++ explainers ++ qandas ++ guides ++ profiles ++ timelines ++ commonsdivisions ++ audios
+  val all: Seq[Atom] = quizzes ++ media ++ interactives ++ recipes ++ reviews ++ storyquestions ++ explainers ++ qandas ++ guides ++ profiles ++ timelines ++ commonsdivisions ++ audios ++ charts
 
   def atomTypes: Map[String, Boolean] = Map(
     "guide" -> !guides.isEmpty,
@@ -42,7 +43,8 @@ final case class Atoms(
     "storyquestions" -> !storyquestions.isEmpty,
     "explainer" -> !explainers.isEmpty,
     "commonsdivision" -> !commonsdivisions.isEmpty,
-    "audio" -> !audios.isEmpty
+    "audio" -> !audios.isEmpty,
+    "chart" -> !charts.isEmpty
   )
 }
 
@@ -226,6 +228,12 @@ final case class AudioAtom(
   data: atomapi.audio.AudioAtom
 ) extends Atom
 
+final case class ChartAtom(
+  override val id: String,
+  atom: AtomApiAtom,
+  data: atomapi.chart.ChartAtom
+) extends Atom
+
 object Atoms extends common.Logging {
 
   def articleConfig(isAdFree: Boolean = false, useAcast: Boolean = false) = {
@@ -286,6 +294,8 @@ object Atoms extends common.Logging {
 
       val audios = extract(atoms.audios, atom => {AudioAtom.make(atom)})
 
+      val charts = extract(atoms.charts, ChartAtom.make)
+
       Atoms(
         quizzes = quizzes,
         media = media,
@@ -299,7 +309,8 @@ object Atoms extends common.Logging {
         profiles = profiles,
         timelines = timelines,
         commonsdivisions = commonsdivisions,
-        audios = audios
+        audios = audios,
+        charts = charts
       )
     }
   }
@@ -659,4 +670,9 @@ object AudioAtom {
     val audio = atom.data.asInstanceOf[AtomData.Audio].audio
     AudioAtom(atom.id, atom, audio)
   }
+}
+
+object ChartAtom {
+  def make(atom: AtomApiAtom): ChartAtom =
+    ChartAtom(atom.id, atom, atom.data.asInstanceOf[AtomData.Chart].chart)
 }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -12,7 +12,7 @@
 )(implicit request: RequestHeader, context: ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
-@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom, CommonsDivisionAtom, AudioAtom}
+@import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom, ExplainerAtom, CommonsDivisionAtom, AudioAtom, ChartAtom}
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
@@ -38,6 +38,7 @@
         case explainer: ExplainerAtom if !amp => Html(ArticleAtomRenderer.getHTML(explainer.atom, config))
         case commonsdivision: CommonsDivisionAtom if !amp => Html(ArticleAtomRenderer.getHTML(commonsdivision.atom, config))
         case audio: AudioAtom if !amp => Html(ArticleAtomRenderer.getHTML(audio.atom, config))
+        case chart: ChartAtom if !amp => Html(ArticleAtomRenderer.getHTML(chart.atom, config))
         case _ =>
     }
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -51,7 +51,8 @@ class AtomCleanerTest extends FlatSpec
     profiles = Nil,
     timelines = Nil,
     commonsdivisions = Nil,
-    audios = Nil
+    audios = Nil,
+    charts = Nil
   )
 )
   def doc: Document = Jsoup.parse( s"""<figure class="element element-atom">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "@guardian/atom-renderer": "0.16.3",
+    "@guardian/atom-renderer": "0.17.0",
     "@guardian/dotcom-rendering": "git+https://git@github.com/guardian/dotcom-rendering#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.16.3"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.17.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/static/src/javascripts/bootstraps/standard/atoms.js
+++ b/static/src/javascripts/bootstraps/standard/atoms.js
@@ -26,6 +26,42 @@ const bootstrapAtom = <A>(atomMaker: AtomMaker<A>, atomType: AtomType) => {
     });
 };
 
+const initCharts = () => {
+    const iframes: HTMLIFrameElement[] = ([
+        ...document.querySelectorAll('.atom--chart > .atom__iframe'),
+    ]: any);
+
+    window.addEventListener('message', event => {
+        const iframe: ?HTMLIFrameElement = iframes.find(i => {
+            try {
+                return i.name === event.source.name;
+            } catch (e) {
+                return false;
+            }
+        });
+        if (iframe) {
+            try {
+                const message = JSON.parse(event.data);
+                switch (message.type) {
+                    case 'set-height':
+                        iframe.height = message.value;
+                        break;
+                    default:
+                }
+                // eslint-disable-next-line no-empty
+            } catch (e) {}
+        }
+    });
+
+    iframes.forEach(iframe => {
+        const src = (iframe.getAttribute('srcdoc') || '').replace(
+            /gu-script/g,
+            'script'
+        );
+        iframe.setAttribute('srcdoc', src);
+    });
+};
+
 const initAtoms = () => {
     if (config.get('page.atomTypes.guide')) {
         require.ensure(
@@ -121,6 +157,10 @@ const initAtoms = () => {
             },
             'audio-atom'
         );
+    }
+
+    if (config.get('page.atomTypes.chart')) {
+        initCharts();
     }
 };
 export { initAtoms };

--- a/static/src/javascripts/bootstraps/standard/atoms.js
+++ b/static/src/javascripts/bootstraps/standard/atoms.js
@@ -54,10 +54,10 @@ const initCharts = () => {
     });
 
     iframes.forEach(iframe => {
-        const src = (iframe.getAttribute('srcdoc') || '').replace(
-            /gu-script/g,
-            'script'
-        );
+        const src = (iframe.getAttribute('srcdoc') || '')
+            .replace(/<gu-script>/g, '<script>')
+            // eslint-disable-next-line no-useless-concat
+            .replace(/<\/gu-script>/g, '<' + '/script>');
         iframe.setAttribute('srcdoc', src);
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,9 +1007,9 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.7.1.tgz#e44e596d03c9f16ba3b127ad333a8a072bcb5a0a"
 
-"@guardian/atom-renderer@0.16.3":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.16.3.tgz#bb96d3a8a5fd05663d0950dfd311bde746ae0107"
+"@guardian/atom-renderer@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.17.0.tgz#fd585a917b0c8fe3e0666e3431a580647a7df455"
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
Pending release of [the library update](https://github.com/guardian/atom-renderer/pull/63).

Adds support for chart atoms pseudo-rendered by the rendering library:

![chart](https://user-images.githubusercontent.com/629976/53351387-1e7d3b00-3919-11e9-858b-457ea8affce8.gif)

This is a temporary solution. Right now the markup/css/js is generated by the visuals tool and embedded in the `defaultHtml` field of the atom. We plan to replace that with our own renderer soon, but in the meantime, we need to get this off the ground.

This is embedded as such in the atom:

```html
<iframe srcdoc="@atom.defaultHtml"></iframe>
```

The only small problem is that the code contains logic to resize the iframe via `postMessage`, and that this event is sent too early, before we have a chance to register a listener. To circumvent that issue, I had to "disable" scripts by renaming the `<script>` tag. It works 😭 