### PR TITLE
Remove outstream css class on passback

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -52,6 +52,18 @@ const resize = (
     });
 };
 
+// When an outstream resizes we want it to revert to its original styling
+const removeAnyOutstreamClass = (adSlot: ?HTMLElement) => {
+    fastdom.write(() => {
+        if (adSlot) {
+            adSlot.classList.remove(
+                'ad-slot--outstream-old',
+                'ad-slot--outstream'
+            );
+        }
+    });
+};
+
 const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
@@ -67,6 +79,7 @@ const init = (register: RegisterListeners) => {
                 // See https://trello.com/c/TtuGq6Iy
                 return null;
             }
+            removeAnyOutstreamClass(adSlot);
             const iframeContainer =
                 iframe && iframe.closest('.ad-slot__content');
             return resize(specs, iframe, iframeContainer, adSlot);


### PR DESCRIPTION
When an outstream ad renders it's given an extra class.
This removes the class when the ad is actually a passback to a standard MPU.
The combined effect is that a postMessage to resize an outstream passback makes it shrink to the right size and render correctly on desktop.
