### PR TITLE
Add formatted time string to blocks in DCR model (to use in liveblogs)

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -45,9 +45,7 @@ case class Block(
     id: String,
     bodyHtml: String,
     elements: List[PageElement],
-    createdOn: Option[Long],
     createdOnDisplay: Option[String],
-    lastUpdated: Option[Long],
     lastUpdatedDisplay: Option[String],
     title: Option[String],
 )
@@ -246,9 +244,7 @@ object DotcomponentsDataModel {
         id = block.id,
         bodyHtml = block.bodyHtml,
         elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks),
-        createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
-        lastUpdated = lastUpdated,
         lastUpdatedDisplay = lastUpdatedDisplay,
         title = block.title,
       )

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -1,13 +1,14 @@
 package views.support
 
 import java.text.DecimalFormat
+import java.util.Locale
 
 import common._
 import model.Cached.WithoutRevalidationResult
 import model._
 import model.pressed.PressedContent
 import org.apache.commons.lang.StringEscapeUtils
-import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -133,6 +134,9 @@ object GUDateTimeFormat {
       case "AU" => date.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
       case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
     }
+  }
+  def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
+    dateTime.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
   }
 }
 


### PR DESCRIPTION
## What does this change?

Add formatted time string to blocks in DCR model (to use in liveblogs)

## Screenshots

<img width="561" alt="Screenshot 2019-05-15 at 15 54 55" src="https://user-images.githubusercontent.com/6035518/57785530-d60c3700-7729-11e9-8c6e-a6d41b2b467d.png">
