### PR TITLE
Add womens world cup to football nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -83,7 +83,7 @@ object NavLinks {
       NavLink("Results", "/football/results", "football/results"),
       NavLink("Competitions", "/football/competitions", "football/competitions"),
       NavLink("Clubs", "/football/teams", "football/teams"),
-      NavLink("World Cup 2018", "/football/world-cup-2018")
+      NavLink("World Cup 2019", "/football/womens-world-cup-2019")
     )
   )
   val soccer = football.copy(title = "Soccer")

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -122,7 +122,7 @@ object CompetitionsProvider {
     Competition("700", "/football/world-cup-2018", "World Cup 2018", "World Cup 2018", "Internationals", showInTeamsList = true, tableDividers = List(2), startDate = Some(new LocalDate(2018, 6, 1))),
     Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true, tableDividers = List(2)),
 
-    Competition("870", "/football/women-s-world-cup-2019", "Women's World Cup 2019", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2)),
+    Competition("870", "/football/women-s-world-cup-2019", "Women's World Cup 2019", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2), startDate =Some(new LocalDate(2019, 6, 7)) ),
     Competition("423", "/football/women-euro-2017", "Women's Euro 2017", "Women's Euro", "Internationals", showInTeamsList = true, tableDividers = List(2)),
     Competition("970", "/football/women-s-champions-league", "Women's Champions League", "Women's Champions League", "European"),
     Competition("333", "/football/womens-fa-cup", "Women's FA Cup", "Women's FA Cup", "English"),


### PR DESCRIPTION
(replacing world cup 2018)...also add a start date to the womens world cup in competitions.scala. Following request from CP

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
