### PR TITLE
Limits the height of the paid for by badge on mobile

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -45,7 +45,10 @@
     }
 
     .badge__logo {
-        max-height: none;
+        max-height: 6 * $gs-baseline;
+        @include mq(tablet) {
+            max-height: none;
+        }
         max-width: 100%;
         margin: 0 0 5px;
     }


### PR DESCRIPTION
## What does this change?
This change limits the height of the paid for by badge on mobile.

## Screenshots
**Before:**
![Screen Shot 2019-05-16 at 15 57 11](https://user-images.githubusercontent.com/48949546/57864224-6bbfc900-77f3-11e9-9021-fa227649290d.png)

**After:**
![Screen Shot 2019-05-16 at 15 56 50](https://user-images.githubusercontent.com/48949546/57864240-724e4080-77f3-11e9-9566-feb68a36e4e7.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [X] Yes (please give details)

### Tested

- [X] Locally
- [ ] On CODE (optional)