### PR TITLE
Correct guardianBaseURL

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -553,7 +553,7 @@ object DotcomponentsDataModel {
       webURL = article.metadata.webUrl,
       linkedData = linkedData,
       config = config,
-      guardianBaseURL = Configuration.amp.baseUrl,
+      guardianBaseURL = Configuration.site.host,
       contentType = jsConfig("contentType").getOrElse(""),
       hasRelated = article.content.showInRelated,
       hasStoryPackage = articlePage.related.hasStoryPackage,


### PR DESCRIPTION
## What does this change?

This gives the the dotcom-rendering datamodel object the correct value for attribute `guardianBaseURL`
