### PR TITLE
Bump renderer to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "@guardian/atom-renderer": "1.0.2",
+    "@guardian/atom-renderer": "1.0.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "1.0.2"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "1.0.3"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/static/src/stylesheets/module/atoms/_explainers.scss
+++ b/static/src/stylesheets/module/atoms/_explainers.scss
@@ -1,9 +1,8 @@
 //style support for legacy explainer atoms
 
 figure.element-atom .atom--explainer a.u-underline {
-    color: $brightness-100;
+    color: inherit;
     &:hover {
-        color: #a8d8f2;
         border-bottom: solid 1px #a8d8f2;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,9 +1063,9 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
-"@guardian/atom-renderer@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.0.2.tgz#5f659517d356f848aca502b8ca291ed9d4eb92c8"
+"@guardian/atom-renderer@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.0.3.tgz#f8027bca91256a220bf75e8d0ebfa3ebecfa8f58"
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
Small visual update to explainer atoms which are resurrected for a special project.

## Screenshots

<img width="550" alt="Screenshot 2019-04-26 at 16 42 44" src="https://user-images.githubusercontent.com/629976/56819907-a06ae100-6842-11e9-97df-2a04dbc37a2c.png">

after

![Screenshot 2019-04-26 at 17 00 07](https://user-images.githubusercontent.com/629976/56820820-cabd9e00-6844-11e9-8214-34b697c25f17.png)
