### PR TITLE
Removing 'splash'

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -79,9 +79,9 @@ final case class Content(
   lazy val isGallery = metadata.contentType.contains(DotcomContentType.Gallery)
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isColumn = fields.displayHint.contains("column")
-  lazy val isNumberedList = fields.displayHint.contains("splash") || fields.displayHint.contains("numberedList")
-  lazy val isSplash = fields.displayHint.contains("column") || fields.displayHint.contains("numberedList") || fields.displayHint.contains("splash")
-  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
+  lazy val isNumberedList = fields.displayHint.contains("numberedList")
+  lazy val isSplash = fields.displayHint.contains("column") || fields.displayHint.contains("numberedList")
+  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle gi|| isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -81,7 +81,7 @@ final case class Content(
   lazy val isColumn = fields.displayHint.contains("column")
   lazy val isNumberedList = fields.displayHint.contains("numberedList")
   lazy val isSplash = fields.displayHint.contains("column") || fields.displayHint.contains("numberedList")
-  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle gi|| isPhotoEssay
+  lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 


### PR DESCRIPTION
Removing temporary display hint name, now it has been renamed here:
https://github.com/guardian/flexible-content/pull/3369