### PR TITLE
Revert "Correct vertical alignment of social share numbers"

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_content.global.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.global.scss
@@ -100,6 +100,7 @@
     text-align: right;
     float: left;
     min-width: 15px; // Min width is the width of the icons
+    padding-top: $gs-baseline / 2;
 }
 
 .meta__number + .meta__number {

--- a/static/src/stylesheets/module/content-garnett/_gallery.head.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.head.scss
@@ -162,6 +162,7 @@
 
     .meta__numbers {
         float: right;
+        padding-top: $gs-baseline/2;
 
         .sharecount__value,
         a {


### PR DESCRIPTION
## What does this change?

Revert this PR: https://github.com/guardian/frontend/pull/21150 , as advertised by @zeftilldeath 