### PR TITLE
Remove obvious AMP related logic in multiple views

### DIFF
--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -2,14 +2,10 @@
 @import common.commercial.hosted.HostedCallToAction
 @(page: HostedPage, cta: HostedCallToAction, isAMP: Boolean)
     <section class="host hosted__container--full">
-        <div class="hosted__banner" @if(!isAMP) {style="background-image: url(@{cta.image});"}>
+        <div class="hosted__banner" style="background-image: url(@{cta.image});">
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">
                 <div class="hostedbadge hostedbadge--pushdown">
-                    @if(isAMP) {
-                        <amp-img layout="responsive" width="@{page.logo.dimensions.map(_.width)}" height="@{page.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}"></amp-img>
-                    } else {
-                        <img class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}">
-                    }
+                    <img class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}">
                 </div>
                 @if(cta.btnText.isEmpty) {
                     <div class="hosted__cta-wrapper content__hosted-body">

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -7,42 +7,10 @@
             <p class="hostedbadge__info">Advertiser content</p>
             @hostedLogo(page, onAmp = isAMP)
         </div>
-        @if(isAMP) {
-            <div class="hosted__label content__hosted-body">
-                <button on="tap:hosted-about-lightbox" class="hosted__tooltip-label">About</button>
-
-                <amp-lightbox id="hosted-about-lightbox" layout="nodisplay">
-                    <div class="hosted__lightbox">
-                        <div class="survey-container" data-link-name="hosted page about overlay" role="dialog" aria-label="about hosted content">
-                            <h3 class="survey-text__header">
-                                Advertiser content
-                                <div class="survey-close">
-                                    <button class="hosted__lightbox-close-btn" data-link-name="hide about hosted message" on="tap:hosted-about-lightbox.close">
-                                        @fragments.inlineSvg("cross", "icon", List("inline-cross hosted__lightbox-close"))
-                                    </button>
-                                </div>
-                            </h3>
-                            <div class="survey-icon">
-                                @fragments.inlineSvg("paid-content", "commercial", List("hosted__lightbox-image"))
-                            </div>
-                            <div class="survey-text">
-                                <p class="survey-text__paragraph">
-                                    Advertiser content. This article was paid for, produced and controlled by the
-                                    advertiser rather than the publisher. It is subject to regulation by the Advertising
-                                    Standards Authority. This content is produced by the advertiser with no involvement
-                                    from Guardian News and Media staff.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </amp-lightbox>
-            </div>
-        } else {
-            <div class="paidfor-label paidfor-meta__more hosted__label has-popup">
-                <button class="u-button-reset paidfor-label__btn popup__toggle hosted__label-btn js-hosted-about" data-link-name="about-advertiser-content">
-                    About</button>
-            </div>
-        }
+        <div class="paidfor-label paidfor-meta__more hosted__label has-popup">
+            <button class="u-button-reset paidfor-label__btn popup__toggle hosted__label-btn js-hosted-about" data-link-name="about-advertiser-content">
+                About</button>
+        </div>
         <div class="hosted-header__spacer"></div>
         <a href="http://www.theguardian.com" class="hosted__glogo">
             <p class="hosted__glogotext">Hosted by</p>

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -1,40 +1,24 @@
 @(className: String, label: String, headline: String, id: String, isAmp: Boolean)(body: Html)(implicit request: RequestHeader)
-@if(!isAmp) {
-<details data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
-  <summary class="explainer-snippet__header">
-    <span class="explainer-snippet__label">@label</span>
-    <h4 class="explainer-snippet__headline">@headline</h4>
-    <button class="button button--large explainer-snippet__handle" aria-hidden="true">
-      <span>@fragments.inlineSvg("plus", "icon") Show</span>
-      <span>@fragments.inlineSvg("minus", "icon") Hide</span>
-    </button>
-  </summary>
-  <div class="explainer-snippet__body">
-    @body
-  </div>
-</details>
-} else {
 <div data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
 
-  <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
-    <span class="explainer-snippet__label">@label</span>
-    <h4 class="explainer-snippet__headline">@headline</h4>
+    <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
+        <span class="explainer-snippet__label">@label</span>
+        <h4 class="explainer-snippet__headline">@headline</h4>
 
-    <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
-      <span id="show-@id">
-        @fragments.inlineSvg("plus", "icon")
-        Show
-      </span>
-      <span hidden="" id="hide-@id">
-        @fragments.inlineSvg("minus", "icon")
-        Hide
-      </span>
-    </button>
-  </div>
-  <div hidden="" id="body-@id" class="explainer-snippet__body">
-  @body
-  </div>
+        <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
+            <span id="show-@id">
+                @fragments.inlineSvg("plus", "icon")
+                Show
+            </span>
+            <span hidden="" id="hide-@id">
+                @fragments.inlineSvg("minus", "icon")
+                Hide
+            </span>
+        </button>
+    </div>
+    <div hidden="" id="body-@id" class="explainer-snippet__body">
+    @body
+    </div>
 
 </div>
-}
 

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -11,16 +11,12 @@
 ){
   @for(img <- guide.image ) {
     <div class="explainer-snippet__image">
-      @if(isAmp) {
-        @fragments.amp.ampImage(img, "Guide")
-      } else {
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Guide",
-          isImmersiveMainMedia = true
-        )
-      }
+    @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Guide",
+        isImmersiveMainMedia = true
+    )
     </div>
   }
 
@@ -32,10 +28,10 @@
       @Html(item.body)
     </div>
   }
