### PR TITLE
Extend lazy load images switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -25,6 +25,6 @@ object LazyLoadImages extends Experiment(
   name = "lazy-load-images",
   description = "Lazy-loaded non-main images for participants on fronts as images approach the viewport",
   owners = Seq(Owner.withGithub("nicl")),
-  sellByDate = new LocalDate(2019, 6, 3),
+  sellByDate = new LocalDate(2019, 6, 11),
   participationGroup = Perc0A
 )


### PR DESCRIPTION
To stop the build from breaking
