### PR TITLE
Position outstream ad on desktop

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -320,12 +320,12 @@
     }
 
     @include mq(desktop) {
-        width: 620px;
-        height: $mpu-ad-label-height + 350px;
+        width: auto;
+        height: auto;
+        margin-right: 6%;
 
-        & > div.ad-slot__label {
-            margin-left: 35px;
-            margin-right: 35px;
+        & > div.ad-slot__content {
+            min-height: 250px;
         }
     }
 }


### PR DESCRIPTION
So that it works for outstream ad and for MPU passback.
 
Outstream:

![image](https://user-images.githubusercontent.com/1722550/53563363-b82c2e80-3b4b-11e9-8c90-29130aacc2eb.png)

Passback (might have to use some imagination with this one but label shows where it will appear):

![image](https://user-images.githubusercontent.com/1722550/53563395-cda15880-3b4b-11e9-9f70-ac059d27861a.png)
