### PR TITLE
Fully release AMP to dotcomponents (removes whitelisting)

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -49,88 +49,6 @@ object AMPPicker {
     logger.withRequestHeaders(request).results(msg, results, page)
   }
 
-  private[this] val sectionsWhitelist: Set[String] = {
-
-    val safeSections = Set[String](
-      "music",
-      "football",
-      "sport",
-      "games",
-      "stage",
-      "artanddesign",
-      "film",
-      "books",
-      "business",
-      "society",
-      "environment",
-      "technology",
-      "lifeandstyle",
-      "money",
-      "travel"
-    )
-
-    if (conf.switches.Switches.DotcomRenderingAMPRollout.isSwitchedOn) {
-      Set("uk-news", "us-news") ++ safeSections
-    } else {
-      safeSections
-    }
-
-  }
-
-  private[this] val tagsWhitelist: Set[String] = {
-    val safeTags = Set[String]("info/series/digital-blog")
-
-    if (conf.switches.Switches.DotcomRenderingAMPRollout.isSwitchedOn) {
-      Set() ++ safeTags
-    } else {
-      safeTags
-    }
-  }
-
-  private[this] val pageWhitelist: Set[String] = Set(
-    "world/2018/oct/14/british-man-shot-dead-by-hunter-in-france",
-    "politics/2018/oct/14/brexit-dominic-raab-rushes-to-brussels-before-eu-crunch-talks",
-    "politics/2018/oct/14/eu-leaders-line-up-no-deal-emergency-brexit-summit-for-november",
-    "world/2018/oct/01/palu-earthquake-and-tsunami-what-we-know-so-far",
-    "info/2018/may/09/why-sign-in-to-the-guardian",
-    "society/2018/oct/14/folic-acid-to-be-added-to-flour-in-effort-to-reduce-serious-birth-defects",
-    "film/2017/dec/08/bryan-singer-denies-sexually-assaulting-17-year-old-boy-at-yacht-party-in-2003",
-    "business/2018/oct/14/china-ambassador-cui-tiankai-stumped-on-who-aides-trump-on-trade",
-    "world/2018/oct/14/bavaria-poll-humiliation-for-angela-merkel-conservative-allies",
-    "world/2017/dec/31/at-least-10-tourists-and-two-pilots-killed-as-plane-crashes-in-costa-rica",
-    "us-news/2017/nov/28/new-york-truck-attack-suspect-sayfullo-saipov",
-    "australia-news/2018/oct/15/us-embassy-apologises-after-mistakenly-sending-cookie-monster-cat-invitation",
-    "politics/2018/oct/15/foreign-office-left-disoriented-and-demoralised-by-brexit-say-diplomats",
-    "film/2018/aug/03/harvey-weinstein-lawyers-new-york-court-sexual-assault-charges",
-    "politics/2018/oct/14/local-welfare-schemes-in-england-on-brink-of-collapse-survey-finds",
-    "society/2018/sep/01/children-social-care-services-councils-austerity",
-    "uk-news/2018/oct/15/mi5-believed-black-people-posed-security-risk-papers-reveal",
-    "info/2018/sep/07/removed-video",
-    "world/2018/aug/24/more-than-25-children-and-four-women-killed-in-air-strikes-in-yemen",
-    "help/2018/may/29/why-do-i-need-to-upgrade-my-browser",
-    "world/2017/oct/23/syria-shocking-images-of-starving-baby-reveal-impact-of-food-crisis",
-    "business/2018/oct/14/saudi-shares-drop-on-fallout-journalists-disappearance-trump",
-    "commentisfree/2018/may/27/royal-wedding-celebration-black-excellence-letters",
-    "uk-news/2018/sep/05/child-sexual-exploitation-18-people-appear-in-huddersfield-court",
-    "us-news/2018/aug/18/colorado-bodies-crude-oil-murder-case",
-    "business/2018/oct/14/uk-scientists-turn-coffee-waste-electricity-fuel-cell-colombia",
-    "info/2018/sep/20/article-removed",
-    "money/2018/oct/15/three-quarters-of-uk-workers-do-not-receive-same-pay-each-month",
-    "info/2018/aug/10/article-removed",
-    "help/2018/apr/18/subscriptions",
-    "uk-news/2018/oct/14/met-police-damian-collins-no-investigation-leave-campaigners-data-misuse",
-    "world/2018/oct/14/nine-climbers-killed-in-storm-in-himalayas-mount-gurja-nepal-south-korea",
-    "help/2017/mar/15/computer-security-tips-for-whistleblowers-and-sources",
-    "uk-news/2018/oct/15/cornwall-murder-lyn-bryant-police-new-dna-evidence",
-    "uk-news/2018/oct/18/man-beaten-to-death-in-south-west-london",
-    "science/2018/oct/17/chinese-city-plans-to-launch-artificial-moon-to-replace-streetlights",
-    "uk-news/2018/oct/17/no-retrial-for-teacher-accused-of-having-sex-with-student-on-plane-eleanor-wilson",
-    "australia-news/2018/oct/18/queensland-man-charged-with-raping-young-english-woman-on-working-holiday",
-    "business/2018/oct/17/man-falls-from-top-floor-of-westfield-stratford-on-to-another-shopper",
-    "uk-news/2018/oct/17/elizabeth-isherwood-wales-death-locked-cupboard-macdonald-resorts-sued",
-    "us-news/2018/oct/17/high-school-cookies-teen-grandfather-ashes"
-  )
-
   private[this] def ampFeatureWhitelist(page: PageWithStoryPackage, request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("isBasicArticle", AMPPageChecks.isBasicArticle(page)),
@@ -141,16 +59,12 @@ object AMPPicker {
   }
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
-    val isWhitelisted =
-      pageWhitelist(page.metadata.id) ||
-      page.metadata.section.exists((s) => sectionsWhitelist(s.value)) ||
-      page.item.tags.tags.exists((s)=>tagsWhitelist(s.id))
 
     val features = ampFeatureWhitelist(page, request)
     val isSupported = features.forall({ case (test, isMet) => isMet})
     val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
-    val tier = if ((isSupported && isEnabled && isWhitelisted && !request.guuiOptOut) || request.isGuui) RemoteRenderAMP else LocalRender
+    val tier = if ((isSupported && isEnabled && !request.guuiOptOut) || request.isGuui) RemoteRenderAMP else LocalRender
 
     tier match {
       case RemoteRenderAMP => logRequest(s"path executing in dotcomponents AMP", features, page)

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -27,16 +27,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val DotcomRenderingAMPRollout = Switch(
-    SwitchGroup.Feature,
-    "dotcom-rendering-amp-rollout",
-    "If this switch is on, we will use the dotcom rendering tier for AMP articles in the next rollout stage",
-    owners = Seq(Owner.withGithub("nicl")),
-    safeState = Off,
-    sellByDate =  new LocalDate(2019, 4, 1),
-    exposeClientSide = false
-  )
-
   val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",


### PR DESCRIPTION
## What does this change?

Removes whitelisting feature from the AMP picker. All articles will go through dotcomponents if they are supported after this is merged.

To merge in Wednesday morning.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
