### PR TITLE
Add showBottomSocialButtons to dotcomponents data model.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -20,7 +20,7 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, GUDateTimeFormat, ImgSrc, Item300}
+import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, GUDateTimeFormat, ImgSrc, Item300}
 import controllers.ArticlePage
 import org.joda.time.{DateTime}
 
@@ -204,7 +204,8 @@ case class DataModelV3(
   starRating: Option[Int],
   trailText: String,
   nav: Nav,
-  designType: String
+  designType: String,
+  showBottomSocialButtons: Boolean
 )
 
 object DataModelV3 {
@@ -566,7 +567,8 @@ object DotcomponentsDataModel {
       starRating = article.content.starRating,
       trailText = article.trail.fields.trailText.getOrElse(""),
       nav = nav,
-      designType = article.metadata.designType.map(_.toString).getOrElse("Article")
+      designType = article.metadata.designType.map(_.toString).getOrElse("Article"),
+      showBottomSocialButtons = ContentLayout.showBottomSocialButtons(article)
     )
   }
 }

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -3,7 +3,7 @@
 @import common.{LinkTo, Localisation}
 @import model.ShareLinkMeta
 @import model.Badges.badgeFor
-@import views.support.ContentLayout.ContentLayout
+@import views.support.ContentLayout
 @import views.support.Seq2zipWithRowInfo
 
 <div class="submeta @if(content.content.tags.isAudio){podcast-section}">
@@ -44,7 +44,7 @@
             }
         </ul>
     </div>
-    @if(content.showBottomSocialButtons) {
+    @if(ContentLayout.showBottomSocialButtons(content)) {
         <div data-component="share" class="submeta__share">
             @Social(content.sharelinks.pageShares)
         </div>

--- a/common/app/views/support/ContentLayout.scala
+++ b/common/app/views/support/ContentLayout.scala
@@ -4,8 +4,7 @@ import model._
 import org.jsoup.Jsoup
 
 object ContentLayout {
-  implicit class ContentLayout(content: model.ContentType) {
-    def showBottomSocialButtons: Boolean = {
+    def showBottomSocialButtons(content: model.ContentType): Boolean = {
       content match {
         case l: Article if l.isLiveBlog => true
         case a: Article =>
@@ -19,16 +18,4 @@ object ContentLayout {
         case _ => true
       }
     }
-
-    def tagTone: Option[String] = {
-      content match {
-        case l: Article if l.isLiveBlog => Some("live")
-        case _: Audio => Some("media")
-        case _: Video => Some("media")
-        case _: Gallery => Some("media")
-        case _: ImageContent => Some("media")
-        case _ => None
-      }
-    }
-  }
 }


### PR DESCRIPTION
## What does this change?
Shares a boolean value with dotcom rendering which determines whether the bottom social buttons are displayed. This will ensure dotcom rendering doesn't show these buttons on 'unshareable' content.

These buttons:
![Screenshot 2019-07-09 at 14 48 16](https://user-images.githubusercontent.com/3606555/60893310-9c9f0600-a258-11e9-80dd-be64eb8efbd7.png)

As part of this I've removed a dodgy implicit class thing and a function that was totally unused

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->