### PR TITLE
Add Youtube, Vimeo and Facebook video the DC Model

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -26,10 +26,10 @@ case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displ
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, caption:String, url:String, originalUrl:String, role: Role) extends PageElement
-case class VideoBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
-case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
-case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
-case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
+case class VideoBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
+case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
+case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
+case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -26,10 +26,10 @@ case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displ
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String], role: Role) extends PageElement
-case class VideoBlockElement(data: Map[String, String], role: Role) extends PageElement
-case class VideoYoutubeBlockElement(data: Map[String, String], role: Role) extends PageElement
-case class VideoVimeoBlockElement(data: Map[String, String], role: Role) extends PageElement
-case class VideoFacebookBlockElement(data: Map[String, String], role: Role) extends PageElement
+case class VideoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
+case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
+case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
+case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -264,25 +264,24 @@ object PageElement {
     } getOrElse Map()
   }
 
-  private def videoDataFor(element: ApiBlockElement):Option[PageElement]  = {
+  private def videoDataFor(element: ApiBlockElement): Option[PageElement] = {
 
-    def extractVideoEmbedElement(element: ApiBlockElement): Option[Map[String, String]] = {
-      element.videoTypeData.map { d =>
-        Map(
-          "caption" -> d.caption,
-          "url" -> d.url,
-          "originalUrl" -> d.originalUrl
-        ) collect { case (k, Some(v)) => (k, v) }
+
+    for {
+      data <- element.videoTypeData
+      source <- data.source
+      caption <- data.caption
+      url <- data.url
+      originalUrl <- data.originalUrl
+    } yield {
+      source match {
+        case "youtube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))
+        case "vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, Role(data.role))
+        case "facebook" => VideoFacebookBlockElement(caption, url, originalUrl, Role(data.role))
+        case _ => VideoBlockElement(caption, url, originalUrl, Role(data.role))
       }
     }
 
-    element.videoTypeData.map { d =>
-      d.source.getOrElse("") match {
-        case "youtube" => VideoYoutubeBlockElement(extractVideoEmbedElement(d))
-        case _ => null
-      } 
-
-    }
 
   }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -26,10 +26,10 @@ case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displ
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, caption:String, url:String, originalUrl:String, role: Role) extends PageElement
-case class VideoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
-case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
-case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
-case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
+case class VideoBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
+case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
+case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
+case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, height:Int, Width:Int, role: Role) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -272,13 +272,16 @@ object PageElement {
       source <- data.source
       caption <- data.caption
       originalUrl <- data.originalUrl
+      height <- data.height
+      width <- data.width
+
       url = data.url.getOrElse(originalUrl)
     } yield {
       source match {
-        case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))
-        case "Vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, Role(data.role))
-        case "Facebook" => VideoFacebookBlockElement(caption, url, originalUrl, Role(data.role))
-        case _ => VideoBlockElement(caption, url, originalUrl, Role(data.role))
+        case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, height, width, Role(data.role))
+        case "Vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, height, width, Role(data.role))
+        case "Facebook" => VideoFacebookBlockElement(caption, url, originalUrl, height, width, Role(data.role))
+        case _ => VideoBlockElement(caption, url, originalUrl, height, width, Role(data.role))
       }
     }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -165,7 +165,7 @@ object PageElement {
             Role(element.videoTypeData.flatMap(_.role)))
           )
         }
-        else List(videoDataFor(element).getOrElse(TextBlockElement("strung")))
+        else videoDataFor(element).toList
 
       case Membership => element.membershipTypeData.map(m => MembershipBlockElement(
         m.originalUrl,
@@ -271,8 +271,8 @@ object PageElement {
       data <- element.videoTypeData
       source <- data.source
       caption <- data.caption
-      url <- data.url
       originalUrl <- data.originalUrl
+      url = data.url.getOrElse(originalUrl)
     } yield {
       source match {
         case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -25,7 +25,7 @@ case class PullquoteBlockElement(html: Option[String], role: Role) extends PageE
 case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean], role: Role, imageSources: Seq[ImageSource]) extends PageElement
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
-case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String], role: Role) extends PageElement
+case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class VideoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, role: Role) extends PageElement
@@ -159,11 +159,13 @@ object PageElement {
             ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
               case (a, i) => ImageAsset.make(a, i)
             }),
-            videoDataFor(element),
+            element.videoTypeData.flatMap(_.caption).getOrElse(""),
+            element.videoTypeData.flatMap(_.url).getOrElse(""),
+            element.videoTypeData.flatMap(_.originalUrl).getOrElse(""),
             Role(element.videoTypeData.flatMap(_.role)))
           )
         }
