### PR TITLE
Fix "extended most read" on fronts layout when no ads shown

### DIFF
--- a/static/src/stylesheets/module/_most-popular.scss
+++ b/static/src/stylesheets/module/_most-popular.scss
@@ -5,7 +5,6 @@
     @include mq(desktop) {
         display: flex;
         justify-content: flex-start;
-        // justify-content: flex-end;
     }
 
     body:not(.has-page-skin) & {
@@ -27,11 +26,11 @@
 
     @include mq(leftCol) {
         margin-left: $gs-gutter / 2;
-        max-width: gs-span(9)+ $gs-gutter;
+        width: gs-span(9)+ $gs-gutter;
     }
     @include mq(wide) {
         margin-left: 0;
-        max-width: gs-span(12) + $gs-gutter;
+        width: gs-span(12) + $gs-gutter;
     }
 }
 

--- a/static/src/stylesheets/module/_most-popular.scss
+++ b/static/src/stylesheets/module/_most-popular.scss
@@ -4,9 +4,9 @@
 
     @include mq(desktop) {
         display: flex;
-        justify-content: flex-end;
+        justify-content: flex-start;
+        // justify-content: flex-end;
     }
-
 
     body:not(.has-page-skin) & {
         @include mq(leftCol) {
@@ -24,6 +24,15 @@
     margin-top: -1px;
     border: 1px solid $brightness-86;
     border-bottom: 0;
+
+    @include mq(leftCol) {
+        margin-left: $gs-gutter / 2;
+        max-width: gs-span(9)+ $gs-gutter;
+    }
+    @include mq(wide) {
+        margin-left: 0;
+        max-width: gs-span(12) + $gs-gutter;
+    }
 }
 
 .most-popular {


### PR DESCRIPTION
## What does this change?

I noticed some layout issues with the "extended most read" list on fronts when no ads where present at the "left column" and "wide" breakpoints.

1) On the lefthand side the list item "1" overlaps the descending vertical rule near "Most viewed"
2) On the righthand side the list item "6" overlaps the "hide" toggle present on all front slices.

This PR fix that by applying a width to the list at the "left column" and "wide" breakpoints.

## Screenshots

**Before (no ads)**
![broken-lc-no-ad](https://user-images.githubusercontent.com/1590704/56574859-304b2980-65bc-11e9-9bab-66d61eca3d74.png)

**After (no ads)**
![fixed-lc-no-ad](https://user-images.githubusercontent.com/1590704/56574873-380ace00-65bc-11e9-8b83-7ea1ac9327dd.png)

**Before (with ads)**
![broken-lc-ad](https://user-images.githubusercontent.com/1590704/56574906-4c4ecb00-65bc-11e9-9eb2-5018df5bef0d.png)

**After (with ads)**
![fixed-lc-ad](https://user-images.githubusercontent.com/1590704/56574917-52dd4280-65bc-11e9-8708-36072c92e835.png)

## What is the value of this and can you measure success?

Looks better 💅 

## Checklist

### Does this affect other platforms?

- [] AMP <!-- AMP question? https://git.io/v9zIE -->
- [] Apps
- [] Other (please specify)


### Tested

- [x] Locally
- [ ] On CODE (optional)