### PR TITLE
Type scale 05

### DIFF
--- a/static/src/stylesheets/layout/nav/_menu-item.scss
+++ b/static/src/stylesheets/layout/nav/_menu-item.scss
@@ -137,6 +137,7 @@
     // only match the ones, which are not in --secondary
     .menu-group--primary > .menu-item > & {
         @include fs-headline(4);
+        font-weight: 700;
         color: $brightness-100;
         padding-bottom: 18px;
         padding-top: $gs-baseline / 2;

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -21,21 +21,11 @@
     z-index: $zindex-popover - 1;
 }
 
-@keyframes reveal {
-    from {transform: translateY(100%);}
-    to {transform: translateY(0);}
-}
-
 .site-message--banner {
     width: 100%;
     z-index: $zindex-popover;
     position: fixed;
     bottom: 0;
-    animation-name: reveal;
-    animation-delay: 2s;
-    animation-duration: 1s;
-    animation-fill-mode: forwards;
-    transform: translateY(100%);
     &.site-message--on-top {
         bottom: auto;
         top: 0;

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -21,11 +21,21 @@
     z-index: $zindex-popover - 1;
 }
 
+@keyframes reveal {
+    from {transform: translateY(100%);}
+    to {transform: translateY(0);}
+}
+
 .site-message--banner {
     width: 100%;
     z-index: $zindex-popover;
     position: fixed;
     bottom: 0;
+    animation-name: reveal;
+    animation-delay: 2s;
+    animation-duration: 1s;
+    animation-fill-mode: forwards;
+    transform: translateY(100%);
     &.site-message--on-top {
         bottom: auto;
         top: 0;

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -201,7 +201,7 @@
 
 .fc-item--list-media-mobile {
     @include mq($until: tablet) {
-        @include fc-item--list-media(3.46, 2);
+        @include fc-item--list-media(3.47, 2);
     }
 }
 

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -5,20 +5,20 @@ $f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial
 $font-scale: (
     header: (
         15: (font-size: 14, line-height: 18),
-        2: (font-size: 17, line-height: 22),
-        3: (font-size: 20, line-height: 24),
-        5: (font-size: 24, line-height: 28),
+        2: (font-size: 17, line-height: 20),
+        3: (font-size: 20, line-height: 23),
+        5: (font-size: 24, line-height: 27),
     ),
     headline: (
         1: (font-size: 14, line-height: 18),
-        2: (font-size: 17, line-height: 22),
-        3: (font-size: 20, line-height: 24),
-        4: (font-size: 24, line-height: 28),
+        2: (font-size: 17, line-height: 20),
+        3: (font-size: 20, line-height: 23),
+        4: (font-size: 24, line-height: 27),
         5: (font-size: 28, line-height: 32),
         6: (font-size: 34, line-height: 38),
         8: (font-size: 42, line-height: 46),
-        9: (font-size: 50, line-height: 54),
-        10: (font-size: 70, line-height: 76),
+        9: (font-size: 50, line-height: 56),
+        10: (font-size: 70, line-height: 78),
     ),
     bodyHeading: (
         1: (font-size: 14, line-height: 22),

--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -4,13 +4,13 @@ $f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial
 
 $font-scale: (
     header: (
-        15: (font-size: 14, line-height: 18),
+        15: (font-size: 14, line-height: 17),
         2: (font-size: 17, line-height: 20),
         3: (font-size: 20, line-height: 23),
         5: (font-size: 24, line-height: 27),
     ),
     headline: (
-        1: (font-size: 14, line-height: 18),
+        1: (font-size: 14, line-height: 17),
         2: (font-size: 17, line-height: 20),
         3: (font-size: 20, line-height: 23),
         4: (font-size: 24, line-height: 27),


### PR DESCRIPTION
Following on from Further type size consolidation following on from https://github.com/guardian/frontend/pull/21326

## What does this change?

- Restores the pillars in the mobile menu to being BOLD
- Updates to line-height of Headline and Text Egyptian for consistent numbers based on a 90% and 95% line-height
- Tweak for nice card/image alignment at mobile

![Screen Shot 2019-04-15 at 16 03 47](https://user-images.githubusercontent.com/14570016/56143268-1eec9680-5f98-11e9-8099-5d752fa67546.png)
