### PR TITLE
Send Ozone customData as a regular JSON object

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -378,10 +378,7 @@ const ozoneClientSideBidder: PrebidBidder = {
                 publisherId: 'OZONENUK0001', // test ID
                 siteId: '4204204201', // test ID
                 placementId: '0420420421', // test ID
-                customData: {
-                    keywords: PAGE_TARGETING,
-                    customParams: PAGE_TARGETING,
-                },
+                customData: PAGE_TARGETING,
                 ozoneData: {}, // TODO: confirm if we need to send any
             }))(),
             window.OzoneLotameData ? { lotameData: window.OzoneLotameData } : {}


### PR DESCRIPTION
## What does this change?

Send page targeting as the value of `customData` based on third-party feedback:

<img width="748" alt="Screenshot 2019-03-19 at 16 08 04" src="https://user-images.githubusercontent.com/8607683/54622286-3d2aa980-4a61-11e9-9030-b080795f8deb.png">


## What is the value of this and can you measure success?

Allow further third-party integration testing.

Commercial BAU: https://trello.com/c/eOnbioKJ

## Checklist

🥚 🐣 🐥 

🌱 🌻 
