### PR TITLE
Update the signature of ContentFields.apply

### DIFF
--- a/article/app/model/ContentFields.scala
+++ b/article/app/model/ContentFields.scala
@@ -7,8 +7,8 @@ import views.{BodyCleaner, MainCleaner}
 
 case class ContentFields(fields: Fields, cleanedMainBlockHtml: String, cleanedBodyHtml: String)
 object ContentFields {
-  def apply(article: Article, isAmp: Boolean = false)(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
-    new ContentFields(article.fields, MainCleaner.apply(article, amp = isAmp).body, BodyCleaner.apply(article, amp = isAmp).body)
+  def apply(article: Article)(implicit request: RequestHeader, context: ApplicationContext): ContentFields =
+    new ContentFields(article.fields, MainCleaner.apply(article, amp = false).body, BodyCleaner.apply(article, amp = false).body)
 
   implicit val contentFieldsWrites: Writes[ContentFields] = Json.writes[ContentFields]
 }


### PR DESCRIPTION
`ContentFields.apply` is called only once from the `ArticleController` at `ContentFields(article.article)`. There therefore never is a case where `isAmp` is `true` in `ContentFields.apply(article: Article, isAmp: Boolean = false)`. We can safely change the signature of `ContentFields.apply` as long as we hard code `false` in its body.


![Screenshot 2019-06-19 at 14 17 26](https://user-images.githubusercontent.com/6035518/59768877-043ae480-929d-11e9-883c-7066041f500b.png)
