### PR TITLE
Clean up after Teads outstream implementation

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -91,13 +91,13 @@ describe('createCommentSlots', () => {
         const commentMpu: HTMLElement = createCommentSlots(false)[0];
         const commentDmpu: HTMLElement = createCommentSlots(true)[0];
         expect(commentMpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid'
+            '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
         );
         expect(commentMpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
         );
         expect(commentDmpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
+            '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
         );
         expect(commentDmpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
@@ -252,7 +252,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -270,7 +270,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -288,7 +288,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid'
+                    '1,1|2,2|300,250|620,1|620,350|300,274|fluid'
                 );
                 done();
             });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -16,8 +16,7 @@ const inlineDefinition = {
             adSizes.empty,
             adSizes.mpu,
             adSizes.video,
-            adSizes.outstreamDesktop, // todo will remove this once Ad Manager updated
-            adSizes.outstreamMobile,
+            adSizes.outstreamDesktop,
             adSizes.googleCard,
             adSizes.fluid,
         ],

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -21,7 +21,7 @@ const inline1Html = `
     data-name="inline1"
     aria-hidden="true"
     data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|620,350|300,197|300,274|fluid">
+    data-desktop="1,1|2,2|300,250|620,1|620,350|300,274|fluid">
 </div>
 `;
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -113,7 +113,7 @@ sizeCallbacks[adSizes.video] = (_, advert) =>
 
 sizeCallbacks[adSizes.outstreamDesktop] = (_, advert) =>
     fastdom.write(() => {
-        advert.updateExtraSlotClasses('ad-slot--outstream-old');
+        advert.updateExtraSlotClasses('ad-slot--outstream');
     });
 
 sizeCallbacks[adSizes.outstreamMobile] = (_, advert) =>

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -56,10 +56,7 @@ const resize = (
 const removeAnyOutstreamClass = (adSlot: ?HTMLElement) => {
     fastdom.write(() => {
         if (adSlot) {
-            adSlot.classList.remove(
-                'ad-slot--outstream-old',
-                'ad-slot--outstream'
-            );
+            adSlot.classList.remove('ad-slot--outstream');
         }
     });
 };

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -317,31 +317,6 @@
     }
 
     @include mq(desktop) {
-        width: auto;
-        height: auto;
-        margin-right: 6%;
-
-        & > div.ad-slot__content {
-            min-height: 250px;
-        }
-    }
-}
-
-// todo: remove when 620x350 size removed
-.ad-slot--outstream-old {
-
-    background: transparent;
-
-    @include mq(mobile) {
-        width: 300px;
-        height: auto;
-
-        & > div.ad-slot__content > iframe {
-            min-height: 250px;
-        }
-    }
-
-    @include mq(desktop) {
         width: 620px;
         height: $mpu-ad-label-height + 350px;
 


### PR DESCRIPTION
This should just be a refactor and have no effect on the site.
It removes an extra size that was added to desktop ad slots, which has now become redundant.
It also merges two CSS classes - one of which has become redundant.
