### PR TITLE
Underlines on standfirst links

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -147,7 +147,6 @@
         @include faux-bullet-point($right-space: 8px);
         margin-bottom: $gs-baseline / 2;
         padding-left: $gs-gutter;
-        overflow: hidden;
 
         &:before {
             margin-left: -$gs-gutter;


### PR DESCRIPTION
Underlines on links in stand-firsts are hidden due to a 2 pixel line-height change by... Me. 

I had to investigate who added `overflow: hidden` (which is hiding the underlines) and after git blaming back into pre-history I found out it was introduced by... Me.

I've removed the overflow hidden and it all seems peachy now. Not sure why it was there in the first place???