### PR TITLE
Fix margin around Teads outstream ads on mobile

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -313,10 +313,7 @@
     @include mq(mobile) {
         width: 300px;
         height: auto;
-
-        & > div.ad-slot__content > iframe {
-            min-height: 250px;
-        }
+        min-height: auto;
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
This fixes the bottom margin of mobile landscape outstream ads.

Mobile landscape:
Before:
![image](https://user-images.githubusercontent.com/1722550/53880403-d0e38b00-4008-11e9-8f71-7d83f919e5da.png)

After:
![image](https://user-images.githubusercontent.com/1722550/53880421-dccf4d00-4008-11e9-994c-c9e607cce577.png)


Mobile square still works and is unaffected by this change:
Before:
![image](https://user-images.githubusercontent.com/1722550/53880500-07b9a100-4009-11e9-8f38-3c92f826ecaf.png)

After:
![image](https://user-images.githubusercontent.com/1722550/53880511-11db9f80-4009-11e9-97d0-aaab202e6c99.png)
