### PR TITLE
Whitelist liveblogs for AMP picker

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -1,19 +1,10 @@
 package services.dotcomponents
 
 import com.gu.contentapi.client.model.v1.{Blocks => APIBlocks}
-import common.Logging
 import controllers.ArticlePage
 import implicits.Requests._
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
-
-
-object AMPPageChecks extends Logging {
-
-  def isBasicArticle(page: PageWithStoryPackage): Boolean = {
-    page.isInstanceOf[ArticlePage] && !page.item.isPhotoEssay
-  }
-}
 
 object AMPPicker {
 
@@ -24,8 +15,12 @@ object AMPPicker {
   }
 
   private[this] def ampFeatureWhitelist(page: PageWithStoryPackage): Map[String, Boolean] = {
+    def isBasicArticle(page: PageWithStoryPackage): Boolean = {
+      page.isInstanceOf[ArticlePage] && !page.item.isPhotoEssay
+    }
+
     Map(
-      ("isBasicArticle", AMPPageChecks.isBasicArticle(page))
+      ("isBasicArticle", isBasicArticle(page))
     )
   }
 

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -14,20 +14,8 @@ object AMPPicker {
     logger.withRequestHeaders(request).results(msg, results, page)
   }
 
-  private[this] def ampFeatureWhitelist(page: PageWithStoryPackage): Map[String, Boolean] = {
-    def isBasicArticle(page: PageWithStoryPackage): Boolean = {
-      page.isInstanceOf[ArticlePage] && !page.item.isPhotoEssay
-    }
-
-    Map(
-      ("isBasicArticle", isBasicArticle(page))
-    )
-  }
-
   def getTier(page: PageWithStoryPackage, blocks: APIBlocks)(implicit request: RequestHeader): RenderType = {
-
-    val features = ampFeatureWhitelist(page)
-    val isSupported = features.forall({ case (test, isMet) => isMet})
+    val isSupported = page.article.content.shouldAmplify
     val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
     val tier = if ((isSupported && isEnabled && !request.guuiOptOut) || request.isGuui) {
@@ -37,8 +25,8 @@ object AMPPicker {
     }
 
     tier match {
-      case RemoteRenderAMP => logRequest(s"path executing in dotcomponents AMP", features, page)
-      case _ => logRequest(s"path executing in web AMP", features, page)
+      case RemoteRenderAMP => logRequest(s"path executing in dotcomponents AMP", Map.empty, page)
+      case _ => logRequest(s"path executing in web AMP", Map.empty, page)
     }
 
     tier

--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -12,9 +12,7 @@ import play.api.mvc.RequestHeader
 object AMPPageChecks extends Logging {
 
   def isBasicArticle(page: PageWithStoryPackage): Boolean = {
-    page.isInstanceOf[ArticlePage] &&
-      !page.item.isLiveBlog &&
-      !page.item.isPhotoEssay
+    page.isInstanceOf[ArticlePage] && !page.item.isPhotoEssay
   }
 
   def hasOnlySupportedElements(blocks: APIBlocks): Boolean = {
@@ -67,7 +65,11 @@ object AMPPicker {
     val isSupported = features.forall({ case (test, isMet) => isMet})
     val isEnabled = conf.switches.Switches.DotcomRenderingAMP.isSwitchedOn
 
-    val tier = if ((isSupported && isEnabled && !request.guuiOptOut) || request.isGuui) RemoteRenderAMP else LocalRender
+    val tier = if ((isSupported && isEnabled && !request.guuiOptOut) || request.isGuui) {
+      RemoteRenderAMP
+    } else {
+      LocalRender
+    }
 
     tier match {
       case RemoteRenderAMP => logRequest(s"path executing in dotcomponents AMP", features, page)


### PR DESCRIPTION
## What does this change?

Will start us rendering AMP liveblogs using the new rendering service!

## What is the value of this and can you measure success?

Will complete the migration and allow us to remove the old AMP code :)
