### PR TITLE
When an article has no body blocks, do not allow under AMP?

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -92,8 +92,9 @@ final case class Content(
     val shouldAmplifyArticles = isAmpSupportedArticleType && AmpArticleSwitch.isSwitchedOn
     val shouldAmplifyLiveBlogs = tags.isLiveBlog && AmpLiveBlogSwitch.isSwitchedOn
     val containsFormStacks: Boolean = fields.body.contains("guardiannewsandmedia.formstack.com")
+    val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
 
-    (shouldAmplifyArticles || shouldAmplifyLiveBlogs) && !containsFormStacks
+    (shouldAmplifyArticles || shouldAmplifyLiveBlogs) && !containsFormStacks && hasBodyBlocks
   }
 
   lazy val hasSingleContributor: Boolean = {


### PR DESCRIPTION
## What does this change?

Pro-actively raising this to fix articles like https://gu.com/theguardian/2012/jan/23/archive-1959-lolita-and-its-critics?amp which have no body blocks.

The strategy taken under this PR is to just not allow these ancient articles under AMP. 

This may not be the right strategy. The other way to tackle this is to create a synthetic body block. ~~But that is probably not possible because the bodyHtml contains the main element as well as the body element, and has extra html that might screw around with Dotcom Rendering.~~ I was wrong, we do have a html field for only the body so we could artificially construct a new body block - but I think that might be hard for a different reason: we have no idea if the body block was going to be a picture, text, etc

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
