### PR TITLE
Move showcase offset fix to avoid worst race condition

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/article.js
+++ b/static/src/javascripts/bootstraps/enhanced/article.js
@@ -12,6 +12,7 @@ import {
     upgradeRichLinks,
 } from 'common/modules/article/rich-links';
 import { upgradeMembershipEvents } from 'common/modules/article/membership-events';
+import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { geoMostPopular } from 'common/modules/onward/geo-most-popular';
 import { handleCompletion as handleQuizCompletion } from 'common/modules/atoms/quiz';
 import { init as initLiveblogCommon } from 'bootstraps/enhanced/article-liveblog-common';
@@ -28,6 +29,17 @@ const modules = {
             $('.element-pass-cmp').each(el => {
                 el.src = `${el.src}?CMP=${allvars.CMP}`;
             });
+        }
+    },
+
+    initShowcaseFix() {
+        if (
+            config.get('page.hasShowcaseMainElement') &&
+            isBreakpoint({
+                min: 'wide',
+            })
+        ) {
+            fixSecondaryColumn();
         }
     },
 
@@ -62,6 +74,7 @@ const init = () => {
     catchErrorsWithContext([
         ['article-trails', initTrails],
         ['article-liveblog-common', initLiveblogCommon],
+        ['article-showcase-fix', modules.initShowcaseFix],
         ['article-righthand-component', modules.initRightHandComponent],
         ['article-cmp-param', modules.initCmpParam],
         ['article-quiz-listeners', modules.initQuizListeners],

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -33,7 +33,6 @@ import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import config from 'lib/config';
 import { newHeaderInit } from 'common/modules/navigation/new-header';
-import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
 import debounce from 'lodash/debounce';
 import ophan from 'ophan/ng';
@@ -261,10 +260,6 @@ const bootStandard = (): void => {
     identityInit();
 
     newHeaderInit();
-
-    if (config.get('page.hasShowcaseMainElement')) {
-        fixSecondaryColumn();
-    }
 
     initAtoms();
 


### PR DESCRIPTION
## What does this change?

Delay the secondary-col padding height adjustment to account for slow connections. For some people, the height adjustment is occurring before the image loads which results in the advert overlapping the showcase image, and the most-viewed component hiding behind it.

Kudos to @gtrufitt for realising that this affects slow connections:  

> I feel like this is non-deterministic. There's been no changes to fix this after the initial PR AFAIK but several reports... Maybe race-condition? Image loading after the positioning is set in JS?

👏 👏 🕵️

Using dev tools to throttle the network allows this issue to be replicated consistently. 

## What is the value of this and can you measure success?

- Removes the worst case scenario for when the showcase loads after the padding height is set
- Reintroduce the overlapping bottom of showcase issue (until this code has time to run)
- Only run the code on article pages as part of the enhanced JS

The issue of the css workaround not applying to all cases still applies...

## Screenshots

#### BEFORE:

![Picture 372](https://user-images.githubusercontent.com/8607683/55820097-350ada80-5af2-11e9-82f3-9aacb852bda1.png)

#### AFTER:

![Picture 373](https://user-images.githubusercontent.com/8607683/55820135-45bb5080-5af2-11e9-988b-567e7c00af62.png)

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] On CODE
