### PR TITLE
SecureDrop is PascalCase and all one word

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -63,7 +63,7 @@
                                         Complaints &amp; corrections</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        Secure Drop</a>
+                                        SecureDrop</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="uk : footer : work for us" href="https://workforus.theguardian.com">
                                         Work for us</a>
@@ -140,7 +140,7 @@
                                         Complaints &amp; corrections</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        Secure Drop</a>
+                                        SecureDrop</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : work for us" href="https://workforus.theguardian.com/">
                                         Work for us</a>
@@ -213,7 +213,7 @@
                                         Contact us</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        Secure Drop</a>
+                                        SecureDrop</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://www.theguardian.com/info/2015/aug/04/guardian-australia-job-vacancies">
                                         Vacancies</a>
@@ -286,7 +286,7 @@
                                         Complaints &amp; corrections</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        Secure Drop</a>
+                                        SecureDrop</a>
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : work for us" href="https://workforus.theguardian.com">
                                         Work for us</a>


### PR DESCRIPTION
## What does this change?

Change footer text that currently shows `Secure Drop` to `SecureDrop`.

This change is being made for all editions since SecureDrop calls itself SecureDrop. 😄

## Screenshots

#### BEFORE:

<img width="486" alt="Screenshot 2019-03-11 at 18 18 04" src="https://user-images.githubusercontent.com/8607683/54147441-13063580-442a-11e9-837e-c542f9d9afc9.png">


#### AFTER:

<img width="486" alt="Screenshot 2019-03-11 at 18 15 01" src="https://user-images.githubusercontent.com/8607683/54147220-9ffcbf00-4429-11e9-80c9-f2a33f71a40e.png">


## What is the value of this and can you measure success?

### 🔐💧

SecureDrop officially uses PascalCase and all one word:

<img width="887" alt="Screenshot 2019-03-11 at 18 02 37" src="https://user-images.githubusercontent.com/8607683/54146725-86a74300-4428-11e9-8bd9-e3c440ef7e83.png">

## Checklist

### Does this affect other platforms?

Nope
