### PR TITLE
Extend sign-in CTA test for another week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
     "test whether having a sign-in CTA negatively impacts acquisitions",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = On,
-    sellByDate = new LocalDate(2019, 6, 18),
+    sellByDate = new LocalDate(2019, 6, 25),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
@@ -26,7 +26,7 @@ export const acquisitionsBannerSignInCta: AcquisitionsABTest = {
     id: 'AcquisitionsBannerSignInCta',
     campaignId: '2019-05-29_acquisitions_banner_sign_in_cta',
     start: '2019-06-04',
-    expiry: '2019-06-18',
+    expiry: '2019-06-25',
     author: 'Guy Dawson',
     description:
         'test whether having a sign-in CTA negatively impacts acquisitions',


### PR DESCRIPTION
## What does this change?

Extends test introduced in #21458 to stop build from breaking.

This test will most likely get removed tomorrow cc @ionamckendrick, @jranks123 