### PR TITLE
Add how to view preview CAPI locally

### DIFF
--- a/docs/03-dev-howtos/22-access-preview-locally.md
+++ b/docs/03-dev-howtos/22-access-preview-locally.md
@@ -1,0 +1,6 @@
+Access Preview Locally
+====================================
+
+- Add `content.api.preview.iam.host="Ping @Dotcom room for value"` to your `devOverrides` in `frontend.conf`
+- Run the preview app (`project preview`)
+- Access articles in preview CAPI (Created in Composer but not yet published)

--- a/docs/03-dev-howtos/22-access-preview-locally.md
+++ b/docs/03-dev-howtos/22-access-preview-locally.md
@@ -2,5 +2,6 @@ Access Preview Locally
 ====================================
 
 - Add `content.api.preview.iam.host="Ping @Dotcom room for value"` to your `devOverrides` in `frontend.conf`
+- Make sure you have CAPI API Gateway invocation credentials from Janus, which is available to all who have frontend dev permissions
 - Run the preview app (`project preview`)
 - Access articles in preview CAPI (Created in Composer but not yet published)


### PR DESCRIPTION
## What does this change?
Documentation to run preview

@guardian/dotcom-platform 