### PR TITLE
Make rich links work locally

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -59,6 +59,8 @@ object Tag {
     val richLinkId = tag.references.find(_.`type` == "rich-link")
       .map(_.id.stripPrefix("rich-link/"))
       .filter(_.matches( """https?://www\.theguardian\.com/.*"""))
+      .map(_.stripPrefix("https://www.theguardian.com"))
+
 
     Tag(
       properties = TagProperties.make(tag),

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -89,6 +89,7 @@
                 }
             </div>
         </div>
-        <a class="rich-link__link u-faux-block-link__overlay" href="@content.metadata.webUrl" aria-label="@content.trail.headline"></a>
+
+        <a class="rich-link__link u-faux-block-link__overlay" href="@content.metadata.url" aria-label="@content.trail.headline"></a>
     </div>
 </div>


### PR DESCRIPTION
## What does this change?

- strip the host from the `richLinkId` received from CAPI
- use relative URL as href for rich links

## Screenshots

## What is the value of this and can you measure success?

Currently, tag rich links don't appear in non-PROD environments. Rich links that do appear always link to the PROD version of the article instead of the environment specific version. This causes friction when debugging rich links in dev mode.

## Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
