### PR TITLE
Add alternative round name for 3/4 place play offs

### DIFF
--- a/sport/app/football/views/wallchart/knockoutSpider.scala.html
+++ b/sport/app/football/views/wallchart/knockoutSpider.scala.html
@@ -50,7 +50,7 @@
                                 football-round--@matches.length-matches
                                 football-round--final
                                 @if(knockoutStage.isActiveRound(round)){football-round--active}
-                                @round.name.filter(n => n == "3rd/4th Play-Offs").map{ name => football-round--playoff}">
+                                @round.name.filter(n => n == "3rd/4th Play-Offs" || n == "3rd/4th Place Play-Off").map{ name => football-round--playoff}">
                         <div class="football-round__name">@round.name.getOrElse("")</div>
                         <div class="football-round__matches">
                             @matches.map{ m =>


### PR DESCRIPTION
## What does this change?

Fixes the wallchart: theguardian.com/football/world-cup-2019/overview - currently the 3/4th place match is where the final ought to be. A bit unfortunate that we're at the whim of whatever PA decides to name each round of the competition, but at least this fixes it.

TODO: document all this crazy stuff somewhere so we know what to do next time :D

## Screenshots
<img width="1230" alt="Screenshot 2019-06-21 at 16 05 21" src="https://user-images.githubusercontent.com/3606555/59932118-67b04800-943e-11e9-8ea0-2b8ac3718a33.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
