### PR TITLE
Banner tests: allow empty leadSentence

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -763,10 +763,12 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             test: () => {},
 
                             engagementBannerParams: {
-                                leadSentence: buildBannerCopy(
-                                    row.leadSentence.trim(),
-                                    hasCountryName
-                                ),
+                                leadSentence: row.leadSentence
+                                    ? buildBannerCopy(
+                                          row.leadSentence.trim(),
+                                          hasCountryName
+                                      )
+                                    : undefined,
                                 messageText: buildBannerCopy(
                                     row.messageText.trim(),
                                     hasCountryName


### PR DESCRIPTION
## What does this change?
The contributions banner tests can have a heading, but we want this field to be optional in the google sheets

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
