### PR TITLE
clean up showSupportMessaging flag to remove redundant cookie references

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -90,10 +90,7 @@
 
 
     function shouldHideSupportMessaging() {
-        return getCookieValue('gu_paying_member') === 'true' ||
-        getCookieValue('gu_digital_subscriber') === 'true' ||
-        getCookieValue('gu_recurring_contributor') === 'true' ||
-        getCookieValue('gu_hide_support_messaging') === 'true';
+        return getCookieValue('gu_hide_support_messaging') === 'true';
     }
 
     function forcePercentagePadding() {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -253,8 +253,6 @@ const shouldNotBeShownSupportMessaging = (): boolean =>
 */
 
 const shouldHideSupportMessaging = (): boolean =>
-    isPayingMember() || // TODO: remove
-    isDigitalSubscriber() || // TODO: remove
     shouldNotBeShownSupportMessaging() ||
     isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
     isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie


### PR DESCRIPTION
Cleanup PR for guardian/frontend/#21311.

Essentially re-implements #21290.