### PR TITLE
Write Navigation static data to S3

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -22,6 +22,7 @@ import router.Routes
 import services.dotcomponents.RenderingTierPicker
 import services.ophan.SurgingContentAgentLifecycle
 import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle}
+import jobs.StoreNavigationLifecycleComponent
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -50,7 +51,8 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
     wire[CachedHealthCheckLifeCycle],
     wire[TargetingLifecycle],
     wire[DiscussionExternalAssetsLifecycle],
-    wire[SkimLinksCacheLifeCycle]
+    wire[SkimLinksCacheLifeCycle],
+    wire[StoreNavigationLifecycleComponent]
   )
 
   lazy val router: Router = wire[Routes]

--- a/article/app/jobs/StoreNavigationLifecycleComponent.scala
+++ b/article/app/jobs/StoreNavigationLifecycleComponent.scala
@@ -1,0 +1,38 @@
+package jobs
+
+import app.LifecycleComponent
+import conf.Configuration
+import navigation.{EditionNavLinks, NavLink, NavigationData}
+import play.api.libs.json.{JsValue, Json}
+import services.S3
+
+import scala.concurrent.ExecutionContext
+
+case class Data()
+
+class StoreNavigationLifecycleComponent(implicit executionContext: ExecutionContext) extends LifecycleComponent{
+
+
+  /**
+    * Pushes Navigation data from NavLinks.scala into S3
+    */
+  override def start(): Unit = {
+
+    implicit val navlinkWrites = Json.writes[NavLink]
+    implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
+    implicit val navlinksInterfaceWrites = Json.writes[NavigationData]
+
+    val data = NavigationData()
+    val json: JsValue = Json.toJson(data)
+
+    S3.putPrivate(
+      key = s"${Configuration.environment.stage}/navigation.json",
+      value = json.toString(),
+      contentType = "application/json"
+    )
+
+
+  }
+
+
+}

