### PR TITLE
Fix liveblog match errors

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -182,6 +182,10 @@ class LiveBlogController(
         Left(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog =>
         createLiveBlogModel(liveBlog, response, range).left.map(_ -> blocks)
+      case unknown => {
+        log.error(s"Requested non-liveblog: ${unknown.metadata.id}")
+        Right(InternalServerError)
+      }
     }
 
     content


### PR DESCRIPTION
Ensures pattern matching is comprehensive to avoid runtime MatchErrors. These are particularly unfortunate because they log the entire Article object, which is very large, twice - in the stack trace and as the message of the log json too.

An example of a path that currently hits this issue (it has 'live' in the path but is not a liveblog):

https://www.theguardian.com/science/head-quarters/live/2014/oct/02/the-greatest-brain-myth-there-ever-was

From a user-perspective this PR doesn't change anything - we still 500. But this is at least explicit and we avoid clogging the logs.