### PR TITLE
Update DotComponents datamodel

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -80,7 +80,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   }
 
   private def getGuuiJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String =
-    DotcomponentsDataModel.toJsonString(DotcomponentsDataModel.fromArticle(article, request, blocks))
+    DotcomponentsDataModel.toJsonString(DotcomponentsDataModel.fromArticle(article, request, blocks, context))
 
   private def render(path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
     Future {

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -485,7 +485,7 @@ object DotcomponentsDataModel {
         article.content.showInRelated,
         article.trail.isCommentable,
         linkedData,
-        jsConfigOptionBoolean("hasShowcaseMainElement").getOrElse(false),
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("hasShowcaseMainElement", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
@@ -495,7 +495,7 @@ object DotcomponentsDataModel {
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("revisionNumber", JsString("")).as[String],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("shouldHideReaderRevenue", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("showNewRecipeDesign", JsBoolean(false)).as[Boolean],
-        jsConfigOptionBoolean("showRelatedContent").getOrElse(false),
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("showRelatedContent", JsBoolean(false)).as[Boolean],
       ),
     )
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -19,7 +19,7 @@ import navigation.UrlHelpers._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, FourByThree, GUDateTimeFormat, ImgSrc, Item1200, OneByOne, GoogleAnalyticsAccount}
+import views.support.{AffiliateLinksCleaner, CamelCase, FourByThree, GUDateTimeFormat, ImgSrc, Item1200, Item300, OneByOne, GoogleAnalyticsAccount}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
 import common.Maps.RichMap
 import navigation.UrlHelpers.{AmpFooter, AmpHeader}

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -297,6 +297,7 @@ object DotcomponentsDataModel {
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
+    val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
     val jsPageData = Configuration.javascript.pageData mapKeys { key =>
       CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,8 +9,8 @@ import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import controllers.ArticlePage
-import model.SubMetaLinks
 import model.content.Atom
+import model.{Page, SubMetaLinks}
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
 import model.meta._
 import navigation.NavMenu
@@ -21,6 +21,12 @@ import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.{AffiliateLinksCleaner, CamelCase, FourByThree, GUDateTimeFormat, ImgSrc, Item1200, OneByOne, GoogleAnalyticsAccount}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
+import common.Maps.RichMap
+import navigation.UrlHelpers.{AmpFooter, AmpHeader}
+import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl}
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
+import model.meta.{Guardian, LinkedData, PotentialAction}
+import views.support.JavaScriptPage
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -97,6 +103,7 @@ case class Commercial(
   editionCommercialProperties: Map[String, EditionCommercialProperties],
   prebidIndexSites: List[PrebidIndexSite],
   commercialProperties: Option[CommercialProperties], //DEPRECATED TO DELETE
+  hbImpl: String
 )
 
 case class GoogleAnalyticsTrackers(
@@ -281,7 +288,7 @@ object DotcomponentsDataModel {
     }
 
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
-
+    
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
     val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
@@ -428,6 +435,7 @@ object DotcomponentsDataModel {
         sites <- commercial.prebidIndexSites
       } yield sites.toList).getOrElse(List()),
       article.metadata.commercial,
+      JavaScriptPage.getMap(articlePage, Edition(request), false).get("hbImpl").map(_.as[String]).getOrElse("none")
     )
 
     val content = DCPage(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -298,7 +298,6 @@ object DotcomponentsDataModel {
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
-    val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
     val jsPageData = Configuration.javascript.pageData mapKeys { key =>
       CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -71,7 +71,8 @@ case class Meta(
   hasStoryPackage: Boolean,
   hasRelated: Boolean,
   isCommentable: Boolean,
-  linkedData: List[LinkedData]
+  linkedData: List[LinkedData],
+  hasShowcaseMainElement: Boolean
 )
 
 case class Tags(
@@ -282,7 +283,7 @@ object DotcomponentsDataModel {
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
-
+    val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
     val jsPageData = Configuration.javascript.pageData mapKeys { key =>
       CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))
@@ -465,7 +466,8 @@ object DotcomponentsDataModel {
         articlePage.related.hasStoryPackage,
         article.content.showInRelated,
         article.trail.isCommentable,
-        linkedData
+        linkedData,
+        jsConfigOptionBoolean("hasShowcaseMainElement").getOrElse(false)
       )
     )
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -112,8 +112,7 @@ case class Commercial(
   editionCommercialProperties: Map[String, EditionCommercialProperties],
   prebidIndexSites: List[PrebidIndexSite],
   commercialProperties: Option[CommercialProperties], //DEPRECATED TO DELETE
-  hbImpl: String,
-  isHosted: Boolean
+  hbImpl: String
 )
 
 case class GoogleAnalyticsTrackers(
@@ -164,7 +163,7 @@ case class DCPage(
   webURL: String,
   starRating: Option[Int],
   commercial: Commercial,
-  meta: Meta,
+  meta: Meta
 )
 
 // the composite data model
@@ -444,8 +443,7 @@ object DotcomponentsDataModel {
         sites <- commercial.prebidIndexSites
       } yield sites.toList).getOrElse(List()),
       article.metadata.commercial,
-      JavaScriptPage.getMap(articlePage, Edition(request), false).get("hbImpl").map(_.as[String]).getOrElse("none"),
-      JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isHosted", JsBoolean(false)).as[Boolean]
+      JavaScriptPage.getMap(articlePage, Edition(request), false).get("hbImpl").map(_.as[String]).getOrElse("none")
     )
 
     val content = DCPage(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -154,7 +154,8 @@ case class DCPage(
   webURL: String,
   starRating: Option[Int],
   commercial: Commercial,
-  meta: Meta
+  meta: Meta,
+  isFront: Boolean
 )
 
 // the composite data model
@@ -288,7 +289,7 @@ object DotcomponentsDataModel {
     }
 
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
-    
+
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
     val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
@@ -476,7 +477,8 @@ object DotcomponentsDataModel {
         article.trail.isCommentable,
         linkedData,
         jsConfigOptionBoolean("hasShowcaseMainElement").getOrElse(false)
-      )
+      ),
+      JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean]
     )
 
     DotcomponentsDataModel(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -103,7 +103,8 @@ case class Commercial(
   editionCommercialProperties: Map[String, EditionCommercialProperties],
   prebidIndexSites: List[PrebidIndexSite],
   commercialProperties: Option[CommercialProperties], //DEPRECATED TO DELETE
-  hbImpl: String
+  hbImpl: String,
+  isHosted: Boolean
 )
 
 case class GoogleAnalyticsTrackers(
@@ -436,7 +437,8 @@ object DotcomponentsDataModel {
         sites <- commercial.prebidIndexSites
       } yield sites.toList).getOrElse(List()),
       article.metadata.commercial,
-      JavaScriptPage.getMap(articlePage, Edition(request), false).get("hbImpl").map(_.as[String]).getOrElse("none")
+      JavaScriptPage.getMap(articlePage, Edition(request), false).get("hbImpl").map(_.as[String]).getOrElse("none"),
+      JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isHosted", JsBoolean(false)).as[Boolean]
     )
 
     val content = DCPage(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -138,7 +138,6 @@ case class DCSite(
   nav: NavMenu,
   readerRevenueLinks: ReaderRevenueLinks,
   commercialUrl: String,
-  assetsPath: String,
   googleAnalytics: GoogleAnalytics
 )
 
@@ -421,7 +420,6 @@ object DotcomponentsDataModel {
       navMenu,
       readerRevenueLinks,
       buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
-      Configuration.assets.path,
       googleAnalytics
     )
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -110,7 +110,8 @@ case class DCSite(
   subscribeWithGoogleApiUrl: String,
   nav: NavMenu,
   readerRevenueLinks: ReaderRevenueLinks,
-  commercialUrl: String
+  commercialUrl: String,
+  assetsPath: String
 )
 
 case class DCPage(
@@ -375,7 +376,8 @@ object DotcomponentsDataModel {
       Configuration.google.subscribeWithGoogleApiUrl,
       navMenu,
       readerRevenueLinks,
-      buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
+      buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
+      Configuration.assets.path
     )
 
     val tags = Tags(
@@ -434,7 +436,7 @@ object DotcomponentsDataModel {
         article.content.showInRelated,
         article.trail.isCommentable,
         linkedData
-      ),
+      )
     )
 
     DotcomponentsDataModel(

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -297,7 +297,6 @@ object DotcomponentsDataModel {
     val dcBlocks = Blocks(mainBlock, bodyBlocks)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
-    val jsConfigOptionBoolean = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[Boolean])
 
     val jsPageData = Configuration.javascript.pageData mapKeys { key =>
       CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -159,10 +159,18 @@ case class DCPage(
   isFront: Boolean
 )
 
+// This class is introduce only because the problem of extending the existing DCPage to more than 22 parameters
+// Once this problem has been solved, DCPage and DCPage2 should e merged. More precisely the attributes of
+// DCPage2 should be added to DCPage
+case class DCPage2(
+  isLiveBlog: Boolean
+)
+
 // the composite data model
 
 case class DotcomponentsDataModel(
   page: DCPage,
+  page2: DCPage2,
   site: DCSite,
   version: Int
 )
@@ -218,6 +226,10 @@ object GoogleAnalytics {
 
 object DCPage {
   implicit val writes = Json.writes[DCPage]
+}
+
+object DCPage2 {
+  implicit val writes = Json.writes[DCPage2]
 }
 
 object DCSite {
@@ -483,8 +495,11 @@ object DotcomponentsDataModel {
       JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean]
     )
 
+      val content2 = DCPage2(true)
+
     DotcomponentsDataModel(
       content,
+      content2,
       site,
       VERSION
     )
@@ -498,6 +513,7 @@ object DotcomponentsDataModel {
     implicit val DotComponentsDataModelWrites = new Writes[DotcomponentsDataModel] {
       def writes(model: DotcomponentsDataModel) = Json.obj(
         "page" -> model.page,
+        "page2" -> model.page2,
         "site" -> model.site,
         "version" -> model.version
       )

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -81,8 +81,13 @@ case class Meta(
   isFront: Boolean,
   isLiveblog: Boolean,
   isMinuteArticle: Boolean,
-  isPaidContent: Boolean
-
+  isPaidContent: Boolean,
+  isPreview: Boolean,
+  isSensitive: Boolean,
+  revisionNumber: String,
+  shouldHideReaderRevenue: Boolean,
+  showNewRecipeDesign: Boolean,
+  showRelatedContent: Boolean
 )
 
 case class Tags(
@@ -484,7 +489,13 @@ object DotcomponentsDataModel {
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
         JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
-        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean]
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
+        context.isPreview,
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("isSensitive", JsBoolean(false)).as[Boolean],
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("revisionNumber", JsString("")).as[String],
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("shouldHideReaderRevenue", JsBoolean(false)).as[Boolean],
+        JavaScriptPage.getMap(articlePage, Edition(request), false).getOrElse("showNewRecipeDesign", JsBoolean(false)).as[Boolean],
+        jsConfigOptionBoolean("showRelatedContent").getOrElse(false),
       ),
     )
 

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.model.v1.Blocks
 import com.osinka.i18n.Lang
 import conf.Configuration
 import controllers.ArticlePage
-import model.Cached
+import model.{ApplicationContext, Cached}
 import model.Cached.RevalidatableResult
 import model.dotcomponents.DotcomponentsDataModel
 import play.api.libs.json._
@@ -53,8 +53,8 @@ class RemoteRenderer {
   }
 
 
-  def getAMPArticle(ws: WSClient, payload: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
+  def getAMPArticle(ws: WSClient, payload: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks, context)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {
@@ -64,8 +64,8 @@ class RemoteRenderer {
 
   }
 
-  def getArticle(ws:WSClient, path: String, article: ArticlePage,  blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
+  def getArticle(ws:WSClient, path: String, article: ArticlePage,  blocks: Blocks)(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks, context)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -27,7 +27,7 @@ class FakePicker extends RenderingTierPicker {
 }
 
 class FakeRemoteRender(implicit context: ApplicationContext) extends renderers.RemoteRenderer {
-  override def getArticle(ws:WSClient, path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+  override def getArticle(ws:WSClient, path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(Cached(article)(RevalidatableResult.Ok(Html("OK"))))
   }


### PR DESCRIPTION
The purpose of this change is to update the DotComponents datamodel in frontend to add to it the information that we now know dotcom-rendering will be using for the commercial module. 

The object we need to update is essentially `DotcomponentsDataModel` which comes in two parts `DCPage` and `DCSite`. 

The following mapping show on the left hand side, keys of the `window.guardian.config` we have identified are being queried by the commercial bundle and on the right hand side where they appear in  `DotComponentsDataModel` and, when relevant, where they come from.

For instance:
 
```
page.assetsPath -> DCPage.assetsPath
```

means that attribute `window.guardian.config.page.assetsPath` in `dotcom-rendering` is now retrieved from `DCPage.assetsPath`.

```
googleAnalytics-> DCSite.googleAnalytics **

ophan.pageViewId # Added client

page.ajaxUrl -> DCSite.ajaxUrl
page.commentable -> DCPage.meta.isCommentable
page.contentType -> DCPage.contentType
page.disableStickyTopBanner # `false` value for the moment
page.edition -> DCPage.editionId
page.hasShowcaseMainElement -> DCPage.meta.hasShowcaseMainElement
page.hbImpl -> Commercial.hbImpl **
page.isDev -> !Configuration.environment.isProd 
page.isFront -> DCPage.meta.isCommentable
page.isHosted -> DCPage.meta.isHosted
page.isLiveBlog -> DCPage.meta.isLiveBlog **
page.isMinuteArticle -> DCPage.meta.isMinuteArticle ** 
page.isPaidContent -> DCPage.meta.isPaidContent ** 
page.isPreview -> DCPage.meta.isPreview ** 
page.isSensitive -> DCPage.meta.isSensitive **
page.pageId -> DCPage.pageId
page.revisionNumber -> DCPage.meta.revisionNumber **
page.section -> DCPage.section
page.shouldHideAdverts -> DCPage.meta shouldHideAdverts **
page.shouldHideReaderRevenue -> DCPage.meta shouldHideReaderRevenue **
page.showNewRecipeDesign -> DCPage.meta.showNewRecipeDesign **
page.showRelatedContent -> DCPage.meta.showRelatedContent **

switches -> DCSite.switches
```

** New property added in this PR.
