### PR TITLE
Updating nav links to remove Masterclasses and add Guardian Print Shop

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -186,7 +186,7 @@ object NavLinks {
   val dating = NavLink("Dating", "https://soulmates.theguardian.com")
   val apps = NavLink("The Guardian app", "https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet")
   val ukMasterClasses = NavLink("Masterclasses", "https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader")
-  val printShop = NavLink("Guardian Print Shop", "https://www.theguardian.com/artanddesign/series/gnm-print-sales")
+  val printShop = NavLink("Guardian Print Shop", "/artanddesign/series/gnm-print-sales")
   val auEvents = NavLink("Events", "/guardian-live-australia")
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -186,6 +186,7 @@ object NavLinks {
   val dating = NavLink("Dating", "https://soulmates.theguardian.com")
   val apps = NavLink("The Guardian app", "https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet")
   val ukMasterClasses = NavLink("Masterclasses", "https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader")
+  val printShop = NavLink("Guardian Print Shop", "https://www.theguardian.com/artanddesign/series/gnm-print-sales")
   val auEvents = NavLink("Events", "/guardian-live-australia")
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
@@ -472,8 +473,7 @@ object NavLinks {
     observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
     NavLink("Professional networks", "/guardian-professional"),
-    crosswords,
-    guardianMasterClasses
+    crosswords
   )
   val auOtherLinks = List(
     apps,
@@ -514,6 +514,7 @@ object NavLinks {
     holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
     ukMasterClasses,
     digitalNewspaperArchive,
+    printShop,
     ukPatrons,
     ukDiscountCode
   )


### PR DESCRIPTION
All credit to @cpking

## What does this change?

Removing 'Masterclasses' from the 'More' links from the Nav, and adding in 'Guardian Print Shop' to the Brand Extension links.

## Screenshots

Before:
![Screen Shot 2019-03-27 at 15 35 42](https://user-images.githubusercontent.com/2051501/55090027-50172c80-50a6-11e9-8417-a69d8dfa7550.png)

After:
![Screen Shot 2019-03-27 at 15 37 49](https://user-images.githubusercontent.com/2051501/55090026-50172c80-50a6-11e9-9ea0-917f8045310b.png)