### PR TITLE
Support banner accessibility improvements

### DIFF
--- a/common/app/views/fragments/message.scala.html
+++ b/common/app/views/fragments/message.scala.html
@@ -1,7 +1,7 @@
 @()(implicit request: RequestHeader)
 
 <div class="site-message-overlay js-site-message-overlay is-hidden" data-link-name="release message : overlay"></div>
-<div class="site-message js-site-message is-hidden" tabindex="-1" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
+<div class="site-message js-site-message is-hidden" tabindex="-1" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message" aria-live="polite" >
     <div class="gs-container">
         <div class="site-message__inner js-site-message-inner">
             <div class="site-message__roundel">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -17,8 +17,8 @@ export const acquisitionsBannerControlTemplate = (
             <div class="engagement-banner__roundel">
                 ${marque36icon.markup}
             </div>
-            <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
-                <span class="u-h">Close</span>
+            <button tabindex="4" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close the support banner</span>
                 ${closeCentralIcon.markup}
             </button>
         </div>
@@ -28,11 +28,11 @@ export const acquisitionsBannerControlTemplate = (
                 ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
             </div>
             <div class="engagement-banner__cta">
-                <button class="button engagement-banner__button" href="${
+                <a tabindex="3" class="button engagement-banner__button" href="${
                     params.linkUrl
                 }">
                     ${params.buttonCaption}${arrowWhiteRight.markup}
-                </button>
+                </a>
                 <div class="engagement-banner__payment-logos">
                     <img
                         src="${config.get(

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -46,6 +46,7 @@ export const acquisitionsBannerControlTemplate = (
             </div>
         </div>
         <a
+            aria-hidden="true"
             class="u-faux-block-link__overlay"
             target="_blank"
             href="${params.linkUrl}"

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-mobile-design-test.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-mobile-design-test.js
@@ -13,8 +13,8 @@ export const acquisitionsBannerMobileDesignTestTemplate = (
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
     return `
         <div class="engagement-banner__close">
-            <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
-                <span class="u-h">Close</span>
+            <button tabindex="4" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close the support banner</span>
                 ${closeCentralIcon.markup}
             </button>
         </div>
@@ -27,7 +27,7 @@ export const acquisitionsBannerMobileDesignTestTemplate = (
                 ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
             </div>
             <div class="engagement-banner__cta">
-                <button class="button engagement-banner__button" href="${
+                <a tabindex="3" class="button engagement-banner__button" href="${
                     params.linkUrl
                 }">
                     <span class="engagement-banner__button-caption hide-until-tablet">${
@@ -35,7 +35,7 @@ export const acquisitionsBannerMobileDesignTestTemplate = (
                     }</span>
                     <span class="engagement-banner__button-caption hide-from-tablet">Support us</span>
                     ${arrowWhiteRight.markup}
-                </button>
+                </a>
                 <div class="engagement-banner__payment-logos">
                     <img
                         src="${config.get(
@@ -49,6 +49,7 @@ export const acquisitionsBannerMobileDesignTestTemplate = (
             </div>
         </div>
         <a
+            aria-hidden="true"
             class="u-faux-block-link__overlay"
             target="_blank"
             href="${params.linkUrl}"

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
@@ -36,7 +36,7 @@ export const acquisitionsBannerSignInCtaTemplate = (
                                 'images.acquisitions.payment-methods',
                                 ''
                             )}"
-                            alt="Accepted paym  ent methods: Visa, Mastercard, American Express and Paypal"
+                            alt="Accepted payment methods: Visa, Mastercard, American Express and Paypal"
                         >
                     </div>
                     <a tabindex="3" class="button engagement-banner__button engagement-banner__button--after-logos" href="${

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-sign-in-cta.js
@@ -13,8 +13,8 @@ export const acquisitionsBannerSignInCtaTemplate = (
             <div class="engagement-banner__roundel">
                 ${marque36icon.markup}
             </div>
-            <button class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
-                <span class="u-h">Close</span>
+            <button tabindex="5" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close the support banner</span>
                 ${closeCentralIcon.markup}
             </button>
         </div>
@@ -25,34 +25,35 @@ export const acquisitionsBannerSignInCtaTemplate = (
             </div>
             <div class="engagement-banner__cta">
                 <div class="engagement-banner__payment-cta">
-                    <button class="button engagement-banner__button engagement-banner__button--before-logos" href="${
+                    <a tabindex="3"     class="button engagement-banner__button engagement-banner__button--before-logos" href="${
                         params.linkUrl
                     }">
                         ${params.buttonCaption}${arrowWhiteRight.markup}
-                    </button>
+                    </a>
                     <div class="engagement-banner__payment-logos">
                         <img
                             src="${config.get(
                                 'images.acquisitions.payment-methods',
                                 ''
                             )}"
-                            alt="Accepted payment methods: Visa, Mastercard, American Express and Paypal"
+                            alt="Accepted paym  ent methods: Visa, Mastercard, American Express and Paypal"
                         >
                     </div>
-                    <button class="button engagement-banner__button engagement-banner__button--after-logos" href="${
+                    <a tabindex="3" class="button engagement-banner__button engagement-banner__button--after-logos" href="${
                         params.linkUrl
                     }">
                         ${params.buttonCaption}${arrowWhiteRight.markup}
-                    </button>
+                    </a>
                 </div>
                 <div class="engagement-banner__sign-in-cta">
-                    <a class="engagement-banner__sign-in-cta-link u-underline js-engagement-banner-close-button" href="${
+                    <a tabindex="4" class="engagement-banner__sign-in-cta-link u-underline js-engagement-banner-close-button" href="${
                         params.signInUrl ? params.signInUrl : ''
                     }">Already a supporter? Sign in</a>
                 </div>
             </div>
         </div>
         <a
+            aria-hidden="true"
             class="u-faux-block-link__overlay"
             target="_blank"
             href="${params.linkUrl}"

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -26,7 +26,7 @@ const doubleBannerHtml = (
     engagementBannerHtml: string,
     customClass: string
 ): string => `
-    <div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner" tabindex="-1" role="dialog" aria-label="welcome" aria-describedby="site-message__message" data-component="AcquisitionsEngagementBannerStylingTweaks_control">
+    <div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner" tabindex="-1" role="dialog" aria-label="welcome" aria-describedby="site-message__message" data-component="AcquisitionsEngagementBannerStylingTweaks_control" aria-live="polite">
         <div class="js-engagement-banner-site-message ${customClass} site-message--engagement-banner">
             <div class="gs-container">
                 <div class="site-message__inner js-site-message-inner">

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -96,7 +96,7 @@
 .engagement-banner__button {
     display: inline-block;
     vertical-align: middle;
-
+    overflow: hidden;
     height: 36px;
     padding: 0 ($gs-gutter / 3) 0 18px;
     margin-right: $gs-gutter / 4;
@@ -125,6 +125,11 @@
     @include mq(tablet) {
         display: block;
         margin-bottom: 8px;
+    }
+
+    &:focus {
+        outline: auto;
+        outline-color: $brightness-7;
     }
 }
 
@@ -192,6 +197,10 @@
     &:focus,
     &:active {
         background: rgba($brightness-7,  .05);
+    }
+
+    &:focus {
+        outline: auto;
     }
 }
 


### PR DESCRIPTION
## What does this change?
- `tabindex` set on support banner links to make them focusable. The indices prioritize the support banner below the cookie banner and above the page content
- Visible focus states added so that it's clear to keyboard users when an element is selected
- Incorrect HTML semantics corrected so that links are followable when a keyboard user would like to follow them
- `aria-live="polite"` added to site message elements
- copy for close button on engagement banner updated so it's more descriptive
- `aria-hidden` added to the banner link overlay

## What is the value of this and can you measure success?
Working towards an ever more accessible Guardian

## Checklist


### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [  ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ X ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [  ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ X ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
