### PR TITLE
Wrap dotcom-rendering service in a circuit breaker

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -20,7 +20,16 @@ import scala.concurrent.Future
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-class ArticleController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents, ws: WSClient, remoteRenderer: renderers.RemoteRenderer = RemoteRenderer())(implicit context: ApplicationContext) extends BaseController with RendersItemResponse with Logging with ImplicitControllerExecutionContext {
+class ArticleController(
+  contentApiClient: ContentApiClient,
+  val controllerComponents: ControllerComponents,
+  ws: WSClient,
+  remoteRenderer: renderers.RemoteRenderer = RemoteRenderer()
+)(implicit context: ApplicationContext)
+  extends BaseController with
+    RendersItemResponse with
+    Logging with
+    ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
 

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -1,18 +1,17 @@
 package renderers
 
 import akka.actor.ActorSystem
-import akka.pattern.CircuitBreaker
 import com.eclipsesource.schema._
 import com.eclipsesource.schema.drafts.Version7
 import com.eclipsesource.schema.drafts.Version7._
 import com.gu.contentapi.client.model.v1.Blocks
 import com.osinka.i18n.Lang
-import common.Logging
+import concurrent.CircuitBreakerRegistry
 import conf.Configuration
-import controllers.ArticlePage
-import model.{Cached, PageWithStoryPackage}
+import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
 import model.dotcomponents.DotcomponentsDataModel
+import model.{Cached, PageWithStoryPackage}
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
@@ -22,49 +21,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.Source
-import conf.switches.Switches.CircuitBreakerSwitch
-
-object CircuitBreakerRegistry extends Logging {
-  // Warning this is a very expensive method, as it creates an actor system
-  def withConfig(
-    prefix: String,
-    maxFailures: Int,
-    callTimeout: FiniteDuration,
-    resetTimeout: FiniteDuration,
-  ): CircuitBreaker = {
-    val system = ActorSystem(s"$prefix-circuit-breaker")
-
-    val cb = new CircuitBreaker(
-      scheduler = system.scheduler,
-      maxFailures = 10,
-      callTimeout = callTimeout,
-      resetTimeout = resetTimeout,
-    )
-
-    cb.onOpen(
-      log.error(s"$prefix circuit breaker: reached error threshold ($maxFailures}). Breaker is OPEN!")
-    )
-
-    cb.onHalfOpen(
-      log.info(s"$prefix circuit breaker: Reset timeout (${resetTimeout}) finished. Entered half open state.")
-    )
-
-    cb.onClose(
-      log.info(s"$prefix circuit breaker: Content API Client looks healthy again, circuit breaker is closed.")
-    )
-
-    cb
-  }
-}
 
 class RemoteRenderer {
 
   private[this] val SCHEMA = "schema/dotcomponentsDataModelV2.jsonschema"
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
-    prefix = "dotcom-rendering-client",
+    name = "dotcom-rendering-client",
+    system = ActorSystem("dotcom-rendering-client-circuit-breaker"),
     maxFailures = Configuration.rendering.circuitBreakerMaxFailures,
-    callTimeout = Configuration.rendering.timeout.plus(400.millis),
+    callTimeout = Configuration.rendering.timeout.plus(200.millis),
     resetTimeout = Configuration.rendering.timeout * 4,
   )
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -151,6 +151,8 @@ class GuardianConfiguration extends Logging {
     lazy val AMPArticleEndpoint = configuration.getMandatoryStringProperty("rendering.AMPArticleEndpoint")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
+    lazy val timeout = 2.seconds
+    lazy val circuitBreakerMaxFailures = 10 // we should increase this as DCR sees increasing usage
   }
 
   object weather {

--- a/common/app/concurrent/CircuitBreakerRegistry.scala
+++ b/common/app/concurrent/CircuitBreakerRegistry.scala
@@ -1,0 +1,41 @@
+package concurrent
+
+import akka.actor.ActorSystem
+import akka.pattern.CircuitBreaker
+import common.Logging
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+object CircuitBreakerRegistry extends Logging {
+
+  def withConfig(
+    name: String,
+    system: ActorSystem,
+    maxFailures: Int,
+    callTimeout: FiniteDuration,
+    resetTimeout: FiniteDuration,
+  ): CircuitBreaker = {
+
+    val cb = new CircuitBreaker(
+      scheduler = system.scheduler,
+      maxFailures = 10,
+      callTimeout = callTimeout,
+      resetTimeout = resetTimeout,
+    )
+
+    cb.onOpen(
+      log.error(s"Circuit breaker ($name) OPEN (exceeded $maxFailures failures)")
+    )
+
+    cb.onHalfOpen(
+      log.info(s"Circuit breaker ($name) reset timeout (${resetTimeout}) finished. Entered half open state.")
+    )
+
+    cb.onClose(
+      log.info(s"Circuit breaker ($name) is closed. Downstream looks healthy again.")
+    )
+
+    cb
+  }
+}


### PR DESCRIPTION
## What does this change?

Wraps calls to dotcom-rendering in a circuit breaker.

## What is the value of this and can you measure success?

This helps achieve [bulkheading](https://stackoverflow.com/questions/30391809/what-is-bulkhead-pattern-used-by-hystrix). Note, this isn't perfect at all, as we use the same web client for both CAPI and DCR still (with the same underlying execution context) but it will help as a failing DCR should short-circuit rather than saturating the client's EC. I'd like to examine using a separate EC in a separate PR but it's more involved due to how our DI works :(

Relates to ongoing performance investigation here: https://docs.google.com/document/d/1m1vX8nqwNuvhGp3IAc6gxlinfAVzDb8c43Nji89uzkw/edit#. 