### PR TITLE
Remove AMP related logic in paidForMeta.scala.html

### DIFF
--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -6,22 +6,11 @@
 
 <div class="paidfor-meta">
     <span class="paidfor-meta__label">Paid content</span>
-    @if(request.isAmp) {
-        <div class="paidfor-label paidfor-meta__more has-popup">
-            <input type="checkbox" value="selected" id="paidforAbout" class="paidfor-input">
-            <label for="paidforAbout" class="tooltip-label">About </label>
-            <div class="popup popup--paidfor">
-                <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
-                <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-            </div>
+    <div class="paidfor-label paidfor-meta__more has-popup">
+        <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About </button>
+        <div class="popup popup--paidfor is-off js-paidfor-popup@dataId">
+            <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
+            <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
         </div>
-    } else {
-        <div class="paidfor-label paidfor-meta__more has-popup">
-            <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About </button>
-            <div class="popup popup--paidfor is-off js-paidfor-popup@dataId">
-                <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
-                <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-            </div>
-        </div>
-    }
+    </div>
 </div>


### PR DESCRIPTION
## What does this change?

Now that we are now 100% AMP traffic on DCR. Remove AMP related logic in paidForMeta.scala.html
