### PR TITLE
Tag more errors emitted from commercial.js with feature: commercial

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -60,7 +60,10 @@ const go = () => {
                 try {
                     return bootCommercial();
                 } catch (err) {
-                    // report sync errors in bootCommercial to Sentry with the commercial feature tag
+                    /**
+                     * report sync errors in bootCommercial to
+                     * Sentry with the commercial feature tag
+                     *  */
                     reportError(
                         err,
                         {
@@ -75,7 +78,10 @@ const go = () => {
                 try {
                     return bootEnhanced();
                 } catch (err) {
-                    // report sync errors in bootEnhanced to Sentry with the enhanced feature tag
+                    /**
+                     * report sync errors in bootEnhanced to
+                     * Sentry with the enhanced feature tag
+                     *  */
                     reportError(
                         err,
                         {

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -107,21 +107,26 @@ const loadModules = (): Promise<void> => {
         const moduleInit: () => void = module[1];
         const moduleDefer: boolean = module[2];
 
-        catchErrorsWithContext([
+        catchErrorsWithContext(
             [
-                moduleName,
-                function pushAfterComplete(): void {
-                    // These modules all have async init procedures which don't block, and return a promise purely for
-                    // perf logging, to time when their async work is done. The command buffer guarantees execution order,
-                    // so we don't use the returned promise to order the bootstrap's module invocations.
-                    const wrapped = moduleDefer
-                        ? defer(moduleName, moduleInit)
-                        : wrap(moduleName, moduleInit);
-                    const result = wrapped();
-                    modulePromises.push(result);
-                },
+                [
+                    moduleName,
+                    function pushAfterComplete(): void {
+                        // These modules all have async init procedures which don't block, and return a promise purely for
+                        // perf logging, to time when their async work is done. The command buffer guarantees execution order,
+                        // so we don't use the returned promise to order the bootstrap's module invocations.
+                        const wrapped = moduleDefer
+                            ? defer(moduleName, moduleInit)
+                            : wrap(moduleName, moduleInit);
+                        const result = wrapped();
+                        modulePromises.push(result);
+                    },
+                ],
             ],
-        ]);
+            {
+                feature: 'commercial',
+            }
+        );
     });
     return Promise.all(modulePromises).then(
         (): void => {
@@ -132,18 +137,23 @@ const loadModules = (): Promise<void> => {
 
 export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');
-    catchErrorsWithContext([
+    catchErrorsWithContext(
         [
-            'ga-user-timing-commercial-start',
-            function runTrackPerformance(): void {
-                trackPerformance(
-                    'Javascript Load',
-                    'commercialStart',
-                    'Commercial start parse time'
-                );
-            },
+            [
+                'ga-user-timing-commercial-start',
+                function runTrackPerformance(): void {
+                    trackPerformance(
+                        'Javascript Load',
+                        'commercialStart',
+                        'Commercial start parse time'
+                    );
+                },
+            ],
         ],
-    ]);
+        {
+            feature: 'commercial',
+        }
+    );
 
     // Stub the command queue
     window.googletag = {
@@ -154,18 +164,23 @@ export const bootCommercial = (): Promise<void> => {
         .then(loadModules)
         .then(() => {
             markTime('commercial end');
-            catchErrorsWithContext([
+            catchErrorsWithContext(
                 [
-                    'ga-user-timing-commercial-end',
-                    function runTrackPerformance(): void {
-                        trackPerformance(
-                            'Javascript Load',
-                            'commercialEnd',
-                            'Commercial end parse time'
-                        );
-                    },
+                    [
+                        'ga-user-timing-commercial-end',
+                        function runTrackPerformance(): void {
+                            trackPerformance(
+                                'Javascript Load',
+                                'commercialEnd',
+                                'Commercial end parse time'
+                            );
+                        },
+                    ],
                 ],
-            ]);
+                {
+                    feature: 'commercial',
+                }
+            );
         })
         .catch(err => {
             // report async errors in bootCommercial to Sentry with the commercial feature tag

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -168,10 +168,13 @@ export const bootCommercial = (): Promise<void> => {
             ]);
         })
         .catch(err => {
-            // Just in case something goes wrong, we don't want it to
-            // prevent enhanced from loading
-            reportError(err, {
-                feature: 'commercial',
-            });
+            // report async errors in bootCommercial to Sentry with the commercial feature tag
+            reportError(
+                err,
+                {
+                    feature: 'commercial',
+                },
+                false
+            );
         });
 };

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -29,7 +29,7 @@ const logError = (
     }
 
     if (tags) {
-        reportError(error, Object.assign({}, { module }, tags), false);
+        reportError(error, Object.assign({ module }, tags), false);
     } else {
         reportError(error, { module }, false);
     }

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -19,24 +19,40 @@ const catchErrors = (fn: Function): ?Error => {
     return error;
 };
 
-const logError = (module: string, error: Error): void => {
+const logError = (
+    module: string,
+    error: Error,
+    tags: ?{ [key: string]: string }
+): void => {
     if (window.console && window.console.warn) {
         window.console.warn('Caught error.', error.stack);
     }
 
-    reportError(error, { module }, false);
-};
-
-const catchAndLogError = (name: string, fn: Function): void => {
-    const error = catchErrors(fn);
-
-    if (error) {
-        logError(name, error);
+    if (tags) {
+        reportError(error, Object.assign({}, { module }, tags), false);
+    } else {
+        reportError(error, { module }, false);
     }
 };
 
-const catchErrorsWithContext = (modules: Array<any>): void =>
-    modules.forEach(([name, fn]) => catchAndLogError(name, fn));
+const catchAndLogError = (
+    name: string,
+    fn: Function,
+    tags: ?{ [key: string]: string }
+): void => {
+    const error = catchErrors(fn);
+
+    if (error) {
+        logError(name, error, tags);
+    }
+};
+
+const catchErrorsWithContext = (
+    modules: Array<any>,
+    tags: ?{ [key: string]: string }
+): void => {
+    modules.forEach(([name, fn]) => catchAndLogError(name, fn, tags));
+};
 
 export { catchErrorsWithContext, logError };
 export const _ = { catchAndLogError };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -1,7 +1,7 @@
 // @flow
 
 import qwery from 'qwery';
-import raven from 'lib/raven';
+import reportError from 'lib/report-error';
 import fastdom from 'lib/fastdom-promise';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { adSizes } from 'commercial/modules/ad-sizes';
@@ -228,5 +228,15 @@ export const renderAdvert = (
                 .then(addRenderedClass)
                 .then(() => isRendered);
         })
-        .catch(raven.captureException);
+        .catch(err => {
+            reportError(
+                err,
+                {
+                    feature: 'commercial',
+                },
+                false
+            );
+
+            return Promise.resolve(false);
+        });
 };


### PR DESCRIPTION
## What does this change?

I've been looking at whether we can tag more errors in `Sentry` with the tag `feature: 'commercial'`. If we can do this it'll be easier to filter errors within `Sentry` to see those relevant to the commercial code.

The changes I've made are as follows:

- **Remove `raven.context` block from `boot.js`.**  The original objective of wrapping this code in `raven.context` was that it'd report errors emitted from inside the block  with the tag `feature: 'commercial'`. However `raven.context` will only capture synchronous errors thrown within the block, because all the code wrapped is asynchronous it changes context, so all errors thrown in the asynchronous code bubble up to the root context - without any feature tag associated. I've checked in Sentry and the only errors tagged with the tag `feature: 'commercial'` are those we've manually thrown elsewhere using the `reportError` function.
- **Wrap `bootCommercial()` and `bootEnhanced()` with `try{} catch(){}` block in `boot.js`.** This means synchronous errors thrown within these functions are caught in the `catch` block, we can then use the `reportError` function to log these in `Sentry` with the associated tags `feature: 'commercial' and `feature: 'enhanced'.
- **Update `catchErrorsWithContext` to take an optional argument `tags`. `catchErrorsWithContext` captures and logs all synchronous errors thrown by the `init()` functions of the dependencies in the `commercialModules` array defined in `commercial.js`. Currently  these errors are logged but have no associated tag other than the module's "id". Now synchronous errors from within these `init()` functions will also have the associated tag `feature: 'commercial'`.
- **Add 3rd argument `false` to the `reportError` call in the `.catch()` block at the end of the `Promise` chain returned by `bootCommercial()`.** I've seen that errors captured in this `catch` block were being logged by `Raven`/`Sentry` twice, this is because without this `false` argument `reportError` re-throws the error. With the `false` flag the error will be logged but not rethrown.
- **Update the `catch()` block at the end of `render-advert.js` to use `reportError` instead on `raven.captureException`**. `reportError` allows us to add the additional tag `feature: 'commercial'` to the error whereas `raven.captureException` logs the error without tags.

## What is the value of this and can you measure success?

Easier to filter errors within `Sentry` to see those relevant to the commercial code.

Note: This won't tag all errors from the commercial code, if asynchronous errors are thrown in unattached promise sequences (promise chains that are not synchronised with parent promises in any way, eg. they are not returned) within the code they will be registered as unhandled promise exceptions, without associated tags. Adding `catch()` blocks to these chains and logging errors with `reportError` would be recommended.