### PR TITLE
Contributor Cookie Analytics

### DIFF
--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -51,7 +51,9 @@ declare type OphanComponentType =
     | 'ACQUISITIONS_NUGGET'
     | 'ACQUISITIONS_STANDFIRST'
     | 'ACQUISITIONS_THRASHER'
-    | 'ACQUISITIONS_EDITORIAL_LINK';
+    | 'ACQUISITIONS_EDITORIAL_LINK'
+    | 'ACQUISITIONS_ONE_OFF_COOKIE'
+    | 'ACQUISITIONS_RECURRING_COOKIE';
 
 declare type OphanComponent = {
     componentType: OphanComponentType,

--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -52,8 +52,7 @@ declare type OphanComponentType =
     | 'ACQUISITIONS_STANDFIRST'
     | 'ACQUISITIONS_THRASHER'
     | 'ACQUISITIONS_EDITORIAL_LINK'
-    | 'ACQUISITIONS_ONE_OFF_COOKIE'
-    | 'ACQUISITIONS_RECURRING_COOKIE';
+    | 'ACQUISITIONS_OTHER';
 
 declare type OphanComponent = {
     componentType: OphanComponentType,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -210,7 +210,7 @@ const getLastRecurringContributionDate = (): number | null => {
     }
 
     if (monthlyMS && annualMS) {
-        return monthlyMS > annualMS ? monthlyMS : annualMS;
+        return Math.max(monthlyMS, annualMS);
     }
 
     return monthlyMS || annualMS || null;

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -192,6 +192,30 @@ const getLastOneOffContributionDate = (): number | null => {
     return null;
 };
 
+const getLastRecurringContributionDate = (): number | null => {
+    // Check for cookies, ensure that cookies parse, and ensure parsed results are integers
+    const monthlyCookie = getCookie(
+        SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE
+    );
+    const annualCookie = getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE);
+    const monthlyTime = monthlyCookie ? parseInt(monthlyCookie, 10) : null;
+    const annualTime = annualCookie ? parseInt(annualCookie, 10) : null;
+    const monthlyMS =
+        monthlyTime && Number.isInteger(monthlyTime) ? monthlyTime : null;
+    const annualMS =
+        annualTime && Number.isInteger(annualTime) ? annualTime : null;
+
+    if (!monthlyMS && !annualMS) {
+        return null;
+    }
+
+    if (monthlyMS && annualMS) {
+        return monthlyMS > annualMS ? monthlyMS : annualMS;
+    }
+
+    return monthlyMS || annualMS || null;
+};
+
 const getDaysSinceLastOneOffContribution = (): number | null => {
     const lastContributionDate = getLastOneOffContributionDate();
     if (lastContributionDate === null) {
@@ -264,6 +288,7 @@ export {
     refresh,
     deleteOldData,
     getLastOneOffContributionDate,
+    getLastRecurringContributionDate,
     getDaysSinceLastOneOffContribution,
     readerRevenueRelevantCookies,
     fakeOneOffContributor,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -15,6 +15,7 @@ import {
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
     shouldNotBeShownSupportMessaging,
+    getLastRecurringContributionDate,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -35,6 +36,10 @@ const PERSISTENCE_KEYS = {
     DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
     HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
+    SUPPORT_MONTHLY_CONTRIBUTION_COOKIE:
+        'gu.contributions.recurring.contrib-timestamp.Monthly',
+    SUPPORT_ANNUAL_CONTRIBUTION_COOKIE:
+        'gu.contributions.recurring.contrib-timestamp.Annual',
 };
 
 const setAllFeaturesData = opts => {
@@ -457,6 +462,60 @@ describe('getting the last one-off contribution date of a user', () => {
     it('returns null if the cookie has been set with an invalid value', () => {
         setOneOffContributionCookie('invalid value');
         expect(getLastOneOffContributionDate()).toBe(null);
+    });
+});
+
+const setMonthlyContributionCookie = (value: any): void =>
+    addCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE, value);
+
+const setAnnualContributionCookie = (value: any): void =>
+    addCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE, value);
+
+const removeMonthlyContributionCookie = (): void =>
+    removeCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE);
+
+const removeAnnualContributionCookie = (): void =>
+    removeCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE);
+
+describe('getting the last recurring contribution date of a user', () => {
+    beforeEach(() => {
+        removeMonthlyContributionCookie();
+        removeAnnualContributionCookie();
+    });
+
+    const monthlyContributionTimestamp = 1556124724;
+    const annualContributionTimestamp = 1556125286;
+
+    it("returns null if the user isn't a recurring contributor", () => {
+        expect(getLastRecurringContributionDate()).toBe(null);
+    });
+
+    it('return the correct date if the user is a monthly recurring contributor', () => {
+        setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
+        expect(getLastRecurringContributionDate()).toBe(
+            monthlyContributionTimestamp
+        );
+    });
+
+    it('return the correct date if the user is a annual recurring contributor', () => {
+        setAnnualContributionCookie(annualContributionTimestamp.toString());
+        expect(getLastRecurringContributionDate()).toBe(
+            annualContributionTimestamp
+        );
+    });
+
+    it('return the correct date if the user is both annual and monthly recurring contributor', () => {
+        setAnnualContributionCookie(annualContributionTimestamp.toString());
+        setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
+        expect(getLastRecurringContributionDate()).toBe(
+            annualContributionTimestamp
+        );
+    });
+
+    it('returns null if the cookie has been set with an invalid value', () => {
+        setAnnualContributionCookie('not a date string one');
+        setMonthlyContributionCookie('not a date string two');
+        expect(getLastRecurringContributionDate()).toBe(null);
     });
 });
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -153,7 +153,8 @@ export const initMembership = (): void => {
     if (lastOneOff) {
         submitViewEvent({
             component: {
-                componentType: 'ACQUISITIONS_ONE_OFF_COOKIE',
+                componentType: 'ACQUISITIONS_OTHER',
+                id: 'acquisitions-cookie-one-off',
             },
             value: lastOneOff.toString(),
         });
@@ -162,7 +163,8 @@ export const initMembership = (): void => {
     if (lastRecurring) {
         submitViewEvent({
             component: {
-                componentType: 'ACQUISITIONS_RECURRING_COOKIE',
+                componentType: 'ACQUISITIONS_OTHER',
+                id: 'acquisitions-cookie-recurring',
             },
             value: lastRecurring.toString(),
         });

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -3,6 +3,8 @@
 import {
     isPayingMember,
     accountDataUpdateWarning,
+    getLastOneOffContributionDate,
+    getLastRecurringContributionDate,
 } from 'common/modules/commercial/user-features';
 import fastdom from 'lib/fastdom-promise';
 import { Message } from 'common/modules/ui/message';
@@ -12,6 +14,7 @@ import arrowRight from 'svgs/icon/arrow-right.svg';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import userPrefs from 'common/modules/user-prefs';
+import { submitViewEvent } from 'common/modules/commercial/acquisitions-ophan';
 
 const createManageBannerLink = manageProductKeyword =>
     `${config.get('page.mmaUrl')}/banner/${manageProductKeyword}?INTCMP=BANNER`;
@@ -144,6 +147,27 @@ export const membershipBanner: Banner = {
 };
 
 export const initMembership = (): void => {
+    const lastOneOff = getLastOneOffContributionDate();
+    const lastRecurring = getLastRecurringContributionDate();
+
+    if (lastOneOff) {
+        submitViewEvent({
+            component: {
+                componentType: 'ACQUISITIONS_ONE_OFF_COOKIE',
+            },
+            value: lastOneOff.toString(),
+        });
+    }
+
+    if (lastRecurring) {
+        submitViewEvent({
+            component: {
+                componentType: 'ACQUISITIONS_RECURRING_COOKIE',
+            },
+            value: lastRecurring.toString(),
+        });
+    }
+
     if (isPayingMember()) {
         fastdom
             .read(() => document.getElementsByClassName('js-become-member'))


### PR DESCRIPTION
## What does this change?
Capture who is visiting our site with recurring cookies and send that data to Ophan

TBD: If we decide this is useful data and want to persist this feature we need to work with the Ophan team to see the best approach to making this part of the `pageview` event instead of `componentEvent`. We can also move this code to a more appropriate place or create a new place for it.

## What is the value of this and can you measure success?

Value: Contributions would like this data in order to (A) know how many people could be communicated to via the presence of this cookie and (B) with that data, know how effective it is to encourage sign in and make updates to the membership API

Measuring success: this will contribute to work towards a KR on encouraging sign in amongst our supporters

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
