### PR TITLE
Disabling support ask section and applying placeholder for content block injection from Braze

### DIFF
--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -13,7 +13,7 @@
                                         <tr>
                                             <td class="no-pad">
                                                 @content
-                                                <!-- Support Ask Placeholder -->
+                                                <!-- Support Ask Placeholder - Footer -->
                                                 @fragments.email.footer(page)
                                             </td>
                                         </tr>

--- a/common/app/views/fragments/page/email/body.scala.html
+++ b/common/app/views/fragments/page/email/body.scala.html
@@ -13,7 +13,7 @@
                                         <tr>
                                             <td class="no-pad">
                                                 @content
-                                                @fragments.email.support(page)
+                                                <!-- Support Ask Placeholder -->
                                                 @fragments.email.footer(page)
                                             </td>
                                         </tr>


### PR DESCRIPTION
## What does this change?
The following change disables "Support Ask" section from fronts emails and allows for content block Braze injections.
## Screenshots
N/A
## What is the value of this and can you measure success?
It will allow for the marketing team to make changes and run A/B tests on the "Support Ask" section.
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] N/A

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
