### PR TITLE
Type scale 17px serif

### DIFF
--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -51,11 +51,11 @@
         margin-bottom: .8em;
     }
     > h2 {
-        font-size: 18px;
+        font-size: 17px;
         line-height: 24px;
     }
     > h3 {
-        font-size: 16px;
+        font-size: 17px;
         line-height: 24px;
         margin: 0;
     }

--- a/static/src/stylesheets/amp/atoms/temporary/_snippets.scss
+++ b/static/src/stylesheets/amp/atoms/temporary/_snippets.scss
@@ -35,7 +35,7 @@
 }
 
 .explainer-snippet__heading {
-    font-size: 18px;
+    font-size: 17px;
     padding-top: 2px;
 }
 
@@ -90,7 +90,7 @@
     @include fs-textSans(1, true);
     color: $brightness-7;
     margin: $gs-baseline 0;
-    
+
     > .inline-icon {
         display: inline-flex;
         background: $brightness-86;

--- a/static/src/stylesheets/module/_most-popular.scss
+++ b/static/src/stylesheets/module/_most-popular.scss
@@ -70,15 +70,7 @@
 .most-popular__container .tabs__tab--most-popular a,
 .simple-content-card__headline,
 .second-tier__title {
-    font-family: $f-serif-headline;
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 20px;
-
-    @include mq(tablet) {
-        font-size: 18px;
-        line-height: 22px;
-    }
+    @include fs-headline(2);
 }
 
 .most-popular__headline {

--- a/static/src/stylesheets/module/atoms/temporary/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/temporary/_storyquestions.scss
@@ -22,7 +22,7 @@
 .user__question-title--secondary {
     color: $brightness-7;
     display: block;
-    font-size: 18px;
+    font-size: 17px;
     font-weight: 400;
 }
 

--- a/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
@@ -72,7 +72,7 @@
                 }
 
                 a {
-                    @include fs-headline(25);
+                    @include fs-headline(2);
                     font-weight: 800;
                 }
 
@@ -175,7 +175,7 @@
 
     // p tags containing ONLY a strong tag will be styled as H3 level headings
     .falseH3 {
-        @include fs-headline(25);
+        @include fs-headline(2);
         border-top: 1px solid $brightness-86;
         color: $brightness-7;
         margin-top: $gs-baseline * 2;

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -368,7 +368,7 @@
         }
 
         > li:before {
-            @include fs-header(1, true);
+            @include fs-header(2, true);
             position: absolute;
             left: -16px;
             content: counter(li);
@@ -1105,7 +1105,7 @@
         font-size: get-font-size(header, 2);
     }
     .rich-link__header {
-        line-height: get-line-height(header, 1);
+        line-height: get-line-height(header, 2);
     }
     .ad-slot__label,
     .ad-slot--inline {

--- a/static/src/stylesheets/module/content-garnett/_content.scss
+++ b/static/src/stylesheets/module/content-garnett/_content.scss
@@ -211,7 +211,7 @@
 }
 
 .content__label {
-    @include fs-header(1);
+    @include fs-header(2);
     display: inline;
     padding-right: $gs-gutter / 3;
 
@@ -544,7 +544,7 @@
 }
 
 .byline {
-    @include fs-header(1);
+    @include fs-header(2);
     border-top: 0;
     color: $brightness-46;
     font-style: italic;
@@ -662,7 +662,7 @@
 }
 
 .content__meta-heading {
-    @include fs-header(1);
+    @include fs-header(2);
     padding-top: ($gs-baseline/3);
     padding-bottom: ($gs-baseline/3)*4;
     margin-bottom: 0;

--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -34,10 +34,8 @@
     }
 
     .content__standfirst {
-        font-size: 18px;
-        @include mq(tablet) {
-            font-size: 20px;
-        }
+        font-size: 20px;
+
         @include mq(leftCol) {
             font-size: 22px;
         }

--- a/static/src/stylesheets/module/content-garnett/_media-player.scss
+++ b/static/src/stylesheets/module/content-garnett/_media-player.scss
@@ -873,7 +873,7 @@ $ima-controls-height: 70px;
     }
 }
 .end-slate-container__heading {
-    @include fs-header(1);
+    @include fs-header(2);
     padding-top: $gs-baseline/3;
     font-weight: bold;
     text-align: left;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -227,8 +227,7 @@ $quote-mark: 35px;
     }
 
     .content__article-body {
-        font-size: 17px;
-        line-height: 24px;
+        @include fs-bodyCopy(2);
 
         @include mq(tablet) {
             margin-left: 0;
@@ -313,8 +312,6 @@ $quote-mark: 35px;
     .content__standfirst {
         @include fs-bodyCopy(2);
         font-weight: 700;
-        font-size: 17px;
-        line-height: 22px;
         border-top: 0;
         color: $brightness-7;
         padding-top: 2px;

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1212,8 +1212,9 @@ $quote-mark: 35px;
 .content--type-review,
 .content--type-recipe {
     &:not(.paid-content) .content__standfirst {
-        @include fs-headline(25);
+        @include fs-headline(2);
         font-weight: 300;
+
         @include mq(tablet) {
             @include fs-headline(3, true);
         }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -578,12 +578,7 @@
     margin-bottom: 0;
     display: inline-block;
     padding-top: $gs-baseline/3;
-    line-height: 20px;
     color: $brightness-46;
-
-    @include mq(tablet) {
-        line-height: 22px;
-    }
 
     @include mq(leftCol) {
         clear: both;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -160,7 +160,7 @@
 }
 
 .content__section-label {
-    @include fs-header(1);
+    @include fs-header(2);
     float: left;
     padding-right: $gs-gutter/3;
 
@@ -185,7 +185,7 @@
     float: left;
 
     @include mq($until: tablet) {
-        @include fs-header(1);
+        @include fs-header(2);
         padding-top: $gs-baseline / 3;
     }
 
@@ -1008,7 +1008,7 @@
 }
 
 .content__meta-heading {
-    @include fs-header(1);
+    @include fs-header(2);
     padding-top: ($gs-baseline/3);
     padding-bottom: ($gs-baseline/3)*4;
     margin-bottom: 0;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -387,7 +387,7 @@
         }
 
         > li:before {
-            @include fs-header(1, true);
+            @include fs-header(2, true);
             position: absolute;
             left: -16px;
             content: counter(li);
@@ -780,7 +780,7 @@
     }
 
     .rich-link__header {
-        line-height: get-line-height(header, 1);
+        line-height: get-line-height(header, 2);
     }
 
     .ad-slot__label,

--- a/static/src/stylesheets/module/content/_gallery.head.scss
+++ b/static/src/stylesheets/module/content/_gallery.head.scss
@@ -45,7 +45,7 @@
 
     .content__series-label,
     .content__section-label {
-        @include fs-header(1, $size-only: true);
+        @include fs-header(2, $size-only: true);
         float: left;
     }
 }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -873,7 +873,7 @@ $ima-controls-height: 70px;
     }
 }
 .end-slate-container__heading {
-    @include fs-header(1);
+    @include fs-header(2);
     padding-top: $gs-baseline/3;
     font-weight: bold;
     text-align: left;

--- a/static/src/stylesheets/module/crosswords/_accessible.scss
+++ b/static/src/stylesheets/module/crosswords/_accessible.scss
@@ -29,7 +29,7 @@
 }
 
 .crossword__accessible-data--header {
-    @include fs-header(1);
+    @include fs-header(2);
     border-top: 1px solid $highlight-main;
     border-bottom: 1px dotted $brightness-86;
     padding-bottom: $gs-baseline * .75;

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -1,5 +1,5 @@
 .crossword__clues-header {
-    @include fs-header(1);
+    @include fs-header(2);
     border-top: 1px solid $lifestyle-main;
     border-bottom: 1px dotted $brightness-86;
     padding-bottom: $gs-baseline * .75;

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -234,9 +234,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
     }
 
     .contributions__adblock-sub {
-        font-family: $f-serif-headline;
-        font-size: 18px;
-        line-height: 20px;
+        @include fs-headline(2);
         padding: 12px 0 10px 10px;
     }
 

--- a/static/src/stylesheets/module/experiments/_update-account.scss
+++ b/static/src/stylesheets/module/experiments/_update-account.scss
@@ -62,7 +62,7 @@
         right: $gs-baseline;
         height: 36px;
         width: 36px;
-        
+
         .inline-icon {
             fill: $brightness-100;
         }
@@ -86,10 +86,9 @@
 
     .site-message__copy-text, .site-message__copy-heading {
         @include banner-copy-alignment;
+        @include fs-bodyCopy(2);
         display: block;
         margin-right: 24px;
-        font-size: 17px;
-        line-height: 22px;
         @include mq(phablet) {
             width: auto;
             margin-right: gs-span(1);
@@ -141,7 +140,7 @@
         &:focus {
             outline: auto;
             outline-color: $sport-bright;
-            outline-width: 5px; 
+            outline-width: 5px;
         }
     }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -68,10 +68,6 @@
     > h3 {
         @include fs-bodyHeading(2);
         margin: 0;
-
-        @include mq(tablet) {
-            @include fs-bodyHeading(3, true);
-        }
     }
     > p,
     > figure,

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -43,14 +43,10 @@
         counter-reset: li;
     }
     > ol > li:before {
-        @include fs-header(1, true);
+        @include fs-header(2, true);
         content: counter(li);
         counter-increment: li;
         margin-right: 4px;
-
-        @include mq(tablet) {
-            @include fs-header(2, true);
-        }
     }
     > ul ul,
     > ol ol {

--- a/static/src/stylesheets/module/external/_witness.scss
+++ b/static/src/stylesheets/module/external/_witness.scss
@@ -86,7 +86,7 @@
     float: left;
     padding-left: $gs-gutter * 2 - 2px;
     font-family: $f-serif-headline;
-    font-size: get-font-size(header, 1);
+    font-size: get-font-size(header, 2);
     font-weight: normal;
     white-space: nowrap;
     margin-right: 0;

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
@@ -33,7 +33,7 @@ x x x x x x x x x x x x x x x x x x x x x x x x
     }
 
     .fc-item__kicker--dreamsnap-list {
-        @include fs-header(1);
+        @include fs-header(2);
         display: block;
         margin: 0;
     }

--- a/static/src/stylesheets/module/football/_tables.scss
+++ b/static/src/stylesheets/module/football/_tables.scss
@@ -101,7 +101,7 @@
 
     @include mq(leftCol) {
         .table__caption--top {
-            @include fs-header(1);
+            @include fs-header(2);
             margin-bottom: ($gs-baseline/3)*4;
             margin-left: ($left-column + $gs-gutter)*-1;
             padding-bottom: ($gs-baseline/3)*4;

--- a/static/src/stylesheets/module/identity/_activity-stream.scss
+++ b/static/src/stylesheets/module/identity/_activity-stream.scss
@@ -23,7 +23,6 @@
     font-weight: normal;
 
     @include mq(leftCol) {
-        @include fs-header(1, true);
         float: left;
         position: relative;
         z-index: 1;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -380,7 +380,7 @@ $identity-header-height: 48px;
         @include pillar-dropdown('Lifestyle', $lifestyle-main);
         @include pillar-dropdown('Comment', $opinion-main);
         .dropdown__label {
-            @include fs-bodyHeading(3);
+            @include fs-bodyHeading(2);
             &:after {
                 content: '';
                 border: 2px solid currentColor;

--- a/static/src/stylesheets/module/identity/upsell/_account-creation.scss
+++ b/static/src/stylesheets/module/identity/upsell/_account-creation.scss
@@ -4,7 +4,7 @@
     margin-bottom: $gs-baseline;
     margin-top: $gs-baseline / 3;
     .identity-upsell-account-creation-bullets__title {
-        @include fs-headline(25);
+        @include fs-headline(2);
         margin-bottom: $gs-baseline / 4;
         font-weight: 600;
     }

--- a/static/src/stylesheets/module/identity/upsell/_card.scss
+++ b/static/src/stylesheets/module/identity/upsell/_card.scss
@@ -21,7 +21,7 @@
     display: flex;
     flex-direction: column;
     .identity-upsell-consent-card__title {
-        @include fs-headline(25);
+        @include fs-headline(2);
         font-weight: 600;
         margin-bottom: $gs-baseline / 2;
     }

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
@@ -148,8 +148,7 @@
                 color: #ff6a56;
             }
             p {
-                font-size: 18px;
-                line-height: 20px;
+                @include fs-bodyCopy(2);
             }
             a {
                 background-color: #121212;

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -192,7 +192,7 @@
             margin-bottom: 6px;
             color: $brightness-20;
             font-weight: 800;
-            font-size: 18px;
+            font-size: 17px;
         }
     }
 

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -97,12 +97,10 @@
                 }
 
                 .flagship-audio__description {
+                    @include fs-bodyCopy(2);
                     padding-top: 6px;
                     margin-top: 2px;
                     margin-bottom: 2px;
-                    line-height: 22px;
-                    font-weight: normal;
-                    font-size: 18px;
                 }
 
                 .flagship-audio__title {

--- a/static/src/stylesheets/module/journalism/_campaigns.scss
+++ b/static/src/stylesheets/module/journalism/_campaigns.scss
@@ -167,11 +167,9 @@
         }
 
         > .campaign--snippet__heading-logo {
+            @include fs-headline(2);
             flex: initial;
             margin-right: 10px;
-            font-size: 18px;
-            font-family: $f-serif-headline;
-            font-weight: 500;
 
             .speech-bubble {
                 color: $brightness-7;
@@ -245,9 +243,7 @@
             }
 
             .campaign--snippet__headline {
-                font-size: 18px;
-                line-height: 22px;
-                font-family: $f-serif-headline;
+                @include fs-headline(2);
                 font-weight: 600;
             }
             p {

--- a/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
@@ -17,8 +17,7 @@
 }
 
 .engagement-banner-ticker__count-label {
-    font-size: 17px;
-    line-height: 1.4;
+    @include fs-bodyCopy(2);
 }
 
 $progress-bar-height: 10px;
@@ -98,8 +97,7 @@ $progress-bar-height: 10px;
 }
 
 .engagement-banner-ticker__exceeded .engagement-banner-ticker__count {
-    font-size: 17px;
-    line-height: 1.4;
+    @include fs-bodyCopy(2);
 }
 
 .engagement-banner-ticker__exceeded .engagement-banner-ticker__count-label {

--- a/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_ad-free-banner.scss
@@ -116,16 +116,13 @@ $btn-height: ($gs-baseline*3.5);
 
     .site-message__copy-text {
         @include banner-copy-alignment;
+        @include fs-headline(2);
         display: block;
         margin-bottom: 12px;
         margin-right: 0;
-        font-size: 16px;
-        line-height: 20px;
         padding-bottom: $gs-baseline * 2;
         flex: 0 0 auto;
         @include mq(phablet) {
-            font-size: 18px;
-            line-height: 24px;
             width: auto;
         }
         @include mq(desktop) {

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -62,8 +62,7 @@
     line-height: 18px;
 
     @include mq(tablet) {
-        font-size: 17px;
-        line-height: 22px;
+        @include fs-bodyCopy(2);
     }
 
     @include mq(desktop) {

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -150,8 +150,6 @@ $btn-height: ($gs-baseline*3.5);
     }
     &.site-message--first-pv-consent__block--intro {
         @include fs-bodyCopy(2);
-        font-size: 17px;
-        line-height: 24px;
 
         .site-message--double-banner & {
             @include fs-textSans(2);

--- a/static/src/stylesheets/module/site-messages/_fiv-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_fiv-banner.scss
@@ -320,8 +320,7 @@ $wide-circle-height: 162px;
     }
 
     @include mq($from: desktop) {
-        font-size: 17px;
-        line-height: 21px;
+        @include fs-bodyCopy(2);
         width: 489px;
     }
 

--- a/static/src/stylesheets/pasteup/forms/_styles.scss
+++ b/static/src/stylesheets/pasteup/forms/_styles.scss
@@ -10,7 +10,7 @@
 }
 
 .form__heading {
-    @include fs-bodyHeading(3);
+    @include fs-bodyHeading(2);
     margin-left: 0;
     margin-right: 0;
 }
@@ -136,7 +136,7 @@
     }
 
     .form-fields__heading {
-        @include fs-bodyHeading(3, true);
+        @include fs-bodyHeading(2, true);
         margin: 0 0 $gs-baseline;
         display: block;
     }

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -29,13 +29,11 @@ $font-scale: (
     bodyHeading: (
         1: (font-size: 14, line-height: 22),
         2: (font-size: 17, line-height: 24),
-        3: (font-size: 18, line-height: 28),
         4: (font-size: 20, line-height: 28),
     ),
     bodyCopy: (
         1: (font-size: 14, line-height: 20),
         2: (font-size: 17, line-height: 24),
-        3: (font-size: 18, line-height: 28),
     ),
     textSans: (
         1: (font-size: 12, line-height: 16),

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -13,8 +13,7 @@ $font-scale: (
     ),
     headline: (
         1: (font-size: 14, line-height: 18),
-        2: (font-size: 16, line-height: 20),
-        25: (font-size: 18, line-height: 22),
+        2: (font-size: 17, line-height: 22),
         3: (font-size: 20, line-height: 24),
         35: (font-size: 22, line-height: 26),
         4: (font-size: 24, line-height: 28),

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -36,7 +36,7 @@ $font-scale: (
     ),
     bodyCopy: (
         1: (font-size: 14, line-height: 20),
-        2: (font-size: 16, line-height: 24),
+        2: (font-size: 17, line-height: 24),
         3: (font-size: 18, line-height: 28),
     ),
     textSans: (

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -30,7 +30,7 @@ $font-scale: (
     ),
     bodyHeading: (
         1: (font-size: 14, line-height: 22),
-        2: (font-size: 16, line-height: 24),
+        2: (font-size: 17, line-height: 24),
         3: (font-size: 18, line-height: 28),
         4: (font-size: 20, line-height: 28),
     ),

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -5,8 +5,7 @@ $f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial
 $font-scale: (
     header: (
         15: (font-size: 14, line-height: 18),
-        1: (font-size: 16, line-height: 20),
-        2: (font-size: 18, line-height: 24),
+        2: (font-size: 17, line-height: 22),
         3: (font-size: 20, line-height: 24),
         4: (font-size: 22, line-height: 28),
         5: (font-size: 24, line-height: 28),


### PR DESCRIPTION
## What does this change?
First step of introducing a coherent font scale.

As our body copy is 17px I'm treating that as default. With that in mind any instances of 16px or 18px are definitely unnecessary as the difference is too slight.

**This PR only affects our headline typeface and our body typeface.** 

- Instances of Headline/Body that are 18px or 16px have been changed to 17px. 
- Line height for body has been left at 24px (although I'd love to loosen it) whereas for headings it is slightly tighter at 22px. 
- I want to align sans with this type scale too but will be doing separate PRs for every step of this. 

When possible I have been ignoring

- AMP (Changing to GUUI)
- Email templates (Not part of the website)
- Nav (Very specific sizes due to fitting in pillars (Although I will visit this))
- Crossword (Crosswords scare me)
- Identity?
