### PR TITLE
Tight H2 + figcaption sharing

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content-garnett/_block-level-sharing.scss
@@ -180,6 +180,7 @@
         figcaption {
             @include mq(tablet) {
                 max-width: gs-span(7) - 20;
+                min-height: $gs-baseline * 2;
             }
         }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -201,10 +201,13 @@ figure {
         display: block;
     }
     &.element {
+        margin-top: ($gs-baseline/3)*4;
+        margin-bottom: $gs-baseline;
         position: relative;
 
         .content__article-body &:first-child {
             margin-top: 0;
+            margin-bottom: 0;
         }
     }
     &.element-image {


### PR DESCRIPTION
A change (https://github.com/guardian/frontend/commit/195c56a64ce4abe4b29668cdae1a5f4aa769a0d3#diff-ef33d6a0b443305f79eeb47d8eec076b) from dotcom a while back introduced some very tightly spaced H2 behaviour. Have reverted that but introduced main-media rules to keep the intention the same.


# Before
<img width="664" alt="Screen Shot 2019-06-20 at 10 51 18" src="https://user-images.githubusercontent.com/14570016/59840215-d19af580-9349-11e9-84b3-7e9dbed7d88f.png">

# After
<img width="674" alt="Screen Shot 2019-06-20 at 10 51 28" src="https://user-images.githubusercontent.com/14570016/59840216-d19af580-9349-11e9-8e24-d87563a9286b.png">
