### PR TITLE
Ensure space between tag rich links and showcase img

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -121,6 +121,12 @@ const getSpacefinderRules = (): SpacefinderRules => ({
             minAbove: 500,
             minBelow: 500,
         },
+        ' .element--showcase': {
+            minAbove: ['desktop', 'leftCol', 'wide'].includes(getBreakpoint())
+                ? 200
+                : 0,
+            minBelow: 0,
+        },
     },
 });
 


### PR DESCRIPTION
## What does this change?

This fix ensures automatic rich links can't be added 200px below a showcase image element. This is limited to `leftCol`, `desktop` and `wide` breakpoints as narrower breakpoints are unaffected.

## Screenshots

**Before**

![screen shot 2019-03-01 at 11 39 42](https://user-images.githubusercontent.com/5931528/53636520-6bfaf000-3c18-11e9-8e26-f56d521f7eb0.png)

**After**

![screen shot 2019-03-01 at 11 39 31](https://user-images.githubusercontent.com/5931528/53636521-6c938680-3c18-11e9-9119-2839e17f5c58.png)

## What is the value of this and can you measure success?

On wider breakpoints, showcase images in the article body intrude on the left column. Rich links that are automatically added to the article based on tag id may clash with the showcase image caption, causing the caption to be hidden. This looks dreadful and may cause copyright issues.

[Example article](https://www.theguardian.com/environment/2018/dec/11/legitimate-zoo-obscure-german-group-endangered-parrots-actp)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
