### PR TITLE
AMP use first published

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -48,7 +48,7 @@ case class Block(
     createdOn: Option[Long],
     createdOnDisplay: Option[String],
     lastUpdatedDisplay: Option[String],
-    publishedOnDisplay: Option[String],
+    firstPublishedDisplay: Option[String],
     title: Option[String],
 )
 
@@ -245,7 +245,7 @@ object DotcomponentsDataModel {
       val createdOn = block.createdDate.map(_.dateTime)
       val createdOnDisplay = createdOn.map(dt => format(dt, edition))
       val lastUpdatedDisplay = block.lastModifiedDate.map(dt => format(dt.dateTime, edition))
-      val publishedOnDisplay = block.publishedDate.map(dt => format(dt.dateTime, edition))
+      val firstPublishedDisplay = block.firstPublishedDate.orElse(block.createdDate).map(dt => format(dt.dateTime, edition))
 
       Block(
         id = block.id,
@@ -255,7 +255,7 @@ object DotcomponentsDataModel {
         createdOnDisplay = createdOnDisplay,
         lastUpdatedDisplay = lastUpdatedDisplay,
         title = block.title,
-        publishedOnDisplay = publishedOnDisplay,
+        firstPublishedDisplay = firstPublishedDisplay,
       )
     }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -48,6 +48,7 @@ case class Block(
     createdOn: Option[Long],
     createdOnDisplay: Option[String],
     lastUpdatedDisplay: Option[String],
+    firstPublished: Option[Long],
     firstPublishedDisplay: Option[String],
     title: Option[String],
 )
@@ -245,7 +246,8 @@ object DotcomponentsDataModel {
       val createdOn = block.createdDate.map(_.dateTime)
       val createdOnDisplay = createdOn.map(dt => format(dt, edition))
       val lastUpdatedDisplay = block.lastModifiedDate.map(dt => format(dt.dateTime, edition))
-      val firstPublishedDisplay = block.firstPublishedDate.orElse(block.createdDate).map(dt => format(dt.dateTime, edition))
+      val firstPublished = block.firstPublishedDate.orElse(block.createdDate).map(_.dateTime)
+      val firstPublishedDisplay = firstPublished.map(dt => format(dt, edition))
 
       Block(
         id = block.id,
@@ -255,6 +257,7 @@ object DotcomponentsDataModel {
         createdOnDisplay = createdOnDisplay,
         lastUpdatedDisplay = lastUpdatedDisplay,
         title = block.title,
+        firstPublished = firstPublished,
         firstPublishedDisplay = firstPublishedDisplay,
       )
     }


### PR DESCRIPTION
Correction to https://github.com/guardian/frontend/pull/21511 to use `firstPublished` rather than `publishedOn`. Also adds an unformatted version as we need this for block sorting with the amp-live-list component.

We should be able to removed the `createdOn*` fields after this goes live and DCR is updated.