### PR TITLE
Set correct footer for Foundation section

### DIFF
--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -32,12 +32,11 @@ object IndexHtml {
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 
-  def html( page: IndexPage)(
+  def html(page: IndexPage)(
     headContent: Html = Html(""),
     bodyContent: Html = Html("")
   )(implicit request: RequestHeader, applicationContext: ApplicationContext): Html = {
     implicit val p: IndexPage = page
-
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -36,7 +36,8 @@ object Section {
         case _ => Some("front")
       },
       javascriptConfigOverrides = javascriptConfigOverrides,
-      commercial = Some(CommercialProperties.fromSection(section))
+      commercial = Some(CommercialProperties.fromSection(section)),
+      isFoundation = sectionIdIsFoundation(id: String)
     )
 
     Section(
@@ -44,9 +45,16 @@ object Section {
       isEditionalised = section.editions.length > 1
     )
   }
+
+  val foundationSectionIds = List("the-guardian-foundation")
+
+  private def sectionIdIsFoundation(id: String): Boolean = {
+    foundationSectionIds.contains(id)
+  }
+
 }
 
-case class Section private(
+case class Section private (
   override val metadata: MetaData,
   isEditionalised: Boolean
 ) extends StandalonePage

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -3,6 +3,7 @@ package model
 import com.gu.contentapi.client.model.v1.{Section => ApiSection}
 import common.Pagination
 import common.commercial.CommercialProperties
+import navigation.GuardianFoundationHelper
 import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 
 object Section {
@@ -37,23 +38,13 @@ object Section {
       },
       javascriptConfigOverrides = javascriptConfigOverrides,
       commercial = Some(CommercialProperties.fromSection(section)),
-      isFoundation = sectionIdIsGuardianFoundation(id: String)
+      isFoundation = GuardianFoundationHelper.sectionIdIsGuardianFoundation(id: String)
     )
 
     Section(
       metadata,
       isEditionalised = section.editions.length > 1
     )
-  }
-
-  val foundationSectionIds = List(
-    "the-guardian-foundation",
-    "newswise",
-    "gnmeducationcentre"
-  )
-
-  private def sectionIdIsGuardianFoundation(id: String): Boolean = {
-    foundationSectionIds.contains(id)
   }
 
 }

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -37,7 +37,7 @@ object Section {
       },
       javascriptConfigOverrides = javascriptConfigOverrides,
       commercial = Some(CommercialProperties.fromSection(section)),
-      isFoundation = sectionIdIsFoundation(id: String)
+      isFoundation = sectionIdIsGuardianFoundation(id: String)
     )
 
     Section(
@@ -46,9 +46,13 @@ object Section {
     )
   }
 
-  val foundationSectionIds = List("the-guardian-foundation")
+  val foundationSectionIds = List(
+    "the-guardian-foundation",
+    "newswise",
+    "gnmeducationcentre"
+  )
 
