### PR TITLE
Prevented font weight default over riding 300

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -402,6 +402,8 @@ $quote-mark: 35px;
         .pullquote-cite,
         .pullquote-paragraph {
             display: inline;
+            font-family: $f-serif-headline;
+            font-weight: 300;
         }
 
         .inline-quote,
@@ -446,7 +448,7 @@ $quote-mark: 35px;
 
         .pullquote-cite,
         .pullquote-paragraph {
-            @include fs-headline(3);
+            @include fs-headline(3, true);
         }
 
         .inline-garnett-quote {
@@ -472,9 +474,9 @@ $quote-mark: 35px;
 
         .pullquote-cite,
         .pullquote-paragraph {
-            @include fs-headline(35);
+            @include fs-headline(35, true);
             @include mq(desktop) {
-                @include fs-headline(36);
+                @include fs-headline(36, true);
             }
         }
     }
@@ -490,9 +492,9 @@ $quote-mark: 35px;
 
         .pullquote-cite,
         .pullquote-paragraph {
-            @include fs-headline(35);
+            @include fs-headline(35, true);
             @include mq(desktop) {
-                @include fs-headline(36);
+                @include fs-headline(36, true);
             }
         }
     }
@@ -518,12 +520,12 @@ $quote-mark: 35px;
 
         .pullquote-cite,
         .pullquote-paragraph {
-            @include fs-headline(36);
+            @include fs-headline(36, true);
             @include mq(phablet) {
-                @include fs-headline(5);
+                @include fs-headline(5, true);
             }
             @include mq(desktop) {
-                @include fs-headline(55);
+                @include fs-headline(55, true);
             }
         }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -865,10 +865,10 @@ $quote-mark: 35px;
         @include fs-headline(55);
         font-weight: 100;
         @include mq(mobileMedium) {
-            @include fs-headline(65);
+            @include fs-headline(65, true);
         }
         @include mq(tablet) {
-            @include fs-headline(75);
+            @include fs-headline(75, true);
         }
     }
 
@@ -1196,7 +1196,7 @@ $quote-mark: 35px;
 .content--type-guardianview {
     .element-pullquote.element--supporting .pullquote-cite,
     .element-pullquote.element--supporting .pullquote-paragraph {
-        font-weight: 200;
+        font-weight: 300;
     }
 
     .content__meta-container {
@@ -1214,9 +1214,9 @@ $quote-mark: 35px;
 .content--type-recipe {
     &:not(.paid-content) .content__standfirst {
         @include fs-headline(25);
-        font-weight: 200;
+        font-weight: 300;
         @include mq(tablet) {
-            @include fs-headline(3);
+            @include fs-headline(3, true);
         }
     }
 }

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -2,9 +2,9 @@
 
 #flagship-audio {
     @include fs-headline(3);
+    font-weight: 300;
     padding-top: 0;
     margin-bottom: 0;
-
 
     .ad-slot,
     .ad-slot--paid-for-badge {


### PR DESCRIPTION
A garnett mixin sneakily had font-weight lighter built into it. So when I added garnett font weights to the default font mixin we lost this font-weight. 

It resulted in some instances of the light font being overridden by a `font-weight: default`. Have resolved this by importing the font sizes only at breakpoints.  