### PR TITLE
Support embeds in new AMP

### DIFF
--- a/article/app/services/dotcomponents/AMPPicker.scala
+++ b/article/app/services/dotcomponents/AMPPicker.scala
@@ -35,6 +35,7 @@ object AMPPageChecks extends Logging {
       case Audio => true
       case Interactive => true
       case MapElement => true
+      case Embed => true
       case _: ElementType => false
     }
 


### PR DESCRIPTION
Our current embed behaviour is just to ignore the embed unless it is mandatory in which case we error. But many embeds are just email signup forms so this isn't usually an issue.

## What does this change?

Supports embed elements in new AMP.

## Screenshots

N/A.

## What is the value of this and can you measure success?

Helps us get to 100%. We can measure the % increase in traffic post live, but it is small (less than 2%).

Example of a typical embed that we don't need on AMP but currently blocks rendering on the new platform:

![Screenshot 2019-06-10 at 17 38 14](https://user-images.githubusercontent.com/858402/59211720-767a3d80-8ba8-11e9-912a-b3ddccbfa003.png)