-  
+
   @guide.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon") 
+      @fragments.inlineSvg("information", "icon")
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -11,16 +11,12 @@
 ){
   @for(img <- profile.image ) {
     <div class="explainer-snippet__image">
-      @if(isAmp) {
-        @fragments.amp.ampImage(img, "Profile")
-      } else {
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Profile",
-          isImmersiveMainMedia = true
-        )
-      }
+    @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Profile",
+        isImmersiveMainMedia = true
+    )
     </div>
   }
 
@@ -35,7 +31,7 @@
 
   @profile.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon") 
+      @fragments.inlineSvg("information", "icon")
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -11,16 +11,12 @@
 ){
   @for(img <- qa.image ) {
     <div class="explainer-snippet__image">
-      @if(isAmp) {
-        @fragments.amp.ampImage(img, "Q&amp;A")
-      } else {
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Q&amp;A",
-          isImmersiveMainMedia = true
-        )
-      }
+    @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Q&amp;A",
+        isImmersiveMainMedia = true
+    )
     </div>
   }
 
@@ -28,7 +24,7 @@
 
   @qa.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon") 
+      @fragments.inlineSvg("information", "icon")
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -10,58 +10,56 @@
     }
 }
 
-@if(!isAmp) {
-    <div class="js-view-tracking-component submeta user__question">
-        <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
+<div class="js-view-tracking-component submeta user__question">
+    <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
 
-        @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
-            <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
-        }
+    @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
+        <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
+    }
 
-        <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
-        @for(questions <- storyquestions.data.editorialQuestions) {
-            @for(qs <- questions) {
-                <p>
-                    <div class="user__question-section"></div>
-                    @for(question <- qs.questions) {
-                        <div class="user__question-container">
-                            <div class="user__questions-text--wrapper js-ask-question-link">
-                                <div class="user__question-text">
-                                    <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
-                                    <span class="user__questions-text--inner">
-                                    @question.questionText
-                                    </span>
-                                </div>
-                                <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
-                                    Ask
-                                </button>
-                                <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ll send you the answer soon.
-                                </span>
-                                <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ve registered your vote.
-                                </span>
-                            </div>
-                            <div class="storyquestion-submission-container js-storyquestion-submission-container">
-                                <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
-                                </span>
-
-                                @for(listId <- StoryQuestionsAtom.getListId(storyquestions)) {
-                                    <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                        <div class="form-field js-storyquestion-email-signup-input-container">
-                                            <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
-                                        </div>
-                                        <input class="" type="hidden" name="listId" value="@listId" />
-                                        <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-                                    </form>
-                                }
-                            </div>
+    <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
+    @for(questions <- storyquestions.data.editorialQuestions) {
+        @for(qs <- questions) {
+            <p>
+            <div class="user__question-section"></div>
+            @for(question <- qs.questions) {
+                <div class="user__question-container">
+                    <div class="user__questions-text--wrapper js-ask-question-link">
+                        <div class="user__question-text">
+                            <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
+                            <span class="user__questions-text--inner">
+                            @question.questionText
+                            </span>
                         </div>
-                    }
-                </p>
-            }
-    </div>
-}
+                        <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
+                                    Ask
+                        </button>
+                        <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ll send you the answer soon.
+                        </span>
+                        <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ve registered your vote.
+                        </span>
+                    </div>
+                    <div class="storyquestion-submission-container js-storyquestion-submission-container">
+                        <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
+                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
+                        </span>
 
-}
+                        @for(listId <- StoryQuestionsAtom.getListId(storyquestions)) {
+                            <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
+                                <div class="form-field js-storyquestion-email-signup-input-container">
+                                    <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
+                                </div>
+                                <input class="" type="hidden" name="listId" value="@listId" />
+                                <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+                            </form>
+                        }
+                    </div>
+                </div>
+            }
+            </p>
+        }
+    }
+</div>
+

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -16,11 +16,9 @@
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
 
     <div class="footer__primary">
-        @if(!isAmp) {
-            @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
-                @fragments.nav.subNav(navMenu, page.metadata.designType, isFooter = true)
-            }
-        }
+    @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+        @fragments.nav.subNav(navMenu, page.metadata.designType, isFooter = true)
+    }
     </div>
 
     <div class="l-footer__secondary js-footer__secondary @if(EmailInlineInFooterSwitch.isSwitchedOff) {l-footer__secondary--no-email} gs-container" role="contentinfo">

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -8,15 +8,7 @@
         @profile.properties.contributorLargeImagePath.map{ src =>
             <div class="media__img meta__image">
                 <div class="byline-img">
-                    @if(request.isAmp) {
-                        @if(model.Tags(tags.tones.toList).isComment) {
-                            <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150"></amp-img>
-                        } else {
-                            <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66"></amp-img>
-                        }
-                    } else {
-                        <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
-                    }
+                    <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
                 </div>
             </div>
         }

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -5,11 +5,7 @@
 @(profileTag: Tag)(implicit request: RequestHeader)
 <div class="liveblog-block-byline">
     @profileTag.contributorImagePath.map { src =>
-        @if(request.isAmp) {
-            <amp-img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" width="36" height="36"></amp-img>
-        } else {
-            <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
-        }
+        <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
     }
     <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
 </div>


### PR DESCRIPTION
## What does this change?

Now that we are now 100% AMP traffic on DCR. Remove AMP related logic in some views. Notably all instances of `@if(isAMP)` in HTML templates.
