### PR TITLE
Make epic support url configurable

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -95,6 +95,7 @@ declare type InitEpicABTestVariant = {
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],
     showTicker?: boolean,
+    supportBaseURL?: string,
 };
 
 declare type InitBannerABTestVariant = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -219,7 +219,7 @@ const makeEpicABTestVariant = (
         }`,
         campaignCode,
         supportURL: addTrackingCodesToUrl({
-            base: supportContributeURL(),
+            base: initVariant.supportBaseURL || supportContributeURL(),
             componentType: parentTest.componentType,
             componentId,
             campaignCode,
@@ -612,6 +612,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 ','
                             ),
                             showTicker: optionalStringToBoolean(row.showTicker),
+                            supportBaseURL: row.supportBaseURL,
                         })),
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -36,6 +36,7 @@ import { userIsSupporter } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
     supportSubscribeGeoRedirectURL,
+    addCountryGroupToSupportLink,
 } from 'common/modules/commercial/support-utilities';
 import { awaitEpicButtonClicked } from 'common/modules/commercial/epic/epic-utils';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
@@ -219,7 +220,9 @@ const makeEpicABTestVariant = (
         }`,
         campaignCode,
         supportURL: addTrackingCodesToUrl({
-            base: initVariant.supportBaseURL || supportContributeURL(),
+            base: initVariant.supportBaseURL
+                ? addCountryGroupToSupportLink(initVariant.supportBaseURL)
+                : supportContributeURL(),
             componentType: parentTest.componentType,
             componentId,
             campaignCode,


### PR DESCRIPTION
## What does this change?
Makes the link in the epic configurable, for use in campaigns

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
