### PR TITLE
Bump facia client to version 3.0.2.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.174"
   val awsVersion = "1.11.240"
   val capiVersion = "14.1"
-  val faciaVersion = "3.0.0"
+  val faciaVersion = "3.0.2"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
Brings in [this](https://github.com/guardian/facia-scala-client/pull/216/files) change to the facia scala client which ensures that the new 'edition' priority is treated the same as 'Training'

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
