### PR TITLE
fix duplicate display of content age warning for showcase.

### DIFF
--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -39,10 +39,6 @@
                     }
                 </h1>
 
-                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice, isHidden = true)
-                }
-
                 @if(article.tags.isInterview) {
                     @article.trail.byline.map { text =>
                         <span class="content__headline--byline-interview">@ContributorLinks(text, article.tags.contributors)</span>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -60,7 +60,7 @@
                     <div class="content__label-interview">Interview</div>
                 }
 
-                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                @if(article.content.tags.tags.exists(_.id == "tone/news") &&  !(article.elements.hasShowcaseMainElement)) {
                     @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
                 }
 

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -60,7 +60,7 @@
                     <div class="content__label-interview">Interview</div>
                 }
 
-                @if(article.content.tags.tags.exists(_.id == "tone/news") &&  !(article.elements.hasShowcaseMainElement)) {
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
                     @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
                 }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1074,6 +1074,9 @@ $quote-mark: 35px;
         .content__headline-standfirst-wrapper {
             @include mq($from: leftCol) {
                 grid-area: standfirst;
+                .old-article-message {
+                    display: none;
+                }
             }
         }
 


### PR DESCRIPTION
## What does this change?
Fixes duplicate display of content age warning for showcase.
## Screenshots
tk
## What is the value of this and can you measure success?

Only warn the once. 

## Checklist
 ### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)

This change affects screenreader text. 

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
