### PR TITLE
Fix targeting parameters going to Ozone via Prebid

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -377,7 +377,10 @@ const ozoneClientSideBidder: PrebidBidder = {
                 publisherId: 'OZONEGMG0001',
                 siteId: '4204204209',
                 placementId: '0420420500',
-                customData: PAGE_TARGETING,
+                customData: {
+                    settings: {},
+                    targeting: PAGE_TARGETING,
+                },
                 ozoneData: {}, // TODO: confirm if we need to send any
             }))(),
             window.OzoneLotameData ? { lotameData: window.OzoneLotameData } : {}


### PR DESCRIPTION
## What does this change?

During an auction within Prebid we send each of our partners targeting keys. One of our integtrations, Ozone, has realised they need it in another format. This changes the format of the parameters.

### Before

```javascript
...
customData: {
  key: value,
}
...
```

### After


```javascript
...
customData: {
  settings: {},
  targeting: {
    key: value,
  }
}
...
```

### Tested

- [ ] Locally
- [ ] On CODE (optional)
