### PR TITLE
Configure OutBrain & Plista to have an even delivery (50|50) split in Australia

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
     "test whether having a sign-in CTA negatively impacts acquisitions",
     owners = Owner.group(SwitchGroup.Identity),
     safeState = On,
-    sellByDate = new LocalDate(2019, 6, 18),
+    sellByDate = new LocalDate(2019, 6, 25),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -1,12 +1,7 @@
 // @flow strict
 /* A regionalised container for all the commercial tags. */
 
-import $ from 'lib/$';
-import config from 'lib/config';
-import fastdom from 'lib/fastdom-promise';
-import template from 'lodash/template';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import externalContentContainerStr from 'raw-loader!common/views/commercial/external-content.html';
 import { imrWorldwide } from 'commercial/modules/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from 'commercial/modules/third-party-tags/imr-worldwide-legacy';
 import { remarketing } from 'commercial/modules/third-party-tags/remarketing';
@@ -14,46 +9,8 @@ import { simpleReach } from 'commercial/modules/third-party-tags/simple-reach';
 import { krux } from 'common/modules/commercial/krux';
 import { ias } from 'commercial/modules/third-party-tags/ias';
 import { inizio } from 'commercial/modules/third-party-tags/inizio';
-import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
-import { plista } from 'commercial/modules/third-party-tags/plista';
 import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
-
-const loadExternalContentWidget = (): void => {
-    const externalTpl = template(externalContentContainerStr);
-
-    const findAnchor = (): Promise<HTMLElement | null> => {
-        const selector = !(
-            config.get('page.seriesId') || config.get('page.blogIds')
-        )
-            ? '.js-related, .js-outbrain-anchor'
-            : '.js-outbrain-anchor';
-        return Promise.resolve(document.querySelector(selector));
-    };
-
-    const renderWidget = (widgetType, init): void => {
-        findAnchor()
-            .then(anchorNode =>
-                fastdom.write(() => {
-                    $(anchorNode).after(
-                        externalTpl({
-                            widgetType,
-                        })
-                    );
-                })
-            )
-            .then(init);
-    };
-
-    const shouldServePlista: boolean =
-        config.get('switches.plistaForOutbrainAu') &&
-        config.get('page.edition', '').toLowerCase() === 'au';
-
-    if (shouldServePlista) {
-        renderWidget('plista', plista.init);
-    } else {
-        renderWidget('outbrain', initOutbrain);
-    }
-};
+import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-party-tags/plista-outbrain-renderer';
 
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
@@ -103,7 +60,7 @@ const init = (): Promise<boolean> => {
     // check above is now sensitive to ad-free, it could be changed independently
     // in the future - even by accident.  Justin.
     if (!commercialFeatures.adFree) {
-        loadExternalContentWidget();
+        initPlistaOutbrainRenderer();
     }
 
     loadOther();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -63,6 +63,19 @@ describe('third party tags', () => {
             });
     });
 
