### PR TITLE
Extend expired switches

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -21,7 +21,7 @@ trait IdentitySwitches {
     "If switched on, users coming from newsletters will get prompts to sign in.",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 28),
+    sellByDate = new LocalDate(2019, 5, 16),
     exposeClientSide = true
   )
 
@@ -31,7 +31,7 @@ trait IdentitySwitches {
     "If switched on, access to the new consent journeys will be enabled.",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 3, 28),
+    sellByDate = new LocalDate(2019, 5, 16),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?
Extends some switches which expired yesterday without us getting alerted 😢 

Now due to expire on a Thursday in May, so we have some time next quarter to reconsider what we want to do with these features (kill or keep).

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
