### PR TITLE
Enable lazy image loading on fronts in Chrome

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -1,6 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
+import org.joda.time.LocalDate
 
 trait PerformanceSwitches {
 
@@ -184,5 +185,15 @@ trait PerformanceSwitches {
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
+  )
+
+  val LazyLoadImages = Switch(
+    SwitchGroup.Performance,
+    "blink-lazy-load-images",
+    "If switched on, explicitly request lazy loading of images on supporting browsers.",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = On,
+    sellByDate = new LocalDate(2029, 9, 3),
+    exposeClientSide = false,
   )
 }

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -26,6 +26,6 @@
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>
-        <img class="@RenderClasses(classes: _*)" alt="" src="@src"/>
+        <img loading="lazy" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
     }
 </picture>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -2,7 +2,7 @@
 @import model.ImageMedia
 @import views.support.{ImgSrc, RenderClasses, SrcSet}
 @import implicits.Requests._
-
+@import conf.switches.Switches
 @import experiments.{ActiveExperiments}
 
 @(
@@ -26,6 +26,6 @@
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>
-        <img loading="lazy" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
+        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
     }
 </picture>


### PR DESCRIPTION
Potentially faster FMP and start render time for some devices and also reduced bandwidth costs for us.

But note, this is only behind a feature flag in Chrome at the moment:

chrome://flags/#enable-lazy-image-loading

At the moment this is only for *fronts* but it is easy to expand to all images once we have seen it actually taking effect.

## Concerns

### Cross-browser support

At the moment there is a proposed HTML spec, but non-Chrome browsers have not expressed interest in implementing. As Chrome represents a significant portion of our mobile traffic
and the cost to implement here is very low, it feels worth adding despite the lack of FF and other support. It is also trivial to remove if support doesn't materialise.

### Image costs

Chrome will send an initial range request to get the image size so that it can add correctly sized placeholders. This may result in more image requests overall. Will need to check cost implications of this as we go.