### PR TITLE
Updating Banner Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,9 +28,9 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-february-moment-banner-copy",
+    "ab-february-moment-banner-copy-more-people",
     "switch on to test the some moment copy on the fiv engagement banner",
-    owners = Seq(Owner.withGithub("jranks123")),
+    owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 9, 30),
     exposeClientSide = true

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-fiv.js
@@ -50,9 +50,6 @@ export const acquisitionsBannerFivTemplate = (
                 }">
                     ${params.buttonCaption}
                 </a>
-                <a class="button engagement-banner__button engagement-banner__button__learn-more js-engagement-banner-close-button js-site-message-close" href="https://www.theguardian.com/membership/2019/feb/20/katharine-viner-qanda-journalists-readers-guardian-future?INTCMP=fiv_banner">
-                    Learn more
-                </a>
             </div>
         </div>
     </div>

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -7,7 +7,7 @@ import { askFourEarning } from 'common/modules/experiments/tests/contributions-e
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import {
-    februaryMomentBannerCopy,
+    februaryMomentBannerCopyMorePeople,
     februaryMomentBannerThankYou,
 } from 'common/modules/experiments/tests/february-moment-banner';
 
@@ -25,6 +25,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    februaryMomentBannerCopy,
+    februaryMomentBannerCopyMorePeople,
     februaryMomentBannerThankYou,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/february-moment-banner.js
@@ -5,11 +5,11 @@ import { canShowBannerSync } from 'common/modules/commercial/contributions-utili
 
 const defaultBold =
     'This is The\xa0Guardian’s model for open, independent journalism';
-const defaultCopy =
-    'Our mission is to keep independent journalism accessible to everyone, regardless of where they live or what they can afford. Funding from our readers safeguards our editorial independence. It also powers our work and maintains this openness. It means more people, across the world, can access accurate information with integrity at its heart.';
 
-const variantCopy =
+const defaultCopy =
     'Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, The Guardian’s editorial independence is safeguarded by our readers. If you’re able to, please support The Guardian today.';
+const variantCopy =
+    'More people around the world are reading The Guardian’s independent, investigative reporting than ever before and we’ve now been funded by over one million readers. Thanks to this essential support, we’re able to keep all of our journalism open for everyone, at a time when factual reporting is critical. If you’re able to, please support The Guardian today – so more people, across the world, can access accurate information with integrity at its heart.';
 
 const thankYouBold =
     'Thank you for supporting The\xa0Guardian’s model for open, independent journalism';
@@ -44,11 +44,11 @@ const bannerShownCallback = () => {
     }
 };
 
-export const februaryMomentBannerCopy: AcquisitionsABTest = {
-    id: 'FebruaryMomentBannerCopy',
-    start: '2019-03-11',
+export const februaryMomentBannerCopyMorePeople: AcquisitionsABTest = {
+    id: 'FebruaryMomentBannerCopyMorePeople',
+    start: '2019-03-18',
     expiry: '2019-09-30',
-    author: 'Jonathan Rankin',
+    author: 'Joshua Lieberman',
     description:
         'test some moment specific copy on fiv moment engagement banner',
     audience: 1,

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -478,12 +478,7 @@ $wide-circle-height: 162px;
         color: $brightness-100;
         border:  $brand-main 1px solid;
     }
-
-    .engagement-banner__button.engagement-banner__button__learn-more {
-        background-color: $highlight-main;
-        border:  $brand-main 1px solid;
-        color: $brand-main;
-    }
+    
 
     @supports (mix-blend-mode: multiply) {
         .fiv-banner__circle {

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -73,11 +73,6 @@ $border-style: $brightness-60 1px solid;
         }
     }
 
-    .engagement-banner__button.engagement-banner__button__learn-more {
-        background-color: $culture-faded;
-        border: $border-style;
-    }
-
     .engagement-banner__roundel {
         display: inline-block;
     }
@@ -419,12 +414,6 @@ $wide-circle-height: 162px;
 
     }
 
-    .engagement-banner__button.engagement-banner__button__learn-more {
-        background-color: $sport-main;
-        border: $border-style-blue;
-        color: $brightness-100;
-    }
-
     @supports (mix-blend-mode: difference) {
         .fiv-banner__circle {
             mix-blend-mode: difference;
@@ -478,7 +467,6 @@ $wide-circle-height: 162px;
         color: $brightness-100;
         border:  $brand-main 1px solid;
     }
-    
 
     @supports (mix-blend-mode: multiply) {
         .fiv-banner__circle {


### PR DESCRIPTION
## What does this change?
Banner variant copy increased revenue by 20% so we are switching it to the default and testing it against a new variant. We are also removing the "Learn more" button as part of this.

## Screenshots
New Control:
<img width="1328" alt="FebruaryMomentBanner2_control" src="https://user-images.githubusercontent.com/3300789/54604428-9c2af700-4a3e-11e9-8f1d-5a3d9b66871c.png">

New Variant:
<img width="1437" alt="FebruaryMomentBanner2_variant" src="https://user-images.githubusercontent.com/3300789/54604483-ba90f280-4a3e-11e9-9663-a3691013cff3.png">


## What is the value of this and can you measure success?
This is an A/B test so yes, we will know if it is a success.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [X] Other (please specify): RR/Contributions

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
