### PR TITLE
Add test for GUDateTimeFormat format with edition

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -117,6 +117,9 @@ object `package` {
 object GUDateTimeFormat {
   def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
     val edition = Edition(request)
+    formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition)
+  }
+  def formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition): String = {
     val timezone = edition.timezone
     date.toString(DateTimeFormat.forPattern("E d MMM yyyy HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
   }

--- a/common/test/views/support/GUDateTimeFormatTest.scala
+++ b/common/test/views/support/GUDateTimeFormatTest.scala
@@ -1,0 +1,18 @@
+package views.support
+
+import common.editions
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+
+class GUDateTimeFormatTest extends FreeSpec with Matchers {
+  val date = DateTime.parse("2019-05-08T10:26:11.000+10:00")
+  "formatDateTimeForDisplayGivenEdition" - {
+    "correctly handles Australian to US timezone conversion" in {
+      GUDateTimeFormat.formatDateTimeForDisplayGivenEdition(date, editions.Us) shouldEqual "Tue 7 May 2019 20.26 EDT"
+    }
+    "correctly handles Australian to UK timezone conversion" in {
+      GUDateTimeFormat.formatDateTimeForDisplayGivenEdition(date, editions.Uk) shouldEqual "Wed 8 May 2019 01.26 BST"
+    }
+
+  }
+}


### PR DESCRIPTION
## What does this change?

Add a Test. Companion PR for https://github.com/guardian/frontend/pull/21392 
