### PR TITLE
Allow ticker to be displayed on epic

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -30,6 +30,7 @@ declare type EpicVariant = Variant & {
     componentName: string,
     template: EpicTemplate,
     classNames: string[],
+    showTicker: boolean,
 
     buttonTemplate?: CtaUrls => string,
     copy?: AcquisitionsEpicTemplateCopy,
@@ -93,6 +94,7 @@ declare type InitEpicABTestVariant = {
     buttonTemplate?: CtaUrls => string,
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],
+    showTicker?: boolean,
 };
 
 declare type InitBannerABTestVariant = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -46,6 +46,7 @@ import {
     isArticleWorthAnEpicImpression,
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
+import { initTicker } from 'common/modules/commercial/ticker';
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -93,6 +94,7 @@ const controlTemplate: EpicTemplate = (
               })
             : undefined,
         epicClassNames: variant.classNames,
+        showTicker: variant.showTicker,
     });
 
 const liveBlogTemplate: EpicTemplate = (
@@ -232,6 +234,7 @@ const makeEpicABTestVariant = (
         buttonTemplate: initVariant.buttonTemplate,
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
+        showTicker: initVariant.showTicker || false,
 
         countryGroups: initVariant.countryGroups || [],
         tagIds: initVariant.tagIds || [],
@@ -354,6 +357,10 @@ const makeEpicABTestVariant = (
                                             'register:end',
                                             trackingCampaignId
                                         );
+
+                                        if (initVariant.showTicker) {
+                                            initTicker('.js-epic-ticker');
+                                        }
                                     });
                                 });
                             }
@@ -588,6 +595,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 row.classNames,
                                 ','
                             ),
+                            showTicker: optionalStringToBoolean(row.showTicker),
                         })),
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -57,6 +57,7 @@ const controlEpicComponent = (
             testimonialBlock,
             epicClassNames: [],
             wrapperClass: '',
+            showTicker: false,
         });
 
         const epicElement = $.create(rawEpic).get(0);

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -1,5 +1,6 @@
 // @flow
 import { appendToLastElement } from 'lib/array-utils';
+import { acquisitionsEpicTickerTemplate } from 'common/modules/commercial/templates/acquisitions-epic-ticker';
 
 const buildFooter = (footer: string[]): string =>
     `<div class="contributions__epic-footer">
@@ -12,18 +13,22 @@ export const acquisitionsEpicControlTemplate = ({
     epicClassNames = [],
     buttonTemplate,
     wrapperClass = '',
+    showTicker = false,
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
     epicClassNames: string[],
     buttonTemplate?: string,
     wrapperClass?: string,
+    showTicker: boolean,
 }) =>
     `<div class="contributions__epic ${epicClassNames.join(
         ' '
     )}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">
             <div>
+                ${showTicker ? acquisitionsEpicTickerTemplate : ''}
+
                 <h2 class="contributions__title">
                     ${heading}
                 </h2>

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -79,12 +79,9 @@ $progress-bar-height: 10px;
     transition: transform 3s cubic-bezier(.25, .55, .2, .85);
 }
 
-.epic-ticker__progress .ticker__filled-progress-under {
-    background-color: #ffe500;
-}
-
+.epic-ticker__progress .ticker__filled-progress-under,
 .epic-ticker__progress .ticker__filled-progress-over {
-    background-color: #ff7f0f;
+    background-color: #ffe500;
 }
 
 .epic-ticker__goal-marker {

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -29,20 +29,26 @@
 
 .epic-ticker {
     position: relative;
-    height: 70px;
+    height: 65px;
     margin-bottom: 25px;
+
+    font-family: $f-serif-headline;
+    font-size: 16px;
+    line-height: 18px;
 }
 
 .epic-ticker__count {
-    @include fs-header(5);
-    font-size: 32px;
     font-weight: 800;
     color: #333333;
 }
 
+.epic-ticker__so-far .epic-ticker__count {
+    font-size: 24px;
+    line-height: 26px;
+}
+
 .epic-ticker__count-label {
-    font-size: 17px;
-    line-height: 1.4;
+    font-style: italic;
 }
 
 $progress-bar-height: 10px;
@@ -117,7 +123,8 @@ $progress-bar-height: 10px;
 
 .epic-ticker__thankyou {
     >:first-child {
-        @include fs-header(5);
+        font-size: 24px;
+        line-height: 26px;
         font-weight: 800;
         color: #333333;
     }
@@ -125,11 +132,6 @@ $progress-bar-height: 10px;
     >:last-child {
         font-style: italic;
     }
-}
-
-.epic-ticker__exceeded .epic-ticker__count {
-    font-size: 17px;
-    line-height: 1.4;
 }
 
 .epic-ticker__exceeded .epic-ticker__count-label {


### PR DESCRIPTION
## What does this change?
We will soon be adding a ticker to the epic for a new campaign.
This PR makes it possible to enable the ticker from the google sheet, per variant.

Note - there may be small design changes before this goes live

## Screenshots
<img width="635" alt="picture 12" src="https://user-images.githubusercontent.com/1513454/53958234-669a1b80-40d8-11e9-947e-77259a53ed7f.png">

<img width="630" alt="picture 11" src="https://user-images.githubusercontent.com/1513454/53958233-669a1b80-40d8-11e9-9928-27f1e204cba5.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
