### PR TITLE
Set discountcode link based of path rather than edition

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -190,10 +190,10 @@ object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodeRoot = "https://discountcode.theguardian.com"
-  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk?INTCMP=guardian_header")
-  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au?INTCMP=guardian_header")
-  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
-  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
+  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk")
+  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au")
+  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot")
+  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/us")
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -190,10 +190,7 @@ object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodeRoot = "https://discountcode.theguardian.com"
-  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk")
-  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au")
-  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot")
-  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/us")
+  val discountCodeNavLink = NavLink("Discount Codes", discountCodeRoot)
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),
@@ -508,31 +505,31 @@ object NavLinks {
     crosswords
   )
 
-  val ukBrandExtensions = List(
+  def ukBrandExtensions(discountCodePath: String) = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
     dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
     ukMasterClasses,
     digitalNewspaperArchive,
     ukPatrons,
-    ukDiscountCode
+    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
   )
-  val auBrandExtensions = List(
+  def auBrandExtensions(discountCodePath: String) = List(
     auEvents,
     digitalNewspaperArchive,
-    auDiscountCode
+    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
   )
-  val usBrandExtensions= List(
+  def usBrandExtensions(discountCodePath: String) = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
     digitalNewspaperArchive,
-    usDiscountCode
+    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
     dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
-    intDiscountCode
+    discountCodeNavLink
   )
 
   // Tertiary Navigation

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -52,8 +52,20 @@ object NavMenu {
 
   private[navigation] case class NavRoot(children: Seq[NavLink], otherLinks: Seq[NavLink], brandExtensions: Seq[NavLink])
 
+  // Vouchercloud links are designed for search engines rather than humans. When the googlebot hits theguardian.com/uk
+  // we want it to see the discountcode path for the UK, rather than the US version (as it would normally see as nav
+  // is based off th edition rather than the path. So this function exists...
+  def getVoucherCloudPath(pageId: String): String = {
+    pageId.take(3) match {
+      case "uk" | "uk/" => "/uk"
+      case "au" | "au/" => "/au"
+      case "us" | "us/" => "/us"
+      case _ => ""
+    }
+  }
+
   def apply(page: Page, edition: Edition): NavMenu = {
-    val root = navRoot(edition)
+    val root = navRoot(edition, discountCodePath = getVoucherCloudPath(page.metadata.id))
     val currentUrl = getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
@@ -128,11 +140,11 @@ object NavMenu {
     )
   }
 
-  private[navigation] def navRoot(edition: Edition): NavRoot = {
+  private[navigation] def navRoot(edition: Edition, discountCodePath: String = ""): NavRoot = {
     edition match {
-      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
-      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
-      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
+      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions(discountCodePath))
+      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions(discountCodePath))
+      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions(discountCodePath))
       case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intCulturePillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
     }
   }

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,3 +1,4 @@
+@import navigation.NavLinks
 @(showNav: Boolean = true, isAmp: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 @import org.joda.time.DateTime
@@ -120,7 +121,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk">
+                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -192,7 +193,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/us">
+                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")>
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -269,7 +270,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au">
+                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")>
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -333,7 +334,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
+                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href=@(NavLinks.discountCodeRoot)>
                                         Discount Codes</a>
                                     </li>
                                 </ul>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -120,7 +120,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -192,7 +192,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/us">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -269,7 +269,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -333,7 +333,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
                                         Discount Codes</a>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## What does this change?
Currently we set the discountcode links in the header/footer based off the edition (which comes from geolocation or whatever the user has set it to in the top right dropdown). This makes sense, until you realise that the links are only really there for bots rather than for people, and so a certain search engine, with servers mainly in the us, will forever keep hitting the US version of the site, when we'd like them to also index discountcode.theguardian.com/uk. 

So this change adds some logic to the header/footer links generation which looks at the first three characters of the path of the page (page.metadata.id) and checks whether it's a /uk /us etc. path

But loads of our paths don't have a country prefix at the start! Well, for these situations we just serve the root link - discountcode.theguardian.com - which leads to a country selector.

The downside of this approach is that users from the uk reading a us news article will get directed to the us discount codes site. But we aren't really expecting anyone to actually click on these links - it's just for transfer of authority.

As part of this change I've been asked to remove the INTCMP tracking parameters from the urls as apparently these could reduce the authority transfer.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
