### PR TITLE
Update date format for DCR liveblog

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -136,7 +136,9 @@ object GUDateTimeFormat {
     }
   }
   def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
-    dateTime.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
+    // The reason for .toLowerCase is that I could not find the code for lowercase half day marker: am or pm
+    // So we "4.59 PM".toLowerCase
+    dateTime.toString(DateTimeFormat.forPattern("h.mm a").withZone(timezone)).toLowerCase
   }
 }
 


### PR DESCRIPTION
## What does this change?

Update date format for DCR liveblog

## Screenshots

The current live blog uses the format `1.53pm` while the DCR liveblog uses `13.34 BST` (which is the way I had set it up originally to help debugging). The change moves the DCR object from `"lastUpdatedDisplay": "16.59 BST"` to `"lastUpdatedDisplay": "4.59 pm"`