### PR TITLE
Pillars in the footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -24,8 +24,26 @@
     </div>
 
     <div class="l-footer__secondary js-footer__secondary @if(EmailInlineInFooterSwitch.isSwitchedOff) {l-footer__secondary--no-email} gs-container" role="contentinfo">
-        <div class="colophon u-cf">
+        <div class="footer__pillars u-cf">
+            @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+                <ul class="pillars pillars--footer">
+                    @navMenu.pillars.map { link =>
+                        <li class="pillars__item">
+                            <a class="@RenderClasses(Map(
+                                "pillar-link--current-section" -> ((link.title == navMenu.currentPillar.map(_.title).getOrElse("")))
+                                ), "pillar-link", s"pillar-link--${link.title}")"
+                            href="@LinkTo(link.url)"
+                            data-link-name="nav2 : primary : @link.title">
 
+                            @link.title
+                            </a>
+                        </li>
+                    }
+            }
+        </div>
+
+
+        <div class="colophon u-cf">
             @defining(Edition(request)) { currentEdition =>
                 @if(EmailInlineInFooterSwitch.isSwitchedOn && !isAmp && !page.metadata.isFoundation) {
                     <div class="footer__email-container js-footer__email-container">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -33,7 +33,7 @@
                                 "pillar-link--current-section" -> ((link.title == navMenu.currentPillar.map(_.title).getOrElse("")))
                                 ), "pillar-link", s"pillar-link--${link.title}")"
                             href="@LinkTo(link.url)"
-                            data-link-name="nav2 : primary : @link.title">
+                            data-link-name="footer : primary : @link.title">
 
                             @link.title
                             </a>

--- a/static/src/stylesheets/layout/footer/_colophon.scss
+++ b/static/src/stylesheets/layout/footer/_colophon.scss
@@ -1,7 +1,10 @@
 .colophon {
-    @include content-gutter();
-    padding-bottom: $gs-baseline * 2;
     border-bottom: 1px solid $brand-pastel;
+    padding: 0 9px ($gs-baseline * 2);
+
+    @include mq(mobileLandscape) {
+        padding: 0 19px ($gs-baseline * 2);
+    }
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline / 2;

--- a/static/src/stylesheets/layout/footer/_footer.scss
+++ b/static/src/stylesheets/layout/footer/_footer.scss
@@ -7,3 +7,8 @@
     @include fs-textSans(1);
     box-sizing: border-box;
 }
+
+.footer__pillars {
+    border: 1px solid $brand-pastel;
+    border-top: 0;
+}

--- a/static/src/stylesheets/layout/footer/_footer.scss
+++ b/static/src/stylesheets/layout/footer/_footer.scss
@@ -11,4 +11,5 @@
 .footer__pillars {
     border: 1px solid $brand-pastel;
     border-top: 0;
+    padding-bottom: $gs-baseline;
 }


### PR DESCRIPTION
## What does this change?
The pillars are now in the footer, making for a more coherent navigation top and bottom. 

<img width="1664" alt="Screen Shot 2019-06-12 at 12 01 13" src="https://user-images.githubusercontent.com/14570016/59346285-db997480-8d09-11e9-8dff-b8ba2d10c3bd.png">

Have tried to write as little new css as possible... 
