### PR TITLE
New epic config items: minArticleViews and articleCountDays

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -128,8 +128,8 @@ declare type InitEpicABTest = {
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
     hasCountryName?: boolean,
-    minArticleViews?: number,
-    articleCountDays?: number,
+    minArticleViews?: ?number,
+    articleCountDays?: ?number,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -128,6 +128,8 @@ declare type InitEpicABTest = {
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
     hasCountryName?: boolean,
+    minArticleViews?: number,
+    articleCountDays?: number,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/lib/string-utils.js
+++ b/static/src/javascripts/lib/string-utils.js
@@ -16,6 +16,9 @@ export const optionalSplitAndTrim = (
 export const optionalStringToBoolean = (str: ?string): boolean =>
     typeof str === 'string' ? str.toLowerCase().trim() === 'true' : false;
 
+export const optionalStringToNumber = (str: ?string): ?number =>
+    str && !Number.isNaN(Number(str)) ? Number(str) : undefined;
+
 export const throwIfEmptyString = (name: string, str: ?string): string => {
     if (typeof str === 'string' && str.trim().length > 0) {
         return str;

--- a/static/src/javascripts/lib/string-utils.spec.js
+++ b/static/src/javascripts/lib/string-utils.spec.js
@@ -6,6 +6,10 @@ describe('optionalStringToNumber', () => {
         expect(optionalStringToNumber('3')).toBe(3);
     });
 
+    it('should return 0', () => {
+        expect(optionalStringToNumber('0')).toBe(0);
+    });
+
     it('should return undefined if undefined', () => {
         expect(optionalStringToNumber(undefined)).toBe(undefined);
     });

--- a/static/src/javascripts/lib/string-utils.spec.js
+++ b/static/src/javascripts/lib/string-utils.spec.js
@@ -1,0 +1,16 @@
+// @flow
+import { optionalStringToNumber } from 'lib/string-utils';
+
+describe('optionalStringToNumber', () => {
+    it('should return a number', () => {
+        expect(optionalStringToNumber('3')).toBe(3);
+    });
+
+    it('should return undefined if undefined', () => {
+        expect(optionalStringToNumber(undefined)).toBe(undefined);
+    });
+
+    it('should return undefined if NaN', () => {
+        expect(optionalStringToNumber('')).toBe(undefined);
+    });
+});

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -594,12 +594,12 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                     const rowWithArticleViews = rows.find(
                         row => row.minArticleViews && row.articleCountDays
                     );
-                    const minArticleViews = rowWithArticleViews
+                    const minArticleViews: ?number = rowWithArticleViews
                         ? optionalStringToNumber(
                               rowWithArticleViews.minArticleViews
                           )
                         : undefined;
-                    const articleCountDays = rowWithArticleViews
+                    const articleCountDays: ?number = rowWithArticleViews
                         ? optionalStringToNumber(
                               rowWithArticleViews.articleCountDays
                           )
@@ -619,7 +619,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         audienceCriteria: 'All',
                         audience,
                         audienceOffset,
-                        useLocalViewLog: rows.find(row =>
+                        useLocalViewLog: rows.some(row =>
                             optionalStringToBoolean(row.useLocalViewLog)
                         ),
                         userCohort,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -590,7 +590,14 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                         optionalStringToBoolean(row.hasCountryName)
                     );
 
-                    // Expect minArticleViews and articleCountDays to appear together or not at all
+                    /**
+                     * Expect minArticleViews and articleCountDays to appear together or not at all.
+                     *
+                     * The user must have viewed minArticleViews articles in the last articleCountDays.
+                     *
+                     * The placeholder %%ARTICLES_READ%% is replaced with a value based on articleCountDays
+                     * and their gu.history.dailyArticleCount state.
+                     */
                     const rowWithArticleViews = rows.find(
                         row => row.minArticleViews && row.articleCountDays
                     );


### PR DESCRIPTION
## What does this change?
We want to show a count of the user's article views in the epic. This was partly added in a previous PR, with the ability to set `%%ARTICLES_READ%%` in the copy.

We also need to:
1. Set the period, in days, in which to count article views (`articleCountDays`),
2. Only put the user in the test if they have read a certain number of articles in that time (`minArticleViews`)

Both of these items must be set on a test for this feature to work.

## Screenshots
<img width="633" alt="Screenshot 2019-06-07 at 14 55 25" src="https://user-images.githubusercontent.com/1513454/59112373-cce24480-893a-11e9-9ebd-c31d731ee5cd.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
