### PR TITLE
Clean team name of teams in knockout stage wallchart.

### DIFF
--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -2,6 +2,7 @@
 
 @import implicits.Football._
 @import conf.Configuration
+@import model.CompetitionDisplayHelpers.cleanTeamName
 
 <div class="football-match" id="football-match-@fm.id">
     <div class="football-match__container">
@@ -9,7 +10,7 @@
             @if(!fm.homeTeam.isGhostTeam){
                 <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.homeTeam.id}.png" />
             }
-            @fm.homeTeam.knockoutName
+            @cleanTeamName(fm.homeTeam.knockoutName)
             @if(fm.hasStarted){
                 <span class="football-match__score">@fm.homeTeam.score</span>
             }
@@ -36,7 +37,7 @@
             @if(!fm.awayTeam.isGhostTeam){
                 <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.awayTeam.id}.png" />
             }
-            @fm.awayTeam.knockoutName
+            @cleanTeamName(fm.awayTeam.knockoutName)
             @if(fm.hasStarted){
                 <span class="football-match__score">@fm.awayTeam.score</span>
             }


### PR DESCRIPTION
## What does this change?
Ensures that the wallchart cleans teams names sent from PA - so that instead of "Japan Women" it shows "Japan Ladies" - see https://www.theguardian.com/football/world-cup-2019/overview
## Screenshots
before

![Screenshot 2019-06-21 at 14 00 07](https://user-images.githubusercontent.com/3606555/59924144-fb791880-942c-11e9-870a-37de8e801143.png)

after

![Screenshot 2019-06-21 at 14 01 06](https://user-images.githubusercontent.com/3606555/59924186-1186d900-942d-11e9-902f-459d9bd5732d.png)

## What is the value of this and can you measure success?

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
