### PR TITLE
Add the ability to choose the focus of an image

### DIFF
--- a/commercial/app/model/capi/CapiImages.scala
+++ b/commercial/app/model/capi/CapiImages.scala
@@ -12,7 +12,7 @@ object CapiImages {
   def buildImageDataFromUrl(imageUrl: String, noImages: Int = 1): ImageInfo = {
     val asset: Asset = Asset(AssetType.Image, Some("image/jpeg"), Some(imageUrl))
     val imageAsset: ImageAsset = ImageAsset.make(asset, 0)
-    val image: ImageMedia = ImageMedia(List(imageAsset))
+    val image: ImageMedia = ImageMedia.make(List(imageAsset))
     buildImageData(Some(image))
   }
 

--- a/common/app/common/commercial/hosted/ContentUtils.scala
+++ b/common/app/common/commercial/hosted/ContentUtils.scala
@@ -30,8 +30,8 @@ object ContentUtils {
       val assets = elements.zipWithIndex flatMap {
         case (element, i) => ModelElement(element, i).images.allImages
       }
-      ImageMedia(assets)
-    } getOrElse ImageMedia(Nil)
+      ImageMedia.make(assets)
+    } getOrElse ImageMedia.make(Nil)
 
   def thumbnailUrl(item: Content): String =
     Item300.bestSrcFor(imageMedia(item)) getOrElse ""

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -83,7 +83,7 @@ final case class ImageMedia(position: ObjectPosition, allImages: Seq[ImageAsset]
 }
 
 sealed abstract class ObjectPosition extends Product with Serializable { self =>
-  def className: String = self match {
+  final val className: String = self match {
     case ObjectPosition.TL => "position--tl"
     case ObjectPosition.TC => "position--tc"
     case ObjectPosition.TR => "position--tr"

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -185,6 +185,23 @@ object PressedContentFormat {
     }
   }
 
+  implicit val objectPositionFormat: Format[ObjectPosition] = new Format[ObjectPosition] {
+    def reads(json: JsValue): JsResult[ObjectPosition] = json match {
+      case JsString("TL") => JsSuccess(ObjectPosition.TL)
+      case JsString("TC") => JsSuccess(ObjectPosition.TC)
+      case JsString("TR") => JsSuccess(ObjectPosition.TR)
+      case JsString("CL") => JsSuccess(ObjectPosition.CL)
+      case JsString("CC") => JsSuccess(ObjectPosition.CC)
+      case JsString("CR") => JsSuccess(ObjectPosition.CR)
+      case JsString("BL") => JsSuccess(ObjectPosition.BL)
+      case JsString("BC") => JsSuccess(ObjectPosition.BC)
+      case JsString("BR") => JsSuccess(ObjectPosition.BR)
+      case _ => JsError(s"Unknow object position: '$json'")
+    }
+
+    def writes(o: ObjectPosition): JsValue = JsString(o.toString)
+  }
+
   implicit val pillarFormat = Json.format[Pillar]
   implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
   implicit val paginationFormat = Json.format[Pagination]

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -196,7 +196,7 @@ object PressedContentFormat {
       case JsString("BL") => JsSuccess(ObjectPosition.BL)
       case JsString("BC") => JsSuccess(ObjectPosition.BC)
       case JsString("BR") => JsSuccess(ObjectPosition.BR)
-      case _ => JsError(s"Unknow object position: '$json'")
+      case _ => JsSuccess(ObjectPosition.default)
     }
 
     def writes(o: ObjectPosition): JsValue = JsString(o.toString)

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -330,7 +330,7 @@ object Atoms extends common.Logging {
       }
     }
 
-    ImageMedia(imageAssets)
+    ImageMedia.make(imageAssets)
   }
 }
 
@@ -366,7 +366,7 @@ object MediaAtom extends common.Logging {
   }
 
   def imageMediaMake(capiImage: AtomApiImage, caption: String): ImageMedia = {
-    ImageMedia(capiImage.assets.map(mediaImageAssetMake(_, caption)))
+    ImageMedia.make(capiImage.assets.map(mediaImageAssetMake(_, caption)))
   }
 
   def mediaAssetMake(mediaAsset: AtomApiMediaAsset): MediaAsset = {
@@ -413,7 +413,7 @@ object Quiz extends common.Logging {
           mimeType = plainAsset.mimeType,
           url = plainAsset.secureUrl.orElse(plainAsset.url))
         }
-        if (assets.nonEmpty) Some(QuizImageMedia(ImageMedia(allImages = assets))) else None
+        if (assets.nonEmpty) Some(QuizImageMedia(ImageMedia.make(assets))) else None
       case error: JsError =>
         log.warn("Quiz atoms: asset json read errors: " + JsError.toFlatForm(error).toString())
         None

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
 import layout.ContentWidths.BodyMedia
 import model.content._
-import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
+import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset, ObjectPosition}
 import org.jsoup.Jsoup
 import play.api.libs.json._
 import views.support.cleaner.AmpSoundcloud
@@ -160,7 +160,7 @@ object PageElement {
         val imageSources: Seq[ImageSource] = BodyMedia.all.map {
           case (weighting, widths) =>
             val srcSet = widths.breakpoints.flatMap { b =>
-              ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)))
+              ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia.make(signedAssets)))
             }
 
             // A few very old articles use non-https hosts, which won't render
