### PR TITLE
Fix liveblogs .json endpoint in devmode

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -99,6 +99,7 @@ class LiveBlogController(
       case (minute: MinutePage, JsonFormat) => Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
       case (minute: MinutePage, EmailFormat) => Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(minute), minute))
       case (minute: MinutePage, HtmlFormat) => Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
+      case (blog: LiveBlogPage, JsonFormat) if request.isGuui => Future.successful(renderGuuiJson(path, blog, blocks))
       case (blog: LiveBlogPage, JsonFormat) => Future.successful(common.renderJson( views.html.liveblog.liveBlogBody(blog), blog))
       case (blog: LiveBlogPage, EmailFormat) => Future.successful(common.renderEmail(LiveBlogHtmlPage.html(blog), blog))
       case (blog: LiveBlogPage, HtmlFormat) => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -94,7 +94,7 @@ final case class Content(
     val containsFormStacks: Boolean = fields.body.contains("guardiannewsandmedia.formstack.com")
     val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
 
-    (shouldAmplifyArticles || shouldAmplifyLiveBlogs) && !containsFormStacks && hasBodyBlocks
+    ((shouldAmplifyArticles && hasBodyBlocks) || shouldAmplifyLiveBlogs) && !containsFormStacks
   }
 
   lazy val hasSingleContributor: Boolean = {


### PR DESCRIPTION
## What does this change?

We missed something on the .json endpoint, accidentally backed out support for ?guui on liveblogs. Fixes this. Fixes one other issue with isAmplify for liveblogs I noticed.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
