### PR TITLE
Use default full-width-style trail image for TiF podcast container on UK email front

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -227,11 +227,7 @@
                     <a class="fc-link" href="@card.header.url.get">
                         @card.displayElement match {
                             case Some(InlineImage(image)) if FlagshipEmailContainerDynamicImageSwitch.isSwitchedOn => {
-                                @itemImage(
-                                    image,
-                                    inlineImage = true,
-                                    widthsByBreakpoint = Some(card.squareImageWidthsByBreakpoint)
-                                )
+                                @imgFromCard(card)
                             }
                             case _ => {
                                 <img class="full-width" src="@FlagshipEmailContainer.AlbumArtUrl" alt="@card.header.headline">


### PR DESCRIPTION
## What does this change?
When enabled for trail images, the Today in Focus podcast was rendering the correct image but at the wrong size, due to breakpoint assessments on the email front.

Now it renders the same image but in the format expected for email delivery

## Screenshots
**Before**
![Screen Shot 2019-03-11 at 17 35 16](https://user-images.githubusercontent.com/690395/54146187-56ab7000-4427-11e9-883b-db2143293f65.png)

**After**
![Screen Shot 2019-03-11 at 17 55 24](https://user-images.githubusercontent.com/690395/54146161-4a271780-4427-11e9-823c-4f586cf5a498.png)

## What is the value of this and can you measure success?
We can re-enable the feature in PROD and send our email subscribers lovely lovely images instead of the boring old default podcast album art.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] Emails

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
