### PR TITLE
Use `config.get` to access all `config` properties - round 2

### DIFF
--- a/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
@@ -1,5 +1,15 @@
 module.exports = {
     create(context) {
+        const configInterface = [
+            'get',
+            'set',
+            'hasTone',
+            'hasSeries',
+            'referencesOfType',
+            'referenceOfType',
+            'webPublicationDateAsUrlPart',
+            'dateFromSlug',
+        ];
         const isDot = token =>
             token && token.type === 'Punctuator' && token.value === '.';
         const isIdentifier = token => token && token.type === 'Identifier';
@@ -14,7 +24,7 @@ module.exports = {
                     if (
                         isDot(dot) &&
                         isIdentifier(child) &&
-                        child.value !== 'get'
+                        !configInterface.includes(child.value)
                     ) {
                         context.report({
                             node,

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -79,7 +79,7 @@ module.exports = {
         'guardian-frontend/global-config': 'error',
         'guardian-frontend/no-multiple-classlist-parameters': 'error',
         'guardian-frontend/no-default-export': 'warn',
-        'guardian-frontend/no-direct-access-config': 'warn',
+        'guardian-frontend/no-direct-access-config': 'error',
 
         // flow should take care of our return values
         'consistent-return': 'off',

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -79,7 +79,7 @@ module.exports = {
         'guardian-frontend/global-config': 'error',
         'guardian-frontend/no-multiple-classlist-parameters': 'error',
         'guardian-frontend/no-default-export': 'warn',
-        'guardian-frontend/no-direct-access-config': 'error',
+        'guardian-frontend/no-direct-access-config': 'warn',
 
         // flow should take care of our return values
         'consistent-return': 'off',

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable guardian-frontend/no-direct-access-config */
 
 // This should be the only module accessing the window config object directly
 // because this is the one that gets imported to all other modules

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable guardian-frontend/no-direct-access-config */
 
 // This should be the only module accessing the window config object directly
 // because this is the one that gets imported to all other modules

--- a/static/src/javascripts/lib/page.spec.js
+++ b/static/src/javascripts/lib/page.spec.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable guardian-frontend/no-direct-access-config */
 
 import config from 'lib/config';
 import { isMatch, isClockwatch, isLiveClockwatch, keywordExists } from './page';

--- a/static/src/javascripts/lib/page.spec.js
+++ b/static/src/javascripts/lib/page.spec.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable guardian-frontend/no-direct-access-config */
 
 import config from 'lib/config';
 import { isMatch, isClockwatch, isLiveClockwatch, keywordExists } from './page';

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -23,7 +23,9 @@ const loadExternalContentWidget = (): void => {
     const externalTpl = template(externalContentContainerStr);
 
     const findAnchor = (): Promise<HTMLElement | null> => {
-        const selector = !(config.page.seriesId || config.page.blogIds)
+        const selector = !(
+            config.get('page.seriesId') || config.get('page.blogIds')
+        )
             ? '.js-related, .js-outbrain-anchor'
             : '.js-outbrain-anchor';
         return Promise.resolve(document.querySelector(selector));
@@ -44,8 +46,8 @@ const loadExternalContentWidget = (): void => {
     };
 
     const shouldServePlista: boolean =
-        config.switches.plistaForOutbrainAu &&
-        config.page.edition.toLowerCase() === 'au';
+        config.get('switches.plistaForOutbrainAu') &&
+        config.get('page.edition', '').toLowerCase() === 'au';
 
     if (shouldServePlista) {
         renderWidget('plista', plista.init);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
@@ -11,9 +11,10 @@ const doubleClickRandom = (): string => {
 
 export const doubleClickAdFree: ThirdPartyTag = {
     shouldRun:
-        commercialFeatures.adFree && config.switches.doubleclickYoutubeAdFree,
+        commercialFeatures.adFree &&
+        config.get('switches.doubleclickYoutubeAdFree'),
     useImage: true,
-    url: `//pubads.g.doubleclick.net/activity;dc_iu=/${
-        config.page.dfpAccountId
-    }/DFPAudiencePixel;ord=${doubleClickRandom()};dc_seg=482549580;af=T?`,
+    url: `//pubads.g.doubleclick.net/activity;dc_iu=/${config.get(
+        'page.dfpAccountId'
+    )}/DFPAudiencePixel;ord=${doubleClickRandom()};dc_seg=482549580;af=T?`,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -9,11 +9,11 @@ export const fbPixel: () => ThirdPartyTag = () => {
     const consent = getAdConsentState(thirdPartyTrackingAdConsent);
     return {
         shouldRun:
-            config.switches.facebookTrackingPixel &&
+            config.get('switches.facebookTrackingPixel') &&
             (consent == null || consent),
-        url: `https://www.facebook.com/tr?id=${
-            config.libs.facebookAccountId
-        }&ev=PageView&noscript=1`,
+        url: `https://www.facebook.com/tr?id=${config.get(
+            'libs.facebookAccountId'
+        )}&ev=PageView&noscript=1`,
         useImage: true,
     };
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -18,12 +18,12 @@ type SetupParams = {
 describe('Facebook tracking pixel', () => {
     beforeEach(() => {
         jest.resetAllMocks();
-        config.libs.facebookAccountId = 'test-account-id';
+        config.set('libs.facebookAccountId', 'test-account-id');
     });
 
     const setup = (params: SetupParams) => {
         getAdConsentState.mockReturnValueOnce(params.consent);
-        config.switches = { facebookTrackingPixel: params.switchedOn };
+        config.set('switches.facebookTrackingPixel', params.switchedOn);
     };
 
     it('should not load if switch is off', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
@@ -17,7 +17,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwideLegacy: ThirdPartyTag = {
-    shouldRun: config.switches.imrWorldwide,
+    shouldRun: config.get('switches.imrWorldwide'),
     url: '//secure-au.imrworldwide.com/v60.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
@@ -3,11 +3,27 @@ import { imrWorldwideLegacy } from './imr-worldwide-legacy';
 
 const { shouldRun, url, onLoad } = imrWorldwideLegacy;
 
-jest.mock('lib/config', () => ({
-    switches: {
-        imrWorldwide: true,
-    },
-}));
+/**
+ * we have to mock config like this because
+ * loading imr-worldwide-legacy has side affects
+ * that are dependent on config.
+ * */
+
+jest.mock('lib/config', () => {
+    const defaultConfig = {
+        switches: {
+            imrWorldwide: true,
+        },
+    };
+
+    return Object.assign({}, defaultConfig, {
+        get: (path: string = '', defaultValue: any) =>
+            path
+                .replace(/\[(.+?)\]/g, '.$1')
+                .split('.')
+                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
+    });
+});
 
 describe('third party tag IMR worldwide legacy', () => {
     it('should exist and have the correct exports', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
@@ -60,7 +60,7 @@ const guMetadata = {
 };
 
 const onLoad = () => {
-    const sectionFromMeta = config.page.section.toLowerCase();
+    const sectionFromMeta = config.get('page.section', '').toLowerCase();
     const subBrandApId =
         guMetadata[sectionFromMeta] || guMetadata['brand-only'];
 
@@ -80,7 +80,7 @@ const onLoad = () => {
 
     const dcrStaticMetadata = {
         type: 'static',
-        assetid: config.page.pageId,
+        assetid: config.get('page.pageId'),
         section: sectionRef,
     };
 
@@ -88,7 +88,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwide: ThirdPartyTag = {
-    shouldRun: config.switches.imrWorldwide,
+    shouldRun: config.get('switches.imrWorldwide'),
     url: '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -4,22 +4,38 @@ import { imrWorldwide } from './imr-worldwide';
 const { shouldRun, url } = imrWorldwide;
 const onLoad: any = imrWorldwide.onLoad;
 
-jest.mock('lib/config', () => ({
-    switches: {
-        imrWorldwide: true,
-    },
-    page: {
-        headline: 'Starship Enterprise',
-        author: 'Captain Kirk',
-        section: 'spaceexploration',
-        sectionName: 'Space Exploration',
-        keywords: 'Space,Travel',
-        webPublicationDate: 1498113262000,
-        isFront: false,
-        isPaidContent: true,
-        pageId: 100,
-    },
-}));
+/**
+ * we have to mock config like this because
+ * loading imr-worldwide has side affects
+ * that are dependent on config.
+ * */
+
+jest.mock('lib/config', () => {
+    const defaultConfig = {
+        switches: {
+            imrWorldwide: true,
+        },
+        page: {
+            headline: 'Starship Enterprise',
+            author: 'Captain Kirk',
+            section: 'spaceexploration',
+            sectionName: 'Space Exploration',
+            keywords: 'Space,Travel',
+            webPublicationDate: 1498113262000,
+            isFront: false,
+            isPaidContent: true,
+            pageId: 100,
+        },
+    };
+
+    return Object.assign({}, defaultConfig, {
+        get: (path: string = '', defaultValue: any) =>
+            path
+                .replace(/\[(.+?)\]/g, '.$1')
+                .split('.')
+                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
+    });
+});
 
 const nSdkInstance = {
     ggInitialize: jest.fn(),

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -65,7 +65,7 @@ const embed = function(publickey, widgetName, geo, u, categories) {
 
 module.load = function() {
     fastdom.write(() => {
-        embed(config.page.plistaPublicApiKey, 'innerArticle', 'au');
+        embed(config.get('page.plistaPublicApiKey'), 'innerArticle', 'au');
     });
 };
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -10,7 +10,7 @@ const onLoad = () => {
 };
 
 export const remarketing: ThirdPartyTag = {
-    shouldRun: config.switches.remarketing,
+    shouldRun: config.get('switches.remarketing'),
     url: '//www.googleadservices.com/pagead/conversion_async.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
@@ -5,11 +5,26 @@ import { remarketing } from 'commercial/modules/third-party-tags/remarketing';
 const { shouldRun, url } = remarketing;
 const onLoad: any = remarketing.onLoad;
 
-jest.mock('lib/config', () => ({
-    switches: {
-        remarketing: true,
-    },
-}));
+/**
+ * we have to mock config like this because
+ * loading remarketing has side affects
+ * that are dependent on config.
+ * */
+jest.mock('lib/config', () => {
+    const defaultConfig = {
+        switches: {
+            remarketing: true,
+        },
+    };
+
+    return Object.assign({}, defaultConfig, {
+        get: (path: string = '', defaultValue: any) =>
+            path
+                .replace(/\[(.+?)\]/g, '.$1')
+                .split('.')
+                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
+    });
+});
 
 describe('Remarketing', () => {
     it('should exist', () => {

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -113,8 +113,9 @@ const trackPerformance = (
     timingLabel: string
 ): void => {
     if (window.performance && window.performance.now && window.ga) {
+        const timingEvents = config.get('googleAnalytics.timingEvents', []);
         const sendDeferredEventQueue = (): void => {
-            config.googleAnalytics.timingEvents.map(sendPerformanceEvent);
+            timingEvents.map(sendPerformanceEvent);
             mediator.off('modules:ga:ready', sendDeferredEventQueue);
         };
         const timeSincePageLoad = Math.round(window.performance.now());
@@ -129,7 +130,7 @@ const trackPerformance = (
             sendPerformanceEvent(event);
         } else {
             mediator.on('modules:ga:ready', sendDeferredEventQueue);
-            config.get('googleAnalytics.timingEvents').push(event);
+            timingEvents.push(event);
         }
     }
 };

--- a/static/src/javascripts/projects/common/modules/audio/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/audio/onward-container.js
@@ -18,7 +18,7 @@ const createComponent = (
 };
 
 const onwardAudio = (el: HTMLElement) => {
-    if (config.page.seriesId) {
+    if (config.get('page.seriesId')) {
         const manipulationType = 'append';
         const endpoint = `/audio/series/${config.get('page.seriesId')}.json`;
 

--- a/static/src/javascripts/projects/common/modules/audio/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/audio/onward-container.js
@@ -11,7 +11,7 @@ const createComponent = (
     const component = new Component();
 
     component.manipulationType = manipulationType;
-    component.endpoint = `${endpoint}?shortUrl=${config.page.shortUrl}`;
+    component.endpoint = `${endpoint}?shortUrl=${config.get('page.shortUrl')}`;
     el.innerHTML = '';
 
     return component.fetch(el, 'html');
@@ -20,7 +20,7 @@ const createComponent = (
 const onwardAudio = (el: HTMLElement) => {
     if (config.page.seriesId) {
         const manipulationType = 'append';
-        const endpoint = `/audio/series/${config.page.seriesId}.json`;
+        const endpoint = `/audio/series/${config.get('page.seriesId')}.json`;
 
         createComponent(el, endpoint, manipulationType);
     }

--- a/static/src/javascripts/projects/common/modules/avatar/api.js
+++ b/static/src/javascripts/projects/common/modules/avatar/api.js
@@ -2,8 +2,8 @@
 import { ajax } from 'lib/ajax';
 import config from 'lib/config';
 
-const apiUrl = `${config.page.avatarApiUrl}/v1`;
-const staticUrl = `${config.page.avatarImagesUrl}/user`;
+const apiUrl = `${config.get('page.avatarApiUrl')}/v1`;
+const staticUrl = `${config.get('page.avatarImagesUrl')}/user`;
 
 type HttpVerb = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/static/src/javascripts/projects/common/modules/business/stocks.js
+++ b/static/src/javascripts/projects/common/modules/business/stocks.js
@@ -10,7 +10,7 @@ import stocksTemplate from 'raw-loader!common/views/business/stocks.html';
 
 const isBusinessFront = () =>
     ['uk/business', 'us/business', 'au/business'].indexOf(
-        config.page.pageId
+        config.get('page.pageId')
     ) !== -1;
 
 const getStocksData = () =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -50,8 +50,10 @@ const abParam = (): Array<string> => {
         }
     );
 
-    if (config.tests) {
-        Object.entries(config.tests).forEach(([testName, testValue]) => {
+    const tests = config.get('tests');
+
+    if (tests) {
+        Object.entries(tests).forEach(([testName, testValue]) => {
             pushAbParams(testName, testValue);
         });
     }

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -69,7 +69,7 @@ class CommercialFeatures {
 
         this.stickyTopBannerAd =
             !this.adFree &&
-            !config.page.disableStickyTopBanner &&
+            !config.get('page.disableStickyTopBanner') &&
             !supportsSticky;
 
         this.articleBodyAdverts =

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -92,7 +92,7 @@ export const getKruxSegments = (): Array<string> => {
 };
 
 export const krux: ThirdPartyTag = {
-    shouldRun: config.get('switches.krux'),
+    shouldRun: !!config.get('switches.krux'),
     url: '//cdn.krxd.net/controltag?confid=JVZiE3vn',
     onLoad,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -92,7 +92,7 @@ export const getKruxSegments = (): Array<string> => {
 };
 
 export const krux: ThirdPartyTag = {
-    shouldRun: config.switches.krux,
+    shouldRun: config.get('switches.krux'),
     url: '//cdn.krxd.net/controltag?confid=JVZiE3vn',
     onLoad,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -92,7 +92,7 @@ export const getKruxSegments = (): Array<string> => {
 };
 
 export const krux: ThirdPartyTag = {
-    shouldRun: !!config.get('switches.krux'),
+    shouldRun: config.get('switches.krux', false),
     url: '//cdn.krxd.net/controltag?confid=JVZiE3vn',
     onLoad,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/krux.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.spec.js
@@ -5,9 +5,27 @@ const { url, shouldRun } = krux;
 
 jest.mock('lib/raven');
 jest.mock('ophan/ng', () => null);
-jest.mock('lib/config', () => ({
-    switches: { krux: false },
-}));
+
+/**
+ * we have to mock config like this because
+ * loading krux has side affects
+ * that are dependent on config.
+ * */
+jest.mock('lib/config', () => {
+    const defaultConfig = {
+        switches: {
+            krux: false,
+        },
+    };
+
+    return Object.assign({}, defaultConfig, {
+        get: (path: string = '', defaultValue: any) =>
+            path
+                .replace(/\[(.+?)\]/g, '.$1')
+                .split('.')
+                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
+    });
+});
 
 describe('Krux', () => {
     it('should not load if switch is off', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
@@ -54,7 +54,7 @@ export const isBlocked = (
 ): boolean => {
     // the enabled block configurations that apply to the provided geolocation
     const activeBlockConfigs: Array<BlockConfig> = switches
-        .filter(switchName => !!config.switches[switchName])
+        .filter(switchName => !!config.get(`switches.${switchName}`))
         .map(switchName => switchBlockConfig[switchName])
         .filter(conf => conf.geolocation === geolocation);
 

--- a/static/src/javascripts/projects/common/modules/commercial/targeting-tool.js
+++ b/static/src/javascripts/projects/common/modules/commercial/targeting-tool.js
@@ -5,11 +5,13 @@ const clean = (str: string): string => str.trim().toLowerCase();
 
 export const campaignsFor = (id: string): Array<Object> => {
     try {
-        return config.page.campaigns.filter(
-            campaign =>
-                campaign.fields &&
-                clean(campaign.fields.campaignId) === clean(id)
-        );
+        return config
+            .get('page.campaigns', [])
+            .filter(
+                campaign =>
+                    campaign.fields &&
+                    clean(campaign.fields.campaignId) === clean(id)
+            );
     } catch (e) {
         return [];
     }

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -95,7 +95,7 @@ const deleteOldData = (): void => {
 };
 
 const requestNewData = (): Promise<void> =>
-    fetchJson(`${config.page.userAttributesApiUrl}/me`, {
+    fetchJson(`${config.get('page.userAttributesApiUrl')}/me`, {
         mode: 'cors',
         credentials: 'include',
     })

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -635,16 +635,16 @@ class Loader extends Component {
 
     renderCommentCount(): void {
         loadDiscussionFrontend(this, {
-            apiHost: config.page.discussionApiUrl,
-            avatarImagesHost: config.page.avatarImagesUrl,
+            apiHost: config.get('page.discussionApiUrl'),
+            avatarImagesHost: config.get('page.avatarImagesUrl'),
             closed: this.getDiscussionClosed(),
             discussionId: this.getDiscussionId(),
             element: document.getElementsByClassName(
                 'js-discussion-external-frontend'
             )[0],
             userFromCookie: !!getUserFromCookie(),
-            profileUrl: config.page.idUrl,
-            profileClientId: config.switches.registerWithPhone
+            profileUrl: config.get('page.idUrl'),
+            profileClientId: config.get('switches.registerWithPhone')
                 ? 'comments'
                 : '',
             Promise,

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.js
@@ -71,11 +71,14 @@ const handle = (
     container: ?Element,
     user: ?DiscussionProfile
 ): Promise<void> => {
-    if (!config.switches.discussionAllowAnonymousRecommendsSwitch && !user) {
+    const discussionAllowAnonymousRecommendsSwitch = config.get(
+        'switches.discussionAllowAnonymousRecommendsSwitch'
+    );
+    if (!discussionAllowAnonymousRecommendsSwitch && !user) {
         target.setAttribute('data-link-name', 'Recommend comment anonymous');
         return showSignInTooltip(target);
     } else if (
-        (config.switches.discussionAllowAnonymousRecommendsSwitch || user) &&
+        (discussionAllowAnonymousRecommendsSwitch || user) &&
         isOpenForRecommendations(container)
     ) {
         const id = target.getAttribute('data-comment-id');

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
@@ -1,18 +1,18 @@
 // @flow
 import { handle, closeTooltip } from 'common/modules/discussion/upvote';
 import { recommendComment as recommendComment_ } from 'common/modules/discussion/api';
-import fakeConfig from 'lib/config';
+import config from 'lib/config';
 
 jest.mock('lib/raven');
 jest.mock('common/modules/discussion/api', () => ({
     recommendComment: jest.fn(),
 }));
 
-jest.mock('lib/config', () => ({
-    switches: {
-        discussionAllowAnonymousRecommendsSwitch: false,
-    },
-}));
+// jest.mock('lib/config', () => ({
+//     switches: {
+//         discussionAllowAnonymousRecommendsSwitch: false,
+//     },
+// }));
 
 const recommendComment: any = recommendComment_;
 
@@ -59,6 +59,8 @@ describe('Recommendations of comments', () => {
         }
 
         recommendComment.mockReset();
+
+        config.set('switches.discussionAllowAnonymousRecommendsSwitch', false);
     });
 
     it('should send a request to discussion API if the user is logged in', () => {
@@ -69,7 +71,8 @@ describe('Recommendations of comments', () => {
         }
 
         recommendComment.mockImplementationOnce(() => Promise.resolve());
-        fakeConfig.switches.discussionAllowAnonymousRecommendsSwitch = false;
+
+        config.set('switches.discussionAllowAnonymousRecommendsSwitch', false);
 
         return handle(
             target,
@@ -94,7 +97,8 @@ describe('Recommendations of comments', () => {
         }
 
         recommendComment.mockImplementationOnce(() => Promise.resolve());
-        fakeConfig.switches.discussionAllowAnonymousRecommendsSwitch = true;
+
+        config.set('switches.discussionAllowAnonymousRecommendsSwitch', true);
 
         return handle(
             target,
@@ -121,7 +125,8 @@ describe('Recommendations of comments', () => {
         recommendComment.mockImplementationOnce(() =>
             Promise.reject(new Error('discussion api error'))
         );
-        fakeConfig.switches.discussionAllowAnonymousRecommendsSwitch = false;
+
+        config.set('switches.discussionAllowAnonymousRecommendsSwitch', false);
 
         return handle(
             target,
@@ -150,7 +155,8 @@ describe('Recommendations of comments', () => {
         recommendComment.mockImplementationOnce(() =>
             Promise.reject(new Error('discussion api error'))
         );
-        fakeConfig.switches.discussionAllowAnonymousRecommendsSwitch = false;
+
+        config.set('switches.discussionAllowAnonymousRecommendsSwitch', false);
 
         return handle(
             target,

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.spec.js
@@ -8,12 +8,6 @@ jest.mock('common/modules/discussion/api', () => ({
     recommendComment: jest.fn(),
 }));
 
-// jest.mock('lib/config', () => ({
-//     switches: {
-//         discussionAllowAnonymousRecommendsSwitch: false,
-//     },
-// }));
-
 const recommendComment: any = recommendComment_;
 
 const fakeUser = {

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -63,7 +63,9 @@ const addToShareCount = (val: number): void => {
 };
 
 const fetch = (): void => {
-    const url = `${config.page.ajaxUrl}/sharecount/${config.page.pageId}.json`;
+    const url = `${config.get('page.ajaxUrl')}/sharecount/${config.get(
+        'page.pageId'
+    )}.json`;
 
     fetchJSON(url, {
         mode: 'cors',
@@ -80,9 +82,9 @@ const loadShareCounts = (): void => {
        when they then crawl them they get 404s which affects later sharing.
       don't call counts in preview */
     if (
-        config.switches.serverShareCounts &&
+        config.get('switches.serverShareCounts') &&
         $shareCountEls.length &&
-        !config.page.isPreview
+        !config.get('page.isPreview')
     ) {
         try {
             fetch();

--- a/static/src/javascripts/projects/common/modules/sport/football/tag-page-stats.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/tag-page-stats.js
@@ -10,9 +10,12 @@ export const tagPageStats = (): void => {
     );
 
     if (firstContainer) {
-        fetchJSON(`/${config.page.pageId}/fixtures-and-results-container`, {
-            mode: 'cors',
-        })
+        fetchJSON(
+            `/${config.get('page.pageId')}/fixtures-and-results-container`,
+            {
+                mode: 'cors',
+            }
+        )
             .then(container => {
                 if (container.html) {
                     firstContainer.insertAdjacentHTML(

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -104,11 +104,11 @@ const updateSelection = (): void => {
         }
 
         const twitterText = encodeURIComponent(twitterMessage);
-        const twitterShortUrl = `${config.page.shortUrl}/stw`;
+        const twitterShortUrl = `${config.get('page.shortUrl')}/stw`;
         const twitterUrl = encodeURI(twitterShortUrl);
         const twitterHref = `https://twitter.com/intent/tweet?text=%E2%80%9C${twitterText}%E2%80%9D&url=${twitterUrl}`;
 
-        const emailSubject = encodeURI(config.page.webTitle);
+        const emailSubject = encodeURI(config.get('page.webTitle'));
         const emailSelection = encodeURI(range.toString());
         const emailShortUrl = `${config.get('page.shortUrl')}/sbl`;
         const emailUrl = encodeURI(emailShortUrl);

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -143,7 +143,7 @@ const bindGoogleAnalyticsEvents = (player: Object, canonicalUrl: string) => {
 const getMediaType = player => (isEmbed ? 'video' : player.guMediaType);
 
 const shouldAutoPlay = player =>
-    isDesktop && !isRevisit(config.page.pageId) && player.guAutoplay;
+    isDesktop && !isRevisit(config.get('page.pageId')) && player.guAutoplay;
 
 const constructEventName = (eventName: string, player: Object): string =>
     `${getMediaType(player)}:${eventName}`;
@@ -274,8 +274,8 @@ const kruxTracking = (player: Object, event: string) => {
     // /music/video/2015/aug/31/vmas-2015-highlights-video
 
     if (
-        config.switches.kruxVideoTracking &&
-        config.switches.krux &&
+        config.get('switches.kruxVideoTracking') &&
+        config.get('switches.krux') &&
         $(player.el()).attr('data-media-id') &&
         desiredVideos.indexOf($(player.el()).attr('data-media-id')) !== -1
     ) {

--- a/static/src/javascripts/projects/common/modules/video/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/video/onward-container.js
@@ -5,13 +5,15 @@ import config from 'lib/config';
 import { Component } from 'common/modules/component';
 
 const getEndpoint = (mediaType: string): string => {
-    const isInSeries = Boolean(config.page.seriesTags);
+    const isInSeries = Boolean(config.get('page.seriesTags'));
 
     if (isInSeries) {
-        return `/video/in-series/${config.page.seriesId}.json`;
+        return `/video/in-series/${config.get('page.seriesId')}.json`;
     }
 
-    return `/${config.page.isPodcast ? 'podcast' : mediaType}/most-viewed.json`;
+    return `/${
+        config.get('page.isPodcast') ? 'podcast' : mediaType
+    }/most-viewed.json`;
 };
 
 const createComponent = (

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -144,7 +144,7 @@ class Button {
             this.setState(DISPLAY_STATE.loading);
         });
 
-        loadShowMore(config.page.pageId, this.id)
+        loadShowMore(config.get('page.pageId'), this.id)
             .then(response => {
                 let dedupedShowMore;
                 const html = response.html.trim();


### PR DESCRIPTION
## What does this change?

🔔 Ding! 🔔 Ding! : 🥊 

Here we have the 2nd (follow up) round of `config.get` updates. This follows the [first](https://github.com/guardian/frontend/pull/21225) which didn't pick up all these instances where we directly access `config`.

Again, this updates all points where we directly access `config` properties to use our `config.get` function. EG. `config.page.assetsPath` becomes `config.get('page.assetsPath')`. Additional changes include:

- Updates all related `.spec.js` files to use `config.set` rather than directly setting the properties on the `config`.
- Updates the `no-direct-access-config` rule to allow use of other methods exposed by `config.js` that are allowed to be accessed directly.

## Screenshots

N/A

## What is the value of this and can you measure success?

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)
