### PR TITLE
update local nginx to use mkcert

### DIFF
--- a/nginx/Brewfile
+++ b/nginx/Brewfile
@@ -1,0 +1,3 @@
+brew "nginx"
+brew "mkcert"
+brew "nss"

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,22 +1,22 @@
 # Frontend Nginx Dev Config
 
-## Install Nginx
+## Install dependencies
 
 __Mac:__ [Install Homebrew:](http://brew.sh/#install)
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-__Nginx:__
+    brew bundle
 
-    # Mac
-    brew install nginx
+__Other operating systems:__
+You need to install:
+- nginx
+- [mkcert](https://github.com/FiloSottile/mkcert)
 
-    # Linux
-    sudo apt-get install nginx
 
 ## Configure Nginx with SSL
 
 1. Ensure you have the correct [hosts](hosts) included in `/etc/hosts` file on your machine
-1. Run `sudo nginx/setup.sh frontend`
+1. Run `sudo nginx/setup.sh`
 1. To setup Dotcom Identity Fronted follow [identity-platform README](https://github.com/guardian/identity-platform)
 

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -19,9 +19,8 @@ server {
     listen 443 ssl;
     server_name m.thegulocal.com;
 
-    ssl on;
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt;
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key;
+    ssl_certificate m.thegulocal.com.crt;
+    ssl_certificate_key m.thegulocal.com.key;
     ssl_session_timeout 5m;
     ssl_protocols SSLv2 SSLv3 TLSv1;
     ssl_ciphers HIGH:!aNULL:!MD5;

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -16,7 +16,7 @@ server {
 
 server {
     proxy_http_version 1.1; # this is essential for chunked responses to work
-    listen 443;
+    listen 443 ssl;
     server_name m.thegulocal.com;
 
     ssl on;

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -43,3 +43,5 @@ else
 fi
 
 echo -e "💯 Done! You can now run frontend locally on https://${DOMAIN}"
+echo -e "👤 To setup Dotcom Identity Frontend please follow identity-platform README."
+echo -e "👋"

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -32,7 +32,9 @@ echo -e "🔗 Symlinking nginx config file"
 ln -sf ${SOURCE_DIR}/frontend.conf ${NGINX_HOME}/servers/frontend.conf
 
 echo -e "🚀 ${YELLOW}Restarting nginx, Requires sudo - enter password when prompted.${NC}"
-sudo nginx -s stop
+if pgrep 'nginx' > /dev/null; then
+  sudo nginx -s stop
+fi
 sudo nginx
 
 if grep '127.0.0.1' /etc/hosts | grep ${DOMAIN} ; then

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,82 +1,38 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Setup Nginx for local developement
-#
-# Copies Nginx configuration and SSL certificates to Nginx home (usually /usr/local/etc/nginx)
-# Make sure you have valid AWS credentials and then run with sudo setup.sh <profile name>
-# Remember to add nginx/hosts to your /etc/hosts
+set -e
 
-SSL_CERT_NAME="STAR_thegulocal_com_exp2020-01-09"
-S3_BUCKET="s3://identity-local-ssl/"
-NGINX_SITE_CONF="frontend.conf"
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
-jdkHome=`/usr/libexec/java_home`
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NGINX_HOME=$(nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g')
+DOMAIN='m.thegulocal.com'
 
-echo "Checking awscli is installed"
-which aws 1>/dev/null 2>&1
-if [[ $? -gt 0 ]]; then
-	echo 'ERROR: Cannot find AWS CLI utility. Please install it before running this script.'
-	exit 1
-fi
+CERT_DIRECTORY=$HOME/.gu/mkcert
+KEY_FILE=${CERT_DIRECTORY}/${DOMAIN}.key
+CERT_FILE=${CERT_DIRECTORY}/${DOMAIN}.crt
 
-echo "Checking AWS credentials are valid"
-if [ -z "$1" ]; then
-	PROFILE=""
-else
-	PROFILE="--profile ${1}"
-fi
+# mkcert requires the JAVA_HOME envvar to be set to add the generated CA to Java's trust store
+# see https://github.com/FiloSottile/mkcert#supported-root-stores
+export JAVA_HOME=$(/usr/libexec/java_home)
 
-aws ${PROFILE} s3 ls ${S3_BUCKET} 1>/dev/null 2>&1
-if [[ $? -gt 0 ]]; then
-	echo "ERROR: You do not have access to the Identity AWS account. Re-run with ${0} <profile name> to use a different profile."
-	exit 2
-fi
+mkcert -install
 
-echo "Checking Nginx sites-enabled directory exists"
-ls "${nginxHome}/sites-enabled" 1>/dev/null 2>&1
-if [[ $? -gt 0 ]]; then
-	echo "ERROR: Missing ${nginxHome}/sites-enabled"
-    echo "Create sites-enabled directory and make sure it is included in your nginx.conf (usually in ${nginxHome}/nginx.conf):
-            http {
-                include       mime.types;
-                default_type  application/octet-stream;
-                # THIS IS WHAT YOU MUST ADD
-                include sites-enabled/*;
-            #..."
-	exit 1
-fi
+echo -e "🔐 Creating certificate for: ${YELLOW}$@${NC}"
+mkdir -p ${CERT_DIRECTORY}
+mkcert -key-file=${KEY_FILE} -cert-file=${CERT_FILE} ${DOMAIN}
 
-function install_ssh_certificate() {
-	KEY_NAME="${1}.key"
-	CRT_NAME="${1}.crt"
-	echo "Downloading SSL certificate $CRT_NAME from $S3_BUCKET"
-	aws ${PROFILE} s3 cp "${S3_BUCKET}${KEY_NAME}" ${DIR} 1>/dev/null
-	echo "Downloading SSL key $KEY_NAME from $S3_BUCKET"
-	aws ${PROFILE} s3 cp "${S3_BUCKET}${CRT_NAME}" ${DIR} 1>/dev/null
+echo -e "🔗 Symlinking the certificate for nginx at ${NGINX_HOME}"
+ln -sf ${KEY_FILE} ${NGINX_HOME}/${DOMAIN}.key
+ln -sf ${CERT_FILE} ${NGINX_HOME}/${DOMAIN}.crt
 
-	echo "Linking SSL certs/keys to $nginxHome"
-	sudo ln -fs "${DIR}/${CRT_NAME}" "${nginxHome}/${CRT_NAME}"
-	sudo ln -fs "${DIR}/${KEY_NAME}" "${nginxHome}/${KEY_NAME}"
-}
+echo -e "🔗 Symlinking nginx config file"
+ln -sf ${SOURCE_DIR}/frontend.conf ${NGINX_HOME}/servers/frontend.conf
 
-function install_ssh_certificate_in_jdk_ca() {
-    echo "Importing SSL certificate into Java keystore ${jdkHome}/jre/lib/security/cacerts"
-	sudo "${jdkHome}/bin/keytool" -import -alias ${1} -keystore "${jdkHome}/jre/lib/security/cacerts" -file "${1}.crt" -storepass "changeit" -noprompt
-}
-
-function install_nginx_configuration() {
-    echo "Linking Nginx configuration ${1} to $nginxHome/sites-enabled"
-    sudo ln -fs "$DIR/${1}" "$nginxHome/sites-enabled/${1}"
-}
-
-install_ssh_certificate ${SSL_CERT_NAME}
-install_ssh_certificate_in_jdk_ca ${SSL_CERT_NAME}
-install_nginx_configuration ${NGINX_SITE_CONF}
-
-echo "Restarting Nginx"
+echo -e "🚀 ${YELLOW}Restarting nginx, which requires sudo - enter password when prompted.${NC}"
 sudo nginx -s stop
 sudo nginx
 
-echo "Done. (To setup Dotcom Identity Frontend please follow identity-platform README.)"
+echo -e "💯 Done. Remember to add an entry to /etc/hosts for ${DOMAIN}."

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -31,8 +31,15 @@ ln -sf ${CERT_FILE} ${NGINX_HOME}/${DOMAIN}.crt
 echo -e "🔗 Symlinking nginx config file"
 ln -sf ${SOURCE_DIR}/frontend.conf ${NGINX_HOME}/servers/frontend.conf
 
-echo -e "🚀 ${YELLOW}Restarting nginx, which requires sudo - enter password when prompted.${NC}"
+echo -e "🚀 ${YELLOW}Restarting nginx, Requires sudo - enter password when prompted.${NC}"
 sudo nginx -s stop
 sudo nginx
 
-echo -e "💯 Done. Remember to add an entry to /etc/hosts for ${DOMAIN}."
+if grep '127.0.0.1' /etc/hosts | grep ${DOMAIN} ; then
+  echo -e "✅ /etc/hosts entry already exists for ${DOMAIN}"
+else
+  echo -e "🔧 ${YELLOW}adding /etc/hosts entry for ${DOMAIN}. Requires sudo - enter password when prompted.${NC}"
+  sudo sh -c "echo '127.0.0.1		${DOMAIN}' >> /etc/hosts"
+fi
+
+echo -e "💯 Done! You can now run frontend locally on https://${DOMAIN}"


### PR DESCRIPTION
## What does this change?
Currently we require `Identity` credentials to setup nginx as we're storing the certificate in S3. This is problematic in a few ways:
- A reliance on S3 to setup nginx
- A reliance on having the correct Janus credentials
- We need to [update the certificate](https://github.com/guardian/frontend/pull/20930) once a year as it expires
- Certificate renewal is handled by another team
- Every machine is using the same certificate; if its compromised once, its compromised everywhere

[mkcert](https://github.com/FiloSottile/mkcert) provides:
- Security as each machine acts as their own CA
- No reliance on S3 or Identity Janus credentials
- Frictionless certificate renewal - we just re-run the script

Also writes nginx site config to `/usr/local/etc/nginx/servers/` directory as is preferred with latest version of nginx.

Related to https://github.com/guardian/dev-nginx-old/pull/37. Ideally the `dev-nginx` scripts would be shared rather than copy pasted, however that repo is private at the moment - once it's public we can migrate.

## Screenshots
![image](https://user-images.githubusercontent.com/836140/58476601-2bdcd800-8149-11e9-9182-f1fb2645ae6d.png)

![image](https://user-images.githubusercontent.com/836140/58476764-ac9bd400-8149-11e9-9646-b4073d6eeef9.png)


## What is the value of this and can you measure success?
- A simplified process to develop on frontend with https
- No reliance on the `Identity` credentials

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
