### PR TITLE
Moment Banner color test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,19 +28,9 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-february-moment-banner-non-uk-round-two",
-    "switch on to test the moment copy of the engagement banner outside the UK",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 9, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-february-moment-banner-uk-round-two",
-    "switch on to enable the moment engagement banner in the UK",
-    owners = Seq(Owner.withGithub("johnduffell")),
+    "ab-february-moment-banner-colour",
+    "switch on to test the moment colour engagement banner test",
+    owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 9, 30),
     exposeClientSide = true

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
@@ -18,8 +18,8 @@ export const acquisitionsBannerFivTemplate = (
         </div>
         <div class="fiv-banner__headline-and-circles">
             <div class="fiv-banner__circles">
-                <div class="fiv-banner__circle fiv-banner__circle-orange"></div>
-                <div class="fiv-banner__circle fiv-banner__circle-blue"></div>
+                <div class="fiv-banner__circle fiv-banner__circle-top"></div>
+                <div class="fiv-banner__circle fiv-banner__circle-bottom"></div>
             </div>
             ${
                 params.titles

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,8 +6,7 @@ import { askFourEarning } from 'common/modules/experiments/tests/contributions-e
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import {
-    februaryMomentBannerNonUkRoundTwo,
-    februaryMomentBannerUkRoundTwo,
+    februaryMomentBannerColour,
     februaryMomentBannerThankYou,
 } from 'common/modules/experiments/tests/february-moment-banner';
 
@@ -24,7 +23,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    februaryMomentBannerNonUkRoundTwo,
-    februaryMomentBannerUkRoundTwo,
+    februaryMomentBannerColour,
     februaryMomentBannerThankYou,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { getSync } from 'lib/geolocation';
 import { acquisitionsBannerFivTemplate } from 'common/modules/commercial/templates/acquisitions-banner-fiv';
 import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
@@ -42,7 +41,6 @@ const bannerShownCallback = () => {
     }
 };
 
-
 export const februaryMomentBannerColour: AcquisitionsABTest = {
     id: 'FebruaryMomentBannerColour',
     start: '2019-01-01',
@@ -70,7 +68,10 @@ export const februaryMomentBannerColour: AcquisitionsABTest = {
                 bannerModifierClass: 'fiv-banner',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
-                titles: ['We chose a different approach', 'Will you support it?'],
+                titles: [
+                    'We chose a different approach',
+                    'Will you support it?',
+                ],
                 bannerShownCallback,
             },
             canRun: () =>
@@ -90,7 +91,10 @@ export const februaryMomentBannerColour: AcquisitionsABTest = {
                 bannerModifierClass: 'fiv-banner fiv-banner--blue',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
-                titles: ['We chose a different approach', 'Will you support it?'],
+                titles: [
+                    'We chose a different approach',
+                    'Will you support it?',
+                ],
                 bannerShownCallback,
             },
             canRun: () =>
@@ -110,7 +114,10 @@ export const februaryMomentBannerColour: AcquisitionsABTest = {
                 bannerModifierClass: 'fiv-banner fiv-banner--yellow',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
-                titles: ['We chose a different approach', 'Will you support it?'],
+                titles: [
+                    'We chose a different approach',
+                    'Will you support it?',
+                ],
                 bannerShownCallback,
             },
             canRun: () =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -42,50 +42,9 @@ const bannerShownCallback = () => {
     }
 };
 
-const openVariant: Variant = {
-    id: 'open',
-    test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
-    engagementBannerParams: {
-        leadSentence: defaultBold,
-        messageText: defaultCopy,
-        // buttonCaption?: string, TO be decided with non engineers
-        template: acquisitionsBannerFivTemplate,
-        bannerModifierClass: 'fiv-banner',
-        minArticlesBeforeShowingBanner,
-        userCohort: userCohortParam.onlyNonSupporters,
-        titles: ['Open journalism is a choice', 'Will you support it?'],
-        bannerShownCallback,
-    },
-    canRun: () =>
-        canShowBannerSync(
-            minArticlesBeforeShowingBanner,
-            userCohortParam.onlyNonSupporters
-        ),
-};
 
-const differentVariant: Variant = {
-    id: 'different',
-    test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
-    engagementBannerParams: {
-        leadSentence: defaultBold,
-        messageText: defaultCopy,
-        // buttonCaption?: string, TO be decided with non engineers
-        template: acquisitionsBannerFivTemplate,
-        bannerModifierClass: 'fiv-banner',
-        minArticlesBeforeShowingBanner,
-        userCohort: userCohortParam.onlyNonSupporters,
-        titles: ['We chose a different approach', 'Will you support it?'],
-        bannerShownCallback,
-    },
-    canRun: () =>
-        canShowBannerSync(
-            minArticlesBeforeShowingBanner,
-            userCohortParam.onlyNonSupporters
-        ),
-};
-
-export const februaryMomentBannerNonUkRoundTwo: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerNonUkRoundTwo',
+export const februaryMomentBannerColour: AcquisitionsABTest = {
+    id: 'FebruaryMomentBannerColour',
     start: '2019-01-01',
     expiry: '2019-09-30',
     author: 'Jonathan Rankin',
@@ -95,7 +54,7 @@ export const februaryMomentBannerNonUkRoundTwo: AcquisitionsABTest = {
     successMeasure: 'AV per impression',
     audienceCriteria: 'All',
     idealOutcome: 'best AV possible',
-    canRun: () => getSync() !== 'GB',
+    canRun: () => true,
     showForSensitive: true,
     campaignId,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
@@ -111,10 +70,7 @@ export const februaryMomentBannerNonUkRoundTwo: AcquisitionsABTest = {
                 bannerModifierClass: 'fiv-banner',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
-                titles: [
-                    "Free for those who can't afford it",
-                    'Supported by those who can',
-                ],
+                titles: ['We chose a different approach', 'Will you support it?'],
                 bannerShownCallback,
             },
             canRun: () =>
@@ -123,40 +79,18 @@ export const februaryMomentBannerNonUkRoundTwo: AcquisitionsABTest = {
                     userCohortParam.onlyNonSupporters
                 ),
         },
-        differentVariant,
-    ],
-};
-
-export const februaryMomentBannerUkRoundTwo: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerUkRoundTwo',
-    start: '2019-01-01',
-    expiry: '2019-09-30',
-    author: 'Jonathan Rankin',
-    description: 'enable engagement banner in UK for the feb moment',
-    audience: 1,
-    audienceOffset: 0,
-    successMeasure: 'AV per impression',
-    audienceCriteria: 'All',
-    idealOutcome: 'best AV possible',
-    canRun: () => getSync() === 'GB',
-    showForSensitive: true,
-    campaignId,
-    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    variants: [
         {
-            id: 'control',
+            id: 'blue',
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
                 leadSentence: defaultBold,
                 messageText: defaultCopy,
+                // buttonCaption?: string, TO be decided with non engineers
                 template: acquisitionsBannerFivTemplate,
-                bannerModifierClass: 'fiv-banner',
+                bannerModifierClass: 'fiv-banner fiv-banner--blue',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
-                titles: [
-                    "We're available for everyone",
-                    'Funded by our\xa0readers',
-                ],
+                titles: ['We chose a different approach', 'Will you support it?'],
                 bannerShownCallback,
             },
             canRun: () =>
@@ -165,8 +99,26 @@ export const februaryMomentBannerUkRoundTwo: AcquisitionsABTest = {
                     userCohortParam.onlyNonSupporters
                 ),
         },
