### PR TITLE
Upgrade webpack from 4.1.1 to 4.29.5 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "svgo": "^0.7.2",
     "uglify-js": "^2.7.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.1.1",
+    "webpack": "^4.29.5",
     "webpack-bundle-analyzer": "^3.0.4",
     "webpack-merge": "^4.1.0",
     "webpack-visualizer-plugin": "^0.1.11",


### PR DESCRIPTION
## What does this change?

Upgrade webpack from 4.1.1 to 4.29.5 in package.json. To consolidate the upgrade from 4.28.3 to 4.29.5 that happened here: https://github.com/guardian/frontend/pull/21170
