### PR TITLE
Add OG exception for PA 😞

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -481,7 +481,7 @@ object Article {
       ("article:tag", tags.keywords.map(_.name).mkString(",")),
       ("article:section", trail.sectionName),
       ("article:publisher", "https://www.facebook.com/theguardian"),
-      ("article:author", author)
+      ("article:author", authorOrPA(author))
     )
 
     content.metadata.copy(
@@ -523,6 +523,11 @@ object Article {
     )
 
     Article(contentOverrides, lightboxProperties)
+  }
+
+  private def authorOrPA: String => String = {
+    case "Press Association" => "https://www.facebook.com/PAMediaGroupUK/"
+    case otherwise => otherwise
   }
 }
 


### PR DESCRIPTION
## What does this change?

Set the `article:author` to be the Facebook profile page of the press association for articles they have authored on the site. This is not 100% standard afaict, but has been a standard feature on Facebook [for a long time](https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/).

## Screenshots

![Screenshot 2019-07-11 at 11 43 06](https://user-images.githubusercontent.com/629976/61044844-705ac500-a3d1-11e9-8227-18a34979f9a5.png)

## What is the value of this and can you measure success?

The second reason why our social clearing lambda breaks is:

> Object at URL 'http://www.theguardian.com/politics/2019/jul/08/boris-johnson-make-uk-match-fit-for-no-deal-brexit' of type 'article' is invalid because the given value 'Press Association' for property 'article:author' could not be parsed as type 'profile'.

It happens many times a day, all with the same author.

### Tested

- [x] Locally
- [ ] On CODE (optional)
