### PR TITLE
Add US vouchercloud link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -190,10 +190,10 @@ object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodeRoot = "https://discountcode.theguardian.com"
-  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk?INTCMP=guardian_header")
-  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au?INTCMP=guardian_header")
-  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
-  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot?INTCMP=guardian_header")
+  val ukDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/uk")
+  val auDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/au")
+  val intDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot")
+  val usDiscountCode = NavLink("Discount Codes", s"$discountCodeRoot/us")
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -120,7 +120,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/uk">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -192,7 +192,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/us">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -269,7 +269,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/au">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -333,7 +333,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com?INTCMP=guardian_footer">
+                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
                                         Discount Codes</a>
                                     </li>
                                 </ul>


### PR DESCRIPTION
This PR https://github.com/guardian/frontend/pull/21255 caused a significant (1%) reduction in cache coverage. We're not certain why yet, but assume that it's to do with the added reliance on needing page ID in order to generate the header/footer (and as a result having a 'different' header/footer for every page). This PR takes out that page ID check, and simply  modifies the discountcode links to remove the INTCMP tracking codes, and add /us to the end of the discountcode link on the US edition

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
