### PR TITLE
Make epic tag/section check 'OR'

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -281,11 +281,10 @@ const makeEpicABTestVariant = (
                 this.countryGroups.length === 0 ||
                 userMatchesCountryGroups(this.countryGroups);
 
-            const matchesTags =
-                this.tagIds.length === 0 || pageMatchesTags(this.tagIds);
-            const matchesSections =
-                this.sections.length === 0 ||
-                pageMatchesSections(this.sections);
+            const matchesTagsOrSections =
+                (this.tagIds.length === 0 && this.sections.length === 0) ||
+                (pageMatchesTags(this.tagIds) || pageMatchesSections(this.sections));
+
             const noExcludedTags = !pageMatchesTags(this.excludedTagIds);
             const notExcludedSection = !pageMatchesSections(
                 this.excludedSections
@@ -294,8 +293,7 @@ const makeEpicABTestVariant = (
             return (
                 meetsMaxViewsConditions &&
                 matchesCountryGroups &&
-                matchesTags &&
-                matchesSections &&
+                matchesTagsOrSections &&
                 noExcludedTags &&
                 notExcludedSection
             );

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -283,7 +283,8 @@ const makeEpicABTestVariant = (
 
             const matchesTagsOrSections =
                 (this.tagIds.length === 0 && this.sections.length === 0) ||
-                (pageMatchesTags(this.tagIds) || pageMatchesSections(this.sections));
+                (pageMatchesTags(this.tagIds) ||
+                    pageMatchesSections(this.sections));
 
             const noExcludedTags = !pageMatchesTags(this.excludedTagIds);
             const notExcludedSection = !pageMatchesSections(


### PR DESCRIPTION
## What does this change?
Changed how we process the epic rule so that tag and sections ID checks are OR'd.
Currently we have to create separate tests if we want to catch sections OR tags

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
