### PR TITLE
Make my account button tab accessible

### DIFF
--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -13,18 +13,21 @@
         Sign in
     </a>
 
-    <button class="dropdown-menu-fallback js-user-account-trigger"
+    <input 
+        type="checkbox"
         id="my-account-toggle"
-        title="user account toggle"
+        aria-controls="my-account-dropdown"
+        class="dropdown-menu-fallback js-enhance-checkbox"
         data-link-name="nav2 : topbar: my account"
-        aria-expanded="false"
-        aria-controls="my-account-dropdown"></button>
+        tabindex="-1"
+    />
 
-    <label class="top-bar__item popup__toggle my-account is-hidden js-navigation-account-actions"
+    <label class="top-bar__item popup__toggle js-navigation-account-actions js-user-account-trigger is-hidden"
         for="my-account-toggle"
-        data-link-name="nav2 : topbar: my account">
-        @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
-        My account
+        data-link-name="nav2 : topbar: my account"        
+        tabindex="0">
+            @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
+            My account
     </label>
     <div class="my-account__overlay"></div>
 

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -308,7 +308,10 @@ const returnFocusToButton = (btnId: string): void => {
         });
 };
 
-const genericToggleMenu = (menuClassName: string, triggerClassName: string): void => {
+const genericToggleMenu = (
+    menuClassName: string,
+    triggerClassName: string
+): void => {
     const menu: ?HTMLElement = document.querySelector(menuClassName);
 
     const trigger: ?HTMLElement = document.querySelector(triggerClassName);
@@ -321,10 +324,17 @@ const genericToggleMenu = (menuClassName: string, triggerClassName: string): voi
     }
 };
 
-const toggleEditionPicker = () => genericToggleMenu('.js-edition-dropdown-menu', '.js-edition-picker-trigger');
+const toggleEditionPicker = () =>
+    genericToggleMenu(
+        '.js-edition-dropdown-menu',
+        '.js-edition-picker-trigger'
+    );
 
-const toggleMyAccountMenu = () => genericToggleMenu('.js-user-account-dropdown-menu', '.js-user-account-trigger');
-
+const toggleMyAccountMenu = () =>
+    genericToggleMenu(
+        '.js-user-account-dropdown-menu',
+        '.js-user-account-trigger'
+    );
 
 const buttonClickHandlers = {
     [MENU_TOGGLE_ID]: toggleMenu,

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -308,59 +308,28 @@ const returnFocusToButton = (btnId: string): void => {
         });
 };
 
