### PR TITLE
Add `.git` to end of `dotcom-rendering` repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "0.17.0",
-    "@guardian/dotcom-rendering": "git+https://git@github.com/guardian/dotcom-rendering.git#version-1-alpha",
+    "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "0.17.0",
-    "@guardian/dotcom-rendering": "git+https://git@github.com/guardian/dotcom-rendering#version-1-alpha",
+    "@guardian/dotcom-rendering": "git+https://git@github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.3.7",


### PR DESCRIPTION
## What does this change?
Adds `.git` to end of the DC repo

## What is the value of this and can you measure success?

Aiming to fix:

```
[Step 3/8] error https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "Invalid tar header. Maybe the tar is corrupted or it needs to be gunzipped?"
```
in `teamcity` using the fix described https://github.com/yarnpkg/yarn/issues/6312

`make reinstall` works locally.

