### PR TITLE
Expose lazy load (image) param

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -83,6 +83,7 @@ class DevParametersHttpRequestHandler(
       context.environment.mode != Prod &&
       !request.isJson &&
       !request.isGuui &&
+      !request.isLazyLoad &&
       !request.uri.startsWith("/oauth2callback") &&
       !request.uri.startsWith("/px.gif")  && // diagnostics box
       !request.uri.startsWith("/tech-feedback") &&

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -41,6 +41,8 @@ trait Requests {
 
     lazy val guuiOptOut: Boolean = r.getQueryString("guui").contains("false")
 
+    lazy val isLazyLoad: Boolean = r.getQueryString("lazy-load").isDefined && !r.getQueryString("lazy-load").contains("false")
+
     lazy val isRss: Boolean = r.path.endsWith("/rss")
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,6 +1,7 @@
 @import layout.WidthsByBreakpoint
 @import model.ImageMedia
 @import views.support.{ImgSrc, RenderClasses, SrcSet}
+@import implicits.Requests._
 
 @import experiments.{ActiveExperiments, LazyLoadImages}
 
@@ -53,7 +54,7 @@
     </picture>
 }
 
-@if(shouldLazyLoad && ActiveExperiments.isParticipating(LazyLoadImages)) {
+@if(shouldLazyLoad && (ActiveExperiments.isParticipating(LazyLoadImages) || request.isLazyLoad)) {
     @lazyLoad()
 } else {
     @eagerlyLoad()


### PR DESCRIPTION
Adds a `lazy-load` query parameter to toggle lazy image loading for easier performance testing on a range of devices and services.