### PR TITLE
Add classList append to mobile nav

### DIFF
--- a/common/app/views/fragments/nav/headerMenu.scala.html
+++ b/common/app/views/fragments/nav/headerMenu.scala.html
@@ -133,7 +133,7 @@
                 @navMenu.brandExtensions.map { item =>
                     <li class="menu-item hide-from-desktop"
                         role="none">
-                        <a class="menu-item__title"
+                        <a class="@{"menu-item__title " ++ item.classList.mkString(" ")}"
                            href="@LinkTo { @item.url }"
                            role="menuitem"
                            data-link-name="nav2 : @item.title">


### PR DESCRIPTION
## What does this change?
We should be adding classes to the mobile nav, which then functionality hangs off.

https://trello.com/c/YYbSSeZL/643-discountcode-links-should-change-destination-on-mobile-as-well-as-desktop

Follows on from: https://github.com/guardian/frontend/pull/21522

## What is the value of this and can you measure success?

In this case, we direct to the right discount codes link.

## Checklist

### Does this affect other platforms?

No.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [X] No

### Does this change break ad-free?

- [X] No

### Does this change update the version of CAPI we're using?

- [X] No, all the existing database files are just fine

### Accessibility test checklist

N/A

### Tested

- [X] Locally

