### PR TITLE
Added spacing and standardised font size on card standfirsts

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -245,12 +245,11 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__standfirst {
     @include fs-bodyCopy(1);
-    font-size: 13px;
-    line-height: 16px;
     color: $brightness-46;
     display: none;
     flex: 1 1 auto;
     padding-right: $gs-gutter * .25;
+    padding-bottom: $gs-baseline / 2;
 
     .fc-item--has-boosted-title & {
         display: none !important;

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -26,7 +26,7 @@ $font-scale: (
         4: (font-size: 20, line-height: 28),
     ),
     bodyCopy: (
-        1: (font-size: 14, line-height: 20),
+        1: (font-size: 14, line-height: 18),
         2: (font-size: 17, line-height: 24),
     ),
     textSans: (


### PR DESCRIPTION
Standfirsts are and have been for some time - too close to the bottom of cards. I've added 6px of padding and increased font-size to 14 cos i'm on a font crusade. 