### PR TITLE
Only fetch geolocation once for epic + banner tests

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -53,7 +53,7 @@ declare type ABTest = {
     variants: $ReadOnlyArray<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,
-    geolocation?: ?string,
+    geolocation: ?string,
 };
 
 declare type Runnable<T: ABTest> = T & {
@@ -130,7 +130,7 @@ declare type InitEpicABTest = {
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
-    geolocation?: ?string,
+    geolocation: ?string,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -53,7 +53,6 @@ declare type ABTest = {
     variants: $ReadOnlyArray<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,
-    geolocation: ?string,
 };
 
 declare type Runnable<T: ABTest> = T & {
@@ -63,6 +62,7 @@ declare type Runnable<T: ABTest> = T & {
 declare type AcquisitionsABTest = ABTest & {
     campaignId: string,
     componentType: OphanComponentType,
+    geolocation: ?string,
 };
 
 declare type MaxViews = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -53,6 +53,7 @@ declare type ABTest = {
     variants: $ReadOnlyArray<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,
+    geolocation?: ?string,
 };
 
 declare type Runnable<T: ABTest> = T & {
@@ -128,7 +129,8 @@ declare type InitEpicABTest = {
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
-    hasCountryName?: boolean,
+    testHasCountryName?: boolean,
+    geolocation?: ?string,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -50,7 +50,7 @@ const init = (): void => {
 const editionToGeolocation = (editionKey: string = 'UK'): string =>
     editionToGeolocationMap[editionKey];
 
-const getSync = (): ?string => {
+const getSync = (): string => {
     const geolocationFromStorage = getFromStorage();
     return (
         geolocationFromStorage ||
@@ -469,6 +469,9 @@ const countryNames = {
     PA: 'Panama',
 };
 
+const getCountryName = (geolocation: ?string): ?string =>
+    geolocation ? countryNames[geolocation] : undefined;
+
 export {
     get,
     countryCodeToCountryGroupId,
@@ -479,5 +482,5 @@ export {
     init,
     setGeolocation,
     extendedCurrencySymbol,
-    countryNames,
+    getCountryName,
 };

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -405,8 +405,14 @@ const extendedCurrencySymbol = {
     International: '$',
 };
 
-const getLocalCurrencySymbol = (): string =>
-    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] || '£';
+const defaultCurrencySymbol = '£';
+
+const getLocalCurrencySymbolSync = (): string =>
+    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] || defaultCurrencySymbol;
+
+const getLocalCurrencySymbol = (geolocation: ?string): string => {
+    return geolocation ? extendedCurrencySymbol[countryCodeToCountryGroupId(geolocation)] || defaultCurrencySymbol : defaultCurrencySymbol;
+};
 
 // A limited set of country names for the test to add country name in the epic copy
 const countryNames = {
@@ -478,6 +484,7 @@ export {
     countryCodeToSupportInternationalisationId,
     getFromStorage,
     getSync,
+    getLocalCurrencySymbolSync,
     getLocalCurrencySymbol,
     init,
     setGeolocation,

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -408,11 +408,14 @@ const extendedCurrencySymbol = {
 const defaultCurrencySymbol = '£';
 
 const getLocalCurrencySymbolSync = (): string =>
-    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] || defaultCurrencySymbol;
+    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] ||
+    defaultCurrencySymbol;
 
-const getLocalCurrencySymbol = (geolocation: ?string): string => {
-    return geolocation ? extendedCurrencySymbol[countryCodeToCountryGroupId(geolocation)] || defaultCurrencySymbol : defaultCurrencySymbol;
-};
+const getLocalCurrencySymbol = (geolocation: ?string): string =>
+    geolocation
+        ? extendedCurrencySymbol[countryCodeToCountryGroupId(geolocation)] ||
+          defaultCurrencySymbol
+        : defaultCurrencySymbol;
 
 // A limited set of country names for the test to add country name in the epic copy
 const countryNames = {

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -50,7 +50,7 @@ const init = (): void => {
 const editionToGeolocation = (editionKey: string = 'UK'): string =>
     editionToGeolocationMap[editionKey];
 
-const getSync = (): string => {
+const getSync = (): ?string => {
     const geolocationFromStorage = getFromStorage();
     return (
         geolocationFromStorage ||

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -1,5 +1,5 @@
 // @flow
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import reportError from 'lib/report-error';
 import { getEpicControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 
@@ -20,7 +20,7 @@ const fallbackCopy = {
         controlCopyParagraphTwo,
         controlCopyParagraphThree,
     ],
-    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
+    highlightedText: `For as little as ${getLocalCurrencySymbolSync()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
 };
 
 const getEpicParams = (
@@ -48,7 +48,7 @@ const getEpicParams = (
         paragraphs: rowsFromGoogleDoc.map(row => row.paragraphs),
         highlightedText: firstRow.highlightedText.replace(
             /%%CURRENCY_SYMBOL%%/g,
-            getLocalCurrencySymbol()
+            getLocalCurrencySymbolSync()
         ),
     };
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -6,10 +6,10 @@ export const epicControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 export const bannerControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
-export const epicMultipleTestsGoogleDocUrl: string = !config.get('page.isDev')
+export const epicMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata-test/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
     : 'https://interactive.guim.co.uk/docsdata/1VQ6yn2thnkFzjxIKt-AfOB_gJnX8omLNodkRyX7_Qbg.json';
-export const bannerMultipleTestsGoogleDocUrl: string = !config.get('page.isDev')
+export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata-test/19AGJYaPL8XpchykYlzqdKqNHxrHBILFktzM8vc5iShc.json'
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -6,10 +6,10 @@ export const epicControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 export const bannerControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
-export const epicMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
+export const epicMultipleTestsGoogleDocUrl: string = !config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata-test/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
     : 'https://interactive.guim.co.uk/docsdata/1VQ6yn2thnkFzjxIKt-AfOB_gJnX8omLNodkRyX7_Qbg.json';
-export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
+export const bannerMultipleTestsGoogleDocUrl: string = !config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata-test/19AGJYaPL8XpchykYlzqdKqNHxrHBILFktzM8vc5iShc.json'
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -540,7 +540,7 @@ const buildEpicCopy = (
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(
                   /%%CURRENCY_SYMBOL%%/g,
-                    getLocalCurrencySymbol(geolocation)
+                  getLocalCurrencySymbol(geolocation)
               )
             : undefined,
         footer: optionalSplitAndTrim(row.footer, '\n'),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -211,6 +211,12 @@ const pageMatchesSections = (sectionIds: string[]): boolean =>
 const copyHasVariables = (text: ?string): boolean =>
     !!text && text.includes('%%');
 
+const countryNameIsOk = (
+    testHasCountryName: boolean,
+    geolocation: ?string
+): boolean => (testHasCountryName ? !!getCountryName(geolocation) : true);
+
+
 const makeEpicABTestVariant = (
     initVariant: InitEpicABTestVariant,
     template: EpicTemplate,
@@ -475,9 +481,11 @@ const makeEpicABTest = ({
         showForSensitive: true,
         geolocation,
         canRun() {
-            const countryNameIsOk =
-                !testHasCountryName || !!getCountryName(geolocation);
-            return canRun() && countryNameIsOk && shouldShowEpic(this);
+            return (
+                canRun() &&
+                countryNameIsOk(testHasCountryName, geolocation) &&
+                shouldShowEpic(this)
+            );
         },
         componentType: 'ACQUISITIONS_EPIC',
         insertEvent: makeEvent(id, 'insert'),
@@ -783,9 +791,6 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
 
                         geolocation,
                         canRun: () => {
-                            const countryNameOk =
-                                !testHasCountryName ||
-                                !!getCountryName(geolocation);
                             const matchesCountryGroups =
                                 countryGroups.length === 0 ||
                                 userMatchesCountryGroups(
@@ -793,7 +798,12 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                                     geolocation
                                 );
 
-                            return countryNameOk && matchesCountryGroups;
+                            return (
+                                countryNameIsOk(
+                                    testHasCountryName,
+                                    geolocation
+                                ) && matchesCountryGroups
+                            );
                         },
 
                         variants: rows.map(row => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -216,7 +216,6 @@ const countryNameIsOk = (
     geolocation: ?string
 ): boolean => (testHasCountryName ? !!getCountryName(geolocation) : true);
 
-
 const makeEpicABTestVariant = (
     initVariant: InitEpicABTestVariant,
     template: EpicTemplate,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -540,7 +540,7 @@ const buildEpicCopy = (
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(
                   /%%CURRENCY_SYMBOL%%/g,
-                  getLocalCurrencySymbol()
+                    getLocalCurrencySymbol(geolocation)
               )
             : undefined,
         footer: optionalSplitAndTrim(row.footer, '\n'),
@@ -604,7 +604,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                     // If testHasCountryName is true but a country name is not available for this user then
                     // they will be excluded from this test
                     const testHasCountryName = rows.some(row =>
-                        optionalStringToBoolean(row.testHasCountryName)
+                        optionalStringToBoolean(row.hasCountryName)
                     );
 
                     const geolocation = geolocationGetSync();
@@ -752,7 +752,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                     // If testHasCountryName is true but a country name is not available for this user then
                     // they will be excluded from this test
                     const testHasCountryName = rows.some(row =>
-                        optionalStringToBoolean(row.testHasCountryName)
+                        optionalStringToBoolean(row.hasCountryName)
                     );
 
                     const rowWithLocations = rows.find(
@@ -813,7 +813,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
 
                             const ctaText = `<span class="engagement-banner__highlight"> ${row.ctaText.replace(
                                 /%%CURRENCY_SYMBOL%%/g,
-                                getLocalCurrencySymbol()
+                                getLocalCurrencySymbol(geolocation)
                             )}</span>`;
 
                             return {

--- a/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import config from 'lib/config';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import { constructQuery as constructURLQuery } from 'lib/url';
 
 import {
@@ -119,7 +119,7 @@ const addEpicDataToUrl = (url: string): string => {
         pvid: config.get('ophan.pageViewId'),
         url: window.location.href.split('?')[0],
         // use to display pricing in local currency
-        lcs: getLocalCurrencySymbol(),
+        lcs: getLocalCurrencySymbolSync(),
     });
     return `${url}?${params}`;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -3,7 +3,7 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 import config from 'lib/config';
 import reportError from 'lib/report-error';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import {
     supportContributeURL,
     addCountryGroupToSupportLink,
@@ -36,7 +36,7 @@ const getAcquisitionsBannerParams = (
 
     const ctaText = `<span class="engagement-banner__highlight"> ${firstRow.ctaText.replace(
         /%%CURRENCY_SYMBOL%%/g,
-        getLocalCurrencySymbol()
+        getLocalCurrencySymbolSync()
     )}</span>`;
 
     return {
@@ -73,7 +73,7 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
 
             return {
                 messageText: fallbackCopy,
-                ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
+                ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbolSync()}1</span>`,
                 buttonCaption: 'Support The Guardian',
                 linkUrl: supportContributeURL(),
                 hasTicker: false,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -24,7 +24,7 @@ jest.mock('lib/url', () => ({
 }));
 jest.mock('lib/geolocation', () => ({
     getSync: jest.fn(() => 'GB'),
-    getLocalCurrencySymbol: () => '£',
+    getLocalCurrencySymbolSync: () => '£',
 }));
 jest.mock('common/modules/experiments/ab', () => ({
     getEngagementBannerTestToRun: jest.fn(() => {

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
@@ -1,18 +1,18 @@
 // @flow
 
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 
 export const acquisitionsBannerTickerTemplate = `
     <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker is-hidden">
         
         <div class="js-ticker-under-goal is-hidden">
             <div class="js-ticker-so-far engagement-banner-ticker__so-far">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">contributed</div>
             </div>
             
             <div class="js-ticker-goal engagement-banner-ticker__goal">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">our goal</div>
             </div>
         </div>
@@ -24,7 +24,7 @@ export const acquisitionsBannerTickerTemplate = `
             </div>
             
             <div class="js-ticker-exceeded engagement-banner-ticker__exceeded">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">contributed</div>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 
 export const acquisitionsEpicTickerTemplate = `
     <div id="epic-ticker" class="js-epic-ticker epic-ticker is-hidden">
@@ -12,7 +12,7 @@ export const acquisitionsEpicTickerTemplate = `
             </div>
             
             <div class="js-ticker-goal epic-ticker__goal">
-                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="js-ticker-label epic-ticker__count-label">our goal</div>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,5 +1,5 @@
 // @flow
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import fetchJSON from 'lib/fetch-json';
 
 type TickerType = 'unlimited' | 'hardstop';
@@ -59,10 +59,10 @@ const increaseCounter = (
         newCount <= count[parentElementSelector] || newCount >= total; // either we've reached the total or the count isn't going up because total is too small
 
     if (finishedCounting) {
-        counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
+        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${total.toLocaleString()}`;
     } else {
         count[parentElementSelector] = newCount;
-        counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
+        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${count[
             parentElementSelector
         ].toLocaleString()}`;
 
@@ -109,7 +109,7 @@ const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
         if (countElement && labelElement) {
             const amount =
                 goalReached() && tickerType === 'unlimited' ? total : goal;
-            countElement.innerHTML = `${getLocalCurrencySymbol()}${amount.toLocaleString()}`;
+            countElement.innerHTML = `${getLocalCurrencySymbolSync()}${amount.toLocaleString()}`;
 
             if (goalReached()) {
                 labelElement.innerHTML = 'contributed';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -3,10 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
     campaignId: 'epic_always_ask_if_tagged',
+
+    geolocation: geolocationGetSync(),
 
     start: '2017-05-23',
     expiry: '2020-01-27',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
@@ -3,6 +3,7 @@
 import { isBreakpoint } from 'lib/detect';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { acquisitionsBannerMobileDesignTestTemplate } from 'common/modules/commercial/templates/acquisitions-banner-mobile-design-test';
+import {getSync as geolocationGetSync} from "lib/geolocation";
 
 const mobileHeader: string = `We chose a different approach.<br/>Will you support it?`;
 const mobileBody: string = `Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, support from our readers is essential in safeguarding The Guardian’s editorial independence. This is our model for open, independent journalism.`;
@@ -25,6 +26,7 @@ export const contributionsGlobalMobileBannerDesign: AcquisitionsABTest = {
         }),
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    geolocation: geolocationGetSync(),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-global-mobile-banner-design.js
@@ -3,7 +3,7 @@
 import { isBreakpoint } from 'lib/detect';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 import { acquisitionsBannerMobileDesignTestTemplate } from 'common/modules/commercial/templates/acquisitions-banner-mobile-design-test';
-import {getSync as geolocationGetSync} from "lib/geolocation";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const mobileHeader: string = `We chose a different approach.<br/>Will you support it?`;
 const mobileBody: string = `Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. We believe that each of us, around the world, deserves access to accurate information with integrity at its heart. At a time when factual reporting is critical, support from our readers is essential in safeguarding The Guardian’s editorial independence. This is our model for open, independent journalism.`;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -5,7 +5,7 @@ import {
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // Use must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -58,7 +58,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     geolocation,
 
     canRun: () =>
-        articleViewCount >= minArticleViews && countryNames[geolocation],
+        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -55,6 +55,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
+    geolocation,
+
     canRun: () =>
         articleViewCount >= minArticleViews && countryNames[geolocation],
 
@@ -65,7 +67,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             products: [],
             copy: buildEpicCopy(
                 isUSUK ? USUKControlCopy : ROWControlCopy,
-                !isUSUK
+                !isUSUK,
+                geolocation
             ),
         },
         {
@@ -82,7 +85,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
                     highlightedText,
                 },
-                false
+                false,
+                geolocation
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -3,10 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import {getSync as geolocationGetSync} from "lib/geolocation";
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
     campaignId: 'kr1_epic_ask_four_earning',
+
+    geolocation: geolocationGetSync(),
 
     start: '2017-01-24',
     expiry: '2020-01-27',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -3,7 +3,7 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
-import {getSync as geolocationGetSync} from "lib/geolocation";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -48,7 +48,7 @@ export const countryName: EpicABTest = makeEpicABTest({
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },
                 true,
-                geolocation,
+                geolocation
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -4,7 +4,7 @@ import {
     defaultButtonTemplate,
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
-import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 const geolocation = geolocationGetSync();
 
@@ -29,7 +29,7 @@ export const countryName: EpicABTest = makeEpicABTest({
     canRun: () =>
         geolocation !== 'US' &&
         geolocation !== 'GB' &&
-        countryNames[geolocation],
+        !!getCountryName(geolocation),
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -47,7 +47,8 @@ export const countryName: EpicABTest = makeEpicABTest({
                     highlightedText:
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },
-                true
+                true,
+                geolocation,
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -6,6 +6,8 @@ import {
 } from 'common/modules/commercial/contributions-utilities';
 import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
 
+const geolocation = geolocationGetSync();
+
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
     campaignId: 'epic_country_name',
@@ -22,14 +24,12 @@ export const countryName: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
-    canRun: () => {
-        const geolocation = geolocationGetSync();
-        return (
-            geolocation !== 'US' &&
-            geolocation !== 'GB' &&
-            countryNames[geolocation]
-        );
-    },
+    geolocation,
+
+    canRun: () =>
+        geolocation !== 'US' &&
+        geolocation !== 'GB' &&
+        countryNames[geolocation],
 
     variants: [
         {


### PR DESCRIPTION
## What does this change?
This fixes a potential race condition.
The epic + banner test logic runs as follows:
1. create each test, including the copy,
2. call the `canRun` function on each test until one returns true.

We currently call `geolocationGetSync` to get the geolocation when we create the copy and also when we check to see if the test can be run. This is problematic because the value returned by `geolocationGetSync` may change between the 2 steps. This can potentially cause bad copy to be displayed to users because their geolocation was not available in step 1, but became available by the time step 2 was executed.

The solution is to fetch geolocation once at the start, store it in the `ABTest` model, and use this value everywhere. We also use geolocation for getting the currency and for filtering users by country.

## Screenshots
Confirming country name test still works -

No country name:
<img width="639" alt="Screenshot 2019-07-09 at 11 45 02" src="https://user-images.githubusercontent.com/1513454/60882089-0dd1bf80-a23f-11e9-8b6d-ea2045f95ab7.png">

Country name:
<img width="639" alt="Screenshot 2019-07-09 at 11 45 46" src="https://user-images.githubusercontent.com/1513454/60882115-1c1fdb80-a23f-11e9-9aa0-497d756fad5c.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
