### PR TITLE
Make sure we're always validating a string

### DIFF
--- a/tools/amp-validation/run.js
+++ b/tools/amp-validation/run.js
@@ -27,7 +27,7 @@ const runValidator = (validator, options) => endpoint =>
             host: isDev ? fetchPage.hosts.dev : fetchPage.hosts.amp,
         })
         .then(res => {
-            const result = validator.validateString(res.body);
+            const result = validator.validateString(res.body.toString());
             const pass = result.status === 'PASS';
             const message = `${result.status} for: ${endpoint}`;
 

--- a/tools/amp-validation/validator-js.js
+++ b/tools/amp-validation/validator-js.js
@@ -55,7 +55,7 @@ const fetchValidator = devChannel => {
             res.pipe(writeStream)
                 .on('finish', () => resolve(writeStream.path))
                 .on('error', error => {
-                    reject(error);
+                    reject(new Error(`Error saving to file: ${error.message}`));
                     writeStream.close();
                 });
         });


### PR DESCRIPTION
## What does this change?
Prevents the random error we've seen from AMP validator (hopefully, it was too random to solidly replicate, though I know where it happened.)