### PR TITLE
A safer lazy-load, and the tests to prove it

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.js
@@ -10,7 +10,7 @@ const displayAd = (adSlot: HTMLElement, forceDisplay: boolean) => {
     const advert: Advert = new Advert(adSlot);
 
     dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
-    if (dfpEnv.shouldLazyLoad() && !forceDisplay && dfpEnv.lazyLoadObserve) {
+    if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
         queueAdvert(advert);
         enableLazyLoad(advert);
     } else {

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -25,12 +25,7 @@ const displayLazyAds = (): void => {
 
     dfpEnv.advertsToLoad.forEach(
         (advert: Advert): void => {
-            if (dfpEnv.lazyLoadObserve) {
-                enableLazyLoad(advert);
-            } else {
-                console.log('unable to lazy-load!');
-                loadAdvert(advert);
-            }
+            enableLazyLoad(advert);
         }
     );
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -41,7 +41,7 @@ const fillAdvertSlots = (): Promise<void> => {
         });
         adverts.forEach(queueAdvert);
 
-        if (dfpEnv.shouldLazyLoad() && dfpEnv.lazyLoadObserve) {
+        if (dfpEnv.shouldLazyLoad()) {
             displayLazyAds();
         } else {
             displayAds();

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -1,13 +1,9 @@
-// @flow
+// @flow strict
 
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { loadAdvert, refreshAdvert } from 'commercial/modules/dfp/load-advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
-import once from 'lodash/once';
-
-const IntersectionObserver = window.IntersectionObserver;
-const IntersectionObserverEntry = window.IntersectionObserverEntry;
 
 const displayAd = (advertId: string): void => {
     const advert = getAdvertById(advertId);
@@ -39,13 +35,17 @@ const onIntersect = (
     );
 };
 
-const getObserver = once(() =>
+const getObserver = (): Promise<IntersectionObserver> =>
     Promise.resolve(
         new window.IntersectionObserver(onIntersect, {
             rootMargin: '200px 0px',
         })
-    )
-);
+    );
 
-export const enableLazyLoad = (advert: Advert): void =>
-    getObserver().then(observer => observer.observe(advert.node));
+export const enableLazyLoad = (advert: Advert): void => {
+    if (dfpEnv.lazyLoadObserve) {
+        getObserver().then(observer => observer.observe(advert.node));
+    } else {
+        displayAd(advert.id);
+    }
+};

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -4,6 +4,7 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { loadAdvert, refreshAdvert } from 'commercial/modules/dfp/load-advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
+import once from 'lodash/once';
 
 const displayAd = (advertId: string): void => {
     const advert = getAdvertById(advertId);
@@ -35,12 +36,13 @@ const onIntersect = (
     );
 };
 
-const getObserver = (): Promise<IntersectionObserver> =>
+const getObserver = once(() =>
     Promise.resolve(
         new window.IntersectionObserver(onIntersect, {
             rootMargin: '200px 0px',
         })
-    );
+    )
+);
 
 export const enableLazyLoad = (advert: Advert): void => {
     if (dfpEnv.lazyLoadObserve) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
@@ -1,0 +1,70 @@
+// @flow
+
+import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
+import { getAdvertById as getAdvertById_ } from 'commercial/modules/dfp/get-advert-by-id';
+import { loadAdvert } from 'commercial/modules/dfp/load-advert';
+import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
+
+jest.mock('lib/config', () => ({
+    get: jest.fn(() => false),
+}));
+
+jest.mock('commercial/modules/dfp/Advert', () =>
+    jest.fn(() => ({ advert: jest.fn() }))
+);
+
+jest.mock('commercial/modules/dfp/get-advert-by-id', () => ({
+    getAdvertById: jest.fn(),
+}));
+
+jest.mock('commercial/modules/dfp/load-advert', () => ({
+    refreshAdvert: jest.fn(),
+    loadAdvert: jest.fn(),
+}));
+
+const getAdvertById: any = getAdvertById_;
+
+describe('enableLazyLoad', () => {
+    const windowIntersectionObserver = window.IntersectionObserver;
+
+    const fakeAdvert: any = {
+        id: 'test-advert',
+        sizes: { desktop: [[300, 250]] },
+        isRendered: false,
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        window.IntersectionObserver = jest.fn(() => ({
+            observe: jest.fn(),
+        }));
+
+        expect.hasAssertions();
+    });
+
+    afterAll(() => {
+        window.IntersectionObserver = windowIntersectionObserver;
+    });
+
+    test('JSDOM and Jest should not have an intersectionObserver', () => {
+        // META TEST! Our the assumptions about Jest and JSDOM correct?
+        expect(windowIntersectionObserver).toBe(undefined);
+    });
+
+    it('should create an observer if lazyLoadObserve is true', () => {
+        dfpEnv.lazyLoadObserve = true;
+        enableLazyLoad(fakeAdvert);
+        expect(loadAdvert).not.toHaveBeenCalled();
+        expect(window.IntersectionObserver.mock.calls[0][1]).toEqual({
+            rootMargin: '200px 0px',
+        });
+    });
+
+    it('should still display the adverts if lazyLoadObserve is false', () => {
+        dfpEnv.lazyLoadObserve = false;
+        getAdvertById.mockReturnValue(fakeAdvert);
+        enableLazyLoad(fakeAdvert);
+        expect(getAdvertById.mock.calls).toEqual([['test-advert']]);
+        expect(loadAdvert).toHaveBeenCalledWith(fakeAdvert);
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
@@ -27,7 +27,7 @@ const getAdvertById: any = getAdvertById_;
 describe('enableLazyLoad', () => {
     const windowIntersectionObserver = window.IntersectionObserver;
 
-    const fakeAdvert: any = {
+    const testAdvert: any = {
         id: 'test-advert',
         sizes: { desktop: [[300, 250]] },
         isRendered: false,
@@ -47,13 +47,13 @@ describe('enableLazyLoad', () => {
     });
 
     test('JSDOM and Jest should not have an intersectionObserver', () => {
-        // META TEST! Our the assumptions about Jest and JSDOM correct?
+        // META TEST! Are the assumptions about Jest and JSDOM correct?
         expect(windowIntersectionObserver).toBe(undefined);
     });
 
     it('should create an observer if lazyLoadObserve is true', () => {
         dfpEnv.lazyLoadObserve = true;
-        enableLazyLoad(fakeAdvert);
+        enableLazyLoad(testAdvert);
         expect(loadAdvert).not.toHaveBeenCalled();
         expect(window.IntersectionObserver.mock.calls[0][1]).toEqual({
             rootMargin: '200px 0px',
@@ -62,9 +62,9 @@ describe('enableLazyLoad', () => {
 
     it('should still display the adverts if lazyLoadObserve is false', () => {
         dfpEnv.lazyLoadObserve = false;
-        getAdvertById.mockReturnValue(fakeAdvert);
-        enableLazyLoad(fakeAdvert);
+        getAdvertById.mockReturnValue(testAdvert);
+        enableLazyLoad(testAdvert);
         expect(getAdvertById.mock.calls).toEqual([['test-advert']]);
-        expect(loadAdvert).toHaveBeenCalledWith(fakeAdvert);
+        expect(loadAdvert).toHaveBeenCalledWith(testAdvert);
     });
 });


### PR DESCRIPTION
## What does this change?

Iterating on a hotfix that was a bit hacky - see PR #21261 for details.

This PR improves the checks around lazyload so that we avoid throwing loads of errors to Sentry if IntersectionObserver is missing.

## What is the value of this and can you measure success?

- Checking for IntersectionObsever before trying to create one

- Testing our code to make sure we are not fatally relying on IntersectionObserver

- Avoiding hitting our Sentry rate limits

## Checklist

### Does this affect other platforms?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
