### PR TITLE
Put country name in contributions banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -724,6 +724,14 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                         optionalStringToBoolean(row.hasCountryName)
                     );
 
+                    const rowWithLocations = rows.find(
+                        row =>
+                            row.locations !== undefined && row.locations !== ''
+                    );
+                    const countryGroups = rowWithLocations
+                        ? optionalSplitAndTrim(rowWithLocations.locations, ',')
+                        : [];
+
                     return {
                         id: testName,
                         campaignId: testName,
@@ -740,9 +748,16 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                         audience: 1,
                         audienceOffset: 0,
 
-                        canRun: () =>
-                            !hasCountryName ||
-                            countryNames[geolocationGetSync()],
+                        canRun: () => {
+                            const countryNameOk =
+                                !hasCountryName ||
+                                countryNames[geolocationGetSync()];
+                            const matchesCountryGroups =
+                                countryGroups.length === 0 ||
+                                userMatchesCountryGroups(countryGroups);
+
+                            return countryNameOk && matchesCountryGroups;
+                        },
 
                         variants: rows.map(row => ({
                             id: row.name.trim().toLowerCase(),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -527,6 +527,14 @@ const buildEpicCopy = (row: any, hasCountryName: boolean) => {
     };
 };
 
+const buildBannerCopy = (text: String, hasCountryName: boolean): string => {
+    const countryName: ?string = hasCountryName
+        ? countryNames[geolocationGetSync()]
+        : undefined;
+
+    return countryName ? replaceCountryName(text, countryName) : text;
+};
+
 export const getEpicTestsFromGoogleDoc = (): Promise<
     $ReadOnlyArray<EpicABTest>
 > =>
@@ -693,14 +701,6 @@ export const canShowBannerSync = (
     );
 };
 
-const buildBannerCopy = (text: String, hasCountryName: boolean): string => {
-    const countryName: ?string = hasCountryName
-        ? countryNames[geolocationGetSync()]
-        : undefined;
-
-    return countryName ? replaceCountryName(text, countryName) : text;
-};
-
 export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
     $ReadOnlyArray<AcquisitionsABTest>
 > =>
@@ -740,7 +740,9 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                         audience: 1,
                         audienceOffset: 0,
 
-                        canRun: () => !hasCountryName || countryNames[geolocationGetSync()],
+                        canRun: () =>
+                            !hasCountryName ||
+                            countryNames[geolocationGetSync()],
 
                         variants: rows.map(row => ({
                             id: row.name.trim().toLowerCase(),
@@ -748,7 +750,10 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             test: () => {},
 
                             engagementBannerParams: {
-                                messageText: buildBannerCopy(row.messageText.trim(), hasCountryName),
+                                messageText: buildBannerCopy(
+                                    row.messageText.trim(),
+                                    hasCountryName
+                                ),
                                 ctaText: `<span class="engagement-banner__highlight"> ${row.ctaText.replace(
                                     /%%CURRENCY_SYMBOL%%/g,
                                     getLocalCurrencySymbol()

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -527,7 +527,7 @@ const buildEpicCopy = (row: any, hasCountryName: boolean) => {
     };
 };
 
-const buildBannerCopy = (text: String, hasCountryName: boolean): string => {
+const buildBannerCopy = (text: string, hasCountryName: boolean): string => {
     const countryName: ?string = hasCountryName
         ? countryNames[geolocationGetSync()]
         : undefined;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -693,6 +693,14 @@ export const canShowBannerSync = (
     );
 };
 
+const buildBannerCopy = (text: String, hasCountryName: boolean): string => {
+    const countryName: ?string = hasCountryName
+        ? countryNames[geolocationGetSync()]
+        : undefined;
+
+    return countryName ? replaceCountryName(text, countryName) : text;
+};
+
 export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
     $ReadOnlyArray<AcquisitionsABTest>
 > =>
@@ -709,6 +717,13 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                 .map(name => {
                     const rows = sheets[name];
                     const testName = name.split('__ON')[0];
+
+                    // If hasCountryName is true but a country name is not available for this user then
+                    // they will be excluded from this test
+                    const hasCountryName = rows.some(row =>
+                        optionalStringToBoolean(row.hasCountryName)
+                    );
+
                     return {
                         id: testName,
                         campaignId: testName,
@@ -725,7 +740,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                         audience: 1,
                         audienceOffset: 0,
 
-                        canRun: () => true,
+                        canRun: () => !hasCountryName || countryNames[geolocationGetSync()],
 
                         variants: rows.map(row => ({
                             id: row.name.trim().toLowerCase(),
@@ -733,7 +748,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             test: () => {},
 
                             engagementBannerParams: {
-                                messageText: row.messageText.trim(),
+                                messageText: buildBannerCopy(row.messageText.trim(), hasCountryName),
                                 ctaText: `<span class="engagement-banner__highlight"> ${row.ctaText.replace(
                                     /%%CURRENCY_SYMBOL%%/g,
                                     getLocalCurrencySymbol()


### PR DESCRIPTION
## What does this change?
This follows a very successful test we've been running on the epic, where the template `%%COUNTRY_NAME%%` is replaced with the user's country. This change does the same for the banner, again configurable from the google sheets.
As with the epic, if the user is not in one of the set of hardcoded countries then they are excluded from the test.

Also added support for a `locations` field, for restricting the test to certain country groups.

## Screenshots
<img width="879" alt="Screenshot 2019-06-18 at 14 05 33" src="https://user-images.githubusercontent.com/1513454/59684792-a5109d80-91d2-11e9-983d-e3b9e5aaa625.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
