### PR TITLE
Update affiliate links disclaimer

### DIFF
--- a/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
+++ b/common/app/views/fragments/affiliateLinksDisclaimer.scala.html
@@ -5,8 +5,7 @@
     <p><em><sup>
         This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
         makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        <br>
-        The links are powered by Skimlinks. By clicking on an affiliate link, you accept that Skimlinks cookies will be set.
+        By clicking on an affiliate link, you accept that third-party cookies will be set.
         <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.
     </sup></em></p>
 }
@@ -14,8 +13,7 @@
 @galleryDisclaimer() = {
     <br><em>This article contains affiliate links, which means we may earn a small commission if a reader clicks through and
         makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.
-        <br>
-        The links are powered by Skimlinks. By clicking on an affiliate link, you accept that Skimlinks cookies will be set.
+        By clicking on an affiliate link, you accept that third-party cookies will be set.
         <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.
     </em>
 }


### PR DESCRIPTION
## What does this change?

Updates the affiliate links disclaimer to remove references to Skimlinks.
