### PR TITLE
Split out the commercial properties into a per edition map for dcr.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -321,16 +321,14 @@ object DotcomponentsDataModel {
       hasStoryPackage = articlePage.related.hasStoryPackage,
       hasRelated = article.content.showInRelated,
       isCommentable = article.trail.isCommentable,
-
-
-
-
-      editionCommercialProperties = article.metadata.commercial.map{_.perEdition.mapKeys(_.id)}.getOrElse(Map.empty[String,EditionCommercialProperties]),
+      editionCommercialProperties = article.metadata.commercial
+        .map(_.perEdition.mapKeys(_.id))
+        .getOrElse(Map.empty[String,EditionCommercialProperties]),
 
       prebidIndexSites = (for {
         commercial <- article.metadata.commercial
         sites <- commercial.prebidIndexSites
-      }yield sites.toList).getOrElse(List()),
+      } yield sites.toList).getOrElse(List()),
 
 
       commercialProperties = article.metadata.commercial,

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{BlockElement => ClientBlockElement, Blocks => APIBlocks}
 import common.Edition
 import common.Maps.RichMap
-import common.commercial.CommercialProperties
+import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
 import conf.Configuration
 import conf.Configuration.affiliatelinks
 import conf.switches.Switches
@@ -99,7 +99,9 @@ case class PageData(
     hasStoryPackage: Boolean,
     hasRelated: Boolean,
     isCommentable: Boolean,
-    commercialProperties: Option[CommercialProperties],
+    editionCommercialProperties: Map[String, EditionCommercialProperties],
+    prebidIndexSites: List[PrebidIndexSite],
+    commercialProperties: Option[CommercialProperties], //DEPRECATED TO DELETE
     starRating: Option[Int],
     trailText: String,
 )
@@ -311,7 +313,7 @@ object DotcomponentsDataModel {
       Configuration.rendering.sentryHost,
       Configuration.rendering.sentryPublicApiKey,
       switches,
-      linkedData = linkedData,
+      linkedData,
       Configuration.google.subscribeWithGoogleApiUrl,
       guardianBaseURL = Configuration.site.host,
       webURL = article.metadata.webUrl,
@@ -319,6 +321,18 @@ object DotcomponentsDataModel {
       hasStoryPackage = articlePage.related.hasStoryPackage,
       hasRelated = article.content.showInRelated,
       isCommentable = article.trail.isCommentable,
+
+
+
+
+      editionCommercialProperties = article.metadata.commercial.map{_.perEdition.mapKeys(_.id)}.getOrElse(Map.empty[String,EditionCommercialProperties]),
+
+      prebidIndexSites = (for {
+        commercial <- article.metadata.commercial
+        sites <- commercial.prebidIndexSites
+      }yield sites.toList).getOrElse(List()),
+
+
       commercialProperties = article.metadata.commercial,
       starRating = article.content.starRating,
       trailText = article.trail.fields.trailText.getOrElse("")

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -42,8 +42,8 @@ case class CommercialProperties(
       .getOrElse(Set.empty)
 
   def perEdition: Map[Edition, EditionCommercialProperties] = {
-    Edition.all.map{
-      edition => (
+    Edition.all.map{ edition =>
+      (
         edition,
         EditionCommercialProperties(
           branding(edition),

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -8,15 +8,27 @@ import common.Edition.defaultEdition
 import common.dfp.DfpAgent
 import play.api.libs.json.Json
 
+case class EditionCommercialProperties (branding: Option[Branding], adTargeting: Set[AdTargetParam])
+
+
+object EditionCommercialProperties {
+  implicit val thirdNeedlessFormatter = EditionAdTargeting.adTargetParamFormat
+  implicit val secondNeedlessFormatter = EditionBranding.brandingFormat
+  implicit val firstNeedlessFormatter = Json.format[EditionCommercialProperties]
+
+}
 case class CommercialProperties(
   editionBrandings: Set[EditionBranding],
   editionAdTargetings: Set[EditionAdTargeting],
   prebidIndexSites: Option[Set[PrebidIndexSite]]
 ) {
+
   val isPaidContent: Boolean = branding(defaultEdition).exists(_.isPaid)
   val isFoundationFunded: Boolean = branding(defaultEdition).exists(_.isFoundationFunded)
   def isSponsored(edition: Edition): Boolean = branding(edition).exists(_.isSponsored)
   val nonRefreshableLineItemIds: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
+
+
 
   def branding(edition: Edition): Option[Branding] = for {
     editionBranding <- editionBrandings.find(_.edition == edition)
@@ -28,6 +40,18 @@ case class CommercialProperties(
       .find(_.edition == edition)
       .flatMap(_.paramSet)
       .getOrElse(Set.empty)
+
+  def perEdition: Map[Edition, EditionCommercialProperties] = {
+    Edition.all.map{
+      edition => (
+        edition,
+        EditionCommercialProperties(
+          branding(edition),
+          adTargeting(edition)
+        )
+      )
+    }.toMap
+  }
 }
 
 object CommercialProperties {


### PR DESCRIPTION
Split commercial properties into two objects and differentiate by object instead of arrays of keys and values which we'll reform in dcr where required. 

(This is safe for running without a dcr update)