### PR TITLE
Default FIV banner to yellow variant, and put out new copy test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,8 +28,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-february-moment-banner-colour",
-    "switch on to test the moment colour engagement banner test",
+    "ab-february-moment-banner-copy",
+    "switch on to test the some moment copy on the fiv engagement banner",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 9, 30),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,7 +6,7 @@ import { askFourEarning } from 'common/modules/experiments/tests/contributions-e
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import {
-    februaryMomentBannerColour,
+    februaryMomentBannerCopy,
     februaryMomentBannerThankYou,
 } from 'common/modules/experiments/tests/february-moment-banner';
 
@@ -23,6 +23,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    februaryMomentBannerColour,
+    februaryMomentBannerCopy,
     februaryMomentBannerThankYou,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -8,6 +8,9 @@ const defaultBold =
 const defaultCopy =
     'Our mission is to keep independent journalism accessible to everyone, regardless of where they live or what they can afford. Funding from our readers safeguards our editorial independence. It also powers our work and maintains this openness. It means more people, across the world, can access accurate information with integrity at its heart.';
 
+const variantCopy =
+    'Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, The Guardian’s editorial independence is safeguarded by our readers. If you’re able to, please support The Guardian today.';
+
 const thankYouBold =
     'Thank you for supporting The\xa0Guardian’s model for open, independent journalism';
 const thankYouCopy =
@@ -41,12 +44,12 @@ const bannerShownCallback = () => {
     }
 };
 
-export const februaryMomentBannerColour: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerColour',
-    start: '2019-01-01',
+export const februaryMomentBannerCopy: AcquisitionsABTest = {
+    id: 'FebruaryMomentBannerCopy',
+    start: '2019-03-11',
     expiry: '2019-09-30',
     author: 'Jonathan Rankin',
-    description: 'test copy on engagement banner outside UK for the feb moment',
+    description: 'test some moment specific copy on fiv moment engagement banner',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -65,7 +68,7 @@ export const februaryMomentBannerColour: AcquisitionsABTest = {
                 messageText: defaultCopy,
                 // buttonCaption?: string, TO be decided with non engineers
                 template: acquisitionsBannerFivTemplate,
-                bannerModifierClass: 'fiv-banner',
+                bannerModifierClass: 'fiv-banner fiv-banner--yellow',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.onlyNonSupporters,
                 titles: [
@@ -81,34 +84,11 @@ export const februaryMomentBannerColour: AcquisitionsABTest = {
                 ),
         },
         {
-            id: 'blue',
+            id: 'variant',
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
                 leadSentence: defaultBold,
-                messageText: defaultCopy,
-                // buttonCaption?: string, TO be decided with non engineers
-                template: acquisitionsBannerFivTemplate,
-                bannerModifierClass: 'fiv-banner fiv-banner--blue',
-                minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.onlyNonSupporters,
-                titles: [
-                    'We chose a different approach',
-                    'Will you support it?',
-                ],
-                bannerShownCallback,
-            },
-            canRun: () =>
-                canShowBannerSync(
-                    minArticlesBeforeShowingBanner,
-                    userCohortParam.onlyNonSupporters
-                ),
-        },
-        {
-            id: 'yellow',
-            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
-            engagementBannerParams: {
-                leadSentence: defaultBold,
-                messageText: defaultCopy,
+                messageText: variantCopy,
                 // buttonCaption?: string, TO be decided with non engineers
                 template: acquisitionsBannerFivTemplate,
                 bannerModifierClass: 'fiv-banner fiv-banner--yellow',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -49,7 +49,8 @@ export const februaryMomentBannerCopy: AcquisitionsABTest = {
     start: '2019-03-11',
     expiry: '2019-09-30',
     author: 'Jonathan Rankin',
-    description: 'test some moment specific copy on fiv moment engagement banner',
+    description:
+        'test some moment specific copy on fiv moment engagement banner',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -363,6 +363,7 @@ $wide-circle-height: 162px;
 .fiv-banner__message-text {
     letter-spacing: -.3px;
     font-weight: 400;
+    margin-right: 10px;
 }
 
 .fiv-banner-thank-you {


### PR DESCRIPTION
## What does this [change?
The Banner colour test ](https://github.com/guardian/frontend/pull/21205) did not reach significance. Regardless, we are going for yellow as our new control.

In place of the colour test, we are testing some new copy.

Below are screenshots done on the smallest breakpoint we support, shown when the cookie consent banner is also displayer (the worst case in terms of how much space there is on the screen for the banner).

on both variants, the cookie banner options go off the screen (although seeing as everyone is going to close this banner anyway, I don't think it matters too much).


| Control | Variant | 
|----|----|
|![control](https://user-images.githubusercontent.com/2844554/54140936-9882e900-441c-11e9-9897-5242f37f6e10.png)|![a](https://user-images.githubusercontent.com/2844554/54140934-9882e900-441c-11e9-90a1-7a63f2325321.png)|



Here are the variants on the wide breakpoint:

| Control | Variant | 
|----|----|
|![controlWide](https://user-images.githubusercontent.com/2844554/54141163-092a0580-441d-11e9-9b4c-af02716fa011.png)|![wideVariant](https://user-images.githubusercontent.com/2844554/54141164-092a0580-441d-11e9-9421-b8d1fa64da83.png)|


