### PR TITLE
track video ad events

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -86,7 +86,10 @@ const setupPlayer = (
     channelId?: string,
     onReady,
     onStateChange,
-    onError
+    onError,
+    onAdStart,
+    onAdEnd,
+    onAdSkip
 ) => {
     const wantPersonalisedAds: boolean =
         getAdConsentState(thirdPartyTrackingAdConsent) !== false;
@@ -113,6 +116,9 @@ const setupPlayer = (
             onReady,
             onStateChange,
             onError,
+            onAdStart,
+            onAdEnd,
+            onAdSkip,
         },
         embedConfig: {
             relatedChannels,
@@ -151,13 +157,31 @@ export const initYoutubePlayer = (
             console.error(`YOUTUBE: ${event}`);
         };
 
+        const onAdStart = event => {
+            const isPreroll = !hasPlayerStarted(event);
+            console.log(`${isPreroll ? 'pre-roll' : 'advert'} started`);
+        };
+
+        const onAdEnd = event => {
+            const isPreroll = !hasPlayerStarted(event);
+            console.log(`${isPreroll ? 'pre-roll' : 'advert'} ended`);
+        };
+
+        const onAdSkip = event => {
+            const isPreroll = !hasPlayerStarted(event);
+            console.log(`${isPreroll ? 'pre-roll' : 'advert'} skipped`);
+        };
+
         return setupPlayer(
             el.id,
             videoId,
             channelId,
             onPlayerReady,
             onPlayerStateChange,
-            onPlayerError
+            onPlayerError,
+            onAdStart,
+            onAdEnd,
+            onAdSkip
         );
     });
 };


### PR DESCRIPTION
## What does this change?
YouTube have recently exposed a few new events allowing us to track adverts!

NB: These new events are only available on whitelisted domains in the PfP programme. That is, we will only see these events on `m.thegulocal.com` in frontend.

This is a skeleton PR. TODO:
- [ ] confirm structure of event to send to Ophan and GA
- [ ] craft PR in Ophan to display new metrics

## Screenshots

## What is the value of this and can you measure success?
Understanding how many adverts we are serving.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
