### PR TITLE
Acquisitions banner - sign-in CTA test update

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
@@ -56,5 +56,5 @@ export const acquisitionsBannerSignInCtaTemplate = (
             class="u-faux-block-link__overlay"
             target="_blank"
             href="${params.linkUrl}"
-        />
+        ></a>
     `;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
@@ -2,13 +2,13 @@
 
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { acquisitionsBannerSignInCtaTemplate } from 'common/modules/commercial/templates/acquisitions-banner-sign-in-cta';
-import { getUrl } from 'common/modules/identity/api';
+import { getUrl, isUserLoggedIn } from 'common/modules/identity/api';
 import { isBreakpoint } from 'lib/detect';
 import { constructQuery } from 'lib/url';
 
 // Only display on desktop since we want to validate test hypothesis as quickly as possible.
 // Running on tablet and mobile would require more design since banner already takes up maximum space allowed on these devices.
-const canRun: () => boolean = () => isBreakpoint({ min: 'desktop' });
+const canRun: () => boolean = () => isBreakpoint({ min: 'desktop' }) && !isUserLoggedIn();
 
 const signInUrl: () => string = () => {
     const signInQueryParams = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
@@ -8,7 +8,9 @@ import { constructQuery } from 'lib/url';
 
 // Only display on desktop since we want to validate test hypothesis as quickly as possible.
 // Running on tablet and mobile would require more design since banner already takes up maximum space allowed on these devices.
-const canRun: () => boolean = () => isBreakpoint({ min: 'desktop' }) && !isUserLoggedIn();
+// Only show to users that aren't signed in, since the non-control variant has a CTA to sign in.
+const canRun: () => boolean = () =>
+    isBreakpoint({ min: 'desktop' }) && !isUserLoggedIn();
 
 const signInUrl: () => string = () => {
     const signInQueryParams = {


### PR DESCRIPTION
## What does this change?

- only show the test introduced in #21458 to users that aren't logged in
- fix a bug which meant the engagement banner hid some of the cookie consent banner

## What is the value of this and can you measure success?

(respectively)
- since one of the variants has a CTA to sign-in, it doesn't make sense to run the test on users that are already signed in
- don't hide the cookie consent banner!

### Screenshots

No longer hiding cookie banner: 

<img width="1256" alt="double_banner" src="https://user-images.githubusercontent.com/4085817/58975451-e198ce00-87bc-11e9-8990-012ac3170101.png">

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
