### PR TITLE
Improving tracking of the contribute and subscribe CTA

### DIFF
--- a/common/app/views/fragments/email/support.scala.html
+++ b/common/app/views/fragments/email/support.scala.html
@@ -8,6 +8,7 @@
     </tr>
     <tr>
         <td class="wrap-pad text-center">
+            @defining(request.path.replace("/", "_")) { pathURL =>
             <!--[if (gte mso 9)|(IE)]>
             <table width="100%">
                 <tr>
@@ -32,11 +33,11 @@
                                     <td class="cta-pad" align="center" valign="middle">
                                         <div>
                                             <!--[if mso]>
-                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
+                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22editorial@{pathURL}_support_ask_contribute%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
                                                 <w:anchorlock></w:anchorlock>
                                                 <center style="color:#000000;font-family:Georgia,serif;font-size:16px;font-weight:bold;">Contribute</center>
                                             </v:roundrect>
-                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskContribute%22%7D&INTCMP=EmailED&">Contribute</a>
+                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22editorial@{pathURL}_support_ask_contribute%22%7D&INTCMP=EmailED&">Contribute</a>
                                         </div>
                                     </td>
                                 </tr>
@@ -44,11 +45,11 @@
                                     <td class="cta-pad" align="center" valign="middle">
                                         <div>
                                             <!--[if mso]>
-                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskSubscribe%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
+                                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22editorial@{pathURL}_support_ask_subscribe%22%7D&INTCMP=EmailED&" style="height:30pt;v-text-anchor:middle;width:97pt;" arcsize="50%" strokecolor="#ffe500" fillcolor="#ffe500">
                                                 <w:anchorlock></w:anchorlock>
                                                 <center style="color:#000000;font-family:Georgia,serif;font-size:16px;font-weight:bold;">Subscribe</center>
                                             </v:roundrect>
-                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22EDSupportAskSubscribe%22%7D&INTCMP=EmailED&">Subscribe</a>
+                                            <![endif]--><a class="sm-btn" href="https://support.theguardian.com/subscribe?acquisitionData=%7B%22source%22%3A%22EMAIL%22%2C%22campaignCode%22%3A%22EmailED%22%2C%22componentId%22%3A%22editorial@{pathURL}_support_ask_subscribe%22%7D&INTCMP=EmailED&">Subscribe</a>
                                         </div>
                                     </td>
                                 </tr>
@@ -59,6 +60,11 @@
                 </tr>
             </table>
             <![endif]-->
+            }
         </td>
     </tr>
 </table>
+
+<div>
+    @if(request.uri == "/") { "Home Menu Selected" }
+</div>


### PR DESCRIPTION
## What does this change?
The following change improves tracking of the 'Contribute' and 'Subscribe' CTA, by adding dynamically generated part of the link, which is retrieved from the URL of the newsletter. 
## Screenshots
![componentid acquisition tracking](https://user-images.githubusercontent.com/47107438/53566646-aef38f80-3b54-11e9-9cc2-98fa8119935d.png)

## What is the value of this and can you measure success?
Improves analytics for individual campaigns
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
N/A
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
