### PR TITLE
Upscale images for dotcom-rendering structured data

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -352,16 +352,6 @@ object DotcomponentsDataModel {
     // See https://developers.google.com/search/docs/data-types/article (and the AMP info too)
     // For example, we need to provide an image of at least 1200px width to be valid here
     val linkedData: List[LinkedData] = {
-      val mainImageURL = {
-        val main = for {
-          elem <- article.trail.trailPicture
-          master <- elem.masterImage
-          url <- master.url
-        } yield url
-
-        main.getOrElse(Configuration.images.fallbackLogo)
-      }
-
       articlePage match {
         case liveblog: LiveBlogPage => LinkedData.forLiveblog(
           liveblog = liveblog,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -127,8 +127,6 @@ final case class Content(
     val isOldNews = tags.tags.exists(_.id == "tone/news") &&
       trail.webPublicationDate.isBefore(DateTime.now().minusYears(1))
 
-    val isStarRating = starRating.isDefined
-
     () match {
       case paid if isPaidContent => Paid
       case commentObserver if tags.isComment && isFromTheObserver => ObserverOpinion
@@ -136,8 +134,8 @@ final case class Content(
       case live if tags.isLiveBlog => Live
       case oldObserver if isOldNews && isFromTheObserver => ObserverOldContent(trail.webPublicationDate.getYear)
       case old if isOldNews => GuardianOldContent(trail.webPublicationDate.getYear)
-      case ratingObserver if isStarRating && isFromTheObserver => ObserverStarRating(starRating.get)
-      case rating if isStarRating => GuardianStarRating(starRating.get)
+      case ratingObserver if starRating.isDefined && isFromTheObserver => ObserverStarRating(starRating.get)
+      case rating if starRating.isDefined => GuardianStarRating(starRating.get)
       case observerDefault if isFromTheObserver => ObserverDefault
       case default => GuardianDefault
     }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -149,7 +149,7 @@ final case class Content(
 
   lazy val openGraphImage: String = ImgSrc(openGraphImageOrFallbackUrl, openGraphImageProfile)
   // These dimensions are just an educated guess (e.g. we don't take into account image-resizer being turned off)
-  lazy val openGraphImageWidth: Option[Int] = openGraphImageProfile.width // TODO avoid repeating here
+  lazy val openGraphImageWidth: Option[Int] = openGraphImageProfile.width
   lazy val openGraphImageHeight: Option[Int] =
     for {
       img <- rawOpenGraphImage

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -146,7 +146,7 @@ final case class Content(
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImageProfile: ElementProfile = {
     val category = shareImageCategory
-    FacebookOpenGraphImage.forCategory(category)
+    OpenGraphImage.forCategory(category, FacebookShareImageLogoOverlay.isSwitchedOn)
   }
 
   lazy val openGraphImage: String = ImgSrc(openGraphImageOrFallbackUrl, openGraphImageProfile)
@@ -160,7 +160,7 @@ final case class Content(
 
   // URL of image to use in the twitter card. Image must be less than 1MB in size: https://dev.twitter.com/cards/overview
   lazy val twitterCardImage = {
-    val profile = TwitterImage.forCategory(shareImageCategory)
+    val profile = OpenGraphImage.forCategory(shareImageCategory, TwitterShareImageLogoOverlay.isSwitchedOn)
     ImgSrc(openGraphImageOrFallbackUrl, profile)
   }
 
@@ -781,7 +781,7 @@ case class GalleryLightbox(
       else if (tags.isLiveBlog) Live
       else GuardianDefault
 
-    FacebookOpenGraphImage.forCategory(category)
+    OpenGraphImage.forCategory(category, FacebookShareImageLogoOverlay.isSwitchedOn)
   }
 
   val galleryImages: Seq[ImageElement] = elements.images.filter(_.properties.isGallery)

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,6 +1,5 @@
 package model.meta
 
-import conf.Static
 import play.api.libs.json.{Json, OFormat}
 
 class LinkedData(

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -167,23 +167,23 @@ trait OverlayBase64 {
     Base64.getUrlEncoder.encodeToString(s"/img/static/overlays/$overlay".getBytes).replace("=", "")
 }
 
-object TwitterImage extends OverlayBase64 {
-  def forCategory(category: ShareImageCategory, shouldUpscale: Boolean = false): ElementProfile = {
+object OpenGraphImage extends OverlayBase64 {
+  def forCategory(category: ShareImageCategory, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ElementProfile = {
     category match {
-      case GuardianDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-default.png")}", TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-default.png")}", TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case GuardianOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-opinions.png")}", TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case Live => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-live.png")}", TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverOldContent(year) => contentAgeNoticeObserver(year, shouldUpscale)
-      case GuardianOldContent(year) => contentAgeNotice(year, shouldUpscale)
-      case ObserverStarRating(rating) => starRatingObserver(rating)
-      case GuardianStarRating(rating) => starRating(rating)
+      case GuardianDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-default.png")}", shouldIncludeOverlay, shouldUpscale)
+      case ObserverDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-default.png")}", shouldIncludeOverlay, shouldUpscale)
+      case ObserverOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", shouldIncludeOverlay, shouldUpscale)
+      case GuardianOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-opinions.png")}", shouldIncludeOverlay, shouldUpscale)
+      case Live => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-live.png")}", shouldIncludeOverlay, shouldUpscale)
+      case ObserverOldContent(year) => contentAgeNoticeObserver(year, shouldIncludeOverlay, shouldUpscale)
+      case GuardianOldContent(year) => contentAgeNotice(year, shouldIncludeOverlay, shouldUpscale)
+      case ObserverStarRating(rating) => starRatingObserver(rating, shouldIncludeOverlay, shouldUpscale)
+      case GuardianStarRating(rating) => starRating(rating, shouldIncludeOverlay, shouldUpscale)
       case Paid => Item700
     }
   }
 
-  private[this] def starRating(rating: Int): ShareImage = {
+  private[this] def starRating(rating: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
     val image = rating match {
       case 0 => s"overlay-base64=${overlayUrlBase64("tg-review-0.png")}"
       case 1 => s"overlay-base64=${overlayUrlBase64("tg-review-1.png")}"
@@ -193,10 +193,10 @@ object TwitterImage extends OverlayBase64 {
       case 5 => s"overlay-base64=${overlayUrlBase64("tg-review-5.png")}"
       case _ => s"overlay-base64=${overlayUrlBase64("tg-default.png")}"
     }
-    new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn)
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
   }
 
-  private[this] def starRatingObserver(rating: Int): ShareImage = {
+  private[this] def starRatingObserver(rating: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
     val image = rating match {
       case 0 => s"overlay-base64=${overlayUrlBase64("to-review-0.png")}"
       case 1 => s"overlay-base64=${overlayUrlBase64("to-review-1.png")}"
@@ -206,7 +206,7 @@ object TwitterImage extends OverlayBase64 {
       case 5 => s"overlay-base64=${overlayUrlBase64("to-review-5.png")}"
       case _ => s"overlay-base64=${overlayUrlBase64("to-default.png")}"
     }
-    new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn)
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
   }
 
   private[this] def getContentAgeFileName(prefix: String, publicationYear: Int): String = {
@@ -218,77 +218,14 @@ object TwitterImage extends OverlayBase64 {
     }
   }
 
-  private[this] def contentAgeNotice(publicationYear: Int, shouldUpscale: Boolean): ShareImage = {
+  private[this] def contentAgeNotice(publicationYear: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
     val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("tg", publicationYear))}"
-    new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
   }
 
-  private[this] def contentAgeNoticeObserver(publicationYear: Int, shouldUpscale: Boolean): ShareImage = {
+  private[this] def contentAgeNoticeObserver(publicationYear: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean): ShareImage = {
     val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to", publicationYear))}"
-    new ShareImage(image, TwitterShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-  }
-}
-
-// TODO lift overlay boolean
-object FacebookOpenGraphImage extends OverlayBase64 {
-  def forCategory(category: ShareImageCategory, shouldUpscale: Boolean = false): ElementProfile = {
-    category match {
-      case GuardianDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-default.png")}", FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverDefault => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-default.png")}", FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case GuardianOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-opinions.png")}", FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case Live => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-live.png")}", FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-      case ObserverOldContent(year) => contentAgeNoticeObserver(year, shouldUpscale)
-      case GuardianOldContent(year) => contentAgeNotice(year, shouldUpscale)
-      case ObserverStarRating(rating) => starRatingObserver(rating)
-      case GuardianStarRating(rating) => starRating(rating)
-      case Paid => Item700
-    }
-  }
-
-  private[this] def starRating(rating: Int): ShareImage = {
-    val image = rating match {
-      case 0 => s"overlay-base64=${overlayUrlBase64("tg-review-0.png")}"
-      case 1 => s"overlay-base64=${overlayUrlBase64("tg-review-1.png")}"
-      case 2 => s"overlay-base64=${overlayUrlBase64("tg-review-2.png")}"
-      case 3 => s"overlay-base64=${overlayUrlBase64("tg-review-3.png")}"
-      case 4 => s"overlay-base64=${overlayUrlBase64("tg-review-4.png")}"
-      case 5 => s"overlay-base64=${overlayUrlBase64("tg-review-5.png")}"
-      case _ => s"overlay-base64=${overlayUrlBase64("tg-default.png")}"
-    }
-    new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn)
-  }
-
-  private[this] def starRatingObserver(rating: Int): ShareImage = {
-    val image = rating match {
-      case 0 => s"overlay-base64=${overlayUrlBase64("to-review-0.png")}"
-      case 1 => s"overlay-base64=${overlayUrlBase64("to-review-1.png")}"
-      case 2 => s"overlay-base64=${overlayUrlBase64("to-review-2.png")}"
-      case 3 => s"overlay-base64=${overlayUrlBase64("to-review-3.png")}"
-      case 4 => s"overlay-base64=${overlayUrlBase64("to-review-4.png")}"
-      case 5 => s"overlay-base64=${overlayUrlBase64("to-review-5.png")}"
-      case _ => s"overlay-base64=${overlayUrlBase64("to-default.png")}"
-    }
-    new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn)
-  }
-
-  private[this] def getContentAgeFileName(prefix: String, publicationYear: Int): String = {
-    // WARNING: we have only produced these content age images up to the year 2025
-    if (publicationYear < 2025) {
-      s"${prefix}-age-${publicationYear}.png"
-    } else {
-      s"${prefix}-default.png"
-    }
-  }
-
-  private[this] def contentAgeNotice(publicationYear: Int, shouldUpscale: Boolean): ShareImage = {
-    val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("tg", publicationYear))}"
-    new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
-  }
-
-  private[this] def contentAgeNoticeObserver(publicationYear: Int, shouldUpscale: Boolean): ShareImage = {
-    val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to", publicationYear))}"
-    new ShareImage(image, FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale)
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
   }
 }
 

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -185,12 +185,7 @@ object OpenGraphImage extends OverlayBase64 {
 
   private[this] def starRating(rating: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
     val image = rating match {
-      case 0 => s"overlay-base64=${overlayUrlBase64("tg-review-0.png")}"
-      case 1 => s"overlay-base64=${overlayUrlBase64("tg-review-1.png")}"
-      case 2 => s"overlay-base64=${overlayUrlBase64("tg-review-2.png")}"
-      case 3 => s"overlay-base64=${overlayUrlBase64("tg-review-3.png")}"
-      case 4 => s"overlay-base64=${overlayUrlBase64("tg-review-4.png")}"
-      case 5 => s"overlay-base64=${overlayUrlBase64("tg-review-5.png")}"
+      case x if 0 to 5 contains x => s"overlay-base64=${overlayUrlBase64(s"tg-review-$x.png")}"
       case _ => s"overlay-base64=${overlayUrlBase64("tg-default.png")}"
     }
     new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
@@ -198,12 +193,7 @@ object OpenGraphImage extends OverlayBase64 {
 
   private[this] def starRatingObserver(rating: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
     val image = rating match {
-      case 0 => s"overlay-base64=${overlayUrlBase64("to-review-0.png")}"
-      case 1 => s"overlay-base64=${overlayUrlBase64("to-review-1.png")}"
-      case 2 => s"overlay-base64=${overlayUrlBase64("to-review-2.png")}"
-      case 3 => s"overlay-base64=${overlayUrlBase64("to-review-3.png")}"
-      case 4 => s"overlay-base64=${overlayUrlBase64("to-review-4.png")}"
-      case 5 => s"overlay-base64=${overlayUrlBase64("to-review-5.png")}"
+      case x if 0 to 5 contains x => s"overlay-base64=${overlayUrlBase64(s"tg-review-$x.png")}"
       case _ => s"overlay-base64=${overlayUrlBase64("to-default.png")}"
     }
     new ShareImage(image, shouldIncludeOverlay, shouldUpscale)


### PR DESCRIPTION
## What does this change?

Adds upscaling for dotcom-rendering structured data images (this is needed as Google want images at least 1200px wide in structured data), but also refactors a lot of related code to avoid duplication, clarify intent (through types), and make things have smaller interfaces.
