### PR TITLE
Use Review type for film review structured data

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -285,32 +285,7 @@ object DotcomponentsDataModel {
         main.getOrElse(Configuration.images.fallbackLogo)
       }
 
-      val authors = article.tags.contributors.map(contributor => {
-        Person(
-          name = contributor.name,
-          sameAs = contributor.metadata.webUrl,
-        )
-      })
-
-      List(
-        NewsArticle(
-          `@id` = Configuration.amp.baseUrl + article.metadata.id,
-          images = Seq(
-            ImgSrc(mainImageURL, OneByOne),
-            ImgSrc(mainImageURL, FourByThree),
-            ImgSrc(mainImageURL, Item1200),
-          ),
-          author = authors,
-          datePublished = article.trail.webPublicationDate.toString(),
-          dateModified = article.fields.lastModified.toString(),
-          headline = article.trail.headline,
-          mainEntityOfPage = article.metadata.webUrl,
-        ),
-        WebPage(
-          `@id` = article.metadata.webUrl,
-          potentialAction = PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/"))
-        )
-      )
+      LinkedData(article, Configuration.amp.baseUrl, Configuration.images.fallbackLogo)
     }
 
     val allTags = article.tags.tags.map(

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -14,6 +14,14 @@
     if (page.article.tags.isReview) "reviewBody" else "articleBody"
 }
 
+@author(name: String, sameAs: String) = {
+    <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <meta itemprop="sameAs" content="@sameAs">
+        <meta itemprop="name" content="@name">
+    </div>
+}
+
+
 @defining(model.article) { article =>
   @defining(isPaidContent(model)) { isPaidContent =>
 
@@ -49,6 +57,10 @@
             @if(isPaidContent) {
                 @fragments.guBand()
                 @fragments.articleHeaderPaidGarnett(article, model, amp = amp)
+            }
+
+            @if(article.tags.isReview) {
+                @article.tags.contributors.map(contributor => author(contributor.name, contributor.metadata.webUrl))
             }
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -40,7 +40,7 @@
             }
 
             @article.content.imdb.map { imdbId =>
-                <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Movie">
+                <div articleprop="itemReviewed" articlescope articletype="http://schema.org/Movie">
                     <link articleprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
                     @defining(article.content.primaryKeyWordTag.map(_.name).getOrElse(".")) { tag =>
                         @* we're not the authority on the film name, but just to keep google validator happy
@@ -50,7 +50,7 @@
             }
 
             @article.content.isbn.map { isbn =>
-                <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Book">
+                <div articleprop="itemReviewed" articlescope articletype="http://schema.org/Book">
                     <meta articleprop="isbn" content="@isbn">
                     <div articleprop="author" articlescope articletype="http://schema.org/Person">
                         <meta articleprop="sameAs" content="http://schema.org/Person@* we can't know *@">

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -96,23 +96,24 @@
                 }
 
                 @article.content.imdb.map { imdbId =>
-                    <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Movie">
-                        <link articleprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
+                    <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Movie">
+                        <link itemprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
                         @defining(article.content.primaryKeyWordTag.map(_.name).getOrElse(".")) { tag =>
                             @* we're not the authority on the film name, but just to keep google validator happy
-                            *@<meta articleprop="name" content="@tag"/>
+                            *@<meta itemprop="name" content="@tag"/>
+                            <meta itemprop="image" content="@article.content.openGraphImage">
                         }
                     </div>
                 }
 
                 @article.content.isbn.map { isbn =>
-                    <div articleprop="articleReviewed" articlescope articletype="http://schema.org/Book">
-                        <meta articleprop="isbn" content="@isbn">
-                        <div articleprop="author" articlescope articletype="http://schema.org/Person">
-                            <meta articleprop="sameAs" content="http://schema.org/Person@* we can't know *@">
-                            <meta articleprop="name" content=".@* we can't know *@">
+                    <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Book">
+                        <meta itemprop="isbn" content="@isbn">
+                        <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+                            <meta itemprop="sameAs" content="http://schema.org/Person@* we can't know *@">
+                            <meta itemprop="name" content=".@* we can't know *@">
                         </div>
-                        <meta articleprop="name" content=".@* we can't know *@">
+                        <meta itemprop="name" content=".@* we can't know *@">
                     </div>
                 }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -287,10 +287,10 @@ import collection.JavaConverters._
         review.$("[articleprop=reviewRating]").text should be("4 / 5 stars")
         review.$("[articleprop=ratingValue]").text should be("4")
 
-        val reviewed = review.el("[articleprop=articleReviewed]")
+        val reviewed = review.el("[itemprop=itemReviewed]")
 
-        reviewed.attribute("articletype") should be("http://schema.org/Movie")
-        reviewed.$("[articleprop=sameAs]").attribute("href") should be("http://www.imdb.com/title/tt3205376/")
+        reviewed.attribute("itemtype") should be("http://schema.org/Movie")
+        reviewed.$("[itemprop=sameAs]").attribute("href") should be("http://www.imdb.com/title/tt3205376/")
       }
     }
 


### PR DESCRIPTION
This applies to the model sent to dotcom-rendering and enables us to send appropriate structured data (including star ratings) for film reviews.

I originally spiked this while investigating some issues with missing star ratings on non-dotcom-rendering stuff, and decided to keep the work. (The original issue turned out to be an upstream issue  - data not being entered in the tools correctly.)