### PR TITLE
Jsonld Image Crops and Open Graph image in Dotcomponents Model

### DIFF
--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -66,6 +66,7 @@ object LinkedData {
           NewsArticle(
             `@id` = baseURL + article.metadata.id,
             images = Seq(
+              article.content.openGraphImage,
               ImgSrc(mainImageURL, OneByOne),
               ImgSrc(mainImageURL, FourByThree),
               ImgSrc(mainImageURL, Item1200),

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -121,8 +121,12 @@ object GoogleStructuredData extends ImageProfile(width = Some(300), height = Som
 // Used for AMP image structured data - see
 // https://developers.google.com/search/docs/data-types/article#article_types
 // and the image advice.
-object OneByOne extends ImageProfile(width = Some(1200), height = Some(1200))
-object FourByThree extends ImageProfile(width = Some(1200), height = Some(900))
+object OneByOne extends ImageProfile(width = Some(1200), height = Some(1200)) {
+  override val fitParam: String = "fit=crop"
+}
+object FourByThree extends ImageProfile(width = Some(1200), height = Some(900)) {
+  override val fitParam: String = "fit=crop"
+}
 
 class ShareImage(overlayUrlParam: String, shouldIncludeOverlay: Boolean) extends ImageProfile(width = Some(1200)) {
   override val heightParam = "height=630"


### PR DESCRIPTION
## What does this change?
Adds the opengraph image that contains the branded logo and adds cropping to the fixed size images to prevent stretching.
## Screenshots
![Screenshot 2019-05-07 at 17 10 58](https://user-images.githubusercontent.com/638051/57315680-f7e33980-70eb-11e9-9d59-567d4ac73826.png)

## What is the value of this and can you measure success?
Currently Google shows badly stretched images in lots of places.

![Screenshot 2019-05-07 at 17 14 14](https://user-images.githubusercontent.com/638051/57315657-f154c200-70eb-11e9-9ddc-2636acbbb02a.png)
![Screenshot 2019-05-07 at 17 14 46](https://user-images.githubusercontent.com/638051/57315658-f1ed5880-70eb-11e9-92c1-588e00a8fdf1.png)

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
