### PR TITLE
Add bidder and switch for Ozone, update Prebid dependency

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -486,7 +486,7 @@ trait PrebidSwitches {
     name = "prebid-ozone",
     description = "Include Ozone adapter direct in Prebid auctions",
     owners = group(Commercial),
-    safeState = On, // TODO: set safeState to off
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true
   )

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -481,6 +481,16 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+  val prebidOzone: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-ozone",
+    description = "Include Ozone adapter direct in Prebid auctions",
+    owners = group(Commercial),
+    safeState = On, // TODO: set safeState to off
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val prebidPangaea: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-pangaea",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#4ea7052",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#df98116",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#df98116",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#0e4ee56",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -108,7 +108,7 @@ const adSlotDefinitions = {
   Returns an array of adSlot HTMLElement(s) with always at least one HTMLDivElement
   which is the main DFP slot.
 
-  Insert those elements as sibblings at the place
+  Insert those elements as siblings at the place
   you want adverts to appear.
 
   Note that for the DFP slot to be filled by GTP, you'll have to

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -45,11 +45,14 @@ import {
     shouldIncludeSonobi,
     shouldIncludeTrustX,
     shouldIncludeXaxis,
+    shouldUseOzoneAdaptor,
     stripDfpAdPrefixFrom,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
 } from './utils';
 import { getAppNexusDirectBidParams, getAppNexusPlacementId } from './appnexus';
+
+const PAGE_TARGETING: {} = buildAppNexusTargetingObject(buildPageTargeting());
 
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');
@@ -371,11 +374,15 @@ const ozoneClientSideBidder: PrebidBidder = {
         Object.assign(
             {},
             (() => ({
+                // TODO: update the test values below once testing over
                 publisherId: 'OZONENUK0001', // test ID
                 siteId: '4204204201', // test ID
                 placementId: '0420420421', // test ID
-                // customData: { key1: 'value1', key2: 'value2' }, this is optional
-                ozoneData: buildAppNexusTargetingObject(buildPageTargeting()),
+                customData: {
+                    keywords: PAGE_TARGETING,
+                    customParams: PAGE_TARGETING,
+                },
+                ozoneData: {}, // TODO: confirm if we need to send any
             }))(),
             window.OzoneLotameData ? { lotameData: window.OzoneLotameData } : {}
         ),
@@ -580,6 +587,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
         ...(inPbTestOr(shouldIncludeAdYouLike(slotSizes))
             ? [adYouLikeBidder]
             : []),
+        ...(inPbTestOr(shouldUseOzoneAdaptor()) ? [ozoneClientSideBidder] : []),
         ...(shouldIncludeOpenx() ? [openxClientSideBidder] : []),
     ];
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -18,6 +18,7 @@ import type {
     PrebidImproveParams,
     PrebidIndexExchangeParams,
     PrebidOpenXParams,
+    PrebidOzoneParams,
     PrebidPubmaticParams,
     PrebidSize,
     PrebidSonobiParams,
@@ -361,6 +362,23 @@ const openxClientSideBidder: PrebidBidder = {
             customParams: buildAppNexusTargetingObject(buildPageTargeting()),
         };
     },
