### PR TITLE
Remove unused Tourism Australia switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -78,16 +78,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val TourismAustraliaSwitch = Switch(
-    Commercial,
-    "tourism-australia",
-    "If this switch is on, the Tourism Australia pixel is added to the Ashes Australia travel section.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-  )
-
   val ImrWorldwideSwitch = Switch(
     Commercial,
     "imr-worldwide",


### PR DESCRIPTION
## What does this change?
Removes unused Tourism Australia switch

## What is the value of this and can you measure success?
One less switch that's not used

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
