### PR TITLE
update docs

### DIFF
--- a/docs/01-start-here/07-faqs.md
+++ b/docs/01-start-here/07-faqs.md
@@ -2,7 +2,7 @@
 
 ## I can see mark-up in my response, but it's not in the application anywhere. Where is it coming from?
 
-If you can't find your element in views, cleaners or JS, it is likely your markup is coming from CAPI and used as-is. You can use Teleporter (ask your neighbour if you don't know what that is) to view the response from CAPI on the page you're seeing the mark-up.
+If you can't find your element in views, cleaners or JS, it is likely your markup is coming from CAPI and used as-is. You can use [Teleporter](https://github.com/guardian/gustaf) to view the response from CAPI on the page you're seeing the mark-up.
 
 For example: you're trying to style a class, but can't find it in the Frontend codebase and want to make sure it's only used in the HTML where you're looking.
 

--- a/docs/03-dev-howtos/02-deployment.md
+++ b/docs/03-dev-howtos/02-deployment.md
@@ -1,4 +1,8 @@
-# What to do when a deployment breaks
+# Deployment
+
+Deploy dotcom using the `dotcom:all` project in riff-raff. This will autodeploy in PROD- and it's usually what you want to do when using CODE.
+
+## What to do when a deployment breaks
 
 ```
 com.amazonaws.AmazonServiceException Status Code: 400, AWS Service:


### PR DESCRIPTION
this just adds something to the docs reassuring people that `dotcom:all` is the right thing to deploy as it's not immediately obvious