### PR TITLE
Pass main media video (Youtube) atoms as elements in dotcom-rendering data model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -207,6 +207,7 @@ object DotcomponentsDataModel {
   def fromArticle(articlePage: ArticlePage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
 
     val article = articlePage.article
+    val atoms = article.content.atoms.flatMap(_.all)
 
     // TODO this logic is duplicated from the cleaners, can we consolidate?
     val shouldAddAffiliateLinks = AffiliateLinksCleaner.shouldAddAffiliateLinks(
@@ -223,7 +224,8 @@ object DotcomponentsDataModel {
       val elems = capiElems.toList.flatMap(el => PageElement.make(
         element = el,
         addAffiliateLinks = affiliateLinks,
-        pageUrl = request.uri
+        pageUrl = request.uri,
+        atoms = atoms
       ))
 
       addDisclaimer(elems, capiElems)

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,6 +11,7 @@ import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import controllers.ArticlePage
 import model.SubMetaLinks
+import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
 import model.meta._
 import navigation.NavMenu
@@ -207,7 +208,7 @@ object DotcomponentsDataModel {
   def fromArticle(articlePage: ArticlePage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
 
     val article = articlePage.article
-    val atoms = article.content.atoms.flatMap(_.all)
+    val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
 
     // TODO this logic is duplicated from the cleaners, can we consolidate?
     val shouldAddAffiliateLinks = AffiliateLinksCleaner.shouldAddAffiliateLinks(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -194,7 +194,7 @@ object PageElement {
           mediaAtom.activeAssets.headOption.map(asset => {
             YoutubeBlockElement(
               mediaAtom.id, //CAPI ID
-              asset.id,
+              asset.id, // Youtube ID
               mediaAtom.channelId, //Channel ID
               mediaAtom.title //Caption
             )

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -195,8 +195,9 @@ object PageElement {
                 asset.id,
                 mediaAtom.channelId, //Channel ID
                 mediaAtom.title //Caption
-              ) //is this atom the main media (alex: not anymore it's not)
+              )
             })
+          case _ => UnknownBlockElement(None)
         }
       }).flatten.toList
 
@@ -279,6 +280,7 @@ object PageElement {
   implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
   implicit val SoundCloudBlockElementWrites: Writes[SoundcloudBlockElement] = Json.writes[SoundcloudBlockElement]
   implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]
+  implicit val YoutubeBlockElementEWrites: Writes[YoutubeBlockElement] = Json.writes[YoutubeBlockElement]
   implicit val PullquoteBlockElementWrites: Writes[PullquoteBlockElement] = Json.writes[PullquoteBlockElement]
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
   implicit val CommentBlockElementWrites: Writes[CommentBlockElement] = Json.writes[CommentBlockElement]


### PR DESCRIPTION
## What does this change?

Extract and pass video elements and youtube block elements to Dotcom-rendering (AMP) in data model.

Purely a change to the Dotcom-rendering data model.

(Raising on behalf on others, but I haven't done the work on this, just tested.)
