### PR TITLE
Prebid update to v2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#7d3a0b1",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#e475698",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#b06a091",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#7839d18",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ophan-tracker-js": "1.3.13",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js.git#7839d18",
+    "prebid.js": "https://github.com/guardian/Prebid.js.git#7d3a0b1",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,9 +8206,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#7839d18":
+"prebid.js@https://github.com/guardian/Prebid.js.git#7d3a0b1":
   version "2.15.0"
-  resolved "https://github.com/guardian/Prebid.js.git#7839d181df267ef854c42d0ccaec58ea17411c7c"
+  resolved "https://github.com/guardian/Prebid.js.git#7d3a0b1f3875f386ce6a2a8c77b90706d66bb93a"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4742,9 +4742,9 @@ fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-fun-hooks@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/fun-hooks/-/fun-hooks-0.8.1.tgz#5ef7866840610a5a1858c26ade97b15d35853434"
+fun-hooks@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/fun-hooks/-/fun-hooks-0.9.2.tgz#c0692316de311bd0ed0e235cde1c769a599930c9"
 
 function-bind@^1.1.0:
   version "1.1.0"
@@ -8206,14 +8206,14 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#b06a091":
-  version "2.13.0"
-  resolved "https://github.com/guardian/Prebid.js.git#b06a0910b92b37f23ae87d157fcdecfee4919cb0"
+"prebid.js@https://github.com/guardian/Prebid.js.git#7839d18":
+  version "2.15.0"
+  resolved "https://github.com/guardian/Prebid.js.git#7839d181df267ef854c42d0ccaec58ea17411c7c"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"
     crypto-js "^3.1.9-1"
-    fun-hooks "^0.8.1"
+    fun-hooks "^0.9.2"
     jsencrypt "^3.0.0-rc.1"
     just-clone "^1.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,9 +8206,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js.git#7d3a0b1":
+"prebid.js@https://github.com/guardian/Prebid.js.git#e475698":
   version "2.15.0"
-  resolved "https://github.com/guardian/Prebid.js.git#7d3a0b1f3875f386ce6a2a8c77b90706d66bb93a"
+  resolved "https://github.com/guardian/Prebid.js.git#e47569882e47fdcbf63466c998870392c1d3430e"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^2.4.1"


### PR DESCRIPTION
## What does this change?

This change updates prebid to version 2.15

## Screenshots

## What is the value of this and can you measure success?

Just a regular update to fix bugs and add features we might use in the future.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
