### PR TITLE
Search SS19

### DIFF
--- a/static/src/stylesheets/layout/nav/_search-dropdown.scss
+++ b/static/src/stylesheets/layout/nav/_search-dropdown.scss
@@ -42,7 +42,7 @@
     top: 0 !important;
 }
 
-.gsc-input-box{
+.gsc-input-box {
     border: 0 !important;
 }
 

--- a/static/src/stylesheets/layout/nav/_search-dropdown.scss
+++ b/static/src/stylesheets/layout/nav/_search-dropdown.scss
@@ -22,7 +22,7 @@
 }
 
 .gsst_a {
-    padding: 13px 0 0 11px !important;
+    padding: 9px 0 0 11px !important;
 }
 
 .sc-control-cse {
@@ -42,7 +42,11 @@
     top: 0 !important;
 }
 
-.gsc-input-box {
+.gsc-input-box{
+    border: 0 !important;
+}
+
+.gsib_a {
     border: 0 !important;
     box-shadow: none !important;
 
@@ -51,6 +55,7 @@
         margin: 0 !important;
         box-sizing: border-box !important;
         background-position-x: 40px !important;
+        // Ensures 'Custom Search' text is after Google logo
         text-indent: 90px !important;
         border: 1px solid $brightness-86 !important;
         border-radius: 999px !important;


### PR DESCRIPTION
# For the past couple of seasons our 'world famous' search has been sporting a daring look:

<img width="1168" alt="Screen Shot 2019-06-03 at 16 12 12" src="https://user-images.githubusercontent.com/14570016/58812994-d7d76500-861a-11e9-8c61-d211f3865a7a.png">

What you're looking at there is a DOUBLE search input, both rounded AND squared off - the ultimate compromise. And a cheeky little close button that got away... hovering over the 'r' in Guardian.



# As daring as this looks, it's spring/summer now, and it's time for a simpler ensemble:
<img width="1146" alt="Screen Shot 2019-06-03 at 16 11 53" src="https://user-images.githubusercontent.com/14570016/58813334-749a0280-861b-11e9-8f43-fd90458df516.png">

Given that our search is a re-skin of Google's custom search, peppered with `!important`s this **will** happen again.

Thank you, 
and stay cool!