### PR TITLE
Epic and banner should never render a %%variable%%

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -268,10 +268,11 @@ const makeEpicABTestVariant = (
         excludedSections: initVariant.excludedSections || [],
 
         canRun() {
-            const isValidCopy =
-                !copyHasVariables(this.copy.heading) &&
-                !this.copy.paragraphs.some(copyHasVariables) &&
-                !copyHasVariables(this.copy.highlightedText);
+            const copyIsValid = () =>
+                !this.copy ||
+                (!copyHasVariables(this.copy.heading) &&
+                    !this.copy.paragraphs.some(copyHasVariables) &&
+                    !copyHasVariables(this.copy.highlightedText));
 
             const checkMaxViews = (maxViews: MaxViews) => {
                 const {
@@ -311,12 +312,12 @@ const makeEpicABTestVariant = (
             );
 
             return (
-                isValidCopy &&
                 meetsMaxViewsConditions &&
                 matchesCountryGroups &&
                 matchesTagsOrSections &&
                 noExcludedTags &&
-                notExcludedSection
+                notExcludedSection &&
+                copyIsValid()
             );
         },
 
@@ -798,12 +799,12 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                                     hasTicker: false,
                                 },
                                 canRun: () => {
-                                    const copyIsValid =
+                                    const copyIsValid = () =>
                                         !copyHasVariables(leadSentence) &&
                                         !copyHasVariables(messageText) &&
                                         !copyHasVariables(ctaText);
 
-                                    return copyIsValid && canShowBannerSync();
+                                    return canShowBannerSync() && copyIsValid();
                                 },
                             };
                         }),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -205,6 +205,9 @@ const userMatchesCountryGroups = (countryGroups: string[]) => {
 const pageMatchesSections = (sectionIds: string[]): boolean =>
     sectionIds.some(section => config.get('page.section') === section);
 
+const copyHasVariables = (text: ?string): boolean =>
+    text && text.includes('%%');
+
 const makeEpicABTestVariant = (
     initVariant: InitEpicABTestVariant,
     template: EpicTemplate,
@@ -265,6 +268,11 @@ const makeEpicABTestVariant = (
         excludedSections: initVariant.excludedSections || [],
 
         canRun() {
+            const isValidCopy =
+                !copyHasVariables(this.copy.heading) &&
+                !this.copy.paragraphs.some(copyHasVariables) &&
+                !copyHasVariables(this.copy.highlightedText);
+
             const checkMaxViews = (maxViews: MaxViews) => {
                 const {
                     count: maxViewCount,
@@ -303,6 +311,7 @@ const makeEpicABTestVariant = (
             );
 
             return (
+                isValidCopy &&
                 meetsMaxViewsConditions &&
                 matchesCountryGroups &&
                 matchesTagsOrSections &&
@@ -757,32 +766,47 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                             return countryNameOk && matchesCountryGroups;
                         },
 
-                        variants: rows.map(row => ({
-                            id: row.name.trim().toLowerCase(),
-                            products: [],
-                            test: () => {},
+                        variants: rows.map(row => {
+                            const leadSentence = row.leadSentence
+                                ? buildBannerCopy(
+                                      row.leadSentence.trim(),
+                                      hasCountryName
+                                  )
+                                : undefined;
 
-                            engagementBannerParams: {
-                                leadSentence: row.leadSentence
-                                    ? buildBannerCopy(
-                                          row.leadSentence.trim(),
-                                          hasCountryName
-                                      )
-                                    : undefined,
-                                messageText: buildBannerCopy(
-                                    row.messageText.trim(),
-                                    hasCountryName
-                                ),
-                                ctaText: `<span class="engagement-banner__highlight"> ${row.ctaText.replace(
-                                    /%%CURRENCY_SYMBOL%%/g,
-                                    getLocalCurrencySymbol()
-                                )}</span>`,
-                                buttonCaption: row.buttonCaption.trim(),
-                                linkUrl: row.linkUrl.trim(),
-                                hasTicker: false,
-                            },
-                            canRun: () => canShowBannerSync(),
-                        })),
+                            const messageText = buildBannerCopy(
+                                row.messageText.trim(),
+                                hasCountryName
+                            );
+
+                            const ctaText = `<span class="engagement-banner__highlight"> ${row.ctaText.replace(
+                                /%%CURRENCY_SYMBOL%%/g,
+                                getLocalCurrencySymbol()
+                            )}</span>`;
+
+                            return {
+                                id: row.name.trim().toLowerCase(),
+                                products: [],
+                                test: () => {},
+
+                                engagementBannerParams: {
+                                    leadSentence,
+                                    messageText,
+                                    ctaText,
+                                    buttonCaption: row.buttonCaption.trim(),
+                                    linkUrl: row.linkUrl.trim(),
+                                    hasTicker: false,
+                                },
+                                canRun: () => {
+                                    const copyIsValid =
+                                        !copyHasVariables(leadSentence) &&
+                                        !copyHasVariables(messageText) &&
+                                        !copyHasVariables(ctaText);
+
+                                    return copyIsValid && canShowBannerSync();
+                                },
+                            };
+                        }),
                     };
                 });
         })

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -206,7 +206,7 @@ const pageMatchesSections = (sectionIds: string[]): boolean =>
     sectionIds.some(section => config.get('page.section') === section);
 
 const copyHasVariables = (text: ?string): boolean =>
-    text && text.includes('%%');
+    !!text && text.includes('%%');
 
 const makeEpicABTestVariant = (
     initVariant: InitEpicABTestVariant,


### PR DESCRIPTION
## What does this change?
In very odd edge cases, variant copy is being built with invalid information so variables `%%this%%` appear in the copy. However, at the time the test runs, the valid information has become available and so the test runs with the invalid copy. This change will scan the variant copy after it has been generated and prevent a user from entering the test if any of the variant copy still has variables present.

Note - we think we know why this race condition involving geolocation occurs and will be making a fix in a separate PR. This PR just guards against this type of error ever occurring.

## Screenshots
Confirming it still works the same -

No country name available, default epic/banner:
<img width="639" alt="Screenshot 2019-07-09 at 09 09 04" src="https://user-images.githubusercontent.com/1513454/60870698-44044480-a229-11e9-9071-e876fb5663d6.png">

With country name:
<img width="639" alt="Screenshot 2019-07-09 at 09 09 46" src="https://user-images.githubusercontent.com/1513454/60870734-51b9ca00-a229-11e9-899a-75fad1cb71f4.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
