### PR TITLE
Don't show affiliate link disclaimer when affiliate links are disabled.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -222,23 +222,25 @@ object DotcomponentsDataModel {
         atoms = atoms
       ))
 
-      addDisclaimer(elems, capiElems)
+      addDisclaimer(elems, capiElems, affiliateLinks)
     }
 
-    def addDisclaimer(elems: List[PageElement], capiElems: Seq[ClientBlockElement]): List[PageElement] = {
-      val hasLinks = capiElems.exists(elem => elem.`type` match {
-        case Text => {
-          val textString = elem.textTypeData.toList.mkString("\n") // just concat all the elems here for this test
-          AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
-        }
-        case _ => false
-      })
+    def addDisclaimer(elems: List[PageElement], capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean): List[PageElement] = {
+      if (affiliateLinks) {
+        val hasLinks = capiElems.exists(elem => elem.`type` match {
+          case Text => {
+            val textString = elem.textTypeData.toList.mkString("\n") // just concat all the elems here for this test
+            AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
+          }
+          case _ => false
+        })
 
-      if (hasLinks) {
-        elems :+ DisclaimerBlockElement(affiliateLinksDisclaimer("article").body)
-      } else {
-        elems
-      }
+        if (hasLinks) {
+          elems :+ DisclaimerBlockElement(affiliateLinksDisclaimer("article").body)
+        } else {
+          elems
+        }
+      } else elems
     }
 
     def buildFullCommercialUrl(bundlePath: String): String = {


### PR DESCRIPTION
## What does this change?
Adds a check to see if affiliate links are enabled for a piece of content before adding the disclaimer. Otherwise pieces containing links to e.g. amazon.co.uk for which affiliate links are disabled will still get the disclaimer showing up in AMP.

Example article: https://amp.theguardian.com/commentisfree/2019/may/12/the-guardian-view-on-a-green-new-deal-we-need-it-now 

<img width="758" alt="Screenshot 2019-05-13 at 11 55 10" src="https://user-images.githubusercontent.com/3606555/57616470-090dc980-7576-11e9-8246-d11b2760b18d.png">


## Screenshots

## What is the value of this and can you measure success?
Less confusion, reduced risk of reputational damage.
## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->