### PR TITLE
Fix Master

### DIFF
--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -2,10 +2,14 @@
 @import common.commercial.hosted.HostedCallToAction
 @(page: HostedPage, cta: HostedCallToAction, isAMP: Boolean)
     <section class="host hosted__container--full">
-        <div class="hosted__banner" style="background-image: url(@{cta.image});">
+        <div class="hosted__banner" @if(!isAMP) {style="background-image: url(@{cta.image});"}>
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">
                 <div class="hostedbadge hostedbadge--pushdown">
-                    <img class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}">
+                    @if(isAMP) {
+                        <amp-img layout="responsive" width="@{page.logo.dimensions.map(_.width)}" height="@{page.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}"></amp-img>
+                    } else {
+                        <img class="hostedbadge__logo" src="@{page.logo.src}" alt="logo @{page.owner}">
+                    }
                 </div>
                 @if(cta.btnText.isEmpty) {
                     <div class="hosted__cta-wrapper content__hosted-body">

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -7,10 +7,42 @@
             <p class="hostedbadge__info">Advertiser content</p>
             @hostedLogo(page, onAmp = isAMP)
         </div>
-        <div class="paidfor-label paidfor-meta__more hosted__label has-popup">
-            <button class="u-button-reset paidfor-label__btn popup__toggle hosted__label-btn js-hosted-about" data-link-name="about-advertiser-content">
-                About</button>
-        </div>
+        @if(isAMP) {
+            <div class="hosted__label content__hosted-body">
+                <button on="tap:hosted-about-lightbox" class="hosted__tooltip-label">About</button>
+
+                <amp-lightbox id="hosted-about-lightbox" layout="nodisplay">
+                    <div class="hosted__lightbox">
+                        <div class="survey-container" data-link-name="hosted page about overlay" role="dialog" aria-label="about hosted content">
+                            <h3 class="survey-text__header">
+                                Advertiser content
+                                <div class="survey-close">
+                                    <button class="hosted__lightbox-close-btn" data-link-name="hide about hosted message" on="tap:hosted-about-lightbox.close">
+                                        @fragments.inlineSvg("cross", "icon", List("inline-cross hosted__lightbox-close"))
+                                    </button>
+                                </div>
+                            </h3>
+                            <div class="survey-icon">
+                                @fragments.inlineSvg("paid-content", "commercial", List("hosted__lightbox-image"))
+                            </div>
+                            <div class="survey-text">
+                                <p class="survey-text__paragraph">
+                                    Advertiser content. This article was paid for, produced and controlled by the
+                                    advertiser rather than the publisher. It is subject to regulation by the Advertising
+                                    Standards Authority. This content is produced by the advertiser with no involvement
+                                    from Guardian News and Media staff.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </amp-lightbox>
+            </div>
+        } else {
+            <div class="paidfor-label paidfor-meta__more hosted__label has-popup">
+                <button class="u-button-reset paidfor-label__btn popup__toggle hosted__label-btn js-hosted-about" data-link-name="about-advertiser-content">
+                    About</button>
+            </div>
+        }
         <div class="hosted-header__spacer"></div>
         <a href="http://www.theguardian.com" class="hosted__glogo">
             <p class="hosted__glogotext">Hosted by</p>

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -1,24 +1,40 @@
 @(className: String, label: String, headline: String, id: String, isAmp: Boolean)(body: Html)(implicit request: RequestHeader)
+@if(!isAmp) {
+<details data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
+  <summary class="explainer-snippet__header">
+    <span class="explainer-snippet__label">@label</span>
+    <h4 class="explainer-snippet__headline">@headline</h4>
+    <button class="button button--large explainer-snippet__handle" aria-hidden="true">
+      <span>@fragments.inlineSvg("plus", "icon") Show</span>
+      <span>@fragments.inlineSvg("minus", "icon") Hide</span>
+    </button>
+  </summary>
+  <div class="explainer-snippet__body">
+    @body
+  </div>
+</details>
+} else {
 <div data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
 
-    <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
-        <span class="explainer-snippet__label">@label</span>
-        <h4 class="explainer-snippet__headline">@headline</h4>
+  <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
+    <span class="explainer-snippet__label">@label</span>
+    <h4 class="explainer-snippet__headline">@headline</h4>
 
-        <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
-            <span id="show-@id">
-                @fragments.inlineSvg("plus", "icon")
-                Show
-            </span>
-            <span hidden="" id="hide-@id">
-                @fragments.inlineSvg("minus", "icon")
-                Hide
-            </span>
-        </button>
-    </div>
-    <div hidden="" id="body-@id" class="explainer-snippet__body">
-    @body
-    </div>
+    <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
+      <span id="show-@id">
+        @fragments.inlineSvg("plus", "icon")
+        Show
+      </span>
+      <span hidden="" id="hide-@id">
+        @fragments.inlineSvg("minus", "icon")
+        Hide
+      </span>
+    </button>
+  </div>
+  <div hidden="" id="body-@id" class="explainer-snippet__body">
+  @body
+  </div>
 
 </div>
+}
 

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- guide.image ) {
     <div class="explainer-snippet__image">
-    @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Guide",
-        isImmersiveMainMedia = true
-    )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Guide")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Guide",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 
@@ -28,10 +32,10 @@
       @Html(item.body)
     </div>
   }
