### PR TITLE
Add font loader library for clients of the /font-loader endpoint

### DIFF
--- a/tools/font-loader-lib/index.js
+++ b/tools/font-loader-lib/index.js
@@ -1,6 +1,6 @@
-(function(window, document) {
+const fetchFonts = (window, document) => {
     const head = document.querySelector('head');
-    const useFont = function(font) {
+    const useFont = font => {
         if (font.css) {
             const style = document.createElement('style');
             style.innerHTML = font.css;
@@ -8,13 +8,13 @@
         }
     };
 
-    const loadFonts = function() {
+    const loadFonts = () => {
         const iframe = document.createElement('iframe');
         iframe.src = 'https://theguardian.com/font-loader';
         iframe.classList = 'guardianFontLoader';
         // add iframe and wait for message
         iframe.style.display = 'none';
-        window.addEventListener('message', function(e) {
+        window.addEventListener('message', e => {
             if (
                 e &&
                 e.data &&
@@ -29,4 +29,6 @@
         document.body.appendChild(iframe);
     };
     loadFonts();
-})(window, document);
+};
+
+export default fetchFonts;

--- a/tools/font-loader-lib/index.js
+++ b/tools/font-loader-lib/index.js
@@ -1,0 +1,32 @@
+(function(window, document) {
+    const head = document.querySelector('head');
+    const useFont = function(font) {
+        if (font.css) {
+            const style = document.createElement('style');
+            style.innerHTML = font.css;
+            head.appendChild(style);
+        }
+    };
+
+    const loadFonts = function() {
+        const iframe = document.createElement('iframe');
+        iframe.src = 'https://theguardian.com/font-loader';
+        iframe.classList = 'guardianFontLoader';
+        // add iframe and wait for message
+        iframe.style.display = 'none';
+        window.addEventListener('message', function(e) {
+            if (
+                e &&
+                e.data &&
+                e.data.name &&
+                e.data.name === 'guardianFonts' &&
+                e.data.fonts &&
+                e.source === iframe.contentWindow
+            ) {
+                e.data.fonts.forEach(useFont);
+            }
+        });
+        document.body.appendChild(iframe);
+    };
+    loadFonts();
+})(window, document);

--- a/tools/font-loader-lib/index.js
+++ b/tools/font-loader-lib/index.js
@@ -11,7 +11,6 @@ const fetchFonts = (window, document) => {
     const loadFonts = () => {
         const iframe = document.createElement('iframe');
         iframe.src = 'https://theguardian.com/font-loader';
-        iframe.classList = 'guardianFontLoader';
         // add iframe and wait for message
         iframe.style.display = 'none';
         window.addEventListener('message', e => {
@@ -28,7 +27,14 @@ const fetchFonts = (window, document) => {
         });
         document.body.appendChild(iframe);
     };
-    loadFonts();
+
+    if (document.readyState === 'loading') {
+        // Loading hasn't finished yet
+        document.addEventListener('DOMContentLoaded', loadFonts);
+    } else {
+        // DOMContentLoaded has already fired
+        loadFonts();
+    }
 };
 
 export default fetchFonts;

--- a/tools/font-loader-lib/package.json
+++ b/tools/font-loader-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/font-loader",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0",
   "description": "A script that inserts an iframe that points to the /font-loader endpoint on gu.com",
   "main": "index.js",
   "scripts": {

--- a/tools/font-loader-lib/package.json
+++ b/tools/font-loader-lib/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@guardian/font-loader",
+  "version": "1.0.0-alpha",
+  "description": "A script that inserts an iframe that points to the /font-loader endpoint on gu.com",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## What does this change?
This PR adds the script that consumers of the `/font-loader` endpoint can use to insert an iframe point to that iframe into the head of their page. 

The result of inserting this script into your code is that any fonts stored in local storage from gu.com will get inserted into the head of your page, allowing the fonts to be shared across different domains. 