### PR TITLE
Enrich ProfileBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -249,7 +249,7 @@ object PageElement {
           case Some(guide: GuideAtom) => {
             Some(ProfileBlockElement(
               id = guide.id,
-              label = guide.atom.labels.headOption.getOrElse("Quick Guide"),
+              label = guide.data.typeLabel.getOrElse("Quick Guide") ,
               title = guide.atom.title.getOrElse(""),
               img = guide.image.flatMap(ImgSrc.getAmpImageUrl),
               html = guide.data.items.map(_.body).mkString(""),
@@ -260,7 +260,7 @@ object PageElement {
           case Some(profile: ProfileAtom) => {
             Some(ProfileBlockElement(
               id = profile.id,
-              label = profile.atom.labels.headOption.getOrElse("Profile"),
+              label = profile.data.typeLabel.getOrElse("Profile"),
               title = profile.atom.title.getOrElse(""),
               img = profile.image.flatMap(ImgSrc.getAmpImageUrl),
               html = profile.data.items.map(_.body).mkString(""),

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -65,7 +65,7 @@ case class TimelineBlockElement(id: String, title: String, description: Option[S
 
 case class QABlockElement(id: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
 case class GuideBlockElement(id: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
-case class ProfileBlockElement(id: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
+case class ProfileBlockElement(id: String, label: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
 
 case class MembershipBlockElement(
   originalUrl: Option[String],
@@ -249,6 +249,7 @@ object PageElement {
           case Some(guide: GuideAtom) => {
             Some(ProfileBlockElement(
               id = guide.id,
+              label = guide.atom.labels.headOption.getOrElse("Quick Guide"),
               title = guide.atom.title.getOrElse(""),
               img = guide.image.flatMap(ImgSrc.getAmpImageUrl),
               html = guide.data.items.map(_.body).mkString(""),
@@ -259,6 +260,7 @@ object PageElement {
           case Some(profile: ProfileAtom) => {
             Some(ProfileBlockElement(
               id = profile.id,
+              label = profile.atom.labels.headOption.getOrElse("Profile"),
               title = profile.atom.title.getOrElse(""),
               img = profile.image.flatMap(ImgSrc.getAmpImageUrl),
               html = profile.data.items.map(_.body).mkString(""),


### PR DESCRIPTION
## What does this change?

The DCR model case class `ProfileBlockElement` is used by `GuideAtom` and `ProfileAtom`. When being rendered on dotcom-rendering the default label "Profile" is being used, which is a problem when the `ProfileBlockElement` was instantiated by a `GuideAtom` (or when for any reason the `ProfileAtom` didn't have that label).

This change adds the correct label to `ProfileBlockElement`. This is the first of two changes, the next change will update the DCR code, to read the value.

Below pictures are before and after of the change from the DCR JSON object.

**Before**

![Screenshot 2019-06-04 at 12 25 46](https://user-images.githubusercontent.com/6035518/58876301-86d07b00-86c5-11e9-856d-3bbc54c5ab98.png)

**After**

![Screenshot 2019-06-04 at 12 25 56](https://user-images.githubusercontent.com/6035518/58876303-89cb6b80-86c5-11e9-9698-d29d7bfaba1e.png)