### PR TITLE
Missing styles added in for tone-live / pillar-Arts case scenario

### DIFF
--- a/static/src/stylesheets/email/_tones.scss
+++ b/static/src/stylesheets/email/_tones.scss
@@ -98,6 +98,19 @@
         }
     }
 
+    &.pillar-Arts {
+        border-top: 1px solid #e7d4b9;
+
+        .fc__kicker {
+            color: #e7d4b9;
+        }
+
+        &,
+        & th {
+            background-color: #6b5840;
+        }
+    }
+
     &.pillar-Lifestyle {
         border-top: 1px solid #ffbac8;
 


### PR DESCRIPTION
## What does this change?
Following commit adds missing styles for tone-live / pillar-Arts case scenario
## Screenshots
![Screen Shot 2019-03-25 at 11 56 06](https://user-images.githubusercontent.com/47107438/54918063-29fe5a80-4ef5-11e9-803d-a7925ad3e52f.png)
## What is the value of this and can you measure success?
Following commit fixes the issue with broken styles where the white text was invisible on the grey background.
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] N/A

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
