### PR TITLE
Update font-loader docs

### DIFF
--- a/docs/06-features-and-components/03-font-loader-route.md
+++ b/docs/06-features-and-components/03-font-loader-route.md
@@ -60,3 +60,6 @@ Below is an example code snippet that can be included inline on you site, this m
    })(window, document);
 </script>
 ```
+
+A version of this script is available on NPM at https://www.npmjs.com/package/@guardian/font-loader
+


### PR DESCRIPTION
## What does this change?
Adds to the documentation of `/font-loader` by pointing out the existence of the NPM module