-        else List(VideoBlockElement(videoDataFor(element), Role(element.videoTypeData.flatMap(_.role))))
+        else List(videoDataFor(element).getOrElse(TextBlockElement("strung")))
 
       case Membership => element.membershipTypeData.map(m => MembershipBlockElement(
         m.originalUrl,
@@ -265,8 +267,7 @@ object PageElement {
   }
 
   private def videoDataFor(element: ApiBlockElement): Option[PageElement] = {
-
-
+    println(element.videoTypeData.get.source)
     for {
       data <- element.videoTypeData
       source <- data.source
@@ -274,10 +275,12 @@ object PageElement {
       url <- data.url
       originalUrl <- data.originalUrl
     } yield {
+      println(data)
+      println(source)
       source match {
-        case "youtube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))
-        case "vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, Role(data.role))
-        case "facebook" => VideoFacebookBlockElement(caption, url, originalUrl, Role(data.role))
+        case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))
+        case "Vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, Role(data.role))
+        case "Facebook" => VideoFacebookBlockElement(caption, url, originalUrl, Role(data.role))
         case _ => VideoBlockElement(caption, url, originalUrl, Role(data.role))
       }
     }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -267,7 +267,6 @@ object PageElement {
   }
 
   private def videoDataFor(element: ApiBlockElement): Option[PageElement] = {
-    println(element.videoTypeData.get.source)
     for {
       data <- element.videoTypeData
       source <- data.source
@@ -275,8 +274,6 @@ object PageElement {
       url <- data.url
       originalUrl <- data.originalUrl
     } yield {
-      println(data)
-      println(source)
       source match {
         case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, Role(data.role))
         case "Vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, Role(data.role))

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -27,6 +27,9 @@ case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String], role: Role) extends PageElement
 case class VideoBlockElement(data: Map[String, String], role: Role) extends PageElement
+case class VideoYoutubeBlockElement(data: Map[String, String], role: Role) extends PageElement
+case class VideoVimeoBlockElement(data: Map[String, String], role: Role) extends PageElement
+case class VideoFacebookBlockElement(data: Map[String, String], role: Role) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -261,12 +264,26 @@ object PageElement {
     } getOrElse Map()
   }
 
-  private def videoDataFor(element: ApiBlockElement): Map[String, String] = {
-    element.videoTypeData.map { d => Map(
-      "caption" -> d.caption,
-      "url" -> d.url
-    ) collect { case (k, Some (v) ) => (k, v) }
-    } getOrElse Map()
+  private def videoDataFor(element: ApiBlockElement):Option[PageElement]  = {
+
+    def extractVideoEmbedElement(element: ApiBlockElement): Option[Map[String, String]] = {
+      element.videoTypeData.map { d =>
+        Map(
+          "caption" -> d.caption,
+          "url" -> d.url,
+          "originalUrl" -> d.originalUrl
+        ) collect { case (k, Some(v)) => (k, v) }
+      }
+    }
+
+    element.videoTypeData.map { d =>
+      d.source.getOrElse("") match {
+        case "youtube" => VideoYoutubeBlockElement(extractVideoEmbedElement(d))
+        case _ => null
+      } 
+
+    }
+
   }
 
   implicit val imageWeightingWrites: Writes[ImageSource] = Json.writes[ImageSource]
@@ -276,6 +293,9 @@ object PageElement {
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
   implicit val VideoBlockElementWrites: Writes[VideoBlockElement] = Json.writes[VideoBlockElement]
+  implicit val VideoYouTubeElementWrites: Writes[VideoYoutubeBlockElement] = Json.writes[VideoYoutubeBlockElement]
+  implicit val VideoVimeoElementWrites: Writes[VideoVimeoBlockElement] = Json.writes[VideoVimeoBlockElement]
+  implicit val VideoFacebookBlockElementWrites: Writes[VideoFacebookBlockElement] = Json.writes[VideoFacebookBlockElement]
   implicit val TweetBlockElementWrites: Writes[TweetBlockElement] = Json.writes[TweetBlockElement]
   implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
   implicit val SoundCloudBlockElementWrites: Writes[SoundcloudBlockElement] = Json.writes[SoundcloudBlockElement]


### PR DESCRIPTION
## What does this change?
*Note:* Please apply your harshest review - my Scala is *bad* and the only good bit is probably the bit @AWare wrote. I'm interested in ways to write this stuff more idiomatic Scala plz (ideally with explanations why it's good so I can learn!).

Adds three types of video embed to enable us to apply them in AMP: https://github.com/guardian/dotcom-rendering/pull/517

## Screenshots
![image](https://user-images.githubusercontent.com/638051/56647700-cdb86300-6679-11e9-9766-b72c2c507ef9.png)

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->