@@ -169,7 +169,7 @@ object PageElement {
         }.toSeq
 
         List(ImageBlockElement(
-          ImageMedia(signedAssets),
+          ImageMedia(ObjectPosition.make(element), signedAssets),
           imageDataFor(element),
           element.imageTypeData.flatMap(_.displayCredit),
           Role(element.imageTypeData.flatMap(_.role)),
@@ -183,7 +183,7 @@ object PageElement {
         if (element.assets.nonEmpty) {
           List(GuVideoBlockElement(
             element.assets.map(VideoAsset.make),
-            ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
+            ImageMedia.make(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
               case (a, i) => ImageAsset.make(a, i)
             }),
             element.videoTypeData.flatMap(_.caption).getOrElse(""),

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -84,7 +84,7 @@ object BlockElement {
       ))
 
       case Image => Some(ImageBlockElement(
-        ImageMedia(element.assets.zipWithIndex.map { case (a, i) => ImageAsset.make(a, i) }),
+        ImageMedia.make(element.assets.zipWithIndex.map { case (a, i) => ImageAsset.make(a, i) }),
         imageDataFor(element),
         element.imageTypeData.flatMap(_.displayCredit)
       ))
@@ -95,7 +95,7 @@ object BlockElement {
         if (element.assets.nonEmpty) {
           Some(GuVideoBlockElement(
             element.assets.map(VideoAsset.make),
-            ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
+            ImageMedia.make(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
               case (a, i) => ImageAsset.make(a, i)
             }),
             videoDataFor(element))

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -55,7 +55,7 @@
 
     <!--[if IE 9]></video><![endif]-->
 
-    <img class="@RenderClasses(classes: _*)"
+    <img class="@RenderClasses(classes: _*) @picture.position.className"
         itemprop="contentUrl"
         alt="@imageAltText"
         src="@ImgSrc.getFallbackUrl(picture)" />

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,5 +1,5 @@
 @import layout.WidthsByBreakpoint
-@import model.ImageMedia
+@import model.{ImageMedia, ObjectPosition}
 @import views.support.{ImgSrc, RenderClasses, SrcSet}
 @import implicits.Requests._
 @import conf.switches.Switches
@@ -26,6 +26,10 @@
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>
-        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
+        <img
+            loading="@{ if (Switches.LazyLoadImages.isSwitchedOn) "lazy" else "auto"}"
+            class="@RenderClasses(classes: _*) @maybeImageMedia.map(_.position).getOrElse(ObjectPosition.default)"
+            alt=""
+            src="@src"/>
     }
 </picture>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -28,7 +28,7 @@
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath).map { src =>
         <img
             loading="@{ if (Switches.LazyLoadImages.isSwitchedOn) "lazy" else "auto"}"
-            class="@RenderClasses(classes: _*) @maybeImageMedia.map(_.position).getOrElse(ObjectPosition.default)"
+            class="@RenderClasses(classes: _*) @maybeImageMedia.fold(ObjectPosition.default)(_.position)"
             alt=""
             src="@src"/>
     }

--- a/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
@@ -16,7 +16,7 @@
             }
 
             case _ => {
-                <img src="@ImgSrc.getFallbackUrl(imageMedia)">
+                <img class="@imageMedia.position.className" src="@ImgSrc.getFallbackUrl(imageMedia)">
             }
         }
     </div>

--- a/static/src/stylesheets/module/_layout-hints.garnett.scss
+++ b/static/src/stylesheets/module/_layout-hints.garnett.scss
@@ -177,3 +177,13 @@ figure {
 
 
 }
+
+.position--tl { object-position: left    top;    }
+.position--tc { object-position: center  top;    }
+.position--tr { object-position: right   top;    }
+.position--cl { object-position: left    center; }
+.position--cc { object-position: center  center; }
+.position--cr { object-position: right   center; }
+.position--bl { object-position: left    bottom; }
+.position--bc { object-position: center  bottom; }
+.position--br { object-position: right   bottom; }

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -191,3 +191,13 @@ figure {
         }
     }
 }
+
+.position--tl { object-position: left    top;    }
+.position--tc { object-position: center  top;    }
+.position--tr { object-position: right   top;    }
+.position--cl { object-position: left    center; }
+.position--cc { object-position: center  center; }
+.position--cr { object-position: right   center; }
+.position--bl { object-position: left    bottom; }
+.position--bc { object-position: center  bottom; }
+.position--br { object-position: right   bottom; }


### PR DESCRIPTION
## What does this change?

Images do not always fit perfectly their containing box, in which case cropping occurs. That cropping centres on the centre of the image, which is not always desirable. It's been an editorial need for long that we now address as part of the ongoing work on the DE. Namely, journalists will have the ability to specify the area of focus of an image in a 3x3 grid. We can use that information directly to provide the correct `object-position` property value.

## Screenshots

In due course.

## What is the value of this and can you measure success?

Longstanding issue with images on mobile, when for instance the image features two people facing each other and the cropped version only shows the void between them.

## Does this affect other platforms?

- [x] Apps
- [x] Others

## Does this change update the version of CAPI we're using?

[Yes](https://github.com/guardian/content-api-models/pull/167), and I will re-run all the tests locally and check in all the updated data/database/xyz files

## Tested

- [ ] Locally
- [ ] On CODE (optional)
