### PR TITLE
AMP Cleaning: Update views' signatures

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -70,7 +70,7 @@
 
                         @if(!isPaidContent) {
                             @if(article.content.isSplash) {
-                                @fragments.articleHeaderColumn(article, model, amp = false)
+                                @fragments.articleHeaderColumn(article, model)
                             } else if(article.metadata.designType.nameOrDefault == "comment" ||
                                     article.metadata.designType.nameOrDefault == "guardianview") {
                                 @fragments.articleHeaderCommentGarnett(article, model, amp = false)

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -56,7 +56,7 @@
 
             @if(isPaidContent) {
                 @fragments.guBand()
-                @fragments.articleHeaderPaidGarnett(article, model, amp = false)
+                @fragments.articleHeaderPaidGarnett(article, model)
             }
 
             @if(article.tags.isReview) {

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -73,7 +73,7 @@
                                 @fragments.articleHeaderColumn(article, model)
                             } else if(article.metadata.designType.nameOrDefault == "comment" ||
                                     article.metadata.designType.nameOrDefault == "guardianview") {
-                                @fragments.articleHeaderCommentGarnett(article, model, amp = false)
+                                @fragments.articleHeaderCommentGarnett(article, model)
                             } else {
                                 @fragments.articleHeaderGarnett(article, model, amp = false)
                             }

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -75,7 +75,7 @@
                                     article.metadata.designType.nameOrDefault == "guardianview") {
                                 @fragments.articleHeaderCommentGarnett(article, model)
                             } else {
-                                @fragments.articleHeaderGarnett(article, model, amp = false)
+                                @fragments.articleHeaderGarnett(article, model)
                             }
                         }
 

--- a/article/app/views/fragments/articleHeaderColumn.scala.html
+++ b/article/app/views/fragments/articleHeaderColumn.scala.html
@@ -1,4 +1,4 @@
-@(article: model.Article, page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(article: model.Article, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import views.support.ContributorLinks
@@ -8,9 +8,9 @@
 
 <header class="content__head content__head--splash content__head--article tonal__head tonal__head--@toneClass(article)
 @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage && article.metadata.designType.nameOrDefault != "analysis") { content__head--byline-pic}">
-    @fragments.mainMedia(article, amp)
+    @fragments.mainMedia(article, false)
 
-    @fragments.meta.metaInline(article, amp)
+    @fragments.meta.metaInline(article, false)
 
     <div class="content__headline-splash-wrapper">
         <div class="content__header tonal__header u-cf">

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -1,4 +1,4 @@
-@(article: model.Article, page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(article: model.Article, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import views.support.ContributorLinks
@@ -7,7 +7,7 @@
 <header class="content__head content__head--article tonal__head tonal__head--@toneClass(article)
     @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) { content__head--byline-pic}">
 
-    @fragments.meta.metaInline(article, amp)
+    @fragments.meta.metaInline(article, false)
 
     <div class="content__header tonal__header">
         <div class="u-cf">
@@ -68,6 +68,6 @@
         }
     </div>
 
-    @fragments.contentMeta(article, page, amp = amp)
-    @fragments.mainMedia(article, amp)
+    @fragments.contentMeta(article, page, amp = false)
+    @fragments.mainMedia(article, false)
 </header>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -1,4 +1,4 @@
-@(article: model.Article, page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(article: model.Article, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import views.support.ContributorLinks
@@ -48,7 +48,7 @@
     </div>
 }
 
-    @fragments.meta.metaInline(article, amp)
+    @fragments.meta.metaInline(article, false)
 
     <div class="content__headline-standfirst-wrapper">
         <div class="content__header tonal__header">
@@ -126,7 +126,7 @@
             }
         </div>
     </div>
-    @fragments.contentMeta(article, page, amp = amp)
+    @fragments.contentMeta(article, page, amp = false)
     @if(article.elements.hasShowcaseMainElement && article.content.starRating.isDefined) {
     <div class="media-primary media-content  media-primary--showcase  ">
         @article.content.starRating.map { rating =>
@@ -139,7 +139,7 @@
         @fragments.items.elements.starRating(rating)
         }
     }
-    @fragments.mainMedia(article, amp)
+    @fragments.mainMedia(article, false)
     @if(article.elements.hasShowcaseMainElement && article.content.starRating.isDefined) {
     </div>
     }

--- a/article/app/views/fragments/articleHeaderPaidGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderPaidGarnett.scala.html
@@ -1,4 +1,4 @@
-@(article: model.Article, page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(article: model.Article, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import model.Badges.badgeFor

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -1,4 +1,4 @@
-@(amp: Boolean = false)(implicit model: ArticlePage, request: RequestHeader, context: _root_.model.ApplicationContext)
+@()(implicit model: ArticlePage, request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import views.html.fragments.langAttributes
 @import common.LinkTo
@@ -59,7 +59,7 @@
                             case None => { }
                         }
 
-                        @fragments.contentMeta(article, model, amp = amp)
+                        @fragments.contentMeta(article, model, amp = false)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
@@ -68,7 +68,7 @@
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                              data-test-id="article-review-body" @langAttributes(article.content)>
-                            @BodyCleaner(article, amp = amp)
+                            @BodyCleaner(article, amp = false)
                             @fragments.submeta(article)
 
                         </div>

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -1,7 +1,7 @@
 @import conf.Configuration
 @import model.LiveBlogCurrentPage
 
-@(id: String, currentPage: LiveBlogCurrentPage, amp: Boolean = false)
+@(id: String, currentPage: LiveBlogCurrentPage)
 
 @currentPage.pagination.map { pagination =>
     <div id="liveblog-navigation" class="liveblog-navigation">
@@ -12,7 +12,7 @@
 
         <div class="liveblog-navigation__newer">
             <a @pagination.newest.map { newest =>
-                href="@if(amp){@Configuration.site.host}/@id@newest.suffix"
+                href="/@id@newest.suffix"
                 title="Go to page @newest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
@@ -29,7 +29,7 @@
             </a>
 
             <a @pagination.newer.map { newer =>
-                href="@if(amp){@Configuration.site.host}/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
+                href="/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
                 title="Go to page @newer.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -47,7 +47,7 @@
 
         <div class="liveblog-navigation__older">
             <a @pagination.older.map { older =>
-                href="@if(amp){@Configuration.site.host}/@id@older.suffix#liveblog-navigation"
+                href="/@id@older.suffix#liveblog-navigation"
                 title="Go to page @older.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -63,7 +63,7 @@
             </a>
 
             <a @pagination.oldest.map { oldest =>
-                href="@if(amp){@Configuration.site.host}/@id@oldest.suffix#liveblog-navigation"
+                href="/@id@oldest.suffix#liveblog-navigation"
                 title="Go to page @oldest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"


### PR DESCRIPTION
## What does this change?

Update views' signatures by removing the `amp: Boolean = false` argument. Limited to the Article app. 
