### PR TITLE
Fix liveblog epic tracking

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -85,7 +85,7 @@ declare type EpicABTest = AcquisitionsABTest & {
 declare type InitEpicABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
-    test?: (html: string, abTest: ABTest) => void,
+    test?: (html: string, variant: EpicVariant, parentTest: ABTest) => void,
     deploymentRules?: DeploymentRules,
     countryGroups?: string[],
     tagIds?: string[],

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -79,19 +79,30 @@ const setEpicLiveblogEntryTimeData = (
     }
 };
 
-const setupViewTracking = (el: HTMLElement, test: EpicABTest): void => {
+const setupViewTracking = (
+    el: HTMLElement,
+    variant: EpicVariant,
+    parentTest: EpicABTest
+): void => {
     // top offset of 18 ensures view only counts when half of element is on screen
     const inView = elementInView(el, window, {
         top: 18,
     });
 
     inView.on('firstview', () => {
-        logView(test.id);
-        mediator.emit(test.viewEvent);
+        logView(variant.id);
+        mediator.emit(parentTest.viewEvent, {
+            componentType: parentTest.componentType,
+            campaignCode: variant.campaignCode,
+        });
     });
 };
 
-const addEpicToBlocks = (epicHtml: string, test: EpicABTest): Promise<void> => {
+const addEpicToBlocks = (
+    epicHtml: string,
+    variant: EpicVariant,
+    parentTest: EpicABTest
+): Promise<void> => {
     const elementsWithTimeData = getBlocksToInsertEpicAfter().map(el => [
         el,
         getLiveblogEntryTimeData(el),
@@ -105,23 +116,24 @@ const addEpicToBlocks = (epicHtml: string, test: EpicABTest): Promise<void> => {
 
             const $epic = $.create(epicHtml);
             $epic.insertAfter(el);
-            mediator.emit(test.insertEvent);
+            mediator.emit(variant.insertEvent);
             $(el).removeClass(INSERT_EPIC_AFTER_CLASS);
             setEpicLiveblogEntryTimeData($epic[0], timeData);
-            setupViewTracking(el, test);
+            setupViewTracking(el, variant, parentTest);
         });
     });
 };
 
 export const setupEpicInLiveblog = (
     epicHtml: string,
-    test: EpicABTest
+    variant: EpicVariant,
+    parentTest: EpicABTest
 ): void => {
-    addEpicToBlocks(epicHtml, test);
+    addEpicToBlocks(epicHtml, variant, parentTest);
 
     if (!isAutoUpdateHandlerBound) {
         mediator.on('modules:autoupdate:updates', () => {
-            addEpicToBlocks(epicHtml, test);
+            addEpicToBlocks(epicHtml, variant, parentTest);
         });
         isAutoUpdateHandlerBound = true;
     }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -116,7 +116,7 @@ const addEpicToBlocks = (
 
             const $epic = $.create(epicHtml);
             $epic.insertAfter(el);
-            mediator.emit(variant.insertEvent);
+            mediator.emit(parentTest.insertEvent);
             $(el).removeClass(INSERT_EPIC_AFTER_CLASS);
             setEpicLiveblogEntryTimeData($epic[0], timeData);
             setupViewTracking(el, variant, parentTest);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -326,7 +326,8 @@ const makeEpicABTestVariant = (
                 )
                 .then(renderedTemplate => {
                     if (initVariant.test) {
-                        initVariant.test(renderedTemplate, this);
+                        const parent = parentTest;
+                        initVariant.test(renderedTemplate, this, parent);
                     } else {
                         // Standard epic insertion. TODO - this could do with a refactor
                         const component = $.create(renderedTemplate);


### PR DESCRIPTION
## What does this change?
We're not currently tracking the insert and view events on the epic in the liveblog.
Tracking of other epics is [handled elsewhere](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L373)

E.g.
<img width="546" alt="Screenshot 2019-06-24 at 13 15 01" src="https://user-images.githubusercontent.com/1513454/60018038-1db7a400-9682-11e9-9719-e265b885530f.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