-        openVariant,
-        differentVariant,
+        {
+            id: 'yellow',
+            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
+            engagementBannerParams: {
+                leadSentence: defaultBold,
+                messageText: defaultCopy,
+                // buttonCaption?: string, TO be decided with non engineers
+                template: acquisitionsBannerFivTemplate,
+                bannerModifierClass: 'fiv-banner fiv-banner--yellow',
+                minArticlesBeforeShowingBanner,
+                userCohort: userCohortParam.onlyNonSupporters,
+                titles: ['We chose a different approach', 'Will you support it?'],
+                bannerShownCallback,
+            },
+            canRun: () =>
+                canShowBannerSync(
+                    minArticlesBeforeShowingBanner,
+                    userCohortParam.onlyNonSupporters
+                ),
+        },
     ],
 };
 

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -127,37 +127,37 @@ $border-style: #999999 1px solid;
 
 .fiv-banner__headline {
     font-size: 27px;
-    line-height: 27px;
+    line-height: 25px;
     font-family: 'GT Guardian Titlepiece', Georgia, serif;
     width: 189px;
     margin-left: 10px;
 
     @include mq($from: 375px) {
         font-size: 32px;
-        line-height: 32px;
+        line-height: 30px;
         width: 222px;
     }
 
     @include mq($from: tablet) {
         font-size: 32px;
-        line-height: 32px;
+        line-height: 30px;
     }
 
     @include mq($from: desktop) {
         font-size: 40px;
-        line-height: 40px;
+        line-height: 38px;
         width: 280px;
         margin-bottom: 0;
     }
 
     @include mq($from: leftCol) {
         font-size: 40px;
-        line-height: 40px
+        line-height: 38px;
     }
 
     @include mq($from: wide) {
         font-size: 50px;
-        line-height: 50px;
+        line-height: 45px;
         width: 341px;
     }
 }
