### PR TITLE
Added personalised ad consent for AMP

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -52,6 +52,7 @@ rules:
         - grid-column-gap
         - grid-row-gap
         - grid-gap
+        - touch-callout
   no-trailing-zero: 1
   no-url-protocols: 0
 

--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -24,7 +24,8 @@ https://support.google.com/dfp_premium/answer/7678538
    {
        "consents": {
            "adconsent": {
-               "promptIfUnknownForGeoGroup": "eea"
+               "promptIfUnknownForGeoGroup": "eea",
+               "promptUI": "adconsent-ui"
            }
        },
        "policy": {
@@ -39,16 +40,19 @@ https://support.google.com/dfp_premium/answer/7678538
    }
   </script>
 
-@*
-  Interface stubs (to be activated with promptUI: 'adconsent-ui' in the 'adconsent'
-  and with postPromptUI: 'post-adconsent-ui in the top application/json structure above.
-  <div id="adconsent-ui" class="with-uk-frame consent-ui">
-      <button on="tap:the-adconsent-element.accept"  role="button">YES DO PERSONALISE</button>
-      <button on="tap:the-adconsent-element.reject"  role="button">DO NOT PERSONALISE</button>
-      <button on="tap:the-adconsent-element.dismiss" role="button">CLOSE</button>
+  <div id="adconsent-ui" class="with-uk-frame consent-ui main-body">
+      <div class="adconsent-message">
+        <p>We use cookies to improve your experience on our site and to show you
+            personalised advertising.</p>
+        <p>To find out more, read our <a class="u-underline" href="https://www.theguardian.com/help/privacy-policy">privacy policy</a>
+            and <a class="u-underline" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
+      </div>
+      <div class="adconsent-actions">
+          <button on="tap:the-adconsent-element.reject" class="u-underline adconsent-reject" role="button">Reject</button>
+          <button on="tap:the-adconsent-element.accept" class="adconsent-accept" role="button">
+              @fragments.inlineSvg("tick", "icon")
+              I'm OK with that
+          </button>
+      </div>
   </div>
-  <div id="post-adconsent-ui">
-      <button on="tap:the-adconsent-element.prompt"  role="button">AD PERSONALISATION SETTING</button>
-  </div>
-*@
 </amp-consent>

--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -33,7 +33,7 @@ https://support.google.com/dfp_premium/answer/7678538
                "waitFor": { "adconsent": [] },
                "timeout": {
                    "seconds": 0,
-                   "fallbackAction": "dismiss"
+                   "fallbackAction": "reject"
                }
            }
        }

--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -42,6 +42,7 @@ https://support.google.com/dfp_premium/answer/7678538
 
   <div id="adconsent-ui" class="with-uk-frame consent-ui main-body">
       <div class="adconsent-message">
+        <h2>Your privacy</h2>
         <p>We use cookies to improve your experience on our site and to show you
             personalised advertising.</p>
         <p>To find out more, read our <a class="u-underline" href="https://www.theguardian.com/help/privacy-policy">privacy policy</a>

--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -48,9 +48,12 @@ https://support.google.com/dfp_premium/answer/7678538
             and <a class="u-underline" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
       </div>
       <div class="adconsent-actions">
-          <button on="tap:the-adconsent-element.reject" class="u-underline adconsent-reject" role="button">Reject</button>
+          <button on="tap:the-adconsent-element.reject" class="u-underline adconsent-reject" role="button">
+              I do not want to see personalised ads
+          </button>
           <button on="tap:the-adconsent-element.accept" class="adconsent-accept" role="button">
-              @fragments.inlineSvg("tick", "icon")
+              @fragments.inlineSvg("tick", "icon", List("inline-icon--black"))
+
               I'm OK with that
           </button>
       </div>

--- a/common/app/views/fragments/amp/adConsent.scala.html
+++ b/common/app/views/fragments/amp/adConsent.scala.html
@@ -48,13 +48,13 @@ https://support.google.com/dfp_premium/answer/7678538
             and <a class="u-underline" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
       </div>
       <div class="adconsent-actions">
-          <button on="tap:the-adconsent-element.reject" class="u-underline adconsent-reject" role="button">
-              I do not want to see personalised ads
-          </button>
           <button on="tap:the-adconsent-element.accept" class="adconsent-accept" role="button">
               @fragments.inlineSvg("tick", "icon", List("inline-icon--black"))
 
               I'm OK with that
