### PR TITLE
Upgrade bootstrap-sass from 3.3.7 to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
-    "bootstrap-sass": "^3.3.7",
+    "bootstrap-sass": "^3.4.1",
     "classnames": "~2.2.0",
     "core-js": "^2.5.3",
     "curl": "cujojs/curl#0.8.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,9 +2157,9 @@ bonzo@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bonzo/-/bonzo-2.0.0.tgz#a871618120acb62d891268377fff809162d159a0"
 
-bootstrap-sass@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
+bootstrap-sass@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz#6843c73b1c258a0ac5cb2cc6f6f5285b664a8e9a"
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
## What does this change?

Upgrade bootstrap-sass from 3.3.7 to 3.4.1

Mostly motivated by a security warning:

![Screenshot 2019-03-18 at 17 46 59](https://user-images.githubusercontent.com/6035518/54551598-4efb4680-49a6-11e9-8977-b86b3ec99f31.png)
