### PR TITLE
End point for Liveblog datamodel object for dotcom-rendering

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -72,7 +72,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
       .map(responseFromHeadline)
   }
 
-  private def getJson(article: ArticlePage)(implicit request: RequestHeader) = {
+  private def getJson(article: ArticlePage)(implicit request: RequestHeader): List[(String, Object)] = {
     val contentFieldsJson = if (request.isGuuiJson) List(
       "contentFields" -> Json.toJson(ContentFields(article.article)),
       "tags" -> Json.toJson(article.article.tags)) else List()

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
+import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiContent}
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
 import contentapi.ContentApiClient
@@ -15,80 +15,126 @@ import services.CAPILookup
 import views.support.RenderOtherStatus
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.dotcomponents.DotcomponentsDataModel
+import play.api.libs.json.Json
 
 import scala.concurrent.Future
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-class LiveBlogController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient)(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
+class LiveBlogController(
+  contentApiClient: ContentApiClient,
+  val controllerComponents: ControllerComponents,
+  ws: WSClient
+)(implicit context: ApplicationContext)
+  extends BaseController with
+    RendersItemResponse with
+    Logging with
+    ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
+
 
   // we support liveblogs and also articles, so that minutes work
   private def isSupported(c: ApiContent) = c.isLiveBlog || c.isArticle
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
-  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Canonical)(render(path, _))
 
-  def renderEmail(path: String): Action[AnyContent] =
+  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
+    mapModel(path, Canonical)((page, blocks) => render(path, page, blocks))
+  }
+
+  def renderEmail(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      mapModel(path, ArticleBlocks) {
-        render(path, _)
+      mapModel(path, ArticleBlocks)((page, blocks) => render(path, page, blocks))
+    }
+  }
+
+  // Main entry points
+
+  def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {
+    Action.async { implicit request =>
+      def renderWithRange(range: BlockRange): Future[Result] = {
+        mapModel(path, range)((page, blocks) => render(path, page, blocks))
+      }
+
+      page.map(ParseBlockId.fromPageParam) match {
+        case Some(ParsedBlockId(id)) => renderWithRange(PageWithBlock(id)) // we know the id of a block
+        case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
+        case None => renderWithRange(Canonical) // no page param
       }
     }
+  }
 
-  def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] =
-      Action.async { implicit request =>
-        def renderWithRange(range: BlockRange) =
-          mapModel(path, range) {
-            render(path, _)
-          }
-        page.map(ParseBlockId.fromPageParam) match {
-          case Some(ParsedBlockId(id)) => renderWithRange(PageWithBlock(id)) // we know the id of a block
-          case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-          case None => renderWithRange(Canonical) // no page param
-        }
-      }
+  def renderJson(
+    path: String,
+    lastUpdate: Option[String],
+    rendered: Option[Boolean],
+    isLivePage: Option[Boolean]
+  ): Action[AnyContent] = {
 
-  def renderJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean]): Action[AnyContent] = {
     Action.async { implicit request =>
       val range = getRange(lastUpdate, rendered)
       mapModel(path, range) {
-        case liveblog: LiveBlogPage if rendered.contains(false) => getJsonForFronts(liveblog)
-        case liveblog: LiveBlogPage if request.isGuui => getGuuiJson(path, liveblog, range, isLivePage)
-        case liveblog: LiveBlogPage => getJson(path, liveblog, range, isLivePage)
-        case minute: MinutePage => render(path, minute)
+        case (liveblog: LiveBlogPage, blocks) => getJson(path, liveblog, range, isLivePage, blocks)
+        case (minute: MinutePage, blocks) => render(path, minute, blocks)
         case _ => Future { Cached(600)(WithoutRevalidationResult(NotFound)) }
       }
     }
   }
 
