### PR TITLE
 Epic test: show count of articles viewed 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,6 +28,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-articles-viewed",
+    "States how many articles a user has viewed in the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 27),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-global-mobile-banner-design",
     "testing mobile-only design changes",
     owners = Seq(Owner.withGithub("jlieb10")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,6 +38,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-country-name",
+    "Displays country name in the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 27),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-global-mobile-banner-design",
     "testing mobile-only design changes",
     owners = Seq(Owner.withGithub("jlieb10")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-contributions-epic-articles-viewed",
     "States how many articles a user has viewed in the epic",
-    owners = Seq(Owner.withGithub("jranks123")),
+    owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 1, 27),
     exposeClientSide = true
@@ -40,7 +40,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-contributions-epic-country-name",
     "Displays country name in the epic",
-    owners = Seq(Owner.withGithub("jranks123")),
+    owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 1, 27),
     exposeClientSide = true

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -118,6 +118,7 @@ declare type InitEpicABTest = {
     audienceCriteria: string,
     idealOutcome: string,
     campaignId: string,
+    canRun?: () => boolean,
     variants: $ReadOnlyArray<InitEpicABTestVariant>,
 
     campaignPrefix?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -801,4 +801,5 @@ export {
     getReaderRevenueRegion,
     userIsInCorrectCohort,
     getVisitCount,
+    buildEpicCopy,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -510,7 +510,9 @@ const buildEpicCopy = (row: any, hasCountryName: boolean) => {
                 : heading,
         paragraphs:
             paragraphs && countryName
-                ? paragraphs.map<string>(para => replaceCountryName(para, countryName))
+                ? paragraphs.map<string>(para =>
+                      replaceCountryName(para, countryName)
+                  )
                 : paragraphs,
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -494,7 +494,7 @@ const makeEpicABTest = ({
 const buildEpicCopy = (row: any, hasCountryName: boolean) => {
     const heading = throwIfEmptyString('heading', row.heading);
 
-    const paragraphs = throwIfEmptyArray(
+    const paragraphs: string[] = throwIfEmptyArray(
         'paragraphs',
         splitAndTrim(row.paragraphs, '\n')
     );
@@ -510,7 +510,7 @@ const buildEpicCopy = (row: any, hasCountryName: boolean) => {
                 : heading,
         paragraphs:
             paragraphs && countryName
-                ? paragraphs.map(para => replaceCountryName(para, countryName))
+                ? paragraphs.map<string>(para => replaceCountryName(para, countryName))
                 : paragraphs,
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -53,7 +53,6 @@ import {
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
 import { initTicker } from 'common/modules/commercial/ticker';
-import { getArticleViewCount } from 'common/modules/onward/history';
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -76,9 +76,6 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
 
 const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
 
-const replaceArticlesRead = (text: string, days: number = 30): string =>
-    text.replace(/%%ARTICLES_READ%%/g, `${getArticleViewCount(days)}`);
-
 const replaceCountryName = (text: string, countryName: string): string =>
     text.replace(/%%COUNTRY_NAME%%/g, countryName);
 
@@ -496,9 +493,7 @@ const makeEpicABTest = ({
 };
 
 const buildEpicCopy = (row: any, hasCountryName: boolean) => {
-    const heading = replaceArticlesRead(
-        throwIfEmptyString('heading', row.heading)
-    );
+    const heading = throwIfEmptyString('heading', row.heading);
 
     const paragraphs = throwIfEmptyArray(
         'paragraphs',

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -453,6 +453,7 @@ const makeEpicABTest = ({
     hasCountryName = false,
     pageCheck = isCompatibleWithArticleEpic,
     template = controlTemplate,
+    canRun = () => true,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -461,7 +462,7 @@ const makeEpicABTest = ({
         canRun() {
             const countryNameIsOk =
                 !hasCountryName || countryNames[geolocationGetSync()];
-            return countryNameIsOk && shouldShowEpic(this);
+            return canRun() && countryNameIsOk && shouldShowEpic(this);
         },
         componentType: 'ACQUISITIONS_EPIC',
         insertEvent: makeEvent(id, 'insert'),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,6 +5,7 @@ import { commercialOutbrainTesting } from 'common/modules/experiments/tests/comm
 import { commercialConsentModalBanner } from 'common/modules/experiments/tests/commercial-consent-modal-banner';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
+import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs-global-mobile-banner-design';
@@ -20,9 +21,9 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialUsMobileSticky,
 ];
 
-export const priorityEpicTests: $ReadOnlyArray<EpicABTest> = [articlesViewed];
-
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
+    articlesViewed,
+    countryName,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,6 +4,7 @@ import { commercialCmpCustomise } from 'common/modules/experiments/tests/commerc
 import { commercialOutbrainTesting } from 'common/modules/experiments/tests/commercial-outbrain-testing.js';
 import { commercialConsentModalBanner } from 'common/modules/experiments/tests/commercial-consent-modal-banner';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
+import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { contributionsGlobalMobileBannerDesign } from 'common/modules/experiments/tests/contribs-global-mobile-banner-design';
@@ -17,6 +18,10 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     adblockTest,
     commercialConsentModalBanner,
     commercialUsMobileSticky,
+];
+
+export const priorityEpicTests: $ReadOnlyArray<EpicABTest> = [
+    articlesViewed
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -20,9 +20,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialUsMobileSticky,
 ];
 
-export const priorityEpicTests: $ReadOnlyArray<EpicABTest> = [
-    articlesViewed
-];
+export const priorityEpicTests: $ReadOnlyArray<EpicABTest> = [articlesViewed];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
     askFourEarning,

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -24,7 +24,6 @@ import {
     concurrentTests,
     engagementBannerTests,
     epicTests,
-    priorityEpicTests,
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
@@ -39,7 +38,6 @@ export const getEpicTestToRun = memoize(
                     config.set(`switches.ab${test.id}`, true)
                 );
                 return firstRunnableTest<EpicABTest>([
-                    ...priorityEpicTests,
                     ...asyncEpicTests,
                     ...epicTests,
                 ]);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -24,6 +24,7 @@ import {
     concurrentTests,
     engagementBannerTests,
     epicTests,
+    priorityEpicTests,
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
@@ -38,6 +39,7 @@ export const getEpicTestToRun = memoize(
                     config.set(`switches.ab${test.id}`, true)
                 );
                 return firstRunnableTest<EpicABTest>([
+                    ...priorityEpicTests,
                     ...asyncEpicTests,
                     ...epicTests,
                 ]);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -60,6 +60,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
         {
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
+            products: [],
             copy: buildEpicCopy(
                 isUSUK ? USUKControlCopy : ROWControlCopy,
                 !isUSUK
@@ -68,6 +69,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,
+            products: [],
             copy: buildEpicCopy(
                 {
                     heading: `You’ve read ${articleViewCount} articles...`,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -17,9 +17,9 @@ const highlightedText =
     'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
 
 const USUKControlCopy = {
-    heading: 'Since you’re here…',
+    heading: 'Since you’re here...',
     paragraphs:
-        '… we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
@@ -74,7 +74,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                 {
                     heading: `You’ve read ${articleViewCount} articles...`,
                     paragraphs:
-                        '… in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
                         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
                         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -2,19 +2,47 @@
 import {
     makeEpicABTest,
     defaultButtonTemplate,
+    buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
-const minArticleViews = 10;
-const articleCountDays = 7;
+// Use must have read at least 5 articles in last 14 days
+const minArticleViews = 5;
+const articleCountDays = 14;
 
 const articleViewCount = getArticleViewCount(articleCountDays);
+
+const highlightedText =
+    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
+
+const USUKControlCopy = {
+    heading: 'Since you’re here…',
+    paragraphs:
+        '… we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+    highlightedText,
+};
+
+const ROWControlCopy = {
+    heading: 'More people in %%COUNTRY_NAME%%...',
+    paragraphs:
+        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+    highlightedText,
+};
+
+const isUSUK = ['GB', 'US'].includes(geolocationGetSync());
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicArticlesViewed',
     campaignId: 'epic_articles_viewed',
 
-    start: '2017-01-24',
+    start: '2019-06-24',
     expiry: '2020-01-27',
 
     author: 'Tom Forbes',
@@ -31,18 +59,27 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     variants: [
         {
             id: 'control',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             buttonTemplate: defaultButtonTemplate,
-            copy: {
-                heading: `You've read ${articleViewCount} articles this week...`,
-                paragraphs: [
-                    '… we have a small favour to ask. More people are reading and supporting our independent, investigative reporting than ever before. And unlike many news organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford.\n',
-                    'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.',
-                    'Every contribution we receive from readers like you, big or small, goes directly into funding our journalism. This support enables us to keep working as we do – but we must maintain and build on it for every year to come.',
-                ],
-                highlightedText:
-                    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-            },
+            copy: buildEpicCopy(
+                isUSUK ? USUKControlCopy : ROWControlCopy,
+                !isUSUK
+            ),
+        },
+        {
+            id: 'variant',
+            buttonTemplate: defaultButtonTemplate,
+            copy: buildEpicCopy(
+                {
+                    heading: `You’ve read ${articleViewCount} articles...`,
+                    paragraphs:
+                        '… in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+                    highlightedText,
+                },
+                false
+            ),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -18,8 +18,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     expiry: '2020-01-27',
 
     author: 'Tom Forbes',
-    description:
-        "States how many articles a user has viewed in the epic",
+    description: 'States how many articles a user has viewed in the epic',
     successMeasure: 'Conversion rate',
     idealOutcome: 'Acquires many Supporters',
 
@@ -39,10 +38,11 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                 paragraphs: [
                     '… we have a small favour to ask. More people are reading and supporting our independent, investigative reporting than ever before. And unlike many news organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford.\n',
                     'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.',
-                    'Every contribution we receive from readers like you, big or small, goes directly into funding our journalism. This support enables us to keep working as we do – but we must maintain and build on it for every year to come.'
+                    'Every contribution we receive from readers like you, big or small, goes directly into funding our journalism. This support enables us to keep working as we do – but we must maintain and build on it for every year to come.',
                 ],
-                highlightedText: 'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-            }
+                highlightedText:
+                    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+            },
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -1,0 +1,48 @@
+// @flow
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+} from 'common/modules/commercial/contributions-utilities';
+import { getArticleViewCount } from 'common/modules/onward/history';
+
+const minArticleViews = 10;
+const articleCountDays = 7;
+
+const articleViewCount = getArticleViewCount(articleCountDays);
+
+export const articlesViewed: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicArticlesViewed',
+    campaignId: 'epic_articles_viewed',
+
+    start: '2017-01-24',
+    expiry: '2020-01-27',
+
+    author: 'Tom Forbes',
+    description:
+        "States how many articles a user has viewed in the epic",
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    canRun: () => articleViewCount >= minArticleViews,
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            buttonTemplate: defaultButtonTemplate,
+            copy: {
+                heading: `You've read ${articleViewCount} articles this week...`,
+                paragraphs: [
+                    '… we have a small favour to ask. More people are reading and supporting our independent, investigative reporting than ever before. And unlike many news organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford.\n',
+                    'The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when factual, honest reporting is critical.',
+                    'Every contribution we receive from readers like you, big or small, goes directly into funding our journalism. This support enables us to keep working as we do – but we must maintain and build on it for every year to come.'
+                ],
+                highlightedText: 'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+            }
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -1,0 +1,50 @@
+// @flow
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+    buildEpicCopy,
+} from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+export const countryName: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicCountryName',
+    campaignId: 'epic_country_name',
+
+    start: '2019-06-24',
+    expiry: '2020-01-27',
+
+    author: 'Tom Forbes',
+    description: 'Displays country name in the epic',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    canRun: () => {
+        const geolocation = geolocationGetSync();
+        return geolocation !== 'US' && geolocation !== 'GB';
+    },
+
+    variants: [
+        {
+            id: 'control',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+            copy: buildEpicCopy(
+                {
+                    heading: 'More people in %%COUNTRY_NAME%%…',
+                    paragraphs:
+                        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+                    highlightedText:
+                        'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+                },
+                true
+            ),
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
This is an alternative to https://github.com/guardian/frontend/pull/21501, which is for the same test but configurable via the google sheets. We decided it's better to hardcode this one for now as it's quite fiddly.

I've removed support for the `%%ARTICLES_READ%%` template in the google sheets.

For the control, the copy depends on whether the user is in the US/UK or not. This is because we want to keep showing the 'country name' test to ROW.

We want the google sheets tests to take priority over this one. But we also want this test to take priority over the 'country name' test. So for now I've hardcoded the 'country name' test as well (it will be switched off in the google spreadsheet).

## Screenshots

#### Variant
<img width="632" alt="Screenshot 2019-06-24 at 14 35 11" src="https://user-images.githubusercontent.com/1513454/60023458-c0295480-968d-11e9-96b8-732e46a537cd.png">

#### US / UK control
<img width="632" alt="Screenshot 2019-06-24 at 14 37 54" src="https://user-images.githubusercontent.com/1513454/60023486-cb7c8000-968d-11e9-953f-99f079e49279.png">

#### ROW control
<img width="632" alt="Screenshot 2019-06-24 at 14 37 34" src="https://user-images.githubusercontent.com/1513454/60023471-c5869f00-968d-11e9-8ec5-9ac00e5ee96f.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
