### PR TITLE
Update ticker design after goal is reached

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -5,13 +5,13 @@ import { getLocalCurrencySymbol } from 'lib/geolocation';
 export const acquisitionsEpicTickerTemplate = `
     <div id="epic-ticker" class="js-epic-ticker epic-ticker is-hidden">
     
-        <div class="js-ticker-amounts is-hidden">
+        <div class="js-ticker-amounts">
             <div class="js-ticker-so-far epic-ticker__so-far">
                 <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
                 <div class="epic-ticker__count-label">contributed</div>
             </div>
             
-            <div class="js-ticker-goal epic-ticker__goal">
+            <div class="js-ticker-goal epic-ticker__goal is-hidden">
                 <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
                 <div class="epic-ticker__count-label">our goal</div>
             </div>
@@ -19,9 +19,8 @@ export const acquisitionsEpicTickerTemplate = `
         
         <div class="epic-ticker__progress-container">
             <div class="epic-ticker__progress">
-                <div class="js-ticker-filled-progress epic-ticker__filled-progress ticker__filled-progress-under"></div>
+                <div class="js-ticker-filled-progress epic-ticker__filled-progress"></div>
             </div>
-            <div class="js-ticker-goal-marker epic-ticker__goal-marker is-hidden"></div>
         </div>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -15,31 +15,20 @@ const percentageTotalAsNegative = (end: number) => {
 };
 
 const animateBar = (parentElement: HTMLElement) => {
-    // If we've exceeded the goal then extend the bar 20% beyond the total
-    const end = total > goal ? total + total * 0.2 : goal;
-
     const progressBarElement = parentElement.querySelector(
         '.js-ticker-filled-progress'
     );
 
     if (progressBarElement && progressBarElement instanceof HTMLElement) {
-        const barTranslate = percentageTotalAsNegative(end);
+        const barTranslate = percentageTotalAsNegative(goal);
         progressBarElement.style.transform = `translateX(${barTranslate}%)`;
 
-        if (end !== goal) {
-            progressBarElement.classList.add('ticker__filled-progress-over');
-            progressBarElement.classList.remove(
-                'ticker__filled-progress-under'
+        if (total >= goal) {
+            const labelElement = parentElement.querySelector(
+                '.epic-ticker__count-label'
             );
-
-            // Show a marker for the goal that has been exceeded
-            const marker = parentElement.querySelector(
-                '.js-ticker-goal-marker'
-            );
-            if (marker) {
-                marker.classList.remove('is-hidden');
-                const markerTranslate = (goal / end) * 100 - 100;
-                marker.style.transform = `translateX(${markerTranslate}%)`;
+            if (labelElement) {
+                labelElement.innerHTML = `contributed of a ${getLocalCurrencySymbol()}${goal.toLocaleString()} goal`;
             }
         }
     }
@@ -76,12 +65,14 @@ const increaseCounter = (
 };
 
 const populateGoal = (parentElement: HTMLElement) => {
-    const goalElement = parentElement.querySelector(
-        '.js-ticker-goal .js-ticker-count'
-    );
+    const goalElement = parentElement.querySelector('.js-ticker-goal');
 
-    if (goalElement && goalElement instanceof HTMLElement) {
-        goalElement.innerHTML = `${getLocalCurrencySymbol()}${goal.toLocaleString()}`;
+    if (goalElement) {
+        const countElement = goalElement.querySelector('.js-ticker-count');
+        if (countElement) {
+            goalElement.classList.remove('is-hidden');
+            countElement.innerHTML = `${getLocalCurrencySymbol()}${goal.toLocaleString()}`;
+        }
     }
 };
 
@@ -91,7 +82,9 @@ const animate = (parentElementSelector: string) => {
     const tickerElementSelector = '.js-ticker-amounts';
 
     if (parentElement && parentElement instanceof HTMLElement) {
-        populateGoal(parentElement);
+        if (total < goal) {
+            populateGoal(parentElement);
+        }
 
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
@@ -106,13 +99,6 @@ const animate = (parentElementSelector: string) => {
         }, 500);
 
         parentElement.classList.remove('is-hidden');
-
-        const tickerElement = parentElement.querySelector(
-            tickerElementSelector
-        );
-        if (tickerElement) {
-            tickerElement.classList.remove('is-hidden');
-        }
     }
 };
 
@@ -126,6 +112,7 @@ const fetchDataAndAnimate = (parentElementSelector: string) => {
             mode: 'cors',
         }).then(data => {
             total = parseInt(data.total, 10);
+            // total = 151000
             goal = parseInt(data.goal, 10);
 
             if (dataSuccessfullyFetched()) {

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -112,7 +112,6 @@ const fetchDataAndAnimate = (parentElementSelector: string) => {
             mode: 'cors',
         }).then(data => {
             total = parseInt(data.total, 10);
-            // total = 151000
             goal = parseInt(data.goal, 10);
 
             if (dataSuccessfullyFetched()) {

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -77,19 +77,7 @@ $progress-bar-height: 10px;
     bottom: 0;
     transform: translateX(-100%);
     transition: transform 3s cubic-bezier(.25, .55, .2, .85);
-}
-
-.epic-ticker__progress .ticker__filled-progress-under,
-.epic-ticker__progress .ticker__filled-progress-over {
     background-color: #ffe500;
-}
-
-.epic-ticker__goal-marker {
-    border-right: 3px solid #121212;
-    content: ' ';
-    display: block;
-    height: 17px;
-    margin-top: -7px;
 }
 
 .epic-ticker__progress-labels {
@@ -105,40 +93,18 @@ $progress-bar-height: 10px;
     top: 5px;
 }
 
-.epic-ticker__goal, .epic-ticker__exceeded {
+.epic-ticker__goal {
     position: absolute;
     right: 0;
     bottom: $progress-bar-height + 5px;
     text-align: right;
 }
 
-.epic-ticker__so-far, .epic-ticker__thankyou {
+.epic-ticker__so-far {
     position: absolute;
     left: 0;
     bottom: $progress-bar-height + 5px;
 }
-
-.epic-ticker__thankyou {
-    >:first-child {
-        font-size: 24px;
-        line-height: 26px;
-        font-weight: 800;
-        color: #333333;
-    }
-
-    >:last-child {
-        font-style: italic;
-    }
-}
-
-.epic-ticker__exceeded .epic-ticker__count-label {
-    font-style: italic;
-}
-
-.epic-ticker__hidden {
-    display: none;
-}
-
 
 .epic-ticker__caption {
     @include fs-textSans(4);


### PR DESCRIPTION
## What does this change?
We've simplified what gets displayed in the epic ticker when a campaign goes over its target.

I've removed code for the old design (which allowed the progress bar to continue beyond the goal)

## Screenshots
### Before goal:
![Picture 12](https://user-images.githubusercontent.com/1513454/54370753-1c80df00-4670-11e9-9366-dad540343609.png)

### After goal:
![Picture 13](https://user-images.githubusercontent.com/1513454/54370754-1c80df00-4670-11e9-9ab9-ae21827c65b7.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
