### PR TITLE
Update prebid loading

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -1,7 +1,6 @@
 // @flow
 import { Advert } from 'commercial/modules/dfp/Advert';
 import prebid from 'commercial/modules/prebid/prebid';
-import config from 'lib/config';
 
 export const loadAdvert = (advert: Advert): void => {
     advert.whenSlotReady
@@ -10,11 +9,6 @@ export const loadAdvert = (advert: Advert): void => {
         })
         .then(() => {
             advert.startLoading();
-            if (config.page.hasPageSkin) {
-                // No point requesting prebid bids. pageSkin slots are all loaded in one
-                // go. See 'fillAdvertSlots' in commercial/modules/dfp/fill-advert-slots.js
-                return Promise.resolve();
-            }
             return prebid.requestBids(advert);
         })
         .then(() => window.googletag.display(advert.id));

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -7,7 +7,7 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import prebid from 'commercial/modules/prebid/prebid';
 
-const isGoogleWebPreview: () => boolean = () =>
+const isGoogleProxy: () => boolean = () =>
     !!(
         navigator &&
         navigator.userAgent &&
@@ -15,7 +15,7 @@ const isGoogleWebPreview: () => boolean = () =>
             navigator.userAgent.indexOf('googleweblight') > -1)
     );
 
-if (!isGoogleWebPreview()) {
+if (!isGoogleProxy()) {
     import(/* webpackMode: "eager" */ 'prebid.js/build/dist/prebid');
 }
 
@@ -25,7 +25,7 @@ const setupPrebid: () => Promise<void> = () => {
         commercialFeatures.dfpAdvertising &&
         !commercialFeatures.adFree &&
         !config.page.hasPageSkin &&
-        !isGoogleWebPreview()
+        !isGoogleProxy()
     ) {
         buildPageTargeting();
         prebid.initialise(window);
@@ -42,6 +42,6 @@ export const init = (start: () => void, stop: () => void): Promise<void> => {
 };
 
 export const _ = {
-    isGoogleWebPreview,
+    isGoogleProxy,
     setupPrebid,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -6,7 +6,7 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { _ } from './prepare-prebid';
 
-const { isGoogleWebPreview, setupPrebid } = _;
+const { isGoogleProxy, setupPrebid } = _;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
@@ -104,21 +104,21 @@ describe('init', () => {
     });
 
     it('isGoogleWebPreview should return false with no navigator or useragent', () => {
-        expect(isGoogleWebPreview()).toBe(false);
+        expect(isGoogleProxy()).toBe(false);
     });
 
     it('isGoogleWebPreview should return false with no navigator or useragent', () => {
         fakeUserAgent('Firefox');
-        expect(isGoogleWebPreview()).toBe(false);
+        expect(isGoogleProxy()).toBe(false);
     });
 
     it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
         fakeUserAgent('Google Web Preview');
-        expect(isGoogleWebPreview()).toBe(true);
+        expect(isGoogleProxy()).toBe(true);
     });
 
     it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
         fakeUserAgent('googleweblight');
-        expect(isGoogleWebPreview()).toBe(true);
+        expect(isGoogleProxy()).toBe(true);
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -115,6 +115,7 @@ class PrebidAdUnit {
 }
 
 let requestQueue: Promise<void> = Promise.resolve();
+let initialised: boolean = false;
 
 const initialise = (window: {
     pbjs: {
@@ -123,6 +124,8 @@ const initialise = (window: {
         enableAnalytics: ([EnableAnalyticsConfig]) => void,
     },
 }): void => {
+    initialised = true;
+
     const userSync = config.get('switches.prebidUserSync', false)
         ? {
               // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
@@ -190,6 +193,10 @@ const requestBids = (
     advert: Advert,
     slotFlatMap?: PrebidSlot => PrebidSlot[]
 ): Promise<void> => {
+    if (!initialised) {
+        return requestQueue;
+    }
+
     const effectiveSlotFlatMap = slotFlatMap || (s => [s]); // default to identity
     if (dfpEnv.externalDemand !== 'prebid') {
         return requestQueue;


### PR DESCRIPTION
## What does this change?

- Adds an `initialised` variable to `prebid`; if it has not been initialised then we don't add to the `requestQueue`. (We will add to the request queue when `requestBids` is called during `load-advert` and during refreshes of the ad-slot.)
- Removes unused code around `hasPageSkin` from `load-advert`.
- Updates the function name from `isGoogleWebPreview` to `isGoogleProxy`

### Tested

- [ ] Locally
- [x] On CODE (optional)

@guardian/commercial-dev 
