### PR TITLE
Added show/hide functionality to video container

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -69,7 +69,7 @@ object Container extends Logging {
   }
 
   def showToggle(container: Container): Boolean = container match {
-    case NavList | NavMediaList | Video => false
+    case NavList | NavMediaList => false
     case _ => true
   }
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -13,12 +13,14 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 <div class="fc-container__inner">
-    <h2 class="video-title fc-container__header__title">
-        <a href="@containerDefinition.href" data-link-name="video-container-title @containerDefinition.displayName">@containerDefinition.displayName</a>
-    </h2>
+    <header class="fc-container__header js-container__header">
+            <h2 class="video-title fc-container__header__title">
+                <a href="@containerDefinition.href" data-link-name="video-container-title @containerDefinition.displayName">@containerDefinition.displayName</a>
+            </h2>
+    </header>
 </div>
 
-<div class="video-playlist video-playlist--start js-video-playlist"
+<div class="video-playlist video-playlist--start js-video-playlist fc-container--rolled-up-hide"
      data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)"
      data-component="video-playlist">
     <a
@@ -32,11 +34,8 @@
         @fragments.inlineSvg("chevron-left", "icon", Seq("video-playlist__icon"))
     </a>
 
-    <ul class="u-unstyled video-playlist__inner js-video-playlist-inner">
+    <ul class="u-unstyled video-playlist__inner js-video-playlist-inner ">
         <li class="video-playlist__item video-title video-title--leftcol fc-container__header__title">
-            <a class="video-title__link" href="@containerDefinition.href" data-link-name="video-container-title @containerDefinition.displayName">
-                @containerDefinition.displayName
-            </a>
             @treats(containerDefinition, frontProperties)
         </li>
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -10,12 +10,13 @@ $video-width-desktop: 700px;
 
     .fc-container__inner {
         border-top: 0;
-        @include mq(leftCol) {
-            display: none;
+    }
 
-            .has-page-skin & {
-                display: block;
-            }
+    .fc-container__toggle {
+        color: $brightness-86;
+
+        &:hover, &:focus {
+            color: $brightness-100;
         }
     }
 
@@ -99,6 +100,10 @@ $video-width-desktop: 700px;
     color: #ffffff;
     display: block;
     margin-bottom: $gs-baseline;
+
+    &:after {
+        content: none;
+    }
 
     a:hover {
         color: #ffffff;


### PR DESCRIPTION
A user pointed out that we don't provide that functionality and 
![pic265025](https://user-images.githubusercontent.com/14570016/60667386-51a07f80-9e61-11e9-8b11-a1e6c48afd36.jpg)
they were right!


# Before
<img width="1297" alt="Screen Shot 2019-07-04 at 13 35 10" src="https://user-images.githubusercontent.com/14570016/60667289-13a35b80-9e61-11e9-9015-86de1c4a9ffe.png">

# After
<img width="1300" alt="Screen Shot 2019-07-04 at 13 34 44" src="https://user-images.githubusercontent.com/14570016/60667299-1c942d00-9e61-11e9-9593-bcd12af0cd59.png">

<img width="1299" alt="Screen Shot 2019-07-04 at 13 34 55" src="https://user-images.githubusercontent.com/14570016/60667310-2453d180-9e61-11e9-960c-bd5af92189b9.png">

<img width="1301" alt="Screen Shot 2019-07-04 at 12 10 49" src="https://user-images.githubusercontent.com/14570016/60667317-27e75880-9e61-11e9-9859-7363fb8323d7.png">