-  private def getRange(lastUpdate: Option[String], rendered: Option[Boolean]): BlockRange = {
+  // Helper methods
+
+  private[this] def render(
+    path: String,
+    page: PageWithStoryPackage,
+    blocks: Blocks
+  )(implicit request: RequestHeader): Future[Result] = {
+    val isMinute = page.isInstanceOf[MinutePage]
+
+    Future.successful {
+      (page, request.getRequestFormat) match {
+        case (minute: MinutePage, JsonFormat) => common.renderJson(views.html.fragments.minuteBody(minute), minute)
+        case (minute: MinutePage, EmailFormat) => common.renderEmail(ArticleEmailHtmlPage.html(minute), minute)
+        case (minute: MinutePage, HtmlFormat) => common.renderHtml(MinuteHtmlPage.html(minute), minute)
+
+        case (blog: LiveBlogPage, JsonFormat) if request.isGuui => renderGuuiJson(path, blog, blocks)
+        case (blog: LiveBlogPage, JsonFormat) => common.renderJson( views.html.liveblog.liveBlogBody(blog), blog)
+        case (blog: LiveBlogPage, EmailFormat) => common.renderEmail(LiveBlogHtmlPage.html(blog), blog)
+        case (blog: LiveBlogPage, HtmlFormat) => common.renderHtml(LiveBlogHtmlPage.html(blog), blog)
+        case (blog: LiveBlogPage, AmpFormat) => common.renderHtml(views.html.liveBlogAMP(blog), blog)
+
+        case _ => NotFound
+      }
+    }
+  }
+
+  private[this] def getRange(lastUpdate: Option[String], rendered: Option[Boolean]): BlockRange = {
     lastUpdate.map(ParseBlockId.fromBlockId) match {
       case Some(ParsedBlockId(id)) => SinceBlockId(id)
       case _ => Canonical
     }
   }
 
-  private def getJsonForFronts(liveblog: LiveBlogPage)(implicit request: RequestHeader): Future[Result] = {
+  private[this] def getJsonForFronts(liveblog: LiveBlogPage)(implicit request: RequestHeader): Future[Result] = {
     Future {
       Cached(liveblog)(JsonComponent("blocks" -> model.LiveBlogHelpers.blockTextJson(liveblog, 6)))
     }
   }
 
-  private def getJson(path: String, liveblog: PageWithStoryPackage, range: BlockRange, isLivePage: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
+  private[this] def getJson(
+    path: String,
+    liveblog: PageWithStoryPackage,
+    range: BlockRange,
+    isLivePage: Option[Boolean],
+    blocks: Blocks
+  )(implicit request: RequestHeader): Future[Result] = {
+
     range match {
       case SinceBlockId(lastBlockId) => renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage)
-      case _ => render(path, liveblog)
+      case _ => render(path, liveblog, blocks)
     }
   }
 
-  private def getGuuiJson(path: String, liveblog: PageWithStoryPackage, range: BlockRange, isLivePage: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
-    Future {
-      Ok(DotcomponentsDataModel.toJsonString(DotcomponentsDataModel.fromLiveBlog()))
-    }
-  }
-
-  private def renderNewerUpdatesJson(page: PageWithStoryPackage, lastUpdateBlockId: SinceBlockId, isLivePage: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
+  private[this] def renderNewerUpdatesJson(page: PageWithStoryPackage, lastUpdateBlockId: SinceBlockId, isLivePage: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
     val newBlocks = page.article.fields.blocks.toSeq.flatMap {
       _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
     }.takeWhile { block =>
@@ -113,56 +159,42 @@ class LiveBlogController(contentApiClient: ContentApiClient, val controllerCompo
     }
   }
 
-  private def renderMinute(path: String, minute: MinutePage)(implicit request: RequestHeader): Future[Result] = {
-    Future {
-      request.getRequestFormat match {
-        case JsonFormat => common.renderJson (views.html.fragments.minuteBody(minute), minute)
-        case EmailFormat => common.renderEmail (ArticleEmailHtmlPage.html(minute), minute)
-        case HtmlFormat => common.renderHtml (MinuteHtmlPage.html(minute), minute)
-        case AmpFormat => NotFound
-      }
-    }
+  private[this] def renderGuuiJson(
+    path: String,
+    blog: LiveBlogPage,
+    blocks: Blocks
+  )(implicit request: RequestHeader): Result = {
+    val model = DotcomponentsDataModel.fromArticle(blog, request, blocks)
+    val json = DotcomponentsDataModel.toJsonString(model)
+
+    common.renderJson(json, blog).as("application/json")
   }
 
-  private def renderLiveBlog(path: String, blog: LiveBlogPage)(implicit request: RequestHeader): Future[Result] = {
-    Future {
-      request.getRequestFormat match {
-        case JsonFormat => common.renderJson( views.html.liveblog.liveBlogBody(blog), blog )
-        case EmailFormat => common.renderEmail( LiveBlogHtmlPage.html(blog), blog )
-        case HtmlFormat => common.renderHtml( LiveBlogHtmlPage.html(blog), blog )
-        case AmpFormat => common.renderHtml( views.html.liveBlogAMP(blog), blog )
-      }
-    }
-  }
-
-  private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader): Future[Result] = page match {
-    case minute: MinutePage => renderMinute(path, minute)
-    case blog: LiveBlogPage => renderLiveBlog(path, blog)
-  }
-
-
-  private def mapModel(path: String, range: BlockRange)(render: PageWithStoryPackage => Future[Result])(implicit request: RequestHeader): Future[Result] = {
+  private[this] def mapModel(path: String, range: BlockRange)(render: (PageWithStoryPackage, Blocks) => Future[Result])(implicit request: RequestHeader): Future[Result] = {
     capiLookup
       .lookup(path, Some(range))
       .map(responseToModelOrResult(range))
       .recover(convertApiExceptions)
       .flatMap {
-        case Left(model) => render(model)
+        case Left((model, blocks)) => render(model, blocks)
         case Right(other) => Future.successful(RenderOtherStatus(other))
       }
   }
 
-  private def responseToModelOrResult(range: BlockRange)(response: ItemResponse)(implicit request: RequestHeader): Either[PageWithStoryPackage, Result] = {
+  private[this] def responseToModelOrResult(range: BlockRange)(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
-    val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap {
+    val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
+
+    val content = supportedContentResult.left.flatMap {
       case minute: Article if minute.isTheMinute =>
-        Left(MinutePage(minute, StoryPackages(minute.metadata.id, response)))
+        Left(MinutePage(minute, StoryPackages(minute.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
-        Left(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)))
+        Left(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog =>
-        createLiveBlogModel(liveBlog, response, range)
+        createLiveBlogModel(liveBlog, response, range).left.map(_ -> blocks)
     }
+
     content
   }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,11 +9,11 @@ import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import controllers.ArticlePage
-import model.SubMetaLinks
+import model.{SubMetaLink, SubMetaLinks}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
 import model.meta._
-import navigation.NavMenu
+import navigation.{NavLink, NavMenu, Subnav}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
 import play.api.libs.json._
@@ -420,10 +420,46 @@ object DotcomponentsDataModel {
 
   }
 
+  def fromLiveBlog(): DotcomponentsDataModel = { // PASCAL: This is a template answer that we will need to upgrade
+    val page = DCPage(
+      Content("", Some(""), "", "", Blocks(None, Nil), "", ""),
+      Tags( None, None, None, None, Nil),
+      "",
+      "",
+      None,
+      0L,
+      "",
+      None,
+      "",
+      "",
+      "",
+      None,
+      None,
+      "",
+      "",
+      None,
+      SubMetaLinks(Nil, Nil),
+      "",
+      None,
+      Commercial(Map[String, EditionCommercialProperties](), Nil, None),
+      Meta( false, false, false, false, false, false, Nil)
+    )
+    val site = DCSite( "", "", None, None, Map[String,Boolean](), "", "",
+      NavMenu( "", Nil, Nil, Nil, None, None, None, None),
+      ReaderRevenueLinks(
+        ReaderRevenueLink("", "", ""),
+        ReaderRevenueLink("", "", ""),
+        ReaderRevenueLink("", "", ""),
+        ReaderRevenueLink("", "", ""),
+        ReaderRevenueLink("", "", "")
+      ),
+      ""
+    )
+    DotcomponentsDataModel(page, site, 1)
+  }
+
   def toJson(model: DotcomponentsDataModel): JsValue = {
-
     // make what we have look a bit closer to what dotcomponents currently expects
-
     implicit val DotComponentsDataModelWrites = new Writes[DotcomponentsDataModel] {
       def writes(model: DotcomponentsDataModel) = Json.obj(
         "page" -> model.page,
@@ -431,14 +467,10 @@ object DotcomponentsDataModel {
         "version" -> model.version
       )
     }
-
     Json.toJson(model)
-
   }
-
 
   def toJsonString(model: DotcomponentsDataModel): String = {
     Json.stringify(toJson(model))
   }
-
 }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -9,7 +9,7 @@ import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import controllers.ArticlePage
-import model.{SubMetaLink, SubMetaLinks}
+import model.{LiveBlogPage, PageWithStoryPackage, SubMetaLink, SubMetaLinks}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
 import model.meta._
@@ -198,7 +198,7 @@ object DotcomponentsDataModel {
 
   val VERSION = 2
 
-  def fromArticle(articlePage: ArticlePage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
+  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
 
     val article = articlePage.article
     val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
@@ -418,44 +418,6 @@ object DotcomponentsDataModel {
       VERSION
     )
 
-  }
-
-  def fromLiveBlog(): DotcomponentsDataModel = { // PASCAL: This is a template answer that we will need to upgrade
-    val page = DCPage(
-      Content("", Some(""), "", "", Blocks(None, Nil), "", ""),
-      Tags( None, None, None, None, Nil),
-      "",
-      "",
-      None,
-      0L,
-      "",
-      None,
-      "",
-      "",
-      "",
-      None,
-      None,
-      "",
-      "",
-      None,
-      SubMetaLinks(Nil, Nil),
-      "",
-      None,
-      Commercial(Map[String, EditionCommercialProperties](), Nil, None),
-      Meta( false, false, false, false, false, false, Nil)
-    )
-    val site = DCSite( "", "", None, None, Map[String,Boolean](), "", "",
-      NavMenu( "", Nil, Nil, Nil, None, None, None, None),
-      ReaderRevenueLinks(
-        ReaderRevenueLink("", "", ""),
-        ReaderRevenueLink("", "", ""),
-        ReaderRevenueLink("", "", ""),
-        ReaderRevenueLink("", "", ""),
-        ReaderRevenueLink("", "", "")
-      ),
-      ""
-    )
-    DotcomponentsDataModel(page, site, 1)
   }
 
   def toJson(model: DotcomponentsDataModel): JsValue = {

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.model.v1.Blocks
 import com.osinka.i18n.Lang
 import conf.Configuration
 import controllers.ArticlePage
-import model.Cached
+import model.{Cached, PageWithStoryPackage}
 import model.Cached.RevalidatableResult
 import model.dotcomponents.DotcomponentsDataModel
 import play.api.libs.json._
@@ -34,7 +34,7 @@ class RemoteRenderer {
   private[this] def get(
     ws:WSClient,
     payload: String,
-    article: ArticlePage,
+    article: PageWithStoryPackage,
     endpoint: String
   )(implicit request: RequestHeader): Future[Result] = {
 
@@ -53,23 +53,23 @@ class RemoteRenderer {
   }
 
 
-  def getAMPArticle(ws: WSClient, payload: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
+  def getAMPArticle(ws: WSClient, payload: String, page: PageWithStoryPackage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {
-      case JsSuccess(_,_) => get(ws, dataString, article, Configuration.rendering.AMPArticleEndpoint)
+      case JsSuccess(_,_) => get(ws, dataString, page, Configuration.rendering.AMPArticleEndpoint)
       case JsError(e) => Future.failed(new Exception(Json.prettyPrint(JsError.toJson(e))))
     }
 
   }
 
-  def getArticle(ws:WSClient, path: String, article: ArticlePage,  blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(article, request, blocks)
+  def getArticle(ws:WSClient, path: String, page: PageWithStoryPackage,  blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
     val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
 
     validate(dataModel) match {
-      case JsSuccess(_,_) => get(ws, dataString, article, Configuration.rendering.renderingEndpoint)
+      case JsSuccess(_,_) => get(ws, dataString, page, Configuration.rendering.renderingEndpoint)
       case JsError(e) => Future.failed(new Exception(Json.prettyPrint(JsError.toJson(e))))
     }
   }

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -27,7 +27,7 @@ class FakePicker extends RenderingTierPicker {
 }
 
 class FakeRemoteRender(implicit context: ApplicationContext) extends renderers.RemoteRenderer {
-  override def getArticle(ws:WSClient, path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
+  override def getArticle(ws:WSClient, path: String, article: PageWithStoryPackage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(Cached(article)(RevalidatableResult.Ok(Html("OK"))))
   }


### PR DESCRIPTION
## What does this change?

Return an empty dotcom-rendering data model object for live blogs. 



*URL*

```
http://localhost:9000/world/live/2019/apr/23/sri-lanka-bombings-attacks-live-news.json?guui
```

*Before*

![Screenshot 2019-05-13 at 13 54 14](https://user-images.githubusercontent.com/6035518/57622990-b557ac00-7586-11e9-8b19-87c7ca1f0a8e.png)


*After*

![Screenshot 2019-05-13 at 13 54 37](https://user-images.githubusercontent.com/6035518/57623004-be487d80-7586-11e9-8e5a-ff7014ee5676.png)

**UPDATE: I've now populated the model as with regular article and also refactored the liveblog controller to hopefully be clearer, so this is okay to review now.**

