### PR TITLE
Correctly encode json in url query params

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -57,8 +57,8 @@ object UrlHelpers {
   )
 
   private val uriEncoder = UriConfig.default.copy(
-    // The default encoder is not enough for json in URL query strings
-    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE ++ Set('"', ':', ',') )
+    // The default encoder does not encode double quotes in the querystring
+    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"')
   )
 
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): String = {

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,9 +1,12 @@
 package navigation
 
+import com.netaporter.uri.config.UriConfig
+import com.netaporter.uri.encoding.PercentEncoder
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
 import navigation.ReaderRevenueSite._
+
 import PartialFunction.condOpt
 
 object UrlHelpers {
@@ -53,6 +56,11 @@ object UrlHelpers {
     NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe"))
   )
 
+  private val uriEncoder = UriConfig.default.copy(
+    // The default encoder is not enough for json in URL query strings
+    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE ++ Set('"', ':', ',') )
+  )
+
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position)(implicit request: RequestHeader): String = {
     val componentId = getComponentId(destination, position)
     val componentType = getComponentType(position)
@@ -72,7 +80,8 @@ object UrlHelpers {
 
     // INTCMP is passed as a separate param because people look at it in Google Analytics
     // It's set to the most specific thing (componentId) to maximise its usefulness
-    destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
+    val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
+    url.toString(uriEncoder)
   }
 
   def getJobUrl(editionId: String): String =


### PR DESCRIPTION
## What does this change?
We send ophan tracking data as json in the url querystring.
The reader revenue links in the header and footer do not correctly encode the querystrings. This is because [the library we use does not encode the full set of chars](https://github.com/lemonlabsuk/scala-uri/blob/master/shared/src/main/scala/io/lemonlabs/uri/encoding/PercentEncoder.scala#L34) that are required.

We have a suspicion that this might be related to some weird requests being received by support-frontend, which appear to be coming from web crawlers.

E.g.
Before:
`href="https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B&quot;source&quot;:&quot;GUARDIAN_WEB&quot;,&quot;componentType&quot;:&quot;ACQUISITIONS_HEADER&quot;,&quot;componentId&quot;:&quot;header_support_contribute&quot;%7D"`

After:
`href="https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support_contribute%22%7D"`

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
