### PR TITLE
Add contributor image to DCR model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -20,15 +20,13 @@ import navigation.UrlHelpers._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, GUDateTimeFormat, ImgSrc, Item1200} // Note, required despite Intellij saying otherwise
-import views.support.{CamelCase, GUDateTimeFormat, ImgSrc, Item1200}
+import views.support.{AffiliateLinksCleaner, CamelCase, FourByThree, GUDateTimeFormat, ImgSrc, Item1200, Item300, OneByOne}
 import common.Maps.RichMap
-import navigation.UrlHelpers.{AmpHeader, AmpFooter}
+import navigation.UrlHelpers.{AmpFooter, AmpHeader}
 import navigation.UrlHelpers.{Footer, Header, SideMenu, getReaderRevenueUrl}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import model.meta.{Guardian, LinkedData, PotentialAction}
 import ai.x.play.json.implicits.optionWithNull // Note, required despite Intellij saying otherwise
-import views.support.{AffiliateLinksCleaner, CamelCase, FourByThree, GUDateTimeFormat, ImgSrc, Item1200, OneByOne} // Note, required despite Intellij saying otherwise
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -40,7 +38,8 @@ case class TagProperties(
     id: String,
     tagType: String,
     webTitle: String,
-    twitterHandle: Option[String]
+    twitterHandle: Option[String],
+    bylineImageUrl: Option[String]
 )
 
 case class Tag(
@@ -326,7 +325,8 @@ object DotcomponentsDataModel {
           t.id,
           t.properties.tagType,
           t.properties.webTitle,
-          t.properties.twitterHandle
+          t.properties.twitterHandle,
+          t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300))
         )
       )
     )


### PR DESCRIPTION
Provides necessary data to DCR to display contributor images on opinion tone (AMP) articles.

See also: https://github.com/guardian/dotcom-rendering/pull/506.