### PR TITLE
Content age notice clashing with interview template

### DIFF
--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -22,13 +22,12 @@
         <div class="content__header tonal__header">
 
             <div class="u-cf">
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                }
 
                 @if((article.tags.isInterview)){
                     <div class="content__label-interview">Interview</div>
-                }
-
-                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
                 }
 
                 <h1 class="content__headline" itemprop="headline" @langAttributes(article.content)>
@@ -55,13 +54,12 @@
         <div class="content__header tonal__header">
 
             <div class="u-cf">
+                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
+                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                }
 
                 @if((article.tags.isInterview)){
                     <div class="content__label-interview">Interview</div>
-                }
-
-                @if(article.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
                 }
 
                 <h1 class="content__headline @if(article.content.starRating && !article.elements.hasShowcaseMainElement) {content__headline--no-margin-bottom}" itemprop="headline" @langAttributes(article.content)>

--- a/common/app/views/fragments/contentAgeNotice.scala.html
+++ b/common/app/views/fragments/contentAgeNotice.scala.html
@@ -1,8 +1,10 @@
 @(ageMessage: String, isHidden: Boolean = false, ariaHidden: Boolean = false)(implicit request: RequestHeader)
 
 @if(ageMessage.nonEmpty) {
-    <div class="old-article-message @if(isHidden){u-h}" @if(ariaHidden){aria-hidden="true"}>
-        @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
-        This article is more than <strong>@ageMessage old</strong>
+    <div class="old-article-message-wrapper @if(isHidden){u-h}" @if(ariaHidden){aria-hidden="true"}>
+        <div class="old-article-message">
+                @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
+                This article is more than <strong>@ageMessage old</strong>
+        </div>
     </div>
 }


### PR DESCRIPTION
You have to guess which is the before and which is the after. Solved the problem by wrapping a div (display: block) around the current (inline-block) element. 

<img width="608" alt="Screen Shot 2019-04-05 at 16 40 29" src="https://user-images.githubusercontent.com/14570016/55639575-a03a7100-57c1-11e9-9181-a7d8f5aa9a5a.png">

<img width="606" alt="Screen Shot 2019-04-05 at 16 40 38" src="https://user-images.githubusercontent.com/14570016/55639576-a03a7100-57c1-11e9-8727-c1c7021fa263.png">
