### PR TITLE
disabled test with documentation

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -7,7 +7,7 @@ import { commercialConsentGlobalNoScroll } from 'common/modules/experiments/test
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
-// import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs_global_mobile_banner_design';
+import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs-global-mobile-banner-design';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -35,10 +35,9 @@ export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
 
      TBD: Re-enable this test to run after the copy test has run
      Steps:
-     1. Re-enable in ab-tests.js
-     2. Enable on switchboard
-     3. Test
-     4. Remove this copy, merge, test again
+     1. Enable on switchboard
+     2. Test
+     3. Remove this copy, merge, test again
      ********************************************************** */
-    // contributionsGlobalMobileBannerDesign,
+    contributionsGlobalMobileBannerDesign,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -7,7 +7,7 @@ import { commercialConsentGlobalNoScroll } from 'common/modules/experiments/test
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
-import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs_global_mobile_banner_design';
+// import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs_global_mobile_banner_design';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -24,5 +24,21 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    contributionsGlobalMobileBannerDesign,
+    /** *********************************************************
+     2 May 2019 - JTL - This test is disabled as of 2 May 2019
+     This test went out on mobile devices the same day as a
+     global copy test went out across all devices. The copy
+     test runs before tests in the code (per `ab.js`) which is
+     desired behavior. A user can only be assigned to one banner
+     test at a time (also desired), so we decided to give the
+     copy test time precedence over this test.
+
+     TBD: Re-enable this test to run after the copy test has run
+     Steps:
+     1. Re-enable in ab-tests.js
+     2. Enable on switchboard
+     3. Test
+     4. Remove this copy, merge, test again
+     ********************************************************** */
+    // contributionsGlobalMobileBannerDesign,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
@@ -11,10 +11,9 @@
 
  TBD: Re-enable this test to run after the copy test has run
  Steps:
- 1. Re-enable in ab-tests.js
- 2. Enable on switchboard
- 3. Test
- 4. Remove this copy, merge, test again
+ 1. Enable on switchboard
+ 2. Test
+ 3. Remove this copy, merge, test again
  ********************************************************** */
 
 import { isBreakpoint } from 'lib/detect';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs_global_mobile_banner_design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs_global_mobile_banner_design.js
@@ -1,5 +1,22 @@
 // @flow
 
+/** *********************************************************
+ 2 May 2019 - JTL - This test is disabled as of 2 May 2019
+ This test went out on mobile devices the same day as a
+ global copy test went out across all devices. The copy
+ test runs before tests in the code (per `ab.js`) which is
+ desired behavior. A user can only be assigned to one banner
+ test at a time (also desired), so we decided to give the
+ copy test time precedence over this test.
+
+ TBD: Re-enable this test to run after the copy test has run
+ Steps:
+ 1. Re-enable in ab-tests.js
+ 2. Enable on switchboard
+ 3. Test
+ 4. Remove this copy, merge, test again
+ ********************************************************** */
+
 import { isBreakpoint } from 'lib/detect';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { acquisitionsBannerMobileDesignTestTemplate } from 'common/modules/commercial/templates/acquisitions-banner-mobile-design-test';


### PR DESCRIPTION
## What does this change?
Disabling the test from [this PR](https://github.com/guardian/frontend/pull/21374)

Inline documentation:
```
/** *********************************************************
 2 May 2019 - JTL - This test is disabled as of 2 May 2019
 This test went out on mobile devices the same day as a
 global copy test went out across all devices. The copy
 test runs before tests in the code (per `ab.js`) which is
 desired behavior. A user can only be assigned to one banner
 test at a time (also desired), so we decided to give the
 copy test time precedence over this test.

 TBD: Re-enable this test to run after the copy test has run
 Steps:
 1. Re-enable in ab-tests.js
 2. Enable on switchboard
 3. Test
 4. Remove this copy, merge, test again
 ********************************************************** */
```

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)
