### PR TITLE
 Make epic cta text configurable 

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -32,7 +32,7 @@ declare type EpicVariant = Variant & {
     classNames: string[],
     showTicker: boolean,
 
-    buttonTemplate?: CtaUrls => string,
+    buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
 }
@@ -92,7 +92,7 @@ declare type InitEpicABTestVariant = {
     sections?: string[],
     excludedTagIds?: string[],
     excludedSections?: string[],
-    buttonTemplate?: CtaUrls => string,
+    buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -33,6 +33,7 @@ declare type EpicVariant = Variant & {
     showTicker: boolean,
 
     buttonTemplate?: CtaUrls => string,
+    ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
 }
 
@@ -92,6 +93,7 @@ declare type InitEpicABTestVariant = {
     excludedTagIds?: string[],
     excludedSections?: string[],
     buttonTemplate?: CtaUrls => string,
+    ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],
     showTicker?: boolean,

--- a/static/src/javascripts/lib/string-utils.js
+++ b/static/src/javascripts/lib/string-utils.js
@@ -23,3 +23,6 @@ export const throwIfEmptyString = (name: string, str: ?string): string => {
 
     throw new Error(`${name} is empty`);
 };
+
+export const filterEmptyString = (str: ?string): ?string =>
+    str && str.trim().length > 0 ? str.trim() : undefined;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -81,9 +81,9 @@ const defaultMaxViews: MaxViews = {
     minDaysBetweenViews: 0,
 };
 
-const defaultButtonTemplate: CtaUrls => string = (
+const defaultButtonTemplate: (CtaUrls, ctaText?: string) => string = (
     url: CtaUrls,
-    ctaText: ?string
+    ctaText?: string
 ) => epicButtonsTemplate(url, ctaText);
 
 const controlTemplate: EpicTemplate = (

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -27,6 +27,7 @@ import {
     optionalSplitAndTrim,
     optionalStringToBoolean,
     throwIfEmptyString,
+    filterEmptyString,
 } from 'lib/string-utils';
 import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
@@ -584,7 +585,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                             buttonTemplate: isThankYou
                                 ? undefined
                                 : defaultButtonTemplate,
-                            ctaText: row.ctaText,
+                            ctaText: filterEmptyString(row.ctaText),
                             countryGroups: optionalSplitAndTrim(
                                 row.locations,
                                 ','

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -81,8 +81,10 @@ const defaultMaxViews: MaxViews = {
     minDaysBetweenViews: 0,
 };
 
-const defaultButtonTemplate: CtaUrls => string = (url: CtaUrls, ctaText: ?string) =>
-    epicButtonsTemplate(url, ctaText);
+const defaultButtonTemplate: CtaUrls => string = (
+    url: CtaUrls,
+    ctaText: ?string
+) => epicButtonsTemplate(url, ctaText);
 
 const controlTemplate: EpicTemplate = (
     variant: EpicVariant,
@@ -92,10 +94,13 @@ const controlTemplate: EpicTemplate = (
         copy,
         componentName: variant.componentName,
         buttonTemplate: variant.buttonTemplate
-            ? variant.buttonTemplate({
-                supportUrl: variant.supportURL,
-                subscribeUrl: variant.subscribeURL,
-            }, variant.ctaText)
+            ? variant.buttonTemplate(
+                  {
+                      supportUrl: variant.supportURL,
+                      subscribeUrl: variant.subscribeURL,
+                  },
+                  variant.ctaText
+              )
             : undefined,
         epicClassNames: variant.classNames,
         showTicker: variant.showTicker,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -81,8 +81,8 @@ const defaultMaxViews: MaxViews = {
     minDaysBetweenViews: 0,
 };
 
-const defaultButtonTemplate: CtaUrls => string = (url: CtaUrls) =>
-    epicButtonsTemplate(url);
+const defaultButtonTemplate: CtaUrls => string = (url: CtaUrls, ctaText: ?string) =>
+    epicButtonsTemplate(url, ctaText);
 
 const controlTemplate: EpicTemplate = (
     variant: EpicVariant,
@@ -93,9 +93,9 @@ const controlTemplate: EpicTemplate = (
         componentName: variant.componentName,
         buttonTemplate: variant.buttonTemplate
             ? variant.buttonTemplate({
-                  supportUrl: variant.supportURL,
-                  subscribeUrl: variant.subscribeURL,
-              })
+                supportUrl: variant.supportURL,
+                subscribeUrl: variant.subscribeURL,
+            }, variant.ctaText)
             : undefined,
         epicClassNames: variant.classNames,
         showTicker: variant.showTicker,
@@ -243,6 +243,7 @@ const makeEpicABTestVariant = (
         }),
         template,
         buttonTemplate: initVariant.buttonTemplate,
+        ctaText: initVariant.ctaText,
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,
@@ -578,6 +579,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                             buttonTemplate: isThankYou
                                 ? undefined
                                 : defaultButtonTemplate,
+                            ctaText: row.ctaText,
                             countryGroups: optionalSplitAndTrim(
                                 row.locations,
                                 ','

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { applePayApiAvailable } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
-export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
+export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls, ctaText: string = 'Support The Guardian') => {
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 
     const supportButtonSupport = `
@@ -11,7 +11,7 @@ export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls) => {
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
               href="${supportUrl}"
               target="_blank">
-              Support The Guardian
+              ${ctaText}
             </a>
         </div>`;
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -3,7 +3,10 @@ import config from 'lib/config';
 import { applePayApiAvailable } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
-export const epicButtonsTemplate = ({ supportUrl = '' }: CtaUrls, ctaText: string = 'Support The Guardian') => {
+export const epicButtonsTemplate = (
+    { supportUrl = '' }: CtaUrls,
+    ctaText: string = 'Support The Guardian'
+) => {
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 
     const supportButtonSupport = `

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -5,7 +5,7 @@ import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
 export const epicButtonsTemplate = (
     { supportUrl = '' }: CtaUrls,
-    ctaText: string = 'Support The Guardian'
+    ctaText?: string = 'Support The Guardian'
 ) => {
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 


### PR DESCRIPTION
## What does this change?
This change makes it possible to configure the text on the epic's cta button from google sheets.
This is required for campaigns.

## Screenshots
The default is 'Support The Guardian'.
<img width="439" alt="Screenshot 2019-05-16 at 14 51 59" src="https://user-images.githubusercontent.com/1513454/57861633-d8849480-77ee-11e9-8c93-dd8dee437512.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
