### PR TITLE
fix small typo

### DIFF
--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -48,7 +48,7 @@ if [[ $? -gt 0 ]]; then
 	exit 1
 fi
 
-function install_ssh_certificate() {
+function install_ssl_certificate() {
 	KEY_NAME="${1}.key"
 	CRT_NAME="${1}.crt"
 	echo "Downloading SSL certificate $CRT_NAME from $S3_BUCKET"
@@ -61,7 +61,7 @@ function install_ssh_certificate() {
 	sudo ln -fs "${DIR}/${KEY_NAME}" "${nginxHome}/${KEY_NAME}"
 }
 
-function install_ssh_certificate_in_jdk_ca() {
+function install_ssl_certificate_in_jdk_ca() {
     echo "Importing SSL certificate into Java keystore ${jdkHome}/jre/lib/security/cacerts"
 	sudo "${jdkHome}/bin/keytool" -import -alias ${1} -keystore "${jdkHome}/jre/lib/security/cacerts" -file "${1}.crt" -storepass "changeit" -noprompt
 }
@@ -71,8 +71,8 @@ function install_nginx_configuration() {
     sudo ln -fs "$DIR/${1}" "$nginxHome/sites-enabled/${1}"
 }
 
-install_ssh_certificate ${SSL_CERT_NAME}
-install_ssh_certificate_in_jdk_ca ${SSL_CERT_NAME}
+install_ssl_certificate ${SSL_CERT_NAME}
+install_ssl_certificate_in_jdk_ca ${SSL_CERT_NAME}
 install_nginx_configuration ${NGINX_SITE_CONF}
 
 echo "Restarting Nginx"


### PR DESCRIPTION
## What does this change?
Just fixes a small typo in a script - ssl not ssh

## Screenshots
![img](https://media.giphy.com/media/MUEq7KfQvNolX9YujV/giphy.gif)

## What is the value of this and can you measure success?
![img](https://media.giphy.com/media/55offP4umeJUAvWwHP/giphy.gif)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
