### PR TITLE
Drop AST if it's not used

### DIFF
--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -83,7 +83,16 @@ class ReauthenticationController(
         // drop the query parameter by redirecting to the same endpoint (/reauthenticate) without including it.
         // This will prevent the token being present in logs or the datalake.
         // TODO: change this once the query parameter is set as a header instead.
-        NoCache(Redirect(routes.ReauthenticationController.renderForm(returnUrl)))
+        val call = routes.ReauthenticationController.renderForm(returnUrl)
+
+        val queryParams = idUrlBuilder
+          .flattenQueryParams(request.queryString)
+          // In addition to the auto sign-in token query parameter,
+          // don't include the returnUrl query parameter since this will already be included
+          // (the returnUrl val has been passed to the renderForm() function call).
+          .filter { case (key, _ ) => key != "autoSignInToken" && key != "returnUrl" }
+
+        NoCache(Redirect(idUrlBuilder.appendQueryParams(call.url, queryParams)))
       }
     }
 

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -82,7 +82,7 @@ class ReauthenticationController(
         // (i.e. the user isn't automatically redirected to the return url)
         // drop the query parameter by redirecting to the same endpoint (/reauthenticate) without including it.
         // This will prevent the token being present in logs or the datalake.
-        // TODO: change this once the query parameter is set as a header instead.
+        // NOTE: this might change in the future if some other (better) mechanism is used to pass auto sign-in tokens.
         val call = routes.ReauthenticationController.renderForm(returnUrl)
 
         val queryParams = idUrlBuilder

--- a/identity/app/services/IdentityUrlBuilder.scala
+++ b/identity/app/services/IdentityUrlBuilder.scala
@@ -17,6 +17,13 @@ class IdentityUrlBuilder(conf: IdConfig) {
     params.flatMap(param => if (param._2.isDefined) Some(param._1 -> param._2.get) else None)
   }
 
+  // Utility function to map Play's modelling of query parameters,
+  // to how query parameters are modelled in this class.
+  def flattenQueryParams(params: Map[String, Seq[String]]): List[(String, String)] =
+    params.foldLeft(List.empty[(String, String)]) { case (acc, (key, values)) =>
+      acc ++ values.map(key -> _)
+    }
+
   def appendQueryParams(url: String, params: List[(String, String)]): String = {
     val separator = if (url.contains("?")) "&" else "?"
     url + {


### PR DESCRIPTION
## What does this change?

Drops AST if not used (by doing a redirect to the same endpoint). Note that this is (potentially) a temporary fix. In future, we might instead include the AST as a header instead.

### Tested

- [ ] Locally
- [x] On CODE (optional)
