### PR TITLE
Revert "Revert "Use showSupportMessaging flag from members-data-api""

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -70,7 +70,7 @@
     }
 
     /*
-        This is a shortened version of shouldSeeReaderRevenue() from
+        This is a shortened version of shouldHideSupportMessaging() from
         user-features.js. Since we are blocking rendering at this time we
         can't inline all required JS from this module.
     */
@@ -88,8 +88,12 @@
         return diffDays <= 180;
     }
 
-    function isPayingMember() {
-        return getCookieValue('gu_paying_member') === 'true';
+    function shouldHideSupportMessaging() {
+        var value = getCookieValue('gu_show_support_messaging');
+        if (!value) {
+            return false;
+        }
+        return value === 'false';
     }
 
     function forcePercentagePadding() {
@@ -140,8 +144,8 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (isPayingMember()) {
-        docClass += ' is-paying-member';
+    if (shouldHideSupportMessaging()) {
+        docClass += ' hide-support-messaging'
     }
 
     if (isRecentContributor()) {

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -148,7 +148,7 @@
     }
 
     if (shouldHideSupportMessaging()) {
-        docClass += ' hide-support-messaging'
+        docClass += ' hide-support-messaging';
     }
 
     if (isRecentContributor()) {

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -88,12 +88,15 @@
         return diffDays <= 180;
     }
 
+
     function shouldHideSupportMessaging() {
-        var value = getCookieValue('gu_show_support_messaging');
-        if (!value) {
-            return false;
-        }
-        return value === 'false';
+        return getCookieValue('gu_paying_member') === 'true' ||
+        getCookieValue('gu_digital_subscriber') === 'true' ||
+        getCookieValue('gu_recurring_contributor') === 'true' ||
+        (
+            !!getCookieValue('gu_show_support_messaging') &&
+            getCookieValue('gu_show_support_messaging') === 'false'
+        );
     }
 
     function forcePercentagePadding() {

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -93,10 +93,7 @@
         return getCookieValue('gu_paying_member') === 'true' ||
         getCookieValue('gu_digital_subscriber') === 'true' ||
         getCookieValue('gu_recurring_contributor') === 'true' ||
-        (
-            !!getCookieValue('gu_show_support_messaging') &&
-            getCookieValue('gu_show_support_messaging') === 'false'
-        );
+        getCookieValue('gu_hide_support_messaging') === 'true';
     }
 
     function forcePercentagePadding() {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -7,7 +7,7 @@ import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import {
     isPayingMember as isPayingMember_,
     isRecentOneOffContributor as isRecentOneOffContributor_,
-    userIsSupporter as userIsSupporter_,
+    shouldHideSupportMessaging as shouldHideSupportMessaging_,
     isAdFreeUser as isAdFreeUser_,
 } from 'common/modules/commercial/user-features';
 
@@ -16,7 +16,10 @@ const isRecentOneOffContributor: JestMockFn<
     *,
     *
 > = (isRecentOneOffContributor_: any);
-const userIsSupporter: JestMockFn<*, *> = (userIsSupporter_: any);
+const shouldHideSupportMessaging: JestMockFn<
+    *,
+    *
+> = (shouldHideSupportMessaging_: any);
 const isAdFreeUser: JestMockFn<*, *> = (isAdFreeUser_: any);
 const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
@@ -26,7 +29,7 @@ const CommercialFeatures = commercialFeatures.constructor;
 jest.mock('common/modules/commercial/user-features', () => ({
     isPayingMember: jest.fn(),
     isRecentOneOffContributor: jest.fn(),
-    userIsSupporter: jest.fn(),
+    shouldHideSupportMessaging: jest.fn(),
     isAdFreeUser: jest.fn(),
 }));
 
@@ -67,7 +70,7 @@ describe('Commercial features', () => {
         getBreakpoint.mockReturnValue('desktop');
         isPayingMember.mockReturnValue(false);
         isRecentOneOffContributor.mockReturnValue(false);
-        userIsSupporter.mockReturnValue(false);
+        shouldHideSupportMessaging.mockReturnValue(false);
         isAdFreeUser.mockReturnValue(false);
         isUserLoggedIn.mockReturnValue(true);
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -32,7 +32,7 @@ import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { userIsSupporter } from 'common/modules/commercial/user-features';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
     supportSubscribeGeoRedirectURL,
@@ -144,9 +144,9 @@ const userIsInCorrectCohort = (
 ): boolean => {
     switch (userCohort) {
         case 'OnlyExistingSupporters':
-            return userIsSupporter();
+            return shouldHideSupportMessaging();
         case 'OnlyNonSupporters':
-            return !userIsSupporter();
+            return !shouldHideSupportMessaging();
         case 'Everyone':
         default:
             return true;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -86,7 +86,7 @@ jest.mock('common/modules/commercial/contributions-utilities', () => ({
     canShowBannerSync: jest.fn(() => false),
 }));
 jest.mock('common/modules/commercial/user-features', () => ({
-    userIsSupporter: jest.fn(() => false),
+    shouldHideSupportMessaging: jest.fn(() => false),
 }));
 jest.mock('lib/fetch-json', () => jest.fn());
 jest.mock('common/modules/user-prefs', () => ({

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -11,7 +11,7 @@ const PAYING_MEMBER_COOKIE = 'gu_paying_member';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
-const SHOW_SUPPORT_MESSAGING_COOKIE = 'gu_show_support_messaging';
+const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 
 // This cookie comes from the user attributes API
 const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
@@ -38,7 +38,7 @@ const userHasData = (): boolean => {
         getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||
         getCookie(AD_FREE_USER_COOKIE) ||
         getCookie(DIGITAL_SUBSCRIBER_COOKIE) ||
-        getCookie(SHOW_SUPPORT_MESSAGING_COOKIE);
+        getCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
     return !!cookie;
 };
 
@@ -67,7 +67,10 @@ const persistResponse = (JsonResponse: () => void) => {
         DIGITAL_SUBSCRIBER_COOKIE,
         JsonResponse.contentAccess.digitalPack
     );
-    addCookie(SHOW_SUPPORT_MESSAGING_COOKIE, JsonResponse.showSupportMessaging);
+    addCookie(
+        HIDE_SUPPORT_MESSAGING_COOKIE,
+        !JsonResponse.showSupportMessaging
+    );
 
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {
@@ -95,7 +98,7 @@ const deleteOldData = (): void => {
     removeCookie(AD_FREE_USER_COOKIE);
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     removeCookie(DIGITAL_SUBSCRIBER_COOKIE);
-    removeCookie(SHOW_SUPPORT_MESSAGING_COOKIE);
+    removeCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
 };
 
 const requestNewData = (): Promise<void> =>
@@ -214,8 +217,8 @@ const isRecurringContributor = (): boolean =>
 const isDigitalSubscriber = (): boolean =>
     getCookie(DIGITAL_SUBSCRIBER_COOKIE) === 'true';
 
-const shouldShowSupportMessaging = (): boolean =>
-    getCookie(SHOW_SUPPORT_MESSAGING_COOKIE) === 'true';
+const shouldNotBeShownSupportMessaging = (): boolean =>
+    getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
 
 /*
     Whenever the checks are updated, please make sure to update
@@ -228,7 +231,7 @@ const shouldShowSupportMessaging = (): boolean =>
 const shouldHideSupportMessaging = (): boolean =>
     isPayingMember() || // TODO: remove
     isDigitalSubscriber() || // TODO: remove
-    !shouldShowSupportMessaging() ||
+    shouldNotBeShownSupportMessaging() ||
     isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
     isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
 
@@ -239,7 +242,7 @@ const readerRevenueRelevantCookies = [
     SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
     SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-    SHOW_SUPPORT_MESSAGING_COOKIE,
+    HIDE_SUPPORT_MESSAGING_COOKIE,
 ];
 
 // For debug/test purposes
@@ -264,5 +267,5 @@ export {
     getDaysSinceLastOneOffContribution,
     readerRevenueRelevantCookies,
     fakeOneOffContributor,
-    shouldShowSupportMessaging,
+    shouldNotBeShownSupportMessaging,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -226,6 +226,8 @@ const shouldShowSupportMessaging = (): boolean =>
 */
 
 const shouldHideSupportMessaging = (): boolean =>
+    isPayingMember() || // TODO: remove
+    isDigitalSubscriber() || // TODO: remove
     !shouldShowSupportMessaging() ||
     isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
     isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -14,6 +14,7 @@ import {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
+    shouldShowSupportMessaging,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -33,6 +34,7 @@ const PERSISTENCE_KEYS = {
     ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
     DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
+    SHOW_SUPPORT_MESSAGING_COOKIE: 'gu_show_support_messaging',
 };
 
 const setAllFeaturesData = opts => {
@@ -47,6 +49,7 @@ const setAllFeaturesData = opts => {
     addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
+    addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
     addCookie(
         PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
         adFreeExpiryDate.getTime().toString()
@@ -75,6 +78,7 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
     removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
+    removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
 };
 
 beforeAll(() => {
@@ -300,6 +304,36 @@ describe('The isDigitalSubscriber getter', () => {
         it('Is false when the user has no digital subscriber cookie', () => {
             removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
             expect(isDigitalSubscriber()).toBe(false);
+        });
+    });
+});
+
+describe('The shouldShowSupportMessaging getter', () => {
+    it('Returns false when the user is logged out', () => {
+        jest.resetAllMocks();
+        isUserLoggedIn.mockReturnValue(false);
+        expect(shouldShowSupportMessaging()).toBe(false);
+    });
+
+    describe('When the user is logged in', () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+            isUserLoggedIn.mockReturnValue(true);
+        });
+
+        it('Returns true when the user has a `true` support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
+            expect(shouldShowSupportMessaging()).toBe(true);
+        });
+
+        it('Returns false when the user has a `false` support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'false');
+            expect(shouldShowSupportMessaging()).toBe(false);
+        });
+
+        it('Returns false when the user has no support messaging cookie', () => {
+            removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
+            expect(shouldShowSupportMessaging()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -14,7 +14,7 @@ import {
     getLastOneOffContributionDate,
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
-    shouldShowSupportMessaging,
+    shouldNotBeShownSupportMessaging,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -34,7 +34,7 @@ const PERSISTENCE_KEYS = {
     ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
     DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
-    SHOW_SUPPORT_MESSAGING_COOKIE: 'gu_show_support_messaging',
+    HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
 };
 
 const setAllFeaturesData = opts => {
@@ -49,7 +49,7 @@ const setAllFeaturesData = opts => {
     addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
     addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
-    addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
+    addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
     addCookie(
         PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
         adFreeExpiryDate.getTime().toString()
@@ -78,7 +78,7 @@ const deleteAllFeaturesData = () => {
     removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
     removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
     removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
+    removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
 };
 
 beforeAll(() => {
@@ -308,11 +308,11 @@ describe('The isDigitalSubscriber getter', () => {
     });
 });
 
-describe('The shouldShowSupportMessaging getter', () => {
+describe('The shouldNotBeShownSupportMessaging getter', () => {
     it('Returns false when the user is logged out', () => {
         jest.resetAllMocks();
         isUserLoggedIn.mockReturnValue(false);
-        expect(shouldShowSupportMessaging()).toBe(false);
+        expect(shouldNotBeShownSupportMessaging()).toBe(false);
     });
 
     describe('When the user is logged in', () => {
@@ -321,19 +321,19 @@ describe('The shouldShowSupportMessaging getter', () => {
             isUserLoggedIn.mockReturnValue(true);
         });
 
-        it('Returns true when the user has a `true` support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'true');
-            expect(shouldShowSupportMessaging()).toBe(true);
+        it('Returns true when the user has a `true` hide support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
+            expect(shouldNotBeShownSupportMessaging()).toBe(true);
         });
 
-        it('Returns false when the user has a `false` support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE, 'false');
-            expect(shouldShowSupportMessaging()).toBe(false);
+        it('Returns false when the user has a `false` hide support messaging cookie', () => {
+            addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'false');
+            expect(shouldNotBeShownSupportMessaging()).toBe(false);
         });
 
-        it('Returns false when the user has no support messaging cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.SHOW_SUPPORT_MESSAGING_COOKIE);
-            expect(shouldShowSupportMessaging()).toBe(false);
+        it('Returns false when the user has no hide support messaging cookie', () => {
+            removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
+            expect(shouldNotBeShownSupportMessaging()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -1,5 +1,5 @@
 // @flow
-import { userIsSupporter } from 'common/modules/commercial/user-features';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
 import { supportContributeURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
@@ -44,7 +44,7 @@ export const adblockTest: ABTest = {
     showForSensitive: true,
     canRun() {
         return (
-            !userIsSupporter() &&
+            !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&
             !config.get('page.hasShowcaseMainElement')
         );

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -73,7 +73,7 @@
     &:last-child {
         margin-right: 0;
 
-        .is-paying-member & > *,
+        .hide-support-messaging & > *,
         .is-recent-contributor & > * {
             display: none;
         }

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -3,7 +3,7 @@
     top: 30px;
     left: $gs-gutter / 2;
 
-    .is-paying-member &,
+    .hide-support-messaging &,
     .is-recent-contributor & {
         display: none;
     }


### PR DESCRIPTION
Re-implements guardian/frontend#21290 but with the addition of other product-related cookies temporarily. This needs to be in place for at least 24 hours and then we'll do a clean-up PR.

Reverts guardian/frontend#21305