### PR TITLE
Prebid updated to 2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#0e4ee56",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#b06a091",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -92,6 +92,7 @@ describe('initialise', () => {
                 is_debug: 'false',
                 maxBids: 1,
                 syncEndpoint: 'https://elb.the-ozone-project.com/cookie_sync',
+                syncUrlModifier: {},
                 timeout: 1500,
             },
             timeoutBuffer: 400,
@@ -125,6 +126,7 @@ describe('initialise', () => {
             adapterOptions: {},
             enabled: false,
             maxBids: 1,
+            syncUrlModifier: {},
             timeout: 1000,
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,9 +8206,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#0e4ee56":
-  version "2.6.0"
-  resolved "https://github.com/guardian/Prebid.js.git#0e4ee564513e9ae009b4eca22046d114e7ac9617"
+"prebid.js@https://github.com/guardian/Prebid.js.git#b06a091":
+  version "2.13.0"
+  resolved "https://github.com/guardian/Prebid.js.git#b06a0910b92b37f23ae87d157fcdecfee4919cb0"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?
This changes prebid version used to 2.13.

Do not merge untill https://github.com/guardian/Prebid.js/pull/92 is merged.

## What is the value of this and can you measure success?
Just a regular update to fix bugs and add features we might use in the future.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
