### PR TITLE
Check country name is available in hardcoded epic tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -5,7 +5,7 @@ import {
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // Use must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -36,7 +36,8 @@ const ROWControlCopy = {
     highlightedText,
 };
 
-const isUSUK = ['GB', 'US'].includes(geolocationGetSync());
+const geolocation = geolocationGetSync();
+const isUSUK = ['GB', 'US'].includes(geolocation);
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicArticlesViewed',
@@ -54,7 +55,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
-    canRun: () => articleViewCount >= minArticleViews,
+    canRun: () =>
+        articleViewCount >= minArticleViews && countryNames[geolocation],
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -4,7 +4,7 @@ import {
     defaultButtonTemplate,
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
-import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
@@ -24,7 +24,11 @@ export const countryName: EpicABTest = makeEpicABTest({
 
     canRun: () => {
         const geolocation = geolocationGetSync();
-        return geolocation !== 'US' && geolocation !== 'GB';
+        return (
+            geolocation !== 'US' &&
+            geolocation !== 'GB' &&
+            countryNames[geolocationGetSync()]
+        );
     },
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -27,7 +27,7 @@ export const countryName: EpicABTest = makeEpicABTest({
         return (
             geolocation !== 'US' &&
             geolocation !== 'GB' &&
-            countryNames[geolocationGetSync()]
+            countryNames[geolocation]
         );
     },
 


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/frontend/pull/21531 introduced a hardcoded version of the 'country name' epic test (so far it's been run from the google spreadsheet). This was necessary because the 'articles viewed' epic test had to be hardcoded.

We have a list of available country names, and users should be exluded from the 'country name' test if they are not in any of these countries. This PR fixes this for the hardcoded version (it was already correct in the google sheets version)

## Screenshots
Valid country name:
<img width="632" alt="Screenshot 2019-06-26 at 09 18 06" src="https://user-images.githubusercontent.com/1513454/60163585-d3eecb00-97f3-11e9-8bec-3a1265d3a0a3.png">

Invalid country name (goes to default epic):
<img width="632" alt="Screenshot 2019-06-26 at 09 18 38" src="https://user-images.githubusercontent.com/1513454/60163586-d3eecb00-97f3-11e9-9cd8-24697b7f1c57.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