+    it('should run if commercial enabled', done => {
+        commercialFeatures.thirdPartyTags = true;
+        commercialFeatures.adFree = false;
+        init()
+            .then((enabled: boolean) => {
+                expect(enabled).toBe(true);
+                done();
+            })
+            .catch(() => {
+                done.fail('init failed');
+            });
+    });
+
     describe('insertScripts', () => {
         const fakeThirdPartyTag: ThirdPartyTag = {
             shouldRun: true,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
@@ -44,7 +44,6 @@ const init = (): Promise<void> => {
         if (randomWidget === 'plista') {
             return renderWidget('plista', plista.init);
         }
-        return renderWidget('outbrain', initOutbrain);
     }
     return renderWidget('outbrain', initOutbrain);
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
@@ -1,3 +1,5 @@
+// @flow
+
 import externalContentContainerStr from 'raw-loader!common/views/commercial/external-content.html';
 import { plista } from 'commercial/modules/third-party-tags/plista';
 import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
@@ -1,0 +1,50 @@
+import externalContentContainerStr from 'raw-loader!common/views/commercial/external-content.html';
+import { plista } from 'commercial/modules/third-party-tags/plista';
+import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
+import template from 'lodash/template';
+import config from 'lib/config';
+import fastdom from 'lib/fastdom-promise';
+import $ from 'lib/$';
+
+const findAnchor = (): Promise<HTMLElement | null> => {
+    const selector = !(
+        config.get('page.seriesId') || config.get('page.blogIds')
+    )
+        ? '.js-related, .js-outbrain-anchor'
+        : '.js-outbrain-anchor';
+    return Promise.resolve(document.querySelector(selector));
+};
+
+const renderWidget = (widgetType: string, init: any): Promise<void> => {
+    const externalTpl = template(externalContentContainerStr);
+    return findAnchor()
+        .then(anchorNode =>
+            fastdom.write(() => {
+                $(anchorNode).after(
+                    externalTpl({
+                        widgetType,
+                    })
+                );
+            })
+        )
+        .then(init);
+};
+
+const init = (): Promise<void> => {
+    const edition = config.get('page.edition', '').toLowerCase();
+    const isSwitchOn = config.get('switches.plistaForOutbrainAu');
+    const shouldServePlistaOrOutbrain: boolean = isSwitchOn && edition === 'au';
+    if (shouldServePlistaOrOutbrain) {
+        const possibleWidgets = ['plista', 'outbrain'];
+        const randomWidget =
+            possibleWidgets[Math.floor(Math.random() * possibleWidgets.length)];
+
+        if (randomWidget === 'plista') {
+            return renderWidget('plista', plista.init);
+        }
+        return renderWidget('outbrain', initOutbrain);
+    }
+    return renderWidget('outbrain', initOutbrain);
+};
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
@@ -1,0 +1,73 @@
+// @flow
+import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-party-tags/plista-outbrain-renderer';
+import { initOutbrain as _initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
+import { plista as _plista } from 'commercial/modules/third-party-tags/plista';
+import config from 'lib/config';
+
+jest.mock('commercial/modules/dfp/track-ad-render', () => ({
+    trackAdRender: jest.fn(),
+}));
+
+jest.mock('common/modules/commercial/commercial-features', () => ({
+    commercialFeatures: {
+        thirdPartyTags: true,
+        outbrain: true,
+    },
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(
+        (testId, variantId) => variantId === 'notintest'
+    ),
+}));
+
+jest.mock('lib/load-script', () => ({ loadScript: jest.fn() }));
+jest.mock('./outbrain-load', () => ({ load: jest.fn() }));
+
+const plista = _plista;
+const initOutbrain = _initOutbrain;
+
+jest.mock('commercial/modules/third-party-tags/plista', () => ({
+    plista: {
+        init: jest.fn(),
+    },
+}));
+
+jest.mock('commercial/modules/third-party-tags/outbrain', () => ({
+    initOutbrain: jest.fn(),
+}));
+
+describe('Plista Outbrain renderer', () => {
+    it('should display Outbrain for UK, US and International Edition', done => {
+        ['uk', 'us', 'int'].forEach((edition, index) => {
+            config.set('switches.plistaForOutbrainAu', true);
+            config.set('page.edition', edition);
+            initPlistaOutbrainRenderer().then(() => {
+                expect(initOutbrain).toHaveBeenCalled();
+                if (index === 2) {
+                    done();
+                }
+            });
+        });
+    });
+
+    it('should pick Outbrain for AU', done => {
+        global.Math.random = () => 1;
+        config.set('switches.plistaForOutbrainAu', true);
+        config.set('page.edition', 'AU');
+        initPlistaOutbrainRenderer().then(() => {
+            expect(initOutbrain).toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should pick Plista for AU', done => {
+        global.Math.random = () => 0;
+        config.set('switches.plistaForOutbrainAu', true);
+        config.set('page.edition', 'AU');
+        initPlistaOutbrainRenderer().then(() => {
+            expect(plista.init).toHaveBeenCalled();
+            done();
+        });
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
@@ -37,6 +37,10 @@ jest.mock('commercial/modules/third-party-tags/outbrain', () => ({
     initOutbrain: jest.fn(),
 }));
 
+afterAll(() => {
+    jest.resetAllMocks();
+});
+
 describe('Plista Outbrain renderer', () => {
     it('should display Outbrain for UK, US and International Edition', done => {
         ['uk', 'us', 'int'].forEach((edition, index) => {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-sign-in-cta.js
@@ -26,7 +26,7 @@ export const acquisitionsBannerSignInCta: AcquisitionsABTest = {
     id: 'AcquisitionsBannerSignInCta',
     campaignId: '2019-05-29_acquisitions_banner_sign_in_cta',
     start: '2019-06-04',
-    expiry: '2019-06-18',
+    expiry: '2019-06-25',
     author: 'Guy Dawson',
     description:
         'test whether having a sign-in CTA negatively impacts acquisitions',


### PR DESCRIPTION
## What does this change?
Change to randomly choose between Outbrain and Plista widgets only in Australia

## What is the value of this and can you measure success?
As an AdOps person in Australia, I want to have our two content recommendation partners (Outbrain and Plista) to serve on an even rotation.

Measured when Plista and Outbrain promoted links are evenly distributed only in Australia
### Tested

- [x] Locally
- [x] On CODE (optional)
