### PR TITLE
Bumped up H2 font size at mobile

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -58,12 +58,8 @@
         margin-bottom: .8em;
     }
     > h2 {
-        @include fs-header(2);
-
-        @include mq(tablet) {
-            @include fs-header(3, true);
-            margin-bottom: 1px;
-        }
+        @include fs-header(3);
+        margin-bottom: 1px;
     }
     > h3 {
         @include fs-bodyHeading(2);


### PR DESCRIPTION
Article H2 elements pre-tablet are the same font size as the body copy, this means they're indistinguishable from a bold p tag. I have bumped them up to the next available size to restore hierarchy. 