### PR TITLE
Remove extra pair of quotes in footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -413,8 +413,6 @@
         <li class="colophon__item"><a class="adconsent-preference" data-link-name="adpreference" on="tap:the-adconsent-element.prompt">
             Your privacy</a>
         </li>
-    }else{
-        ""
     }
 }
 


### PR DESCRIPTION
## What does this change?

Correct an erroneous pair of quotes in the footer. (Previous version of the code was written without realising that the pair of quote in the `false` case would be interpreted as the output, rather than as specifying an empty string).

## Screenshots

Before: 

![unnamed](https://user-images.githubusercontent.com/6035518/54120896-dcf88f80-43f0-11e9-99a8-d7933fcdc343.png)

After:

![Screenshot 2019-03-11 at 11 26 32](https://user-images.githubusercontent.com/6035518/54120901-e1bd4380-43f0-11e9-97a6-7d57b2c7f64d.png)