### PR TITLE
Re-release Mobile Banner Design Test 

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -24,20 +24,5 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    /** *********************************************************
-     2 May 2019 - JTL - This test is disabled as of 2 May 2019
-     This test went out on mobile devices the same day as a
-     global copy test went out across all devices. The copy
-     test runs before tests in the code (per `ab.js`) which is
-     desired behavior. A user can only be assigned to one banner
-     test at a time (also desired), so we decided to give the
-     copy test time precedence over this test.
-
-     TBD: Re-enable this test to run after the copy test has run
-     Steps:
-     1. Enable on switchboard
-     2. Test
-     3. Remove this copy, merge, test again
-     ********************************************************** */
     contributionsGlobalMobileBannerDesign,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
@@ -1,27 +1,11 @@
 // @flow
 
-/** *********************************************************
- 2 May 2019 - JTL - This test is disabled as of 2 May 2019
- This test went out on mobile devices the same day as a
- global copy test went out across all devices. The copy
- test runs before tests in the code (per `ab.js`) which is
- desired behavior. A user can only be assigned to one banner
- test at a time (also desired), so we decided to give the
- copy test time precedence over this test.
-
- TBD: Re-enable this test to run after the copy test has run
- Steps:
- 1. Enable on switchboard
- 2. Test
- 3. Remove this copy, merge, test again
- ********************************************************** */
-
 import { isBreakpoint } from 'lib/detect';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { acquisitionsBannerMobileDesignTestTemplate } from 'common/modules/commercial/templates/acquisitions-banner-mobile-design-test';
 
-const mobileHeader: string = `The Guardian is editorially independent...`;
-const mobileBody: string = `...our journalism is free from the influence of billionaire owners or politicians. No one edits our editor. No one steers our opinion.  This means we can pursue difficult investigations, challenging the powerful and holding them to account. And unlike many others, we have chosen an approach that allows us to keep our journalism open and accessible to all, regardless of where they live or what they can afford. But we depend on voluntary contributions from readers to keep working as we do.`;
+const mobileHeader: string = `We chose a different approach.<br/>Will you support it?`;
+const mobileBody: string = `Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, support from our readers is essential in safeguarding The Guardian’s editorial independence. This is our model for open, independent journalism.`
 
 export const contributionsGlobalMobileBannerDesign: AcquisitionsABTest = {
     id: 'ContributionsGlobalMobileBannerDesign',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
@@ -5,7 +5,7 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 import { acquisitionsBannerMobileDesignTestTemplate } from 'common/modules/commercial/templates/acquisitions-banner-mobile-design-test';
 
 const mobileHeader: string = `We chose a different approach.<br/>Will you support it?`;
-const mobileBody: string = `Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, support from our readers is essential in safeguarding The Guardian’s editorial independence. This is our model for open, independent journalism.`
+const mobileBody: string = `Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, support from our readers is essential in safeguarding The Guardian’s editorial independence. This is our model for open, independent journalism.`;
 
 export const contributionsGlobalMobileBannerDesign: AcquisitionsABTest = {
     id: 'ContributionsGlobalMobileBannerDesign',

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -197,10 +197,9 @@
 
 // For Mobile Design test:
 .engagement-banner__header {
-    @include fs-headline(3);
-    min-height: 50px;
+    @include fs-headline(2);
     font-weight: 700;
-    margin: 0 -10px $gs-gutter / 2;
-    padding: 0 10px $gs-gutter / 2;
+    margin: 0 -10px $gs-gutter / 4;
+    padding: 0 10px $gs-gutter / 4;
     border-bottom: 1px solid  rgba($brightness-7,  .3);
 }


### PR DESCRIPTION
## What does this change?
Re-introduce a previously blocked mobile-only test to make sure that our new mobile banner design don't hurt our contributions

Related PR (initial release): https://github.com/guardian/frontend/pull/21374
Related PR (rollback): https://github.com/guardian/frontend/pull/21384

## Screenshots
Control:
![mobile design test control](https://user-images.githubusercontent.com/3300789/58100438-89b37200-7bd5-11e9-80f5-d6507bf17386.png)

Variant:
![mobile design test variant](https://user-images.githubusercontent.com/3300789/58100446-8d46f900-7bd5-11e9-81bc-eb3c709548cf.png)

## What is the value of this and can you measure success?
We will be measuring the results as Annualized Value (AV). If the variant doesn't hurt AV, that will become the control.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
