### PR TITLE
Reserve height of feature showcase image container

### DIFF
--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -28,7 +28,7 @@
 @if(!isImmersiveMainMedia) {
     @picture.largestImage.map{ largestImage =>
         <div
-            @if(!isFeatureAndShowcase) {class="u-responsive-ratio" style="padding-bottom: @{"%.2f".format(100 * largestImage.height.toDouble / largestImage.width)}%"}
+            class="u-responsive-ratio" style="padding-bottom: @{"%.2f".format(100 * largestImage.height.toDouble / largestImage.width)}%"
         >
     }
 }


### PR DESCRIPTION
## What does this change?

This PR aims to fix a longstanding bug that causes the righthand MPU and/or the righthand most-read list to sit on top of a feature showcase image.

The showcase image breaks out of the main column and overflows into the righthand column, because of this we have to add enough `padding-top` to the righthand column that it'll sit beneath the showcase image.

We have a module [fix-secondary-column.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/fix-secondary-column.js ) that adds this `padding-top`, this module calculates the necessary padding by reading the height of the showcase image's container. Unfortunately this sometimes miscalculates the height of the container due to a race-condition that occurs when the calculation takes place before the image has loaded - before the image loads the initial height of the container `0px`, it only gets a height once the image has loaded - so on slow connections it may be a number of seconds before the true height can be known.

The fix proposed in this PR is to"reserve" the initial height of the showcase image container. We can do this by calculating the aspect ratio of the image and applying a `padding-bottom` rule that forces the container's aspect ratio to match that of the image, this gives it a height even when the image hasn't loaded. The approach is one we use elsewhere on the site and you can read more about it here https://css-tricks.com/aspect-ratio-boxes. 

We actually do this on main-media images to prevent page Jank, however we were explicitly not doing it on feature showcase images. So, to apply this fix all I had to do was remove the `@if(!isFeatureAndShowcase) { ... }` around this logic in `image.scala.html`.

After reading this https://github.com/guardian/frontend/pull/20448 there was a concern that a side affect of removing `@if(!isFeatureAndShowcase) { ... }` would be the showcase image gets an incorrect `5:3` crop applied to it, however this should never be the case because the aspect-ratio calculation uses the image's height/width to get the custom aspect-ratio of the image being displayed. 

For example the image in the screen shots below is a tall showcase image, so not your standard `5:3` crop. It has `width: 2000px` and `height: 1556px`, this translates to aspect ratio `5:3.89`, so the reseved height is 77.8% of width is:

![Screenshot 2019-05-24 at 13 54 05](https://user-images.githubusercontent.com/1590704/58329019-7863a300-7e2b-11e9-8d6b-c37d53e0995b.png)

There are 2 benefits of setting this:

1. The `fixSecondaryColumn` function doesn't need to wait for the image to load to know the height of the image container, eliminating the race condition causing the overlapping MPU bug.
2. Less page Jank as the space is reserved at the correct height whilst the image loads, as shown below...

## Screenshots (wait a few seconds for refresh)

**Before...**
![beforeARfix](https://user-images.githubusercontent.com/1590704/58329753-2e7bbc80-7e2d-11e9-9462-1243565a440a.gif)

**After...**
![afterARfix](https://user-images.githubusercontent.com/1590704/58329788-49e6c780-7e2d-11e9-8996-5cf7b5ec94ff.gif)

### Tested

- [x] Locally
- [x] On CODE (optional)