### PR TITLE
Women World Cup: Replace JAP by JPN

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -158,4 +158,8 @@ object CompetitionDisplayHelpers {
   def cleanTeamName(teamName: String): String = {
     teamName.replace("Ladies", "")
   }
+
+  def cleanTeamCode(teamCode: String): String = {
+    teamCode.replace("JAP", "JPN")
+  }
 }

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -3,7 +3,7 @@
 @import views.support.RenderClasses
 @import views.{NudgePercent, PercentMaker}
 @import pa.LineUpPlayer
-@import model.CompetitionDisplayHelpers.cleanTeamName
+@import model.CompetitionDisplayHelpers.{cleanTeamName, cleanTeamCode}
 
 @(page: MatchPage)(implicit request: RequestHeader)
 
@@ -47,8 +47,8 @@
                        data-chart-show-values="true">
                     <thead hidden>
                         <tr>
-                            <th>@pa.TeamCodes.codeFor(away)</th>
-                            <th>@pa.TeamCodes.codeFor(home)</th>
+                            <th>@cleanTeamCode(pa.TeamCodes.codeFor(away))</th>
+                            <th>@cleanTeamCode(pa.TeamCodes.codeFor(home))</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## What does this change?

Introduce `CompetitionDisplayHelpers.cleanTeamCode` to replace `JAP` by `JPN`, substitution of the Women World Cup, and apply it to the relevant template