+          </button>
+          <button on="tap:the-adconsent-element.reject" class="u-underline adconsent-reject" role="button">
+              I do not want to see personalised ads
           </button>
       </div>
   </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -411,7 +411,7 @@
 @adPreference(isAmp: Boolean) = {
     @if(isAmp){
         <li class="colophon__item"><a class="adconsent-preference" data-link-name="adpreference" on="tap:the-adconsent-element.prompt">
-            Ad preferences</a>
+            Your privacy</a>
         </li>
     }else{
         ""

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -74,9 +74,7 @@
                                     <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                         Cookie policy</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="adpreference" on="tap:the-adconsent-element.prompt">
-                                        Ad preferences</a>
-                                    </li>
+                                    @adPreference(isAmp)
                                     <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                         Terms &amp; conditions</a>
                                     </li>
@@ -153,6 +151,7 @@
                                     <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                         Cookie policy</a>
                                     </li>
+                                    @adPreference(isAmp)
                                     <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                         Terms &amp; conditions</a>
                                     </li>
@@ -225,6 +224,7 @@
                                     <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                         Cookie policy</a>
                                     </li>
+                                    @adPreference(isAmp)
                                     <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                         Terms &amp; conditions</a>
                                     </li>
@@ -297,6 +297,7 @@
                                     <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                         Cookie policy</a>
                                     </li>
+                                    @adPreference(isAmp)
                                     <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                         Terms &amp; conditions</a>
                                     </li>
@@ -371,6 +372,7 @@
                                     Cookie policy
                                 </a>
                             </li>
+                            @adPreference(isAmp)
                             <li class="colophon__item">
                                 <a data-link-name="foundation : footer : terms" href="@LinkTo {/help/terms-of-service}">
                                     Terms &amp; conditions
@@ -405,6 +407,16 @@
         </div>
     </div>
 </footer>
+
+@adPreference(isAmp: Boolean) = {
+    @if(isAmp){
+        <li class="colophon__item"><a class="adconsent-preference" data-link-name="adpreference" on="tap:the-adconsent-element.prompt">
+            Ad preferences</a>
+        </li>
+    }else{
+        ""
+    }
+}
 
 @readerRevenueLinks(editionId: String) =  {
     <div class="colophon__list">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -74,6 +74,9 @@
                                     <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                         Cookie policy</a>
                                     </li>
+                                    <li class="colophon__item"><a data-link-name="adpreference" on="tap:the-adconsent-element.prompt">
+                                        Ad preferences</a>
+                                    </li>
                                     <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                         Terms &amp; conditions</a>
                                     </li>

--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -35,3 +35,5 @@
 @import 'amp/_from-content-api';
 
 @import 'amp/_geo';
+@import 'amp/_adconsent';
+

--- a/static/src/stylesheets/amp/_adconsent.scss
+++ b/static/src/stylesheets/amp/_adconsent.scss
@@ -15,6 +15,10 @@ div.consent-ui {
     color: $brightness-97;
     background-color: rgb(51, 51, 51);
 
+    h2 {
+        margin-bottom: 1em;
+    }
+
     a {
         color: $brightness-97;
     }

--- a/static/src/stylesheets/amp/_adconsent.scss
+++ b/static/src/stylesheets/amp/_adconsent.scss
@@ -1,0 +1,35 @@
+amp-consent { background: none; }
+.consent-ui {
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-size: 1rem;
+    line-height: 1.25rem;
+
+    color: $brightness-97;
+    background-color: rgb(51, 51, 51);
+
+    a {
+        color: $brightness-97;
+    }
+    a:hover {
+        text-decoration: 0;
+    }
+
+    div {
+        margin: 1em;
+    }
+    div.adconsent-actions {
+        text-align: right;
+        button {
+            border: 0;
+            background: transparent;
+            font: inherit;
+            color: inherit;
+        }
+        button.adconsent-accept {
+            @include circular;
+            border: .0625rem solid rgba(255, 255, 255, .3);
+            padding: 5px 20px;
+            font-weight: bold;
+        }
+    }
+}

--- a/static/src/stylesheets/amp/_adconsent.scss
+++ b/static/src/stylesheets/amp/_adconsent.scss
@@ -20,14 +20,22 @@ amp-consent { background: none; }
     div.adconsent-actions {
         text-align: right;
         button {
+            font: inherit;
+
             border: 0;
             background: transparent;
-            font: inherit;
             color: inherit;
+
+            display: block;
+            width: 100%;
+            margin-top: 1em;
         }
         button.adconsent-accept {
             @include circular;
             border: .0625rem solid rgba(255, 255, 255, .3);
+            background: $highlight-main;
+            color: $brightness-7;
+
             padding: 5px 20px;
             font-weight: bold;
         }

--- a/static/src/stylesheets/amp/_adconsent.scss
+++ b/static/src/stylesheets/amp/_adconsent.scss
@@ -1,5 +1,13 @@
 amp-consent { background: none; }
-.consent-ui {
+a.adconsent-preference {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+div.consent-ui {
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     font-size: 1rem;
     line-height: 1.25rem;
@@ -29,6 +37,9 @@ amp-consent { background: none; }
             display: block;
             width: 100%;
             margin-top: 1em;
+        }
+        button.adconsent-reject {
+            text-decoration: underline;
         }
         button.adconsent-accept {
             @include circular;

--- a/static/src/stylesheets/base/_inline-svgs.scss
+++ b/static/src/stylesheets/base/_inline-svgs.scss
@@ -10,6 +10,10 @@
     fill: $brightness-86;
 }
 
+.inline-icon--black {
+    fill: $brightness-7;
+}
+
 .inline-close--small svg {
     height: 100%;
     width: 45%;
@@ -18,6 +22,7 @@
 .inline-tone-fill {
     fill: $sport-dark;
 }
+
 
 .inline-icon__fallback {
     display: none;


### PR DESCRIPTION
## What does this change?

Adds the consent component on AMP, for eea and a link in the footer to change your preference on AMP.

## Screenshots

![screen shot 2019-02-25 at 17 59 27](https://user-images.githubusercontent.com/103262/53358222-a1a58d80-3927-11e9-8627-f4ca72dfe8d5.png)
![screen shot 2019-02-25 at 17 59 12](https://user-images.githubusercontent.com/103262/53358225-a1a58d80-3927-11e9-881a-40d5d6b9fb48.png)

## Checklist

### Does this affect other platforms?

- [ X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [X ] Locally
- [ ] On CODE (optional)
