### PR TITLE
Custom tracking for double banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -115,10 +115,18 @@ const show = (): Promise<boolean> => {
     trackFirstPvConsent();
     return getEngagementBannerTestToRun()
         .then(deriveEngagementBannerParams)
-        .then(params => ({
-            params,
-            html: engagementBannerParamsToHtml(params),
-        }))
+        .then(params => {
+            // A/B test information is still preserved in the dedicated abTest field
+            // But we can identify the double banner via campaignCode/componentId
+            const paramsWithCustomCampaignCode = {
+                ...params,
+                campaignCode: 'double_banner'
+            };
+            return {
+                paramsWithCustomCampaignCode,
+                html: engagementBannerParamsToHtml(paramsWithCustomCampaignCode),
+            };
+        })
         .then(paramsAndEngagementBannerHtml =>
             fastdom.write(() => {
                 const modifierClass = paramsAndEngagementBannerHtml.params

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -120,11 +120,13 @@ const show = (): Promise<boolean> => {
             // But we can identify the double banner via campaignCode/componentId
             const paramsWithCustomCampaignCode = {
                 ...params,
-                campaignCode: 'double_banner'
+                campaignCode: 'double_banner',
             };
             return {
                 paramsWithCustomCampaignCode,
-                html: engagementBannerParamsToHtml(paramsWithCustomCampaignCode),
+                html: engagementBannerParamsToHtml(
+                    paramsWithCustomCampaignCode
+                ),
             };
         })
         .then(paramsAndEngagementBannerHtml =>

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -123,7 +123,7 @@ const show = (): Promise<boolean> => {
                 campaignCode: 'double_banner',
             };
             return {
-                paramsWithCustomCampaignCode,
+                params: paramsWithCustomCampaignCode,
                 html: engagementBannerParamsToHtml(
                     paramsWithCustomCampaignCode
                 ),


### PR DESCRIPTION
Adds a custom `campaignCode` (which is also duplicated as the `componentId`) for the double banner, so we can see how much money it's making us these days and whether it's worth it