### PR TITLE
Add fallback for author if empty

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -463,6 +463,11 @@ object DotcomponentsDataModel {
       article.metadata.commercial,
     )
 
+    val author = article.tags.contributors.map(_.name) match {
+      case Nil => "Guardian staff reporter"
+      case contributors => contributors.mkString(","),
+    }
+
     val content = DCPage(
       Content(
         article.trail.headline,
@@ -475,7 +480,7 @@ object DotcomponentsDataModel {
       ),
       tags,
       pagination = pagination,
-      article.tags.contributors.map(_.name).mkString(","),
+      author,
       article.metadata.id,
       article.metadata.pillar.map(_.toString),
       article.trail.webPublicationDate.getMillis,


### PR DESCRIPTION
## What does this change?

Fallback to 'Guardian staff reporter' for articles when no byline for AMP - we need this to validate structured data with Google.

## What is the value of this and can you measure success?

Enables more articles to have valid structured data according to Google's requirements. E.g. articles like:

https://www.theguardian.com/world/2011/jun/14/sarah-palin-emails-the-documents1886
