### PR TITLE
Update AMP validator to take into account skipped or non-amp pages

### DIFF
--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -16,26 +16,15 @@ const fetch = options => {
 
     return promiseRetry(
         retry =>
-            new Promise((resolve, reject) => {
+            new Promise(resolve => {
                 const errorMessage = `Unable to fetch ${options.endpoint}`;
 
                 request(
                     `${options.host + options.endpoint}`,
                     (error, resp, body) => {
                         if (error || resp.statusCode !== 200) {
-                            const errorDetails = error ? error.message : '';
-                            const statusCodeMessage = resp
-                                ? ` Status code was ${
-                                      resp ? resp.statusCode : ''
-                                  }`
-                                : '';
-
-                            reject(
-                                new Error(
-                                    `${errorMessage +
-                                        statusCodeMessage}\n${errorDetails}`
-                                )
-                            );
+                            console.error(errorMessage);
+                            resolve({}); // Resolve with empty so we can skip endpoint validation
                         } else {
                             resolve({ resp, body });
                         }

--- a/tools/amp-validation/run.js
+++ b/tools/amp-validation/run.js
@@ -86,15 +86,21 @@ const checkEndpoints = (endpoints, options) => validatorFilePath =>
                 notAmp: values.filter(x => x === 'not AMP').length,
             };
 
-            const exitValue = results.failed > failureThreshold ? 1 : 0; // every promise returns true <=> exit value is zero, build in some failure threshold
+            const failed = results.failed > failureThreshold;
+            const exitValue = failed ? 1 : 0; // every promise returns true <=> exit value is zero, build in some failure threshold
+            const completionMessage = `Validator finished, there were ${
+                results.passed
+            } passes, ${results.failed} failures ${
+                results.skipped
+            } skipped and ${results.notAmp} non-AMP pages`;
+            if (failed) {
+                console.log(
+                    `##teamcity[buildProblem description='${completionMessage}' identity='AMPValidation']`
+                );
+            } else {
+                console.log(completionMessage);
+            }
 
-            console.log(
-                `Validator finished, there were ${results.passed} passes, ${
-                    results.failed
-                } failures ${results.skipped} skipped and ${
-                    results.notAmp
-                } non-AMP pages`
-            );
             validatorJs.cleanUp();
             process.exit(exitValue);
         });

--- a/tools/amp-validation/run.js
+++ b/tools/amp-validation/run.js
@@ -1,6 +1,4 @@
 const amphtmlValidator = require('amphtml-validator');
-const partition = require('lodash/partition');
-
 const validatorJs = require('./validator-js');
 const fetchPage = require('./fetch-page');
 
@@ -42,7 +40,7 @@ const runValidator = (validator, options) => endpoint =>
                 });
             }
 
-            return pass;
+            return result.status;
         })
         .catch(onError);
 
@@ -59,6 +57,11 @@ const maybeRunValidator = (validator, options) => endpoint => {
             host: fetchPage.hosts.amp,
         })
         .then(res => {
+            if (res.resp === undefined) {
+                console.info('Skip failed fetch for', endpoint);
+                return Promise.resolve('skipped');
+            }
+
             if (
                 (options.checkIfAmp &&
                     res.body.includes('<link rel="amphtml" href="')) ||
@@ -67,7 +70,7 @@ const maybeRunValidator = (validator, options) => endpoint => {
             ) {
                 return validate(endpoint);
             }
-            return Promise.resolve(true);
+            return Promise.resolve('not AMP');
         })
         .catch(onError);
 };
@@ -75,15 +78,22 @@ const maybeRunValidator = (validator, options) => endpoint => {
 const checkEndpoints = (endpoints, options) => validatorFilePath =>
     amphtmlValidator.getInstance(validatorFilePath).then(validator => {
         const tests = endpoints.map(maybeRunValidator(validator, options));
-
         Promise.all(tests).then(values => {
-            const results = partition(values, Boolean);
-            const exitValue = results[1].length > failureThreshold ? 1 : 0; // every promise returns true <=> exit value is zero, build in some failure threshold
+            const results = {
+                passed: values.filter(x => x === 'PASS').length,
+                failed: values.filter(x => x === 'FAIL').length,
+                skipped: values.filter(x => x === 'skipped').length,
+                notAmp: values.filter(x => x === 'not AMP').length,
+            };
+
+            const exitValue = results.failed > failureThreshold ? 1 : 0; // every promise returns true <=> exit value is zero, build in some failure threshold
 
             console.log(
-                `Validator finished, there were ${
-                    results[0].length
-                } passes and ${results[1].length} failures.`
+                `Validator finished, there were ${results.passed} passes, ${
+                    results.failed
+                } failures ${results.skipped} skipped and ${
+                    results.notAmp
+                } non-AMP pages`
             );
             validatorJs.cleanUp();
             process.exit(exitValue);


### PR DESCRIPTION
## What does this change?
Quick update to the AMP validator so that it no longer fails out on not being able to fetch a page and also is more accurate in its reporting.

## Screenshots
![image](https://user-images.githubusercontent.com/638051/56277484-583e1700-60fc-11e9-86ef-5b4586568138.png)

## What is the value of this and can you measure success?
It's useful as a failsafe on AMP problems that get to production either via code or content.