### PR TITLE
Bring back adverts on browsers without IntersectionObserver

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.js
@@ -10,7 +10,7 @@ const displayAd = (adSlot: HTMLElement, forceDisplay: boolean) => {
     const advert: Advert = new Advert(adSlot);
 
     dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
-    if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
+    if (dfpEnv.shouldLazyLoad() && !forceDisplay && dfpEnv.lazyLoadObserve) {
         queueAdvert(advert);
         enableLazyLoad(advert);
     } else {

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -22,9 +22,15 @@ const displayLazyAds = (): void => {
     window.googletag.pubads().collapseEmptyDivs();
     window.googletag.enableServices();
     instantLoad();
+
     dfpEnv.advertsToLoad.forEach(
         (advert: Advert): void => {
-            enableLazyLoad(advert);
+            if (dfpEnv.lazyLoadObserve) {
+                enableLazyLoad(advert);
+            } else {
+                console.log('unable to lazy-load!');
+                loadAdvert(advert);
+            }
         }
     );
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -41,7 +41,7 @@ const fillAdvertSlots = (): Promise<void> => {
         });
         adverts.forEach(queueAdvert);
 
-        if (dfpEnv.shouldLazyLoad()) {
+        if (dfpEnv.shouldLazyLoad() && dfpEnv.lazyLoadObserve) {
             displayLazyAds();
         } else {
             displayAds();


### PR DESCRIPTION
## What does this change?

Fix for adverts in Safari

```
Unhandled Promise Rejection: 
    TypeError: undefined is not a constructor (
        evaluating 'new window.IntersectionObserver(Ue,{rootMargin:"200px 0px"})'
    )
```

## Screenshots

##### ISSUE: 

![image](https://user-images.githubusercontent.com/8607683/54490430-a49ff800-48ad-11e9-8976-cc8a6c560f5d.png)

## What is the value of this and can you measure success?

Bring adverts back to Safari! 💸 

Still lazy load adverts where possible, but load adverts at once if lazy-load will not work...

## Checklist

### Does this affect other platforms?

This PR removes lazyload from browsers (Safari) that do not support IntersectionObserver

### Does this change break ad-free?

Nope

### Tested?

- [x] Locally