@@ -165,6 +165,7 @@ $border-style: #999999 1px solid;
 
 .fiv-banner__headline1 {
     color: #ef7d21;
+    margin-bottom: 8px;
 }
 .fiv-banner__headline2 {
     color: #0084c6;
@@ -244,7 +245,7 @@ $wide-circle-height: 162px;
     will-change: transform;
 }
 
-.fiv-banner__circle-orange {
+.fiv-banner__circle-top {
     position: absolute;
     background: #ff7f0f;
     top: 0;
@@ -252,7 +253,7 @@ $wide-circle-height: 162px;
     z-index: 30;
 }
 
-.fiv-banner__circle-blue {
+.fiv-banner__circle-bottom {
     position: absolute;
     background: #0084c6;
     bottom: 0;
@@ -264,11 +265,11 @@ $wide-circle-height: 162px;
         transition: all 2s cubic-bezier(.645, .045, .355, 1);
     }
 
-    .fiv-banner__circle-orange {
+    .fiv-banner__circle-top {
         top: -25%;
     }
 
-    .fiv-banner__circle-blue {
+    .fiv-banner__circle-bottom {
         bottom: -25%;
     }
 }
@@ -368,3 +369,85 @@ $wide-circle-height: 162px;
     }
 }
 
+
+.site-message--fiv-banner.fiv-banner--blue {
+    background-color: #0084c6;
+
+    .fiv-banner__copy-and-ctas, .fiv-banner__lead-sentence {
+        color: #ffffff;
+    }
+
+    .fiv-banner__headline1 {
+        color: #ffe500;
+    }
+    .fiv-banner__headline2 {
+        color: #041f4a;
+    }
+
+    .fiv-banner__circle-top {
+        background: #ffe500;
+
+    }
+
+    .fiv-banner__circle-bottom {
+        background: #052962;
+
+    }
+
+    .engagement-banner__button.engagement-banner__button__learn-more {
+        background-color: #0084c6;
+        border:  #ffffff 1px solid;
+        color: #ffffff;
+    }
+
+    @supports (mix-blend-mode: difference) {
+        .fiv-banner__circle {
+            mix-blend-mode: difference;
+            opacity: 1;
+        }
+    }
+}
+
+.site-message--fiv-banner.fiv-banner--yellow {
+    background-color: #ffe500;
+
+    .fiv-banner__copy-and-ctas, .fiv-banner__lead-sentence {
+        color: #052962;
+    }
+
+    .fiv-banner__headline1 {
+        color: #052962;
+    }
+    .fiv-banner__headline2 {
+        color: #ff4e36;
+    }
+
+    .fiv-banner__circle-top {
+        background: #0084c6;
+
+    }
+
+    .fiv-banner__circle-bottom {
+        background: #ff4e36;
+
+    }
+
+    .engagement-banner__button__support {
+        background-color: #052962;
+        color: #ffffff;
+        border:  #052962 1px solid;
+    }
+
+    .engagement-banner__button.engagement-banner__button__learn-more {
+        background-color: #ffe500;
+        border:  #052962 1px solid;
+        color: #052962;
+    }
+
+    @supports (mix-blend-mode: multiply) {
+        .fiv-banner__circle {
+            mix-blend-mode: multiply;
+            opacity: 1;
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
A test that tries out some new color schemes on the banner. Forgive my American spelling but when you're writing CSS all day it creeps in and I'm just gonna roll with it now. 

This also rolls out the "We chose a different approach. Will you support it?" messaging globally

| Control |

![control](https://user-images.githubusercontent.com/2844554/53747158-92c85900-3e9a-11e9-8af5-05cda0917a8c.png)

| Blue | 
![blue](https://user-images.githubusercontent.com/2844554/53747157-92c85900-3e9a-11e9-8a52-6dec7cae04cc.png)

| Yellow |
![yellow](https://user-images.githubusercontent.com/2844554/53747159-9360ef80-3e9a-11e9-888d-ded2952fffd3.png)

Also made a couple of adjustments to the line spacing, at @blongden73's request