### PR TITLE
Numbered list main media

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -23,9 +23,9 @@
         <article id="article" data-test-id="article-root"
 
         class="@RenderClasses(Map(
-            "has-feature-showcase-element" -> (!article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isColumn),
-            "has-feature-showcase-opinion" -> (article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isColumn),
-            "content--type-column" -> article.content.isColumn,
+            "has-feature-showcase-element" -> (!article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isSplash),
+            "has-feature-showcase-opinion" -> (article.tags.isComment && article.elements.hasShowcaseMainElement && !article.content.isSplash),
+            "content--type-splash" -> article.content.isSplash,
             "content--type-numbered-list" -> article.content.isNumberedList,
             "paid-content" -> isPaidContent,
             "content--pillar-special-report" -> (toneClass(article) == "tone-special-report")
@@ -57,7 +57,7 @@
 
 
                         @if(!isPaidContent) {
-                            @if(article.content.isColumn) {
+                            @if(article.content.isSplash) {
                                 @fragments.articleHeaderColumn(article, model, amp = amp)
                             } else if(article.metadata.designType.nameOrDefault == "comment" ||
                                     article.metadata.designType.nameOrDefault == "guardianview") {
@@ -76,7 +76,7 @@
                                 @fragments.mainMedia(article, amp)
                             }
 
-                            @if(article.content.isColumn){
+                            @if(article.content.isSplash){
                                 @fragments.contentMeta(article, model, amp = amp)
                             }
 

--- a/article/app/views/fragments/articleHeaderColumn.scala.html
+++ b/article/app/views/fragments/articleHeaderColumn.scala.html
@@ -6,13 +6,13 @@
 @import _root_.model.ContentDesignType.RichContentDesignType
 
 
-<header class="content__head content__head--column content__head--article tonal__head tonal__head--@toneClass(article)
+<header class="content__head content__head--splash content__head--article tonal__head tonal__head--@toneClass(article)
 @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") { content__head--byline-pic}">
     @fragments.mainMedia(article, amp)
 
     @fragments.meta.metaInline(article, amp)
 
-    <div class="content__headline-splash-wrapper content__headline-splash-wrapper--column">
+    <div class="content__headline-splash-wrapper">
         <div class="content__header tonal__header u-cf">
             <h1 class="content__headline content__headline--splash @if(article.content.hasTonalHeaderByline) {content__headline--no-margin-bottom}" articleprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)

--- a/article/app/views/fragments/articleHeaderColumn.scala.html
+++ b/article/app/views/fragments/articleHeaderColumn.scala.html
@@ -12,9 +12,9 @@
 
     @fragments.meta.metaInline(article, amp)
 
-    <div class="content__headline-column-wrapper content__headline-column-wrapper--column">
+    <div class="content__headline-splash-wrapper content__headline-splash-wrapper--column">
         <div class="content__header tonal__header u-cf">
-            <h1 class="content__headline content__headline--column @if(article.content.hasTonalHeaderByline) {content__headline--no-margin-bottom}" articleprop="headline" @langAttributes(article.content)>
+            <h1 class="content__headline content__headline--splash @if(article.content.hasTonalHeaderByline) {content__headline--no-margin-bottom}" articleprop="headline" @langAttributes(article.content)>
                 @Html(article.trail.headline)
             </h1>
 
@@ -24,7 +24,7 @@
 
             @if(article.content.hasTonalHeaderByline) {
                 @article.trail.byline.map { text =>
-                    <span class="content__headline content__headline--byline content__headline--column">@ContributorLinks(text, article.tags.contributors)</span>
+                    <span class="content__headline content__headline--byline content__headline--splash">@ContributorLinks(text, article.tags.contributors)</span>
                 }
             }
 

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -57,7 +57,7 @@
                     if(article.lightbox.isMainMediaLightboxable) Some(1) else None,
                     article.elements.hasShowcaseMainElement,
                     article.tags.isFeature,
-                    article.content.isColumn,
+                    article.content.isSplash,
                     MainMediaWidths(article),
                     amp = amp
                 )

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -80,6 +80,7 @@ final case class Content(
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
   lazy val isNumberedList = fields.displayHint.contains("splash")
+  lazy val isSplash = fields.displayHint.contains("column") || fields.displayHint.contains("splash")
   lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
@@ -258,6 +259,7 @@ final case class Content(
     ("isImmersive", JsBoolean(isImmersive)),
     ("isColumn", JsBoolean(isColumn)),
     ("isNumberedList", JsBoolean(isNumberedList)),
+    ("isSplash", JsBoolean(isSplash)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
     ("contributorBio", JsString(contributorBio.getOrElse("")))
@@ -471,6 +473,7 @@ object Article {
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isColumn", JsBoolean(content.isColumn)),
       ("isNumberedList", JsBoolean(content.isNumberedList)),
+      ("isSplash", JsBoolean(content.isSplash)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
       "videoDuration" -> videoDuration
     ) ++ bookReviewIsbn ++ AtomProperties(content.atoms)
@@ -544,6 +547,7 @@ final case class Article (
   val isPhotoEssay: Boolean = content.isPhotoEssay
   val isColumn: Boolean = content.isColumn
   val isNumberedList: Boolean = content.isNumberedList
+  val isSplash: Boolean = content.isSplash
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().asScala.headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -7,7 +7,7 @@
     lightboxIndex: Option[Int] = None,
     isShowcase: Boolean = false,
     isFeature: Boolean = false,
-    isColumn: Boolean = false,
+    isSplash: Boolean = false,
     widthsByBreakpoint: layout.WidthsByBreakpoint = MainMedia.inline,
     image_figureClasses: Option[(model.ImageAsset, String)] = None,
     shareInfo: Option[(Seq[model.ShareLink], DotcomContentType)] = None,
@@ -18,7 +18,7 @@
 
 @defining(image_figureClasses match {
     case Some((image, figureClasses)) => (Some(image), s"element element-image $figureClasses", false)
-    case None => (ImgSrc.getFallbackAsset(picture), s"media-primary media-content ${if(isShowcase && !isColumn) "media-primary--showcase"}", true)
+    case None => (ImgSrc.getFallbackAsset(picture), s"media-primary media-content ${if(isShowcase && !isSplash) "media-primary--showcase"}", true)
 } ) { case (imageOption, figureClasses, isMain) =>
 
     <figure
@@ -102,7 +102,7 @@
     @imageOption.map { img =>
         @if(img.showCaption) {
             @if(isMain) {
-                @if(!isColumn) {
+                @if(!isSplash) {
                     <input type="checkbox" id="show-caption" class="mobile-only u-h reveal-caption__checkbox">
 
                     <label class="mobile-only reveal-caption reveal-caption--img" for="show-caption">

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -8,7 +8,7 @@
         "content__labels--gallery" -> item.content.isGallery,
         "content__labels--paidgallery" -> (item.content.isGallery && item.content.isPaidContent || item.content.isPhotoEssay && item.content.isPaidContent),
         "content__labels--not-immersive" -> !item.content.isImmersive,
-        "content__labels--column" -> item.content.isColumn,
+        "content__labels--splash" -> item.content.isSplash,
         "content__labels--immersive" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || badgeFor(item).isDefined),
         "content__labels--panel" -> (item.content.isImmersive && item.content.blogOrSeriesTag.isDefined || item.content.isGallery && item.content.blogOrSeriesTag.isDefined),
         "content__labels--flagship"  -> item.tags.isAudio
@@ -28,7 +28,7 @@
         <div class="@RenderClasses(Map(
                 "content__series-label--immersive-article content__label" -> (item.content.isImmersive && item.content.tags.isArticle),
                 "content__series-label--photo-essay" -> item.content.isPhotoEssay,
-                "content__series-label--column" -> item.content.isColumn
+                "content__series-label--splash" -> item.content.isSplash
             ), "content__series-label content__label")
           ">
             <a class="content__label__link" href="@LinkTo {/@series.id}">
@@ -38,7 +38,7 @@
             </a>
         </div>
 
-        @if(item.content.isColumn && !amp) {
+        @if(item.content.isSplash && !amp) {
             <div class="content__series-cta">
                     @fragments.inlineSvg("arrow-right", "icon", List("content__series-cta__icon", "rounded-icon centered-icon"))
                     <span class="content__series-cta__text hide-until-leftcol">
@@ -66,7 +66,7 @@
               </a>
           </div>
         } else {
-            @if(!(item.content.isImmersive && item.content.tags.isArticle || item.content.isColumn || item.content.tags.isGallery)) {
+            @if(!(item.content.isImmersive && item.content.tags.isArticle || item.content.isSplash || item.content.tags.isGallery)) {
               <div class="content__section-label content__label">
                   <a class="content__label__link"
                       data-link-name="article section"

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -24,7 +24,7 @@
 @import 'module/_live-pulse';
 @import 'module/content-garnett/_article-immersive';
 @import 'module/content-garnett/_article-numbered-list';
-@import 'module/content-garnett/_article-column';
+@import 'module/content-garnett/_article-splash';
 @import 'module/content-garnett/_article-special-report';
 @import 'module/content-garnett/_article-minute';
 @import 'module/content-garnett/_gallery.head';

--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -1,4 +1,4 @@
-.content--pillar-special-report:not(.content--type-immersive):not(.content--media):not(.content--type-column) {
+.content--pillar-special-report:not(.content--type-immersive):not(.content--media):not(.content--type-splash) {
     background-color: #eff1f2;
 
     .content__headline--byline .tone-colour {

--- a/static/src/stylesheets/module/content-garnett/_article-splash.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-splash.scss
@@ -115,6 +115,11 @@
     .content__headline-standfirst-wrapper {
         @include mq(tablet) {
             padding-bottom: $gs-baseline * 2;
+
+            .content__standfirst {
+                font-size: 24px;
+                line-height: 28px;
+            }
         }
 
         @include mq(leftCol) {
@@ -142,8 +147,8 @@
         padding: 0;
 
         @include mq(tablet) {
-            font-size: 32px;
-            line-height: 36px;
+            font-size: 38px;
+            line-height: 40px;
         }
     }
 
@@ -188,7 +193,15 @@
 
         // Opinion layout with byline pic
         .content__head--byline-pic {
-            .content__headline-splash-wrapper--column {
+            .content__headline-splash-wrapper {
+                padding-bottom: 0;
+            }
+
+            .content__headline--byline {
+                @include mq($until: leftCol) {
+                    padding-right: gs-span(2);
+                }
+
                 padding-bottom: $gs-baseline * 3;
             }
 
@@ -201,10 +214,10 @@
             }
 
             .byline-img {
-                margin-bottom: -$gs-baseline * 3;
+                position: relative;
+                right: -30px;
 
                 @include mq(leftCol) {
-                    right: -30px;
                     position: absolute;
                 }
             }
@@ -239,6 +252,7 @@
     color: #ffffff;
     @include fs-textSans(5);
     font-weight: 700;
+    vertical-align: middle;
 }
 
 .content__series-cta__icon {

--- a/static/src/stylesheets/module/content-garnett/_article-splash.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-splash.scss
@@ -39,7 +39,7 @@
             grid-area: media-primary;
             margin-bottom: -70px;
             // TODO this should be done in a more intelligent way
-            max-height: 460px;
+            max-height: 560px;
             overflow: hidden;
         }
     }
@@ -47,6 +47,7 @@
     .content__labels--splash {
         margin-right: $gs-gutter;
         padding: ($gs-baseline / 2) ($gs-gutter / 2);
+        order: 0;
 
         @include mq(mobileLandscape, $until: tablet) {
             padding-left: $gs-gutter;
@@ -70,7 +71,7 @@
     }
 
     .content__headline-splash-wrapper {
-        border-top: 1px solid #ffffff;
+        border-top: 1px solid rgba(0, 0, 0, .2);
         box-sizing: border-box;
         margin: 0 $gs-gutter 0 0;
         padding: 0 ($gs-gutter / 2) ($gs-baseline * 3);
@@ -92,7 +93,7 @@
             padding-bottom: $gs-baseline * 4;
 
             @supports (display: grid) {
-                border-left: 1px solid #ffffff;
+                border-left: 1px solid rgba(0, 0, 0, .2);
             }
         }
 
@@ -236,13 +237,12 @@
 
 .content__series-cta__text {
     color: #ffffff;
-    font-size: 16px;
-    font-style: italic;
+    @include fs-textSans(5);
+    font-weight: 700;
 }
 
 .content__series-cta__icon {
     background-color: #ffffff;
-    fill: $brightness-7;
     height: 34px;
     width: 34px;
 }

--- a/static/src/stylesheets/module/content-garnett/_article-splash.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-splash.scss
@@ -153,8 +153,6 @@
     }
 
     .content__series-label--splash {
-        font-size: 20px;
-
         .content__label__link {
             color: #ffffff;
             font-weight: 700;

--- a/static/src/stylesheets/module/content-garnett/_article-splash.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-splash.scss
@@ -1,5 +1,5 @@
 // I hate this specificty. So far this is the only way I can see to override template specific rules with multiple declared classes
-.content.content--article.content--type-column {
+.content.content--article.content--type-splash {
     .content__head--article {
         @supports (display: grid) {
             @include mq(leftCol) {
@@ -44,7 +44,7 @@
         }
     }
 
-    .content__labels--column {
+    .content__labels--splash {
         margin-right: $gs-gutter;
         padding: ($gs-baseline / 2) ($gs-gutter / 2);
 
@@ -69,7 +69,7 @@
         }
     }
 
-    .content__headline-column-wrapper {
+    .content__headline-splash-wrapper {
         border-top: 1px solid #ffffff;
         box-sizing: border-box;
         margin: 0 $gs-gutter 0 0;
@@ -136,7 +136,7 @@
         }
     }
 
-    .content__headline--column {
+    .content__headline--splash {
         color: #ffffff;
         padding: 0;
 
@@ -146,7 +146,7 @@
         }
     }
 
-    .content__series-label--column {
+    .content__series-label--splash {
         font-size: 20px;
 
         .content__label__link {
@@ -163,7 +163,7 @@
 
     // Opinion specific styling
     &.content--type-comment {
-        .content__headline-column-wrapper {
+        .content__headline-splash-wrapper {
             overflow: hidden;
 
             .content__header {
@@ -181,13 +181,13 @@
         }
 
         // Fix for visible hover on series panel
-        .content__labels--column:hover {
+        .content__labels--splash:hover {
             background-color: $opinion-dark;
         }
 
         // Opinion layout with byline pic
         .content__head--byline-pic {
-            .content__headline-column-wrapper--column {
+            .content__headline-splash-wrapper--column {
                 padding-bottom: $gs-baseline * 3;
             }
 

--- a/static/src/stylesheets/module/content-garnett/_article-splash.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-splash.scss
@@ -247,8 +247,8 @@
 }
 
 .content__series-cta__text {
-    color: #ffffff;
     @include fs-textSans(5);
+    color: #ffffff;
     font-weight: 700;
     vertical-align: middle;
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -19,7 +19,7 @@
     }
 
     .button--primary,
-    .content__labels--column:hover {
+    .content__labels--splash:hover {
         background: $pillarColor;
     }
 
@@ -59,8 +59,8 @@
     }
 
     .bullet::before,
-    .content__headline-column-wrapper--column,
-    .content__labels--column,
+    .content__headline-splash-wrapper--column,
+    .content__labels--splash,
     .content__labels--panel {
         background-color: $kickerColor;
     }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -50,7 +50,8 @@
         fill: $kickerColor;
     }
 
-    .inline-garnett-quote svg {
+    .inline-garnett-quote svg,
+    .content__series-cta__icon {
         fill: $kickerColor;
     }
 
@@ -59,7 +60,7 @@
     }
 
     .bullet::before,
-    .content__headline-splash-wrapper--column,
+    .content__headline-splash-wrapper,
     .content__labels--splash,
     .content__labels--panel {
         background-color: $kickerColor;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -781,7 +781,7 @@ $quote-mark: 35px;
 
 // *************** Opinion Styles ***************
 
-.content--type-guardianview:not(.content--type-column),
+.content--type-guardianview:not(.content--type-splash),
 .content--type-comment {
     .content__main {
         background-color: $opinion-faded;


### PR DESCRIPTION
# What have I done?
Articles with the display hint of `Splash` or `Column` will both have the article header previously attributed to the `Column` template. 

# To do, following this PR:
- Add captions to the main media in this template


# And what does it look like?
<img width="374" alt="Screen Shot 2019-03-20 at 13 48 20" src="https://user-images.githubusercontent.com/14570016/54689410-63128580-4b17-11e9-8777-6f68f05a54ea.png">
<img width="1666" alt="Screen Shot 2019-03-20 at 13 49 03" src="https://user-images.githubusercontent.com/14570016/54689413-63ab1c00-4b17-11e9-9429-f2d2deca579e.png">

