### PR TITLE
Lint for svg issues.

### DIFF
--- a/tools/__tasks__/compile/images/index.js
+++ b/tools/__tasks__/compile/images/index.js
@@ -1,4 +1,9 @@
 module.exports = {
     description: 'Compile images',
-    task: [require('./clean'), require('./copy'), require('./icons')],
+    task: [
+        require('./clean'),
+        require('./copy'),
+        require('./icons'),
+        require('./svg'),
+    ],
 };

--- a/tools/__tasks__/compile/images/svg.js
+++ b/tools/__tasks__/compile/images/svg.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const fs = require('fs');
+
+const glob = require('glob');
+const pify = require('pify');
+
+const readFile = pify(fs.readFile);
+const stat = pify(fs.stat);
+
+const { src } = require('../../config').paths;
+
+const srcDir = path.resolve(src);
+
+module.exports = {
+    description:
+        'Prohibit inline data URIs in svgs and other unoptimised things',
+    task: () =>
+        Promise.all(
+            glob.sync('**/*.svg', { cwd: srcDir }).map(svgPath =>
+                Promise.all([
+                    stat(path.resolve(srcDir, svgPath)).then(
+                        fileStats =>
+                            new Promise((resolve, reject) => {
+                                if (fileStats.size > 136 * 1000) {
+                                    reject(
+                                        new Error(
+                                            `whooahh ${svgPath} is much too large at ${fileStats.size /
+                                                1000}kB`
+                                        )
+                                    );
+                                }
+                                resolve();
+                            })
+                    ),
+                    readFile(path.resolve(srcDir, svgPath), 'utf-8').then(
+                        fileData =>
+                            new Promise((resolve, reject) => {
+                                if (fileData.includes(';base64,')) {
+                                    reject(
+                                        new Error(
+                                            `base64 encoded data detected in ${svgPath}`
+                                        )
+                                    );
+                                }
+                                resolve();
+                            })
+                    ),
+                ])
+            )
+        ),
+};


### PR DESCRIPTION
## What does this change?
Fails the compile if you have anything base64'd in a png, or if it's too big*

*currently 136kb, we might need to better target this