### PR TITLE
Use CAPI element model for AMPPicker

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -39,7 +39,7 @@ class ArticleController(contentApiClient: ContentApiClient, val controllerCompon
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
       mapModel(path, ArticleBlocks)( (article, blocks) => {
-        renderingTierPicker.getTier(article) match {
+        renderingTierPicker.getTier(article, blocks) match {
           case RemoteRender => remoteRenderer.getArticle(ws, path, article, blocks)
           case RemoteRenderAMP => remoteRenderer.getAMPArticle(ws, path, article, blocks)
           case LocalRender => render(path, article, blocks)

--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -1,15 +1,17 @@
 package services.dotcomponents
 
+import com.gu.contentapi.client.model.v1.{Blocks => APIBlocks}
 import implicits.Requests._
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
 
+
 class RenderingTierPicker {
 
-  def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
+  def getTier(page: PageWithStoryPackage, blocks: APIBlocks)(implicit request: RequestHeader): RenderType = {
 
     if(request.isAmp) {
-      AMPPicker.getTier(page)
+      AMPPicker.getTier(page, blocks)
     } else {
       ArticlePicker.getTier(page)
     }

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 // these
 
 class FakePicker extends RenderingTierPicker {
-  override def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
+  override def getTier(page: PageWithStoryPackage, blocks: Blocks)(implicit request: RequestHeader): RenderType = {
     RemoteRender
   }
 }


### PR DESCRIPTION
Previously we used the liveblog model but this isn't a great fit
here as it doesn't map so obviously to what we actually support.

Using the CAPI element model maps directly to our actual logic in
PageElement.scala where we translate the model to suit DCR.

**TODO: test on CODE!**

Relates to: https://github.com/guardian/frontend/pull/21368 cc @gtrufitt .

@MatthewJWalls would be great to get your thoughts on this too in case this is not a good approach. Thanks :)
