### PR TITLE
CALLOUTS: fix base64 string

### DIFF
--- a/static/src/javascripts/projects/journalism/modules/submit-form.js
+++ b/static/src/javascripts/projects/journalism/modules/submit-form.js
@@ -51,7 +51,10 @@ const readFile = (file, cForm) =>
         reader.addEventListener(
             'load',
             () => {
-                const fileAsBase64 = reader.result.toString();
+                const fileAsBase64 = reader.result
+                    .toString()
+                    .split(';base64,')[1];
+                // remove data:*/*;base64, from the start of the base64 string
                 res(fileAsBase64);
             },
             false


### PR DESCRIPTION
## What does this change?
Previously the image was getting encoded like: `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/....`
but it should be like:
`/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBAQ`

Formstack file upload api here: https://formstack.readme.io/v1.0/docs/submit-post

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
