### PR TITLE
Whitelist interactives

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -37,6 +37,7 @@ object AMPPageChecks extends Logging {
       case Video => true
       case Contentatom => true
       case Audio => true
+      case Interactive => true
       case _: ElementType => false
     }
 


### PR DESCRIPTION
Whitelists element-type interactives (atom versions are already live).

This affects very few articles but is necessary for the AMP migration!