### PR TITLE
Extend SwG feature toggle until end of April

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,7 +512,7 @@ trait FeatureSwitches {
     "If switched on, a Subscribe with Google button will appear on AMP articles.",
     owners = Seq(Owner.withName("adem.gaygusuz")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 4, 1),
+    sellByDate = new LocalDate(2019, 4, 25),
     exposeClientSide = true
   )
 }


### PR DESCRIPTION
## What does this change?

Extends switch until a few days before the end of @damien-shaw-guardian and Bill Beatie's contract.

Expires Thursday 25/04/2019 
