### PR TITLE
Remove opinion filter

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -37,8 +37,6 @@ object AMPPageChecks extends Logging {
       case None => true
     }
   }
-
-  def isNotOpinion(page:PageWithStoryPackage): Boolean = ! page.item.tags.isComment
 }
 
 object AMPPicker {
@@ -53,7 +51,6 @@ object AMPPicker {
     Map(
       ("isBasicArticle", AMPPageChecks.isBasicArticle(page)),
       ("hasOnlySupportedElements", AMPPageChecks.hasOnlySupportedElements(page)),
-      ("isNotOpinionP", AMPPageChecks.isNotOpinion(page)),
       ("isNotPaidContent", AMPPageChecks.isNotPaidContent(page)),
     )
   }


### PR DESCRIPTION
Adds support for comment tone pieces in DCR AMP.

*Note, this should only go live after: https://github.com/guardian/dotcom-rendering/pull/506.*