### PR TITLE
Remove host variable from SubMetaLink constructor

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -684,9 +684,9 @@ object SubMetaLinks {
     } else None
 
     val secondaryLink = if (blogOrSeriesTag.isDefined) {
-      blogOrSeriesTag.map(t => SubMetaLink(s"${Configuration.site.host}/${t.id}", t.name))
+      blogOrSeriesTag.map(t => SubMetaLink(s"/${t.id}", t.name))
     } else if (isFromTheObserver) {
-      Some(SubMetaLink(s"${Configuration.site.host}/observer", "The Observer"))
+      Some(SubMetaLink("/observer", "The Observer"))
     } else {
       None
     }


### PR DESCRIPTION
## What does this change?

Secondary tag links on AMP pages were returning 404s because the site hostname was being added twice, in Frontend and Dotcom-rendering (for example: `https://www.theguardian.com/https://www.theguardian.com/food/series/how-to-eat`)

We are removing site hostname from Frontend so it's only generated in Dotcom-rendering. 

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
