### PR TITLE
Add designType to DC model

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -204,6 +204,7 @@ case class DataModelV3(
   starRating: Option[Int],
   trailText: String,
   nav: Nav,
+  designType: String
 )
 
 object DataModelV3 {
@@ -249,6 +250,7 @@ object DataModelV3 {
       "starRating" -> model.starRating,
       "trailText" -> model.trailText,
       "nav" -> model.nav,
+      "designType" -> model.designType
     )
   }
 
@@ -564,6 +566,7 @@ object DotcomponentsDataModel {
       starRating = article.content.starRating,
       trailText = article.trail.fields.trailText.getOrElse(""),
       nav = nav,
+      designType = article.metadata.designType.map(_.toString).getOrElse("Article")
     )
   }
 }


### PR DESCRIPTION
## What does this change?

Adds the designType field to DC model which relates to [CAPI designType](https://github.com/guardian/content-api-scala-client/blob/633f566faa855949dd06025fc35782588dbed491/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala) field and used for [styling](https://github.com/guardian/frontend/blob/9da928907a334e6f9aebe4e64888ae1ed8c739b3/article/app/views/fragments/articleBodyGarnett.scala.html#L31) alongside Pillar.

[Trello.](https://trello.com/c/d4XhfFIX/597-difference-in-topic-colour-between-mobile-and-amp-version)

For reference, here are the classes applied that relate to styling of pillar and/or design type (example under opinion & news):

```css
.content--pillar-opinion:not(.paid-content) .byline, .content--pillar-opinion:not(.paid-content) .content--media .content__headline, .content--pillar-opinion:not(.paid-content) .content__label__link, .content--pillar-opinion:not(.paid-content) .pullquote-cite, .content--pillar-opinion:not(.paid-content) a, .content--type-comment:not(.paid-content) .byline, .content--type-comment:not(.paid-content) .content--media .content__headline, .content--type-comment:not(.paid-content) .content__label__link, .content--type-comment:not(.paid-content) .pullquote-cite, .content--type-comment:not(.paid-content) a, .content--type-guardianview:not(.paid-content) .byline, .content--type-guardianview:not(.paid-content) .content--media .content__headline, .content--type-guardianview:not(.paid-content) .content__label__link, .content--type-guardianview:not(.paid-content) .pullquote-cite, .content--type-guardianview:not(.paid-content) a {
    color: #e05e00; // Comment
}

// Cascade below
.content--pillar-news:not(.paid-content) .byline, .content--pillar-news:not(.paid-content) .content--media .content__headline, .content--pillar-news:not(.paid-content) .content__label__link, .content--pillar-news:not(.paid-content) .pullquote-cite, .content--pillar-news:not(.paid-content) a {
    color: #c70000; // News
}
```

## What is the value of this and can you measure success?

Correct styles for AMP and Dotcom in DCR.

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] Yes (please give details)

I'll need to make sure paid content is not affected by the style in AMP.

### Does this change break ad-free?

- [X] No

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine

### Accessibility test checklist
N/A

### Tested

- [X] Locally

cc/ @guardian/dotcom-platform 