### PR TITLE
Add cricket world cup teams

### DIFF
--- a/common/app/conf/cricketPa/CricketTeams.scala
+++ b/common/app/conf/cricketPa/CricketTeams.scala
@@ -15,7 +15,14 @@ object CricketTeams {
   val teams: Seq[CricketTeam] = Seq(
     CricketTeam("sport/england-cricket-team", "a359844f-fc07-9cfa-d4cc-9a9ac0d5d075"),
     CricketTeam("sport/australia-cricket-team", "f7f611a1-e667-2aa2-c3e0-6dbc6981cfa4"),
-    CricketTeam("sport/indiacricketteam", "f822b9f9-9fdc-399f-54f9-e621edaf0a28")
+    CricketTeam("sport/indiacricketteam", "f822b9f9-9fdc-399f-54f9-e621edaf0a28"),
+    CricketTeam("sport/south-africa-cricket-team", "73f5d08d-0950-ca50-796a-a1cdbc9bd602"),
+    CricketTeam("sport/west-indies-cricket-team", "cc5f2bda-bfc0-f974-09dc-e4727b3681cf"),
+    CricketTeam("sport/pakistancricketteam", "d8ea81a1-538e-3cbe-f121-c65551738832"),
+    CricketTeam("sport/new-zealand-cricket-team", "110c70b5-c05f-3be7-6670-baecd50a8c6b"),
+    CricketTeam("sport/sri-lanka-cricket-team", "0cbc23be-e7cc-9574-611a-06561460eb8b"),
+    CricketTeam("sport/afghanistan-cricket-team", "8fa4bd05-1313-eaa4-3a2d-a5ba198c17da"),
+    CricketTeam("sport/bangladesh-cricket-team", "3d5e10fc-5a3f-1f06-6f1b-f86f4a7e8c10")
   )
 
   val teamTagIds: Seq[String] = teams.map(_.tagId)

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -36,7 +36,8 @@ class CricketThrottler(actorSystem: ActorSystem, materializer: Materializer) {
   private val cricketThrottlerActor: ActorRef = actorSystem.actorOf(Props(new CricketThrottlerActor()(materializer)))
 
   def throttle[T](task: () => Future[T])(implicit ec: ExecutionContext, tag: ClassTag[T]): Future[T] = {
-    implicit val timeout: Timeout = Timeout(30, TimeUnit.SECONDS)
+    // we have a long timeout to allow for the large number of requests to be made when the app starts up, at 1s/request
+    implicit val timeout: Timeout = Timeout(120, TimeUnit.SECONDS)
     (cricketThrottlerActor ? CricketThrottledTask(task)).mapTo[T]
   }
 }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -58,7 +58,7 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     val fixtures = getTeamMatches(team, "fixtures", LocalDate.now, LocalDate.now)
 
     // Get results for England over the last year.
-    val results = getTeamMatches(team, "results", LocalDate.now.minusYears(1), LocalDate.now)
+    val results = getTeamMatches(team, "results", LocalDate.now.minusMonths(6), LocalDate.now)
 
     Future.sequence(Seq(fixtures, results)).map(_.flatten)
   }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -58,7 +58,7 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     val fixtures = getTeamMatches(team, "fixtures", LocalDate.now, LocalDate.now)
 
     // Get results for England over the last year.
-    val results = getTeamMatches(team, "results", LocalDate.now.minusMonths(6), LocalDate.now)
+    val results = getTeamMatches(team, "results", LocalDate.now.minusMonths(2), LocalDate.now)
 
     Future.sequence(Seq(fixtures, results)).map(_.flatten)
   }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -44,7 +44,7 @@ class CricketStatsJob(paFeed: PaFeed) extends Logging {
 
       paFeed.getMatchIds(team).map { matchIds =>
 
-        val matches = matchIds.diff(loadedMatches).take(10)
+        val matches = matchIds.diff(loadedMatches).take(50)
 
         matches.map { matchId =>
 

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -44,7 +44,7 @@ class CricketStatsJob(paFeed: PaFeed) extends Logging {
 
       paFeed.getMatchIds(team).map { matchIds =>
 
-        val matches = matchIds.diff(loadedMatches).take(50)
+        val matches = matchIds.diff(loadedMatches).take(10)
 
         matches.map { matchId =>
 


### PR DESCRIPTION
## What does this change?
Reimplements https://github.com/guardian/frontend/pull/21467 with some changes:

 - increase the timeout of the 'throttler' (which ensures we only make 1 request to PA/second)
 - reduce the time period we are fetching games for to 2 months instead of 1 year. This is a hack to get round issues I was seeing when I initially added the 7 extra teams for the cricket world cup, with too many matches being attempted to be fetched. After the world cup or whenever we get some time we should try and tidy this up so that we can display a longer period of historical results (if we care about this!)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
