### PR TITLE
Add supported videos to AMPPicker

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -5,6 +5,7 @@ import controllers.ArticlePage
 import implicits.Requests._
 import model.PageWithStoryPackage
 import model.liveblog._
+import model.dotcomrendering.pageElements._
 import play.api.mvc.RequestHeader
 
 object AMPPageChecks extends Logging {

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -29,6 +29,10 @@ object AMPPageChecks extends Logging {
       case _: RichLinkBlockElement => true
       case _: CommentBlockElement => true
       case _: PullquoteBlockElement => true
+      case _: GuVideoBlockElement => true
+      case _: VideoYoutubeBlockElement => true
+      case _: VideoVimeoBlockElement => true
+      case _: VideoFacebookBlockElement => true
       case _ => false
     }
 

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -4,7 +4,7 @@ import common.Logging
 import controllers.ArticlePage
 import implicits.Requests._
 import model.PageWithStoryPackage
-import model.liveblog._
+import model.liveblog.BlockElement
 import model.dotcomrendering.pageElements._
 import play.api.mvc.RequestHeader
 


### PR DESCRIPTION
## What does this change?
Turns on Videos for AMP Picker

## What is the value of this and can you measure success?
Supporting internal and external videos in DCR AMP

@guardian/dotcom-platform 