### PR TITLE
Add outstream mobile size to desktop inline slots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -91,13 +91,13 @@ describe('createCommentSlots', () => {
         const commentMpu: HTMLElement = createCommentSlots(false)[0];
         const commentDmpu: HTMLElement = createCommentSlots(true)[0];
         expect(commentMpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
+            '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid'
         );
         expect(commentMpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
         );
         expect(commentDmpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
+            '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
         );
         expect(commentDmpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
@@ -252,7 +252,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -270,7 +270,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -288,7 +288,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
+                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid'
                 );
                 done();
             });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -16,7 +16,8 @@ const inlineDefinition = {
             adSizes.empty,
             adSizes.mpu,
             adSizes.video,
-            adSizes.outstreamDesktop,
+            adSizes.outstreamDesktop, // todo will remove this once Ad Manager updated
+            adSizes.outstreamMobile,
             adSizes.googleCard,
             adSizes.fluid,
         ],

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -21,7 +21,7 @@ const inline1Html = `
     data-name="inline1"
     aria-hidden="true"
     data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|620,350|300,274|fluid">
+    data-desktop="1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid">
 </div>
 `;
 


### PR DESCRIPTION
This is a transition of the outstream size on desktop to be the same as the outstream size on mobile, as safeframes can only expand.