### PR TITLE
Revert "Defensive handling of country name in epic"

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -33,7 +33,7 @@ declare type EpicVariant = Variant & {
 
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
-    copy?: ?AcquisitionsEpicTemplateCopy,
+    copy?: AcquisitionsEpicTemplateCopy,
     backgroundImageUrl?: string,
 }
 
@@ -94,7 +94,7 @@ declare type InitEpicABTestVariant = {
     excludedSections?: string[],
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
-    copy?: ?AcquisitionsEpicTemplateCopy,
+    copy?: AcquisitionsEpicTemplateCopy,
     showTicker?: boolean,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -63,21 +63,27 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(isUSUK ? USUKControlCopy : ROWControlCopy),
+            copy: buildEpicCopy(
+                isUSUK ? USUKControlCopy : ROWControlCopy,
+                !isUSUK
+            ),
         },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy({
-                heading: `You’ve read ${articleViewCount} articles...`,
-                paragraphs:
-                    '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                    'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                    'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                    'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
-                highlightedText,
-            }),
+            copy: buildEpicCopy(
+                {
+                    heading: `You’ve read ${articleViewCount} articles...`,
+                    paragraphs:
+                        '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+                    highlightedText,
+                },
+                false
+            ),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -36,16 +36,19 @@ export const countryName: EpicABTest = makeEpicABTest({
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy({
-                heading: 'More people in %%COUNTRY_NAME%%…',
-                paragraphs:
-                    '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                    'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                    'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                    'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
-                highlightedText:
-                    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-            }),
+            copy: buildEpicCopy(
+                {
+                    heading: 'More people in %%COUNTRY_NAME%%…',
+                    paragraphs:
+                        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+                    highlightedText:
+                        'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+                },
+                true
+            ),
         },
     ],
 });


### PR DESCRIPTION
Reverts guardian/frontend#21617
Reverting because it's creating some very noisy sentry logs, so this needs a rethink