### PR TITLE
Override title style to fix visual bug on fronts

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -143,23 +143,6 @@ $header-image-size-desktop: 100px;
         }
     }
 
-    &:after {
-        content: '';
-        display: none;
-        position: absolute;
-        height: $gs-gutter * 1.5;
-        width: 1px;
-        background-color: $brightness-86;
-        // Offset by 1px to the right so that it coincides
-        // with the rule in the body of articles
-        right: -$gs-gutter / 2 - 1;
-        top: -$gs-baseline / 2;
-
-        @include mq($from: leftCol) {
-            display: block;
-        }
-    }
-
     a {
         color: inherit;
 
@@ -181,6 +164,40 @@ $header-image-size-desktop: 100px;
         }
     }
 }
+
+.fc-container__header__title {
+    &:after {
+        content: '';
+        display: none;
+        position: absolute;
+        height: $gs-gutter * 1.5;
+        width: 1px;
+        background-color: $brightness-86;
+
+        // Offset by 1px to the right so that it coincides
+        // with the rule in the body of articles
+        right: -$gs-gutter / 2 - 1;
+        top: -$gs-baseline / 2;
+
+        @include mq($from: leftCol) {
+            display: block;
+        }
+    }
+
+    .has-page-skin:after {
+        display: none;
+    }
+}
+
+.fc-container__title__text {
+    &:after {
+        @include mq($from: leftCol) {
+            display: none; // override to fix display issue on containers
+        }
+    }
+}
+
+
 
 .fc-container__header__title--sticky {
     display: block;


### PR DESCRIPTION
## What does this change?

Small visual fix for a header title bug. @zeftilldeath I think my 'fix' here is quite a hack, but I don't understand the use of these classes well enough to override in place. Do you have any thoughts on a good solution here?

## Screenshots

Before: (note the vertical line in the text)
<img width="165" alt="Screenshot 2019-04-16 at 17 09 30" src="https://user-images.githubusercontent.com/858402/56294050-2cce2300-6122-11e9-8922-b91ee016744b.png">

After:
(it's gone)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)