### PR TITLE
Fixed size of "paid for by" content badges 

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -45,7 +45,8 @@
     }
 
     .badge__logo {
-        max-height: 6 * $gs-baseline;
+        max-height: none;
+        max-width: 100%;
         margin: 0 0 5px;
     }
 


### PR DESCRIPTION
## What does this change?
This change fixes a bug where badges on "paid for by" content were incorrectly rendering with a smaller size than they should.

## Screenshots

**Before**:
![Screen Shot 2019-05-15 at 12 23 20](https://user-images.githubusercontent.com/48949546/57772034-50c65980-770c-11e9-83f4-8a5d87255dd0.png)

**After**:
![Screen Shot 2019-05-15 at 12 23 28](https://user-images.githubusercontent.com/48949546/57772055-5b80ee80-770c-11e9-89e2-290f5f86deff.png)


## What is the value of this and can you measure success?
This will avoid clients complaining of lack of brand visibility.


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [X] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
