### PR TITLE
Change prebid so it doesn't load when there is a pageskin

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -1,5 +1,6 @@
 // @flow
 
+import config from 'lib/config';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -23,6 +24,7 @@ const setupPrebid: () => Promise<void> = () => {
         dfpEnv.externalDemand === 'prebid' &&
         commercialFeatures.dfpAdvertising &&
         !commercialFeatures.adFree &&
+        !config.page.hasPageSkin &&
         !isGoogleWebPreview()
     ) {
         buildPageTargeting();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -1,5 +1,6 @@
 // @flow
 
+import config from 'lib/config';
 import prebid from 'commercial/modules/prebid/prebid';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
@@ -25,6 +26,12 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
 
 jest.mock('commercial/modules/prebid/bid-config', () => ({
     isInVariant: jest.fn(),
+}));
+
+jest.mock('lib/config', () => ({
+    page: {
+        hasPageSkin: false,
+    },
 }));
 
 const fakeUserAgent = (userAgent: string): void => {
@@ -76,6 +83,24 @@ describe('init', () => {
         commercialFeatures.adFree = true;
         setupPrebid();
         expect(prebid.initialise).not.toBeCalled();
+    });
+
+    it('should not initialise Prebid when the page has a pageskin', () => {
+        dfpEnv.externalDemand = 'prebid';
+        commercialFeatures.dfpAdvertising = true;
+        commercialFeatures.adFree = false;
+        config.page.hasPageSkin = true;
+        setupPrebid();
+        expect(prebid.initialise).not.toBeCalled();
+    });
+
+    it('should initialise Prebid when the page has no pageskin', () => {
+        dfpEnv.externalDemand = 'prebid';
+        commercialFeatures.dfpAdvertising = true;
+        commercialFeatures.adFree = false;
+        config.page.hasPageSkin = false;
+        setupPrebid();
+        expect(prebid.initialise).toBeCalled();
     });
 
     it('isGoogleWebPreview should return false with no navigator or useragent', () => {


### PR DESCRIPTION
## What does this change?

This updates `prepare-prebid` to only load `Prebid.js` when there is no pageskin.

## What is the value of this and can you measure success?

We run auctions on pageviews that will always discard the result of the auction; there is no point in loading prebid in these cases.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

@guardian/commercial-dev 