### PR TITLE
World Cup match lists. Correct team names to replace 'Ladies' by 'Women'

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -149,3 +149,13 @@ case class TeamColours(homeTeam: LineUpTeam, awayTeam: LineUpTeam) {
     "#%02x%02x%02x".format(darker.getRed, darker.getGreen, darker.getBlue)
   }
 }
+
+object CompetitionDisplayHelpers {
+
+  // This function is applied to team names during the making of matches lists.
+  // It should be without effects for men competitions. For women competitions it
+  // rewrite, for instance, "Norway Ladies" into "Norway Women".
+  def correctTeamName(teamName: String): String = {
+    teamName.replace("Ladies", "Women")
+  }
+}

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -50,14 +50,14 @@
                     <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
                         <div class="football-match__team football-match__team--home football-team">
                             <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.homeTeam)">
-                                <span class="team-name__long">@theMatch.homeTeam.name</span>
+                                <span class="team-name__long">@model.CompetitionDisplayHelpers.correctTeamName(theMatch.homeTeam.name)</span>
                             </div>
                             <div class="football-team__score">@theMatch.homeTeam.score</div>
                         </div>
 
                         <div class="football-match__team football-match__team--away football-team">
                             <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.awayTeam)">
-                                <span class="team-name__long">@theMatch.awayTeam.name</span>
+                                <span class="team-name__long">@model.CompetitionDisplayHelpers.correctTeamName(theMatch.awayTeam.name)</span>
                             </div>
                             <div class="football-team__score">@theMatch.awayTeam.score</div>
                         </div>


### PR DESCRIPTION
## What does this change?

Prevent the display of "Ladies" in team names and replace it by "Women"

## Screenshots

![Screenshot 2019-05-03 at 14 13 55](https://user-images.githubusercontent.com/6035518/57139722-ec230a80-6dad-11e9-9e2e-40f7e8dc4816.png)
