### PR TITLE
Remove AMP related logic in RenderingTierPicker

### DIFF
--- a/article/app/services/dotcomponents/RenderingTierPicker.scala
+++ b/article/app/services/dotcomponents/RenderingTierPicker.scala
@@ -9,13 +9,7 @@ import play.api.mvc.RequestHeader
 class RenderingTierPicker {
 
   def getTier(page: PageWithStoryPackage, blocks: APIBlocks)(implicit request: RequestHeader): RenderType = {
-
-    if(request.isAmp) {
-      AMPPicker.getTier(page, blocks)
-    } else {
-      ArticlePicker.getTier(page)
-    }
-
+    ArticlePicker.getTier(page)
   }
 
 }


### PR DESCRIPTION
## What does this change?

Remove AMP related logic in RenderingTierPicker
