### PR TITLE
Correct epic ticker behaviour once goal is reached

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -21,6 +21,7 @@ export const acquisitionsEpicTickerTemplate = `
             <div class="epic-ticker__progress">
                 <div class="js-ticker-filled-progress epic-ticker__filled-progress"></div>
             </div>
+            <div class="js-ticker-goal-marker epic-ticker__goal-marker is-hidden"></div>
         </div>
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -12,13 +12,11 @@ const goalReached = () => total >= goal;
 
 /**
  * The filled bar begins 100% to the left, and is animated rightwards.
- * If the goal is reached and type is 'unlimited' then only 85% is filled.
  */
-const percentageToTranslate = (tickerType: TickerType) => {
-    const percentage = (total / goal) * 100 - 100;
-    const endOfFillPercentage = () => (tickerType === 'unlimited' ? -15 : 0);
+const percentageToTranslate = (total: number, end: number) => {
+    const percentage = (total / end) * 100 - 100;
 
-    return percentage >= 0 ? endOfFillPercentage() : percentage;
+    return percentage >= 0 ? 0 : percentage;
 };
 
 const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
@@ -27,8 +25,23 @@ const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
     );
 
     if (progressBarElement && progressBarElement instanceof HTMLElement) {
-        const barTranslate = percentageToTranslate(tickerType);
+        // If we've exceeded the goal then extend the bar 15% beyond the total
+        const end = tickerType === 'unlimited' && total > goal ? total + total * 0.15 : goal;
+
+        const barTranslate = percentageToTranslate(total, end);
         progressBarElement.style.transform = `translate3d(${barTranslate}%, 0, 0)`;
+
+        if (end > goal) {
+            // Show a marker for the goal that has been exceeded
+            const marker = parentElement.querySelector(
+                '.js-ticker-goal-marker'
+            );
+            if (marker) {
+                marker.classList.remove('is-hidden');
+                const markerTranslate = (goal / end) * 100 - 100;
+                marker.style.transform = `translate3d(${markerTranslate}%, 0, 0)`;
+            }
+        }
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -13,7 +13,7 @@ const goalReached = () => total >= goal;
 /**
  * The filled bar begins 100% to the left, and is animated rightwards.
  */
-const percentageToTranslate = (total: number, end: number) => {
+const percentageToTranslate = (end: number) => {
     const percentage = (total / end) * 100 - 100;
 
     return percentage >= 0 ? 0 : percentage;
@@ -26,9 +26,12 @@ const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
 
     if (progressBarElement && progressBarElement instanceof HTMLElement) {
         // If we've exceeded the goal then extend the bar 15% beyond the total
-        const end = tickerType === 'unlimited' && total > goal ? total + total * 0.15 : goal;
+        const end =
+            tickerType === 'unlimited' && total > goal
+                ? total + total * 0.15
+                : goal;
 
-        const barTranslate = percentageToTranslate(total, end);
+        const barTranslate = percentageToTranslate(end);
         progressBarElement.style.transform = `translate3d(${barTranslate}%, 0, 0)`;
 
         if (end > goal) {

--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -85,18 +85,12 @@ $progress-bar-height: 10px;
     background-color: #ffe500;
 }
 
-.epic-ticker__goal-reached .epic-ticker__progress-container:after {
-    content: '';
-    position: absolute;
-    background: $brightness-7;
-    width: 2px;
-    height: 15px;
-    right: 0;
-    bottom: 0;
-}
-
-.epic-ticker__goal-reached.epic-ticker__unlimited .epic-ticker__progress-container:after {
-    right: 20%;
+.epic-ticker__goal-marker {
+    border-right: 2px solid #121212;
+    content: ' ';
+    display: block;
+    height: 12px;
+    margin-top: -2px;
 }
 
 .epic-ticker__progress-labels {


### PR DESCRIPTION
## What does this change?
The position of the progress bar relative to the marker is currently incorrect when we exceed the goal.
This PR fixes it, going back to the original logic introduced here https://github.com/guardian/frontend/pull/20874/files
I've had to make the marker a div rather than an after so that it can be transformed.

Before the change, the yellow bar is wrong:
<img width="624" alt="Screenshot 2019-05-24 at 17 37 34" src="https://user-images.githubusercontent.com/1513454/58461960-c4af2b80-8128-11e9-988f-51e3ae614fcd.png">


## Screenshots
Above goal:
<img width="632" alt="Screenshot 2019-05-24 at 17 07 43" src="https://user-images.githubusercontent.com/1513454/58341772-eec1ce80-7e46-11e9-9a3d-f2bd3d789c7b.png">

Below goal:
<img width="632" alt="Screenshot 2019-05-24 at 17 07 23" src="https://user-images.githubusercontent.com/1513454/58341800-fda88100-7e46-11e9-8cdf-53d543a44dea.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
