### PR TITLE
Outbrain testing switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -76,4 +76,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-commercial-outbrain-testing",
+    "Test the outbrain widget",
+    owners = Seq(Owner.withGithub("frankie297")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 3, 25),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Test the outbrain widget",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 25),
+    sellByDate = new LocalDate(2019, 3, 29),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -18,13 +18,8 @@ type OutbrainDfpConditions = {
     useMerchandiseAdSlot: boolean,
 };
 
-const isInOutbrainTestingVariant = (): boolean => {
+const isInOutbrainTestingVariant = (): boolean =>
     isInVariantSynchronous(commercialOutbrainTesting, 'variant');
-};
-
-const shouldTestOutbrainWidget = (isInOutbrainTestingVariant());
-
-
 
 const noMerchSlotsExpected = (): Promise<boolean> =>
     // Loading Outbrain is dependent on successful return of high relevance component
@@ -98,9 +93,12 @@ export const getOutbrainComplianceTargeting = (): Promise<
   true              false               false             n/a              false         false      true      non-compliant
   true              false               false             n/a              false         false      false     compliant
 */
+
+export const shouldTestOutbrainWidget = isInOutbrainTestingVariant();
+
 export const initOutbrain = (): Promise<void> =>
     getOutbrainPageConditions().then(pageConditions => {
-        if (!pageConditions.outbrainEnabled) {
+        if (!pageConditions.outbrainEnabled && !shouldTestOutbrainWidget) {
             return;
         }
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -1,4 +1,6 @@
 // @flow
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
 import { adblockInUse } from 'lib/detect';
 import { waitForCheck } from 'common/modules/check-mediator';
 import { load } from './outbrain-load';
@@ -15,6 +17,14 @@ type OutbrainDfpConditions = {
     blockedByAds: boolean,
     useMerchandiseAdSlot: boolean,
 };
+
+const isInOutbrainTestingVariant = (): boolean => {
+    isInVariantSynchronous(commercialOutbrainTesting, 'variant');
+};
+
+const shouldTestOutbrainWidget = (isInOutbrainTestingVariant());
+
+
 
 const noMerchSlotsExpected = (): Promise<boolean> =>
     // Loading Outbrain is dependent on successful return of high relevance component

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
 import { adblockInUse } from 'lib/detect';
@@ -17,9 +17,6 @@ type OutbrainDfpConditions = {
     blockedByAds: boolean,
     useMerchandiseAdSlot: boolean,
 };
-
-const isInOutbrainTestingVariant = (): boolean =>
-    isInVariantSynchronous(commercialOutbrainTesting, 'variant');
 
 const noMerchSlotsExpected = (): Promise<boolean> =>
     // Loading Outbrain is dependent on successful return of high relevance component
@@ -94,11 +91,15 @@ export const getOutbrainComplianceTargeting = (): Promise<
   true              false               false             n/a              false         false      false     compliant
 */
 
-export const shouldTestOutbrainWidget = isInOutbrainTestingVariant();
-
 export const initOutbrain = (): Promise<void> =>
     getOutbrainPageConditions().then(pageConditions => {
-        if (!pageConditions.outbrainEnabled && !shouldTestOutbrainWidget) {
+        // temporary addition based on a zero participation AB test
+        // Remove after 19-03-25 as testing will be complete.
+        if (isInVariantSynchronous(commercialOutbrainTesting, 'variant')) {
+            return load('defaults');
+        }
+
+        if (!pageConditions.outbrainEnabled) {
             return;
         }
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -95,11 +95,12 @@ export const initOutbrain = (): Promise<void> =>
     getOutbrainPageConditions().then(pageConditions => {
         // temporary addition based on a zero participation AB test
         // Remove after 19-03-25 as testing will be complete.
-        if (isInVariantSynchronous(commercialOutbrainTesting, 'variant')) {
-            return load('defaults');
-        }
+        const shouldTestOutbrainWidget: boolean = isInVariantSynchronous(
+            commercialOutbrainTesting,
+            'variant'
+        );
 
-        if (!pageConditions.outbrainEnabled) {
+        if (!pageConditions.outbrainEnabled && !shouldTestOutbrainWidget) {
             return;
         }
 
@@ -118,7 +119,7 @@ export const initOutbrain = (): Promise<void> =>
         } else {
             // only wait for dfp conditions if we really have to.
             return getOutbrainDfpConditions().then(dfpConditions => {
-                if (dfpConditions.blockedByAds) {
+                if (dfpConditions.blockedByAds && !shouldTestOutbrainWidget) {
                     return;
                 }
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { initCheckMediator, resolveCheck } from 'common/modules/check-mediator';
 import { adblockInUse as adblockInUse_ } from 'lib/detect';
 import { load } from './outbrain-load';
-import { initOutbrain } from './outbrain';
+import { initOutbrain, shouldTestOutbrainWidget } from './outbrain';
 import { getSection } from './outbrain-sections';
 
 const adblockInUse: any = adblockInUse_;
@@ -169,6 +169,10 @@ describe('Outbrain', () => {
             });
         });
     });
+
+    // it('should show outbrain widget if in test variant', () => {
+    //     expect(shouldTestOutbrainWidget).toBe('true');
+    // });
 
     describe('Sections', () => {
         it('should return "news" for news sections', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { initCheckMediator, resolveCheck } from 'common/modules/check-mediator';
 import { adblockInUse as adblockInUse_ } from 'lib/detect';
 import { load } from './outbrain-load';
-import { initOutbrain, shouldTestOutbrainWidget } from './outbrain';
+import { initOutbrain } from './outbrain';
 import { getSection } from './outbrain-sections';
 
 const adblockInUse: any = adblockInUse_;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -44,13 +44,12 @@ describe('Outbrain', () => {
                 <div class="js-outbrain"><div class="js-outbrain-container"></div></div>
                 `;
         }
-        jest.resetAllMocks();
         // init checkMediator so we can resolve checks in tests
         initCheckMediator();
 
-        config.switches.abCommercialOutbrainTesting = true;
         config.switches.outbrain = true;
         config.switches.emailInArticleOutbrain = false;
+        config.switches.abCommercialOutbrainTesting = true;
         config.page = {
             section: 'uk-news',
             commentable: true,
@@ -84,10 +83,12 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', true);
             resolveCheck('isStoryQuestionsOnPage', true);
 
+            resolveCheck('isOutbrainBlockedByAds', false);
+            resolveCheck('isOutbrainMerchandiseCompliant', false);
+
             isInVariantSynchronous.mockImplementationOnce(
                 (testId, variantId) => variantId === 'variant'
             );
-
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalled();
             });
@@ -99,6 +100,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', true);
             resolveCheck('isStoryQuestionsOnPage', true);
 
+            config.switches.abCommercialOutbrainTesting = true;
             isInVariantSynchronous.mockImplementationOnce(
                 (testId, variantId) => variantId === 'control'
             );
@@ -209,10 +211,6 @@ describe('Outbrain', () => {
             });
         });
     });
-
-    // it('should show outbrain widget if in test variant', () => {
-    //     expect(shouldTestOutbrainWidget).toBe('true');
-    // });
 
     describe('Sections', () => {
         it('should return "news" for news sections', () => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,6 +2,7 @@
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
+import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
@@ -14,6 +15,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialAdVerification,
     commercialCmpCustomise,
+    commercialOutbrainTesting,
     adblockTest,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
@@ -1,0 +1,22 @@
+// @flow
+
+export const commercialOutbrainTesting: ABTest = {
+    id: 'CommercialOutbrainTesting',
+    start: '2019-03-12',
+    expiry: '2019-03-25',
+    author: 'Frankie Hammond',
+    description: '0% participation AB test for testing Outbrain',
+    audience: 0,
+    audienceOffset: 0,
+    successMeasure: 'Outbrain widget testing',
+    audienceCriteria: 'internal',
+    dataLinkNames: '',
+    idealOutcome: 'Outbrain can be tested for different widget designs',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
@@ -3,7 +3,7 @@
 export const commercialOutbrainTesting: ABTest = {
     id: 'CommercialOutbrainTesting',
     start: '2019-03-12',
-    expiry: '2019-03-25',
+    expiry: '2019-03-29',
     author: 'Frankie Hammond',
     description: '0% participation AB test for testing Outbrain',
     audience: 0,


### PR DESCRIPTION
## What does this change?

Adds a zero percent participation test that can be opted into.
Being in the `variant` of this test will cause Outbrain to load on every possible page.

## Screenshots

#### NOT IN TEST:

<img width="1178" alt="Screenshot 2019-03-14 at 19 43 56" src="https://user-images.githubusercontent.com/8607683/54387569-a55d4200-4693-11e9-905f-6fb62bc733fa.png">


#### VARIANT:

<img width="1300" alt="Screenshot 2019-03-14 at 19 41 01" src="https://user-images.githubusercontent.com/8607683/54386727-8a89ce00-4691-11e9-8901-8997b261b70e.png">

## What is the value of this and can you measure success?

Outbrain on every possible page! 👍 🚀 👩‍🎤 

Commercial BAU 🤘 https://trello.com/c/xfKtAev9

#### 👉 Opt-in by following this link, or adding this to the end of a URL: 
[#ab-CommercialOutbrainTesting=variant](https://www.theguardian.com/uk#ab-CommercialOutbrainTesting=variant)

#### 👉 Opt-out by following this link, or adding this to the end of a URL: 
[#ab-CommercialOutbrainTesting=notintest](https://www.theguardian.com/uk#ab-CommercialOutbrainTesting=notintest)

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [x] On CODE (optional)
