### PR TITLE
Add a switch to enable Confiant

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -357,6 +357,16 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val confiantAdVerification: Switch = Switch(
+    group = Commercial,
+    name = "confiant-ad-verification",
+    description = "Enable Confiant ad verification",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }
 
 trait PrebidSwitches {

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -1,5 +1,5 @@
 // @flow strict
-
+import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialAdVerification } from 'common/modules/experiments/tests/commercial-ad-verification.js';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
@@ -15,7 +15,10 @@ export const init = (start: () => void): Promise<void> => {
 
     start();
 
-    if (isInVariantSynchronous(commercialAdVerification, 'variant')) {
+    if (
+        config.get('switches.confiantAdVerification') ||
+        isInVariantSynchronous(commercialAdVerification, 'variant')
+    ) {
         return loadScript(
             `//${host}/7oDgiTsq88US4rrBG0_Nxpafkrg/gpt_and_prebid/config.js`,
             { async: true }


### PR DESCRIPTION
## What does this change?
This PR adds a switch that can be used to enable Confiant ad verification on the main page.

## What is the value of this and can you measure success?
This will allows us to switch Confiant ad verification on or off independently. In case of an ad malware attack this is preferable to switches off the entire commercial bundle.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [X] Locally
- [ ] On CODE (optional)