### PR TITLE
Temporarily prevent the display of team crests on world cup match listings

### DIFF
--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -44,7 +44,9 @@
                     }
                 </td>
                 <td class="football-match__crest football-match__crest--home">
+                    <!--
                     <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{theMatch.homeTeam.id}.png" />
+                    -->
                 </td>
                 <td class="football-match__teams table-column--main">
                     <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
@@ -70,7 +72,9 @@
                     </a>
                 </td>
                 <td class="football-match__crest football-match__crest--home">
+                    <!--
                     <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{theMatch.awayTeam.id}.png" />
+                    -->
                 </td>
             </tr>
         }


### PR DESCRIPTION

## What does this change?

Temporarily prevent the display of crests for World Cup match listings. This, because we do not currently have crests for the women teams (and some web browsers highlight missing pictures). This change will be reverted as soon as we have them.
