### PR TITLE
Epic format broken when image too close to the bottom of the article

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -9,6 +9,7 @@
 .contributions__epic {
     border-top: 1px solid $highlight-main;
     background-color: $brightness-97;
+    clear: both;
     margin-top: $gs-baseline * 2;
     padding: ($gs-baseline / 3) ($gs-gutter / 4) $gs-baseline;
 


### PR DESCRIPTION
## What does this change?
Small visual bug when epics float against images at the bottom of articles. Making sure the epic clears the document structure above it.

## Screenshots
Bug:
<img width="1210" alt="epic bug" src="https://user-images.githubusercontent.com/3300789/60960648-61f1a800-a302-11e9-9e33-c82a20030aa1.png">

Bug fix:
<img width="1246" alt="epic bug fix" src="https://user-images.githubusercontent.com/3300789/60960696-75047800-a302-11e9-9f7e-7ac2d1b79df8.png">

Doesn't affect tablet:
<img width="747" alt="epic bug fix control" src="https://user-images.githubusercontent.com/3300789/60960754-906f8300-a302-11e9-9034-b164b14e59ac.png">

Doesn't affect mobile:
<img width="328" alt="epic bug fix control mobile" src="https://user-images.githubusercontent.com/3300789/60960752-906f8300-a302-11e9-8697-cc5eb22a7cff.png">

## What is the value of this and can you measure success?
Beauty is immeasurable

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
