### PR TITLE
Add mandatory OG tag for video pages

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -638,7 +638,7 @@ object Video {
           "og:video:url" -> content.metadata.webUrl,
           "og:video:secure_url" -> content.metadata.webUrl
         )
-      else Nil
+      else Map.empty
     val opengraphProperties = Map(
       // Not using the og:video properties here because we want end-users to visit the guardian website
       // when they click the thumbnail in the FB feed rather than playing the video "in-place"

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -632,7 +632,13 @@ object Video {
       "videoDuration" -> elements.videos.find(_.properties.isMain).map{ v => JsNumber(v.videos.duration)}.getOrElse(JsNull)) ++ AtomProperties(content.atoms)
 
 
-    val optionalOpengraphProperties = if(content.metadata.webUrl.startsWith("https://")) Map("og:video:secure_url" -> content.metadata.webUrl) else Nil
+    val optionalOpengraphProperties =
+      if(content.metadata.webUrl.startsWith("https://"))
+        Map(
+          "og:video:url" -> content.metadata.webUrl,
+          "og:video:secure_url" -> content.metadata.webUrl
+        )
+      else Nil
     val opengraphProperties = Map(
       // Not using the og:video properties here because we want end-users to visit the guardian website
       // when they click the thumbnail in the FB feed rather than playing the video "in-place"


### PR DESCRIPTION
## What does this change?

Adds a `meta` tag to appease the god of open graph protocols.

![Screenshot 2019-07-11 at 11 00 08](https://user-images.githubusercontent.com/629976/61041917-16570100-a3cb-11e9-81d6-7926bc96f00e.png)

## What is the value of this and can you measure success?

Our social cache clearing lambda is failing many times with the following error:

> Object at URL "http://www.theguardian.com/world/video/2019/jul/08/scientists-discover-snowball-the-cockatoo-has-16-distinct-dance-moves-video" of type "article" is invalid because a required property "og:video:url" of type "url" was not provided.

### Tested

- [x] Locally
- [ ] On CODE (optional)
