### PR TITLE
Remove old content overlay whitelist

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -130,7 +130,6 @@ final case class Content(
     else if(tags.isComment) FacebookOpenGraphImage.opinions
     else if(tags.isLiveBlog) FacebookOpenGraphImage.live
     else if(
-      metadata.id == "education/2016/aug/07/senior-tories-likely-to-resist-theresa-mays-grammar-schools-agenda" &&
       tags.tags.exists(_.id == "tone/news") &&
       trail.webPublicationDate.getYear < DateTime.now().getYear()
     ) {
@@ -170,7 +169,6 @@ final case class Content(
     else if(tags.isComment) TwitterImage.opinions
     else if(tags.isLiveBlog) TwitterImage.live
     else if(
-        metadata.id == "education/2016/aug/07/senior-tories-likely-to-resist-theresa-mays-grammar-schools-agenda" &&
         tags.tags.exists(_.id == "tone/news") &&
         trail.webPublicationDate.getYear < DateTime.now().getYear()
     ) {


### PR DESCRIPTION
## What does this change?

Removes the article whitelist that restricts the old content overlay from appearing on every old news article.

Related: #21306 

## Screenshots

![Screenshot 2019-03-29 at 15 12 39](https://user-images.githubusercontent.com/5931528/55246381-06147f00-523d-11e9-9e08-3bdd6b7a2a08.png)

## What is the value of this and can you measure success?

When merged, all old news articles will have the fancy "From 20xx" overlay when shared on social media. Hopefully old Tweets and Facebook posts will also pick up this change within 7 days.

