### PR TITLE
Remove RHS from Print Sales articles, add missing closing DIV

### DIFF
--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -78,10 +78,17 @@
 
                     <div class="content__secondary-column js-secondary-column" aria-hidden="true">
 
-                        @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes(false), false)
+                        @if(!article.tags.isPrintSalesSeries){
+                            @fragments.articleAsideSlot(
+                                shouldShowAds(model),
+                                articleAsideOptionalSizes(article.elements.hasShowcaseMainElement),
+                                false
+                            )
+                        }
 
                     </div>
                 </div>
+            </div>
         </article>
 
         @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -784,6 +784,7 @@ final case class Tags(
     tags.exists(t => t.id == "sport/rugby-union")
 
   lazy val isClimateChangeSeries: Boolean = tags.exists(t => t.id =="environment/series/keep-it-in-the-ground")
+  lazy val isPrintSalesSeries: Boolean = tags.exists(t => t.id == "artanddesign/series/gnm-print-sales")
   lazy val isTheMinuteArticle: Boolean = tags.exists(t => t.id == "tone/minute")
   //this is for the immersive header to access this info
   lazy val isPaidContent: Boolean = tags.exists( t => t.id == "tone/advertisement-features" )


### PR DESCRIPTION
## What does this change?

#### 👉 Remove RHS adslot from print-sales content

In this buy-a-Guardian-print series, there is a race between the adslot being resized, and DFP inserting an advert, leading to the RHS slot overlapping the image:

https://www.theguardian.com/artanddesign/2019/mar/02/buy-your-own-guardian-classic-photograph-dance-theatre-of-harlem-1976

https://www.theguardian.com/artanddesign/2019/feb/23/buy-your-own-guardian-classic-photograph-aonach-mor-march-2018

https://www.theguardian.com/artanddesign/2019/feb/09/buy-your-own-guardian-classic-photograph-stonehenge-2004

#### 👉 Add missing closing DIV to the immersive template

IntelliJ was shouting at me:

![Screenshot 2019-03-12 at 10 44 42](https://user-images.githubusercontent.com/8607683/54194366-01697000-44b4-11e9-8d19-d6c52d94083b.png)

## Screenshots

##### BEFORE

<img width="1332" alt="Screenshot 2019-03-12 at 10 51 40" src="https://user-images.githubusercontent.com/8607683/54194739-d9c6d780-44b4-11e9-86da-df2b5756d7d2.png">

##### AFTER

<img width="1332" alt="Screenshot 2019-03-12 at 10 51 21" src="https://user-images.githubusercontent.com/8607683/54194762-e51a0300-44b4-11e9-84b8-acef8d9d38e6.png">


## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope, only affects immersive content with the tag `artanddesign/series/gnm-print-sales`

### Does this change break ad-free?

Nope

### Does this change update the version of CAPI we're using?

Nope

### Accessibility test checklist

N/A

### Tested

- [x] Locally
