### PR TITLE
Fix epic ticker for low amounts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -53,14 +53,16 @@ const increaseCounter = (
     counterElement: HTMLElement
 ) => {
     // Count is local to the parent element
-    count[parentElementSelector] += Math.floor(total / 100);
+    const newCount = count[parentElementSelector] + Math.floor(total / 100);
 
-    counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
-        parentElementSelector
-    ].toLocaleString()}`;
-    if (count[parentElementSelector] >= total) {
+    if (newCount >= total || newCount <= count[parentElementSelector]) {
         counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
     } else {
+        count[parentElementSelector] = newCount;
+        counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
+            parentElementSelector
+        ].toLocaleString()}`;
+
         window.requestAnimationFrame(() =>
             increaseCounter(parentElementSelector, counterElement)
         );

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -55,7 +55,10 @@ const increaseCounter = (
     // Count is local to the parent element
     const newCount = count[parentElementSelector] + Math.floor(total / 100);
 
-    if (newCount >= total || newCount <= count[parentElementSelector]) {
+    const finishedCounting =
+        newCount <= count[parentElementSelector] || newCount >= total; // either we've reached the total or the count isn't going up because total is too small
+
+    if (finishedCounting) {
         counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
     } else {
         count[parentElementSelector] = newCount;


### PR DESCRIPTION
## What does this change?
Currently if the ticker amount is below 100 then it doesn't show. This change fixes this by jumping straight to the total.

## Screenshots
<img width="632" alt="Screenshot 2019-05-24 at 11 59 34" src="https://user-images.githubusercontent.com/1513454/58323459-f15afe80-7e1b-11e9-856d-051bb69db07b.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
