### PR TITLE
Reduce threshold for tablet breakpoint

### DIFF
--- a/common/app/layout/Breakpoint.scala
+++ b/common/app/layout/Breakpoint.scala
@@ -24,7 +24,7 @@ case object Phablet extends Breakpoint {
 }
 
 case object Tablet extends Breakpoint {
-  val minWidth = Some(740)
+  val minWidth = Some(712)
 }
 
 case object Desktop extends Breakpoint {

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -60,7 +60,7 @@ const breakpoints: Array<Breakpoint> = [
     {
         name: 'tablet',
         isTweakpoint: false,
-        width: 740,
+        width: 712,
     },
     {
         name: 'desktop',

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -50,7 +50,7 @@ $mq-breakpoints: (
     mobileMedium:    gs-span(5)  - $gs-gutter,   // 360px
     mobileLandscape: gs-span(6)  + $gs-gutter,   // 480px
     phablet:         gs-span(8)  + $gs-gutter*2, // 660px
-    tablet:          gs-span(9)  + $gs-gutter*2, // 740px
+    tablet:          gs-span(9)  + $gs-gutter*3/5, // 712px
     desktop:         gs-span(12) + $gs-gutter*2, // 980px
     leftCol:         gs-span(14) + $gs-gutter*2, // 1140px
     wide:            gs-span(16) + $gs-gutter*2, // 1300px


### PR DESCRIPTION
I am reliably informed that the Samsung Galaxy Tab S4 is considered by some to be the most popular and highly-rated Android tablet.  But because it has a viewport width of 712px it is currently treated as a mobile device by our breakpoint system.

This change recognises narrower tablets, that are still generally reckoned to be tablets, as tablets.

The motivation for doing this is that a new tablet ad format isn't working on some tablets, because they're being targeted as mobile devices.
