### PR TITLE
Bump CommercialConsentGlobalBanner test end date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Test whether changes to Consent Banner increases proportion of non-EU users who interact with it",
     owners = Owner.group(Commercial),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 5, 31),
+    sellByDate = new LocalDate(2019, 6, 3),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-global-banner.js
@@ -4,7 +4,7 @@ import { getCookie } from 'lib/cookies';
 export const commercialConsentGlobalBanner: ABTest = {
     id: 'CommercialConsentGlobalBanner',
     start: '2019-05-01',
-    expiry: '2019-05-31',
+    expiry: '2019-06-03',
     author: 'George Haberis',
     description:
         'Test whether changes to Consent Banner increases proportion of non-EU users who interact with it',


### PR DESCRIPTION
## What does this change?

Bumps the end date of `CommercialConsentGlobalBanner` to next week when we will be replacing it with https://github.com/guardian/frontend/pull/21464. We need to bump it today as it expires at 23.59 tonight and which will block `master` builds.