### PR TITLE
Remove unused switches

### DIFF
--- a/common/app/conf/switches/IdentitySwitches.scala
+++ b/common/app/conf/switches/IdentitySwitches.scala
@@ -14,25 +14,4 @@ trait IdentitySwitches {
     sellByDate = never,
     exposeClientSide = true
   )
-
-  val IdentityEmailSignInUpsellSwitch = Switch(
-    SwitchGroup.Identity,
-    "id-email-sign-in-upsell",
-    "If switched on, users coming from newsletters will get prompts to sign in.",
-    owners = Owner.group(SwitchGroup.Identity),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 6, 21),
-    exposeClientSide = true
-  )
-
-  val IdentityEnableUpsellJourneysSwitch = Switch(
-    SwitchGroup.Identity,
-    "id-enable-upsell-journeys",
-    "If switched on, access to the new consent journeys will be enabled.",
-    owners = Owner.group(SwitchGroup.Identity),
-    safeState = Off,
-    sellByDate = new LocalDate(2019, 6, 21),
-    exposeClientSide = false
-  )
-
 }

--- a/identity/app/controllers/UpsellController.scala
+++ b/identity/app/controllers/UpsellController.scala
@@ -48,7 +48,7 @@ class UpsellController(
 
   import UpsellController._
 
-  def confirmEmailThankYou(returnUrl: Option[String]): Action[AnyContent] = if (IdentityEnableUpsellJourneysSwitch.isSwitchedOn) csrfAddToken {
+  def confirmEmailThankYou(returnUrl: Option[String]): Action[AnyContent] = csrfAddToken {
     authenticatedActions.consentAuthWithIdapiUserWithEmailValidation.async { implicit request =>
       val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request)
       val email = request.user.primaryEmailAddress
@@ -65,8 +65,6 @@ class UpsellController(
         )
       )
     }
-  } else {
-    Action(NotFound(views.html.errors._404()))
   }
 }
 


### PR DESCRIPTION
## What does this change?
Identity currently has two switches that have a sellByDate set. These two switches have both been deleted in this PR for the following reasons.

**id-email-sign-in-upsell**
This has been removed because there isn't anything behind the switch throughout the codebase.

**id-enable-upsell-journeys**
Although we have the 'new' consents page behind this switch, users never hit the endpoint that triggers this action as the AB test was not successful, causing us to set the CTA in emails back to /consents rather than confirm-email/thank-you. This switch has been on for the last few months but no users have been sent to the endpoint. I have checked the Kibana logs over the last 14 days for "/confirm-email/thank-you" and can confirm this.

I have created a separate [card](https://trello.com/c/ael7CtZC/1461-remove-the-confirm-email-thank-you-endpoint-from-frontend-identity-subproject) to remove the code that was written for the /confirm-email/thank-you page. 

## What is the value of this and can you measure success?
We will stop receiving annoying switch expiry emails.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally (since the switch was redundant, I tested that the page still loads without the switch condition should anyone hit the endpoint but soon the endpoint should be removed anyway)
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
