### PR TITLE
Update the way the title field in the head of document is generated

### DIFF
--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -34,17 +34,31 @@ object Title {
   }
 
   private def titleFromSectionId(sectionId: String): String = sectionId.toLowerCase match {
-    case "Uk-news" => "UK news"
     case "theobserver" => "The Observer"
     case _ => sectionId
   }
 
-  private def getSectionConsideringWebtitle(webTitle: String, section: Option[String]): String =
+  private def guCapitalization(str: String): String = {
+    str match {
+      case "uk-news" => "UK news"
+      case "us-news" => "US news"
+      case _ => str.capitalize
+    }
+  }
+
+  private def getSectionConsideringWebtitle(webTitle: String, section: Option[String]): String = {
     section.filter(_.nonEmpty)
       .filterNot(_.toLowerCase == webTitle.toLowerCase)
       .filterNot(SectionsToIgnore.contains)
       .map(titleFromSectionId)
-      .fold("") { s => s" | ${s.capitalize}"}
+      .fold("") { s => s" | ${guCapitalization(s)}" }}
+
+//  private def getSectionConsideringWebtitle(webTitle: String, section: Option[String]): String =
+//    section.filter(_.nonEmpty)
+//      .filterNot(_.toLowerCase == webTitle.toLowerCase)
+//      .filterNot(SectionsToIgnore.contains)
+//      .map(titleFromSectionId)
+//      .fold("") { s => s" | ${s.capitalize}"}
 
   private def pagination(page: Page) = page.metadata.pagination.filterNot(_.isFirstPage).map{ pagination =>
     s" | Page ${pagination.currentPage} of ${pagination.lastPage}"

--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -53,13 +53,6 @@ object Title {
       .map(titleFromSectionId)
       .fold("") { s => s" | ${guCapitalization(s)}" }}
 
-//  private def getSectionConsideringWebtitle(webTitle: String, section: Option[String]): String =
-//    section.filter(_.nonEmpty)
-//      .filterNot(_.toLowerCase == webTitle.toLowerCase)
-//      .filterNot(SectionsToIgnore.contains)
-//      .map(titleFromSectionId)
-//      .fold("") { s => s" | ${s.capitalize}"}
-
   private def pagination(page: Page) = page.metadata.pagination.filterNot(_.isFirstPage).map{ pagination =>
     s" | Page ${pagination.currentPage} of ${pagination.lastPage}"
   }.getOrElse("")

--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -34,6 +34,7 @@ object Title {
   }
 
   private def titleFromSectionId(sectionId: String): String = sectionId.toLowerCase match {
+    case "Uk-news" => "UK news"
     case "theobserver" => "The Observer"
     case _ => sectionId
   }


### PR DESCRIPTION
## What does this change?
In order to ensure that US news and UK news are using the correct case in the title field in the head of the document, this adds specific handling of tag pages within those sections. If it's wrong, blame @shtukas 😛 

Before:
Stonehenge | Uk-news | The Guardian
Texas | Us-news | The Guardian

After:
Stonehenge | UK news | The Guardian
Texas | US news | The Guardian