### PR TITLE
Update conditions for support messaging on password confirmation

### DIFF
--- a/identity/app/model/ReturnJourney.scala
+++ b/identity/app/model/ReturnJourney.scala
@@ -6,8 +6,6 @@ import scala.util.Try
 
 object ReturnJourney {
   private val paymentFailureCodes = Set("PF", "PF1", "PF2", "PF3", "PF4", "CCX")
-  private val subscriptionsClientId = "subscriptions"
-  private val contributionsClientId = "recurringContributions"
 
   sealed trait Journey {
     def applies(returnUri: Uri): Boolean
@@ -26,19 +24,19 @@ object ReturnJourney {
   }
 
   case object Subscriptions extends Journey {
+    // e.g. /subscribe/paper/checkout or /subscribe/digital/checkout
     override def applies(returnUri: Uri): Boolean =
-      returnUri.query
-        .param("clientId")
-        .contains(subscriptionsClientId)
+      returnUri.host.contains("support.theguardian.com") &&
+        returnUri.pathParts.head.part == "subscribe"
 
     override val continueCopy: String = "Back to my subscription"
   }
 
   case object Contributions extends Journey {
+    // e.g. /au/contribute or /uk/contribute
     override def applies(returnUri: Uri): Boolean =
-      returnUri.query
-        .param("clientId")
-        .contains(contributionsClientId)
+      returnUri.host.contains("support.theguardian.com") &&
+        returnUri.pathParts.last.part == "contribute"
 
     override val continueCopy: String = "Back to my contribution"
   }


### PR DESCRIPTION
## What does this change?
Correction to https://github.com/guardian/frontend/pull/21442 using the correct conditions for support messaging on password confirmation pages.

I've gone through the routes in support-frontend and these conditions appear to be all-encompassing while being flexible enough to allow some basic changes on the support side (e.g. another region)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
