### PR TITLE
No redirect for contribute links

### DIFF
--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -378,9 +378,7 @@ const countryGroups: CountryGroups = {
 
 // These are the different 'country groups' we accept when taking payment.
 // See https://github.com/guardian/support-internationalisation/blob/master/src/main/scala/com/gu/i18n/CountryGroup.scala for more context.
-const countryCodeToCountryGroupId = (
-    countryCode: string
-): CountryGroupId => {
+const countryCodeToCountryGroupId = (countryCode: string): CountryGroupId => {
     const availableCountryGroups = Object.keys(countryGroups);
     let response = null;
     availableCountryGroups.forEach(countryGroup => {

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -378,7 +378,9 @@ const countryGroups: CountryGroups = {
 
 // These are the different 'country groups' we accept when taking payment.
 // See https://github.com/guardian/support-internationalisation/blob/master/src/main/scala/com/gu/i18n/CountryGroup.scala for more context.
-const countryToSupporterCountryGroup = (countryCode: string): CountryGroupId => {
+const countryToSupporterCountryGroup = (
+    countryCode: string
+): CountryGroupId => {
     const availableCountryGroups = Object.keys(countryGroups);
     let response = null;
     availableCountryGroups.forEach(countryGroup => {
@@ -389,9 +391,11 @@ const countryToSupporterCountryGroup = (countryCode: string): CountryGroupId => 
     return response || 'International';
 };
 
-const countryToSupportInternationalisationId = (countryCode: string): SupportInternationalisationId =>
-    countryGroups[countryToSupporterCountryGroup(countryCode)].supportInternationalisationId;
-
+const countryToSupportInternationalisationId = (
+    countryCode: string
+): SupportInternationalisationId =>
+    countryGroups[countryToSupporterCountryGroup(countryCode)]
+        .supportInternationalisationId;
 
 const extendedCurrencySymbol = {
     GBPCountries: '£',

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -67,6 +67,15 @@ export type CountryGroupId =
     | 'NZDCountries'
     | 'Canada';
 
+export type SupportInternationalisationId =
+    | 'uk'
+    | 'us'
+    | 'au'
+    | 'eu'
+    | 'int'
+    | 'nz'
+    | 'ca';
+
 /*
   Note: supportInternationalizationId should match an existing
   id from support-internationalisation library. We use it to
@@ -80,7 +89,7 @@ export type CountryGroup = {
     name: string,
     currency: IsoCurrency,
     countries: string[],
-    supportInternationalisationId: string,
+    supportInternationalisationId: SupportInternationalisationId,
 };
 
 type CountryGroups = {
@@ -369,19 +378,20 @@ const countryGroups: CountryGroups = {
 
 // These are the different 'country groups' we accept when taking payment.
 // See https://github.com/guardian/support-internationalisation/blob/master/src/main/scala/com/gu/i18n/CountryGroup.scala for more context.
-const getSupporterCountryGroup = (location: string): CountryGroupId => {
+const countryToSupporterCountryGroup = (countryCode: string): CountryGroupId => {
     const availableCountryGroups = Object.keys(countryGroups);
     let response = null;
     availableCountryGroups.forEach(countryGroup => {
-        if (countryGroups[countryGroup].countries.includes(location)) {
+        if (countryGroups[countryGroup].countries.includes(countryCode)) {
             response = countryGroup;
         }
     });
     return response || 'International';
 };
 
-const getSupportInternationalisationIdSync = (): string =>
-    countryGroups[getSupporterCountryGroup(getSync())].supportInternationalisationId;
+const countryToSupportInternationalisationId = (countryCode: string): SupportInternationalisationId =>
+    countryGroups[countryToSupporterCountryGroup(countryCode)].supportInternationalisationId;
+
 
 const extendedCurrencySymbol = {
     GBPCountries: '£',
@@ -394,12 +404,12 @@ const extendedCurrencySymbol = {
 };
 
 const getLocalCurrencySymbol = (): string =>
-    extendedCurrencySymbol[getSupporterCountryGroup(getSync())] || '£';
+    extendedCurrencySymbol[countryToSupporterCountryGroup(getSync())] || '£';
 
 export {
     get,
-    getSupporterCountryGroup,
-    getSupportInternationalisationIdSync,
+    countryToSupporterCountryGroup,
+    countryToSupportInternationalisationId,
     getSync,
     getLocalCurrencySymbol,
     init,

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -377,8 +377,11 @@ const getSupporterCountryGroup = (location: string): CountryGroupId => {
             response = countryGroup;
         }
     });
-    return response || 'GBPCountries';
+    return response || 'International';
 };
+
+const getSupportInternationalisationIdSync = (): string =>
+    countryGroups[getSupporterCountryGroup(getSync())].supportInternationalisationId;
 
 const extendedCurrencySymbol = {
     GBPCountries: '£',
@@ -396,6 +399,7 @@ const getLocalCurrencySymbol = (): string =>
 export {
     get,
     getSupporterCountryGroup,
+    getSupportInternationalisationIdSync,
     getSync,
     getLocalCurrencySymbol,
     init,

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -378,7 +378,7 @@ const countryGroups: CountryGroups = {
 
 // These are the different 'country groups' we accept when taking payment.
 // See https://github.com/guardian/support-internationalisation/blob/master/src/main/scala/com/gu/i18n/CountryGroup.scala for more context.
-const countryToSupporterCountryGroup = (
+const countryCodeToCountryGroupId = (
     countryCode: string
 ): CountryGroupId => {
     const availableCountryGroups = Object.keys(countryGroups);
@@ -391,10 +391,10 @@ const countryToSupporterCountryGroup = (
     return response || 'International';
 };
 
-const countryToSupportInternationalisationId = (
+const countryCodeToSupportInternationalisationId = (
     countryCode: string
 ): SupportInternationalisationId =>
-    countryGroups[countryToSupporterCountryGroup(countryCode)]
+    countryGroups[countryCodeToCountryGroupId(countryCode)]
         .supportInternationalisationId;
 
 const extendedCurrencySymbol = {
@@ -408,12 +408,12 @@ const extendedCurrencySymbol = {
 };
 
 const getLocalCurrencySymbol = (): string =>
-    extendedCurrencySymbol[countryToSupporterCountryGroup(getSync())] || '£';
+    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] || '£';
 
 export {
     get,
-    countryToSupporterCountryGroup,
-    countryToSupportInternationalisationId,
+    countryCodeToCountryGroupId,
+    countryCodeToSupportInternationalisationId,
     getSync,
     getLocalCurrencySymbol,
     init,

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -414,6 +414,7 @@ export {
     get,
     countryCodeToCountryGroupId,
     countryCodeToSupportInternationalisationId,
+    getFromStorage,
     getSync,
     getLocalCurrencySymbol,
     init,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,10 +1,8 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import fastdom from 'lib/fastdom-promise';
-import {
-    get as getGeolocation,
-    countryToSupportInternationalisationId,
-} from 'lib/geolocation';
+import { countryToSupportInternationalisationId, get as getGeolocation, } from 'lib/geolocation';
+import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -53,18 +51,9 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
     return url.toString();
 };
 
-const addCountryGroupToContributionLink = (
-    rawUrl: string,
-    countryGroup: string
-): string =>
-    rawUrl.replace(
-        'support.theguardian.com/contribute',
-        `support.theguardian.com/${countryGroup.toLowerCase()}/contribute`
-    );
-
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
-const makeContributionLinksRegionSpecific = (): Promise<void> =>
+const makeAcquisitionLinksRegionSpecific = (): Promise<void> =>
     getGeolocation().then(countryCode => {
         const supportInternationalisationId = countryToSupportInternationalisationId(
             countryCode
@@ -76,15 +65,13 @@ const makeContributionLinksRegionSpecific = (): Promise<void> =>
         links.forEach(el => {
             const link = el.getAttribute('href');
             if (link) {
-                fastdom.write(() => {
-                    el.setAttribute(
-                        'href',
-                        addCountryGroupToContributionLink(
-                            link,
-                            supportInternationalisationId
-                        )
-                    );
-                });
+                el.setAttribute(
+                    'href',
+                    addCountryGroupToSupportLink(
+                        link,
+                        supportInternationalisationId
+                    )
+                );
             }
         });
     });
@@ -95,18 +82,13 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     );
 
     links.forEach(el => {
-        fastdom
-            .read(() => el.getAttribute('href'))
-            .then(link => {
-                if (link) {
-                    fastdom.write(() => {
-                        el.setAttribute(
-                            'href',
-                            addReferrerDataToAcquisitionLink(link)
-                        );
-                    });
-                }
-            });
+        const link = el.getAttribute('href');
+        if (link) {
+            el.setAttribute(
+                'href',
+                addReferrerDataToAcquisitionLink(link)
+            );
+        }
     });
 };
 
@@ -158,5 +140,5 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
     addReferrerDataToAcquisitionLinksOnPage();
-    makeContributionLinksRegionSpecific();
+    makeAcquisitionLinksRegionSpecific();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,7 +1,10 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import fastdom from 'lib/fastdom-promise';
-import { get as getGeolocation, countryToSupportInternationalisationId } from 'lib/geolocation';
+import {
+    get as getGeolocation,
+    countryToSupportInternationalisationId,
+} from 'lib/geolocation';
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -50,7 +53,10 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
     return url.toString();
 };
 
-const addCountryGroupToContributionLink = (rawUrl: string, countryGroup: string): string =>
+const addCountryGroupToContributionLink = (
+    rawUrl: string,
+    countryGroup: string
+): string =>
     rawUrl.replace(
         'support.theguardian.com/contribute',
         `support.theguardian.com/${countryGroup.toLowerCase()}/contribute`
@@ -60,7 +66,9 @@ const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const makeContributionLinksRegionSpecific = (): Promise<void> =>
     getGeolocation().then(countryCode => {
-        const supportInternationalisationId = countryToSupportInternationalisationId(countryCode);
+        const supportInternationalisationId = countryToSupportInternationalisationId(
+            countryCode
+        );
         const links = Array.from(
             document.getElementsByClassName(ACQUISITION_LINK_CLASS)
         );
@@ -71,13 +79,15 @@ const makeContributionLinksRegionSpecific = (): Promise<void> =>
                 fastdom.write(() => {
                     el.setAttribute(
                         'href',
-                        addCountryGroupToContributionLink(link, supportInternationalisationId)
+                        addCountryGroupToContributionLink(
+                            link,
+                            supportInternationalisationId
+                        )
                     );
                 });
             }
         });
     });
-
 
 const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     const links = Array.from(

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,7 +1,9 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
-import fastdom from 'lib/fastdom-promise';
-import { countryToSupportInternationalisationId, get as getGeolocation, } from 'lib/geolocation';
+import {
+    countryToSupportInternationalisationId,
+    get as getGeolocation,
+} from 'lib/geolocation';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
 
 // Currently the only acquisition components on the site are
@@ -84,10 +86,7 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     links.forEach(el => {
         const link = el.getAttribute('href');
         if (link) {
-            el.setAttribute(
-                'href',
-                addReferrerDataToAcquisitionLink(link)
-            );
+            el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
         }
     });
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,7 +1,7 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import {
-    countryToSupportInternationalisationId,
+    countryCodeToSupportInternationalisationId,
     get as getGeolocation,
 } from 'lib/geolocation';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
@@ -57,7 +57,7 @@ const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const makeAcquisitionLinksRegionSpecific = (): Promise<void> =>
     getGeolocation().then(countryCode => {
-        const supportInternationalisationId = countryToSupportInternationalisationId(
+        const supportInternationalisationId = countryCodeToSupportInternationalisationId(
             countryCode
         );
         const links = Array.from(

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,9 +1,5 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
-import {
-    countryCodeToSupportInternationalisationId,
-    get as getGeolocation,
-} from 'lib/geolocation';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
 
 // Currently the only acquisition components on the site are
@@ -55,30 +51,7 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
 
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
-const makeAcquisitionLinksRegionSpecific = (): Promise<void> =>
-    getGeolocation().then(countryCode => {
-        const supportInternationalisationId = countryCodeToSupportInternationalisationId(
-            countryCode
-        );
-        const links = Array.from(
-            document.getElementsByClassName(ACQUISITION_LINK_CLASS)
-        );
-
-        links.forEach(el => {
-            const link = el.getAttribute('href');
-            if (link) {
-                el.setAttribute(
-                    'href',
-                    addCountryGroupToSupportLink(
-                        link,
-                        supportInternationalisationId
-                    )
-                );
-            }
-        });
-    });
-
-const addReferrerDataToAcquisitionLinksOnPage = (): void => {
+const enrichAcquisitionLinksOnPage = (): void => {
     const links = Array.from(
         document.getElementsByClassName(ACQUISITION_LINK_CLASS)
     );
@@ -86,7 +59,9 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     links.forEach(el => {
         const link = el.getAttribute('href');
         if (link) {
-            el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
+            let modifiedLink = addReferrerDataToAcquisitionLink(link);
+            modifiedLink = addCountryGroupToSupportLink(modifiedLink);
+            el.setAttribute('href', modifiedLink);
         }
     });
 };
@@ -138,6 +113,5 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
 
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
-    addReferrerDataToAcquisitionLinksOnPage();
-    makeAcquisitionLinksRegionSpecific();
+    enrichAcquisitionLinksOnPage();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -50,7 +50,7 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
     return url.toString();
 };
 
-const addCountryGroupToAcquisitionLink = (rawUrl: string, countryGroup: string): string =>
+const addCountryGroupToContributionLink = (rawUrl: string, countryGroup: string): string =>
     rawUrl.replace(
         'support.theguardian.com/contribute',
         `support.theguardian.com/${countryGroup.toLowerCase()}/contribute`
@@ -58,7 +58,7 @@ const addCountryGroupToAcquisitionLink = (rawUrl: string, countryGroup: string):
 
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
-const makeAcquisitionLinksRegionSpecific = (): Promise<void> =>
+const makeContributionLinksRegionSpecific = (): Promise<void> =>
     getGeolocation().then(countryCode => {
         const supportInternationalisationId = countryToSupportInternationalisationId(countryCode);
         const links = Array.from(
@@ -71,7 +71,7 @@ const makeAcquisitionLinksRegionSpecific = (): Promise<void> =>
                 fastdom.write(() => {
                     el.setAttribute(
                         'href',
-                        addCountryGroupToAcquisitionLink(link, supportInternationalisationId)
+                        addCountryGroupToContributionLink(link, supportInternationalisationId)
                     );
                 });
             }
@@ -148,5 +148,5 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
     addReferrerDataToAcquisitionLinksOnPage();
-    makeAcquisitionLinksRegionSpecific();
+    makeContributionLinksRegionSpecific();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,7 +33,10 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { userIsSupporter } from 'common/modules/commercial/user-features';
-import { supportContributeURL, supportSubscribeGeoRedirectURL } from 'common/modules/commercial/support-utilities';
+import {
+    supportContributeLocalURL,
+    supportSubscribeGeoRedirectURL,
+} from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import {
@@ -209,7 +212,7 @@ const makeEpicABTestVariant = (
         }`,
         campaignCode,
         supportURL: addTrackingCodesToUrl({
-            base: supportContributeURL(),
+            base: supportContributeLocalURL(),
             componentType: parentTest.componentType,
             componentId,
             campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -20,7 +20,7 @@ import mediator from 'lib/mediator';
 import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
-    getSupporterCountryGroup,
+    countryToSupporterCountryGroup,
 } from 'lib/geolocation';
 import {
     splitAndTrim,
@@ -173,7 +173,7 @@ const pageMatchesTags = (tagIds: string[]): boolean =>
     );
 
 const userMatchesCountryGroups = (countryGroups: string[]) => {
-    const userCountryGroupId = getSupporterCountryGroup(
+    const userCountryGroupId = countryToSupporterCountryGroup(
         geolocationGetSync()
     ).toUpperCase();
     return countryGroups.some(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -34,7 +34,7 @@ import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templ
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { userIsSupporter } from 'common/modules/commercial/user-features';
 import {
-    supportContributeLocalURL,
+    supportContributeURL,
     supportSubscribeGeoRedirectURL,
 } from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
@@ -212,7 +212,7 @@ const makeEpicABTestVariant = (
         }`,
         campaignCode,
         supportURL: addTrackingCodesToUrl({
-            base: supportContributeLocalURL(),
+            base: supportContributeURL(),
             componentType: parentTest.componentType,
             componentId,
             campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,7 +33,7 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { userIsSupporter } from 'common/modules/commercial/user-features';
-import { supportContributeURL } from 'common/modules/commercial/support-utilities';
+import { supportContributeURL, supportSubscribeGeoRedirectURL } from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import {
@@ -219,7 +219,7 @@ const makeEpicABTestVariant = (
             },
         }),
         subscribeURL: addTrackingCodesToUrl({
-            base: 'https://support.theguardian.com/subscribe',
+            base: supportSubscribeGeoRedirectURL,
             componentType: parentTest.componentType,
             componentId,
             campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -20,7 +20,7 @@ import mediator from 'lib/mediator';
 import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
-    countryToSupporterCountryGroup,
+    countryCodeToCountryGroupId,
 } from 'lib/geolocation';
 import {
     splitAndTrim,
@@ -176,7 +176,7 @@ const pageMatchesTags = (tagIds: string[]): boolean =>
     );
 
 const userMatchesCountryGroups = (countryGroups: string[]) => {
-    const userCountryGroupId = countryToSupporterCountryGroup(
+    const userCountryGroupId = countryCodeToCountryGroupId(
         geolocationGetSync()
     ).toUpperCase();
     return countryGroups.some(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -209,7 +209,7 @@ const makeEpicABTestVariant = (
         }`,
         campaignCode,
         supportURL: addTrackingCodesToUrl({
-            base: supportContributeURL,
+            base: supportContributeURL(),
             componentType: parentTest.componentType,
             componentId,
             campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -7,7 +7,7 @@ import reportError from 'lib/report-error';
 import mediator from 'lib/mediator';
 
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
-import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
+import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import {
     addTrackingCodesToUrl,
@@ -47,7 +47,7 @@ const controlEpicComponent = (
             componentName: '', // TODO: confirm data-component not needed
             buttonTemplate: epicButtonsTemplate({
                 supportUrl: addTrackingCodesToUrl({
-                    base: supportContributeLocalURL(),
+                    base: supportContributeURL(),
                     componentType: epicComponentType,
                     componentId: epicId,
                     campaignCode: epicId,

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -7,7 +7,7 @@ import reportError from 'lib/report-error';
 import mediator from 'lib/mediator';
 
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
-import { supportContributeURL } from 'common/modules/commercial/support-utilities';
+import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import {
     addTrackingCodesToUrl,
@@ -47,7 +47,7 @@ const controlEpicComponent = (
             componentName: '', // TODO: confirm data-component not needed
             buttonTemplate: epicButtonsTemplate({
                 supportUrl: addTrackingCodesToUrl({
-                    base: supportContributeURL(),
+                    base: supportContributeLocalURL(),
                     componentType: epicComponentType,
                     componentId: epicId,
                     campaignCode: epicId,

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -47,7 +47,7 @@ const controlEpicComponent = (
             componentName: '', // TODO: confirm data-component not needed
             buttonTemplate: epicButtonsTemplate({
                 supportUrl: addTrackingCodesToUrl({
-                    base: supportContributeURL,
+                    base: supportContributeURL(),
                     componentType: epicComponentType,
                     componentId: epicId,
                     campaignCode: epicId,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -4,7 +4,7 @@ import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commerci
 import config from 'lib/config';
 import reportError from 'lib/report-error';
 import {
-    countryToSupportInternationalisationId,
+    countryCodeToSupportInternationalisationId,
     getLocalCurrencySymbol,
     getSync,
 } from 'lib/geolocation';
@@ -49,7 +49,7 @@ const getAcquisitionsBannerParams = (
         buttonCaption: firstRow.buttonCaption,
         linkUrl: addCountryGroupToSupportLink(
             firstRow.linkUrl,
-            countryToSupportInternationalisationId(getSync())
+            countryCodeToSupportInternationalisationId(getSync())
         ),
         hasTicker: false,
         campaignCode: 'control_banner_from_google_doc',

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -3,9 +3,7 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 import config from 'lib/config';
 import reportError from 'lib/report-error';
-import {
-    getLocalCurrencySymbol,
-} from 'lib/geolocation';
+import { getLocalCurrencySymbol } from 'lib/geolocation';
 import {
     supportContributeLocalURL,
     addCountryGroupToSupportLink,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -5,7 +5,7 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import { getLocalCurrencySymbol } from 'lib/geolocation';
 import {
-    supportContributeLocalURL,
+    supportContributeURL,
     addCountryGroupToSupportLink,
 } from './support-utilities';
 
@@ -75,7 +75,7 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
                 messageText: fallbackCopy,
                 ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
                 buttonCaption: 'Support The Guardian',
-                linkUrl: supportContributeLocalURL(),
+                linkUrl: supportContributeURL(),
                 hasTicker: false,
                 campaignCode: 'fallback_hardcoded_banner',
                 pageviewId: config.get('ophan.pageViewId', 'not_found'),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -1,10 +1,17 @@
 // @flow
-import config from 'lib/config';
-import reportError from 'lib/report-error';
-import { countryToSupportInternationalisationId, getLocalCurrencySymbol, getSync } from 'lib/geolocation';
-import { supportContributeURL, addCountryGroupToSupportLink } from './support-utilities';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
+import config from 'lib/config';
+import reportError from 'lib/report-error';
+import {
+    countryToSupportInternationalisationId,
+    getLocalCurrencySymbol,
+    getSync,
+} from 'lib/geolocation';
+import {
+    supportContributeLocalURL,
+    addCountryGroupToSupportLink,
+} from './support-utilities';
 
 const fallbackCopy: string = `<strong>The Guardian is editorially independent &ndash;
     our journalism is free from the influence of billionaire owners or politicians.
@@ -75,7 +82,7 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
                 messageText: fallbackCopy,
                 ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
                 buttonCaption: 'Support The Guardian',
-                linkUrl: supportContributeURL(),
+                linkUrl: supportContributeLocalURL(),
                 hasTicker: false,
                 campaignCode: 'fallback_hardcoded_banner',
                 pageviewId: config.get('ophan.pageViewId', 'not_found'),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -47,10 +47,7 @@ const getAcquisitionsBannerParams = (
         messageText: firstRow.messageText,
         ctaText,
         buttonCaption: firstRow.buttonCaption,
-        linkUrl: addCountryGroupToSupportLink(
-            firstRow.linkUrl,
-            countryCodeToSupportInternationalisationId(getSync())
-        ),
+        linkUrl: addCountryGroupToSupportLink(firstRow.linkUrl),
         hasTicker: false,
         campaignCode: 'control_banner_from_google_doc',
         pageviewId: config.get('ophan.pageViewId', 'not_found'),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -4,9 +4,7 @@ import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commerci
 import config from 'lib/config';
 import reportError from 'lib/report-error';
 import {
-    countryCodeToSupportInternationalisationId,
     getLocalCurrencySymbol,
-    getSync,
 } from 'lib/geolocation';
 import {
     supportContributeLocalURL,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -1,12 +1,10 @@
 // @flow
-import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
-
-// @flow
 import config from 'lib/config';
 import reportError from 'lib/report-error';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { countryToSupportInternationalisationId, getLocalCurrencySymbol, getSync } from 'lib/geolocation';
+import { supportContributeURL, addCountryGroupToSupportLink } from './support-utilities';
+import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
-import { supportContributeURL } from './support-utilities';
 
 const fallbackCopy: string = `<strong>The Guardian is editorially independent &ndash;
     our journalism is free from the influence of billionaire owners or politicians.
@@ -42,7 +40,10 @@ const getAcquisitionsBannerParams = (
         messageText: firstRow.messageText,
         ctaText,
         buttonCaption: firstRow.buttonCaption,
-        linkUrl: firstRow.linkUrl,
+        linkUrl: addCountryGroupToSupportLink(
+            firstRow.linkUrl,
+            countryToSupportInternationalisationId(getSync())
+        ),
         hasTicker: false,
         campaignCode: 'control_banner_from_google_doc',
         pageviewId: config.get('ophan.pageViewId', 'not_found'),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -74,7 +74,7 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
                 messageText: fallbackCopy,
                 ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
                 buttonCaption: 'Support The Guardian',
-                linkUrl: supportContributeURL,
+                linkUrl: supportContributeURL(),
                 hasTicker: false,
                 campaignCode: 'fallback_hardcoded_banner',
                 pageviewId: config.get('ophan.pageViewId', 'not_found'),

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,8 +1,8 @@
 // @flow
-import { getSupportInternationalisationIdSync } from 'lib/geolocation';
+import { countryToSupportInternationalisationId, getSync } from 'lib/geolocation';
 
 const supportContributeURL = (): string =>
-    `https://support.theguardian.com/${getSupportInternationalisationIdSync()}/contribute`;
+    `https://support.theguardian.com/${countryToSupportInternationalisationId(getSync())}/contribute`;
 const supportContributeGeoRedirectURL = 'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL = 'https://support.theguardian.com/subscribe';
 

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,20 +1,33 @@
 // @flow
-import {
-    countryToSupportInternationalisationId,
-    getSync,
-} from 'lib/geolocation';
+import { countryToSupportInternationalisationId, getSync, } from 'lib/geolocation';
 
-const supportContributeURL = (): string =>
-    `https://support.theguardian.com/${countryToSupportInternationalisationId(
-        getSync()
-    )}/contribute`;
+const addCountryGroupToSupportLink = (
+    rawUrl: string,
+    countryGroup: string
+): string =>
+    rawUrl.replace(
+        /(support.theguardian.com)\/(contribute|subscribe)/,
+        (_, domain, path) => `${domain}/${countryGroup.toLowerCase()}/${path}`
+    );
+
 const supportContributeGeoRedirectURL =
     'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL =
     'https://support.theguardian.com/subscribe';
+const supportContributeURL = (): string =>
+    addCountryGroupToSupportLink(
+        supportContributeGeoRedirectURL,
+        countryToSupportInternationalisationId(getSync())
+    );
+const supportSubscribeURL = (): string =>
+    addCountryGroupToSupportLink(
+        supportSubscribeGeoRedirectURL,
+        countryToSupportInternationalisationId(getSync())
+    );
 
 export {
     supportContributeURL,
     supportContributeGeoRedirectURL,
     supportSubscribeGeoRedirectURL,
+    addCountryGroupToSupportLink
 };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,5 +1,8 @@
 // @flow
-import { countryToSupportInternationalisationId, getSync, } from 'lib/geolocation';
+import {
+    countryToSupportInternationalisationId,
+    getSync,
+} from 'lib/geolocation';
 
 const addCountryGroupToSupportLink = (
     rawUrl: string,
@@ -14,20 +17,21 @@ const supportContributeGeoRedirectURL =
     'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL =
     'https://support.theguardian.com/subscribe';
-const supportContributeURL = (): string =>
+const supportContributeLocalURL = (): string =>
     addCountryGroupToSupportLink(
         supportContributeGeoRedirectURL,
         countryToSupportInternationalisationId(getSync())
     );
-const supportSubscribeURL = (): string =>
+const supportSubscribeLocalURL = (): string =>
     addCountryGroupToSupportLink(
         supportSubscribeGeoRedirectURL,
         countryToSupportInternationalisationId(getSync())
     );
 
 export {
-    supportContributeURL,
     supportContributeGeoRedirectURL,
     supportSubscribeGeoRedirectURL,
-    addCountryGroupToSupportLink
+    supportContributeLocalURL,
+    supportSubscribeLocalURL,
+    addCountryGroupToSupportLink,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,32 +1,34 @@
 // @flow
 import {
     countryCodeToSupportInternationalisationId,
-    getSync,
+    getFromStorage,
 } from 'lib/geolocation';
 
+// Will not change the link if there's no country code in localStorage
+// (i.e. it bypasses the edition fallback of getSync from lib/geolocation)
 const addCountryGroupToSupportLink = (
     rawUrl: string,
-    countryGroup: string
-): string =>
-    rawUrl.replace(
-        /(support.theguardian.com)\/(contribute|subscribe)/,
-        (_, domain, path) => `${domain}/${countryGroup.toLowerCase()}/${path}`
-    );
+): string => {
+    const countryCode = getFromStorage();
+    if (countryCode) {
+        const countryGroup = countryCodeToSupportInternationalisationId(countryCode);
+        return rawUrl.replace(
+            /(support.theguardian.com)\/(contribute|subscribe)/,
+            (_, domain, path) => `${domain}/${countryGroup.toLowerCase()}/${path}`
+        );
+    }
+
+    return rawUrl;
+};
 
 const supportContributeGeoRedirectURL =
     'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL =
     'https://support.theguardian.com/subscribe';
 const supportContributeLocalURL = (): string =>
-    addCountryGroupToSupportLink(
-        supportContributeGeoRedirectURL,
-        countryCodeToSupportInternationalisationId(getSync())
-    );
+    addCountryGroupToSupportLink(supportContributeGeoRedirectURL);
 const supportSubscribeLocalURL = (): string =>
-    addCountryGroupToSupportLink(
-        supportSubscribeGeoRedirectURL,
-        countryCodeToSupportInternationalisationId(getSync())
-    );
+    addCountryGroupToSupportLink(supportSubscribeGeoRedirectURL);
 
 export {
     supportContributeGeoRedirectURL,

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-    countryToSupportInternationalisationId,
+    countryCodeToSupportInternationalisationId,
     getSync,
 } from 'lib/geolocation';
 
@@ -20,12 +20,12 @@ const supportSubscribeGeoRedirectURL =
 const supportContributeLocalURL = (): string =>
     addCountryGroupToSupportLink(
         supportContributeGeoRedirectURL,
-        countryToSupportInternationalisationId(getSync())
+        countryCodeToSupportInternationalisationId(getSync())
     );
 const supportSubscribeLocalURL = (): string =>
     addCountryGroupToSupportLink(
         supportSubscribeGeoRedirectURL,
-        countryToSupportInternationalisationId(getSync())
+        countryCodeToSupportInternationalisationId(getSync())
     );
 
 export {

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -6,15 +6,16 @@ import {
 
 // Will not change the link if there's no country code in localStorage
 // (i.e. it bypasses the edition fallback of getSync from lib/geolocation)
-const addCountryGroupToSupportLink = (
-    rawUrl: string,
-): string => {
+const addCountryGroupToSupportLink = (rawUrl: string): string => {
     const countryCode = getFromStorage();
     if (countryCode) {
-        const countryGroup = countryCodeToSupportInternationalisationId(countryCode);
+        const countryGroup = countryCodeToSupportInternationalisationId(
+            countryCode
+        );
         return rawUrl.replace(
             /(support.theguardian.com)\/(contribute|subscribe)/,
-            (_, domain, path) => `${domain}/${countryGroup.toLowerCase()}/${path}`
+            (_, domain, path) =>
+                `${domain}/${countryGroup.toLowerCase()}/${path}`
         );
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,9 +1,20 @@
 // @flow
-import { countryToSupportInternationalisationId, getSync } from 'lib/geolocation';
+import {
+    countryToSupportInternationalisationId,
+    getSync,
+} from 'lib/geolocation';
 
 const supportContributeURL = (): string =>
-    `https://support.theguardian.com/${countryToSupportInternationalisationId(getSync())}/contribute`;
-const supportContributeGeoRedirectURL = 'https://support.theguardian.com/contribute';
-const supportSubscribeGeoRedirectURL = 'https://support.theguardian.com/subscribe';
+    `https://support.theguardian.com/${countryToSupportInternationalisationId(
+        getSync()
+    )}/contribute`;
+const supportContributeGeoRedirectURL =
+    'https://support.theguardian.com/contribute';
+const supportSubscribeGeoRedirectURL =
+    'https://support.theguardian.com/subscribe';
 
-export { supportContributeURL, supportContributeGeoRedirectURL, supportSubscribeGeoRedirectURL };
+export {
+    supportContributeURL,
+    supportContributeGeoRedirectURL,
+    supportSubscribeGeoRedirectURL,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -26,15 +26,15 @@ const supportContributeGeoRedirectURL =
     'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL =
     'https://support.theguardian.com/subscribe';
-const supportContributeLocalURL = (): string =>
+const supportContributeURL = (): string =>
     addCountryGroupToSupportLink(supportContributeGeoRedirectURL);
-const supportSubscribeLocalURL = (): string =>
+const supportSubscribeURL = (): string =>
     addCountryGroupToSupportLink(supportSubscribeGeoRedirectURL);
 
 export {
     supportContributeGeoRedirectURL,
     supportSubscribeGeoRedirectURL,
-    supportContributeLocalURL,
-    supportSubscribeLocalURL,
+    supportContributeURL,
+    supportSubscribeURL,
     addCountryGroupToSupportLink,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,5 +1,9 @@
 // @flow
-const supportContributeURL = 'https://support.theguardian.com/contribute';
-const supportSubscribeURL = 'https://support.theguardian.com/subscribe';
+import { getSupportInternationalisationIdSync } from 'lib/geolocation';
 
-export { supportContributeURL, supportSubscribeURL };
+const supportContributeURL = (): string =>
+    `https://support.theguardian.com/${getSupportInternationalisationIdSync()}/contribute`;
+const supportContributeGeoRedirectURL = 'https://support.theguardian.com/contribute';
+const supportSubscribeGeoRedirectURL = 'https://support.theguardian.com/subscribe';
+
+export { supportContributeURL, supportContributeGeoRedirectURL, supportSubscribeGeoRedirectURL };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
@@ -8,7 +8,7 @@ describe('addCountryGroupToSupportLink', () => {
         setGeolocation('GB');
         expect(
             addCountryGroupToSupportLink(
-                'https://support.theguardian.com/subscribe',
+                'https://support.theguardian.com/subscribe'
             )
         ).toEqual('https://support.theguardian.com/uk/subscribe');
     });
@@ -26,7 +26,7 @@ describe('addCountryGroupToSupportLink', () => {
         setGeolocation('GB');
         expect(
             addCountryGroupToSupportLink(
-                'https://support.theguardian.com/int/contribute',
+                'https://support.theguardian.com/int/contribute'
             )
         ).toEqual('https://support.theguardian.com/int/contribute');
     });

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
@@ -1,31 +1,32 @@
 // @flow
 
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
+import { setGeolocation } from 'lib/geolocation';
 
 describe('addCountryGroupToSupportLink', () => {
     test('adds country group to subscribe link', () => {
+        setGeolocation('GB');
         expect(
             addCountryGroupToSupportLink(
                 'https://support.theguardian.com/subscribe',
-                'uk'
             )
         ).toEqual('https://support.theguardian.com/uk/subscribe');
     });
 
     test('adds country group to contribute link', () => {
+        setGeolocation('FR');
         expect(
             addCountryGroupToSupportLink(
-                'https://support.theguardian.com/contribute',
-                'int'
+                'https://support.theguardian.com/contribute'
             )
-        ).toEqual('https://support.theguardian.com/int/contribute');
+        ).toEqual('https://support.theguardian.com/eu/contribute');
     });
 
     test('does not add country group to contribute link with country group already in it', () => {
+        setGeolocation('GB');
         expect(
             addCountryGroupToSupportLink(
                 'https://support.theguardian.com/int/contribute',
-                'uk'
             )
         ).toEqual('https://support.theguardian.com/int/contribute');
     });

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
@@ -1,0 +1,32 @@
+// @flow
+
+import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
+
+describe('addCountryGroupToSupportLink', () => {
+    test('adds country group to subscribe link', () => {
+        expect(
+            addCountryGroupToSupportLink(
+                'https://support.theguardian.com/subscribe',
+                'uk'
+            )
+        ).toEqual('https://support.theguardian.com/uk/subscribe');
+    });
+
+    test('adds country group to contribute link', () => {
+        expect(
+            addCountryGroupToSupportLink(
+                'https://support.theguardian.com/contribute',
+                'int'
+            )
+        ).toEqual('https://support.theguardian.com/int/contribute');
+    });
+
+    test('does not add country group to contribute link with country group already in it', () => {
+        expect(
+            addCountryGroupToSupportLink(
+                'https://support.theguardian.com/int/contribute',
+                'uk'
+            )
+        ).toEqual('https://support.theguardian.com/int/contribute');
+    });
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,10 +1,10 @@
 // @flow
 import { userIsSupporter } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
-import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
+import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
 
-const supportUrl = `${supportContributeLocalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
+const supportUrl = `${supportContributeURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
 const askHtml = `
 <div class="contributions__adblock--moment">

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,10 +1,11 @@
 // @flow
 import { userIsSupporter } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
 
 const supportUrl =
-    'https://support.theguardian.com/contribute?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019';
+    `${supportContributeLocalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
 const askHtml = `
 <div class="contributions__adblock--moment">

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -4,8 +4,7 @@ import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contribut
 import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
 
-const supportUrl =
-    `${supportContributeLocalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
+const supportUrl = `${supportContributeLocalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
 const askHtml = `
 <div class="contributions__adblock--moment">

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -6,7 +6,9 @@ import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContribut
 import { supportContributeURL } from '../../common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
-    const banner = template(audioContribBanner)({ supportContributeURL: supportContributeURL() });
+    const banner = template(audioContribBanner)({
+        supportContributeURL: supportContributeURL(),
+    });
 
     fastdom.write(() => {
         el.insertAdjacentHTML('afterend', banner);

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -3,7 +3,7 @@
 import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/template';
 import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContributions.html';
-import { supportContributeLocalURL } from '../../common/modules/commercial/support-utilities';
+import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
     const banner = template(audioContribBanner)({

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -6,7 +6,7 @@ import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContribut
 import { supportContributeURL } from '../../common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
-    const banner = template(audioContribBanner)({ supportContributeURL });
+    const banner = template(audioContribBanner)({ supportContributeURL: supportContributeURL() });
 
     fastdom.write(() => {
         el.insertAdjacentHTML('afterend', banner);

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -3,11 +3,11 @@
 import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/template';
 import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContributions.html';
-import { supportContributeURL } from '../../common/modules/commercial/support-utilities';
+import { supportContributeLocalURL } from '../../common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
     const banner = template(audioContribBanner)({
-        supportContributeURL: supportContributeURL(),
+        supportContributeURL: supportContributeLocalURL(),
     });
 
     fastdom.write(() => {

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -3,11 +3,11 @@
 import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/template';
 import audioContribBanner from 'raw-loader!journalism/views/audioSeriesContributions.html';
-import { supportContributeLocalURL } from 'common/modules/commercial/support-utilities';
+import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 
 const renderContributionsBanner = el => {
     const banner = template(audioContribBanner)({
-        supportContributeURL: supportContributeLocalURL(),
+        supportContributeURL: supportContributeURL(),
     });
 
     fastdom.write(() => {


### PR DESCRIPTION
Link directly to the country group which the user belongs to according to theguardian.com's logic, avoiding an unnecessary redirect.

If there isn't a geolocation already in local storage when it tries to set a given link, it will leave the link unchanged - it will not use the edition fallback. This ensures we never send people to a version of the contribute page which isn't in sync with the country they're currently in.

We can keep an eye on referrals from theguardian.com to the `/contribute` geolocate endpoint to see how often these cases actually occur. If they're frequent, we could consider refactoring to make sure we always have an accurate geolocation before rendering the epic or banner.