-
+  
   @guide.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon")
+      @fragments.inlineSvg("information", "icon") 
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- profile.image ) {
     <div class="explainer-snippet__image">
-    @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Profile",
-        isImmersiveMainMedia = true
-    )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Profile")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Profile",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 
@@ -31,7 +35,7 @@
 
   @profile.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon")
+      @fragments.inlineSvg("information", "icon") 
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- qa.image ) {
     <div class="explainer-snippet__image">
-    @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Q&amp;A",
-        isImmersiveMainMedia = true
-    )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Q&amp;A")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Q&amp;A",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 
@@ -24,7 +28,7 @@
 
   @qa.credit.map { credit =>
     <div class="explainer-snippet__credit">
-      @fragments.inlineSvg("information", "icon")
+      @fragments.inlineSvg("information", "icon") 
       @credit
     </div>
   }

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -10,56 +10,58 @@
     }
 }
 
-<div class="js-view-tracking-component submeta user__question">
-    <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
+@if(!isAmp) {
+    <div class="js-view-tracking-component submeta user__question">
+        <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
 
-    @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
-        <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
-    }
-
-    <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
-    @for(questions <- storyquestions.data.editorialQuestions) {
-        @for(qs <- questions) {
-            <p>
-            <div class="user__question-section"></div>
-            @for(question <- qs.questions) {
-                <div class="user__question-container">
-                    <div class="user__questions-text--wrapper js-ask-question-link">
-                        <div class="user__question-text">
-                            <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
-                            <span class="user__questions-text--inner">
-                            @question.questionText
-                            </span>
-                        </div>
-                        <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
-                                    Ask
-                        </button>
-                        <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ll send you the answer soon.
-                        </span>
-                        <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ve registered your vote.
-                        </span>
-                    </div>
-                    <div class="storyquestion-submission-container js-storyquestion-submission-container">
-                        <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
-                        </span>
-
-                        @for(listId <- StoryQuestionsAtom.getListId(storyquestions)) {
-                            <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                <div class="form-field js-storyquestion-email-signup-input-container">
-                                    <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
-                                </div>
-                                <input class="" type="hidden" name="listId" value="@listId" />
-                                <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-                            </form>
-                        }
-                    </div>
-                </div>
-            }
-            </p>
+        @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
+            <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
         }
-    }
-</div>
 
+        <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
+        @for(questions <- storyquestions.data.editorialQuestions) {
+            @for(qs <- questions) {
+                <p>
+                    <div class="user__question-section"></div>
+                    @for(question <- qs.questions) {
+                        <div class="user__question-container">
+                            <div class="user__questions-text--wrapper js-ask-question-link">
+                                <div class="user__question-text">
+                                    <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
+                                    <span class="user__questions-text--inner">
+                                    @question.questionText
+                                    </span>
+                                </div>
+                                <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
+                                    Ask
+                                </button>
+                                <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ll send you the answer soon.
+                                </span>
+                                <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ve registered your vote.
+                                </span>
+                            </div>
+                            <div class="storyquestion-submission-container js-storyquestion-submission-container">
+                                <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
+                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
+                                </span>
+
+                                @for(listId <- StoryQuestionsAtom.getListId(storyquestions)) {
+                                    <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
+                                        <div class="form-field js-storyquestion-email-signup-input-container">
+                                            <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
+                                        </div>
+                                        <input class="" type="hidden" name="listId" value="@listId" />
+                                        <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+                                    </form>
+                                }
+                            </div>
+                        </div>
+                    }
+                </p>
+            }
+    </div>
+}
+
+}

--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -22,12 +22,22 @@
   @branding.logo.label
 </div>
 <a class="badge__link" href="@branding.logo.link" data-sponsor="@branding.sponsorName.toLowerCase" rel="nofollow">
