### PR TITLE
Enable upscaling on opengraph images

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -144,7 +144,7 @@ final case class Content(
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImageProfile: ElementProfile = {
     val category = shareImageCategory
-    OpenGraphImage.forCategory(category, FacebookShareImageLogoOverlay.isSwitchedOn)
+    OpenGraphImage.forCategory(category, shouldIncludeOverlay = FacebookShareImageLogoOverlay.isSwitchedOn, shouldUpscale = true)
   }
 
   lazy val openGraphImage: String = ImgSrc(openGraphImageOrFallbackUrl, openGraphImageProfile)


### PR DESCRIPTION
Somehow I forgot to enable this when adding the original code - original PR here: https://github.com/guardian/frontend/pull/21457

At the moment we are getting a lot of warnings on structured data with Google for AMP because we are serving images that are below their recommended size (1200px). But outside AMP it is worthwhile too in order to ensure we meet FB and Google recommended sizes for regular content too.
