### PR TITLE
update nvm version in setup/readme

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -106,7 +106,7 @@ just `nvm use` (or `nvm install` if you don't have 8 installed yet).
 To install nvm:
 
 ```bash
-$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.1/install.sh | bash
+$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 ```
 
 You may find it useful to add [this script](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb) to your 

--- a/setup.sh
+++ b/setup.sh
@@ -88,7 +88,7 @@ install_node() {
       fi
     fi
 
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
     nvm install
     EXTRA_STEPS+=("Add https://git.io/vKTnK to your .bash_profile")
   else


### PR DESCRIPTION
I noticed NVM isn't on the latest (or even the same) version in the instructions/setup script.  I have a feeling you get the latest regardless, but it makes sense to look on the safe side.
See: https://github.com/creationix/nvm#install-script