### PR TITLE
Expand the consent banner worldwide except North America

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -2,7 +2,6 @@
 
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
-import { getFromStorage } from 'lib/geolocation';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
 
@@ -90,16 +89,10 @@ const isInCommercialConsentModalBannerTest = (): boolean =>
         'nonDismissableVariant'
     );
 
-const isInEU = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
+const isInNA = (): boolean =>
+    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
 
-const isInAU = (): boolean => {
-    const countryCode = (getFromStorage() || 'OTHER').toUpperCase();
-
-    return countryCode === 'AU' || countryCode === 'NZ';
-};
-
-const gdprApplies = (): boolean => isInEU() || isInAU();
+const gdprApplies = (): boolean => !isInNA();
 
 class CmpService {
     isLoaded: boolean;

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -145,7 +145,7 @@ describe('cmp', () => {
         cmp.processCommand('getVendorConsents', null, result => {
             expect(result).toEqual({
                 metadata: undefined,
-                gdprApplies: false,
+                gdprApplies: true,
                 hasGlobalScope: false,
             });
         });
@@ -162,7 +162,7 @@ describe('cmp', () => {
         cmp.processCommand('getConsentData', null, result => {
             expect(result).toEqual({
                 consentData: undefined,
-                gdprApplies: false,
+                gdprApplies: true,
                 hasGlobalScope: false,
             });
         });

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,7 +1,6 @@
 // @flow
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
-import { getFromStorage } from 'lib/geolocation';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import checkIcon from 'svgs/icon/tick.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
@@ -139,16 +138,10 @@ const makeHtml = (): string => `
     </div>
 `;
 
-const isInEU = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'EU';
+const isInNA = (): boolean =>
+    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
 
-const isInAU = (): boolean => {
-    const countryCode = (getFromStorage() || 'OTHER').toUpperCase();
-
-    return countryCode === 'AU' || countryCode === 'NZ';
-};
-
-const gdprApplies = (): boolean => isInEU() || isInAU();
+const gdprApplies = (): boolean => !isInNA();
 
 const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -108,17 +108,45 @@ describe('First PV consents banner', () => {
         beforeEach(() => {
             test.clearTestVariants();
         });
-        it('should render inside the EU', async () => {
+        it('should render in EU', async () => {
             getCookie.mockImplementation(_ => {
                 if (_ === 'GU_geo_continent') return 'EU';
                 return null;
             });
             return expect(await banner.canShow()).toBe(true);
         });
-        it('should not render outside the EU', async () => {
+        it('should render in AS', async () => {
+            getCookie.mockImplementation(_ => {
+                if (_ === 'GU_geo_continent') return 'AS';
+                return null;
+            });
+            return expect(await banner.canShow()).toBe(true);
+        });
+        it('should render in OC', async () => {
+            getCookie.mockImplementation(_ => {
+                if (_ === 'GU_geo_continent') return 'OC';
+                return null;
+            });
+            return expect(await banner.canShow()).toBe(true);
+        });
+        it('should render in AF', async () => {
+            getCookie.mockImplementation(_ => {
+                if (_ === 'GU_geo_continent') return 'AF';
+                return null;
+            });
+            return expect(await banner.canShow()).toBe(true);
+        });
+        it('should render in SA', async () => {
+            getCookie.mockImplementation(_ => {
+                if (_ === 'GU_geo_continent') return 'SA';
+                return null;
+            });
+            return expect(await banner.canShow()).toBe(true);
+        });
+        it('should not render in NA', async () => {
             isInVariantSynchronous.mockImplementation(() => false);
             getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return '??';
+                if (_ === 'GU_geo_continent') return 'NA';
                 return null;
             });
             return expect(await banner.canShow()).toBe(false);


### PR DESCRIPTION
## What does this change?
This change expands our consent banner to run worldwide, with the exception of North American/

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [X] Locally
- [X] On CODE (optional)