### PR TITLE
Update pangaea adapter IDs from test to production

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -374,10 +374,9 @@ const ozoneClientSideBidder: PrebidBidder = {
         Object.assign(
             {},
             (() => ({
-                // TODO: update the test values below once testing over
-                publisherId: 'OZONENUK0001', // test ID
-                siteId: '4204204201', // test ID
-                placementId: '0420420421', // test ID
+                publisherId: 'OZONEGMG0001',
+                siteId: '4204204209',
+                placementId: '0420420500',
                 customData: PAGE_TARGETING,
                 ozoneData: {}, // TODO: confirm if we need to send any
             }))(),


### PR DESCRIPTION
## What does this change?

This updates the Pangaea adapter to use new IDs to be used on production. The old IDs were only used for testing purposes.

This needs to be tested directl on production by adops.

@guardian/commercial-dev 
