### PR TITLE
Styles added in for tone-live & pillar-Opinion case scenario

### DIFF
--- a/static/src/stylesheets/email/_tones.scss
+++ b/static/src/stylesheets/email/_tones.scss
@@ -124,6 +124,19 @@
         }
     }
 
+    &.pillar-Opinion {
+        border-top: 1px solid #f9b376;
+
+        .fc__kicker {
+            color: #f9b376;
+        }
+
+        &,
+        & th {
+            background-color: #bd5318;
+        }
+    }
+
     .headline,
     .fc-link,
     .trail-text {


### PR DESCRIPTION
## What does this change?
Following commit adds missing styles for tone-live / pillar-Opinion case scenario
## Screenshots
![Screen Shot 2019-03-27 at 11 14 53](https://user-images.githubusercontent.com/47107438/55071845-95753300-5081-11e9-884a-16ad52abd9a9.png)
## What is the value of this and can you measure success?
This is related to the following pull request [link](https://github.com/guardian/frontend/pull/21285) 
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] N/A

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
