### PR TITLE
Confiant Ad Verification

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -78,6 +78,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-commercial-ad-verification-q-a",
+    "Test the impact of verifiyng ads for QA before rolling it out to wider audiance",
+    owners = Seq(Owner.withGithub("guardiancosta")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-commercial-outbrain-testing",
     "Test the outbrain widget",
     owners = Seq(Owner.withGithub("frankie297")),

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 import { loadScript } from 'lib/load-script';
-import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
+import { commercialAdVerificationQA } from 'common/modules/experiments/tests/commercial-ad-verification-qa.js';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 const errorHandler = (error: Error) => {
@@ -11,32 +11,15 @@ const errorHandler = (error: Error) => {
 };
 
 export const init = (start: () => void): Promise<void> => {
-    const host = 'clarium.global.ssl.fastly.net';
-    const activationString =
-        '|||MjE5NzUwMDg3,|||MjQxMTU4MzI3,|||MjM4NzY0MTY0Mg==,|||MjM4NzY0MTY0NQ==,|||MjM4NzY0MTY0OA==,|||MjM4NzY0MTY1MQ==,|||MjM4NzY0MTY1NA==,|||MjM4NzY0MTY1Nw==,|||MjM4NzY0MTY2MA==,|||MjM4NzY0MTY2Mw==,|||MjM4NzY0MTY2Ng==,|||MjM4NzY0MTY2OQ==,|||MjM4NzY0MTY3Mg==,|||MjM4NzY0MTY3NQ==,|||MjM4NzY0MTY3OA==,|||MjM4NzY0MTgwMQ==,|||MjM4NzY0MTgwNA==,|||MjM4NzY0MTgwNw==,|||MjM4NzY5MjUzMw==,|||MjM4NzY5MjUzNg==,|||MjM4NzY5NTkwOA==,|||MjM4NzY5NTkxMQ==,|||MjM4NzY5NTkxNA==,|||MjM4NzY5NTkxNw==,|||MjM4NzY5NjA0MA==,|||MjM4NzY5NjA0Mw==,|||MjM4NzY5NjA0Ng==,|||MjM4NzY5NjA0OQ==,|||MjE4NTM0MTI3,|||MzcxMTIwNzI3,|||MjQ4NTY3NTgyNw==,|||MjQ4NTcxNTQyOA==,|||MjQ4NDc3NTg5NQ==,|||MjQ4NTE4MjY3OQ==,|||MjQ4NTM0NTY3OQ==,|||MjQ4NTcyMjY3Mw==,|||MjQ4NTcyMjY3Ng==,|||MjQ4NTc5MTAzNw==,|||MjQ4NTcyMjY3OQ==,|||MjQ4NTM0NTgwMg==,|||MjQ4NTcyMjY4Mg==,|||MjQ4NTQxMTgzOA==,|||MjQ4NTc5MTA0MA==,|||MjQ4NzQ2NTAxMw==,|||MjQ4NTQ3NDA2MQ==,|||MjQ4NTQ3NDA2Nw==,|||MjQ4NTQ3NDA2NA==,|||MjQ4NTQ3NDA3MA==,|||MjQ4NTg2MDE0NQ==,|||MjQ4NTQ3NDA3Mw==,|||MjQ4ODAxNjg2OA==,|||MjQ4NzQ2NDU2Ng==,|||MjQ4NzQ2NTAwNA==,|||MjQ4NTQ3NDA3Ng==,|||MjQ4NzQ2NTAxMA==,|||MjQ4ODA1NDk4Mw==,|||MjQ1ODAxODQ0OQ==,|||MzUwMDYwNzI3,|||MzUwNjE1ODQ3';
+    const host = 'confiant-integrations.global.ssl.fastly.net';
 
     start();
 
-    if (isInVariantSynchronous(commercialAdVerification, 'variant')) {
-        // vivify the _clrm object
-
-        /* eslint-disable no-underscore-dangle */
-        window._clrm = window._clrm || {};
-        window._clrm.gpt = {
-            propertyId: '7oDgiTsq88US4rrBG0_Nxpafkrg',
-            confiantCdn: host,
-            mapping:
-                'W3siaSI6MiwidCI6Int7b319Ont7d319eHt7aH19IiwicCI6MCwiRCI6MSwiciI6W119XQ==',
-            activation: activationString,
-            callback(...args) {
-                console.log('w00t one more bad ad nixed.', args);
-            },
-        };
-        /* eslint-enable no-underscore-dangle */
-
-        return loadScript(`//${host}/gpt/a/wrap.js`, { async: true }).catch(
-            errorHandler
-        );
+    if (isInVariantSynchronous(commercialAdVerificationQA, 'variant')) {
+        return loadScript(
+            `//${host}/7oDgiTsq88US4rrBG0_Nxpafkrg/gpt_and_prebid/config.js`,
+            { async: true }
+        ).catch(errorHandler);
     }
     return Promise.resolve();
 };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,6 +1,7 @@
 // @flow
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
+import { commercialAdVerificationQA } from 'common/modules/experiments/tests/commercial-ad-verification-qa.js';
 import { commercialCmpCustomise } from 'common/modules/experiments/tests/commercial-cmp-customise.js';
 import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
 import { commercialConsentGlobalNoScroll } from 'common/modules/experiments/tests/commercial-consent-global-no-scroll.js';
@@ -15,6 +16,7 @@ import {
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialAdVerification,
+    commercialAdVerificationQA,
     commercialCmpCustomise,
     commercialOutbrainTesting,
     commercialConsentGlobalNoScroll,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification-qa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification-qa.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const commercialAdVerificationQA: ABTest = {
+    id: 'CommercialAdVerificationQA',
+    start: '2018-06-29',
+    expiry: '2019-09-30',
+    author: 'Ricardo Costa',
+    description: 'This test will implemement our ad verification framework for QA (0% audience/manual optIn)',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'Impact of ad verification on yield or fillrate',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'No significant impact of ad verification on yield or fillrate',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification-qa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-ad-verification-qa.js
@@ -5,7 +5,8 @@ export const commercialAdVerificationQA: ABTest = {
     start: '2018-06-29',
     expiry: '2019-09-30',
     author: 'Ricardo Costa',
-    description: 'This test will implemement our ad verification framework for QA (0% audience/manual optIn)',
+    description:
+        'This test will implemement our ad verification framework for QA (0% audience/manual optIn)',
     audience: 0.0,
     audienceOffset: 0.0,
     successMeasure: 'Impact of ad verification on yield or fillrate',


### PR DESCRIPTION
## What does this change?
Adds a new Confiant ad verification for prebid and dfp behind a 0% AB test so we're able to do QA on this change before exposing it to public.

This meant creating a new AB test and corresponding switch (commercialAdVerificationQA) as well as edit the code that prepares ad verification.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
