### PR TITLE
Applying DPI fix for outlook email clients

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -25,6 +25,6 @@ object LazyLoadImages extends Experiment(
   name = "lazy-load-images",
   description = "Lazy-loaded non-main images for participants on fronts as images approach the viewport",
   owners = Seq(Owner.withGithub("nicl")),
-  sellByDate = new LocalDate(2019, 6, 11),
+  sellByDate = new LocalDate(2019, 7, 3),
   participationGroup = Perc0A
 )

--- a/common/app/views/fragments/page/email/head.scala.html
+++ b/common/app/views/fragments/page/email/head.scala.html
@@ -2,6 +2,10 @@
 @import common.{LinkTo, CanonicalLink}
 @import views.support.EmailHelpers.Images.footerG
 <head>
+    @*
+    * Outlook doesn't scale images properly when DPI scaling is enabled.
+    * More info about the fix can be found here: https://litmus.com/community/snippets/112-outlook-2013-120dpi-make-images-scale-properly
+    *@
     <!--[if gte mso 9]>
     <xml>
         <o:OfficeDocumentSettings>

--- a/common/app/views/fragments/page/email/head.scala.html
+++ b/common/app/views/fragments/page/email/head.scala.html
@@ -2,6 +2,14 @@
 @import common.{LinkTo, CanonicalLink}
 @import views.support.EmailHelpers.Images.footerG
 <head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width"/>
     <meta name="robots" content="noindex">

--- a/common/app/views/fragments/page/email/htmlTag.scala.html
+++ b/common/app/views/fragments/page/email/htmlTag.scala.html
@@ -2,6 +2,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+xmlns:o="urn:schemas-microsoft-com:office:office" lang="en" xml:lang="en">
     @stacked(fragments:_*)
 </html>


### PR DESCRIPTION
## What does this change?
The following change helps images scale properly on Outlook with 120DPI enabled. More info can be found here: https://litmus.com/community/snippets/112-outlook-2013-120dpi-make-images-scale-properly.
## Screenshots
DPI issue before fix

![3 _DPI_issue_before_fix](https://user-images.githubusercontent.com/47107438/59285002-2614e580-8c65-11e9-97eb-ea9a31203502.png)
DPI issue after fix

![3 _DPI_issue_fixed](https://user-images.githubusercontent.com/47107438/59285051-3cbb3c80-8c65-11e9-923f-ad7fe6621c42.png)

## What is the value of this and can you measure success?
It improves the rendering and scaling of the images on Outlook with 120DPI enabled.
## Checklist
N/A
### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] N/A

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
