### PR TITLE
Make userCohort configurable in epic tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -150,6 +150,11 @@ const userIsInCorrectCohort = (
     }
 };
 
+const isValidCohort = (cohort: string): boolean =>
+    ['OnlyExistingSupporters', 'OnlyNonSupporters', 'Everyone'].includes(
+        cohort
+    );
+
 const shouldShowEpic = (test: EpicABTest): boolean => {
     const onCompatiblePage = test.pageCheck(config.get('page'));
 
@@ -497,6 +502,13 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         ? rowWithAudience.audienceOffset
                         : 0;
 
+                    const rowWithUserCohort = rows.find(
+                        row => row.userCohort && isValidCohort(row.userCohort)
+                    );
+                    const userCohort = rowWithUserCohort
+                        ? rowWithUserCohort.userCohort
+                        : 'OnlyNonSupporters';
+
                     return makeEpicABTest({
                         id: testName,
                         campaignId: testName,
@@ -514,6 +526,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         useLocalViewLog: rows.some(row =>
                             optionalStringToBoolean(row.useLocalViewLog)
                         ),
+                        userCohort,
                         ...(isLiveBlog
                             ? {
                                   template: liveBlogTemplate,


### PR DESCRIPTION
## What does this change?
The `userCohort` field allows us to configure whether supporters/non-supporters should see a particular epic test.
This change makes it possible to configure this from the google doc.
By default epic tests are only displayed to non-supporters.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
