### PR TITLE
Expand EmbedBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -31,7 +31,7 @@ case class VideoBlockElement(caption:String, url:String, originalUrl:String, hei
 case class VideoYoutubeBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
 case class VideoVimeoBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
 case class VideoFacebookBlockElement(caption:String, url:String, originalUrl:String, height:Int, width:Int, role: Role) extends PageElement
-case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
+case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean, pageUrl: String) extends PageElement
 case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, isMandatory: Boolean) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
 case class YoutubeBlockElement(id: String, assetId: String, channelId: Option[String], mediaTitle: String) extends PageElement
@@ -172,8 +172,7 @@ object PageElement {
         ))
 
       case Audio => extractAudio(element).toList
-
-
+        
       case Video =>
         if (element.assets.nonEmpty) {
           List(GuVideoBlockElement(
@@ -215,7 +214,7 @@ object PageElement {
         )
       }).toList
 
-      case Embed => extractEmbed(element).toList
+      case Embed => extractEmbed(element, pageUrl).toList
 
       case Contentatom =>
         (extractAtom match {
@@ -342,13 +341,13 @@ object PageElement {
     }
   }
 
-  private def extractEmbed(element: ApiBlockElement): Option[PageElement] = {
+  private def extractEmbed(element: ApiBlockElement, pageUrl: String): Option[PageElement] = {
     for {
       d <- element.embedTypeData
       html <- d.html
       mandatory = d.isMandatory.getOrElse(false)
     } yield {
-      extractSoundcloud(html, mandatory) getOrElse EmbedBlockElement(html, d.safeEmbedCode, d.alt, mandatory)
+      extractSoundcloud(html, mandatory) getOrElse EmbedBlockElement(html, d.safeEmbedCode, d.alt, mandatory, pageUrl)
     }
   }
 


### PR DESCRIPTION
## What does this change?

This change adds a new field to PageElement `EmbedBlockElement`: the path of the current request. 

We do this because we want to start showing to the readers, in this case AMP readers, a link to the article page of embeds which can't be shown. Several solutions were possible but this one is the one that is the most _natural_. 

Note that (to make this very clear) that the value of this field is the path of the request. This explain while during testing we have 

```
{
    "html": "(...)",
    "safe": false,
    "alt": "Test content",
    "isMandatory": false,
    "pageUrl": "/path/to/page.json?guui",
    "_type": "model.dotcomrendering.pageElements.EmbedBlockElement"
}
```

This is the first of two changes, the other one will modify the DCR code with the necessary rendering code. 