### PR TITLE
Update the signature of contentMeta.scala.html

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -64,7 +64,7 @@
             }
 
             <div class="podcast__byline">
-                @fragments.contentMeta(audio, page, false)
+                @fragments.contentMeta(audio, page)
             </div>
 
             <div class="from-content-api podcast__body">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -52,7 +52,7 @@
                         <div class="js-score"></div>
                         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
 
-                        @fragments.contentMeta(article, model, amp = false)
+                        @fragments.contentMeta(article, model)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && (article.elements.elements("main") && article.elements.elements("main").isEmpty)) {
                             <hr class="content__hr hide-until-leftcol" />

--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -84,12 +84,12 @@
 
 
                             @if(isPaidContent){
-                                @fragments.contentMeta(article, model, amp = false)
+                                @fragments.contentMeta(article, model)
                                 @fragments.mainMedia(article, false)
                             }
 
                             @if(article.content.isSplash){
-                                @fragments.contentMeta(article, model, amp = false)
+                                @fragments.contentMeta(article, model)
                             }
 
                             @BodyCleaner(article, amp = false)

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -68,6 +68,6 @@
         }
     </div>
 
-    @fragments.contentMeta(article, page, amp = false)
+    @fragments.contentMeta(article, page)
     @fragments.mainMedia(article, false)
 </header>

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -126,7 +126,7 @@
             }
         </div>
     </div>
-    @fragments.contentMeta(article, page, amp = false)
+    @fragments.contentMeta(article, page)
     @if(article.elements.hasShowcaseMainElement && article.content.starRating.isDefined) {
     <div class="media-primary media-content  media-primary--showcase  ">
         @article.content.starRating.map { rating =>

--- a/article/app/views/fragments/immersiveGarnettBody.scala.html
+++ b/article/app/views/fragments/immersiveGarnettBody.scala.html
@@ -59,7 +59,7 @@
                             case None => { }
                         }
 
-                        @fragments.contentMeta(article, model, amp = false)
+                        @fragments.contentMeta(article, model)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -69,7 +69,7 @@
 
                     <div class="blog__left-col">
 
-                        @fragments.contentMeta(article, model, amp = false)
+                        @fragments.contentMeta(article, model)
 
                         <div class="js-top-marker"></div>
                         <div class="js-live-blog__sticky-components">

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,4 +1,4 @@
-@(item: model.ContentType, page: model.Page, showExtras: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
+@(item: model.ContentType, page: model.Page, showExtras: Boolean = true)(implicit request: RequestHeader)
 @import model._
 @import views.support.Commercial.isPaidContent
 @import _root_.model.ContentDesignType.RichContentDesignType
@@ -33,10 +33,10 @@
         @item.content.contributorBio.map { bio => <p class="meta__bio" data-link-name="byline" data-component="meta-byline">@bio</p> }
 
         @if(item.content.tags.contributors.length == 1) {
-            @if(!amp && item.content.hasTonalHeaderByline && (item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty) || item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty))) {
+            @if(item.content.hasTonalHeaderByline && (item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty) || item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty))) {
                 <p class="meta__contact-header">Contact author</p>
             }
-            @fragments.meta.contactAuthor(item.tags, amp)
+            @fragments.meta.contactAuthor(item.tags, false)
         }
 
         @if(!(item.trail.shouldHidePublicationDate || item.content.isGallery)) {
@@ -54,10 +54,8 @@
     @if(showExtras) {
         <div class="meta__extras">
             <div class="meta__social" data-component="share">
-                @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier, amp = amp)
+                @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier, amp = false)
             </div>
-
-            @if(!amp) {
                 <div class="meta__numbers">
                     <div class="u-h meta__number js-sharecount">
                     </div>
@@ -66,7 +64,6 @@
                     }">
                     </div>
                 </div>
-            }
         </div>
     }
 }


### PR DESCRIPTION
`contentMeta.scala.html` is only called from

- frontend/article/app/views/fragments/articleBody.scala.html:55:36
- frontend/article/app/views/fragments/articleBodyGarnett.scala.html:87:44
- frontend/article/app/views/fragments/articleBodyGarnett.scala.html:87:72
- frontend/article/app/views/fragments/articleHeaderCommentGarnett.scala.html:71:16
- frontend/article/app/views/fragments/articleHeaderGarnett.scala.html:129:16
- frontend/article/app/views/fragments/immersiveGarnettBody.scala.html:62:36
- frontend/article/app/views/fragments/photoEssayBody.scala.html:26:36
- frontend/article/app/views/liveblog/liveBlogBody.scala.html:72:36
- frontend/applications/app/views/fragments/audioBody.scala.html:67:28
- frontend/applications/app/views/fragments/galleryHeader.scala.html:13:24
- frontend/applications/app/views/fragments/imageContentBody.scala.html:38:32
- frontend/applications/app/views/fragments/interactiveBody.scala.html:52:40
- frontend/applications/app/views/fragments/mediaBody.scala.html:112:48

either without a second parameters or massing the default value. This simplify the signature of `contentMeta.scala.html`
