### PR TITLE
Revert "Revert "Adding US elections 2020 to nav""

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -16,6 +16,7 @@ private object NavLinks {
   val indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx")
   val usNews = NavLink("US", "/us-news", longTitle = "US news")
   val usPolitics = NavLink("US Politics", "/us-news/us-politics", longTitle = "US politics")
+  val usElections2020 = NavLink("Elections 2020", "/us-news/us-elections-2020", longTitle = "Elections 2020")
 
   val education = {
     val teachers = NavLink("Teachers", "/teacher-network")
@@ -239,6 +240,7 @@ private object NavLinks {
   )
   val usNewsPillar = ukNewsPillar.copy(children = List(
       usNews,
+      usElections2020,
       world,
       ukEnvironment,
       soccer,


### PR DESCRIPTION
Adds the US election 2020 link properly. Please don't merge until thusday lunchtime.

Reverts guardian/frontend#21517
