### PR TITLE
Add rendering-platform identifier to Amp ad calls

### DIFF
--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -13,11 +13,17 @@ import play.api.libs.json._
 case class AmpAd(article: Article, uri: String, edition: String) {
 
   val toJson: JsValue = {
-    def setAmpPlatform(targeting: Map[String, AdTargetParamValue]) = targeting + ("p" -> SingleValue("amp"))
+
+    // to distinguish from web and from dotcom-rendering
+    def setFrontendAmpPlatform(targeting: Map[String, AdTargetParamValue]) =
+      targeting ++ Map(
+        "rp" -> SingleValue("dotcom-platform"),
+        "p" -> SingleValue("amp")
+      )
 
     val editionToTarget = Edition.byId(edition) getOrElse Edition.defaultEdition
     val targeting       = article.metadata.commercial.map(_.adTargeting(editionToTarget)).getOrElse(Set.empty)
-    val csvTargeting = Json.toJson(setAmpPlatform(toMap(targeting)) mapValues {
+    val csvTargeting = Json.toJson(setFrontendAmpPlatform(toMap(targeting)) mapValues {
       case SingleValue(v)     => v
       case MultipleValues(vs) => vs.mkString(",")
     })

--- a/common/test/views/support/AmpAdTest.scala
+++ b/common/test/views/support/AmpAdTest.scala
@@ -96,6 +96,17 @@ class AmpAdTest extends FlatSpec with Matchers {
     targetingBlogs should be("blog")
   }
 
+  it should "return a JSON object containing a rendering platform value" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val blogTag = tag("blog", "Blog", TagType.Blog)
+    val result = AmpAd(article(sectionId, blogTag), uri, edition).toJson
+    val renderingPlatform = (result \ "targeting" \ "rp").as[JsString].value
+
+    renderingPlatform should be("dotcom-platform")
+  }
+
   private def article(sectionId: String, tags: ApiTag*) = {
     val contentApiItem = contentApi(sectionId, tags.toList)
     val content = Content.make(contentApiItem)


### PR DESCRIPTION
This follows on from https://github.com/guardian/dotcom-rendering/pull/443 so that we can tell if there is any change in ad impressions between the two platforms.
