### PR TITLE
Catch Confiant errors to avoid barraging Sentry

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -1,7 +1,13 @@
-// @flow
+// @flow strict
 
 import { loadScript } from 'lib/load-script';
 import config from 'lib/config';
+
+const errorHandler = (error: Error) => {
+    // Looks like some plugins block ad-verification
+    // Avoid barraging Sentry with errors from these pageviews
+    console.log('Failed to load Confiant:', error);
+};
 
 export const init = (start: () => void): Promise<void> => {
     const host = 'clarium.global.ssl.fastly.net';
@@ -27,9 +33,9 @@ export const init = (start: () => void): Promise<void> => {
         };
         /* eslint-enable no-underscore-dangle */
 
-        // and load the script tag
-        return loadScript(`//${host}/gpt/a/wrap.js`, { async: true });
+        return loadScript(`//${host}/gpt/a/wrap.js`, { async: true }).catch(
+            errorHandler
+        );
     }
-    // Do nothing.
     return Promise.resolve();
 };


### PR DESCRIPTION
## What does this change?

Catch error from loadscript when we fail to load ad-verification from clarium.global.ssl.fastly.net

I have a theory... that this error is getting thrown in browsers that are using an adblocker. UBlock Origin flags and blocks this script:

`https://clarium.global.ssl.fastly.net/gpt/a/wrap.js net::ERR_BLOCKED_BY_CLIENT` 

Therefore adding a catch into prepare-ad-verification will stop these errors hammering Sentry.

## Screenshots

The big jump in Sentry alerts coincides with rolling Confiant to 100%:

<img width="331" alt="Screenshot 2019-03-22 at 11 23 34" src="https://user-images.githubusercontent.com/8607683/54819873-25d40200-4c95-11e9-861b-0c537e1c65a1.png">


## What is the value of this and can you measure success?

- Fewer Sentry errors for something outside our control.

- Avoid hitting our Sentry limits.

## Checklist

### Does this affect other platforms?

Nope


### Does this change break ad-free?

Nope

### Tested

- [x] Locally
