### PR TITLE
Fixing sign-in icon z-index

### DIFF
--- a/static/src/stylesheets/layout/nav/_top-bar.scss
+++ b/static/src/stylesheets/layout/nav/_top-bar.scss
@@ -72,10 +72,10 @@
 .new-header__user-account-container {
     float: left;
     position: relative;
-    z-index: $zindex-main-menu + 2;
+    z-index: $zindex-ads;
 
     .new-header--open & {
         // Needs to sit below the menu, and the veggie burger
-        z-index: $zindex-main-menu - 2;
+        z-index: $zindex-ads;
     }
 }


### PR DESCRIPTION
## What does this change?
Before:
![Screen Shot 2019-06-07 at 16 00 33](https://user-images.githubusercontent.com/2051501/59113781-9fe36100-893d-11e9-8c5c-6d6efbbdef8d.png)
After:
![Screen Shot 2019-06-07 at 16 00 10](https://user-images.githubusercontent.com/2051501/59113780-9fe36100-893d-11e9-9e3e-200df67fd5bb.png)


