### PR TITLE
Implement heading block elements (dotcom-rendering)

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -94,20 +94,10 @@ object PageElement {
         block <- element.textTypeData.toList
         text <- block.html.toList
         element <- Cleaner.split(text)
-      } yield {
-        val doc = Jsoup.parseBodyFragment(element)
-        val para = doc.getElementsByTag("p").html()
-
-        if (para != "") {
-          val textElement = TextBlockElement(para)
-          if (addAffiliateLinks) {
-            AffiliateLinksCleaner.replaceLinksInElement(textElement, pageUrl = pageUrl, contentType = "article")
-          } else {
-            textElement
-          }
-        } else {
-          val heading = doc.getElementsByTag("h2").html()
-          HeadingBlockElement(heading)
+      } yield { element match {
+        case ("h2", heading) => HeadingBlockElement(heading)
+        case (_ , para) if (addAffiliateLinks) => AffiliateLinksCleaner.replaceLinksInElement(para, pageUrl = pageUrl, contentType = "article")
+        case (_, para) => TextBlockElement(para)
         }
       }
 
@@ -301,14 +291,14 @@ object PageElement {
 }
 
 object Cleaner{
-  def split(html: String):List[String] = {
+  def split(html: String):List[(String, String)] = {
     Jsoup
       .parseBodyFragment(html)
       .body()
       .children()
       .asScala
       .toList
-      .map(_.outerHtml())
+      .map(el => (el.tagName, el.outerHtml))
   }
 }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -18,7 +18,7 @@ import views.support.{AffiliateLinksCleaner, ImageProfile, ImageUrlSigner, ImgSr
 
 sealed trait PageElement
 case class TextBlockElement(html: String) extends PageElement
-case class HeadingBlockElement(html: String) extends PageElement
+case class SubheadingBlockElement(html: String) extends PageElement
 case class TweetBlockElement(html: String, url: String, id: String, hasMedia: Boolean, role: Role) extends PageElement
 case class PullquoteBlockElement(html: Option[String], role: Role) extends PageElement
 case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean], role: Role, imageSources: Seq[ImageSource]) extends PageElement
@@ -107,7 +107,7 @@ object PageElement {
           }
         } else {
           val heading = doc.getElementsByTag("h2").html()
-          HeadingBlockElement(heading)
+          SubheadingBlockElement(heading)
         }
       }
 
@@ -263,7 +263,7 @@ object PageElement {
 
   implicit val imageWeightingWrites: Writes[ImageSource] = Json.writes[ImageSource]
   implicit val textBlockElementWrites: Writes[TextBlockElement] = Json.writes[TextBlockElement]
-  implicit val headingBlockElementWrites: Writes[HeadingBlockElement] = Json.writes[HeadingBlockElement]
+  implicit val subheadingBlockElementWrites: Writes[SubheadingBlockElement] = Json.writes[SubheadingBlockElement]
   implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -857,15 +857,16 @@ object AffiliateLinksCleaner {
     else html
   }
 
-  def replaceLinksInElement(element: TextBlockElement, pageUrl: String, contentType: String): PageElement = {
-    val doc = Jsoup.parseBodyFragment(element.html)
+  def replaceLinksInElement(html: String, pageUrl: String, contentType: String): TextBlockElement
+  = {
+    val doc = Jsoup.parseBodyFragment(html)
     val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(doc)
     linksToReplace.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
 
     if (linksToReplace.nonEmpty) {
         TextBlockElement(doc.outerHtml())
     } else {
-      element
+        TextBlockElement(html)
     }
   }
 


### PR DESCRIPTION
## What does this change?

The current implementation of `TextBlockElement` doesn't really care what HTML element it takes. Most instances of `TextBlockElement` are `<p>` tags. But some articles ([example](https://www.theguardian.com/crosswords/crossword-blog/2019/feb/04/meet-the-setter-cullen-smurf)) split the text content into sections using `<h2>` elements. As a result the `<h2>` elements are also `TextBlockElements`.

This change casts `<h2>` elements as newly-defined `HeaderBlockElement`s. 

As a side effect, it removes the wrapper tag from `HeaderBlockElement` and `TextBlockElement`

**Before**

```json
{
  "elements": [
    {
      "html": "<p>Lorem ipsum</p>",
      "_type": "model.dotcomrendering.pageElements.TextBlockElement"
    },
    {
      "html": "<h2>Dolor sit alor</h2>",
      "_type": "model.dotcomrendering.pageElements.TextBlockElement"
    }
  ]
}
```
**After**

```json
{
  "elements": [
    {
      "html": "Lorem ipsum",
      "_type": "model.dotcomrendering.pageElements.TextBlockElement"
    },
    {
      "html": "Dolor sit alor",
      "_type": "model.dotcomrendering.pageElements.HeadingBlockElement"
    }
  ]
}
```

I'm open to suggestion on:

- whether the removal of wrapper elements is a good thing
- the naming
- how to improve the horrible imperative Scala
-  whether this whole thing is even a good idea at all

## What is the value of this and can you measure success?

In `dotcom-rendering` (AMP), we insert ads between `TextBlockElements`. However it is undesirable to add an ad immediately after a `<h2>`. By casting `<h2>`s as a newly-defined `HeadingBlockElement`, all our problems are solved.

In the future, we could possibly do _other things_ with the `HeadingBlockElement` in `dotcom-rendering`.

## Checklist

### Does this affect other platforms?

We'll need to update dotcom-rendering to account for `HeadingBlockElement`s before we merge this change

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
