### PR TITLE
Show old content overlay if pubdate > 1 yr ago

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -131,7 +131,7 @@ final case class Content(
     else if(tags.isLiveBlog) FacebookOpenGraphImage.live
     else if(
       tags.tags.exists(_.id == "tone/news") &&
-      trail.webPublicationDate.getYear < DateTime.now().getYear()
+      trail.webPublicationDate.isBefore(DateTime.now().minusYears(1))
     ) {
       if(isFromTheObserver) {
         TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)
@@ -170,7 +170,7 @@ final case class Content(
     else if(tags.isLiveBlog) TwitterImage.live
     else if(
         tags.tags.exists(_.id == "tone/news") &&
-        trail.webPublicationDate.getYear < DateTime.now().getYear()
+        trail.webPublicationDate.isBefore(DateTime.now().minusYears(1))
     ) {
       if(isFromTheObserver) {
         TwitterImage.contentAgeNoticeObserver(trail.webPublicationDate.getYear)


### PR DESCRIPTION
## What does this change?

Currently, the old content overlay on social sharing images is appearing if the content was published last year. This changes the logic to show the overlay if the content is more than one year old.

## Screenshots

**Before**

<img width="1215" alt="Screenshot 2019-04-05 at 11 26 36" src="https://user-images.githubusercontent.com/5931528/55621542-b5010f80-5795-11e9-899a-5f3a5ab1f290.png">

**After**

<img width="1209" alt="Screenshot 2019-04-05 at 11 26 12" src="https://user-images.githubusercontent.com/5931528/55621541-b5010f80-5795-11e9-8fa0-2afe61f8212f.png">

## What is the value of this and can you measure success?

Correctly display old content overlay on old content, not just content published before the current calendar year.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
