### PR TITLE
Merge WebPage and NewArticle structured data

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -89,7 +89,7 @@ case class PageData(
     sentryHost: String,
     sentryPublicApiKey: String,
     switches: Map[String,Boolean],
-    linkedData: List[LinkedData],
+    linkedData: LinkedData,
     subscribeWithGoogleApiUrl: String,
 
     // AMP specific
@@ -246,7 +246,7 @@ object DotcomponentsDataModel {
 
     // See https://developers.google.com/search/docs/data-types/article (and the AMP info too)
     // For example, we need to provide an image of at least 1200px width to be valid here
-    val linkedData: List[LinkedData] = {
+    val linkedData: LinkedData = {
       val mainImageURL = {
         val main = for {
           elem <- article.trail.trailPicture
@@ -264,24 +264,19 @@ object DotcomponentsDataModel {
         )
       })
 
-      List(
-        NewsArticle(
-          `@id` = Configuration.amp.baseUrl + article.metadata.id,
-          images = Seq(
-            ImgSrc(mainImageURL, OneByOne),
-            ImgSrc(mainImageURL, FourByThree),
-            ImgSrc(mainImageURL, Item1200),
-          ),
-          author = authors,
-          datePublished = article.trail.webPublicationDate.toString(),
-          dateModified = article.fields.lastModified.toString(),
-          headline = article.trail.headline,
-          mainEntityOfPage = article.metadata.webUrl,
+      NewsArticle(
+        `@id` = article.metadata.webUrl,
+        images = Seq(
+          ImgSrc(mainImageURL, OneByOne),
+          ImgSrc(mainImageURL, FourByThree),
+          ImgSrc(mainImageURL, Item1200),
         ),
-        WebPage(
-          `@id` = article.metadata.webUrl,
-          potentialAction = PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/"))
-        )
+        author = authors,
+        datePublished = article.trail.webPublicationDate.toString(),
+        dateModified = article.fields.lastModified.toString(),
+        headline = article.trail.headline,
+        mainEntityOfPage = article.metadata.webUrl,
+        potentialAction = PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/"))
       )
     }
 

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -142,6 +142,7 @@ case class NewsArticle(
   headline: String,
   dateModified: String,
   mainEntityOfPage: String,
+  potentialAction: PotentialAction
 ) extends LinkedData
 
 object NewsArticle {
@@ -153,6 +154,7 @@ object NewsArticle {
     headline: String,
     dateModified: String,
     mainEntityOfPage: String,
+    potentialAction: PotentialAction
   ): NewsArticle = NewsArticle(
     `@id` = `@id`,
     image = images,
@@ -161,6 +163,7 @@ object NewsArticle {
     datePublished = datePublished,
     dateModified = dateModified,
     mainEntityOfPage = mainEntityOfPage,
+    potentialAction = potentialAction
   )
 
   implicit val formats: OFormat[NewsArticle] = Json.format[NewsArticle]


### PR DESCRIPTION
## What does this change?
* Changes linked data from a list of `WebPage` and `NewsArticle`, to a single `NewsArticle`.
* Move `potentialAction` field from `Webpage` to `NewsArticle`.

## Screenshots
n/a

## What is the value of this and can you measure success?
* Having a `NewsArticle` and a `WebPage` arguably isn't necessary. I believe `DotcomponentsDataModel` currently only serves articles, so `NewsArticle` should be fine.
* As long as `NewsArticle.potentialAction` works the same as `WebPage.potentialAction`, i'm not sure about the exact purpose of `potentialAction`?
* Having structured data set as an array breaks our Subscribe with Google Amp extension (the real reason behind this PR 😜 ).

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
