### PR TITLE
Fix adblock padding and stop showing on showcase pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,6 +1,7 @@
 // @flow
 import { userIsSupporter } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import config from 'lib/config';
 
 const supportUrl =
     'https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019';
@@ -40,9 +41,11 @@ export const adblockTest: ABTest = {
     audienceCriteria: '',
     showForSensitive: true,
     canRun() {
-        return !userIsSupporter()
-            && !pageShouldHideReaderRevenue()
-            && !window.guardian.config.page.hasShowcaseMainElement;
+        return (
+            !userIsSupporter() &&
+            !pageShouldHideReaderRevenue() &&
+            !config.get('page.hasShowcaseMainElement')
+        );
     },
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -40,7 +40,9 @@ export const adblockTest: ABTest = {
     audienceCriteria: '',
     showForSensitive: true,
     canRun() {
-        return !userIsSupporter() && !pageShouldHideReaderRevenue();
+        return !userIsSupporter()
+            && !pageShouldHideReaderRevenue()
+            && !window.guardian.config.page.hasShowcaseMainElement;
     },
 
     variants: [

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -247,7 +247,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
 
     .contributions__adblock--moment-button {
         padding-left: 5px;
-        padding-bottom: 13px;
+        padding-bottom: 4px;
         a {
             color: #052962;
             margin: $gs-baseline/3 $gs-gutter/2 $gs-baseline/3 0;


### PR DESCRIPTION
## What does this change?
2 issues.

- Padding issue that caused the ad to slightly obscure the Most Viewed component:

|Before|After|
|----|----|
|![oldpadding](https://user-images.githubusercontent.com/2844554/53495217-64f8a400-3a97-11e9-8b68-582471b78c9b.png)|![newpadding](https://user-images.githubusercontent.com/2844554/53495216-64f8a400-3a97-11e9-97b0-43128f364951.png)|


- Removes the ad from pages with a showcase image"

|Before|After|
|----|----|
|![elxabefore](https://user-images.githubusercontent.com/2844554/53495262-7e015500-3a97-11e9-8c67-8c7ed0ae2a0b.png)|![elxaafter](https://user-images.githubusercontent.com/2844554/53495261-7e015500-3a97-11e9-93b1-7b7663c61476.png)|




