### PR TITLE
Video image width update for Article emails

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -3,7 +3,7 @@
 @()(implicit page: PageWithStoryPackage, request: RequestHeader)
 
 @import views.support.{EmailImage, EmailVideoImage}
-@import views.support.EmailHelpers.{imgForArticle, icon}
+@import views.support.EmailHelpers.{imgForArticle, icon, imgForVideo}
 @import fragments.email._
 @import model.liveblog._
 @import model.EmailAddons.EmailContentType
@@ -189,11 +189,11 @@
                                         @asset.platform match {
                                             case MediaAssetPlatform.Youtube => {
                                                 <a href="https://www.youtube.com/watch?v=@asset.id">
-                                                @imgForArticle(imageUrl, Some(atom.title))
+                                                @imgForVideo(imageUrl, Some(atom.title))
                                                 </a>
                                             }
                                             case _ => {
-                                                @imgForArticle(imageUrl, Some(atom.title))
+                                                @imgForVideo(imageUrl, Some(atom.title))
                                             }
                                         }
                                     }

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -45,6 +45,7 @@ object EmailHelpers {
   }
 
   def imgForArticle: (String, Option[String]) => Html = img(EmailImage.knownWidth) _
+  def imgForVideo: (String, Option[String]) => Html = img(EmailVideoImage.knownWidth) _
 
   def imgForFront: (String, Option[String]) => Html = img(width=EmailImageParams.fullWidth) _
 

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -12,6 +12,7 @@ import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import common.Environment.{app, awsRegion, stage}
 import play.api.libs.json.{Json, Writes}
+import views.support.EmailImage.width
 
 import Function.const
 
@@ -215,11 +216,12 @@ object EmailImage extends ImageProfile(width = Some(EmailImageParams.articleFull
   val knownWidth: Int = width.get
 }
 
-object EmailVideoImage extends ImageProfile(width = Some(EmailImageParams.articleFullWidth), autoFormat = false) with OverlayBase64 {
+object EmailVideoImage extends ImageProfile(width = Some(EmailImageParams.videoFullWidth), autoFormat = false) with OverlayBase64 {
   override val qualityparam: String = EmailImage.qualityparam
   override val dprParam: String = EmailImageParams.dprParam
   val overlayAlignParam = "overlay-align=bottom,left"
   val overlayUrlParam = s"overlay-base64=${overlayUrlBase64("playx2.png")}"
+  val knownWidth: Int = width.get
 
   override def resizeString: String = {
     val params = Seq(widthParam, heightParam, qualityparam, autoParam, dprParam, overlayAlignParam, overlayUrlParam).filter(_.nonEmpty).mkString("&")
@@ -232,6 +234,7 @@ object EmailImageParams {
   val sharpenParam: String = "sharpen=a0.8,r1,t1"
   val fullWidth: Int = 500
   val articleFullWidth: Int = 580
+  val videoFullWidth: Int = 560
   val dprParam: String = "dpr=2"
 }
 

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -12,7 +12,6 @@ import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import common.Environment.{app, awsRegion, stage}
 import play.api.libs.json.{Json, Writes}
-import views.support.EmailImage.width
 
 import Function.const
 


### PR DESCRIPTION
## What does this change?
In this commit, logic for video images has been separated from the logic for Article images, as the actual width required for a video image was 560px.
## Screenshots
![video image container was set to 580px 10px on each side](https://user-images.githubusercontent.com/47107438/53971450-da4a2180-40f4-11e9-8bec-8183c49acc35.png)
## What is the value of this and can you measure success?
The following change fixes the problem with Outlook, where video container was set to 580px + 10px on each side, which in total, gave 600px. This was creating extra white space on the right - as highlighted on the screenshot. 
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] N/A
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
