### PR TITLE
Fix media atom detection - check it is Youtube

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -42,6 +42,9 @@ case class MapBlockElement(html: Option[String],  role: Role, isMandatory: Optio
 case class UnknownBlockElement(html: Option[String]) extends PageElement
 case class DisclaimerBlockElement(html: String) extends PageElement
 
+// Intended for unstructured html that we can't model, typically rejected by consumers
+case class HTMLFallbackBlockElement(html: String) extends PageElement
+
 // atoms
 
 // TODO dates are being rendered as strings to avoid duplication of the
@@ -209,14 +212,22 @@ object PageElement {
       case Contentatom =>
         (extractAtom match {
           case Some(mediaAtom: MediaAtom) => {
-            mediaAtom.activeAssets.headOption.map(asset => {
-              YoutubeBlockElement(
-                mediaAtom.id, //CAPI ID
-                asset.id, // Youtube ID
-                mediaAtom.channelId, //Channel ID
-                mediaAtom.title //Caption
-              )
-            })
+
+            mediaAtom match {
+              case youtube if mediaAtom.assets.headOption.exists(_.platform == MediaAssetPlatform.Youtube) => {
+                mediaAtom.activeAssets.headOption.map(asset => {
+                  YoutubeBlockElement(
+                    mediaAtom.id, //CAPI ID
+                    asset.id, // Youtube ID
+                    mediaAtom.channelId, //Channel ID
+                    mediaAtom.title //Caption
+                  )
+                })
+              }
+
+              // TODO - handle self-hosted video case.
+              case htmlBlob if mediaAtom.assets.nonEmpty => Some(HTMLFallbackBlockElement(mediaAtom.defaultHtml))
+            }
           }
 
           case Some(qa: QandaAtom) => {
@@ -360,6 +371,7 @@ object PageElement {
   implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
   implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
   implicit val DiscalimerBlockElementWrites: Writes[DisclaimerBlockElement] = Json.writes[DisclaimerBlockElement]
+  implicit val HTMLBlockElementWrites: Writes[HTMLFallbackBlockElement] = Json.writes[HTMLFallbackBlockElement]
 
   // atoms
   implicit val TimelineEventWrites = Json.writes[TimelineEvent]


### PR DESCRIPTION
Ensures we correctly filter media atoms to the youtube platform before transforming into a YoutubeBlockElement.

Also introduces a rather dubious `HTMLBlockElement` as a catchall for unrecognised stuff here. I'm mixed on this so happy to be persuaded either way.