### PR TITLE
Epic articles viewed test: 30 days

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,8 +28,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-articles-viewed",
-    "States how many articles a user has viewed in the epic",
+    "ab-contributions-epic-articles-viewed-month",
+    "States how many articles a user has viewed in the epic in a month",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 1, 27),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -7,9 +7,9 @@ import {
 import { getArticleViewCount } from 'common/modules/onward/history';
 import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
-// Use must have read at least 5 articles in last 14 days
+// Use must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
-const articleCountDays = 14;
+const articleCountDays = 30;
 
 const articleViewCount = getArticleViewCount(articleCountDays);
 
@@ -40,8 +40,8 @@ const geolocation = geolocationGetSync();
 const isUSUK = ['GB', 'US'].includes(geolocation);
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
-    id: 'ContributionsEpicArticlesViewed',
-    campaignId: 'epic_articles_viewed',
+    id: 'ContributionsEpicArticlesViewedMonth',
+    campaignId: 'epic_articles_viewed_month',
 
     start: '2019-06-24',
     expiry: '2020-01-27',
@@ -79,7 +79,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                 {
                     heading: `You’ve read ${articleViewCount} articles...`,
                     paragraphs:
-                        '... in the last two weeks. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+                        '... in the last month. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
                         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
                         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',


### PR DESCRIPTION
## What does this change?
A new test that just increases the time period from 14 to 30 days.
[Original test](https://github.com/guardian/frontend/pull/21531)
We'll break it down but number of articles read in the analysis afterwards.

## Screenshots
<img width="633" alt="Screenshot 2019-07-10 at 14 29 01" src="https://user-images.githubusercontent.com/1513454/60973316-eef72a00-a31f-11e9-9c2d-e9eca3698091.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
