### PR TITLE
Update DCR MapBlockElement

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -5,7 +5,7 @@ import common.Logging
 import controllers.ArticlePage
 import implicits.Requests._
 import model.PageWithStoryPackage
-import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _} // prevent overriding normal Map type
+import com.gu.contentapi.client.model.v1.ElementType.{Map => MapElement, _} // prevent overriding normal Map type
 import play.api.mvc.RequestHeader
 
 
@@ -38,6 +38,7 @@ object AMPPageChecks extends Logging {
       case Contentatom => true
       case Audio => true
       case Interactive => true
+      case MapElement => true
       case _: ElementType => false
     }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -42,7 +42,7 @@ case class WitnessBlockElement(html: Option[String]) extends PageElement
 case class DocumentBlockElement(html: Option[String], role: Role, isMandatory: Option[Boolean]) extends PageElement
 case class InstagramBlockElement(url: String, html: Option[String], hasCaption: Boolean) extends PageElement
 case class VineBlockElement(html: Option[String]) extends PageElement
-case class MapBlockElement(html: Option[String],  role: Role, isMandatory: Option[Boolean]) extends PageElement
+case class MapBlockElement(url: String) extends PageElement
 case class UnknownBlockElement(html: Option[String]) extends PageElement
 case class DisclaimerBlockElement(html: String) extends PageElement
 
@@ -293,6 +293,16 @@ object PageElement {
           case _ => None
         }).toList
 
+      case ElementType.Map => {
+        for {
+          mapElem <-  element.mapTypeData
+          html <- mapElem.html
+          src <- getIframeSrc(html)
+
+        } yield MapBlockElement(src)
+      }.toList
+
+
       case Pullquote => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html, Role(None))).toList
       case Interactive => element.interactiveTypeData.flatMap(_.iframeUrl).map(url => InteractiveUrlBlockElement(url)).toList
       case Table => element.tableTypeData.map(d => TableBlockElement(d.html, Role(d.role), d.isMandatory)).toList
@@ -300,11 +310,16 @@ object PageElement {
       case Document => element.documentTypeData.map(d => DocumentBlockElement(d.html, Role(d.role), d.isMandatory)).toList
       case Instagram => element.instagramTypeData.map(d => InstagramBlockElement(d.originalUrl, d.html, d.caption.isDefined)).toList
       case Vine => element.vineTypeData.map(d => VineBlockElement(d.html)).toList
-      case ElementType.Map => element.mapTypeData.map(d => MapBlockElement(d.html, Role(d.role), d.isMandatory)).toList
       case Code => List(CodeBlockElement(None))
       case Form => List(FormBlockElement(None))
       case EnumUnknownElementType(f) => List(UnknownBlockElement(None))
     }
+  }
+
+  private[this] def getIframeSrc(html: String): Option[String] = {
+    val doc = Jsoup.parseBodyFragment(html)
+    doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("src"))
+
   }
 
   private def extractAudio(element: ApiBlockElement) = {
@@ -328,12 +343,10 @@ object PageElement {
   }
 
   private def extractSoundcloud(html: String, isMandatory: Boolean): Option[SoundcloudBlockElement] = {
+    val src = getIframeSrc(html)
 
-    val doc = Jsoup.parseBodyFragment(html)
-    doc.getElementsByTag("iframe").asScala.headOption.flatMap {
-      iframe =>
-        val src = iframe.attr("src")
-        (AmpSoundcloud.getTrackIdFromUrl(src), AmpSoundcloud.getPlaylistIdFromUrl(src)) match {
+    src.flatMap { s =>
+        (AmpSoundcloud.getTrackIdFromUrl(s), AmpSoundcloud.getPlaylistIdFromUrl(s)) match {
           case (Some(track), _) => Some(SoundcloudBlockElement(html, track, isTrack = true, isMandatory))
           case (_, Some(playlist)) => Some(SoundcloudBlockElement(html, playlist, isTrack = false, isMandatory))
           case _ => None

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -300,12 +300,10 @@ object PageElement {
           source <- mapElem.source
           html <- mapElem.html
           src <- getIframeSrc(html)
-        } yield MapBlockElement(
-                  src,
-                  originalUrl,
-                  source,
-                  element.mapTypeData.flatMap(_.caption).getOrElse(""),
-                  element.mapTypeData.flatMap(_.title).getOrElse(""))
+
+          caption = mapElem.caption.getOrElse("")
+          title = mapElem.title.getOrElse("")
+        } yield MapBlockElement(src, originalUrl, source, caption, title)
       }.toList
 
       case Pullquote => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html, Role(None))).toList


### PR DESCRIPTION
## What does this change?

Updates the  DCR MapBlockElement case class with necessary data for AMP.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
