### PR TITLE
Record daily article view count

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -28,6 +28,7 @@ import {
     logHistory,
     logSummary,
     showInMegaNav,
+    incrementDailyArticleCount,
 } from 'common/modules/onward/history';
 import { initTechFeedback } from 'common/modules/onward/tech-feedback';
 import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-prefs';
@@ -148,6 +149,14 @@ const updateHistory = (): void => {
         }
 
         logHistory(page);
+    }
+};
+
+const updateDailyArticleCount = (): void => {
+    const page = config.get('page');
+
+    if (page) {
+        incrementDailyArticleCount(page);
     }
 };
 
@@ -342,6 +351,7 @@ const init = (): void => {
         ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],
         ['c-banner-picker', initialiseBanner],
+        ['c-increment-daily-count', updateDailyArticleCount],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
     ]);
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -76,7 +76,7 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
 const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
 
 const replaceArticlesRead = (text: string, days: number = 30): string =>
-    text.replace(/%%ARTICLES_READ%%/g, getArticleViewCount(days));
+    text.replace(/%%ARTICLES_READ%%/g, `${getArticleViewCount(days)}`);
 
 // How many times the user can see the Epic,
 // e.g. 6 times within 7 days with minimum of 1 day in between views.

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -52,6 +52,7 @@ import {
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
 import { initTicker } from 'common/modules/commercial/ticker';
+import { getArticleViewCount } from 'common/modules/onward/history';
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -73,6 +74,9 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
 };
 
 const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
+
+const replaceArticlesRead = (text: string, days: number = 30): string =>
+    text.replace(/%%ARTICLES_READ%%/g, getArticleViewCount(days));
 
 // How many times the user can see the Epic,
 // e.g. 6 times within 7 days with minimum of 1 day in between views.
