### PR TITLE
Document dependency with fastly cache purger [docs only]

### DIFF
--- a/article/conf/routes
+++ b/article/conf/routes
@@ -20,7 +20,10 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/03/mainsection
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
-# liveblogs, minutes
+# liveblogs, minutes. 
+# NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used
+# See https://github.com/guardian/fastly-cache-purger/blob/master/src/main/scala/com/gu/fastly/Lambda.scala 
+# and https://github.com/guardian/fastly-cache-purger/pull/14 for details
 
 GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/fastly-cache-purger/pull/14 - add docs warning people that the cache purger depends on the name of a route in dotcom.
