### PR TITLE
 Make contributions ticker configurable 

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -7,13 +7,13 @@ export const acquisitionsEpicTickerTemplate = `
     
         <div class="js-ticker-amounts">
             <div class="js-ticker-so-far epic-ticker__so-far">
-                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
-                <div class="epic-ticker__count-label">contributed</div>
+                <div class="js-ticker-count epic-ticker__count"></div>
+                <div class="js-ticker-label epic-ticker__count-label is-hidden">contributed</div>
             </div>
             
-            <div class="js-ticker-goal epic-ticker__goal is-hidden">
+            <div class="js-ticker-goal epic-ticker__goal">
                 <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
-                <div class="epic-ticker__count-label">our goal</div>
+                <div class="js-ticker-label epic-ticker__count-label">our goal</div>
             </div>
         </div>
         

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -16,7 +16,7 @@ const goalReached = () => total >= goal;
  */
 const percentageToTranslate = (tickerType: TickerType) => {
     const percentage = (total / goal) * 100 - 100;
-    const endOfFillPercentage = () => tickerType === 'unlimited' ? -15 : 0;
+    const endOfFillPercentage = () => (tickerType === 'unlimited' ? -15 : 0);
 
     return percentage >= 0 ? endOfFillPercentage() : percentage;
 };
@@ -32,13 +32,16 @@ const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
     }
 };
 
-const increaseCounter = (parentElementSelector: string, counterElement: HTMLElement) => {
+const increaseCounter = (
+    parentElementSelector: string,
+    counterElement: HTMLElement
+) => {
     // Count is local to the parent element
     count[parentElementSelector] += Math.floor(total / 100);
 
     counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
         parentElementSelector
-        ].toLocaleString()}`;
+    ].toLocaleString()}`;
     if (count[parentElementSelector] >= total) {
         counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
     } else {
@@ -48,7 +51,11 @@ const increaseCounter = (parentElementSelector: string, counterElement: HTMLElem
     }
 };
 
-const populateStatusSoFar = (parentElementSelector: string, parentElement: HTMLElement, tickerType: TickerType) => {
+const populateStatusSoFar = (
+    parentElementSelector: string,
+    parentElement: HTMLElement,
+    tickerType: TickerType
+) => {
     const counterElement = parentElement.querySelector(
         `.js-ticker-amounts .js-ticker-count`
     );
@@ -66,7 +73,7 @@ const populateStatusSoFar = (parentElementSelector: string, parentElement: HTMLE
             }
         } else {
             labelElement.classList.remove('is-hidden');
-            increaseCounter(parentElementSelector, counterElement)
+            increaseCounter(parentElementSelector, counterElement);
         }
     }
 };
@@ -102,7 +109,11 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
             window.requestAnimationFrame(() =>
-                populateStatusSoFar(parentElementSelector, parentElement, tickerType)
+                populateStatusSoFar(
+                    parentElementSelector,
+                    parentElement,
+                    tickerType
+                )
             );
             animateBar(parentElement, tickerType);
         }, 500);
@@ -114,7 +125,10 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
 
 const dataSuccessfullyFetched = () => total && goal;
 
-const fetchDataAndAnimate = (parentElementSelector: string, tickerType: TickerType) => {
+const fetchDataAndAnimate = (
+    parentElementSelector: string,
+    tickerType: TickerType
+) => {
     if (dataSuccessfullyFetched()) {
         animate(parentElementSelector, tickerType);
     } else {
@@ -131,6 +145,9 @@ const fetchDataAndAnimate = (parentElementSelector: string, tickerType: TickerTy
     }
 };
 
-export const initTicker = (parentElementSelector: string, tickerType?: TickerType) => {
+export const initTicker = (
+    parentElementSelector: string,
+    tickerType?: TickerType
+) => {
     fetchDataAndAnimate(parentElementSelector, tickerType || 'hardstop');
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -86,7 +86,8 @@ const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
         const labelElement = goalElement.querySelector('.js-ticker-label');
 
         if (countElement && labelElement) {
-            const amount = goalReached() && tickerType === 'unlimited' ? total : goal;
+            const amount =
+                goalReached() && tickerType === 'unlimited' ? total : goal;
             countElement.innerHTML = `${getLocalCurrencySymbol()}${amount.toLocaleString()}`;
 
             if (goalReached()) {

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -78,19 +78,19 @@ const populateStatusSoFar = (
     }
 };
 
-const populateGoal = (parentElement: HTMLElement) => {
+const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
     const goalElement = parentElement.querySelector('.js-ticker-goal');
 
     if (goalElement) {
         const countElement = goalElement.querySelector('.js-ticker-count');
-        if (countElement) {
-            countElement.innerHTML = `${getLocalCurrencySymbol()}${goal.toLocaleString()}`;
-        }
+        const labelElement = goalElement.querySelector('.js-ticker-label');
 
-        if (goalReached()) {
-            const label = goalElement.querySelector('.js-ticker-label');
-            if (label) {
-                label.innerHTML = 'contributed';
+        if (countElement && labelElement) {
+            const amount = goalReached() && tickerType === 'unlimited' ? total : goal;
+            countElement.innerHTML = `${getLocalCurrencySymbol()}${amount.toLocaleString()}`;
+
+            if (goalReached()) {
+                labelElement.innerHTML = 'contributed';
             }
         }
     }
@@ -104,7 +104,7 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
             parentElement.classList.add('epic-ticker__goal-reached');
         }
 
-        populateGoal(parentElement);
+        populateGoal(parentElement, tickerType);
 
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
@@ -149,5 +149,5 @@ export const initTicker = (
     parentElementSelector: string,
     tickerType?: TickerType
 ) => {
-    fetchDataAndAnimate(parentElementSelector, tickerType || 'hardstop');
+    fetchDataAndAnimate(parentElementSelector, tickerType || 'unlimited');
 };

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -88,7 +88,7 @@ $progress-bar-height: 10px;
 .epic-ticker__goal-reached .epic-ticker__progress-container:after {
     content: '';
     position: absolute;
-    background: #121212;
+    background: $brightness-7;
     width: 2px;
     height: 15px;
     right: 0;

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -47,6 +47,11 @@
     line-height: 26px;
 }
 
+.epic-ticker__goal-reached .epic-ticker__so-far .epic-ticker__count {
+    font-size: 16px;
+    line-height: 18px;
+}
+
 .epic-ticker__count-label {
     font-style: italic;
 }
@@ -78,6 +83,20 @@ $progress-bar-height: 10px;
     transform: translateX(-100%);
     transition: transform 3s cubic-bezier(.25, .55, .2, .85);
     background-color: #ffe500;
+}
+
+.epic-ticker__goal-reached .epic-ticker__progress-container:after {
+    content: '';
+    position: absolute;
+    background: #121212;
+    width: 2px;
+    height: 15px;
+    right: 0;
+    bottom: 0;
+}
+
+.epic-ticker__goal-reached.epic-ticker__unlimited .epic-ticker__progress-container:after {
+    right: 20%;
 }
 
 .epic-ticker__progress-labels {


### PR DESCRIPTION
## What does this change?
We've changed the ticker design a few times now - this PR supports two options for what happens when the goal is reached: `unlimited` and `hardstop`.
This setting can be passed into the ticker component, though I'm reluctant to make this configurable from the google sheet for now, as that stuff is complicated enough already.

Follows the support-frontend implementation - https://github.com/guardian/support-frontend/pull/1791

## Screenshots
#### Before goal reached:
<img width="689" alt="Screenshot 2019-05-15 at 09 30 34" src="https://user-images.githubusercontent.com/1513454/57763065-9842ea80-76f8-11e9-8c71-13f2309b3bc2.png">

#### Hardstop:
<img width="689" alt="Screenshot 2019-05-15 at 09 30 16" src="https://user-images.githubusercontent.com/1513454/57763064-9842ea80-76f8-11e9-9bc4-50d15d256e1f.png">

#### Unlimited:
<img width="689" alt="Screenshot 2019-05-15 at 10 53 21" src="https://user-images.githubusercontent.com/1513454/57766688-bb24cd00-76ff-11e9-96e7-fa635edb497e.png">


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
