### PR TITLE
Filter paid content from dotcom-rendering

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -16,7 +16,7 @@ object AMPPageChecks extends Logging {
   }
 
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = {
-    ! page.article.tags.isPaidContent
+    !page.article.tags.isPaidContent
   }
 
   def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
@@ -54,7 +54,7 @@ object AMPPicker {
       ("isBasicArticle", AMPPageChecks.isBasicArticle(page)),
       ("hasOnlySupportedElements", AMPPageChecks.hasOnlySupportedElements(page)),
       ("isNotOpinionP", AMPPageChecks.isNotOpinion(page)),
-      ("isNotPaidContent", AMPPageChecks.isNotOpinion(page)),
+      ("isNotPaidContent", AMPPageChecks.isNotPaidContent(page)),
     )
   }
 

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -123,7 +123,7 @@ object ArticlePicker {
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page)),
-      ("isNotPaidContent", ArticlePageChecks.isNotOpinion(page)),
+      ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Currently AMP paid content is being rendered by dotcom-rendering,
despite not being properly supported. This is due to a copy-paste
bug, fixed in this change.

## What is the value of this and can you measure success?

Correctly removes Paid Content from dotcom-rendering safe list

## Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
