### PR TITLE
The Frontline campaign epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -19,8 +19,7 @@ export const acquisitionsEpicTickerTemplate = `
         
         <div class="js-ticker-over-goal is-hidden">
             <div class="epic-ticker__thankyou">
-                <div>Help us beat our goal - thank you</div>
-                <div>Please keep contributing into the new year</div>
+                <div>We've met our goal — thank you</div>
             </div>
             
             <div class="js-ticker-exceeded epic-ticker__exceeded">

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -97,6 +97,10 @@ const animate = (parentElementSelector: string) => {
         total > goal ? '.js-ticker-over-goal' : '.js-ticker-under-goal';
 
     if (parentElement && parentElement instanceof HTMLElement) {
+        const heightClass =
+            total > goal ? 'epic-ticker--short' : 'epic-ticker--tall';
+        parentElement.classList.add(heightClass);
+
         if (total < goal) {
             populateGoal(parentElement);
         }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -264,7 +264,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
         &:before {
             content: '';
             background-repeat: no-repeat;
-            margin: 10px -5px 12px -5px;
+            margin: 10px -5px 12px;
             background-image: url('https://media.guim.co.uk/b9ed1767866d29186f198b523cd5571aeda02a88/0_1269_5184_1516/1000.jpg');
             background-size: 100%;
             background-position: center bottom;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -254,3 +254,30 @@ a[href].contributions__contribute.contributions__contribute--epic,
         }
     }
 }
+
+.contributions__epic--thefrontline {
+    .contributions__title {
+        @include fs-header(5);
+        font-size: 28px;
+        line-height: 28px;
+
+        &:before {
+            content: '';
+            background-repeat: no-repeat;
+            margin: 10px -5px 12px -5px;
+            background-image: url('https://media.guim.co.uk/b9ed1767866d29186f198b523cd5571aeda02a88/0_1269_5184_1516/1000.jpg');
+            background-size: 100%;
+            background-position: center bottom;
+            height: 150px;
+
+            display: none;
+            @include mq($from: tablet) {
+                display: block;
+            }
+        }
+    }
+
+    p:last-child {
+        font-weight: bold;
+    }
+}

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -29,12 +29,19 @@
 
 .epic-ticker {
     position: relative;
-    height: 60px;
     margin-bottom: 15px;
 
     font-family: $f-serif-headline;
     font-size: 16px;
     line-height: 18px;
+}
+
+.epic-ticker--tall {
+    height: 60px;
+}
+
+.epic-ticker--short {
+    height: 50px;
 }
 
 .epic-ticker__count {

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -30,7 +30,7 @@
 .epic-ticker {
     position: relative;
     height: 65px;
-    margin-bottom: 25px;
+    margin-bottom: 15px;
 
     font-family: $f-serif-headline;
     font-size: 16px;

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -29,7 +29,7 @@
 
 .epic-ticker {
     position: relative;
-    height: 65px;
+    height: 60px;
     margin-bottom: 15px;
 
     font-family: $f-serif-headline;
@@ -119,16 +119,7 @@ $progress-bar-height: 10px;
 }
 
 .epic-ticker__thankyou {
-    >:first-child {
-        font-size: 24px;
-        line-height: 26px;
-        font-weight: 800;
-        color: #333333;
-    }
-
-    >:last-child {
-        font-style: italic;
-    }
+    font-weight: 800;
 }
 
 .epic-ticker__exceeded .epic-ticker__count-label {


### PR DESCRIPTION
## What does this change?
Updated ticker/epic styling for the Frontline campaign.
An image is displayed below the ticker, unless on mobile.
We are not taking contributions specifically for the campaign once we beat the target amount, so the ticker stops at the target amount.

Note - the design/copy on the ticker will update automatically once the target is reached.
But the necessary epic copy/url changes will be done manually from the google doc. Any delay here is not an issue.

## Screenshots

### Below goal, from tablet
![Picture 2](https://user-images.githubusercontent.com/1513454/54125215-4f22a180-43fc-11e9-9426-9336f93a4c6f.png)

### Below goal, mobile
![Picture 4](https://user-images.githubusercontent.com/1513454/54125217-4fbb3800-43fc-11e9-97a9-f07937395575.png)

### Above goal, from tablet
![Picture 1](https://user-images.githubusercontent.com/1513454/54125214-4f22a180-43fc-11e9-87da-187a2f0ce93d.png)

### Above goal, mobile
![Picture 3](https://user-images.githubusercontent.com/1513454/54125216-4f22a180-43fc-11e9-9518-14f871f7e362.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
