### PR TITLE
Only fix secondary column position on breakpoint leftCol and up

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -31,6 +31,7 @@ import { removeCookie, addCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
+import { isBreakpoint } from 'lib/detect';
 import config from 'lib/config';
 import { newHeaderInit } from 'common/modules/navigation/new-header';
 import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
@@ -267,7 +268,10 @@ const bootStandard = (): void => {
 
     newHeaderInit();
 
-    if (config.get('page.hasShowcaseMainElement')) {
+    const isLeftCol: boolean = isBreakpoint({ min: 'leftCol' });
+
+    // we only need to fix the secondary column from leftCol breakpoint up
+    if (config.get('page.hasShowcaseMainElement') && isLeftCol) {
         fixSecondaryColumn();
     }
 

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -268,10 +268,10 @@ const bootStandard = (): void => {
 
     newHeaderInit();
 
-    const isLeftCol: boolean = isBreakpoint({ min: 'leftCol' });
+    const isAtLeastLeftCol: boolean = isBreakpoint({ min: 'leftCol' });
 
     // we only need to fix the secondary column from leftCol breakpoint up
-    if (config.get('page.hasShowcaseMainElement') && isLeftCol) {
+    if (config.get('page.hasShowcaseMainElement') && isAtLeastLeftCol) {
         fixSecondaryColumn();
     }
 


### PR DESCRIPTION
## What does this change?

We're current adding `padding-top` to the secondary column at all breakpoints to account for a full width feature showcase image, however feature showcase images only go full width from the `leftCol` breakpoint and up so we're adding this extra `padding-top` unnecessarily - a side affect of this is that the secondary column, including the righthand MPU is pushed unnecessarily off screen.

## Screenshots

**Before...**
![Screenshot 2019-05-24 at 15 02 26](https://user-images.githubusercontent.com/1590704/58334146-d34ec780-7e36-11e9-97da-e20d0b5b2a4a.png)

**After...**
![Screenshot 2019-05-24 at 15 02 38](https://user-images.githubusercontent.com/1590704/58334169-df3a8980-7e36-11e9-9c44-503e7c0fa4de.png)

## What is the value of this and can you measure success?

More ad impressions and less white space