### PR TITLE
Filter out unsupported main media

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -4,6 +4,7 @@ import common.Logging
 import controllers.ArticlePage
 import implicits.Requests._
 import model.PageWithStoryPackage
+import model.dotcomrendering.pageElements.YoutubeBlockElement
 import model.liveblog._
 import play.api.mvc.RequestHeader
 
@@ -38,6 +39,21 @@ object AMPPageChecks extends Logging {
       case None => true
     }
   }
+
+  def hasOnlySupportedMainElements(page: PageWithStoryPackage): Boolean = {
+    def supported(block: BlockElement): Boolean = block match {
+      case _: ImageBlockElement => true
+      case _: YoutubeBlockElement => true
+      case _ => false
+    }
+
+    val areSupported = for {
+      blocks <- page.article.blocks
+      main <- blocks.main
+    } yield main.elements.forall(supported)
+
+    areSupported.getOrElse(true)
+  }
 }
 
 object AMPPicker {
@@ -52,6 +68,7 @@ object AMPPicker {
     Map(
       ("isBasicArticle", AMPPageChecks.isBasicArticle(page)),
       ("hasOnlySupportedElements", AMPPageChecks.hasOnlySupportedElements(page)),
+      ("hasOnlySupportedMainElements", AMPPageChecks.hasOnlySupportedMainElements(page)),
       ("isNotPaidContent", AMPPageChecks.isNotPaidContent(page)),
     )
   }


### PR DESCRIPTION
## What does this change?

Prevents us serving content with main media that is not yet supported for AMP dotcom-rendering.

Note, we will need to amend this when https://github.com/guardian/frontend/pull/21263 is merged in.