-const initiateUserAccountDropdown = (): void => {
-    fastdom
-        .read(() => ({
-            menu: document.querySelector('.js-user-account-dropdown-menu'),
-            trigger: document.querySelector('.js-user-account-trigger'),
-        }))
-        .then((userAccountDropdownEls: MenuAndTriggerEls) => {
-            const button = userAccountDropdownEls.trigger;
+const genericToggleMenu = (menuClassName: string, triggerClassName: string): void => {
+    const menu: ?HTMLElement = document.querySelector(menuClassName);
 
-            if (button && button instanceof HTMLButtonElement) {
-                button.addEventListener('click', () =>
-                    toggleDropdown(userAccountDropdownEls)
-                );
-            }
-
-            const { menu } = userAccountDropdownEls;
-
-            if (menu) {
-                menu.addEventListener(
-                    'keyup',
-                    (event: KeyboardEvent): void => {
-                        if (event.key === 'Escape') {
-                            toggleDropdown(userAccountDropdownEls);
-                            returnFocusToButton(MY_ACCOUNT_ID);
-                        }
-                    }
-                );
-            }
-        });
-};
-
-const toggleEditionPicker = (): void => {
-    const menu: ?HTMLElement = document.querySelector(
-        '.js-edition-dropdown-menu'
-    );
-
-    const trigger: ?HTMLElement = document.querySelector(
-        '.js-edition-picker-trigger'
-    );
+    const trigger: ?HTMLElement = document.querySelector(triggerClassName);
 
     if (menu && trigger) {
-        const editionPickerDropdownEls: MenuAndTriggerEls = {
+        toggleDropdown({
             menu,
             trigger,
-        };
-
-        toggleDropdown(editionPickerDropdownEls);
+        });
     }
 };
+
+const toggleEditionPicker = () => genericToggleMenu('.js-edition-dropdown-menu', '.js-edition-picker-trigger');
+
+const toggleMyAccountMenu = () => genericToggleMenu('.js-user-account-dropdown-menu', '.js-user-account-trigger');
+
 
 const buttonClickHandlers = {
     [MENU_TOGGLE_ID]: toggleMenu,
     [EDITION_PICKER_TOGGLE_ID]: toggleEditionPicker,
+    [MY_ACCOUNT_ID]: toggleMyAccountMenu,
 };
 
 const menuKeyHandlers = {
@@ -374,6 +343,12 @@ const menuKeyHandlers = {
         if (event.key === 'Escape') {
             toggleEditionPicker();
             returnFocusToButton(EDITION_PICKER_TOGGLE_ID);
+        }
+    },
+    [MY_ACCOUNT_ID]: (event: KeyboardEvent): void => {
+        if (event.key === 'Escape') {
+            toggleMyAccountMenu();
+            returnFocusToButton(MY_ACCOUNT_ID);
         }
     },
 };
@@ -618,7 +593,6 @@ export const newHeaderInit = (): void => {
     addEventHandler();
     showMyAccountIfNecessary();
     bindCredentialsApiSignIn();
-    initiateUserAccountDropdown();
     closeAllMenuSections();
     trackRecentSearch();
 };

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -39,32 +39,28 @@ const showMyAccountIfNecessary = (): void => {
             ),
             commentItems: Array.from(
                 document.querySelectorAll('.js-show-comment-activity')
-            ),
-            accountTrigger: document.querySelector('.js-user-account-trigger'),
+            )
         }))
         .then(els => {
             const {
                 signIns,
                 accountActionsLists,
                 commentItems,
-                accountTrigger,
             } = els;
-
             return fastdom
                 .write(() => {
                     signIns.forEach(signIn => {
                         signIn.remove();
                     });
-
                     accountActionsLists.forEach(accountActions => {
                         accountActions.classList.remove('is-hidden');
                     });
-
-                    // We still want the button to be hidden, but tabbable now
-                    if (accountTrigger) {
+                    
+                    Array.from(
+                        document.querySelectorAll('.js-user-account-trigger')
+                    ).forEach(accountTrigger => {
                         accountTrigger.classList.remove('is-hidden');
-                        accountTrigger.classList.add('u-h');
-                    }
+                    })
                 })
                 .then(() => {
                     updateCommentLink(commentItems);

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -39,14 +39,10 @@ const showMyAccountIfNecessary = (): void => {
             ),
             commentItems: Array.from(
                 document.querySelectorAll('.js-show-comment-activity')
-            )
+            ),
         }))
         .then(els => {
-            const {
-                signIns,
-                accountActionsLists,
-                commentItems,
-            } = els;
+            const { signIns, accountActionsLists, commentItems } = els;
             return fastdom
                 .write(() => {
                     signIns.forEach(signIn => {
@@ -55,12 +51,12 @@ const showMyAccountIfNecessary = (): void => {
                     accountActionsLists.forEach(accountActions => {
                         accountActions.classList.remove('is-hidden');
                     });
-                    
+
                     Array.from(
                         document.querySelectorAll('.js-user-account-trigger')
                     ).forEach(accountTrigger => {
                         accountTrigger.classList.remove('is-hidden');
-                    })
+                    });
                 })
                 .then(() => {
                     updateCommentLink(commentItems);

--- a/static/src/stylesheets/layout/nav/_my-account.scss
+++ b/static/src/stylesheets/layout/nav/_my-account.scss
@@ -6,6 +6,15 @@
     }
 }
 
+.my-account-toggle-button {
+    border: 0;
+    background: none;
+    text-align: left;
+    @include mq($until: tablet) {
+        padding-left: 0;
+    }
+}
+
 .my-account--icon {
     svg {
         height: 18px;


### PR DESCRIPTION
## What does this change?
Tabbing through the navigation while logged in, the 'My account' button was skipped over and thus not keyboard accessible. Once made tabbable, the menu could not be opened by pressing Enter key (only clicking with mouse worked).

What was done:
* Made 'My account' button accessible by using Tab key
* Made 'My Account' dropdown menu accessible by using Enter/Space keys and Escape key to exit
* Ensured 'My account' button aligned correctly on mobile as well as desktop/tablet

## Screenshots
![image](https://user-images.githubusercontent.com/15648334/53968474-02cf1d00-40ef-11e9-9ec3-cef85c128790.png)

## What is the value of this and can you measure success?
Keyboard and screen reader users can now access their account details where they could not before.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
