### PR TITLE
use dev-nginx project for local nginx setup

### DIFF
--- a/nginx/Brewfile
+++ b/nginx/Brewfile
@@ -1,3 +1,2 @@
-brew "nginx"
-brew "mkcert"
-brew "nss"
+tap "guardian/devtools"
+brew "guardian/devtools/dev-nginx"

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -11,12 +11,11 @@ __Mac:__ [Install Homebrew:](http://brew.sh/#install)
 __Other operating systems:__
 You need to install:
 - nginx
-- [mkcert](https://github.com/FiloSottile/mkcert)
+- [dev-nginx](https://github.com/guardian/dev-nginx)
 
 
 ## Configure Nginx with SSL
 
-1. Ensure you have the correct [hosts](hosts) included in `/etc/hosts` file on your machine
-1. Run `sudo nginx/setup.sh`
+1. Run `nginx/setup.sh`
 1. To setup Dotcom Identity Fronted follow [identity-platform README](https://github.com/guardian/identity-platform)
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -6,43 +6,13 @@ set -e
 YELLOW='\033[1;33m'
 NC='\033[0m' # no colour - reset console colour
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-NGINX_HOME=$(nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g')
 DOMAIN='m.thegulocal.com'
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-CERT_DIRECTORY=$HOME/.gu/mkcert
-KEY_FILE=${CERT_DIRECTORY}/${DOMAIN}.key
-CERT_FILE=${CERT_DIRECTORY}/${DOMAIN}.crt
-
-# mkcert requires the JAVA_HOME envvar to be set to add the generated CA to Java's trust store
-# see https://github.com/FiloSottile/mkcert#supported-root-stores
-export JAVA_HOME=$(/usr/libexec/java_home)
-
-mkcert -install
-
-echo -e "🔐 Creating certificate for: ${YELLOW}$@${NC}"
-mkdir -p ${CERT_DIRECTORY}
-mkcert -key-file=${KEY_FILE} -cert-file=${CERT_FILE} ${DOMAIN}
-
-echo -e "🔗 Symlinking the certificate for nginx at ${NGINX_HOME}"
-ln -sf ${KEY_FILE} ${NGINX_HOME}/${DOMAIN}.key
-ln -sf ${CERT_FILE} ${NGINX_HOME}/${DOMAIN}.crt
-
-echo -e "🔗 Symlinking nginx config file"
-ln -sf ${SOURCE_DIR}/frontend.conf ${NGINX_HOME}/servers/frontend.conf
-
-echo -e "🚀 ${YELLOW}Restarting nginx, Requires sudo - enter password when prompted.${NC}"
-if pgrep 'nginx' > /dev/null; then
-  sudo nginx -s stop
-fi
-sudo nginx
-
-if grep '127.0.0.1' /etc/hosts | grep ${DOMAIN} ; then
-  echo -e "✅ /etc/hosts entry already exists for ${DOMAIN}"
-else
-  echo -e "🔧 ${YELLOW}adding /etc/hosts entry for ${DOMAIN}. Requires sudo - enter password when prompted.${NC}"
-  sudo sh -c "echo '127.0.0.1		${DOMAIN}' >> /etc/hosts"
-fi
+dev-nginx setup-cert ${DOMAIN}
+dev-nginx link-config ${SOURCE_DIR}/frontend.conf
+dev-nginx add-to-hosts-file ${DOMAIN}
+dev-nginx restart-nginx
 
 echo -e "💯 Done! You can now run frontend locally on https://${DOMAIN}"
 echo -e "👤 To setup Dotcom Identity Frontend please follow identity-platform README."

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -11,7 +11,6 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 dev-nginx setup-cert ${DOMAIN}
 dev-nginx link-config ${SOURCE_DIR}/frontend.conf
-dev-nginx add-to-hosts-file ${DOMAIN}
 dev-nginx restart-nginx
 
 echo -e "💯 Done! You can now run frontend locally on https://${DOMAIN}"


### PR DESCRIPTION
## What does this change?
Following on from https://github.com/guardian/frontend/pull/21455, use the dev-nginx tool and simplifies setup script.

Depends on:
- https://github.com/guardian/dev-nginx/pull/5
- https://github.com/guardian/homebrew-devtools/pull/35

## Screenshots
![img](https://media.giphy.com/media/AiTautetbU6S65X5LE/giphy.gif)

## What is the value of this and can you measure success?
Fewer LOC?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
