### PR TITLE
 Side effect free, but working version of dotcom-rendering-commercial.js

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -6,7 +6,7 @@ import com.gu.contentapi.client.model.v1.{BlockElement => ClientBlockElement, Bl
 import common.Edition
 import common.Maps.RichMap
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
-import conf.Configuration
+import conf.{Configuration, Static}
 import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import controllers.ArticlePage
@@ -115,7 +115,8 @@ case class DCSite(
   beaconUrl: String,
   subscribeWithGoogleApiUrl: String,
   nav: NavMenu,
-  readerRevenueLinks: ReaderRevenueLinks
+  readerRevenueLinks: ReaderRevenueLinks,
+  commercialUrl: String
 )
 
 case class DCPage(
@@ -367,7 +368,8 @@ object DotcomponentsDataModel {
       Configuration.debug.beaconUrl,
       Configuration.google.subscribeWithGoogleApiUrl,
       navMenu,
-      readerRevenueLinks
+      readerRevenueLinks,
+      Static("javascripts/graun.dotcom-rendering-commercial.js")
     )
 
     val tags = Tags(

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -1,0 +1,185 @@
+// @flow
+import config from 'lib/config';
+import { catchErrorsWithContext } from 'lib/robust';
+import { markTime } from 'lib/user-timing';
+import reportError from 'lib/report-error';
+// import { init as initHighMerch } from 'commercial/modules/high-merch';
+// import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
+// import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
+// import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
+// import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
+import { init as initCmpService } from 'commercial/modules/cmp/cmp';
+// import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
+// import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
+// import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
+import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+// import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
+// import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
+// import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
+import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
+// import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
+// import { paidContainers } from 'commercial/modules/paid-containers';
+import {
+    defer,
+    wrap,
+    addStartTimeBaseline,
+    addEndTimeBaseline,
+    primaryBaseline,
+} from 'commercial/modules/dfp/performance-logging';
+import { trackPerformance } from 'common/modules/analytics/google';
+// import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+// import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
+// import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+
+const commercialModules: Array<Array<any>> = [
+    // ['cm-adFreeSlotRemove', adFreeSlotRemove],
+    // ['cm-closeDisabledSlots', closeDisabledSlots],
+    ['cm-prepare-cmp', initCmpService],
+    ['cm-track-cmp-consent', trackCmpConsent],
+    ['cm-thirdPartyTags', initThirdPartyTags],
+    // ['cm-prepare-prebid', preparePrebid, true],
+    ['cm-prepare-googletag', prepareGoogletag, true],
+    // ['cm-checkDispatcher', initCheckDispatcher],
+    // ['cm-lotame-cmp', initLotameCmp],
+    // ['cm-lotame-data-extract', initLotameDataExtract, true],
+];
+
+// if (!commercialFeatures.adFree) {
+//     commercialModules.push(
+//         ['cm-prepare-adverification', prepareAdVerification, true],
+//         ['cm-highMerch', initHighMerch],
+//         ['cm-articleAsideAdverts', initArticleAsideAdverts, true],
+//         ['cm-articleBodyAdverts', initArticleBodyAdverts, true],
+//         ['cm-liveblogAdverts', initLiveblogAdverts, true],
+//         ['cm-stickyTopBanner', initStickyTopBanner],
+//         ['cm-paidContainers', paidContainers],
+//         ['cm-paidforBand', initPaidForBand],
+//         ['cm-commentAdverts', initCommentAdverts]
+//     );
+// }
+
+const loadHostedBundle = (): Promise<void> => {
+    if (config.page.isHosted) {
+        return new Promise(resolve => {
+            require.ensure(
+                [],
+                require => {
+                    const hostedAbout = require('commercial/modules/hosted/about');
+                    const initHostedVideo = require('commercial/modules/hosted/video');
+                    const hostedGallery = require('commercial/modules/hosted/gallery');
+                    const initHostedCarousel = require('commercial/modules/hosted/onward-journey-carousel');
+                    const loadOnwardComponent = require('commercial/modules/hosted/onward');
+                    commercialModules.push(
+                        ['cm-hostedAbout', hostedAbout.init],
+                        [
+                            'cm-hostedVideo',
+                            initHostedVideo.initHostedVideo,
+                            true,
+                        ],
+                        ['cm-hostedGallery', hostedGallery.init],
+                        [
+                            'cm-hostedOnward',
+                            loadOnwardComponent.loadOnwardComponent,
+                            true,
+                        ],
+                        [
+                            'cm-hostedOJCarousel',
+                            initHostedCarousel.initHostedCarousel,
+                        ]
+                    );
+                    resolve();
+                },
+                'commercial-hosted'
+            );
+        });
+    }
+    return Promise.resolve();
+};
+
+const loadModules = (): Promise<void> => {
+    addStartTimeBaseline(primaryBaseline);
+
+    const modulePromises = [];
+
+    commercialModules.forEach(module => {
+        const moduleName: string = module[0];
+        const moduleInit: () => void = module[1];
+        const moduleDefer: boolean = module[2];
+
+        catchErrorsWithContext([
+            [
+                moduleName,
+                function pushAfterComplete(): void {
+                    // These modules all have async init procedures which don't block, and return a promise purely for
+                    // perf logging, to time when their async work is done. The command buffer guarantees execution order,
+                    // so we don't use the returned promise to order the bootstrap's module invocations.
+                    const wrapped = moduleDefer
+                        ? defer(moduleName, moduleInit)
+                        : wrap(moduleName, moduleInit);
+                    const result = wrapped();
+                    modulePromises.push(result);
+                },
+            ],
+        ]);
+    });
+    return Promise.all(modulePromises).then(
+        (): void => {
+            addEndTimeBaseline(primaryBaseline);
+        }
+    );
+};
+
+const bootCommercial = (): Promise<void> => {
+    markTime('commercial start');
+
+    catchErrorsWithContext([
+        [
+            'ga-user-timing-commercial-start',
+            function runTrackPerformance(): void {
+                trackPerformance(
+                    'Javascript Load',
+                    'commercialStart',
+                    'Commercial start parse time'
+                );
+            },
+        ],
+    ]);
+
+    // Stub the command queue
+    window.googletag = {
+        cmd: [],
+    };
+
+    return loadHostedBundle()
+        .then(loadModules)
+        .then(() => {
+            markTime('commercial end');
+            catchErrorsWithContext([
+                [
+                    'ga-user-timing-commercial-end',
+                    function runTrackPerformance(): void {
+                        trackPerformance(
+                            'Javascript Load',
+                            'commercialEnd',
+                            'Commercial end parse time'
+                        );
+                    },
+                ],
+            ]);
+        })
+        .catch(err => {
+            // Just in case something goes wrong, we don't want it to
+            // prevent enhanced from loading
+            reportError(err, {
+                feature: 'commercial',
+            });
+        });
+};
+
+// make sure we've patched the env before running the app
+if (window.guardian.polyfilled) {
+    bootCommercial();
+} else {
+    window.guardian.onPolyfilled = bootCommercial;
+}

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -1,25 +1,15 @@
 // @flow
+/*
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
-// import { init as initHighMerch } from 'commercial/modules/high-merch';
-// import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
-// import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
-// import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
-// import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
-import { init as initCmpService } from 'commercial/modules/cmp/cmp';
-// import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
-// import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
-import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
-// import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
-import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
-// import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
-// import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
-// import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
-import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
-// import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
-// import { paidContainers } from 'commercial/modules/paid-containers';
+*/
+// import { init as initCmpService } from 'commercial/modules/cmp/cmp';
+// import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
+// import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+// import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
+/*
 import {
     defer,
     wrap,
@@ -28,37 +18,16 @@ import {
     primaryBaseline,
 } from 'commercial/modules/dfp/performance-logging';
 import { trackPerformance } from 'common/modules/analytics/google';
-// import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-// import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
-// import { initCommentAdverts } from 'commercial/modules/comment-adverts';
-
+*/
+/*
 const commercialModules: Array<Array<any>> = [
-    // ['cm-adFreeSlotRemove', adFreeSlotRemove],
-    // ['cm-closeDisabledSlots', closeDisabledSlots],
-    ['cm-prepare-cmp', initCmpService],
-    ['cm-track-cmp-consent', trackCmpConsent],
-    ['cm-thirdPartyTags', initThirdPartyTags],
-    // ['cm-prepare-prebid', preparePrebid, true],
-    ['cm-prepare-googletag', prepareGoogletag, true],
-    // ['cm-checkDispatcher', initCheckDispatcher],
-    // ['cm-lotame-cmp', initLotameCmp],
-    // ['cm-lotame-data-extract', initLotameDataExtract, true],
+    //['cm-prepare-cmp', initCmpService],
+    //['cm-track-cmp-consent', trackCmpConsent],
+    //['cm-thirdPartyTags', initThirdPartyTags],
+    //['cm-prepare-googletag', prepareGoogletag, true],
 ];
-
-// if (!commercialFeatures.adFree) {
-//     commercialModules.push(
-//         ['cm-prepare-adverification', prepareAdVerification, true],
-//         ['cm-highMerch', initHighMerch],
-//         ['cm-articleAsideAdverts', initArticleAsideAdverts, true],
-//         ['cm-articleBodyAdverts', initArticleBodyAdverts, true],
-//         ['cm-liveblogAdverts', initLiveblogAdverts, true],
-//         ['cm-stickyTopBanner', initStickyTopBanner],
-//         ['cm-paidContainers', paidContainers],
-//         ['cm-paidforBand', initPaidForBand],
-//         ['cm-commentAdverts', initCommentAdverts]
-//     );
-// }
-
+*/
+/*
 const loadHostedBundle = (): Promise<void> => {
     if (config.page.isHosted) {
         return new Promise(resolve => {
@@ -96,7 +65,6 @@ const loadHostedBundle = (): Promise<void> => {
     }
     return Promise.resolve();
 };
-
 const loadModules = (): Promise<void> => {
     addStartTimeBaseline(primaryBaseline);
 
@@ -129,8 +97,9 @@ const loadModules = (): Promise<void> => {
         }
     );
 };
-
-const bootCommercial = (): Promise<void> => {
+*/
+const bootCommercial = () => {
+    /*
     markTime('commercial start');
 
     catchErrorsWithContext([
@@ -175,11 +144,7 @@ const bootCommercial = (): Promise<void> => {
                 feature: 'commercial',
             });
         });
+    */
 };
 
-// make sure we've patched the env before running the app
-if (window.guardian.polyfilled) {
-    bootCommercial();
-} else {
-    window.guardian.onPolyfilled = bootCommercial;
-}
+bootCommercial();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,14 @@ module.exports = {
             'bootstraps',
             'youtube-embed.js'
         ),
+        'dotcom-rendering-commercial': path.join(
+            __dirname,
+            'static',
+            'src',
+            'javascripts',
+            'bootstraps',
+            'dotcom-rendering-commercial.js'
+        ),
     },
     output: {
         path: path.join(__dirname, 'static', 'target', 'javascripts'),
@@ -78,7 +86,13 @@ module.exports = {
             // TODO: atom-renderer's loaders are actually dependencies of frontend, not atom-renderer
             // They should be listed as peerDependencies in atom-renderer
             // https://github.com/guardian/atom-renderer/issues/41
-            path.resolve(__dirname, 'node_modules', '@guardian', 'atom-renderer', 'node_modules'),
+            path.resolve(
+                __dirname,
+                'node_modules',
+                '@guardian',
+                'atom-renderer',
+                'node_modules'
+            ),
             'node_modules',
         ],
     },
@@ -101,7 +115,14 @@ module.exports = {
             // module below exposes a loader that catches requests for
             // atoms's CSS and automatically swaps in values for these variables
             ...require('@guardian/atom-renderer/webpack/css')({
-                cssVarsPath: path.join(__dirname, 'static', 'src', 'stylesheets', 'atoms', 'vars.scss')
+                cssVarsPath: path.join(
+                    __dirname,
+                    'static',
+                    'src',
+                    'stylesheets',
+                    'atoms',
+                    'vars.scss'
+                ),
             }),
         ],
     },


### PR DESCRIPTION
## What does this change?

This change introduces a side effect free, but working version of the new dotcom-rendering-commercial.js bundle.

**Q**: Why do we need a new bundle in frontend ?
**A**: This is not going to be used by frontend, only generated by frontend. The client for this bundle is dotcom-rendering (for this aim a sister dotcom-rendering PR will be submitted soon).

**Q**: Ok, fine, but why did you leave it empty ? Why isn't it doing *something* ?
**A**: Well, for two reasons. First it was hard enough to get one running despite the fact that it doesn't do anything, so you're welcome. Second, we are interested in seeing the impact of an empty script on dotcom rendering, for instance the impact on time to first paint. 

**Q**: Ok, I get it. So this has no impact on frontend anyway, right ?
**A**: Nope!

**Q**: Oh, yes, last question. Why can't dotcom-rendering generate their own bundle ?
**A**: Well, you know... code reuse, man. That's pretty much it :) 
