### PR TITLE
Localise discount code links based off the path

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -191,7 +191,7 @@ private object NavLinks {
   val auEvents = NavLink("Events", "/guardian-live-australia")
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
-  val discountCodes = NavLink("Discount Codes", s"https://discountcode.theguardian.com")
+  val discountCodes = NavLink("Discount Codes", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -120,7 +120,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item js-discount-code-link"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -192,7 +192,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item js-discount-code-link"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -269,7 +269,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item js-discount-code-link"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -333,7 +333,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
+                                    <li class="colophon__item js-discount-code-link"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
                                         Discount Codes</a>
                                     </li>
                                 </ul>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -120,7 +120,7 @@
                                     <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
                                         Patrons</a>
                                     </li>
-                                    <li class="colophon__item js-discount-code-link"><a data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -192,7 +192,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item js-discount-code-link"><a data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>
@@ -269,7 +269,7 @@
                                     </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
                                         Dating</a>
-                                    <li class="colophon__item js-discount-code-link"><a data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/">
+                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/">
                                         Discount Codes</a>
                                     </li>
                                 </ul>

--- a/common/app/views/fragments/nav/headerMenu.scala.html
+++ b/common/app/views/fragments/nav/headerMenu.scala.html
@@ -47,7 +47,7 @@
 @brandExtensions(item: NavLink) = {
     <li class="menu-item--brand-extension">
         <a href="@LinkTo { @item.url }"
-           class="menu-item__title menu-item__title--brand-extension"
+           class="@{"menu-item__title menu-item__title--brand-extension " ++ item.classList.mkString(" ")}"
            data-link-name="nav2 : brand extension : @item.title">
             @{item.title}
         </a>

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -80,21 +80,28 @@ const enableMegaNavToggle = (): void => {
 };
 
 const getDiscountCodePath = (path: string): string => {
-    const firstPart = path.split("/")[1];
-    if (firstPart === "us" || firstPart === "us-news") {
-        return "us";
-    } else if (firstPart === "uk" || firstPart === "uk-news") {
-        return "uk";
-    } else if (firstPart ==="au" || firstPart === "australia-news") {
-        return "au";
-    } else return "";
-}
+    const firstPart = path.split('/')[1];
+    if (firstPart === 'us' || firstPart === 'us-news') {
+        return 'us';
+    } else if (firstPart === 'uk' || firstPart === 'uk-news') {
+        return 'uk';
+    } else if (firstPart === 'au' || firstPart === 'australia-news') {
+        return 'au';
+    }
+    return '';
+};
 
 const localiseDiscountCodeLinks = (): void => {
     const path = window.location.pathname;
-    const discountCodeLinks = Array.from(document.getElementsByClassName("js-discount-code-link"));
-    discountCodeLinks.map((link) => link.href = link.href + getDiscountCodePath(path))
-}
+    const discountCodeLinks = Array.from(
+        document.getElementsByClassName('js-discount-code-link')
+    );
+    console.log(discountCodeLinks);
+    discountCodeLinks.map((link: any) => {
+        link.href += getDiscountCodePath(path);
+        return true;
+    });
+};
 
 const initNavigation = (): Promise<any> => {
     enableMegaNavToggle();

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -79,8 +79,26 @@ const enableMegaNavToggle = (): void => {
     });
 };
 
+const getDiscountCodePath = (path: string): string => {
+    const firstPart = path.split("/")[1];
+    if (firstPart === "us" || firstPart === "us-news") {
+        return "us";
+    } else if (firstPart === "uk" || firstPart === "uk-news") {
+        return "uk";
+    } else if (firstPart ==="au" || firstPart === "australia-news") {
+        return "au";
+    } else return "";
+}
+
+const localiseDiscountCodeLinks = (): void => {
+    const path = window.location.pathname;
+    const discountCodeLinks = Array.from(document.getElementsByClassName("js-discount-code-link"));
+    discountCodeLinks.map((link) => link.href = link.href + getDiscountCodePath(path))
+}
+
 const initNavigation = (): Promise<any> => {
     enableMegaNavToggle();
+    localiseDiscountCodeLinks();
 
     const modifications = [
         jsEnableFooterNav(),
@@ -100,4 +118,4 @@ const initNavigation = (): Promise<any> => {
     return Promise.all(modifications);
 };
 
-export { initNavigation };
+export { initNavigation, getDiscountCodePath };

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { initNavigation } from 'common/modules/navigation/navigation';
+import { initNavigation, getDiscountCodePath } from 'common/modules/navigation/navigation';
 
 jest.mock('lib/fastdom-promise');
 
@@ -82,5 +82,11 @@ describe('Navigation', () => {
                 );
             }
         });
+    });
+
+    it('should return correct discount code path', () => {
+        const paths = ["/us", "/politics", "/uk/jeremy-corbyn", "/australia-news/", "/au/being-upside-down", ""];
+        expect(paths.map(getDiscountCodePath)).toEqual(["us", "", "uk", "au", "au", ""]);
+
     });
 });

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
@@ -1,5 +1,8 @@
 // @flow
-import { initNavigation, getDiscountCodePath } from 'common/modules/navigation/navigation';
+import {
+    initNavigation,
+    getDiscountCodePath,
+} from 'common/modules/navigation/navigation';
 
 jest.mock('lib/fastdom-promise');
 
@@ -85,8 +88,21 @@ describe('Navigation', () => {
     });
 
     it('should return correct discount code path', () => {
-        const paths = ["/us", "/politics", "/uk/jeremy-corbyn", "/australia-news/", "/au/being-upside-down", ""];
-        expect(paths.map(getDiscountCodePath)).toEqual(["us", "", "uk", "au", "au", ""]);
-
+        const paths = [
+            '/us',
+            '/politics',
+            '/uk/jeremy-corbyn',
+            '/australia-news/',
+            '/au/being-upside-down',
+            '',
+        ];
+        expect(paths.map(getDiscountCodePath)).toEqual([
+            'us',
+            '',
+            'uk',
+            'au',
+            'au',
+            '',
+        ]);
     });
 });


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/frontend/pull/21259 - which had to be reverted because it split the cache and caused loads of extra origin traffic, lets do the same thing client side.


cc @vlbee 
### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
