### PR TITLE
Fix GUDateTimeFormat

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -116,7 +116,9 @@ object `package` {
 
 object GUDateTimeFormat {
   def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
-    s"${formatDateForDisplay(date, request)} ${formatTimeForDisplay(date, request)}"
+    val edition = Edition(request)
+    val timezone = edition.timezone
+    date.toString(DateTimeFormat.forPattern("E d MMM yyyy HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
   }
   def formatDateForDisplay(date: DateTime, request: RequestHeader): String = {
     date.toString("E d MMM yyyy")


### PR DESCRIPTION
## What does this change?

This corrects a mistake I introduced when I created `GUDateTimeFormat`, a while ago, by which essentially any article written in Australia (more exactly which has been set with a `+10:00` timezone), when served as AMP, has been displayed with a datetime set in the future (more exactly incorrect date, resulting in the entire datetime being 24 hours ahead) when seen by American readers (more exactly when Edition is set to `US`) 😬

Timestamp from CAPI `2019-05-08T10:26:11.000+10:00`, the case for this article: https://www.theguardian.com/us-news/2019/may/07/white-house-don-mcgahn-congress-subpoena

**Before**: 

```
2019-05-08T10:26:11.000+10:00 
    -> Wed 8 May 2019 20.26 EDT
```

**After**:

```
2019-05-08T10:26:11.000+10:00 
    -> Tue 7 May 2019 20.26 EDT
    -> Wed 8 May 2019 01.26 BST
```

It is interesting that the problem was caused by the initial version of `GUDateTimeFormat.formatDateTimeForDisplay` formatting the date and the time independently of each other. This problem should **not** have occurred, but did because `formatDateForDisplay` and `formatTimeForDisplay` were making inconsistent formatting choices, which didn't show up when the code was tested with timezones with a small drift compared to UTC. 

Lesson: Be super careful with datetime manipulation. 

