### PR TITLE
Enabled consent banner on AU and NZ

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -93,9 +93,11 @@ const isInCommercialConsentModalBannerTest = (): boolean =>
 const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
-const isInAU = (): boolean =>
-    (getFromStorage() || 'OTHER').toUpperCase() === 'AU' ||
-    (getFromStorage() || 'OTHER').toUpperCase() === 'NZ';
+const isInAU = (): boolean => {
+    const countryCode = (getFromStorage() || 'OTHER').toUpperCase();
+
+    return countryCode === 'AU' || countryCode === 'NZ';
+};
 
 const gdprApplies = (): boolean => isInEU() || isInAU();
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -2,6 +2,7 @@
 
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
+import { getFromStorage } from 'lib/geolocation';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
 
@@ -92,6 +93,12 @@ const isInCommercialConsentModalBannerTest = (): boolean =>
 const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
+const isInAU = (): boolean =>
+    (getFromStorage() || 'OTHER').toUpperCase() === 'AU' ||
+    (getFromStorage() || 'OTHER').toUpperCase() === 'NZ';
+
+const gdprApplies = (): boolean => isInEU() || isInAU();
+
 class CmpService {
     isLoaded: boolean;
     cmpReady: boolean;
@@ -114,7 +121,7 @@ class CmpService {
             this.cmpConfig.logging = 'debug';
             log.info('Set logging level to DEBUG');
         }
-        if (isInEU() || isInCommercialConsentModalBannerTest()) {
+        if (gdprApplies() || isInCommercialConsentModalBannerTest()) {
             this.cmpConfig.gdprApplies = true;
         }
     }

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,6 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
+import { getFromStorage } from 'lib/geolocation';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import checkIcon from 'svgs/icon/tick.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
@@ -141,6 +142,12 @@ const makeHtml = (): string => `
 const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
+const isInAU = (): boolean =>
+    (getFromStorage() || 'OTHER').toUpperCase() === 'AU' ||
+    (getFromStorage() || 'OTHER').toUpperCase() === 'NZ';
+
+const gdprApplies = (): boolean => isInEU() || isInAU();
+
 const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);
 
@@ -169,7 +176,7 @@ const trackInteraction = (interaction: string): void => {
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
         hasUnsetAdChoices() &&
-            (isInEU() || isInCommercialConsentModalBannerTest()) &&
+            (gdprApplies() || isInCommercialConsentModalBannerTest()) &&
             !hasUserAcknowledgedBanner(messageCode)
     );
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -142,9 +142,11 @@ const makeHtml = (): string => `
 const isInEU = (): boolean =>
     (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
 
-const isInAU = (): boolean =>
-    (getFromStorage() || 'OTHER').toUpperCase() === 'AU' ||
-    (getFromStorage() || 'OTHER').toUpperCase() === 'NZ';
+const isInAU = (): boolean => {
+    const countryCode = (getFromStorage() || 'OTHER').toUpperCase();
+
+    return countryCode === 'AU' || countryCode === 'NZ';
+};
 
 const gdprApplies = (): boolean => isInEU() || isInAU();
 


### PR DESCRIPTION
## What does this change?
This change enables the current personalized ads consent banner to be shown to AU and NZ readers.

DO NOT MERGE until further notice.

## What is the value of this and can you measure success?
N/A

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
