### PR TITLE
Add an AB test that will run the consent banner globally for those in the variant

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -79,8 +79,8 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-commercial-consent-global",
-    "Test the TCF globally",
-    owners = Seq(Owner.withGithub("frankie297")),
+    "Test the consent banner globally",
+    owners = Owner.group(Commercial),
     safeState = Off,
     sellByDate = new LocalDate(2019, 4, 16),
     exposeClientSide = true

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -76,4 +76,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-commercial-consent-global",
+    "Test the TCF globally",
+    owners = Seq(Owner.withGithub("frankie297")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 4, 16),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -6,6 +6,7 @@ import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
 
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise';
+import { commercialConsentGlobal } from 'common/modules/experiments/tests/commercial-consent-global';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { log } from './log';
 import { CmpStore } from './store';
@@ -77,6 +78,9 @@ const generateStore = (isInTest: boolean): CmpStore => {
     return store;
 };
 
+const isInConsentGlobalTest = (): boolean =>
+    isInVariantSynchronous(commercialConsentGlobal, 'variant');
+
 const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
@@ -102,7 +106,7 @@ class CmpService {
             this.cmpConfig.logging = 'debug';
             log.info('Set logging level to DEBUG');
         }
-        if (isInEU()) {
+        if (isInEU() || isInConsentGlobalTest()) {
             this.cmpConfig.gdprApplies = true;
         }
     }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,6 +2,7 @@
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
+import { commercialConsentGlobal } from 'common/modules/experiments/tests/commercial-consent-global.js';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
@@ -14,6 +15,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialCmpCustomise,
     commercialOutbrainTesting,
+    commercialConsentGlobal,
     adblockTest,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
@@ -9,7 +9,7 @@ export const commercialConsentGlobal: ABTest = {
     audience: 0.02,
     audienceOffset: 0.1,
     successMeasure: 'TCF is served globally',
-    audienceCriteria: 'internal',
+    audienceCriteria: 'all users',
     dataLinkNames: '',
     idealOutcome: 'TCF can be served globally',
     canRun: () => true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
@@ -1,0 +1,26 @@
+// @flow
+
+export const commercialConsentGlobal: ABTest = {
+    id: 'CommercialConsentGlobal',
+    start: '2019-03-25',
+    expiry: '2019-04-16',
+    author: 'Frankie Hammond',
+    description: 'Test the TCF globally',
+    audience: 0.02,
+    audienceOffset: 0.1,
+    successMeasure: 'TCF is served globally',
+    audienceCriteria: 'internal',
+    dataLinkNames: '',
+    idealOutcome: 'TCF can be served globally',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global.js
@@ -5,13 +5,13 @@ export const commercialConsentGlobal: ABTest = {
     start: '2019-03-25',
     expiry: '2019-04-16',
     author: 'Frankie Hammond',
-    description: 'Test the TCF globally',
+    description: 'Test the consent banner globally',
     audience: 0.02,
     audienceOffset: 0.1,
-    successMeasure: 'TCF is served globally',
+    successMeasure: 'Users outside of the EU interact with the consent banner',
     audienceCriteria: 'all users',
     dataLinkNames: '',
-    idealOutcome: 'TCF can be served globally',
+    idealOutcome: '',
     canRun: () => true,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -13,6 +13,8 @@ import ophan from 'ophan/ng';
 import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import { commercialConsentGlobal } from 'common/modules/experiments/tests/commercial-consent-global';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 type Template = {
     heading: string,
@@ -103,10 +105,13 @@ const trackInteraction = (interaction: string): void => {
     trackNonClickInteraction(interaction);
 };
 
+const isInConsentGlobalTest = (): boolean =>
+    isInVariantSynchronous(commercialConsentGlobal, 'variant');
+
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
         hasUnsetAdChoices() &&
-            isInEU() &&
+            (isInEU() || isInConsentGlobalTest()) &&
             !hasUserAcknowledgedBanner(messageCode)
     );
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -1,9 +1,9 @@
 // @flow
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import {
     firstPvConsentBanner as banner,
     _ as test,
 } from './first-pv-consent-banner';
-import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 
 const getAdConsentState: any = require('common/modules/commercial/ad-prefs.lib')
     .getAdConsentState;

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -119,7 +119,8 @@ describe('First PV consents banner', () => {
             });
             return expect(await banner.canShow()).toBe(false);
         });
-        it('should render outside the EU if in test', async () => {
+        // two temporary tests that can be removed after 31/03/2019
+        it('should render outside the EU, when commercial consent test participation is "variant"', async () => {
             isInVariantSynchronous.mockImplementation(
                 (testId, variantId) => variantId === 'variant'
             );
@@ -128,6 +129,16 @@ describe('First PV consents banner', () => {
                 return null;
             });
             return expect(await banner.canShow()).toBe(true);
+        });
+        it('should not render outside the EU, when commercial consent test participation is "control"', async () => {
+            isInVariantSynchronous.mockImplementation(
+                (testId, variantId) => variantId === 'control'
+            );
+            getCookie.mockImplementation(_ => {
+                if (_ === 'GU_geo_continent') return '??';
+                return null;
+            });
+            return expect(await banner.canShow()).toBe(false);
         });
     });
 


### PR DESCRIPTION
## What does this change?

Adds an AB test to run the first pageview consent banner globally

## What is the value of this and can you measure success?

Users outside of the EU interact with the consent banner

Commercial BAU  🚀✨

See Trello for more details and todos: https://trello.com/c/QicSuoHc

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
