### PR TITLE
Fix mistake in font-loader docs

### DIFF
--- a/docs/06-features-and-components/03-font-loader-route.md
+++ b/docs/06-features-and-components/03-font-loader-route.md
@@ -56,7 +56,7 @@ Below is an example code snippet that can be included inline on you site, this m
        document.body.appendChild(iframe);
      };
 
-     document.addEventListener('DomContentLoaded', loadFonts);
+     document.addEventListener('DOMContentLoaded', loadFonts);
    })(window, document);
 </script>
 ```


### PR DESCRIPTION
Fix mistake in font-loader docs, `DomContentLoaded` becomes `DOMContentLoaded`.