+};
+
+const ozoneClientSideBidder: PrebidBidder = {
+    name: 'ozone',
+    switchName: 'prebidOzone',
+    bidParams: (): PrebidOzoneParams =>
+        Object.assign(
+            {},
+            (() => ({
+                publisherId: 'OZONENUK0001', // test ID
+                siteId: '4204204201', // test ID
+                placementId: '0420420421', // test ID
+                // customData: { key1: 'value1', key2: 'value2' }, this is optional
+                ozoneData: buildAppNexusTargetingObject(buildPageTargeting()),
+            }))(),
+            window.OzoneLotameData ? { lotameData: window.OzoneLotameData } : {}
+        ),
 };
 
 const sonobiBidder: PrebidBidder = {

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -88,7 +88,7 @@ const consentManagement: ConsentManagement = {
 const s2sConfig: S2SConfig = {
     accountId: '1',
     enabled: true,
-    bidders: ['appnexus', 'openx', 'pangaea', 'ozone'],
+    bidders: ['appnexus', 'openx', 'pangaea'],
     timeout: bidderTimeout,
     adapter: 'prebidServer',
     is_debug: 'false',

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -33,7 +33,7 @@ type S2SConfig = {
     bidders: Array<string>,
     timeout: number,
     adapter: string,
-    is_debug: string, // true or false string
+    is_debug: 'true' | 'false',
     endpoint: string,
     syncEndpoint: string,
     cookieSet: boolean,
@@ -88,7 +88,7 @@ const consentManagement: ConsentManagement = {
 const s2sConfig: S2SConfig = {
     accountId: '1',
     enabled: true,
-    bidders: ['appnexus', 'openx', 'pangaea'],
+    bidders: ['appnexus', 'openx', 'pangaea', 'ozone'],
     timeout: bidderTimeout,
     adapter: 'prebidServer',
     is_debug: 'false',

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -2,6 +2,14 @@
 
 export type PrebidSize = [number, number];
 
+export type PrebidOzoneParams = {
+    publisherId: string,
+    siteId: string,
+    placementId: string,
+    customData?: { [string]: string },
+    ozoneData: { [string]: string },
+};
+
 export type PrebidSonobiParams = {
     ad_unit: string,
     dom_id: string,
@@ -80,6 +88,7 @@ export type PrebidBidder = {
         | PrebidXaxisParams
         | PrebidAppNexusParams
         | PrebidOpenXParams
+        | PrebidOzoneParams
         | PrebidAdYouLikeParams
         | PrebidPubmaticParams,
 };
@@ -94,6 +103,7 @@ export type PrebidBid = {
         | PrebidXaxisParams
         | PrebidAppNexusParams
         | PrebidOpenXParams
+        | PrebidOzoneParams
         | PrebidAdYouLikeParams
         | PrebidPubmaticParams,
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -6,8 +6,8 @@ export type PrebidOzoneParams = {
     publisherId: string,
     siteId: string,
     placementId: string,
-    customData?: { [string]: string },
-    ozoneData: { [string]: string },
+    customData?: { [string]: mixed },
+    ozoneData?: { [string]: mixed },
 };
 
 export type PrebidSonobiParams = {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -113,6 +113,10 @@ export const shouldIncludeAdYouLike = (slotSizes: PrebidSize[]): boolean =>
 export const shouldIncludeOzone = (): boolean =>
     !isInUsRegion() && !isInAuRegion();
 
+// TODO: Check is we want regional restrictions on where we load the ozoneBidAdapter
+export const shouldUseOzoneAdaptor = (): boolean =>
+    !isInUsRegion() && !isInAuRegion() && config.get('switches.prebidOzone');
+
 export const shouldIncludeAppNexus = (): boolean =>
     isInAuRegion() ||
     ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,9 +8206,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#4ea7052":
+"prebid.js@https://github.com/guardian/Prebid.js.git#df98116":
   version "2.5.0"
-  resolved "https://github.com/guardian/Prebid.js.git#4ea7052ff40291885d43373317618a4bd6423924"
+  resolved "https://github.com/guardian/Prebid.js.git#df98116b4a266204524c2ddeb22bec08010adac2"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,9 +8206,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#df98116":
-  version "2.5.0"
-  resolved "https://github.com/guardian/Prebid.js.git#df98116b4a266204524c2ddeb22bec08010adac2"
+"prebid.js@https://github.com/guardian/Prebid.js.git#0e4ee56":
+  version "2.6.0"
+  resolved "https://github.com/guardian/Prebid.js.git#0e4ee564513e9ae009b4eca22046d114e7ac9617"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?

#### 👉  Add a switch and client-side bidder for Ozone

First steps to using an adapter rather than the server-side component.

#### 👉Update Prebid to version 2.6.0 with some extra modules

Latest Prebid release includes required updates to the ozone adapter, the build referenced also includes two required modules.

See PR: https://github.com/guardian/Prebid.js/pull/91 

## Screenshots

<img width="699" alt="Screenshot 2019-03-13 at 17 27 08" src="https://user-images.githubusercontent.com/8607683/54343870-a3659580-4637-11e9-9b1f-924b9fe47f6c.png">


## What is the value of this and can you measure success?

Commercial BAU: https://trello.com/c/eOnbioKJ

Bidder is behind a switch, however we can use the test params to test this on PROD.

Currently using test params but this is required until we get the adapter working correctly.

### Tested

- [x] Locally
