### PR TITLE
Remove spurious Content-Type headers on GET requests

### DIFF
--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -22,9 +22,6 @@ const get = (): Promise<string> =>
         }
 
         fetchJSON('/geolocation', {
-            headers: {
-                'Content-Type': 'application/json',
-            },
             mode: 'cors',
         })
             .then(response => {

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -123,9 +123,6 @@ const fetchDataAndAnimate = (parentElementSelector: string) => {
         animate(parentElementSelector);
     } else {
         fetchJSON('https://support.theguardian.com/ticker.json', {
-            headers: {
-                'Content-Type': 'application/json',
-            },
             mode: 'cors',
         }).then(data => {
             total = parseInt(data.total, 10);


### PR DESCRIPTION
`Content-Type` is only applicable to responses, or to request such as `POST` or `PUT` where there is a body sent.

In the below GET requests, this header is at best redundant and at worst harmful. We noticed that for `https://support.theguardian.com/ticker.json`, it caused an unnecessary preflight `OPTIONS` request (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests) and (for reasons we couldn't quite figure out) occasionally caused the browser to erroneously claim that there were no CORS headers on the resource and fail to send the request.

It's possible that this has been affecting `/geolocation` too, since it gets rewritten to `https://api.nextgen.guardianapps.co.uk/geolocation` by our fetchJSON shim. It might not have been noticed, since geolocation falls back to a localStorage value if present, and the edition if all else fails. So we may have been falling back to the edition unnecessarily in some cases.