### PR TITLE
Update keyEventData to use published or created date

### DIFF
--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -19,7 +19,7 @@ object KeyEventData {
     val TimelineMaxEntries = 7
     val latestSummary = blocks.find(_.eventType == SummaryEvent)
     val keyEvents = blocks.filter(_.eventType == KeyEvent)
-    val bodyBlocks = (latestSummary.toSeq ++ keyEvents).sortBy(_.lastModifiedDate.getOrElse(new DateTime(0)).toInstant.getMillis).reverse.take(TimelineMaxEntries)
+    val bodyBlocks = (latestSummary.toSeq ++ keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
 
     bodyBlocks.map { bodyBlock =>
       KeyEventData(bodyBlock.id, bodyBlock.publishedCreatedDate(timezone), bodyBlock.title)


### PR DESCRIPTION
## What does this change?

Uses the firstPublishedDate as ordering of keyevents. (or created date if not publised - preview)

- Matches [MAPI](https://github.com/guardian/mobile-apps-api/blob/3762adc9cdea056b2d5965b6022a484d4d0ce2a1/common-play/src/main/scala/models/contentitem/LiveBlogItem.scala#L159) 
- Matches 'timestamp'
- Matches main block ordering

Uses existing helper:

![image](https://user-images.githubusercontent.com/638051/57071017-0b983580-6cd1-11e9-8a7a-36711c53275f.png)

## Screenshots

### Before (note halftime)

![Screenshot 2019-05-02 at 11 46 57](https://user-images.githubusercontent.com/638051/57070800-6d0bd480-6cd0-11e9-8787-6221943f7481.png)

### After

![Screenshot 2019-05-02 at 11 46 43](https://user-images.githubusercontent.com/638051/57070808-7432e280-6cd0-11e9-8b23-8f88d33a95bc.png)

#### AMP

![image](https://user-images.githubusercontent.com/638051/57070916-c116b900-6cd0-11e9-825f-bff282920cd9.png)

## What is the value of this and can you measure success?

Makes more sense to users.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps - Matches Apps

### Tested

- [x] Locally

