### PR TITLE
Fix cricket stats jobs

### DIFF
--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -21,10 +21,10 @@ class CricketLifecycle(
 
   private def scheduleJobs() {
     jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 15.seconds) {
-      Future(cricketStatsJob.run(cricketStatsJob.paFeed.getCurrentMatchIds))
+      Future(cricketStatsJob.run(includeHistorical = false, matchesToFetch = 1))
     }
     jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", 10.minutes) {
-      Future(cricketStatsJob.run(cricketStatsJob.paFeed.getHistoricalMatchIds))
+      Future(cricketStatsJob.run(includeHistorical = true, matchesToFetch = 10))
     }
   }
 
@@ -39,7 +39,7 @@ class CricketLifecycle(
 
     // ensure that we populate the cricket stats cache immediately
     akkaAsync.after1s {
-      cricketStatsJob.run(cricketStatsJob.paFeed.getHistoricalMatchIds)
+      cricketStatsJob.run(includeHistorical = true, matchesToFetch = 10)
     }
   }
 }

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -21,7 +21,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
   private case class TaskWithSender[+T](sender: ActorRef, task: () => Future[T])
 
   val throttler: ActorRef = Source.actorRef[CricketThrottledTask[Nothing]](bufferSize = 1024, OverflowStrategy.dropNew)
-    .throttle(1, 1.second, 1, ThrottleMode.Shaping)
+    .throttle(1, 0.5.second, 1, ThrottleMode.Shaping)
     .to(Sink.actorRef(self, NotUsed))
     .run()
 

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -21,7 +21,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
   private case class TaskWithSender[+T](sender: ActorRef, task: () => Future[T])
 
   val throttler: ActorRef = Source.actorRef[CricketThrottledTask[Nothing]](bufferSize = 1024, OverflowStrategy.dropNew)
-    .throttle(1, 0.5.second, 1, ThrottleMode.Shaping)
+    .throttle(1, 500.millisecond, 1, ThrottleMode.Shaping)
     .to(Sink.actorRef(self, NotUsed))
     .run()
 

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import common.Logging
 import cricket.feed.CricketThrottler
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, LocalDate}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import play.api.libs.ws.WSClient
 
@@ -52,38 +52,36 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     }
   }
 
-  def getMatchIds(team: CricketTeam)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
-
-    // Get fixtures for England for today.
-    val fixtures = getTeamMatches(team, "fixtures", LocalDate.now, LocalDate.now)
-
-    // Get results for England over the last year.
-    val results = getTeamMatches(team, "results", LocalDate.now.minusMonths(2), LocalDate.now)
-
-    Future.sequence(Seq(fixtures, results)).map(_.flatten)
+  def getCurrentMatchIds(team:CricketTeam)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
+    getTeamMatches(team, "fixtures", LocalDate.now, LocalDate.now)
   }
 
-  private def getTeamMatches(team: CricketTeam, matchType: String, startDate: LocalDate, endDate: LocalDate)(implicit executionContext: ExecutionContext): Future[Seq[String]] =
-    credentials.map ( header => throttler.throttle { () =>
+  def getHistoricalMatchIds(team: CricketTeam)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
+    getTeamMatches(team, "results", LocalDate.now.minusMonths(2), LocalDate.now)
+  }
+
+  private def getTeamMatches(team: CricketTeam, matchType: String, startDate: LocalDate, endDate: LocalDate)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
+
+    credentials.map(header => throttler.throttle { () =>
       val start = PaFeed.dateFormat.print(startDate)
       val end = PaFeed.dateFormat.print(endDate)
       val endpoint = s"$paEndpoint/team/${team.paId}/$matchType"
 
       wsClient.url(endpoint)
         .withHttpHeaders(header, xmlContentType)
-        .withQueryStringParameters(("startDate", start),("endDate", end))
+        .withQueryStringParameters(("startDate", start), ("endDate", end))
         .get
         .map { response =>
 
-        response.status match {
-          case 200 => XML.loadString(response.body) \\ "match" map (content =>
-            (content \ "@id").text )
+          response.status match {
+            case 200 => XML.loadString(response.body) \\ "match" map (content =>
+              (content \ "@id").text)
 
-          case 204 => Nil // No content for this date range.
+            case 204 => Nil // No content for this date range.
 
-          case _ => throw CricketFeedException(s"PA endpoint returned: ${response.status} $start $end $endpoint")
+            case _ => throw CricketFeedException(s"PA endpoint returned: ${response.status} $start $end $endpoint")
+          }
         }
-      }
     }).getOrElse(Future.failed(CricketFeedException("No cricket api key found")))
-
+  }
 }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -52,12 +52,11 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     }
   }
 
-  def getCurrentMatchIds(team:CricketTeam)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
-    getTeamMatches(team, "fixtures", LocalDate.now, LocalDate.now)
-  }
-
-  def getHistoricalMatchIds(team: CricketTeam)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
-    getTeamMatches(team, "results", LocalDate.now.minusMonths(2), LocalDate.now)
+  def getMatchIds(team:CricketTeam, fromDate: LocalDate)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {
+    Future.sequence(Seq(
+      getTeamMatches(team, "fixtures", fromDate, LocalDate.now),
+      getTeamMatches(team, "results", fromDate, LocalDate.now)
+    )).map(_.flatten)
   }
 
   private def getTeamMatches(team: CricketTeam, matchType: String, startDate: LocalDate, endDate: LocalDate)(implicit executionContext: ExecutionContext): Future[Seq[String]] = {

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -32,7 +32,7 @@ class CricketStatsJob(paFeed: PaFeed) extends Logging {
     matchObjects.flatten.headOption
   }
 
-  def run(includeHistorical: Boolean, matchesToFetch: Int)(implicit executionContext: ExecutionContext): Unit = {
+  def run(fromDate: LocalDate, matchesToFetch: Int)(implicit executionContext: ExecutionContext): Unit = {
 
     cricketStatsAgents.foreach { case (team, agent) =>
 
@@ -42,9 +42,7 @@ class CricketStatsJob(paFeed: PaFeed) extends Logging {
         Days.daysBetween(cricketMatch.gameDate.toLocalDate, LocalDate.now).getDays > 5
       ).map(_.matchId).toSeq
 
-      val matchIds = if (includeHistorical) paFeed.getHistoricalMatchIds(team) else paFeed.getCurrentMatchIds(team)
-
-      matchIds.map { matchIds =>
+        paFeed.getMatchIds(team, fromDate).map { matchIds =>
 
         // never fetch more than 10 matches
         val matches = matchIds.diff(loadedMatches).take(Math.min(matchesToFetch, 10))


### PR DESCRIPTION
## What does this change?
Modifies the cricket stats scheduler so that instead of fetching all matches for all teams for the last 2 months every 60 seconds, it instead will fetch the stats for the matches TODAY every 15 seconds, and fetch historical matches only every 10 minutes. This should deal with issues we've encountered with cricket stats not getting updated due to the job timing out (we only make 1 request to pa every second, so fetching the last 10 matches for 10 teams every 60 seconds results in 100 matches being updated every minute, which adds up to 110 requests to PA (including the inital request to find out the match ids for each team) - which takes 110 seconds to complete, by which point we've scheduled another 110 matches...etc)
## Screenshots

## What is the value of this and can you measure success?
Cricket stats should remain up to date on the website
## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->