### PR TITLE
Exclude RHS and Inline2-n from resize event

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -56,7 +56,12 @@ const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
             const adSlot = iframe && iframe.closest('.js-ad-slot');
-            if (adSlot && adSlot.classList.contains('ad-slot--mostpop')) {
+            if (
+                adSlot &&
+                (adSlot.classList.contains('ad-slot--mostpop') ||
+                    adSlot.classList.contains('ad-slot--right') ||
+                    adSlot.classList.contains('ad-slot--offset-right'))
+            ) {
                 // We ignore resize events (sent mainly by apnx)
                 // for the mostpop (Most popular) slot
                 // See https://trello.com/c/TtuGq6Iy


### PR DESCRIPTION
## What does this change?
Excludes the Right hand slot and the inline2-n slots from the resize event causing a width and height to be set on the ad container when it doesn't need to be.
## Screenshots
before:
![picture 263](https://user-images.githubusercontent.com/19835654/53488124-4ee1e800-3a85-11e9-925b-bbf6b8ad9f29.png)

after:
![picture 264](https://user-images.githubusercontent.com/19835654/53488138-55705f80-3a85-11e9-9a75-391802e2f4f7.png)

## What is the value of this and can you measure success?
will fix overlapping issue of the most viewed right component, and issues with the skyscraper. Potentially allowing the skyscraper to serve in the RHS slot.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
