### PR TITLE
extend subscribe-with-google switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,7 +512,7 @@ trait FeatureSwitches {
     "If switched on, a Subscribe with Google button will appear on AMP articles.",
     owners = Seq(Owner.withName("adem.gaygusuz")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 20),
+    sellByDate = new LocalDate(2019, 3, 27),
     exposeClientSide = true
   )
 }


### PR DESCRIPTION
## What does this change?

Extend `subscribe-with-google` switch by 7 days as `master` won't build because it's expired. 