@@ -601,9 +605,8 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 ','
                             ),
                             copy: {
-                                heading: throwIfEmptyString(
-                                    'heading',
-                                    row.heading
+                                heading: replaceArticlesRead(
+                                    throwIfEmptyString('heading', row.heading)
                                 ),
                                 paragraphs: throwIfEmptyArray(
                                     'paragraphs',

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -334,6 +334,7 @@ const reset = (): void => {
     summaryCache = undefined;
     local.remove(storageKeyHistory);
     local.remove(storageKeySummary);
+    local.remove(storageKeyDailyArticleCount);
 };
 
 const logHistory = (pageConfig: Object): void => {
@@ -470,12 +471,14 @@ const incrementDailyArticleCount = (pageConfig: Object): void => {
         if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
             dailyCount[0].count += 1;
         } else {
-            //New day
-            dailyCount.unshift({day: today, count: 1});
+            // New day
+            dailyCount.unshift({ day: today, count: 1 });
 
-            //Remove any old days
+            // Remove any days older than 30
             const cutOff = today - 30;
-            const firstOldDayIndex = dailyCount.findIndex(c => c.day && c.day < cutOff);
+            const firstOldDayIndex = dailyCount.findIndex(
+                c => c.day && c.day < cutOff
+            );
             if (firstOldDayIndex > 0) {
                 dailyCount.splice(firstOldDayIndex);
             }
@@ -489,13 +492,13 @@ const getArticleViewCount = (days: number): number => {
     const dailyCount = local.get(storageKeyDailyArticleCount) || [];
     const cutOff = today - days;
 
-    const firstOldDayIndex = dailyCount.findIndex(c => c.day && c.day < cutOff);
-    const dailyCountWindow = firstOldDayIndex >= 0 ? dailyCount.slice(0, firstOldDayIndex) : dailyCount;
+    const firstOldDayIndex = dailyCount.findIndex(c => c.day && c.day <= cutOff);
+    const dailyCountWindow =
+        firstOldDayIndex >= 0
+            ? dailyCount.slice(0, firstOldDayIndex)
+            : dailyCount;
 
-    return dailyCountWindow.reduce(
-        (acc, current) => current.count + acc,
-        0
-    );
+    return dailyCountWindow.reduce((acc, current) => current.count + acc, 0);
 };
 
 export {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -492,7 +492,9 @@ const getArticleViewCount = (days: number): number => {
     const dailyCount = local.get(storageKeyDailyArticleCount) || [];
     const cutOff = today - days;
 
-    const firstOldDayIndex = dailyCount.findIndex(c => c.day && c.day <= cutOff);
+    const firstOldDayIndex = dailyCount.findIndex(
+        c => c.day && c.day <= cutOff
+    );
     const dailyCountWindow =
         firstOldDayIndex >= 0
             ? dailyCount.slice(0, firstOldDayIndex)

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -10,7 +10,8 @@ import {
     reset,
     seriesSummary,
     mostViewedSeries,
-    _,
+    getArticleViewCount,
+    _, incrementDailyArticleCount,
 } from 'common/modules/onward/history';
 import { local as localStorageStub } from 'lib/storage';
 
@@ -64,6 +65,7 @@ const lessVisited = {
 describe('history', () => {
     let mockContains;
     let mockSummary;
+    let mockDailyArticleCount;
 
     beforeEach(() => {
         mockContains = contains;
@@ -73,6 +75,8 @@ describe('history', () => {
                 return mockContains;
             } else if (key === 'gu.history.summary') {
                 return mockSummary;
+            } else if (key === 'gu.history.dailyArticleCount') {
+                return mockDailyArticleCount;
             }
         });
 
@@ -81,6 +85,8 @@ describe('history', () => {
                 mockContains = data;
             } else if (key === 'gu.history.summary') {
                 mockSummary = data;
+            } else if (key === 'gu.history.dailyArticleCount') {
+                mockDailyArticleCount = data;
             }
         });
     });
@@ -344,5 +350,39 @@ describe('history', () => {
 
         expect(getContributors().length).toEqual(1);
         expect(getContributors()[0][0]).toEqual('Finbarr Saunders');
+    });
+
+    // dailyArticleCount tests
+    it('gets article count for today only', () => {
+        const counts = [{day: today, count: 1}, {day: today-1, count: 1}];
+        localStorageStub.set('gu.history.dailyArticleCount', counts);
+
+        expect(getArticleViewCount(1)).toEqual(1);
+    });
+
+    it('gets article count for 2 days', () => {
+        const counts = [{day: today, count: 1}, {day: today-1, count: 1}];
+        localStorageStub.set('gu.history.dailyArticleCount', counts);
+
+        expect(getArticleViewCount(2)).toEqual(2);
+    });
+
+    it('increments the article count', () => {
+        const counts = [{day: today, count: 1}];
+        localStorageStub.set('gu.history.dailyArticleCount', counts);
+
+        incrementDailyArticleCount(pageConfig);
+
+        expect(getArticleViewCount(1)).toEqual(2);
+    });
+
+    it('removes old history while incrementing the article count', () => {
+        const counts = [{day: today-40, count: 9}];
+        localStorageStub.set('gu.history.dailyArticleCount', counts);
+
+        incrementDailyArticleCount(pageConfig);
+
+        expect(localStorageStub.get('gu.history.dailyArticleCount', counts))
+            .toEqual([{day: today, count: 1}])
     });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -384,7 +384,7 @@ describe('history', () => {
         incrementDailyArticleCount(pageConfig);
 
         expect(
-            localStorageStub.get('gu.history.dailyArticleCount', counts)
+            localStorageStub.get('gu.history.dailyArticleCount')
         ).toEqual([{ day: today, count: 1 }]);
     });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -11,7 +11,8 @@ import {
     seriesSummary,
     mostViewedSeries,
     getArticleViewCount,
-    _, incrementDailyArticleCount,
+    _,
+    incrementDailyArticleCount,
 } from 'common/modules/onward/history';
 import { local as localStorageStub } from 'lib/storage';
 
@@ -354,21 +355,21 @@ describe('history', () => {
 
     // dailyArticleCount tests
     it('gets article count for today only', () => {
-        const counts = [{day: today, count: 1}, {day: today-1, count: 1}];
+        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
         expect(getArticleViewCount(1)).toEqual(1);
     });
 
     it('gets article count for 2 days', () => {
-        const counts = [{day: today, count: 1}, {day: today-1, count: 1}];
+        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
         expect(getArticleViewCount(2)).toEqual(2);
     });
 
     it('increments the article count', () => {
-        const counts = [{day: today, count: 1}];
+        const counts = [{ day: today, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
         incrementDailyArticleCount(pageConfig);
@@ -377,12 +378,13 @@ describe('history', () => {
     });
 
     it('removes old history while incrementing the article count', () => {
-        const counts = [{day: today-40, count: 9}];
+        const counts = [{ day: today - 40, count: 9 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
         incrementDailyArticleCount(pageConfig);
 
-        expect(localStorageStub.get('gu.history.dailyArticleCount', counts))
-            .toEqual([{day: today, count: 1}])
+        expect(
+            localStorageStub.get('gu.history.dailyArticleCount', counts)
+        ).toEqual([{ day: today, count: 1 }]);
     });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -383,8 +383,8 @@ describe('history', () => {
 
         incrementDailyArticleCount(pageConfig);
 
-        expect(
-            localStorageStub.get('gu.history.dailyArticleCount')
-        ).toEqual([{ day: today, count: 1 }]);
+        expect(localStorageStub.get('gu.history.dailyArticleCount')).toEqual([
+            { day: today, count: 1 },
+        ]);
     });
 });


### PR DESCRIPTION
## What does this change?
Adds a new local storage item, `gu.history.dailyArticleCount`, which holds counts of articles viewed per day for the past 30 days.

This is required for customised messages in the epic.
There is some additional work to be done before adding this to the epic, as we need to avoid showing it to users with a count below a certain theshold. But we do want to start counting article views now.

<img width="643" alt="Screenshot 2019-05-29 at 16 52 15" src="https://user-images.githubusercontent.com/1513454/58571680-2ad3a580-8232-11e9-974b-792dd9c036c1.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