-  private def sectionIdIsFoundation(id: String): Boolean = {
+  private def sectionIdIsGuardianFoundation(id: String): Boolean = {
     foundationSectionIds.contains(id)
   }
 

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -7,6 +7,7 @@ import conf.Configuration
 import contentapi.SectionTagLookUp
 import play.api.libs.json._
 import views.support.{Contributor, ImgSrc, Item140}
+import navigation.GuardianFoundationHelper
 
 object Tag {
 
@@ -55,7 +56,7 @@ object Tag {
       opengraphPropertiesOverrides = openGraphPropertiesOverrides,
       twitterPropertiesOverrides = Map("twitter:card" -> "summary"),
       commercial = tag.commercial,
-      isFoundation = isGuardianFoundation(tag.sectionId)
+      isFoundation = GuardianFoundationHelper.sectionIdIsGuardianFoundation(tag.sectionId)
     )
   }
 

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -29,6 +29,10 @@ object Tag {
       optionalMapEntry("og:description", openGraphDescription) ++
         optionalMapEntry("og:image", openGraphImage)
 
+    def isGuardianFoundation(sectionId: String): Boolean = {
+      tag.sectionId.startsWith("the-guardian-foundation")
+    }
+
     MetaData(
       id = tag.id,
       webUrl = tag.webUrl,
@@ -50,17 +54,16 @@ object Tag {
       javascriptConfigOverrides = javascriptConfigOverrides,
       opengraphPropertiesOverrides = openGraphPropertiesOverrides,
       twitterPropertiesOverrides = Map("twitter:card" -> "summary"),
-      commercial = tag.commercial
+      commercial = tag.commercial,
+      isFoundation = isGuardianFoundation(tag.sectionId)
     )
   }
 
   def make(tag: ApiTag, pagination: Option[Pagination] = None): Tag = {
-
     val richLinkId = tag.references.find(_.`type` == "rich-link")
       .map(_.id.stripPrefix("rich-link/"))
       .filter(_.matches( """https?://www\.theguardian\.com/.*"""))
       .map(_.stripPrefix("https://www.theguardian.com"))
-
 
     Tag(
       properties = TagProperties.make(tag),
@@ -68,6 +71,7 @@ object Tag {
       richLinkId = richLinkId
     )
   }
+
   implicit val tagWrites: Writes[Tag] = Json.writes[Tag]
 }
 

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -30,10 +30,6 @@ object Tag {
       optionalMapEntry("og:description", openGraphDescription) ++
         optionalMapEntry("og:image", openGraphImage)
 
-    def isGuardianFoundation(sectionId: String): Boolean = {
-      tag.sectionId.startsWith("the-guardian-foundation")
-    }
-
     MetaData(
       id = tag.id,
       webUrl = tag.webUrl,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -20,6 +20,7 @@ import play.api.libs.json._
 import play.api.libs.json.JodaWrites.JodaDateTimeWrites
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
+import navigation.GuardianFoundationHelper
 
 import scala.util.matching.Regex
 
@@ -764,7 +765,7 @@ final case class Tags(
   lazy val isCrossword: Boolean = types.exists(_.id == Tags.Crossword)
   lazy val isMatchReport: Boolean = tones.exists(_.id == Tags.MatchReports)
   lazy val isQuiz: Boolean = tones.exists(_.id == Tags.quizzes)
-  lazy val isFoundation: Boolean = tags.exists(t => Tags.foundationMappings.contains(t.id))
+  lazy val isFoundation: Boolean = tags.exists(t => GuardianFoundationHelper.tagIdIsGuardianFoundation(t.id))
 
   lazy val isArticle: Boolean = tags.exists { _.id == Tags.Article }
   lazy val isSudoku: Boolean = tags.exists { _.id == Tags.Sudoku } || tags.exists(t => t.id == "lifeandstyle/series/sudoku")
@@ -855,14 +856,6 @@ object Tags {
     "tone/albumreview",
     "tone/livereview",
     "tone/childrens-user-reviews"
-  )
-
-  val foundationMappings = Seq(
-    "the-guardian-foundation/the-guardian-foundation",
-    "gnmeducationcentre/gnmeducationcentre",
-    "newswise/newswise",
-    "gnm-archive/gnm-archive",
-    "the-guardian-foundation/series/guardian-exhibitions"
   )
 
   val interviewMappings = Seq(

--- a/common/app/navigation/GuardianFoundationHelper.scala
+++ b/common/app/navigation/GuardianFoundationHelper.scala
@@ -17,5 +17,5 @@ object GuardianFoundationHelper {
     foundationSectionIds.contains(id.split('/').headOption.getOrElse(""))
 
   }
-  
+
 }

--- a/common/app/navigation/GuardianFoundationHelper.scala
+++ b/common/app/navigation/GuardianFoundationHelper.scala
@@ -1,0 +1,21 @@
+package navigation
+
+object GuardianFoundationHelper {
+
+  val foundationSectionIds = List(
+    "the-guardian-foundation",
+    "newswise",
+    "gnmeducationcentre",
+    "gnm-archive"
+  )
+
+  def sectionIdIsGuardianFoundation(id: String): Boolean = {
+    foundationSectionIds.contains(id)
+  }
+
+  def tagIdIsGuardianFoundation(id: String): Boolean = {
+    foundationSectionIds.contains(id.split('/').headOption.getOrElse(""))
+
+  }
+  
+}

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -148,8 +148,7 @@ trait Index extends ConciergeRepository with Collections {
     val latestContent = response.results.getOrElse(Nil).filterNot(c => editorsPicksIds contains c.id)
     val trails = (editorsPicks ++ latestContent).map(IndexPageItem(_))
     val commercial = Commercial.empty
-
-    IndexPage(page = section, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None, commercial)
+    IndexPage(page = section, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None, commercial = commercial)
   }
 
   private def tag(response: ItemResponse, page: Int): Option[IndexPage] = {

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -163,6 +163,7 @@ trait Index extends ConciergeRepository with Collections {
 
     val latest: Seq[IndexPageItem] = response.results.getOrElse(Nil).map(IndexPageItem(_)).filterNot(c => leadContentIds.contains(c.item.metadata.id))
     val allTrails = (leadContent ++ editorsPicks ++ latest).distinctBy(_.item.metadata.id)
+
     tag map { tag =>
       IndexPage(page = tag, contents = allTrails, tags = Tags(List(tag)), date = DateTime.now, tzOverride = None)
     }


### PR DESCRIPTION
## What does this change?

We make section building and tag building aware of the fact that the Guardian Foundation has its own footer. This work is the follow up to what had been done when pages with Foundation tags needed their own footer ( https://github.com/guardian/frontend/pull/20996 ).
