### PR TITLE
Upgrade React from 16.7.0 to 16.8.3 (in package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",
-    "react": "^16.7.0",
+    "react": "^16.8.3",
     "react-dom": "16.7.0",
     "react-emotion": "^9.2.4",
     "reqwest": "2.0.5",


### PR DESCRIPTION
## What does this change?

Upgrade React from 16.7.0 to 16.8.3 (in package.json). This consolidate the change made here: https://github.com/guardian/frontend/pull/21171
