### PR TITLE
Adding support for app-ads.txt

### DIFF
--- a/admin/app/views/commercial/adsDotText.scala.html
+++ b/admin/app/views/commercial/adsDotText.scala.html
@@ -1,15 +1,15 @@
 @import controllers.admin.commercial.AdsTextSellers
 @import helper._
 
-@(sellersForm: Form[AdsTextSellers])(
+@(name: String, saveRoute: Call, sellersForm: Form[AdsTextSellers])(
   implicit messages: Messages,
   request: RequestHeader,
   context: model.ApplicationContext
 )
 @admin_main("ads.txt editor", isAuthed = true) {
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")">
-    <h1>ads.txt editor</h1>
-    @form(action = controllers.admin.commercial.routes.AdsDotTextEditController.postAdsDotText()) {
+    <h1>@{name} editor</h1>
+    @form(action = saveRoute) {
         @if(sellersForm.hasGlobalErrors) {
             <ul>
             @for(error <- sellersForm.globalErrors) {

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -88,7 +88,8 @@
                 <div class="panel-body">
                     <ul>
                         <li><a href="@controllers.admin.commercial.routes.TakeoverWithEmptyMPUsController.viewList()">Takeovers with empty MPUs</a></li>
-                        <li><a href="@controllers.admin.commercial.routes.AdsDotTextEditController.renderAdsDotText()">Ads.txt editor</a></li>
+                        <li><a href="@controllers.admin.commercial.routes.AdsDotTextEditController.renderAdsDotText()">ads.txt editor</a></li>
+                        <li><a href="@controllers.admin.commercial.routes.AdsDotTextEditController.renderAppAdsDotText()">app-ads.txt editor</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -88,6 +88,8 @@ GET         /commercial/adgrabber/order/:orderId                                
 GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 GET         /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.renderAdsDotText()
 POST        /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.postAdsDotText()
+GET         /commercial/adops/app-ads-txt                                                           controllers.admin.commercial.AdsDotTextEditController.renderAppAdsDotText()
+POST        /commercial/adops/app-ads-txt                                                           controllers.admin.commercial.AdsDotTextEditController.postAppAdsDotText()
 GET         /commercial/prebid/revenue                                                              controllers.admin.commercial.TeamKPIController.renderPrebidDashboard()
 
 # Config

--- a/commercial/app/controllers/AdsDotTextViewController.scala
+++ b/commercial/app/controllers/AdsDotTextViewController.scala
@@ -4,7 +4,7 @@ import model.{ApplicationContext, Cached}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import services.S3
-import conf.Configuration.commercial.adsTextObjectKey
+import conf.Configuration.commercial.{adsTextObjectKey, appAdsTextObjectKey}
 import model.Cached.RevalidatableResult
 
 import scala.concurrent.duration._
@@ -13,7 +13,11 @@ class AdsDotTextViewController(val controllerComponents: ControllerComponents)(i
   extends BaseController with I18nSupport {
 
   def renderTextFile(): Action[AnyContent] = Action { implicit request =>
-    Cached(30.minutes)(RevalidatableResult.Ok(S3.get(adsTextObjectKey).getOrElse("")))
+    Cached(30.minutes)(RevalidatableResult.Ok(S3.get(adsTextObjectKey).getOrElse("#empty ads.txt")))
+  }
+
+  def renderAppTextFile(): Action[AnyContent] = Action{ implicit request =>
+    Cached(30.minutes)(RevalidatableResult.Ok(S3.get(appAdsTextObjectKey).getOrElse("#empty app-ads.txt")))
   }
 
 }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -39,8 +39,9 @@ GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  comm
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
 
 
-# ADS.TXT Standard
+# ADS.TXT + APP-ADS.txt Standard
 GET         /ads.txt                                                        commercial.controllers.AdsDotTextViewController.renderTextFile()
+GET         /app-ads.txt                                                    commercial.controllers.AdsDotTextViewController.renderAppTextFile()
 
 # Analytics
 POST        /commercial/api/hb                                              commercial.controllers.PrebidAnalyticsController.insert()

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -427,6 +427,7 @@ class GuardianConfiguration extends Logging {
     lazy val dfpCustomTargetingKey = s"$dfpRoot/custom-targeting-key-values.json"
     lazy val topAboveNavSlotTakeoversKey = s"$dfpRoot/top-above-nav-slot-takeovers-v2.json"
     lazy val adsTextObjectKey = s"$commercialRoot/ads.txt"
+    lazy val appAdsTextObjectKey = s"$commercialRoot/app-ads.txt"
     lazy val takeoversWithEmptyMPUsKey = s"$commercialRoot/takeovers-with-empty-mpus.json"
 
     private lazy val merchandisingFeedsRoot = s"$commercialRoot/merchandising"

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -307,6 +307,8 @@ GET         /commercial/adgrabber/order/:orderId                                
 GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                                               controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 GET         /commercial/adops/ads-txt                                                                                            controllers.admin.commercial.AdsDotTextEditController.renderAdsDotText()
 POST        /commercial/adops/ads-txt                                                                                            controllers.admin.commercial.AdsDotTextEditController.postAdsDotText()
+GET         /commercial/adops/app-ads-txt                                                                                        controllers.admin.commercial.AdsDotTextEditController.renderAppAdsDotText()
+POST        /commercial/adops/app-ads-txt                                                                                        controllers.admin.commercial.AdsDotTextEditController.postAppAdsDotText()
 
 # Breaking News
 GET            /news-alert/alerts                                                                                                controllers.NewsAlertController.alerts()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -275,6 +275,7 @@ GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json   
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
 GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize
 GET            /ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderTextFile()
+GET            /app-ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderAppTextFile()
 GET            /commercial/prebid/revenue                                                                                        controllers.admin.commercial.TeamKPIController.renderPrebidDashboard()
 POST           /commercial/api/hb                                                                                                commercial.controllers.PrebidAnalyticsController.insert()
 POST           /commercial/api/pv                                                                                                commercial.controllers.PageViewAnalyticsController.insert()


### PR DESCRIPTION
This implements https://trello.com/c/kOwHpm1O/408-app-adstxt-file, allowing adops to set the value of https://theguardian.com/app-ads.txt

