### PR TITLE
Show ticker if amount is 0

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -124,7 +124,7 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
     }
 };
 
-const dataSuccessfullyFetched = () => !(isNaN(total) || isNaN(goal));
+const dataSuccessfullyFetched = () => !(Number.isNaN(Number(total)) || Number.isNaN(Number(goal)));
 
 const fetchDataAndAnimate = (
     parentElementSelector: string,

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -124,7 +124,7 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
     }
 };
 
-const dataSuccessfullyFetched = () => total && goal;
+const dataSuccessfullyFetched = () => !(isNaN(total) || isNaN(goal));
 
 const fetchDataAndAnimate = (
     parentElementSelector: string,

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -124,7 +124,8 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
     }
 };
 
-const dataSuccessfullyFetched = () => !(Number.isNaN(Number(total)) || Number.isNaN(Number(goal)));
+const dataSuccessfullyFetched = () =>
+    !(Number.isNaN(Number(total)) || Number.isNaN(Number(goal)));
 
 const fetchDataAndAnimate = (
     parentElementSelector: string,


### PR DESCRIPTION
## What does this change?
Previously the ticker on the epic would not display if the amount was 0.
This hasn't been a problem previously becuase we've always had an initial amount.

## Screenshots
<img width="631" alt="Screenshot 2019-05-21 at 16 34 58" src="https://user-images.githubusercontent.com/1513454/58110922-5a5a3080-7be8-11e9-9878-a10fb7ad1ad4.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
