### PR TITLE
 Make epic image configurable 

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -35,6 +35,7 @@ declare type EpicVariant = Variant & {
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
+    backgroundImageUrl?: string,
 }
 
 declare type ABTest = {
@@ -98,6 +99,7 @@ declare type InitEpicABTestVariant = {
     classNames?: string[],
     showTicker?: boolean,
     supportBaseURL?: string,
+    backgroundImageUrl?: string,
 };
 
 declare type InitBannerABTestVariant = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -29,7 +29,6 @@ declare type EpicVariant = Variant & {
     subscribeURL: string,
     componentName: string,
     template: EpicTemplate,
-    classNames: string[],
     showTicker: boolean,
 
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
@@ -96,7 +95,6 @@ declare type InitEpicABTestVariant = {
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
-    classNames?: string[],
     showTicker?: boolean,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -103,8 +103,8 @@ const controlTemplate: EpicTemplate = (
                   variant.ctaText
               )
             : undefined,
-        epicClassNames: variant.classNames,
         showTicker: variant.showTicker,
+        backgroundImageUrl: variant.backgroundImageUrl,
     });
 
 const liveBlogTemplate: EpicTemplate = (
@@ -251,8 +251,8 @@ const makeEpicABTestVariant = (
         buttonTemplate: initVariant.buttonTemplate,
         ctaText: initVariant.ctaText,
         copy: initVariant.copy,
-        classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,
+        backgroundImageUrl: initVariant.backgroundImageUrl,
 
         countryGroups: initVariant.countryGroups || [],
         tagIds: initVariant.tagIds || [],
@@ -617,12 +617,9 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                     : undefined,
                                 footer: optionalSplitAndTrim(row.footer, '\n'),
                             },
-                            classNames: optionalSplitAndTrim(
-                                row.classNames,
-                                ','
-                            ),
                             showTicker: optionalStringToBoolean(row.showTicker),
                             supportBaseURL: row.supportBaseURL,
+                            backgroundImageUrl: filterEmptyString(row.backgroundImageUrl),
                         })),
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -619,7 +619,9 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                             },
                             showTicker: optionalStringToBoolean(row.showTicker),
                             supportBaseURL: row.supportBaseURL,
-                            backgroundImageUrl: filterEmptyString(row.backgroundImageUrl),
+                            backgroundImageUrl: filterEmptyString(
+                                row.backgroundImageUrl
+                            ),
                         })),
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -15,7 +15,6 @@ const buildImage = (url: string): string =>
 export const acquisitionsEpicControlTemplate = ({
     copy: { heading = '', paragraphs, highlightedText, footer },
     componentName,
-    epicClassNames = [],
     buttonTemplate,
     wrapperClass = '',
     showTicker = false,
@@ -23,13 +22,14 @@ export const acquisitionsEpicControlTemplate = ({
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
-    epicClassNames: string[],
     buttonTemplate?: string,
     wrapperClass?: string,
     showTicker: boolean,
     backgroundImageUrl?: string,
 }) => {
-    const extraClasses = backgroundImageUrl ? 'contributions__epic--with-image' : '';
+    const extraClasses = backgroundImageUrl
+        ? 'contributions__epic--with-image'
+        : '';
 
     return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -7,6 +7,11 @@ const buildFooter = (footer: string[]): string =>
         ${footer.map(line => `<h2>${line}</h2>`).join('')}
     </div>`;
 
+const buildImage = (url: string): string =>
+    `<div class="contributions__epic-image">
+        <img src="${url}" alt="Image for Guardian contributions message"/>
+    </div>`;
+
 export const acquisitionsEpicControlTemplate = ({
     copy: { heading = '', paragraphs, highlightedText, footer },
     componentName,
@@ -14,6 +19,7 @@ export const acquisitionsEpicControlTemplate = ({
     buttonTemplate,
     wrapperClass = '',
     showTicker = false,
+    backgroundImageUrl,
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
@@ -21,13 +27,16 @@ export const acquisitionsEpicControlTemplate = ({
     buttonTemplate?: string,
     wrapperClass?: string,
     showTicker: boolean,
-}) =>
-    `<div class="contributions__epic ${epicClassNames.join(
-        ' '
-    )}" data-component="${componentName}" data-link-name="epic">
+    backgroundImageUrl?: string,
+}) => {
+    const extraClasses = backgroundImageUrl ? 'contributions__epic--with-image' : '';
+
+    return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">
             <div>
                 ${showTicker ? acquisitionsEpicTickerTemplate : ''}
+                
+                ${backgroundImageUrl ? buildImage(backgroundImageUrl) : ''}
 
                 <h2 class="contributions__title">
                     ${heading}
@@ -47,3 +56,4 @@ export const acquisitionsEpicControlTemplate = ({
             ${footer ? buildFooter(footer) : ''}
         </div>
     </div>`;
+};

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -286,26 +286,28 @@ a[href].contributions__contribute.contributions__contribute--epic,
     }
 }
 
-.contributions__epic--thefrontline {
+.contributions__epic-image {
+    display: none;
+    @include mq($from: tablet) {
+        display: block;
+    }
+
+    margin: 10px -5px 12px;
+    height: 150px;
+    width: calc(100% + 10px);
+
+    img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+    }
+}
+
+.contributions__epic--with-image {
     .contributions__title {
         @include fs-header(5);
         font-size: 28px;
         line-height: 28px;
-
-        &:before {
-            content: '';
-            background-repeat: no-repeat;
-            margin: 10px -5px 12px;
-            background-image: url('https://media.guim.co.uk/b9ed1767866d29186f198b523cd5571aeda02a88/0_1269_5184_1516/1000.jpg');
-            background-size: 100%;
-            background-position: center bottom;
-            height: 150px;
-
-            display: none;
-            @include mq($from: tablet) {
-                display: block;
-            }
-        }
     }
 
     p:last-child {


### PR DESCRIPTION
## What does this change?
Makes it possible to set an image url in the epic google sheet.
I've removed the ability to add css classes from the google sheet. This was how we were adding campaign-specific style/image, but now that we've agreed on a set format for campaigns only the image needs to be configurable.

## Screenshots
<img width="633" alt="Screenshot 2019-05-17 at 14 27 00" src="https://user-images.githubusercontent.com/1513454/57932996-04b61900-78b4-11e9-8d40-5fc0acfe4d04.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
