### PR TITLE
Revert "Set discountcode link based of path rather than edition"

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -190,7 +190,10 @@ object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodeRoot = "https://discountcode.theguardian.com"
-  val discountCodeNavLink = NavLink("Discount Codes", discountCodeRoot)
+  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk?INTCMP=guardian_header")
+  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au?INTCMP=guardian_header")
+  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
+  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),
@@ -505,31 +508,31 @@ object NavLinks {
     crosswords
   )
 
-  def ukBrandExtensions(discountCodePath: String) = List(
+  val ukBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
     dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
     ukMasterClasses,
     digitalNewspaperArchive,
     ukPatrons,
-    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
+    ukDiscountCode
   )
-  def auBrandExtensions(discountCodePath: String) = List(
+  val auBrandExtensions = List(
     auEvents,
     digitalNewspaperArchive,
-    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
+    auDiscountCode
   )
-  def usBrandExtensions(discountCodePath: String) = List(
+  val usBrandExtensions= List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
     digitalNewspaperArchive,
-    discountCodeNavLink.copy(url = s"$discountCodeRoot$discountCodePath")
+    usDiscountCode
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
     dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
-    discountCodeNavLink
+    intDiscountCode
   )
 
   // Tertiary Navigation

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -52,20 +52,8 @@ object NavMenu {
 
   private[navigation] case class NavRoot(children: Seq[NavLink], otherLinks: Seq[NavLink], brandExtensions: Seq[NavLink])
 
-  // Vouchercloud links are designed for search engines rather than humans. When the googlebot hits theguardian.com/uk
-  // we want it to see the discountcode path for the UK, rather than the US version (as it would normally see as nav
-  // is based off th edition rather than the path. So this function exists...
-  def getVoucherCloudPath(pageId: String): String = {
-    pageId.take(3) match {
-      case "uk" | "uk/" => "/uk"
-      case "au" | "au/" => "/au"
-      case "us" | "us/" => "/us"
-      case _ => ""
-    }
-  }
-
   def apply(page: Page, edition: Edition): NavMenu = {
-    val root = navRoot(edition, discountCodePath = getVoucherCloudPath(page.metadata.id))
+    val root = navRoot(edition)
     val currentUrl = getSectionOrPageUrl(page, edition)
     val currentNavLink = findDescendantByUrl(currentUrl, edition, root.children, root.otherLinks)
     val currentParent = currentNavLink.flatMap(link => findParent(link, edition, root.children, root.otherLinks))
@@ -140,11 +128,11 @@ object NavMenu {
     )
   }
 
-  private[navigation] def navRoot(edition: Edition, discountCodePath: String = ""): NavRoot = {
+  private[navigation] def navRoot(edition: Edition): NavRoot = {
     edition match {
-      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions(discountCodePath))
-      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions(discountCodePath))
-      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions(discountCodePath))
+      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
+      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
+      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
       case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intCulturePillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
     }
   }

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,4 +1,3 @@
-@import navigation.NavLinks
 @(showNav: Boolean = true, isAmp: Boolean = false)(implicit page: model.Page, request: RequestHeader)
 
 @import org.joda.time.DateTime
@@ -121,7 +120,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")">
+                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk?INTCMP=guardian_footer">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -193,7 +192,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")>
+                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -270,7 +269,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href=@(s"${NavLinks.discountCodeRoot}${NavMenu.getVoucherCloudPath(page.metadata.id)}")>
+                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au?INTCMP=guardian_footer">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -334,7 +333,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href=@(NavLinks.discountCodeRoot)>
+                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
                                         Discount Codes</a>
                                     </li>
                                 </ul>


### PR DESCRIPTION
Reverts guardian/frontend#21255 as it resulted in a crazy traffic increase to the article ELB. Further investigation needed

<img width="867" alt="Screenshot 2019-03-15 at 16 16 55" src="https://user-images.githubusercontent.com/3606555/54445952-c5e1d680-473d-11e9-8c48-57d0586488bc.png">
