### PR TITLE
Change prebid to not run for googleweblight clients

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -10,7 +10,8 @@ const isGoogleWebPreview: () => boolean = () =>
     !!(
         navigator &&
         navigator.userAgent &&
-        navigator.userAgent.indexOf('Google Web Preview') > -1
+        (navigator.userAgent.indexOf('Google Web Preview') > -1 ||
+            navigator.userAgent.indexOf('googleweblight') > -1)
     );
 
 if (!isGoogleWebPreview()) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -99,4 +99,9 @@ describe('init', () => {
         fakeUserAgent('Google Web Preview');
         expect(isGoogleWebPreview()).toBe(true);
     });
+
+    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+        fakeUserAgent('googleweblight');
+        expect(isGoogleWebPreview()).toBe(true);
+    });
 });


### PR DESCRIPTION
## What does this change?

This updates the logic around when we decide NOT to run Prebid; currently we do not run it for `Google Web Preview`, however after a big of investigation I have found that `googleweblight` is an even bigger problem for repeated `page_view_id`s AND `auction_id`s.

## Checklist

- [x] Check how Prebid performs (if at all) on a googleweblight page
- [ ] Find out if we can properly measure any impact on revenue

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (Google Web Light impressions)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