--- a/article/app/jobs/StoreNavigationLifecycleComponent.scala
+++ b/article/app/jobs/StoreNavigationLifecycleComponent.scala
@@ -17,6 +17,10 @@ class StoreNavigationLifecycleComponent(implicit executionContext: ExecutionCont
     */
   override def start(): Unit = {
 
+    if(Configuration.environment.stage.equalsIgnoreCase("DEVINFRA")){
+      return
+    }
+
     implicit val navlinkWrites = Json.writes[NavLink]
     implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
     implicit val navlinksInterfaceWrites = Json.writes[NavigationData]

--- a/article/app/jobs/StoreNavigationLifecycleComponent.scala
+++ b/article/app/jobs/StoreNavigationLifecycleComponent.scala
@@ -12,7 +12,6 @@ case class Data()
 
 class StoreNavigationLifecycleComponent(implicit executionContext: ExecutionContext) extends LifecycleComponent{
 
-
   /**
     * Pushes Navigation data from NavLinks.scala into S3
     */
@@ -22,15 +21,13 @@ class StoreNavigationLifecycleComponent(implicit executionContext: ExecutionCont
     implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
     implicit val navlinksInterfaceWrites = Json.writes[NavigationData]
 
-    val data = NavigationData()
-    val json: JsValue = Json.toJson(data)
+    val nav: JsValue = Json.toJson(NavigationData())
 
     S3.putPrivate(
       key = s"${Configuration.environment.stage}/navigation.json",
-      value = json.toString(),
+      value = nav.toString(),
       contentType = "application/json"
     )
-
 
   }
 

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -1,6 +1,7 @@
 package navigation
 
-object NavLinks {
+private object NavLinks {
+
   /* NEWS */
   val science = NavLink("Science", "/science")
   val tech = NavLink("Tech", "/technology")
@@ -634,4 +635,62 @@ object NavLinks {
     "commentisfree/commentisfree",
     "education/education"
   )
+
 }
+
+case class EditionNavLinks(
+  newsPillar: NavLink,
+  opinionPillar: NavLink,
+  sportPillar: NavLink,
+  culturePillar: NavLink,
+  lifestylePillar: NavLink,
+  otherLinks: List[NavLink],
+  brandExtensions: List[NavLink]
+)
+
+case class NavigationData (
+
+  uk: EditionNavLinks = EditionNavLinks(
+    NavLinks.ukNewsPillar,
+    NavLinks.ukOpinionPillar,
+    NavLinks.ukSportPillar,
+    NavLinks.ukCulturePillar,
+    NavLinks.ukLifestylePillar,
+    NavLinks.ukOtherLinks,
+    NavLinks.ukBrandExtensions,
+  ),
+
+  us: EditionNavLinks = EditionNavLinks(
+    NavLinks.usNewsPillar,
+    NavLinks.usOpinionPillar,
+    NavLinks.usSportPillar,
+    NavLinks.usCulturePillar,
+    NavLinks.usLifestylePillar,
+    NavLinks.usOtherLinks,
+    NavLinks.usBrandExtensions,
+  ),
+
+  au: EditionNavLinks = EditionNavLinks(
+    NavLinks.auNewsPillar,
+    NavLinks.auOpinionPillar,
+    NavLinks.auSportPillar,
+    NavLinks.auCulturePillar,
+    NavLinks.auLifestylePillar,
+    NavLinks.auOtherLinks,
+    NavLinks.auBrandExtensions,
+  ),
+
+  international: EditionNavLinks = EditionNavLinks(
+    NavLinks.intNewsPillar,
+    NavLinks.intOpinionPillar,
+    NavLinks.intSportPillar,
+    NavLinks.intCulturePillar,
+    NavLinks.intLifestylePillar,
+    NavLinks.intOtherLinks,
+    NavLinks.intBrandExtensions,
+  ),
+
+  tagPages: List[String] = NavLinks.tagPages
+
+)
+

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -134,7 +134,7 @@ object NavMenu {
     edition match {
             case editions.Uk => NavRoot(Seq(navigationData.uk.newsPillar, navigationData.uk.opinionPillar, navigationData.uk.sportPillar, navigationData.uk.culturePillar, navigationData.uk.lifestylePillar), navigationData.uk.otherLinks, navigationData.uk.brandExtensions)
             case editions.Us => NavRoot(Seq(navigationData.us.newsPillar, navigationData.us.opinionPillar, navigationData.us.sportPillar, navigationData.us.culturePillar, navigationData.us.lifestylePillar), navigationData.us.otherLinks, navigationData.us.brandExtensions)
-            case editions.Au => NavRoot(Seq(navigationData.uk.newsPillar, navigationData.uk.opinionPillar, navigationData.uk.sportPillar, navigationData.uk.culturePillar, navigationData.uk.lifestylePillar), navigationData.uk.otherLinks, navigationData.uk.brandExtensions)
+            case editions.Au => NavRoot(Seq(navigationData.au.newsPillar, navigationData.au.opinionPillar, navigationData.au.sportPillar, navigationData.au.culturePillar, navigationData.au.lifestylePillar), navigationData.au.otherLinks, navigationData.au.brandExtensions)
             case editions.International => NavRoot(Seq(navigationData.international.newsPillar, navigationData.international.opinionPillar, navigationData.international.sportPillar, navigationData.international.culturePillar, navigationData.international.lifestylePillar), navigationData.international.otherLinks, navigationData.international.brandExtensions)
           }
   }

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -3,7 +3,6 @@ package navigation
 
 import _root_.model.{NavItem, Page, Tags}
 import common.{Edition, editions}
-import navigation.NavLinks._
 import play.api.libs.json.{Json, Writes}
 
 import scala.annotation.tailrec
@@ -40,6 +39,8 @@ case class NavMenu(
 )
 
 object NavMenu {
+
+  val navigationData = NavigationData()
 
   implicit val navlinkWrites = Json.writes[NavLink]
   implicit val flatSubnavWrites = Json.writes[FlatSubnav]
@@ -124,17 +125,18 @@ object NavMenu {
         None
       } else if (pillars.contains(parent)) {
         currentParent
-      } else findParent(parent, edition, pillars, otherLinks).orElse(Some(ukNewsPillar))
+      } else findParent(parent, edition, pillars, otherLinks).orElse(Some(navigationData.uk.newsPillar))
     )
   }
 
   private[navigation] def navRoot(edition: Edition): NavRoot = {
+
     edition match {
-      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
-      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usCulturePillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
-      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auCulturePillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
-      case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intCulturePillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
-    }
+            case editions.Uk => NavRoot(Seq(navigationData.uk.newsPillar, navigationData.uk.opinionPillar, navigationData.uk.sportPillar, navigationData.uk.culturePillar, navigationData.uk.lifestylePillar), navigationData.uk.otherLinks, navigationData.uk.brandExtensions)
+            case editions.Us => NavRoot(Seq(navigationData.us.newsPillar, navigationData.us.opinionPillar, navigationData.us.sportPillar, navigationData.us.culturePillar, navigationData.us.lifestylePillar), navigationData.us.otherLinks, navigationData.us.brandExtensions)
+            case editions.Au => NavRoot(Seq(navigationData.uk.newsPillar, navigationData.uk.opinionPillar, navigationData.uk.sportPillar, navigationData.uk.culturePillar, navigationData.uk.lifestylePillar), navigationData.uk.otherLinks, navigationData.uk.brandExtensions)
+            case editions.International => NavRoot(Seq(navigationData.international.newsPillar, navigationData.international.opinionPillar, navigationData.international.sportPillar, navigationData.international.culturePillar, navigationData.international.lifestylePillar), navigationData.international.otherLinks, navigationData.international.brandExtensions)
+          }
   }
 
   private[navigation] def getTagsFromPage(page: Page): Tags = {
@@ -155,8 +157,8 @@ object NavMenu {
     )
     val networkFronts = Seq("uk", "us", "au", "international")
     val tags = getTagsFromPage(page)
-    val commonKeywords = tags.keywordIds.intersect(tagPages).sortWith(tags.keywordIds.indexOf(_) < tags.keywordIds.indexOf(_))
-    val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && tagPages.contains(page.metadata.id)
+    val commonKeywords = tags.keywordIds.intersect(navigationData.tagPages).sortWith(tags.keywordIds.indexOf(_) < tags.keywordIds.indexOf(_))
+    val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && navigationData.tagPages.contains(page.metadata.id)
     val isArticleInTagPageSection = commonKeywords.nonEmpty
 
     val id = if (networkFronts.contains(page.metadata.sectionId)) {

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -131,12 +131,25 @@ object NavMenu {
 
   private[navigation] def navRoot(edition: Edition): NavRoot = {
 
-    edition match {
-            case editions.Uk => NavRoot(Seq(navigationData.uk.newsPillar, navigationData.uk.opinionPillar, navigationData.uk.sportPillar, navigationData.uk.culturePillar, navigationData.uk.lifestylePillar), navigationData.uk.otherLinks, navigationData.uk.brandExtensions)
-            case editions.Us => NavRoot(Seq(navigationData.us.newsPillar, navigationData.us.opinionPillar, navigationData.us.sportPillar, navigationData.us.culturePillar, navigationData.us.lifestylePillar), navigationData.us.otherLinks, navigationData.us.brandExtensions)
-            case editions.Au => NavRoot(Seq(navigationData.au.newsPillar, navigationData.au.opinionPillar, navigationData.au.sportPillar, navigationData.au.culturePillar, navigationData.au.lifestylePillar), navigationData.au.otherLinks, navigationData.au.brandExtensions)
-            case editions.International => NavRoot(Seq(navigationData.international.newsPillar, navigationData.international.opinionPillar, navigationData.international.sportPillar, navigationData.international.culturePillar, navigationData.international.lifestylePillar), navigationData.international.otherLinks, navigationData.international.brandExtensions)
-          }
+    val editionLinks: EditionNavLinks = edition match {
+      case editions.Uk => navigationData.uk
+      case editions.Us => navigationData.us
+      case editions.Au => navigationData.au
+      case editions.International => navigationData.international
+    }
+
+    NavRoot(
+      Seq(
+        editionLinks.newsPillar,
+        editionLinks.opinionPillar,
+        editionLinks.sportPillar,
+        editionLinks.culturePillar,
+        editionLinks.lifestylePillar
+      ),
+      editionLinks.otherLinks,
+      editionLinks.brandExtensions
+    )
+
   }
 
   private[navigation] def getTagsFromPage(page: Page): Tags = {

--- a/common/app/services/ParameterStore.scala
+++ b/common/app/services/ParameterStore.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.simplesystemsmanagement.model.{GetParameterRequest, GetParametersByPathRequest, PutParameterRequest, PutParameterResult}
+import com.amazonaws.services.simplesystemsmanagement.model.{GetParameterRequest, GetParametersByPathRequest}
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 import common.GuardianConfiguration
 import conf.Configuration
@@ -49,19 +49,4 @@ class ParameterStore(region: String) {
 
     pagination(Map.empty, None)
   }
-
-  def putPath(name: String, value: String): String = {
-
-    val result: PutParameterResult = client.putParameter(
-      new PutParameterRequest()
-        .withName(name)
-        .withType("SecureString")
-        .withOverwrite(true)
-        .withValue(value)
-    )
-
-    result.toString
-
-  }
-
 }

--- a/common/app/services/ParameterStore.scala
+++ b/common/app/services/ParameterStore.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.services.simplesystemsmanagement.model.{GetParameterRequest, GetParametersByPathRequest}
+import com.amazonaws.services.simplesystemsmanagement.model.{GetParameterRequest, GetParametersByPathRequest, PutParameterRequest, PutParameterResult}
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 import common.GuardianConfiguration
 import conf.Configuration
@@ -49,4 +49,19 @@ class ParameterStore(region: String) {
 
     pagination(Map.empty, None)
   }
+
+  def putPath(name: String, value: String): String = {
+
+    val result: PutParameterResult = client.putParameter(
+      new PutParameterRequest()
+        .withName(name)
+        .withType("SecureString")
+        .withOverwrite(true)
+        .withValue(value)
+    )
+
+    result.toString
+
+  }
+
 }


### PR DESCRIPTION
## What does this change?

This PR is the FIRST OF THREE which will remove navdata from frontend so it can be shared with dotcom-rendering as configuration.

This PR will cause the article app to write navigation data (NavLinks) to S3 under aws-frontend-store/<STAGE>/navigation.json

There will be a second PR for dotcom-rendering to make it start processing this data.

### Work done:

* Introduced new case class NavigationData and EditionNavLinks
    * Introduced because I wanted to prevent access to NavLinks directly (easier to reason about only the params it exposes) and didn't want to change NavLinks itself into a class because it's freaking massive.
    * Also introduced because trying to marshal an object singleton to json was problematic.
* introduced a new lifecycle job into article which writes the contents of the navigation data to S3.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
