### PR TITLE
Update height of paid for logo container

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1278,6 +1278,7 @@ $quote-mark: 35px;
     .content__meta-container {
         border-top: 1px solid $brightness-60;
         padding-top: $gs-baseline / 4;
+        height: inherit;
     }
 
     .content__article-body::before {


### PR DESCRIPTION
Update the height of the container with the sponsor logo in on paid content pages so the logo doesn't clash with the byline if the standfirst is short.

## Screenshots
![before](https://user-images.githubusercontent.com/4101937/56574796-0abe2000-65bc-11e9-8859-05feae466f67.png)
![after](https://user-images.githubusercontent.com/4101937/56574817-13aef180-65bc-11e9-9ef0-6c1ed9309930.png)
