### PR TITLE
Adding US elections 2020 to nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -16,6 +16,7 @@ private object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = "US news")
   val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = "US politics")
+  val usElections2020 = NavLink("Elections 2020", "/us-news/us-elections-2020", longTitle = "Elections 2020")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -239,6 +240,7 @@ private object NavLinks {
   )
   val usNewsPillar = ukNewsPillar.copy(children = List(
       usNews,
+      usElections2020,
       world,
       ukEnvironment,
       soccer,


### PR DESCRIPTION
## What does this change?
Adds the Elections 2020 link in the US edition nav links.

![Screen Shot 2019-06-11 at 09 11 50](https://user-images.githubusercontent.com/2051501/59255127-66ef0900-8c29-11e9-8ce8-3eb0ddadf157.png)

