### PR TITLE
Update adblock contributions message + design

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -7,23 +7,25 @@ import config from 'lib/config';
 const supportUrl = `${supportContributeURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
 const askHtml = `
-<div class="contributions__adblock--moment">
-    <div class="contributions__adblock--moment-content">
-        <div class="contributions__adblock--moment-header">
-            <h2 class="contributions__adblock--moment-header--blue">Support</h2>
-            <h2 class="contributions__adblock--moment-header--blue">The Guardian’s</h2>
-            <h2 class="contributions__adblock--moment-header--orange">model for open, independent journalism</h2>
+<div class="contributions__adblock">
+    <div class="contributions__adblock-content">
+        <div class="contributions__adblock-header">
+            <h2>
+                Editorially<br>
+                independent,<br>
+                open to everyone
+            </h2>
         </div>
-        <div class="contributions__adblock--moment-sub">
-            We’re available for everyone, supported by our readers
+        <div class="contributions__adblock-sub">
+            We chose a different approach —<br>
+            will you support it?
         </div>
-        <div class="contributions__adblock--moment-button">
-            <a class="contributions__option-button contributions__contribute "
-              href="${supportUrl}"
-              target="_blank">
-              Support The Guardian
-            </a>
-        </div>
+        <a class="contributions__adblock-button" href="${supportUrl}">
+            <span class="component-button__content">Support The Guardian</span>
+            <svg class="svg-arrow-right-straight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 17.89" preserveAspectRatio="xMinYMid">
+                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z"></path>
+            </svg>
+        </a>
     </div>
 </div>
 `;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -112,7 +112,7 @@
 
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic,
-.contributions__adblock--moment-button a {
+.contributions__adblock-button a {
     margin-top: 0;
     background-color: $highlight-main;
     color: $brightness-7;
@@ -211,46 +211,81 @@ a[href].contributions__contribute.contributions__contribute--epic,
     }
 }
 
-.contributions__adblock--moment {
+.contributions__adblock {
     position: absolute;
     top: 0;
     padding-top: $gs-baseline/2;
+    width: 100%;
 
-    .contributions__adblock--moment-content {
-        border-top: 5px solid #052962;
-        background-color: #f6f6f6;
+    .contributions__adblock-content {
+        border-top: 5px solid $highlight-main;
+        margin-right: 20px;
     }
 
-    .contributions__adblock--moment-header {
-        padding-left: 13px;
+    .contributions__adblock-header {
+        padding-left: 10px;
+        padding-top: 3px;
 
         h2 {
             @include fs-header(5);
             font-size: 32px;
-            line-height: 32px;
-        }
-
-        .contributions__adblock--moment-header--blue {
-            color: #0084c6;
-        }
-        .contributions__adblock--moment-header--orange {
-            color: #ff7f0f;
+            line-height: 36px;
         }
     }
 
-    .contributions__adblock--moment-sub {
-        color: #052962;
-        font-size: 16px;
+    .contributions__adblock-sub {
+        font-family: $f-serif-headline;
+        font-size: 18px;
         line-height: 20px;
-        padding: 10px 0 8px 13px;
+        padding: 12px 0 10px 10px;
     }
 
-    .contributions__adblock--moment-button {
-        padding-left: 5px;
-        padding-bottom: 4px;
-        a {
-            color: #052962;
-            margin: $gs-baseline/3 $gs-gutter/2 $gs-baseline/3 0;
+    .contributions__adblock-button {
+        margin-top: 10px;
+        margin-left: 5px;
+        background-color: $highlight-main;
+        color: $brightness-7 !important;
+        font-size: 1rem;
+        line-height: 1.375rem;
+        font-family: $f-sans-serif-text;
+        display: inline-flex;
+        align-items: center;
+        text-decoration: none;
+        font-weight: bold;
+        height: 2.625rem;
+        min-height: 2.625rem;
+        padding: 0 1.3125rem;
+        border: none;
+        border-radius: 1.3125rem;
+        box-sizing: border-box;
+        cursor: pointer;
+        transition: 0.3s ease-in-out;
+        justify-content: space-between;
+        position: relative;
+
+        &:hover, &:focus {
+            background-color: $highlight-dark;
+            svg {
+                transform: translateX(20%);
+            }
+        }
+
+        span {
+            flex: 0 0 auto;
+            display: block;
+        }
+
+        svg {
+            flex: 0 0 auto;
+            display: block;
+
+            transition: 0.3s ease-in-out transform;
+            will-change: transform;
+            margin: 0 -0.32813rem 0 0.65625rem;
+            fill: currentColor;
+            position: relative;
+            width: 1.3125rem;
+            height: auto;
         }
     }
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -245,18 +245,17 @@ a[href].contributions__contribute.contributions__contribute--epic,
         margin-left: 5px;
         background-color: $highlight-main;
         color: $brightness-7 !important;
-        font-size: 1rem;
-        line-height: 1.375rem;
+        font-size: 16px;
+        line-height: 22px;
         font-family: $f-sans-serif-text;
         display: inline-flex;
         align-items: center;
         text-decoration: none;
         font-weight: bold;
-        height: 2.625rem;
-        min-height: 2.625rem;
-        padding: 0 1.3125rem;
-        border: none;
-        border-radius: 1.3125rem;
+        height: 42px;
+        min-height: 42px;
+        padding: 0 21px;
+        border-radius: 21px;
         box-sizing: border-box;
         cursor: pointer;
         transition: 0.3s ease-in-out;
@@ -281,10 +280,10 @@ a[href].contributions__contribute.contributions__contribute--epic,
 
             transition: 0.3s ease-in-out transform;
             will-change: transform;
-            margin: 0 -0.32813rem 0 0.65625rem;
+            margin: 0 -5px 0 10px;
             fill: currentColor;
             position: relative;
-            width: 1.3125rem;
+            width: 21px;
             height: auto;
         }
     }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -258,7 +258,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
         border-radius: 21px;
         box-sizing: border-box;
         cursor: pointer;
-        transition: 0.3s ease-in-out;
+        transition: .3s ease-in-out;
         justify-content: space-between;
         position: relative;
 
@@ -278,7 +278,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
             flex: 0 0 auto;
             display: block;
 
-            transition: 0.3s ease-in-out transform;
+            transition: .3s ease-in-out transform;
             will-change: transform;
             margin: 0 -5px 0 10px;
             fill: currentColor;


### PR DESCRIPTION
## What does this change?
This is the message/button hidden under the adslot in articles, visible only to users with adblockers.
The previous design was specific to our Feburary campaign.

1. Update the design
2. Update the text
3. Rename classes from `contributions__adblock--moment...` to `contributions__adblock...`
4. Use button design from 'story book', including animation on hover

## Screenshots
### before:
<img width="1171" alt="Screenshot 2019-03-27 at 16 44 58" src="https://user-images.githubusercontent.com/1513454/55095224-b05e9c00-50af-11e9-8fac-4966602b1140.png">

### after:
<img width="1171" alt="Screenshot 2019-03-27 at 16 38 59" src="https://user-images.githubusercontent.com/1513454/55095007-54941300-50af-11e9-8b2d-c4100be6edc7.png">

### on hover:
<img width="1171" alt="Screenshot 2019-03-27 at 16 39 19" src="https://user-images.githubusercontent.com/1513454/55095009-54941300-50af-11e9-8c0c-4d45b4bebd1a.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
