### PR TITLE
Content age message

### DIFF
--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -27,6 +27,10 @@
                     <div class="content__label-interview">Interview</div>
                 }
 
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                }
+
                 <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
                     @if(article.tags.isInterview) {
                         <span class="content__headline--interview-wrapper">@Html(article.trail.headline)</span>
@@ -36,7 +40,7 @@
                 </h1>
 
                 @if(article.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice)
+                    @fragments.contentAgeNotice(ageNotice, isHidden = true)
                 }
 
                 @if(article.tags.isInterview) {
@@ -61,7 +65,7 @@
                 }
 
                 @if(article.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice)
+                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
                 }
 
                 <h1 class="content__headline @if(article.content.starRating && !article.elements.hasShowcaseMainElement) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>
@@ -71,6 +75,10 @@
                         @Html(article.trail.headline)
                     }
                 </h1>
+
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice, isHidden = true)
+                }
 
                 @if(article.tags.isInterview) {
                     @article.trail.byline.map { text =>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -3,7 +3,12 @@
 @import views.html.fragments.langAttributes
 @import views.support.ContributorLinks
 @import views.support.TrailCssClasses.toneClass
+@import views.support.ContentOldAgeDescriber
 @import _root_.model.ContentDesignType.RichContentDesignType
+
+@ageNotice() = @{
+    ContentOldAgeDescriber(article.content)
+}
 
 
     <header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)">
@@ -30,6 +35,10 @@
                     }
                 </h1>
 
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice)
+                }
+
                 @if(article.tags.isInterview) {
                     @article.trail.byline.map { text =>
                         <span class="content__headline--byline-interview">@ContributorLinks(text, article.tags.contributors)</span>
@@ -49,6 +58,10 @@
 
                 @if((article.tags.isInterview)){
                     <div class="content__label-interview">Interview</div>
+                }
+
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice)
                 }
 
                 <h1 class="content__headline @if(article.content.starRating && !article.elements.hasShowcaseMainElement) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>

