### PR TITLE
Use showSupportMessaging flag from members-data-api

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -70,7 +70,7 @@
     }
 
     /*
-        This is a shortened version of shouldSeeReaderRevenue() from
+        This is a shortened version of shouldHideSupportMessaging() from
         user-features.js. Since we are blocking rendering at this time we
         can't inline all required JS from this module.
     */
@@ -88,8 +88,12 @@
         return diffDays <= 180;
     }
 
-    function isPayingMember() {
-        return getCookieValue('gu_paying_member') === 'true';
+    function shouldHideSupportMessaging() {
+        var value = getCookieValue('gu_show_support_messaging');
+        if (!value) {
+            return false;
+        }
+        return value === 'false';
     }
 
     function forcePercentagePadding() {
@@ -140,8 +144,8 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (isPayingMember()) {
-        docClass += ' is-paying-member';
+    if (shouldHideSupportMessaging()) {
+        docClass += ' hide-support-messaging'
     }
 
     if (isRecentContributor()) {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -7,7 +7,7 @@ import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import {
     isPayingMember as isPayingMember_,
     isRecentOneOffContributor as isRecentOneOffContributor_,
-    userIsSupporter as userIsSupporter_,
+    shouldHideSupportMessaging as shouldHideSupportMessaging_,
     isAdFreeUser as isAdFreeUser_,
 } from 'common/modules/commercial/user-features';
 
@@ -16,7 +16,10 @@ const isRecentOneOffContributor: JestMockFn<
     *,
     *
 > = (isRecentOneOffContributor_: any);
-const userIsSupporter: JestMockFn<*, *> = (userIsSupporter_: any);
+const shouldHideSupportMessaging: JestMockFn<
+    *,
+    *
+> = (shouldHideSupportMessaging_: any);
 const isAdFreeUser: JestMockFn<*, *> = (isAdFreeUser_: any);
 const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
@@ -26,7 +29,7 @@ const CommercialFeatures = commercialFeatures.constructor;
 jest.mock('common/modules/commercial/user-features', () => ({
     isPayingMember: jest.fn(),
     isRecentOneOffContributor: jest.fn(),
-    userIsSupporter: jest.fn(),
+    shouldHideSupportMessaging: jest.fn(),
     isAdFreeUser: jest.fn(),
 }));
 
@@ -67,7 +70,7 @@ describe('Commercial features', () => {
         getBreakpoint.mockReturnValue('desktop');
         isPayingMember.mockReturnValue(false);
         isRecentOneOffContributor.mockReturnValue(false);
-        userIsSupporter.mockReturnValue(false);
+        shouldHideSupportMessaging.mockReturnValue(false);
         isAdFreeUser.mockReturnValue(false);
         isUserLoggedIn.mockReturnValue(true);
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -32,7 +32,7 @@ import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { userIsSupporter } from 'common/modules/commercial/user-features';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
     supportSubscribeGeoRedirectURL,
@@ -144,9 +144,9 @@ const userIsInCorrectCohort = (
 ): boolean => {
     switch (userCohort) {
         case 'OnlyExistingSupporters':
-            return userIsSupporter();
+            return shouldHideSupportMessaging();
         case 'OnlyNonSupporters':
-            return !userIsSupporter();
+            return !shouldHideSupportMessaging();
         case 'Everyone':
         default:
             return true;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -86,7 +86,7 @@ jest.mock('common/modules/commercial/contributions-utilities', () => ({
     canShowBannerSync: jest.fn(() => false),
 }));
 jest.mock('common/modules/commercial/user-features', () => ({
-    userIsSupporter: jest.fn(() => false),
+    shouldHideSupportMessaging: jest.fn(() => false),
 }));
 jest.mock('lib/fetch-json', () => jest.fn());
 jest.mock('common/modules/user-prefs', () => ({

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -14,6 +14,7 @@ import {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
+    shouldShowSupportMessaging,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -33,6 +34,7 @@ const PERSISTENCE_KEYS = {
     ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
     DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
+    SHOW_SUPPORT_MESSAGING_COOKIE: 'gu_show_support_messaging',
 };
 
 const setAllFeaturesData = opts => {
@@ -47,6 +49,7 @@ const setAllFeaturesData = opts => {
     addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
+    addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
     addCookie(
         PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
         adFreeExpiryDate.getTime().toString()
@@ -75,6 +78,7 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
     removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
+    removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
 };
 
 beforeAll(() => {
@@ -300,6 +304,36 @@ describe('The isDigitalSubscriber getter', () => {
         it('Is false when the user has no digital subscriber cookie', () => {
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
             expect(isDigitalSubscriber()).toBe(false);
+        });
+    });
+});
+
+describe('The shouldShowSupportMessaging getter', () => {
+    it('Returns false when the user is logged out', () => {
+        jest.resetAllMocks();
+        isUserLoggedIn.mockReturnValue(false);
+        expect(shouldShowSupportMessaging()).toBe(false);
+    });
+
+    describe('When the user is logged in', () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+            isUserLoggedIn.mockReturnValue(true);
+        });
+
+        it('Returns true when the user has a `true` support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
+            expect(shouldShowSupportMessaging()).toBe(true);
+        });
+
+        it('Returns false when the user has a `false` support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'false');
+            expect(shouldShowSupportMessaging()).toBe(false);
+        });
+
+        it('Returns false when the user has no support messaging cookie', () => {
+            removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
+            expect(shouldShowSupportMessaging()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,5 +1,5 @@
 // @flow
-import { userIsSupporter } from 'common/modules/commercial/user-features';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
@@ -42,7 +42,7 @@ export const adblockTest: ABTest = {
     showForSensitive: true,
     canRun() {
         return (
-            !userIsSupporter() &&
+            !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&
             !config.get('page.hasShowcaseMainElement')
         );

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -73,7 +73,7 @@
     &:last-child {
         margin-right: 0;
 
-        .is-paying-member & > *,
+        .hide-support-messaging & > *,
         .is-recent-contributor & > * {
             display: none;
         }

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -3,7 +3,7 @@
     top: 30px;
     left: $gs-gutter / 2;
 
-    .is-paying-member &,
+    .hide-support-messaging &,
     .is-recent-contributor & {
         display: none;
     }


### PR DESCRIPTION
## What does this change?

Support messaging is now hidden based on the boolean `showSupportMessaging` flag in the `members-data-api` response, which contains information about print subscribers in addition to other supporters.

## Screenshots
| | Header | Footer |
| ------------------ | ------------------ | ------------------|
| Signed-in print subscribers before | ![image](https://user-images.githubusercontent.com/15648334/55010830-da935980-4fdc-11e9-807c-4d47d3f7c3ee.png) | ![image](https://user-images.githubusercontent.com/15648334/55010874-f0088380-4fdc-11e9-8a43-a9225a8c628b.png) |
| Signed in print subscribers after | ![image](https://user-images.githubusercontent.com/15648334/55010951-162e2380-4fdd-11e9-84fb-ba995781a1ee.png) | ![image](https://user-images.githubusercontent.com/15648334/55010983-21814f00-4fdd-11e9-9556-92c1c59e67b8.png) |






## What is the value of this and can you measure success?

Previously, support messaging was not hidden for print subscribers when they logged in. Using the new flag means that users who have a print subscription (paper/Guardian Weekly) are not shown support messaging when they log in.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
