### PR TITLE
Remove dependency of ad height on rich link position

### DIFF
--- a/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
+++ b/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
@@ -80,7 +80,14 @@
 .element-rich-link {
     float: left;
     margin: 5px $gs-gutter $gs-baseline 0;
-    clear: left;
+    clear: both;
+
+    // Decouple rich link position from height of ad in RHS.
+    // This prevents the rich link from shifting when the
+    // height of the ad changes
+    @include mq($from: desktop) {
+        clear: left;
+    }
 
     @include mq($until: mobileLandscape) {
         width: $gs-gutter * 6.5;

--- a/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
+++ b/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
@@ -80,7 +80,7 @@
 .element-rich-link {
     float: left;
     margin: 5px $gs-gutter $gs-baseline 0;
-    clear: both;
+    clear: left;
 
     @include mq($until: mobileLandscape) {
         width: $gs-gutter * 6.5;

--- a/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
+++ b/static/src/stylesheets/module/onward-garnett/_rich-links-default.head.scss
@@ -82,9 +82,9 @@
     margin: 5px $gs-gutter $gs-baseline 0;
     clear: both;
 
-    // Decouple rich link position from height of ad in RHS.
-    // This prevents the rich link from shifting when the
-    // height of the ad changes
+    // Decouple rich link position from height of ads that are offset right.
+    // This prevents the rich link from shifting when the height of the ad
+    // changes. Currently the tall ads are allowed only on desktop and above.
     @include mq($from: desktop) {
         clear: left;
     }


### PR DESCRIPTION
## What does this change?

Currently the position of rich links is dependent on the height of an ad. By clearing content  to the left only, instead of content to the left and right, this dependency is removed.

## Screenshots

![mar-04-2019 11-08-46](https://user-images.githubusercontent.com/5931528/53744701-6cec8580-3e95-11e9-9932-ba480f7130f4.gif)

## What is the value of this and can you measure success?

When the rich link position is dependent on sibling ad height, it creates jarring experiences such as the rich moving up and down the page as ad height changes (which can happen these days)

## Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