--- a/common/app/views/fragments/contentAgeNotice.scala.html
+++ b/common/app/views/fragments/contentAgeNotice.scala.html
@@ -1,7 +1,7 @@
-@(ageMessage: String)(implicit request: RequestHeader)
+@(ageMessage: String, isHidden: Boolean = false, ariaHidden: Boolean = false)(implicit request: RequestHeader)
 
 @if(ageMessage.nonEmpty) {
-    <div class="old-article-message">
+    <div class="old-article-message @if(isHidden){u-h}" @if(ariaHidden){aria-hidden="true"}>
         @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
         This article is over <strong>@ageMessage old</strong>
     </div>

--- a/common/app/views/fragments/contentAgeNotice.scala.html
+++ b/common/app/views/fragments/contentAgeNotice.scala.html
@@ -3,6 +3,6 @@
 @if(ageMessage.nonEmpty) {
     <div class="old-article-message @if(isHidden){u-h}" @if(ariaHidden){aria-hidden="true"}>
         @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
-        This article is over <strong>@ageMessage old</strong>
+        This article is more than <strong>@ageMessage old</strong>
     </div>
 }

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,7 +1,6 @@
 @(item: model.ContentType, page: model.Page, showExtras: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 @import model._
 @import views.support.Commercial.isPaidContent
-@import views.support.ContentOldAgeDescriber
 @import _root_.model.ContentDesignType.RichContentDesignType
 @import views.support.RenderClasses
 
@@ -15,10 +14,6 @@
 
 @iconModifier() = @{
     if (item.content.isGallery) List("social-icon-media") else Nil
-}
-
-@ageNotice() = @{
-    ContentOldAgeDescriber(item.content)
 }
 
 @metaBody() = {
@@ -57,13 +52,11 @@
     }
 
     @if(showExtras) {
-        <div class="meta__extras @if(!ageNotice.isEmpty){ meta__extras--notice }">
+        <div class="meta__extras">
             <div class="meta__social" data-component="share">
                 @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier, amp = amp)
             </div>
-            @if(item.content.tags.tags.exists(_.id == "tone/news")) {
-                @fragments.contentAgeNotice(ageNotice)
-            }
+
             @if(!amp) {
                 <div class="meta__numbers">
                     <div class="u-h meta__number js-sharecount">

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -70,7 +70,7 @@ object MetaDataMatcher extends Matchers  {
     status(result) should be(200)
 
     val elements = body.getElementsByClass("old-article-message")
-    elements.size() should be(1)
+    elements.size() should be(2)
   }
 
   def ensureNoOldArticleMessage(result: Future[Result], articleUrl: String) {

--- a/static/src/stylesheets/module/_headline-list-garnett.scss
+++ b/static/src/stylesheets/module/_headline-list-garnett.scss
@@ -103,8 +103,8 @@
         }
     }
 
-    .old-article-message {
-        margin-bottom: 0;
+    .old-article-message svg {
+        vertical-align: middle;
     }
 
 }

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -867,7 +867,7 @@
 
     .content__headline-standfirst-wrapper & {
         @include fs-textSans(5);
-        padding: ($gs-baseline / 2) ($gs-gutter / 2) ($gs-baseline / 2) ($gs-gutter / 2);
+        padding: ($gs-baseline / 2) ($gs-gutter / 2);
         margin-top: $gs-baseline / 2;
 
         @include mq(mobileLandscape) {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -855,34 +855,33 @@
 
 .old-article-message {
     @include fs-textSans(1);
+    background: $highlight-main;
     display: inline-block;
-    color: $brightness-46;
-    margin-bottom: $gs-baseline;
+    color: $brightness-7;
+    margin-bottom: $gs-baseline / 2;
+    padding: ($gs-baseline / 4) ($gs-gutter / 4);
 
     .old-article-message--clock svg {
-        fill: $brightness-46;
-        margin-bottom: -1px;
+        fill: currentColor;
     }
-}
 
-.tonal--tone-media {
-    .old-article-message {
-        color: $brightness-86;
+    .content__headline-standfirst-wrapper & {
+        @include fs-textSans(5);
+        padding: ($gs-baseline / 2) ($gs-gutter / 2) ($gs-baseline / 2) ($gs-gutter / 2);
+        margin-top: $gs-baseline / 2;
 
-        .old-article-message--clock svg {
-            fill: $brightness-86;
+        @include mq(mobileLandscape) {
+            padding-left: $gs-gutter;
         }
-    }
-}
 
-.content--interactive {
-    .tonal__main--tone-news {
-        .old-article-message {
-            @include mq(tablet) {
-                position: absolute;
-                left: 0;
-                top: 44px;
-            }
+        @include mq(tablet) {
+            margin-left: -$gs-gutter;
+        }
+
+        @include mq(leftCol) {
+            margin-left: -$gs-gutter / 2;
+            margin-top: 0;
+            padding-left: $gs-gutter / 2;
         }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -26,7 +26,6 @@
     .byline,
     .content--media .content__headline,
     .content__label__link,
-    .old-article-message,
     .pullquote-cite,
     a {
         color: $kickerColor;
@@ -203,7 +202,6 @@
     .block-share__item .inline-icon,
     .commentcount2__heading span,
     .inline-close svg,
-    .old-article-message .old-article-message--clock svg,
     .social-icon svg,
     .social-icon__svg {
         fill: $kickerColor;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -37,7 +37,6 @@ $quote-mark: 35px;
     .content__headline,
     .content__labels,
     .content__standfirst,
-    .old-article-message,
     .meta__extras,
     .meta__contact-wrap {
         padding-left: $gs-gutter/2;
@@ -125,10 +124,6 @@ $quote-mark: 35px;
         border-top: 0;
         padding-top: 0;
         padding-bottom: $gs-baseline;
-    }
-
-    .old-article-message {
-        order: 4;
     }
 
     .meta__contact-header {


### PR DESCRIPTION
## What does this change?
Increased prominence of content age message. To prevent miss-leading spreading of news. 

**Accessibility BONUS:**
Following sage advice from DR Adcock, I have duplicated the content age notice. One instance is invisible to screen readers and sits before the `H1` and one is hidden from view but readable by screen readers and sits below the `H1`.

# Before
![Screen Shot 2019-03-26 at 15 25 56](https://user-images.githubusercontent.com/14570016/55012892-06fca500-4fe0-11e9-8eb6-a0ec4783f6a7.png)


![Screen Shot 2019-03-26 at 15 24 57](https://user-images.githubusercontent.com/14570016/55012843-efbdb780-4fdf-11e9-8135-f341136969a4.png)

# Before
<img width="400" alt="Screen Shot 2019-03-26 at 14 58 29" src="https://user-images.githubusercontent.com/14570016/55012880-0106c400-4fe0-11e9-941b-1db236a27e3e.png">


# After
![Screen Shot 2019-03-26 at 15 27 34](https://user-images.githubusercontent.com/14570016/55012851-f4826b80-4fdf-11e9-9439-8b5e0e3df537.png)


TODO: 
AMP and apps support.