### PR TITLE
Correct copy for password reset continue button

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.ImplicitControllerExecutionContext
-import model.{ApplicationContext, IdentityPage, NoCache}
+import model.{ApplicationContext, IdentityPage, NoCache, ReturnJourney}
 import play.api.mvc._
 import play.api.data.{Form, Forms}
 import play.api.data.Forms._
@@ -78,12 +78,15 @@ class ChangePasswordController(
   }
 
   def renderPasswordConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action { implicit request =>
+    // TODO: returnUrl doesn't appear to be used by this route.
+    //  Leaving to be fixed by consolidating the whole route with *reset* confirmation
+    val returnJourney = ReturnJourney(returnUrl)
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     NoCache(
       Ok(
         IdentityHtmlPage.html(
-          views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, None)
+          views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, returnJourney)
         )(page, request, context)
       ))
   }

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -1,10 +1,10 @@
 package controllers
 
-import com.netaporter.uri.Uri
+import com.netaporter.uri.{QueryString, Uri}
 import common.ImplicitControllerExecutionContext
 import form.Mappings
 import idapiclient.IdApiClient
-import model.{ApplicationContext, IdentityPage, NoCache}
+import model.{ApplicationContext, IdentityPage, NoCache, ReturnJourney}
 import pages.IdentityHtmlPage
 import play.api.data.Forms._
 import play.api.data.format.Formats._
@@ -19,6 +19,7 @@ import utils.SafeLogging
 import scala.concurrent.Future
 import scala.util.Try
 
+
 class ResetPasswordController(
   api : IdApiClient,
   idRequestParser: IdRequestParser,
@@ -32,7 +33,7 @@ class ResetPasswordController(
 
   private val page = IdentityPage("/reset-password", "Reset Password", isFlow = true)
 
-  private val paymentFailureCodes = Set("PF", "PF1", "PF2", "PF3", "PF4", "CCX")
+
 
   private val requestPasswordResetForm = Form(
     Forms.single(
@@ -124,26 +125,15 @@ class ResetPasswordController(
     boundForm.fold[Future[Result]](onError, onSuccess)
   }
 
-  // Checks for INTCMP parameter in returnUrl after manage.theguardian redirects to signin with this parameter for payment failure flows
-  // If parameter exists and is for payment failure, the 'continue' button reads 'Update your payment method'
-  def getPaymentFailureCode(url: Uri): Option[String] = {
-    val queryString = url.query
-    queryString
-      .param("INTCMP")
-      .filter(paymentFailureCodes.contains)
-  }
+
+
 
   def renderPasswordResetConfirmation(returnUrl: Option[String]): Action[AnyContent] = Action{ implicit request =>
-    val isPaymentFailure = (for {
-      url <- returnUrl
-      parsedUrl <- Try(Uri.parse(url)).toOption
-      paymentFailure <- getPaymentFailureCode(parsedUrl)
-    } yield paymentFailure).orElse(None)
-
+    val returnJourney = ReturnJourney(returnUrl)
     val idRequest = idRequestParser(request)
     val userIsLoggedIn = authenticationService.userIsFullyAuthenticated(request)
     Ok(IdentityHtmlPage.html(
-      views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, isPaymentFailure)
+      views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn, returnUrl, returnJourney)
     )(page, request, context))
   }
 

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import com.netaporter.uri.{QueryString, Uri}
 import common.ImplicitControllerExecutionContext
 import form.Mappings
 import idapiclient.IdApiClient
@@ -17,7 +16,6 @@ import services._
 import utils.SafeLogging
 
 import scala.concurrent.Future
-import scala.util.Try
 
 
 class ResetPasswordController(

--- a/identity/app/model/ReturnJourney.scala
+++ b/identity/app/model/ReturnJourney.scala
@@ -1,0 +1,58 @@
+package model
+
+import com.netaporter.uri.Uri
+
+import scala.util.Try
+
+object ReturnJourney {
+  private val paymentFailureCodes = Set("PF", "PF1", "PF2", "PF3", "PF4", "CCX")
+  private val subscriptionsClientId = "subscriptions"
+  private val contributionsClientId = "recurringContributions"
+
+  sealed trait Journey {
+    def applies(returnUri: Uri): Boolean
+    val continueCopy: String = "Continue"
+  }
+
+  // Checks for INTCMP parameter in returnUrl after manage.theguardian redirects to signin with this parameter for payment failure flows
+  // If parameter exists and is for payment failure, the 'continue' button reads 'Update your payment method'
+  case object PaymentFailure extends Journey {
+    override def applies(returnUri: Uri): Boolean =
+      returnUri.query
+        .param("INTCMP")
+        .exists(paymentFailureCodes.contains)
+
+    override val continueCopy: String = "Update your payment method"
+  }
+
+  case object Subscriptions extends Journey {
+    override def applies(returnUri: Uri): Boolean =
+      returnUri.query
+        .param("clientId")
+        .contains(subscriptionsClientId)
+
+    override val continueCopy: String = "Back to my subscription"
+  }
+
+  case object Contributions extends Journey {
+    override def applies(returnUri: Uri): Boolean =
+      returnUri.query
+        .param("clientId")
+        .contains(contributionsClientId)
+
+    override val continueCopy: String = "Back to my contribution"
+  }
+
+  case object Other extends Journey {
+    override def applies(returnUri: Uri): Boolean = true
+  }
+
+  private val all = List(PaymentFailure, Subscriptions, Contributions, Other)
+
+  def apply(returnUrl: Option[String]): Journey =
+    (for {
+      url <- returnUrl
+      parsedUrl <- Try(Uri.parse(url)).toOption
+      returnJourney <- all.find(_.applies(parsedUrl))
+    } yield returnJourney).getOrElse(Other)
+}

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -3,7 +3,8 @@
 @import services.{IdentityRequest, IdentityUrlBuilder}
 @import views.html.fragments.registrationFooter
 
-@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String], isPaymentFailure: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
+@import model.ReturnJourney
+@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String], returnJourney: ReturnJourney.Journey)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 
 <div class="identity-wrapper monocolumn-wrapper">
@@ -27,11 +28,7 @@
 
                 @returnUrl.map { url =>
                     <p><a class="manage-account__button--icon manage-account__button manage-account__button--main" href="@url" data-link-name="Continue">
-                        @(url match {
-                            case url if url.contains("support.") => "Back to my contribution"
-                            case url if isPaymentFailure.isDefined => "Update your payment method"
-                            case _ => "Continue"
-                        })
+                        @returnJourney.continueCopy
                         @fragments.inlineSvg("arrow-right", "icon")
                     </a></p>
                 }.getOrElse {


### PR DESCRIPTION
## What does this change?
Corrects the copy of a button from the password reset/change confirmation screen.  For any `returnUrl` starting with support.theguardian.com this would have said "Back to my contribution", but we now also sell subscriptions through the support site.

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/58247770-55b18b80-7d52-11e9-8853-318227cf8f2c.png)


## What is the value of this and can you measure success?
Less misleading copy

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
