### PR TITLE
More consistent URL for the commercial bundle for dotcom-rendering

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -245,6 +245,15 @@ object DotcomponentsDataModel {
       }
     }
 
+    def buildFullCommercialUrl(bundlePath: String): String = {
+      // This function exists because for some reasons `Static` behaves differently in { PROD and CODE } versus LOCAL
+      if(Configuration.environment.isProd || Configuration.environment.isCode){
+        Static(bundlePath)
+      } else {
+        s"${Configuration.site.host}${Static(bundlePath)}"
+      }
+    }
+
     val bodyBlocks: List[Block] = {
       val bodyBlocks = blocks.body.getOrElse(Nil)
       bodyBlocks.map(block => Block(block.bodyHtml, blocksToPageElements(block.elements, shouldAddAffiliateLinks))).toList
@@ -369,7 +378,7 @@ object DotcomponentsDataModel {
       Configuration.google.subscribeWithGoogleApiUrl,
       navMenu,
       readerRevenueLinks,
-      Static("javascripts/graun.dotcom-rendering-commercial.js")
+      buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
     )
 
     val tags = Tags(


### PR DESCRIPTION
## What does this change?

Tiny change in the `DotcomponentsDataModel` file so that the url to the commercial bundle is always a full url. This now makes it possible for a local instance of dotcom-rendering to seamlessly point at local instance of frontend together with the prod instance of frontend.