-    @if(onDarkBackground && branding.logoForDarkBackground.nonEmpty) {
-        @for(highContrastLogo <- branding.logoForDarkBackground) {
-            @standardLogo(highContrastLogo)
+    @if(request.isAmp) {
+        @if(onDarkBackground && branding.logoForDarkBackground.nonEmpty) {
+            @for(highContrastLogo <- branding.logoForDarkBackground) {
+                @ampLogo(highContrastLogo)
+            }
+        } else {
+            @ampLogo(branding.logo)
         }
     } else {
-        @standardLogo(branding.logo)
+        @if(onDarkBackground && branding.logoForDarkBackground.nonEmpty) {
+            @for(highContrastLogo <- branding.logoForDarkBackground) {
+                @standardLogo(highContrastLogo)
+            }
+        } else {
+            @standardLogo(branding.logo)
+        }
     }
 </a>
 @if(!branding.isPaid) {

--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -6,11 +6,22 @@
 
 <div class="paidfor-meta">
     <span class="paidfor-meta__label">Paid content</span>
-    <div class="paidfor-label paidfor-meta__more has-popup">
-        <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About </button>
-        <div class="popup popup--paidfor is-off js-paidfor-popup@dataId">
-            <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
-            <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+    @if(request.isAmp) {
+        <div class="paidfor-label paidfor-meta__more has-popup">
+            <input type="checkbox" value="selected" id="paidforAbout" class="paidfor-input">
+            <label for="paidforAbout" class="tooltip-label">About </label>
+            <div class="popup popup--paidfor">
+                <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
+                <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+            </div>
         </div>
-    </div>
+    } else {
+        <div class="paidfor-label paidfor-meta__more has-popup">
+            <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About </button>
+            <div class="popup popup--paidfor is-off js-paidfor-popup@dataId">
+                <span class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team.</span>
+                <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+            </div>
+        </div>
+    }
 </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -16,9 +16,11 @@
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
 
     <div class="footer__primary">
-    @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
-        @fragments.nav.subNav(navMenu, page.metadata.designType, isFooter = true)
-    }
+        @if(!isAmp) {
+            @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
+                @fragments.nav.subNav(navMenu, page.metadata.designType, isFooter = true)
+            }
+        }
     </div>
 
     <div class="l-footer__secondary js-footer__secondary @if(EmailInlineInFooterSwitch.isSwitchedOff) {l-footer__secondary--no-email} gs-container" role="contentinfo">

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -8,7 +8,15 @@
         @profile.properties.contributorLargeImagePath.map{ src =>
             <div class="media__img meta__image">
                 <div class="byline-img">
-                    <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
+                    @if(request.isAmp) {
+                        @if(model.Tags(tags.tones.toList).isComment) {
+                            <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150"></amp-img>
+                        } else {
+                            <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66"></amp-img>
+                        }
+                    } else {
+                        <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
+                    }
                 </div>
             </div>
         }

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -5,7 +5,11 @@
 @(profileTag: Tag)(implicit request: RequestHeader)
 <div class="liveblog-block-byline">
     @profileTag.contributorImagePath.map { src =>
-        <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+        @if(request.isAmp) {
+            <amp-img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" width="36" height="36"></amp-img>
+        } else {
+            <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+        }
     }
     <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
 </div>


### PR DESCRIPTION
## What does this change?

This reverts all AMP cleanup commits from yesterday morning up to now. 


The changes Pascal made since yesterday were

```
1. https://github.com/guardian/frontend/pull/21523 [already reverted]
5fb6d85855bfc4de8e51179f2e9840d62ec391c8 / Remove AMP related logic in HostedContentController

2. https://github.com/guardian/frontend/pull/21525
24c6ac8a9fba9201bd6ad595e0c8298a101021f8 / Remove AMP related logic in logo.scala.html

3. https://github.com/guardian/frontend/pull/21527
1fa442b329cfe0bd0d2538552d651cfedc957a13 / Remove AMP related logic in paidForMeta.scala.html

4. https://github.com/guardian/frontend/pull/21529
e2ca0718e70b8fac6e6735bd4fb140f3e7e7db14 / Remove obvious AMP related logic in multiple views

5. https://github.com/guardian/frontend/pull/21530 [already reverted]
1c838dfd83ae4f45e71a50439e2f6c7b27bf4442 / Remove un-used code
1231eb4097366b45ec1abf1fed234b12049f9a3e / Remove unused files
da88d9f0c23c2b7e81da5b63ff539eaffdc3e92f / Simplify the signature of view guardianHostedHeader.scala.html
5b90c2bf63c7e2793614dedeec6c992d84b79fcb / Simplify signature of view hostedLogo.scala.html
e679dba7281a82a8a833439d0b0ac53fb84cbab0 / Simplify signatures of multiple views
e79e5a2c3ced5e02a40b15042d57aba1a09ec508 / Remove obsolete test
```

[1] and [5] have already been reverted here https://github.com/guardian/frontend/commit/15ccdac651062ca7d32e2506ddaa84348adaaa9b and here https://github.com/guardian/frontend/commit/cd0dae0f80d85c6fa96ff79695328183e516514a

In this change are are making a single PR for the commits of [2], [3] and [4].