### PR TITLE
Update public profile name

### DIFF
--- a/docs/03-dev-howtos/22-access-preview-locally.md
+++ b/docs/03-dev-howtos/22-access-preview-locally.md
@@ -2,5 +2,6 @@ Access Preview Locally
 ====================================
 
 - Add `content.api.preview.iam.host="Ping @Dotcom room for value"` to your `devOverrides` in `frontend.conf`
+- Make sure you have CAPI API Gateway invocation credentials from Janus, which is available to all who have frontend dev permissions
 - Run the preview app (`project preview`)
 - Access articles in preview CAPI (Created in Composer but not yet published)

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -40,13 +40,10 @@ class PublicProfileController(
           NotFound(views.html.errors._404())
 
         case Right(user) =>
-          // When a user signs up through profile.theguardian.com with an email address,
-          // their display name is first name, last name and their username is empty.
-          // If they go to comment, they are prompted to set a username which is used as the display name.
+          // When a user goes to comment, they are prompted to set a username which is used as the display name.
           // Since the user has publicised this information (via commenting), we are ok making it public too.
-          //
           // Conversely if username hasn't been set, we don't want to use their display name,
-          // since it could be (by default) first name, last name; something the user might not want displayed.
+          // since it is something the user might not want made public.
           // In these cases, default to using their identity id instead of e.g. a not found response.
           // This behaviour means that in edge cases where a user has commented but hasn't got a username
           // (possible on e.g. apps) and someone has clicked through on their profile from comments,

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -8,27 +8,30 @@
 
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--stretched">
     <div class="identity-layout__header">
-        <div class="user-profile u-cf">
-            <div class="identity-title identity-title--public-profile">
-                <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
-                <div class="user-profile__rows">
-                    <h1 class="user-profile__name" data-userid="@user.id">@user.publicFields.displayName</h1>
-                    @user.dates.accountCreatedDate.map { accountCreatedDate =>
-                        <p class="user-profile__last-seen">
-                            Registered on @accountCreatedDate.toString("d MMM yyyy")
-                        </p>
-                    }
+
+        @user.publicFields.username.map { username =>
+            <div class="user-profile u-cf">
+                <div class="identity-title identity-title--public-profile">
+                    <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
+                    <div class="user-profile__rows">
+                        <h1 class="user-profile__name" data-userid="@user.id">@username</h1>
+                        @user.dates.accountCreatedDate.map { accountCreatedDate =>
+                            <p class="user-profile__last-seen">
+                                Registered on @accountCreatedDate.toString("d MMM yyyy")
+                            </p>
+                        }
+                    </div>
                 </div>
+                @user.publicFields.aboutMe.map { aboutMe =>
+                    <div class="user-profile__about">
+                        <p>@aboutMe</p>
+                        @user.publicFields.interests.filter(_!="").map{ interests =>
+                            <p><b>Interests:</b> @interests</p>
+                        }
+                    </div>
+                }
             </div>
-            @user.publicFields.aboutMe.map{ aboutMe =>
-                <div class="user-profile__about">
-                    <p>@aboutMe</p>
-                    @user.publicFields.interests.filter(_!="").map{ interests =>
-                        <p><b>Interests:</b> @interests</p>
-                    }
-                </div>
-            }
-        </div>
+        }
 
         <div class="modern-visible">
             @defining("/user/id/"+user.id){ link =>

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -31,6 +31,7 @@ class PublicProfileControllerTest extends path.FreeSpec
   val user = User("test@example.com", userId,
     publicFields = PublicFields(
       displayName = Some("John Smith"),
+      username = Some("John Smith"),
       aboutMe = Some("I read the Guardian"),
       location = Some("London"),
       interests = Some("I like stuff"),
@@ -63,8 +64,8 @@ class PublicProfileControllerTest extends path.FreeSpec
       }
 
       val content = contentAsString(result)
-      "then rendered profile should include display name" in {
-        content should include(user.publicFields.displayName.get)
+      "then rendered profile should include username" in {
+        content should include(user.publicFields.username.get)
       }
       "then rendered profile should include account creation date" in {
         content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
@@ -92,8 +93,8 @@ class PublicProfileControllerTest extends path.FreeSpec
       }
 
       val content = contentAsString(result)
-      "then rendered profile should include display name" in {
-        content should include(user.publicFields.displayName.get)
+      "then rendered profile should include username" in {
+        content should include(user.publicFields.username.get)
       }
       "then rendered profile should include account creation date" in {
         content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
@@ -108,16 +109,20 @@ class PublicProfileControllerTest extends path.FreeSpec
       }
     }
 
-    "with no display name for the specified user" - {
-      val guestUser = user.copy(publicFields = user.publicFields.copy(displayName = None))
+    "with no username for the specified user" - {
+      val guestUser = user.copy(publicFields = user.publicFields.copy(username = None))
       when(api.userFromVanityUrl(MockitoMatchers.anyString, MockitoMatchers.any[Auth])) thenReturn Future.successful(Left(Nil))
       when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(guestUser))
       val result = controller.renderProfileFromVanityUrl(vanityUrl, "discussions")(request)
 
-      "then should return status 404" in {
-        status(result) should be(404)
+      "then should return status 200" in {
+        status(result) should be(200)
+      }
+
+      "then should omit the profile section with the user's username" in {
+        val content = contentAsString(result)
+        content should not include """<div class="user-profile u-cf">"""
       }
     }
   }
-
 }


### PR DESCRIPTION
## What does this change?
Use username instead of display name for public profile; omit the top section if the username has not been set.

### Username
<img width="1259" alt="username" src="https://user-images.githubusercontent.com/4085817/54605860-2d4f9d00-4a42-11e9-85f1-b145ba436608.png">

### No username
<img width="1255" alt="no_username" src="https://user-images.githubusercontent.com/4085817/54605875-36406e80-4a42-11e9-92a4-543de6aaab66.png">

Alternative ways to handle username not being set:
- return not found for such users
    - pros: simple
    - cons: if a user has commented without a username and someone clicks on this user in the comments section, they'll get a not found response
- make a server side call to discussion API to see if a user has made comments, in which case use the display name, otherwise return a not found response
    - pros: in the case where a user has no username but has commented and someone clicks on their profile in the comments section, they'll see a comment history display name matching the respective comment
    - cons: server-side call to discussion API; more complicated implementation

Could people let me know if they're ok with the current solution, in which case I'll update the affected tests; otherwise, please let me know if you think one of the other solutions is preferable.