### PR TITLE
Remove terms ladies and women from team name

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -154,7 +154,7 @@ object CompetitionDisplayHelpers {
 
   // This function is applied to team names during the making of matches lists.
   // It should be without effects for men competitions. For women competitions it
-  // rewrite, for instance, "Norway Ladies" into "Norway Women".
+  // removes the term from the PA data we receive.
   def cleanTeamName(teamName: String): String = {
     teamName.replace("Ladies", "")
   }

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -156,6 +156,6 @@ object CompetitionDisplayHelpers {
   // It should be without effects for men competitions. For women competitions it
   // rewrite, for instance, "Norway Ladies" into "Norway Women".
   def cleanTeamName(teamName: String): String = {
-    teamName.replace("Ladies", "Women")
+    teamName.replace("Ladies", "")
   }
 }


### PR DESCRIPTION
Rather than replacing the term ladies, which we receive from PA, with women, sport are asking us to remove the suffix altogether.