### PR TITLE
Add inskin targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,7 +1,11 @@
 // @flow strict
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
-import { getReferrer as detectGetReferrer, getBreakpoint } from 'lib/detect';
+import {
+    getReferrer as detectGetReferrer,
+    getBreakpoint,
+    getViewport,
+} from 'lib/detect';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { local } from 'lib/storage';
 import { getUrlVars } from 'lib/url';
@@ -36,6 +40,13 @@ const findBreakpoint = (): string => {
         default:
             return 'mobile';
     }
+};
+
+const inskinTargetting = (): string => {
+    // eslint-disable-next-line no-console
+    console.log('WIDTH', getViewport().width);
+    if (getViewport().width >= 1560) return 't';
+    return 'f';
 };
 
 const format = (keyword: string): string =>
@@ -223,6 +234,7 @@ const buildPageTargeting = once(
                 cc: geolocationGetSync(),
                 s: page.section, // for reference in a macro, so cannot be extracted from ad unit
                 pr: 'dotcom-platform', // rendering platform
+                inskin: inskinTargetting(),
             },
             page.sharedAdTargeting,
             paTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -43,9 +43,8 @@ const findBreakpoint = (): string => {
 };
 
 const inskinTargetting = (): string => {
-    // eslint-disable-next-line no-console
-    console.log('WIDTH', getViewport().width);
-    if (getViewport().width >= 1560) return 't';
+    const vp = getViewport();
+    if (vp && vp.width >= 1560) return 't';
     return 'f';
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -33,6 +33,7 @@ jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
 }));
 jest.mock('lib/detect', () => ({
+    getViewport: jest.fn(),
     getBreakpoint: jest.fn(),
     getReferrer: jest.fn(),
     hasPushStateSupport: jest.fn(),
@@ -216,6 +217,7 @@ describe('Build Page Targeting', () => {
             ab: ['MtMaster-variantName'],
             pv: '123456',
             fr: '0',
+            inskin: 'f',
             cc: 'US',
             pr: 'dotcom-platform',
         });


### PR DESCRIPTION
## What does this change?
Currently inskin's page skins are loaded on all viewport widths. On viewports below 1560 pixels wide the sides of the skin don't show correctly, cutting off some of the messaging. This change uses page targeting to prevent inskin's creatives being served by DFP when the page width is below 1560 pixels. This is achieved by adding the following key/value pair:

**key**: inskin
**value**: 't' if viewport width >= 1560px, 'f' otherwise.

## Screenshots

![Screenshot 2019-06-11 at 11 29 10](https://user-images.githubusercontent.com/48949546/59264955-36649a80-8c3c-11e9-8c92-5c59c722968c.png)


## What is the value of this and can you measure success?
This will prevent the serving of inskin creatives when they don't fit the page correctly, making for a better user experience and avoiding the loading on unnecessary creative.


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)