### PR TITLE
Add rendering-platform key-value to ad call

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -202,6 +202,7 @@ const buildPageTargeting = once(
                     : undefined,
                 cc: geolocationGetSync(),
                 s: page.section, // for reference in a macro, so cannot be extracted from ad unit
+                pr: 'dotcom-platform', // rendering platform
             },
             page.sharedAdTargeting,
             paTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -151,6 +151,7 @@ describe('Build Page Targeting', () => {
         expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
         expect(pageTargeting.pa).toEqual(undefined);
         expect(pageTargeting.cc).toEqual('US');
+        expect(pageTargeting.pr).toEqual('dotcom-platform');
     });
 
     it('should set correct personalized ad (pa) param', () => {
@@ -216,6 +217,7 @@ describe('Build Page Targeting', () => {
             pv: '123456',
             fr: '0',
             cc: 'US',
+            pr: 'dotcom-platform',
         });
     });
 


### PR DESCRIPTION
This change will allow us to distinguish between ad impressions on the legacy platform and on the new dotcom-rendering platform.  It sends a platform-identifying parameter in ad calls, which can then be used for reporting in Ad Manager and the data lake.

See also:
* https://github.com/guardian/dotcom-rendering/pull/443
* https://github.com/guardian/frontend/pull/21243
