### PR TITLE
Add KnockoutSpider.ordering data for Women World Cup 2019

### DIFF
--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -27,7 +27,6 @@ class WallchartController(
         .stagesFromCompetition(competition, KnockoutSpider.orderings)
 
       val nextMatch = WallchartController.nextMatch(competition.matches, DateTime.now())
-
       Cached(60) {
         if(embed) RevalidatableResult.Ok(football.views.html.wallchart.embed(page, competition, competitionStages, nextMatch))
         else RevalidatableResult.Ok(football.views.html.wallchart.page(page, competition, competitionStages, nextMatch))

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -26,7 +26,6 @@ class CompetitionStage(competitions: Seq[Competition]) {
       // work out stage type
       val stageLeagueEntries = competition.leagueTable.filter(_.stageNumber == stage.stageNumber)
       val rounds = stageMatches.map(_.round).distinct.sortBy(_.roundNumber)
-
       if (stageLeagueEntries.isEmpty) {
         if (rounds.size > 1) {
           orderings.get(competition.id) match {
@@ -63,8 +62,8 @@ class CompetitionStage(competitions: Seq[Competition]) {
   private def orderingsApplyToTheseMatches(matchDates: List[DateTime], matches: List[FootballMatch]): Boolean = {
     KnockoutSpider
       .makeMatchIntervals(matchDates)
-      .exists(interval => matches
-        .exists(fMatch => interval.contains(fMatch.date))
+      .exists(interval =>
+        matches.exists(fMatch => interval.contains(fMatch.date))
       )
   }
 }
@@ -123,6 +122,28 @@ object KnockoutSpider {
 
      new DateTime(2018, 7, 14, 15, 0, DateTimeZone.forID("Europe/London")), // 3rd/4th Play-Offs 4044570
      new DateTime(2018, 7, 15, 16, 0, DateTimeZone.forID("Europe/London"))  // Final 4044571
+   ),
+    // women world cup 2019
+   "870" -> List(
+     new DateTime(2019, 6,22, 16, 30, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,22, 20, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,23, 16, 30, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,23, 20, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,24, 18, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,24, 20, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,25, 17, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+     new DateTime(2019, 6,25, 20, 0, DateTimeZone.forID("Europe/London")), // Round of 16
+
+     new DateTime(2019, 6,27, 20, 0, DateTimeZone.forID("Europe/London")), // Quarter Final
+     new DateTime(2019, 6,28, 20, 0, DateTimeZone.forID("Europe/London")), // Quarter Final
+     new DateTime(2019, 6,29, 14, 0, DateTimeZone.forID("Europe/London")), // Quarter Final
+     new DateTime(2019, 6,29, 17, 30, DateTimeZone.forID("Europe/London")), // Quarter Final
+
+     new DateTime(2019, 7, 2, 20, 0, DateTimeZone.forID("Europe/London")), // Semi-Final
+     new DateTime(2019, 7, 3, 20, 0, DateTimeZone.forID("Europe/London")), // Semi-Final
+
+     new DateTime(2019, 7, 6, 16, 0, DateTimeZone.forID("Europe/London")), // 3rd/4th Play-Offs
+     new DateTime(2019, 7, 7, 16, 0, DateTimeZone.forID("Europe/London"))  // Final
    )
   )
 


### PR DESCRIPTION
## What does this change?

Add the missing `KnockoutSpider.ordering` dates for the coming Women World Cup 2019. 

