### PR TITLE
Numbered list styling

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -26,6 +26,7 @@
             "has-feature-showcase-element" -> (!article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isColumn),
             "has-feature-showcase-opinion" -> (article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isColumn),
             "content--type-column" -> article.content.isColumn,
+            "content--type-numbered-list" -> article.content.isNumberedList,
             "paid-content" -> isPaidContent,
             "content--pillar-special-report" -> (toneClass(article) == "tone-special-report")
         ),

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -74,6 +74,7 @@ object BodyCleaner {
       PhotoEssayBlockQuote(article.isPhotoEssay),
       PhotoEssayCaptions(article.isPhotoEssay),
       ImmersiveLinks(article.isImmersive),
+      NumberedListFurniture(article.isNumberedList),
       TimestampCleaner(article),
       MinuteCleaner(article),
       GarnettQuoteCleaner,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -79,6 +79,7 @@ final case class Content(
   lazy val isGallery = metadata.contentType.contains(DotcomContentType.Gallery)
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
+  lazy val isNumberedList = fields.displayHint.contains("splash")
   lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
@@ -256,6 +257,7 @@ final case class Content(
     ("productionOffice", JsString(productionOffice.getOrElse(""))),
     ("isImmersive", JsBoolean(isImmersive)),
     ("isColumn", JsBoolean(isColumn)),
+    ("isNumberedList", JsBoolean(isNumberedList)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
     ("contributorBio", JsString(contributorBio.getOrElse("")))
@@ -468,6 +470,7 @@ object Article {
       ("isHosted", JsBoolean(false)),
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
+      ("isNumberedList", JsBoolean(content.isNumberedList)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
       "videoDuration" -> videoDuration
     ) ++ bookReviewIsbn ++ AtomProperties(content.atoms)
@@ -540,6 +543,7 @@ final case class Article (
   val isImmersive: Boolean = content.isImmersive
   val isPhotoEssay: Boolean = content.isPhotoEssay
   val isColumn: Boolean = content.isColumn
+  val isNumberedList: Boolean = content.isNumberedList
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().asScala.headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -574,6 +574,32 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: B
   }
 }
 
+case class NumberedListFurniture(isNumberedList: Boolean) extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    if(isNumberedList) {
+      // Adds yellow styling to star ratings mid article
+      document.select("p:containsOwn(★)").asScala.foreach { star =>
+        star.addClass("stars")
+      }
+
+      // Styled link/section end
+      document.select("ul > li:only-child").asScala.foreach{ li =>
+        val ul = li.parent();
+          ul.addClass("article-link")
+      }
+
+      // Faux h3 headings, for second level of heading hierarchy in numbered list articles
+      document.select("p > strong").asScala.foreach{ strong =>
+        val p = strong.parent();
+        if (p.is("p:matchesOwn(^$)") && !p.children().is("a")) {
+          p.addClass("falseH3")
+        }
+      }
+    }
+    document
+  }
+}
+
 // Gallery Caption's don't come back as structured data
 // This is a hack to serve the correct html
 object GalleryCaptionCleaner extends HtmlCleaner {

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -23,6 +23,7 @@
 @import 'module/_social';
 @import 'module/_live-pulse';
 @import 'module/content-garnett/_article-immersive';
+@import 'module/content-garnett/_article-numbered-list';
 @import 'module/content-garnett/_article-column';
 @import 'module/content-garnett/_article-special-report';
 @import 'module/content-garnett/_article-minute';

--- a/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
@@ -1,5 +1,13 @@
-/// Can I do this -->
-@font-face{font-family:"Guardian Titlepiece";src:url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2") format("woff2"),url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff") format("woff"),url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf") format("truetype");font-weight:700;font-style:normal}
+/// Can I do this? -->
+@font-face {
+    font-family: 'Guardian Titlepiece';
+    src:
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff') format('woff'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf') format('truetype');
+    font-weight: 700;
+    font-style: normal;
+}
 
 .content.content--article.content--type-numbered-list {
     counter-reset: section;
@@ -51,7 +59,7 @@
 
             li {
                 border: 1px solid $brightness-86;
-                padding: ($gs-baseline / 2) ($gs-gutter / 2) ($gs-baseline * 1.5) !important;
+                padding: $gs-baseline ($gs-gutter / 2) ($gs-baseline + $gs-baseline / 2) !important;
                 margin: 0 ($gs-gutter / 2);
                 max-width: gs-span(6) - $gs-gutter / 2;
 
@@ -64,15 +72,12 @@
                 }
 
                 a {
-                    font-family: 'Guardian Egyptian Web', Georgia, serif;
-                    font-size: 18px;
-                    line-height: 20px;
+                    @include fs-headlineGarnett(0);
                     font-weight: 800;
                 }
 
                 strong {
-                    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
-                    font-size: 16px;
+                    @include fs-textSans(5);
                     font-weight: 400;
                     color: $brightness-46;
                     display: block;
@@ -90,12 +95,11 @@
         $large-number: 99px;
 
         & > h2 {
+            @include fs-headlineGarnett(2);
+            font-weight: 500;
             box-sizing: border-box;
             border-top: 4px solid $brightness-86;
-            font-family: 'Guardian Egyptian Web', Georgia, serif;
             color: $brightness-7;
-            font-size: 24px;
-            line-height: 26px;
             min-height: $small-number + $gs-baseline;
             position: relative;
             margin-left: -$gs-gutter / 2;
@@ -110,7 +114,8 @@
             }
 
             @include mq(tablet) {
-                font-size: 36px;
+                @include fs-headlineGarnett(7);
+                font-weight: 500;
                 line-height: 40px;
                 margin-right: 0;
                 margin-top: $gs-baseline * 8;
@@ -127,29 +132,25 @@
             // Optional way of forcing text onto seperate lines, with different colours
             strong {
                 display: block;
+                font-weight: 500;
             }
 
             // Large numbered heading
             &:before {
-                font-family: "Guardian Titlepiece", "Guardian Headline Full", "Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
+                font-family: 'Guardian Titlepiece', Georgia, serif;
+                font-size: 60px;
+                line-height: 60px;
                 content: counter(section);
                 box-sizing: border-box;
                 counter-increment: section;
                 border: 1px solid $brightness-86;
                 border-top-width: 4px;
                 font-variant-numeric: lining-nums;
-                line-height: 56px;
-                font-size: 60px;
                 height: $small-number;
                 width: $small-number;
                 color: $brightness-100;
-                // -webkit-text-stroke-width: 1px;
-                // -webkit-text-stroke-color: $brightness-86;
-                text-shadow:
-                    -1px -1px 0 $brightness-86,
-                    1px -1px 0 $brightness-86,
-                    -1px 1px 0 $brightness-86,
-                    1px 1px 0 $brightness-86;
+                -webkit-text-stroke-width: 1px;
+                -webkit-text-stroke-color: $brightness-86;
                 text-align: center;
                 position: absolute;
                 top: -4px;
@@ -174,11 +175,9 @@
 
     // p tags containing ONLY a strong tag will be styled as H3 level headings
     .falseH3 {
+        @include fs-headlineGarnett(0);
         border-top: 1px solid $brightness-86;
-        font-family: 'Guardian Egyptian Web', Georgia, serif;
         color: $brightness-7;
-        font-size: 18px;
-        line-height: 22px;
         margin-top: $gs-baseline * 2;
         margin-bottom: 3px;
         margin-left: -10px;
@@ -212,7 +211,7 @@
         line-height: 1;
         height: 30px;
         letter-spacing: 2px;
-        margin: 0 0 $gs-baseline -$gs-gutter / 2;
+        margin: 0 0 $gs-baseline (-$gs-gutter / 2);
         position: relative;
         z-index: $zindex-ui;
 
@@ -228,10 +227,9 @@
             margin-left: -$gs-gutter / 2;
         }
 
-
         & + .element-image {
             @include mq(leftCol) {
-                margin-top: -32px;
+                margin-top: -42px;
             }
         }
     }
@@ -248,7 +246,7 @@
 
 @include numberedListPillarColours('news', $news-main);
 @include numberedListPillarColours('opinion', $opinion-main);
-@include numberedListPillarColours('sport',$sport-main);
+@include numberedListPillarColours('sport', $sport-main);
 @include numberedListPillarColours('arts', $culture-main);
 @include numberedListPillarColours('lifestyle', $lifestyle-main);
 @include numberedListPillarColours('special-report', $special-report-dark);

--- a/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
@@ -1,0 +1,254 @@
+/// Can I do this -->
+@font-face{font-family:"Guardian Titlepiece";src:url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2") format("woff2"),url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff") format("woff"),url("https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf") format("truetype");font-weight:700;font-style:normal}
+
+.content.content--article.content--type-numbered-list {
+    counter-reset: section;
+
+    .content__article-body {
+        figure.element--thumbnail {
+            @include mq($until: tablet) {
+                float: right;
+                margin-left: $gs-gutter;
+                margin-right: 0;
+            }
+        }
+
+        // Thumnail sized image has rounded corners
+        .element--thumbnail img {
+            border-radius: 50%;
+            overflow: hidden;
+        }
+
+        ul.article-link {
+            display: block;
+            position: relative;
+            margin-left: -$gs-gutter / 2;
+            margin-right: -$gs-gutter / 2;
+            margin-top: $gs-baseline * 2;
+            margin-bottom: $gs-baseline * 3;
+
+            @include mq(mobileLandscape) {
+                margin-left: -$gs-gutter;
+                margin-right: -$gs-gutter;
+            }
+
+            @include mq(tablet) {
+                margin-right: 0;
+            }
+
+            @include mq(leftCol) {
+                margin-left: -$gs-gutter / 2;
+            }
+
+            &:after {
+                content: '';
+                border-bottom: 1px solid $brightness-86;
+                position: absolute;
+                left: 0;
+                right: 0;
+                top: 0;
+            }
+
+            li {
+                border: 1px solid $brightness-86;
+                padding: ($gs-baseline / 2) ($gs-gutter / 2) ($gs-baseline * 1.5) !important;
+                margin: 0 ($gs-gutter / 2);
+                max-width: gs-span(6) - $gs-gutter / 2;
+
+                @include mq(mobileLandscape) {
+                    margin: 0 $gs-gutter;
+                }
+
+                @include mq(leftCol) {
+                    margin-left: 0;
+                }
+
+                a {
+                    font-family: 'Guardian Egyptian Web', Georgia, serif;
+                    font-size: 18px;
+                    line-height: 20px;
+                    font-weight: 800;
+                }
+
+                strong {
+                    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+                    font-size: 16px;
+                    font-weight: 400;
+                    color: $brightness-46;
+                    display: block;
+                }
+
+                &:before {
+                    // Hides bullet icon
+                    content: none !important;
+                }
+            }
+        }
+
+        // Prominent H2 styling with optional different coloured secondary level
+        $small-number: 68px;
+        $large-number: 99px;
+
+        & > h2 {
+            box-sizing: border-box;
+            border-top: 4px solid $brightness-86;
+            font-family: 'Guardian Egyptian Web', Georgia, serif;
+            color: $brightness-7;
+            font-size: 24px;
+            line-height: 26px;
+            min-height: $small-number + $gs-baseline;
+            position: relative;
+            margin-left: -$gs-gutter / 2;
+            margin-right: -$gs-gutter / 2;
+            margin-top: $gs-baseline * 4;
+            padding: ($gs-baseline / 4) ($gs-gutter / 2) $gs-baseline ($small-number + $gs-gutter);
+
+            @include mq(mobileLandscape) {
+                margin-left: -$gs-gutter;
+                margin-right: -$gs-gutter;
+                padding: ($gs-baseline / 4) $gs-gutter $gs-baseline 98px;
+            }
+
+            @include mq(tablet) {
+                font-size: 36px;
+                line-height: 40px;
+                margin-right: 0;
+                margin-top: $gs-baseline * 8;
+                min-height: $large-number + $gs-baseline;
+                padding: ($gs-baseline / 2) ($gs-gutter / 2) $gs-baseline ($large-number + $gs-gutter + $gs-gutter / 2);
+            }
+
+            @include mq(leftCol) {
+                min-height: auto;
+                margin-left: -$gs-gutter / 2;
+                padding: ($gs-baseline / 2) ($gs-gutter / 2) $gs-baseline;
+            }
+
+            // Optional way of forcing text onto seperate lines, with different colours
+            strong {
+                display: block;
+            }
+
+            // Large numbered heading
+            &:before {
+                font-family: "Guardian Titlepiece", "Guardian Headline Full", "Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
+                content: counter(section);
+                box-sizing: border-box;
+                counter-increment: section;
+                border: 1px solid $brightness-86;
+                border-top-width: 4px;
+                font-variant-numeric: lining-nums;
+                line-height: 56px;
+                font-size: 60px;
+                height: $small-number;
+                width: $small-number;
+                color: $brightness-100;
+                // -webkit-text-stroke-width: 1px;
+                // -webkit-text-stroke-color: $brightness-86;
+                text-shadow:
+                    -1px -1px 0 $brightness-86,
+                    1px -1px 0 $brightness-86,
+                    -1px 1px 0 $brightness-86,
+                    1px 1px 0 $brightness-86;
+                text-align: center;
+                position: absolute;
+                top: -4px;
+                left: $gs-gutter / 2;
+
+                @include mq(tablet) {
+                    line-height: 88px;
+                    font-size: 88px;
+                    height: $large-number;
+                    width: $large-number;
+                    left: $gs-gutter;
+                }
+
+                @include mq(leftCol) {
+                    left: 1px;
+                    top: -4px;
+                    transform: translateX(-100%);
+                }
+            }
+         }
+    }
+
+    // p tags containing ONLY a strong tag will be styled as H3 level headings
+    .falseH3 {
+        border-top: 1px solid $brightness-86;
+        font-family: 'Guardian Egyptian Web', Georgia, serif;
+        color: $brightness-7;
+        font-size: 18px;
+        line-height: 22px;
+        margin-top: $gs-baseline * 2;
+        margin-bottom: 3px;
+        margin-left: -10px;
+        margin-right: -10px;
+        padding: ($gs-baseline / 4) ($gs-gutter / 2) ($gs-baseline / 2);
+
+        @include mq(mobileLandscape) {
+            padding: ($gs-baseline / 4) $gs-gutter ($gs-baseline / 2);
+            margin-left: -$gs-gutter;
+            margin-right: -$gs-gutter;
+        }
+
+        @include mq(tablet) {
+            display: block;
+            margin-left: -$gs-gutter;
+            margin-right: 0;
+            font-size: 24px;
+            line-height: 28px;
+        }
+
+        @include mq(leftCol) {
+            margin-left: -$gs-gutter / 2;
+            padding: ($gs-baseline / 4) ($gs-gutter / 2) ($gs-baseline / 2);
+        }
+    }
+
+    // Star glyphs eg: ★, ☆ will be styled with yellow background
+    .stars {
+        box-sizing: border-box;
+        font-size: 20px;
+        line-height: 1;
+        height: 30px;
+        letter-spacing: 2px;
+        margin: 0 0 $gs-baseline -$gs-gutter / 2;
+        position: relative;
+        z-index: $zindex-ui;
+
+        @include mq(mobileLandscape) {
+            margin-left: -$gs-gutter;
+        }
+
+        @include mq(tablet) {
+            margin-left: 0;
+        }
+
+        @include mq(leftCol) {
+            margin-left: -$gs-gutter / 2;
+        }
+
+
+        & + .element-image {
+            @include mq(leftCol) {
+                margin-top: -32px;
+            }
+        }
+    }
+}
+
+// Variable pillar colours
+@mixin numberedListPillarColours($pillar, $color) {
+    .content--pillar-#{$pillar}.content--type-numbered-list {
+        h2 strong {
+            color: $color;
+        }
+    }
+}
+
+@include numberedListPillarColours('news', $news-main);
+@include numberedListPillarColours('opinion', $opinion-main);
+@include numberedListPillarColours('sport',$sport-main);
+@include numberedListPillarColours('arts', $culture-main);
+@include numberedListPillarColours('lifestyle', $lifestyle-main);
+@include numberedListPillarColours('special-report', $special-report-dark);


### PR DESCRIPTION
## What does this change?
Different visual styling for articles with the content type "splash" (the name will change).

We currently don't have any ways of helping distinguish hierarchy of content on long articles, aside from h2 elements. In Buyers guide articles there is a huge amount of information, including star ratings and sub headings and we currently have no way of visually styling them. 

**Points**
- H2 headings are larger, and if they contains a `<strong>` tag they'll will be broken up onto two lines and further differentiated by tonal colouring.
- H2 headings will have large numbers alongside them.
- Thumbnail images are rounded (So they must be square crops)
- A bulleted list containing a single  `<li>` containing an  `<anchor>` tag will be styled as a card, and visually separate the end of a sub-section.
- An isolated `<strong>` tag containing NOTHING else will be styled as a sub heading.
- Any instance of star glyphs in the article body `★ ☆` will be styled in the usual way.

Brief doc here:
https://docs.google.com/document/d/1F42WH-l0QvfdXez7tNHkr6wvnho_K7XoEAXN793BTOc/edit

I appreciate some of these rules are strange, but with the current restraints of Composers limited tool set and not wanting to write anything that would output oddly without the HTML cleaner, this is where I arrived. If any of the logic can be improved please say.

# Numbered two tone headings
<img width="1665" alt="Screen Shot 2019-03-18 at 09 15 16" src="https://user-images.githubusercontent.com/14570016/54519502-9cec5c00-495e-11e9-8bef-d2713df5861e.png">

# Mobile view
<img width="376" alt="Screen Shot 2019-03-18 at 09 16 36" src="https://user-images.githubusercontent.com/14570016/54519504-9cec5c00-495e-11e9-99d1-81b378a008a4.png">

### Does this affect other platforms?
I've been careful that any necessary styling will still look good in apps/amp and make semantic sense.
