### PR TITLE
Fixing padding of main media atoms

### DIFF
--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -20,7 +20,6 @@ $caption-button-size: 32px;
 }
 
 .caption--main {
-    min-height: ($gs-baseline / 3) * 7;
     max-width: gs-span(7);
     padding: ($gs-baseline / 3) * 2 $gs-gutter / 2 $gs-baseline * 2;
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -214,8 +214,6 @@ figure {
         display: block;
     }
     &.element {
-        margin-top: ($gs-baseline/3)*4;
-        margin-bottom: $gs-baseline;
         position: relative;
 
         .content__article-body &:first-child {


### PR DESCRIPTION
## What does this change?
Removes top and bottom unnecessary margins from media atoms when they are main media
## Screenshots
Before
![Screen Shot 2019-03-11 at 16 44 48](https://user-images.githubusercontent.com/2051501/54141205-22cb4d00-441d-11e9-81f2-140b60cdabdd.png)

After
![Screen Shot 2019-03-11 at 16 43 56](https://user-images.githubusercontent.com/2051501/54141204-22cb4d00-441d-11e9-9199-1cd263f9279c.png)

