### PR TITLE
Update app logo in banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -32,7 +32,7 @@ const DATA = {
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK:
-            'https://app.adjust.com/642i3r?deep_link=x-gu://www.theguardian.com/?source=adjust',
+            'https://play.google.com/store/apps/details?id=com.guardian',
         STORE: 'in Google Play',
     },
 };

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -21,15 +21,15 @@ const COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER';
 const DATA = {
     IOS: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS: 
+        SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-        LINK: 
+        LINK:
             'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
         STORE: 'on the App Store',
     },
     ANDROID: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS: 
+        SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK: 'https://play.google.com/store/apps/details?id=com.guardian',
         STORE: 'in Google Play',

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -21,18 +21,14 @@ const COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER';
 const DATA = {
     IOS: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS:
-            'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-        LINK:
-            'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
+        SCREENSHOTS: 'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
+        LINK: 'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
         STORE: 'on the App Store',
     },
     ANDROID: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS:
-            'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-        LINK:
-            'https://play.google.com/store/apps/details?id=com.guardian',
+        SCREENSHOTS: 'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
+        LINK: 'https://play.google.com/store/apps/details?id=com.guardian',
         STORE: 'in Google Play',
     },
 };

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -20,7 +20,7 @@ const COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER';
 
 const DATA = {
     IOS: {
-        LOGO: 'https://assets.guim.co.uk/images/apps/ios-logo.png',
+        LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK:
@@ -28,7 +28,7 @@ const DATA = {
         STORE: 'on the App Store',
     },
     ANDROID: {
-        LOGO: 'https://assets.guim.co.uk/images/apps/android-logo-2x.png',
+        LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK:

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -21,13 +21,16 @@ const COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER';
 const DATA = {
     IOS: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS: 'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-        LINK: 'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
+        SCREENSHOTS: 
+            'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
+        LINK: 
+            'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
         STORE: 'on the App Store',
     },
     ANDROID: {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
-        SCREENSHOTS: 'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
+        SCREENSHOTS: 
+            'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK: 'https://play.google.com/store/apps/details?id=com.guardian',
         STORE: 'in Google Play',
     },

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -240,6 +240,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         position: relative;
         padding-top: $gs-baseline/2;
         padding-bottom: $gs-baseline/2;
+        box-sizing: border-box;
     }
 
     .site-message__close {

--- a/static/src/stylesheets/module/_site-message.scss
+++ b/static/src/stylesheets/module/_site-message.scss
@@ -285,7 +285,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
     .app__logo {
         width: 50px;
-        margin-left: $gs-gutter*.75;
+        margin-left: $gs-gutter*1.25;
         margin-right: $gs-gutter/4;
     }
 


### PR DESCRIPTION
Updates the app logo and link to the play store.
To recreate:
1. Incognito window on Android
2. Clear cookie banner
3. Visit Opinion or another pillar

## What does this change?

## Screenshots
Sorry for the photos, you can't screenshot incognito chrome now.

| Before Android | After Android |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/61222085-e03eb780-a711-11e9-8e42-19ca6c77fa28.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/61229442-171bca00-a720-11e9-8a1d-493d65d2c62e.png" width="300"/>

iOS is already ok: 
<img src="https://user-images.githubusercontent.com/11618797/61229428-0ff4bc00-a720-11e9-80a6-17f84922135b.PNG" width="300"/>

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
