### PR TITLE
Allow for the upgrade of transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "engines": {
     "yarn": "1.8.0"
   },
+  "resolutions": {
+    "**/**/node-gyp": "^3.8.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "0.17.0",


### PR DESCRIPTION
## What does this change?

Add an instruction to `package.json` to allow for the upgrade of transitive dependencies. This is enabled by 

```
yarn upgrade-interactive
```

## What is the value of this and can you measure success?

Resolves security notifications.
