### PR TITLE
CALLOUTS: clean up submission

### DIFF
--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -82,7 +82,6 @@
                 <input name="field_<%=field.id%>"
                        type="file"
                        accept="image/*, .pdf"
-                       multiple="multiple"
                 <% if (field.required == "1") { %> required <% } %>
                 />
                 <p class="form-info-text">We accept images and pdfs. Maximum total file size: 6MB</p>

--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -81,9 +81,11 @@
                 <% } else if(field.type === "file") { %>
                 <input name="field_<%=field.id%>"
                        type="file"
-                       accept="image/*, .pdf, .doc, .xml, .docx"
+                       accept="image/*, ,video/*, .pdf"
+                       multiple="multiple"
                 <% if (field.required == "1") { %> required <% } %>
                 />
+                <p class="form-info-text">Maximum total size: 6MB.</p>
 
                 <% } else { %>
                 <input name="field_<%=field.id%>"
@@ -96,7 +98,7 @@
         </div>
 
         <% }) %>
-        <div class="form_input form_input--twitter-handle">
+        <div class="form_input form_input--twitter-handle" aria-hidden="true">
             <div class="form_field">
                 <input name="twitter-handle" type="text" id="twitter-handle" placeholder="@mytwitterhandle"/>
             </div>

--- a/static/src/javascripts/projects/journalism/views/campaignForm.html
+++ b/static/src/javascripts/projects/journalism/views/campaignForm.html
@@ -81,11 +81,11 @@
                 <% } else if(field.type === "file") { %>
                 <input name="field_<%=field.id%>"
                        type="file"
-                       accept="image/*, ,video/*, .pdf"
+                       accept="image/*, .pdf"
                        multiple="multiple"
                 <% if (field.required == "1") { %> required <% } %>
                 />
-                <p class="form-info-text">Maximum total size: 6MB.</p>
+                <p class="form-info-text">We accept images and pdfs. Maximum total file size: 6MB</p>
 
                 <% } else { %>
                 <input name="field_<%=field.id%>"

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -424,6 +424,8 @@
     }
 
     .form-info-text {
+        margin: 1px 0 6px 3px;
+        padding: 0 10px;
         line-height: 15px;
         font-size: 12px;
         font-weight: 400;

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -379,7 +379,7 @@
 
     &.form_input--twitter-handle {
         position: absolute;
-        left: -600px;
+        left: -1000px;
     }
 
     textarea {
@@ -421,6 +421,13 @@
     }
     select {
         height: 40px;
+    }
+
+    .form-info-text {
+        line-height: 15px;
+        font-size: 12px;
+        font-weight: 400;
+        font-family: $f-sans-serif-text;
     }
 
     .form_field_label {


### PR DESCRIPTION
## What does this change?

This adds a warning about the max size of upload - which is set by the 6MB payload on a lambda. Therefore that is the maximum file size we can allow people to upload.
I'm removing word docs because we don't need them.

I'm also cleaning up the twitter field and making it more accessible

## Screenshots
![Screenshot 2019-04-01 at 16 02 00](https://user-images.githubusercontent.com/10324129/55338128-e927b800-5497-11e9-871f-15d969e7af4c.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
