### PR TITLE
Add women's world cup to football tables.

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -20,7 +20,9 @@ class LeagueTableController(
   val controllerComponents: ControllerComponents
 )(implicit context: ApplicationContext) extends BaseController with Logging with CompetitionTableFilters with ImplicitControllerExecutionContext {
 
-    val tableOrder = Seq(
+  // Competitions must be added to this list to show up at /football/tables
+    val tableOrder: Seq[String] = Seq(
+        "Women's World Cup 2019",
         "Premier League",
         "Women's Super League",
         "La Liga",


### PR DESCRIPTION
## What does this change?
Adds women's world cup to the league table controller so that we can see the results table here: https://www.theguardian.com/football/premierleague/table

## Screenshots
![Screenshot 2019-06-10 at 12 07 00](https://user-images.githubusercontent.com/3606555/59191770-4dda4f80-8b78-11e9-904a-3c58c677bdf8.png)
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->