### PR TITLE
Add new email banner - Changed line 368 from 'Word of Mouth' to 'Word Of Mouth'

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -366,7 +366,7 @@ case object GunsAndLiesInAmerica extends FrontEmailMetadata {
 }
 
 case object WordOfMouth extends FrontEmailMetadata {
-  val name = "Word of Mouth"
+  val name = "Word Of Mouth"
   override val banner = Some("word-of-mouth.png")
 }
 


### PR DESCRIPTION
## What does this change?
Added a new email banner for word of mouth email news letter.
https://www.theguardian.com/email/word-of-mouth

## Screenshots
![word-of-mouth](https://user-images.githubusercontent.com/5967941/60679720-9556b180-9e80-11e9-95c3-ff41acca0a38.png)

## What is the value of this and can you measure success?
N/A

## Checklist

### Does this affect other platforms?
No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

### Does this change break ad-free?
No

### Does this change update the version of CAPI we're using?
No

### Accessibility test checklist
[Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested
No

