### PR TITLE
Migrate to version 3 dotcom-rendering model

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -5,7 +5,7 @@ import common._
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.dotcomponents.DotcomponentsDataModel
+import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
 import model.{ContentType, PageWithStoryPackage, _}
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json
@@ -85,7 +85,7 @@ class ArticleController(
   }
 
   private def getGuuiJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String =
-    DotcomponentsDataModel.toJsonString(DotcomponentsDataModel.fromArticle(article, request, blocks))
+    DataModelV3.toJson(DotcomponentsDataModel.fromArticle(article, request, blocks))
 
   private def render(path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {
     val tier = ArticlePicker.getTier(article)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import services.CAPILookup
 import views.support.RenderOtherStatus
 import implicits.{AmpFormat, HtmlFormat}
-import model.dotcomponents.DotcomponentsDataModel
+import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
 import renderers.RemoteRenderer
 
 import scala.concurrent.Future
@@ -154,7 +154,7 @@ class LiveBlogController(
     blocks: Blocks
   )(implicit request: RequestHeader): Result = {
     val model = DotcomponentsDataModel.fromArticle(blog, request, blocks)
-    val json = DotcomponentsDataModel.toJsonString(model)
+    val json = DataModelV3.toJson(model)
 
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -8,19 +8,18 @@ import common.commercial.{CommercialProperties, EditionCommercialProperties, Pre
 import conf.Configuration.affiliatelinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
+import controllers.ArticlePage
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
-import model.{Article, Canonical, LiveBlogPage, PageWithStoryPackage, SubMetaLinks}
+import model.{Canonical, LiveBlogPage, PageWithStoryPackage}
 import navigation.NavMenu
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
+import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.{AffiliateLinksCleaner, CamelCase, GUDateTimeFormat, ImgSrc, Item300}
-import ai.x.play.json.implicits.optionWithNull
-import controllers.ArticlePage
-import org.joda.time.{DateTime, DateTimeZone}
 
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
@@ -29,18 +28,14 @@ import org.joda.time.{DateTime, DateTimeZone}
 // only one reason for change.
 // exceptions: we do resuse the existing Nav & BlockElement classes right now
 
-case class TagProperties(
-    id: String,
-    tagType: String,
-    webTitle: String,
-    twitterHandle: Option[String],
-    bylineImageUrl: Option[String]
-)
-
 case class Tag(
-    properties: TagProperties
+  id: String,
+  `type`: String,
+  title: String,
+  twitterHandle: Option[String],
+  bylineImageUrl: Option[String]
 )
-
+//
 case class Block(
     id: String,
     elements: List[PageElement],
@@ -52,13 +47,6 @@ case class Block(
     title: Option[String],
 )
 
-case class Blocks(
-    main: Option[Block],
-    body: List[Block],
-    keyEvents: List[Block],
-)
-
-// For liveblogs
 case class Pagination(
   currentPage: Int,
   totalPages: Int,
@@ -67,7 +55,7 @@ case class Pagination(
   oldest: Option[String],
   older: Option[String],
 )
-
+//
 case class ReaderRevenueLink(
   contribute: String,
   subscribe: String,
@@ -82,85 +70,10 @@ case class ReaderRevenueLinks(
   ampFooter: ReaderRevenueLink
 )
 
-case class Meta(
-  isImmersive: Boolean,
-  isHosted: Boolean,
-  shouldHideAds: Boolean,
-  hasStoryPackage: Boolean,
-  hasRelated: Boolean,
-  isCommentable: Boolean,
-  linkedData: List[LinkedData]
-)
-
-case class Tags(
-  authorIds: Option[String],
-  toneIds: Option[String],
-  keywordIds: Option[String],
-  commissioningDesks: Option[String],
-  all: List[Tag]
-)
-
-case class Content(
-  headline: String,
-  standfirst: Option[String],
-  main: String,
-  blocks: Blocks,
-  byline: String,
-  trailText: String
-)
-
 case class Commercial(
   editionCommercialProperties: Map[String, EditionCommercialProperties],
   prebidIndexSites: List[PrebidIndexSite],
   commercialProperties: Option[CommercialProperties], //DEPRECATED TO DELETE
-)
-
-// top-level structures
-
-case class DCSite(
-  ajaxUrl: String,
-  guardianBaseURL: String,
-  sentryHost: Option[String],
-  sentryPublicApiKey: Option[String],
-  switches: Map[String,Boolean],
-  beaconUrl: String,
-  subscribeWithGoogleApiUrl: String,
-  nav: NavMenu,
-  readerRevenueLinks: ReaderRevenueLinks,
-  commercialUrl: String
-)
-
-case class DCPage(
-  content: Content,
-  tags: Tags,
-  pagination: Option[Pagination],
-  author: String,
-  pageId: String,
-  pillar: Option[String],
-  webPublicationDate: Long,
-  webPublicationDateDisplay: String,
-  section: Option[String],
-  sectionLabel: String,
-  sectionUrl: String,
-  webTitle: String,
-  contentId: Option[String],
-  seriesId: Option[String],
-  editionId: String,
-  edition: String,
-  contentType: Option[String],
-  subMetaLinks: SubMetaLinks,
-  webURL: String,
-  starRating: Option[Int],
-  commercial: Commercial,
-  meta: Meta
-)
-
-// the composite data model
-
-case class DotcomponentsDataModel(
-  page: DCPage,
-  site: DCSite,
-  version: Int
 )
 
 object Block {
@@ -172,28 +85,8 @@ object Commercial {
   implicit val writes = Json.writes[Commercial]
 }
 
-object Blocks {
-  implicit val writes = Json.writes[Blocks]
-}
-
-object TagProperties {
-  implicit val writes = Json.writes[TagProperties]
-}
-
-object Content {
-  implicit val writes = Json.writes[Content]
-}
-
 object Tag {
   implicit val writes = Json.writes[Tag]
-}
-
-object Tags {
-  implicit val writes = Json.writes[Tags]
-}
-
-object Meta {
-  implicit val writes = Json.writes[Meta]
 }
 
 object ReaderRevenueLink {
@@ -203,24 +96,150 @@ object ReaderRevenueLink {
 object ReaderRevenueLinks {
   implicit val writes = Json.writes[ReaderRevenueLinks]
 }
-
+//
 object Pagination {
   implicit val writes = Json.writes[Pagination]
 }
 
-object DCPage {
-  implicit val writes = Json.writes[DCPage]
+case class Config(
+  ajaxUrl: String,
+  sentryPublicApiKey: String,
+  sentryHost: String,
+  switches: Map[String, Boolean],
+  dfpAccountId: String,
+  commercialUrl: String,
+)
+
+object Config {
+  implicit val writes = Json.writes[Config]
 }
 
-object DCSite {
-  implicit val writes = Json.writes[DCSite]
+case class SubMetaLink(
+  url: String,
+  title: String,
+)
+
+object SubMetaLink {
+  implicit val format = Json.format[SubMetaLink]
+
+  def apply(sml: model.SubMetaLink): SubMetaLink = {
+    SubMetaLink(
+      url = sml.link,
+      title = sml.text,
+    )
+  }
+}
+
+case class Author(
+  byline: String,
+  twitterHandle: Option[String],
+)
+
+object Author {
+  implicit val writes = Json.writes[Author]
+}
+
+case class DataModelV3(
+  version: Int,
+  headline: String,
+  standfirst: String,
+  webTitle: String,
+  mainMediaElements: List[PageElement],
+  main: String,
+  keyEvents: List[Block],
+  blocks: List[Block],
+  pagination: Option[Pagination],
+  author: Author,
+  webPublicationDate: String,
+  webPublicationDateDisplay: String, // TODO remove
+  editionLongForm: String,
+  editionId: String,
+  pageId: String,
+  tags: List[Tag],
+  pillar: String,
+  isImmersive: Boolean,
+  sectionLabel: String,
+  sectionUrl: String,
+  sectionName: Option[String],
+  subMetaSectionLinks: List[SubMetaLink],
+  subMetaKeywordLinks: List[SubMetaLink],
+  shouldHideAds: Boolean,
+  webURL: String,
+  linkedData: List[LinkedData],
+  config: Config,
+  guardianBaseURL: String,
+  contentType: String,
+  hasRelated: Boolean,
+  hasStoryPackage: Boolean,
+  beaconURL: String,
+  isCommentable: Boolean,
+  commercialProperties: Map[String, EditionCommercialProperties],
+  starRating: Option[Int],
+  trailText: String,
+  nav: NavMenu,
+)
+
+object DataModelV3 {
+  implicit val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
+
+  implicit val writes = new Writes[DataModelV3] {
+    def writes(model: DataModelV3) = Json.obj(
+      "version" -> model.version,
+      "headline" -> model.headline,
+      "standfirst" -> model.standfirst,
+      "webTitle" -> model.webTitle,
+      "mainMediaElements" -> Json.toJson(model.mainMediaElements),
+      "main" -> model.main,
+      "keyEvents" -> model.keyEvents,
+      "blocks" -> model.blocks,
+      "pagination" -> model.pagination,
+      "author" -> model.author,
+      "webPublicationDate" -> model.webPublicationDate,
+      "webPublicationDateDisplay" -> model.webPublicationDateDisplay,
+      "editionLongForm" -> model.editionLongForm,
+      "editionId" -> model.editionId,
+      "pageId" -> model.pageId,
+      "tags" -> model.tags,
+      "pillar" -> model.pillar,
+      "isImmersive" -> model.isImmersive,
+      "sectionLabel" -> model.sectionLabel,
+      "sectionUrl" -> model.sectionUrl,
+      "sectionName" -> model.sectionName,
+      "subMetaSectionLinks" -> model.subMetaSectionLinks,
+      "subMetaKeywordLinks" -> model.subMetaKeywordLinks,
+      "shouldHideAds" -> model.shouldHideAds,
+      "webURL" -> model.webURL,
+      "linkedData" -> model.linkedData,
+      "config" -> model.config,
+      "guardianBaseURL" -> model.guardianBaseURL,
+      "contentType" -> model.contentType,
+      "hasRelated" -> model.hasRelated,
+      "hasStoryPackage" -> model.hasStoryPackage,
+      "beaconURL" -> model.beaconURL,
+      "isCommentable" -> model.isCommentable,
+      "commercialProperties" -> model.commercialProperties,
+      "starRating" -> model.starRating,
+      "trailText" -> model.trailText,
+      "nav" -> model.nav,
+    )
+  }
+
+  def toJson(model: DataModelV3): String = {
+    def withoutNull(json: JsValue): JsValue = json match {
+      case JsObject(fields) => JsObject(fields.filterNot{ case (_, value) => value == JsNull })
+      case other => other
+    }
+
+    val jsValue = Json.toJson(model)
+    Json.stringify(withoutNull(jsValue))
+  }
 }
 
 object DotcomponentsDataModel {
 
   val VERSION = 2
 
-  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks): DotcomponentsDataModel = {
+  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks): DataModelV3 = {
 
     val article = articlePage.article
     val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
@@ -346,7 +365,7 @@ object DotcomponentsDataModel {
         .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
     }
 
-    val dcBlocks = Blocks(mainBlock, bodyBlocks, keyEvents.toList)
+    //val dcBlocks = Blocks(mainBlock, bodyBlocks, keyEvents.toList)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
 
@@ -378,13 +397,11 @@ object DotcomponentsDataModel {
 
     val allTags = article.tags.tags.map(
       t => Tag(
-        TagProperties(
-          t.id,
-          t.properties.tagType,
-          t.properties.webTitle,
-          t.properties.twitterHandle,
-          t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300))
-        )
+        t.id,
+        t.properties.tagType,
+        t.properties.webTitle,
+        t.properties.twitterHandle,
+        t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300))
       )
     )
 
@@ -428,27 +445,6 @@ object DotcomponentsDataModel {
       ampFooterReaderRevenueLink
     )
 
-    val site = DCSite(
-      Configuration.ajax.url,
-      Configuration.site.host,
-      jsPageData.get("sentryHost"),
-      jsPageData.get("sentryPublicApiKey"),
-      switches,
-      Configuration.debug.beaconUrl,
-      Configuration.google.subscribeWithGoogleApiUrl,
-      navMenu,
-      readerRevenueLinks,
-      buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
-    )
-
-    val tags = Tags(
-      jsConfig("authorIds"),
-      jsConfig("keywordIds"),
-      jsConfig("toneIds"),
-      jsConfig("commissioningDesks"),
-      allTags
-    )
-
     val commercial = Commercial(
       editionCommercialProperties =
         article.metadata.commercial.map{_.perEdition.mapKeys(_.id)}
@@ -460,72 +456,63 @@ object DotcomponentsDataModel {
       article.metadata.commercial,
     )
 
-    val author = article.tags.contributors.map(_.name) match {
+    val byline = article.tags.contributors.map(_.name) match {
       case Nil => "Guardian staff reporter"
       case contributors => contributors.mkString(",")
     }
 
-    val content = DCPage(
-      Content(
-        article.trail.headline,
-        article.fields.standfirst,
-        article.fields.main,
-        dcBlocks,
-        article.trail.byline.getOrElse(""),
-        trailText = article.trail.fields.trailText.getOrElse("")
-      ),
-      tags,
+    val config = Config(
+      ajaxUrl = Configuration.ajax.url,
+      sentryPublicApiKey = jsPageData.get("sentryPublicApiKey").getOrElse(""),
+      sentryHost = jsPageData.get("sentryHost").getOrElse(""),
+      switches = switches,
+      dfpAccountId = "", // TODO
+      commercialUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
+    )
+
+    val author = Author(
+      byline = byline,
+      twitterHandle = article.tags.contributors.headOption.flatMap(_.properties.twitterHandle)
+    )
+
+    DataModelV3(
+      version = 3,
+      headline = article.trail.headline,
+      standfirst = article.fields.standfirst.getOrElse(""),
+      webTitle = article.metadata.webTitle,
+      mainMediaElements = mainBlock.toList.flatMap(_.elements),
+      main = article.fields.main,
+      keyEvents = keyEvents.toList,
+      blocks = bodyBlocks,
       pagination = pagination,
-      author,
-      article.metadata.id,
-      article.metadata.pillar.map(_.toString),
-      article.trail.webPublicationDate.getMillis,
-      GUDateTimeFormat.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
-      article.metadata.section.map(_.value),
-      article.content.sectionLabelName,
-      article.content.sectionLabelLink,
-      article.metadata.webTitle,
-      jsConfig("contentId"),   // source: content.scala
-      jsConfig("seriesId"),    // source: content.scala
-      Edition(request).id,
-      Edition(request).displayName,
-      jsConfig("contentType"),
-      article.content.submetaLinks,
-      article.metadata.webUrl,
-      article.content.starRating,
-      commercial,
-      meta = Meta (
-        article.isImmersive,
-        article.metadata.isHosted,
-        article.content.shouldHideAdverts,
-        articlePage.related.hasStoryPackage,
-        article.content.showInRelated,
-        article.trail.isCommentable,
-        linkedData
-      ),
+      author = author,
+      webPublicationDate = article.trail.webPublicationDate.toString, // TODO check format
+      webPublicationDateDisplay = GUDateTimeFormat.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
+      editionLongForm = Edition(request).displayName, // TODO check
+      editionId = Edition(request).id,
+      pageId = article.metadata.id,
+      tags = allTags,
+      pillar = article.metadata.pillar.map(_.toString.toLowerCase).getOrElse("news"),
+      isImmersive = article.isImmersive,
+      sectionLabel = article.content.sectionLabelName,
+      sectionUrl = article.content.sectionLabelLink,
+      sectionName = article.metadata.section.map(_.value),
+      subMetaSectionLinks = article.content.submetaLinks.sectionLabels.map(SubMetaLink.apply),
+      subMetaKeywordLinks = article.content.submetaLinks.keywords.map(SubMetaLink.apply),
+      shouldHideAds = article.content.shouldHideAdverts,
+      webURL = article.metadata.webUrl,
+      linkedData = linkedData,
+      config = config,
+      guardianBaseURL = Configuration.amp.baseUrl,
+      contentType = jsConfig("contentType").getOrElse(""),
+      hasRelated = article.content.showInRelated,
+      hasStoryPackage = articlePage.related.hasStoryPackage,
+      beaconURL = Configuration.debug.beaconUrl,
+      isCommentable = article.trail.isCommentable,
+      commercialProperties = commercial.editionCommercialProperties,
+      starRating = article.content.starRating,
+      trailText = article.trail.fields.trailText.getOrElse(""),
+      nav = navMenu,
     )
-
-    DotcomponentsDataModel(
-      content,
-      site,
-      VERSION
-    )
-
-  }
-
-  def toJson(model: DotcomponentsDataModel): JsValue = {
-    // make what we have look a bit closer to what dotcomponents currently expects
-    implicit val DotComponentsDataModelWrites = new Writes[DotcomponentsDataModel] {
-      def writes(model: DotcomponentsDataModel) = Json.obj(
-        "page" -> model.page,
-        "site" -> model.site,
-        "version" -> model.version
-      )
-    }
-    Json.toJson(model)
-  }
-
-  def toJsonString(model: DotcomponentsDataModel): String = {
-    Json.stringify(toJson(model))
   }
 }

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -1,18 +1,13 @@
 package renderers
 
 import akka.actor.ActorSystem
-import com.eclipsesource.schema._
-import com.eclipsesource.schema.drafts.Version7
-import com.eclipsesource.schema.drafts.Version7._
 import com.gu.contentapi.client.model.v1.Blocks
-import com.osinka.i18n.Lang
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
-import model.dotcomponents.DotcomponentsDataModel
+import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
 import model.{Cached, PageWithStoryPackage}
-import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
@@ -20,11 +15,8 @@ import play.twirl.api.Html
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.io.Source
 
 class RemoteRenderer {
-
-  private[this] val SCHEMA = "schema/dotcomponentsDataModelV2.jsonschema"
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
     name = "dotcom-rendering-client",
@@ -33,14 +25,6 @@ class RemoteRenderer {
     callTimeout = Configuration.rendering.timeout.plus(200.millis),
     resetTimeout = Configuration.rendering.timeout * 4,
   )
-
-  private[this] def validate(model: DotcomponentsDataModel): JsResult[JsValue] = {
-    val rawschema: String = Source.fromResource(SCHEMA).getLines.mkString("\n")
-    val schema = Json.fromJson[SchemaType](Json.parse(rawschema)).get
-    val validator = new SchemaValidator(Some(Version7))(Lang.Default)
-
-    validator.validate(schema, DotcomponentsDataModel.toJson(model))
-  }
 
   private[this] def get(
     ws: WSClient,
@@ -79,14 +63,9 @@ class RemoteRenderer {
     blocks: Blocks
   )(implicit request: RequestHeader): Future[Result] = {
 
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
-    val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
-
-    validate(dataModel) match {
-      case JsSuccess(_,_) => get(ws, dataString, page, Configuration.rendering.AMPArticleEndpoint)
-      case JsError(e) => Future.failed(new Exception(Json.prettyPrint(JsError.toJson(e))))
-    }
-
+    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
+    val json = DataModelV3.toJson(dataModel)
+    get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
   }
 
   def getArticle(
@@ -96,13 +75,9 @@ class RemoteRenderer {
     blocks: Blocks
   )(implicit request: RequestHeader): Future[Result] = {
 
-    val dataModel: DotcomponentsDataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
-    val dataString: String = DotcomponentsDataModel.toJsonString(dataModel)
-
-    validate(dataModel) match {
-      case JsSuccess(_,_) => get(ws, dataString, page, Configuration.rendering.renderingEndpoint)
-      case JsError(e) => Future.failed(new Exception(Json.prettyPrint(JsError.toJson(e))))
-    }
+    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks)
+    val json = DataModelV3.toJson(dataModel)
+    get(ws, json, page, Configuration.rendering.renderingEndpoint)
   }
 }
 


### PR DESCRIPTION
This model dramatically simplifies the code on the DCR side without increasing the work here that much.

See https://github.com/guardian/dotcom-rendering/pull/637 for related changes.