### PR TITLE
Enable upscale on opengraph images

### DIFF
--- a/article/app/model/dotcomponents/LinkedData.scala
+++ b/article/app/model/dotcomponents/LinkedData.scala
@@ -134,7 +134,6 @@ object LinkedData {
       article.content.openGraphImage,
       ImgSrc(mainImageURL, OneByOne),
       ImgSrc(mainImageURL, FourByThree),
-      ImgSrc(mainImageURL, Item1200),
     )
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -144,7 +144,7 @@ final case class Content(
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImageProfile: ElementProfile = {
     val category = shareImageCategory
-    OpenGraphImage.forCategory(category, FacebookShareImageLogoOverlay.isSwitchedOn)
+    OpenGraphImage.forCategory(category, shouldIncludeOverlay = FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale = true)
   }
 
   lazy val openGraphImage: String = ImgSrc(openGraphImageOrFallbackUrl, openGraphImageProfile)


### PR DESCRIPTION
This option was added in a previous series of commits, but never enabled (an oversight).

At the moment we have a large number of AMP articles receiving warnings in the Google console as their structured data returns an image that is too small (less than 1200px). This is because for older (pre 2014 roughly) content, our image assets are not large enough here for some cases.

Note, this upscales open graph images for AMP **and regular articles** (the latter is new behaviour) where they are otherwise below the 1200px width limit. Google requires 976px for non-AMP and 1200px for AMP at the moment. Facebook recommends at least 1080px for images (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images) so upscaling all seems sensible, even though upscaling generally is undesirable (https://docs.fastly.com/api/imageopto/enable#notes). 

Original PR (now live) was here: https://github.com/guardian/frontend/pull/21457.