### PR TITLE
Bump indentity library versions

### DIFF
--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -49,7 +49,7 @@ class AuthenticationService(
   private def hasRecentlyAuthenticated(user: User, cookie: Option[Cookie]): Boolean = {
     cookie.exists(scGuLa =>
       cookieDecoder.userHasRecentScGuLaCookie(
-        user,
+        user.id,
         scGuLa.value,
         Hours.hours(1).toStandardDuration))
   }

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -70,7 +70,7 @@ import scala.concurrent.Future
 
     when(returnUrlVerifier.defaultReturnUrl) thenReturn "http://1234.67"
     when(returnUrlVerifier.getVerifiedReturnUrl(any[RequestHeader])) thenReturn None
-    when(api.userEmails(anyString(), any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
+    when(api.userEmails(anyString(), any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")), "subscribed")))
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -70,7 +70,7 @@ import scala.concurrent.Future
     when(idRequest.trackingData) thenReturn trackingData
     when(idRequest.returnUrl) thenReturn None
 
-    when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")))))
+    when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(Subscriber("Text", List(EmailList("37")), "subscribed")))
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,
@@ -414,7 +414,7 @@ import scala.concurrent.Future
 
         val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listId.toString))
         when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("HTML", userEmailSubscriptions))))
+          .thenReturn(Future.successful(Right(Subscriber("HTML", userEmailSubscriptions, "subscribed"))))
 
         val result = controller.displayEmailPrefsForm(false, None).apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.174"
+  val identityLibVersion = "3.180"
   val awsVersion = "1.11.240"
   val capiVersion = "14.1"
   val faciaVersion = "3.0.2"


### PR DESCRIPTION
## What does this change?
This bumps identity library version to add new newsletter definitions from https://github.com/guardian/identity/pull/1536

It also updates `AuthenticationService.scala` to match new method signature for `userHasRecentScGuLaCookie` from release `3.173` (https://github.com/guardian/identity/pull/1535)

## Screenshots
<img width="600" alt="Screen Shot 2019-05-15 at 15 04 39" src="https://user-images.githubusercontent.com/1289259/57781801-d05f2300-7722-11e9-9cad-c4a45c1cce4b.png">

<img width="500" alt="Screen Shot 2019-05-15 at 15 28 40" src="https://user-images.githubusercontent.com/1289259/57783640-65175000-7726-11e9-8442-268fe72d8270.png">

## What is the value of this and can you measure success?
moar newsletters
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
