### PR TITLE
Revert "Use showSupportMessaging flag from members-data-api"

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -70,7 +70,7 @@
     }
 
     /*
-        This is a shortened version of shouldHideSupportMessaging() from
+        This is a shortened version of shouldSeeReaderRevenue() from
         user-features.js. Since we are blocking rendering at this time we
         can't inline all required JS from this module.
     */
@@ -88,12 +88,8 @@
         return diffDays <= 180;
     }
 
-    function shouldHideSupportMessaging() {
-        var value = getCookieValue('gu_show_support_messaging');
-        if (!value) {
-            return false;
-        }
-        return value === 'false';
+    function isPayingMember() {
+        return getCookieValue('gu_paying_member') === 'true';
     }
 
     function forcePercentagePadding() {
@@ -144,8 +140,8 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (shouldHideSupportMessaging()) {
-        docClass += ' hide-support-messaging'
+    if (isPayingMember()) {
+        docClass += ' is-paying-member';
     }
 
     if (isRecentContributor()) {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -7,7 +7,7 @@ import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import {
     isPayingMember as isPayingMember_,
     isRecentOneOffContributor as isRecentOneOffContributor_,
-    shouldHideSupportMessaging as shouldHideSupportMessaging_,
+    userIsSupporter as userIsSupporter_,
     isAdFreeUser as isAdFreeUser_,
 } from 'common/modules/commercial/user-features';
 
@@ -16,10 +16,7 @@ const isRecentOneOffContributor: JestMockFn<
     *,
     *
 > = (isRecentOneOffContributor_: any);
-const shouldHideSupportMessaging: JestMockFn<
-    *,
-    *
-> = (shouldHideSupportMessaging_: any);
+const userIsSupporter: JestMockFn<*, *> = (userIsSupporter_: any);
 const isAdFreeUser: JestMockFn<*, *> = (isAdFreeUser_: any);
 const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
@@ -29,7 +26,7 @@ const CommercialFeatures = commercialFeatures.constructor;
 jest.mock('common/modules/commercial/user-features', () => ({
     isPayingMember: jest.fn(),
     isRecentOneOffContributor: jest.fn(),
-    shouldHideSupportMessaging: jest.fn(),
+    userIsSupporter: jest.fn(),
     isAdFreeUser: jest.fn(),
 }));
 
@@ -70,7 +67,7 @@ describe('Commercial features', () => {
         getBreakpoint.mockReturnValue('desktop');
         isPayingMember.mockReturnValue(false);
         isRecentOneOffContributor.mockReturnValue(false);
-        shouldHideSupportMessaging.mockReturnValue(false);
+        userIsSupporter.mockReturnValue(false);
         isAdFreeUser.mockReturnValue(false);
         isUserLoggedIn.mockReturnValue(true);
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -32,7 +32,7 @@ import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
+import { userIsSupporter } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
     supportSubscribeGeoRedirectURL,
@@ -144,9 +144,9 @@ const userIsInCorrectCohort = (
 ): boolean => {
     switch (userCohort) {
         case 'OnlyExistingSupporters':
-            return shouldHideSupportMessaging();
+            return userIsSupporter();
         case 'OnlyNonSupporters':
-            return !shouldHideSupportMessaging();
+            return !userIsSupporter();
         case 'Everyone':
         default:
             return true;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -86,7 +86,7 @@ jest.mock('common/modules/commercial/contributions-utilities', () => ({
     canShowBannerSync: jest.fn(() => false),
 }));
 jest.mock('common/modules/commercial/user-features', () => ({
-    shouldHideSupportMessaging: jest.fn(() => false),
+    userIsSupporter: jest.fn(() => false),
 }));
 jest.mock('lib/fetch-json', () => jest.fn());
 jest.mock('common/modules/user-prefs', () => ({

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -11,7 +11,6 @@ const PAYING_MEMBER_COOKIE = 'gu_paying_member';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
-const SHOW_SUPPORT_MESSAGING_COOKIE = 'gu_show_support_messaging';
 
 // This cookie comes from the user attributes API
 const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
@@ -37,8 +36,7 @@ const userHasData = (): boolean => {
         getCookie(PAYING_MEMBER_COOKIE) ||
         getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||
         getCookie(AD_FREE_USER_COOKIE) ||
-        getCookie(DIGITAL_SUBSCRIBER_COOKIE) ||
-        getCookie(SHOW_SUPPORT_MESSAGING_COOKIE);
+        getCookie(DIGITAL_SUBSCRIBER_COOKIE);
     return !!cookie;
 };
 
@@ -67,7 +65,6 @@ const persistResponse = (JsonResponse: () => void) => {
         DIGITAL_SUBSCRIBER_COOKIE,
         JsonResponse.contentAccess.digitalPack
     );
-    addCookie(SHOW_SUPPORT_MESSAGING_COOKIE, JsonResponse.showSupportMessaging);
 
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
@@ -95,7 +92,6 @@ const deleteOldData = (): void => {
     removeCookie(AD_FREE_USER_COOKIE);
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     removeCookie(DIGITAL_SUBSCRIBER_COOKIE);
-    removeCookie(SHOW_SUPPORT_MESSAGING_COOKIE);
 };
 
 const requestNewData = (): Promise<void> =>
@@ -214,9 +210,6 @@ const isRecurringContributor = (): boolean =>
 const isDigitalSubscriber = (): boolean =>
     getCookie(DIGITAL_SUBSCRIBER_COOKIE) === 'true';
 
-const shouldShowSupportMessaging = (): boolean =>
-    getCookie(SHOW_SUPPORT_MESSAGING_COOKIE) === 'true';
-
 /*
     Whenever the checks are updated, please make sure to update
     applyRenderConditions.scala.js too, where the global CSS class, indicating
@@ -224,11 +217,11 @@ const shouldShowSupportMessaging = (): boolean =>
     Please also update readerRevenueRelevantCookies below, if changing the cookies
     which this function is dependent on.
 */
-
-const shouldHideSupportMessaging = (): boolean =>
-    !shouldShowSupportMessaging() ||
-    isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
-    isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
+const userIsSupporter = (): boolean =>
+    isPayingMember() ||
+    isRecentOneOffContributor() ||
+    isRecurringContributor() ||
+    isDigitalSubscriber();
 
 const readerRevenueRelevantCookies = [
     PAYING_MEMBER_COOKIE,
@@ -237,7 +230,6 @@ const readerRevenueRelevantCookies = [
     SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
     SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-    SHOW_SUPPORT_MESSAGING_COOKIE,
 ];
 
 // For debug/test purposes
@@ -255,12 +247,11 @@ export {
     isRecentOneOffContributor,
     isRecurringContributor,
     isDigitalSubscriber,
-    shouldHideSupportMessaging,
+    userIsSupporter,
     refresh,
     deleteOldData,
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     readerRevenueRelevantCookies,
     fakeOneOffContributor,
-    shouldShowSupportMessaging,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -14,7 +14,6 @@ import {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
-    shouldShowSupportMessaging,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -34,7 +33,6 @@ const PERSISTENCE_KEYS = {
     ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
     DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
-    SHOW_SUPPORT_MESSAGING_COOKIE: 'gu_show_support_messaging',
 };
 
 const setAllFeaturesData = opts => {
@@ -49,7 +47,6 @@ const setAllFeaturesData = opts => {
     addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
-    addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
     addCookie(
         PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
         adFreeExpiryDate.getTime().toString()
@@ -78,7 +75,6 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
     removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
 };
 
 beforeAll(() => {
@@ -304,36 +300,6 @@ describe('The isDigitalSubscriber getter', () => {
         it('Is false when the user has no digital subscriber cookie', () => {
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
             expect(isDigitalSubscriber()).toBe(false);
-        });
-    });
-});
-
-describe('The shouldShowSupportMessaging getter', () => {
-    it('Returns false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(shouldShowSupportMessaging()).toBe(false);
-    });
-
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
-
-        it('Returns true when the user has a `true` support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
-            expect(shouldShowSupportMessaging()).toBe(true);
-        });
-
-        it('Returns false when the user has a `false` support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'false');
-            expect(shouldShowSupportMessaging()).toBe(false);
-        });
-
-        it('Returns false when the user has no support messaging cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
-            expect(shouldShowSupportMessaging()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,5 +1,5 @@
 // @flow
-import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
+import { userIsSupporter } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
@@ -44,7 +44,7 @@ export const adblockTest: ABTest = {
     showForSensitive: true,
     canRun() {
         return (
-            !shouldHideSupportMessaging() &&
+            !userIsSupporter() &&
             !pageShouldHideReaderRevenue() &&
             !config.get('page.hasShowcaseMainElement')
         );

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -73,7 +73,7 @@
     &:last-child {
         margin-right: 0;
 
-        .hide-support-messaging & > *,
+        .is-paying-member & > *,
         .is-recent-contributor & > * {
             display: none;
         }

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -3,7 +3,7 @@
     top: 30px;
     left: $gs-gutter / 2;
 
-    .hide-support-messaging &,
+    .is-paying-member &,
     .is-recent-contributor & {
         display: none;
     }


### PR DESCRIPTION
Unfortunately I'm reverting this as it has the side effect that the users already signed in and thus without the new cookie will start seeing support messaging regardless of their paid status until the next members-data-api call which could be up to 24 hours.

Fortunately I spotted this behaviour (rather than user complaint - as far as I am aware) and it has been live for less than 30mins.

_We will need to do a phased re-release of this feature at some point in the future - where it checks in the old way and the new way, followed by a cleanup PR after 24 hours_