### PR TITLE
Commercial - Ensure iframes provided by Google DFP are sandboxed to prevent redirection 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -221,7 +221,9 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slot.setTargeting('ad_h', new Date().getUTCHours().toString());
     }
 
-    slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
+    slot.setSafeFrameConfig({ sandbox: true })
+        .addService(window.googletag.pubads())
+        .setTargeting('slot', slotTarget);
 
     return {
         slot,

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -57,6 +57,9 @@ export const refreshAdvert = (advert: Advert): void => {
                     advert.slot.defineSizeMapping([[[0, 0], [advert.size]]]);
                 }
             }
-            window.googletag.pubads().refresh([advert.slot]);
+            window.googletag
+                .pubads()
+                .setForceSafeFrame(true)
+                .refresh([advert.slot]);
         });
 };


### PR DESCRIPTION
## What does this change?

The associated changes enabled `sandbox` option for the [`iframe`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) returned by Google DFP and force the usage of `Safeframe` to reduce the possibility of redirection from an ads.  The redirection issue is unfortunately a know problem of the adtech, and you can notably find more details on this [prebid issue](https://github.com/prebid/Prebid.js/issues/927).  

#### Safeframe

A [SafeFrame](https://www.iab.com/guidelines/safeframe/) is an `iFrame` that is served off a different domain meaning it doesn't benefit from the `Same-Origin` policy; it also provides an API around viewability and positioning, among other things. :nerd_face:.

`SafeFrame` offer the following benefits for a publisher such as the Guardian:
<img width="677" alt="screenshot 2019-03-04 at 09 24 22" src="https://user-images.githubusercontent.com/615085/53724567-0ac65d00-3e62-11e9-94c4-906b24ba0b02.png">


 

Google recommend using the `SafeFrame` and `sandbox` feature.

> [To minimize the chances of malicious creatives serving, we recommend enabling SafeFrame whenever possible, in conjunction with the HTML5 sandbox attribute to prevent top-level navigation.](https://support.google.com/admanager/answer/6023110?hl=en)

Using `sandbox` attribute  of `iframe` can prevent redirection to happen because `allow-top-navigation` value is not added. 

## Screenshots

Here is an example of a redirection to a dodgy website who happened  yesterday to a user:

![unnamed](https://user-images.githubusercontent.com/615085/53630073-208c1600-3c07-11e9-965e-eb5c7496815c.jpg)


## What is the value of this and can you measure success?


## Additional work

As @jeteve mentioned we need to let our partners knows, that their creative work will need to to be working in the context of `SafeFrame` with the `sandbox` attribute.


>Before turning on SafeFrame, work with the advertisers or vendors who provide your creatives to determine if those creatives are SafeFrame-compatible. **If you're using the sandbox attribute, work with the agency or advertiser to ensure that clicks open the landing page in a new tab rather than navigating from the current page.**

### Prebid implemenation

[Todo write about our work on Prebid safeframe]