### PR TITLE
Mobile acquisitions banner update

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -763,7 +763,10 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             test: () => {},
 
                             engagementBannerParams: {
-                                leadSentence: row.leadSentence,
+                                leadSentence: buildBannerCopy(
+                                    row.leadSentence.trim(),
+                                    hasCountryName
+                                ),
                                 messageText: buildBannerCopy(
                                     row.messageText.trim(),
                                     hasCountryName

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -763,6 +763,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             test: () => {},
 
                             engagementBannerParams: {
+                                leadSentence: row.leadSentence,
                                 messageText: buildBannerCopy(
                                     row.messageText.trim(),
                                     hasCountryName

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -22,7 +22,7 @@ export const acquisitionsBannerControlTemplate = (
                 ${closeCentralIcon.markup}
             </button>
         </div>
-        <div class="engagement-banner__container testing">
+        <div class="engagement-banner__container">
             <div class="engagement-banner__text">
                 ${
                     params.leadSentence

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -14,7 +14,7 @@ export const acquisitionsBannerControlTemplate = (
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
     return `
         <div class="engagement-banner__close">
-            <div class="engagement-banner__roundel">
+            <div class="engagement-banner__roundel hide-until-phablet">
                 ${marque36icon.markup}
             </div>
             <button tabindex="4" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
@@ -22,8 +22,15 @@ export const acquisitionsBannerControlTemplate = (
                 ${closeCentralIcon.markup}
             </button>
         </div>
-        <div class="engagement-banner__container">
+        <div class="engagement-banner__container testing">
             <div class="engagement-banner__text">
+                ${
+                    params.leadSentence
+                        ? `<div class="engagement-banner__header">
+                        ${params.leadSentence}
+                    </div>`
+                        : ''
+                }
                 ${params.messageText}${params.ctaText}
                 ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
             </div>

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -294,7 +294,7 @@
 }
 
 @mixin banner-copy-alignment {
-    @include mq(tablet) {
+    @include mq(phablet) {
         width: gs-span(7) + $gs-gutter;
     }
 

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -26,6 +26,12 @@
     }
 }
 
+.hide-until-phablet {
+    @include mq($until: phablet) {
+        display: none !important;
+    }
+}
+
 .hide-until-leftcol {
     @include mq($until: leftCol) {
         display: none !important;

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -123,7 +123,6 @@
     }
 
     @include mq(tablet) {
-        display: block;
         margin-bottom: 8px;
     }
 

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -203,11 +203,11 @@
     }
 }
 
-// For Mobile Design test:
 .engagement-banner__header {
+    font-weight: 700;
+
     @include mq($until: phablet) {
         @include fs-headline(2);
-        font-weight: 700;
         margin: 0 -10px $gs-gutter / 4;
         padding: 0 10px $gs-gutter / 4;
         border-bottom: 1px solid rgba($brightness-7, .3);
@@ -216,6 +216,5 @@
 
     @include mq(phablet) {
         display: inline;
-        font-weight: 700;
     }
 }

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -206,9 +206,17 @@
 
 // For Mobile Design test:
 .engagement-banner__header {
-    @include fs-headline(2);
-    font-weight: 700;
-    margin: 0 -10px $gs-gutter / 4;
-    padding: 0 10px $gs-gutter / 4;
-    border-bottom: 1px solid  rgba($brightness-7,  .3);
+    @include mq($until: phablet) {
+        @include fs-headline(2);
+        font-weight: 700;
+        margin: 0 -10px $gs-gutter / 4;
+        padding: 0 10px $gs-gutter / 4;
+        border-bottom: 1px solid rgba($brightness-7, .3);
+        min-height: 40px;
+    }
+
+    @include mq(phablet) {
+        display: inline;
+        font-weight: 700;
+    }
 }


### PR DESCRIPTION
## What does this change?
[This PR](https://github.com/guardian/frontend/pull/21374) tested a different design for the mobile banner.
It performed well, so this change moves that design into the default banner template.
It also adds the optional `leadSentence` field to the google sheet. At mobile breakpoints this is displayed above the main text.
Note - this change is backwards compatible with how we currently do bold text in the banner from the sheets (using `<strong>` tags)

## Screenshots

Up to 660px (<= mobileLandscape) - NEW DESIGN
<img width="386" alt="Screenshot 2019-06-20 at 14 15 11" src="https://user-images.githubusercontent.com/1513454/59852074-00bf6000-9366-11e9-96ee-a8f4cdd065d6.png">

660px-740px (phablet) - UNCHANGED
![phablet banner](https://user-images.githubusercontent.com/3300789/60274705-72f8ed00-98f0-11e9-95d7-85069b221a6e.png)

740px-980px (tablet)- UNCHANGED
![tablet banner](https://user-images.githubusercontent.com/3300789/60274713-768c7400-98f0-11e9-9356-f60c5c8444ec.png)

980px-1140px (desktop)- UNCHANGED
<img width="1101" alt="Screenshot 2019-06-20 at 14 15 57" src="https://user-images.githubusercontent.com/1513454/59852081-01f08d00-9366-11e9-9773-70a9a0a9e7fd.png">

1140px- (>= leftcol)- UNCHANGED
<img width="1260" alt="Screenshot 2019-06-20 at 14 16 06" src="https://user-images.githubusercontent.com/1513454/59852084-02892380-9366-11e9-8a43-dd6cddb9dfd6.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
