### PR TITLE
Defensive handling of country name in epic

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -33,7 +33,7 @@ declare type EpicVariant = Variant & {
 
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
-    copy?: AcquisitionsEpicTemplateCopy,
+    copy?: ?AcquisitionsEpicTemplateCopy,
     backgroundImageUrl?: string,
 }
 
@@ -94,7 +94,7 @@ declare type InitEpicABTestVariant = {
     excludedSections?: string[],
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
-    copy?: AcquisitionsEpicTemplateCopy,
+    copy?: ?AcquisitionsEpicTemplateCopy,
     showTicker?: boolean,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -544,21 +544,7 @@ const buildEpicCopy = (row: any): ?AcquisitionsEpicTemplateCopy => {
 const buildBannerCopy = (text: string): string => {
     const countryName: ?string = countryNames[geolocationGetSync()];
 
-    try {
-        return replaceCountryName(text, countryName);
-    } catch (err) {
-        reportError(
-            new Error(
-                `Error building banner copy. ${err.message}. Stack: ${
-                    err.stack
-                }`
-            ),
-            {
-                feature: 'epic',
-            },
-            true
-        );
-    }
+    return replaceCountryName(text, countryName);
 };
 
 export const getEpicTestsFromGoogleDoc = (): Promise<

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -75,7 +75,7 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
 
 const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
 
-const replaceCountryName = (text: string, countryName: ?string): ?string => {
+const replaceCountryName = (text: string, countryName: ?string): string => {
     if (!countryName) {
         if (text.includes('%%COUNTRY_NAME%%'))
             throw new Error('Missing country name');
@@ -665,7 +665,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                                 row.excludedSections,
                                 ','
                             ),
-                            copy: buildEpicCopy(row, hasCountryName),
+                            copy: buildEpicCopy(row),
                             showTicker: optionalStringToBoolean(row.showTicker),
                             supportBaseURL: row.supportBaseURL,
                             backgroundImageUrl: filterEmptyString(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -526,7 +526,17 @@ const buildEpicCopy = (row: any): ?AcquisitionsEpicTemplateCopy => {
                 : undefined,
             footer: optionalSplitAndTrim(row.footer, '\n'),
         };
-    } catch (e) {
+    } catch (err) {
+        reportError(
+            new Error(
+                `Error building epic copy. ${err.message}. Stack: ${err.stack}`
+            ),
+            {
+                feature: 'epic',
+            },
+            false
+        );
+
         return undefined;
     }
 };
@@ -534,7 +544,21 @@ const buildEpicCopy = (row: any): ?AcquisitionsEpicTemplateCopy => {
 const buildBannerCopy = (text: string): string => {
     const countryName: ?string = countryNames[geolocationGetSync()];
 
-    return replaceCountryName(text, countryName);
+    try {
+        return replaceCountryName(text, countryName);
+    } catch (err) {
+        reportError(
+            new Error(
+                `Error building banner copy. ${err.message}. Stack: ${
+                    err.stack
+                }`
+            ),
+            {
+                feature: 'epic',
+            },
+            true
+        );
+    }
 };
 
 export const getEpicTestsFromGoogleDoc = (): Promise<

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -77,7 +77,8 @@ const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
 
 const replaceCountryName = (text: string, countryName: ?string): ?string => {
     if (!countryName) {
-        if (text.includes("%%COUNTRY_NAME%%")) throw new Error("Missing country name");
+        if (text.includes('%%COUNTRY_NAME%%'))
+            throw new Error('Missing country name');
         else return text;
     } else return text.replace(/%%COUNTRY_NAME%%/g, countryName);
 };
@@ -509,25 +510,23 @@ const buildEpicCopy = (row: any): ?AcquisitionsEpicTemplateCopy => {
     // In case replaceCountryName throws an error
     try {
         return {
-            heading:
-                heading
-                    ? replaceCountryName(heading, countryName)
-                    : heading,
-            paragraphs:
-                paragraphs
-                    ? paragraphs.map<string>(para =>
-                        replaceCountryName(para, countryName)
-                    )
-                    : paragraphs,
+            heading: heading
+                ? replaceCountryName(heading, countryName)
+                : heading,
+            paragraphs: paragraphs
+                ? paragraphs.map<string>(para =>
+                      replaceCountryName(para, countryName)
+                  )
+                : paragraphs,
             highlightedText: row.highlightedText
                 ? row.highlightedText.replace(
-                    /%%CURRENCY_SYMBOL%%/g,
-                    getLocalCurrencySymbol()
-                )
+                      /%%CURRENCY_SYMBOL%%/g,
+                      getLocalCurrencySymbol()
+                  )
                 : undefined,
             footer: optionalSplitAndTrim(row.footer, '\n'),
         };
-    } catch(e) {
+    } catch (e) {
         return undefined;
     }
 };
@@ -537,7 +536,7 @@ const buildBannerCopy = (text: string): ?string => {
 
     try {
         return replaceCountryName(text, countryName);
-    } catch(e) {
+    } catch (e) {
         return undefined;
     }
 };
@@ -773,9 +772,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
 
                             engagementBannerParams: {
                                 leadSentence: row.leadSentence
-                                    ? buildBannerCopy(
-                                          row.leadSentence.trim()
-                                      )
+                                    ? buildBannerCopy(row.leadSentence.trim())
                                     : undefined,
                                 messageText: buildBannerCopy(
                                     row.messageText.trim()

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -531,14 +531,10 @@ const buildEpicCopy = (row: any): ?AcquisitionsEpicTemplateCopy => {
     }
 };
 
-const buildBannerCopy = (text: string): ?string => {
+const buildBannerCopy = (text: string): string => {
     const countryName: ?string = countryNames[geolocationGetSync()];
 
-    try {
-        return replaceCountryName(text, countryName);
-    } catch (e) {
-        return undefined;
-    }
+    return replaceCountryName(text, countryName);
 };
 
 export const getEpicTestsFromGoogleDoc = (): Promise<

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -64,8 +64,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             buttonTemplate: defaultButtonTemplate,
             products: [],
             copy: buildEpicCopy(
-                isUSUK ? USUKControlCopy : ROWControlCopy,
-                !isUSUK
+                isUSUK ? USUKControlCopy : ROWControlCopy
             ),
         },
         {
@@ -81,8 +80,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
                     highlightedText,
-                },
-                false
+                }
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -63,25 +63,21 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(
-                isUSUK ? USUKControlCopy : ROWControlCopy
-            ),
+            copy: buildEpicCopy(isUSUK ? USUKControlCopy : ROWControlCopy),
         },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(
-                {
-                    heading: `You’ve read ${articleViewCount} articles...`,
-                    paragraphs:
-                        '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
-                    highlightedText,
-                }
-            ),
+            copy: buildEpicCopy({
+                heading: `You’ve read ${articleViewCount} articles...`,
+                paragraphs:
+                    '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                    'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                    'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                    'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+                highlightedText,
+            }),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -36,18 +36,16 @@ export const countryName: EpicABTest = makeEpicABTest({
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(
-                {
-                    heading: 'More people in %%COUNTRY_NAME%%…',
-                    paragraphs:
-                        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
-                    highlightedText:
-                        'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-                }
-            ),
+            copy: buildEpicCopy({
+                heading: 'More people in %%COUNTRY_NAME%%…',
+                paragraphs:
+                    '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                    'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                    'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                    'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+                highlightedText:
+                    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+            }),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -46,8 +46,7 @@ export const countryName: EpicABTest = makeEpicABTest({
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
                     highlightedText:
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-                },
-                true
+                }
             ),
         },
     ],


### PR DESCRIPTION
## What does this change?
We have epics and banners showing the user's country name. There is already logic to ensure a user cannot be entered into a test if their country name is not available, but this change ensures we can never show the template to them if something goes wrong with test selection.

If the `replaceCountryName` function fails because of a missing country name then the default epic copy will be displayed (though they'll actually still be in the test). It's harder to do this for the banner, so instead the user will see nothing.

### Confirming no change to existing behaviour:
A valid country:
<img width="639" alt="Screenshot 2019-07-05 at 15 41 25" src="https://user-images.githubusercontent.com/1513454/60729827-85e86e80-9f3b-11e9-828f-b6c2e7b62247.png">

Not a valid country:
<img width="639" alt="Screenshot 2019-07-05 at 15 41 50" src="https://user-images.githubusercontent.com/1513454/60729853-97317b00-9f3b-11e9-94ad-08c3444fb3a9.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
