### PR TITLE
Overlay media image on Twitter with content age

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -129,7 +129,11 @@ final case class Content(
     else if(isFromTheObserver && tags.isComment) FacebookOpenGraphImage.opinionsObserver
     else if(tags.isComment) FacebookOpenGraphImage.opinions
     else if(tags.isLiveBlog) FacebookOpenGraphImage.live
-    else if(tags.tags.exists(_.id == "tone/news") && trail.webPublicationDate.getYear < DateTime.now().getYear()) {
+    else if(
+      metadata.id == "education/2016/aug/07/senior-tories-likely-to-resist-theresa-mays-grammar-schools-agenda" &&
+      tags.tags.exists(_.id == "tone/news") &&
+      trail.webPublicationDate.getYear < DateTime.now().getYear()
+    ) {
       if(isFromTheObserver) {
         TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)
       } else {
@@ -165,7 +169,11 @@ final case class Content(
     else if(isFromTheObserver && tags.isComment) TwitterImage.opinionsObserver
     else if(tags.isComment) TwitterImage.opinions
     else if(tags.isLiveBlog) TwitterImage.live
-    else if(tags.tags.exists(_.id == "tone/news") && trail.webPublicationDate.getYear < DateTime.now().getYear()) {
+    else if(
+        metadata.id == "education/2016/aug/07/senior-tories-likely-to-resist-theresa-mays-grammar-schools-agenda" &&
+        tags.tags.exists(_.id == "tone/news") &&
+        trail.webPublicationDate.getYear < DateTime.now().getYear()
+    ) {
       if(isFromTheObserver) {
         TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)
       } else {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -22,6 +22,7 @@ import views.support._
 import scala.collection.JavaConverters._
 import scala.util.Try
 import implicits.Booleans._
+import org.joda.time.DateTime
 
 sealed trait ContentType {
   def content: Content
@@ -157,6 +158,13 @@ final case class Content(
     else if(isFromTheObserver && tags.isComment) TwitterImage.opinionsObserver
     else if(tags.isComment) TwitterImage.opinions
     else if(tags.isLiveBlog) TwitterImage.live
+    else if(tags.tags.exists(_.id == "tone/news") && trail.webPublicationDate.getYear < DateTime.now().getYear()) {
+      if(isFromTheObserver) {
+        TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)
+      } else {
+        TwitterImage.contentAgeNotice(trail.webPublicationDate.getYear)
+      }
+    }
     else starRating.map(rating =>
         if(isFromTheObserver) {
             TwitterImage.starRatingObserver(rating)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -129,6 +129,13 @@ final case class Content(
     else if(isFromTheObserver && tags.isComment) FacebookOpenGraphImage.opinionsObserver
     else if(tags.isComment) FacebookOpenGraphImage.opinions
     else if(tags.isLiveBlog) FacebookOpenGraphImage.live
+    else if(tags.tags.exists(_.id == "tone/news") && trail.webPublicationDate.getYear < DateTime.now().getYear()) {
+      if(isFromTheObserver) {
+        TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)
+      } else {
+        TwitterImage.contentAgeNotice(trail.webPublicationDate.getYear)
+      }
+    }
     else starRating.map(rating =>
         if(isFromTheObserver) {
             FacebookOpenGraphImage.starRatingObserver(rating)

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -11,6 +11,7 @@ import model._
 import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import common.Environment.{app, awsRegion, stage}
+import org.joda.time.DateTime
 import play.api.libs.json.{Json, Writes}
 
 import Function.const
@@ -171,6 +172,24 @@ object TwitterImage extends OverlayBase64 {
             case _ => s"overlay-base64=${overlayUrlBase64("to-default.png")}"
         }
         new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn)
+    }
+    def getContentAgeFileName(prefix: String, publicationYear: Int): String = {
+      // WARNING: we have only produced these content age images up to the year 2025
+      if (publicationYear < 2025) {
+        s"${prefix}-age-${publicationYear}.png"
+      } else {
+        s"${prefix}-default.png"
+      }
+    }
+    def contentAgeNotice(publicationYear: Int): ShareImage = {
+      val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("tg", publicationYear))}"
+
+      new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn)
+    }
+    def contentAgeNoticeObserver(publicationYear: Int): ShareImage = {
+      val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to", publicationYear))}"
+
+      new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn)
     }
     val defaultObserver = new ShareImage(s"overlay-base64=${overlayUrlBase64("to-default.png")}", TwitterShareImageLogoOverlay.isSwitchedOn)
     val opinionsObserver = new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", TwitterShareImageLogoOverlay.isSwitchedOn)

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -223,6 +223,24 @@ object FacebookOpenGraphImage extends OverlayBase64 {
         }
         new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn)
     }
+    def getContentAgeFileName(prefix: String, publicationYear: Int): String = {
+      // WARNING: we have only produced these content age images up to the year 2025
+      if (publicationYear < 2025) {
+        s"${prefix}-age-${publicationYear}.png"
+      } else {
+        s"${prefix}-default.png"
+      }
+    }
+    def contentAgeNotice(publicationYear: Int): ShareImage = {
+      val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("tg", publicationYear))}"
+
+      new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn)
+    }
+    def contentAgeNoticeObserver(publicationYear: Int): ShareImage = {
+      val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to", publicationYear))}"
+
+      new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn)
+    }
     val defaultObserver = new ShareImage(s"overlay-base64=${overlayUrlBase64("to-default.png")}", FacebookShareImageLogoOverlay.isSwitchedOn)
     val opinionsObserver = new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", FacebookShareImageLogoOverlay.isSwitchedOn)
 }


### PR DESCRIPTION
## What does this change?

Old articles may be shared on Twitter, which could give readers a
misleading picture of a news story.

This change overlays older articles with a PNG that displays the year
the article was published.

This change is limited to [a single whitelisted article](https://www.theguardian.com/education/2016/aug/07/senior-tories-likely-to-resist-theresa-mays-grammar-schools-agenda) for the purposes of testing, before we roll out to all news articles. An old Tweet linking to this article can be found [here](https://twitter.com/guardian/status/762353605840080896), for testing whether old tweets are updated correctly.

It would be worth considering rolling this out beyond just news to liveblogs and more if it is successful.

## Screenshots

**Before**

![Screenshot 2019-03-29 at 15 14 18](https://user-images.githubusercontent.com/5931528/55242611-83d48c80-5235-11e9-9094-9657f9ebd3f8.png)


**After**

![Screenshot 2019-03-29 at 15 12 39](https://user-images.githubusercontent.com/5931528/55242623-8931d700-5235-11e9-96d7-291ec8b17532.png)


## What is the value of this and can you measure success?

Gives more context to the reader and
allows them to disregard stories that are no longer relevant.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [X] Other (please specify)

Only Twitter

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/) - not great for screen reader as this is just an image overlayed on another image
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
