### PR TITLE
Extend Outbrain AB Test for another 365 days

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Test the outbrain widget",
     owners = Seq(Owner.withGithub("frankie297")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 4, 22),
+    sellByDate = new LocalDate(2020, 4, 22),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
@@ -5,7 +5,8 @@ export const commercialOutbrainTesting: ABTest = {
     start: '2019-03-12',
     expiry: '2020-04-22',
     author: 'Frankie Hammond',
-    description: '0% participation development switch AB test for testing Outbrain',
+    description:
+        '0% participation development switch AB test for testing Outbrain',
     audience: 0,
     audienceOffset: 0,
     successMeasure: 'Outbrain widget testing',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-outbrain-testing.js
@@ -3,9 +3,9 @@
 export const commercialOutbrainTesting: ABTest = {
     id: 'CommercialOutbrainTesting',
     start: '2019-03-12',
-    expiry: '2019-03-29',
+    expiry: '2020-04-22',
     author: 'Frankie Hammond',
-    description: '0% participation AB test for testing Outbrain',
+    description: '0% participation development switch AB test for testing Outbrain',
     audience: 0,
     audienceOffset: 0,
     successMeasure: 'Outbrain widget testing',


### PR DESCRIPTION
...and clarify the test's description.

## What does this change?
- Changes the Outbrain AB Test timeframe so it is extended a further 365 days.
- Improved the description of the test so it's easier to understand.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
N/A
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
