### PR TITLE
Added Mobile Sticky leaderboard to Prebid in US

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 7, 31),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-mobile-sticky",
+    "Test asking prebid for mobile sticky slots in US",
+    owners = Owner.group(Commercial),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 9, 30),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -19,8 +19,8 @@ const isInNA = (): boolean =>
 
 export const init = (): Promise<void> => {
     if (
-        //isInNA() && // User is in North America
-        //isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
+        isInNA() && // User is in North America
+        isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
         config.get('page.contentType') === 'Article' // User is accessing an article
     ) {
         const mobileStickyWrapper = createAdWrapper();

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -19,8 +19,8 @@ const isInNA = (): boolean =>
 
 export const init = (): Promise<void> => {
     if (
-        isInNA() && // User is in North America
-        isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
+        //isInNA() && // User is in North America
+        //isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
         config.get('page.contentType') === 'Article' // User is accessing an article
     ) {
         const mobileStickyWrapper = createAdWrapper();
@@ -34,7 +34,7 @@ export const init = (): Promise<void> => {
                 const mobileStickyAdSlot = mobileStickyWrapper.querySelector(
                     '#dfp-ad--mobile-sticky'
                 );
-                if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, false);
+                if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, true);
             });
     }
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.spec.js
@@ -21,6 +21,12 @@ jest.mock('commercial/modules/dfp/get-advert-by-id', () => ({
     getAdvertById: jest.fn(),
 }));
 
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(
+        (testId, variantId) => variantId === 'variant'
+    ),
+}));
+
 describe('initialise', () => {
     beforeEach(() => {
         config.set('switches.enableConsentManagementService', true);

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -77,6 +77,7 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
         },
     ];
 
+    // TODO: add mobile sticky only in us
     const mobileSlots: Array<PrebidSlot> = [
         {
             key: 'top-above-nav',
@@ -89,7 +90,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
         {
             key: 'mostpop',
             sizes: [[300, 250]],
-        },{
+        },
+        {
             key: 'mobile-sticky',
             sizes: [[320, 50]],
         },

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -8,7 +8,6 @@ import {
 import config from 'lib/config';
 
 import type { PrebidSlot } from 'commercial/modules/prebid/types';
-import { getCookie } from 'lib/cookies';
 import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
@@ -23,9 +22,6 @@ const filterByAdvertId = (
     );
     return adUnits;
 };
-
-const isInNA = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
 
 const getSlots = (contentType: string): Array<PrebidSlot> => {
     const isArticle = contentType === 'Article';
@@ -105,8 +101,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
-            return isInNA() &&
-                isInVariantSynchronous(prebidUsMobileSticky, 'variant')
+            // Add Check if location is NA when A/B test gets removed
+            return isInVariantSynchronous(prebidUsMobileSticky, 'variant')
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -8,6 +8,7 @@ import {
 import config from 'lib/config';
 
 import type { PrebidSlot } from 'commercial/modules/prebid/types';
+import { getCookie } from 'lib/cookies';
 
 const filterByAdvertId = (
     advertId: string,
@@ -20,6 +21,9 @@ const filterByAdvertId = (
     );
     return adUnits;
 };
+
+const isInNA = (): boolean =>
+    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
 
 const getSlots = (contentType: string): Array<PrebidSlot> => {
     const isArticle = contentType === 'Article';
@@ -77,7 +81,6 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
         },
     ];
 
-    // TODO: add mobile sticky only in us
     const mobileSlots: Array<PrebidSlot> = [
         {
             key: 'top-above-nav',
@@ -91,15 +94,18 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
             key: 'mostpop',
             sizes: [[300, 250]],
         },
-        {
-            key: 'mobile-sticky',
-            sizes: [[320, 50]],
-        },
     ];
+
+    const mobileStickySlot: PrebidSlot = {
+        key: 'mobile-sticky',
+        sizes: [[320, 50]],
+    };
 
     switch (getBreakpointKey()) {
         case 'M':
-            return commonSlots.concat(mobileSlots);
+            return isInNA()
+                ? commonSlots.concat([...mobileSlots, mobileStickySlot])
+                : commonSlots.concat(mobileSlots);
         case 'T':
             return commonSlots.concat(tabletSlots);
         default:

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -9,6 +9,8 @@ import config from 'lib/config';
 
 import type { PrebidSlot } from 'commercial/modules/prebid/types';
 import { getCookie } from 'lib/cookies';
+import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 const filterByAdvertId = (
     advertId: string,
@@ -103,7 +105,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
-            return isInNA()
+            return isInNA() &&
+                isInVariantSynchronous(prebidUsMobileSticky, 'variant')
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -89,6 +89,9 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
         {
             key: 'mostpop',
             sizes: [[300, 250]],
+        },{
+            key: 'mobile-sticky',
+            sizes: [[320, 50]],
         },
     ];
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -51,6 +51,7 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint M non NA', () => {
         getBreakpointKey.mockReturnValue('M');
+        isInVariantSynchronous.mockReturnValue(false);
         getCookie.mockReturnValue('EU');
         expect(getSlots('Article')).toEqual([
             {

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -49,9 +49,9 @@ describe('getSlots', () => {
         jest.resetAllMocks();
     });
 
-    test('should return the correct slots at breakpoint M', () => {
+    test('should return the correct slots at breakpoint M non NA', () => {
         getBreakpointKey.mockReturnValue('M');
-        getCookie.mockReturnValue('UK');
+        getCookie.mockReturnValue('EU');
         expect(getSlots('Article')).toEqual([
             {
                 key: 'right',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -2,6 +2,7 @@
 
 import config from 'lib/config';
 import { getCookie as getCookie_ } from 'lib/cookies';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import { slots, _ } from './slot-config';
 import { getBreakpointKey as getBreakpointKey_ } from './utils';
 
@@ -9,6 +10,7 @@ const { getSlots } = _;
 
 const getBreakpointKey: any = getBreakpointKey_;
 const getCookie: any = getCookie_;
+const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 jest.mock('./utils', () => {
     // $FlowFixMe property requireActual is actually not missing Flow.
@@ -18,6 +20,20 @@ jest.mock('./utils', () => {
         getBreakpointKey: jest.fn(),
     };
 });
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(
+        (testId, variantId) => variantId === 'variant'
+    ),
+}));
+
+jest.mock('lib/detect', () => ({
+    hasCrossedBreakpoint: jest.fn(),
+    isBreakpoint: jest.fn(),
+    getBreakpoint: jest.fn(),
+    getViewport: jest.fn(),
+    hasPushStateSupport: jest.fn(),
+}));
 
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
@@ -61,6 +77,7 @@ describe('getSlots', () => {
     });
 
     test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
+        isInVariantSynchronous.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         getCookie.mockReturnValue('NA');
         expect(getSlots('Article')).toEqual([
@@ -191,6 +208,7 @@ describe('slots', () => {
     test('should return the correct mobile-sticky slot at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
         getCookie.mockReturnValue('NA');
+        isInVariantSynchronous.mockReturnValue(true);
         expect(slots('mobile-sticky', '')).toEqual([
             {
                 key: 'mobile-sticky',

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -50,6 +50,10 @@ describe('getSlots', () => {
                 key: 'mostpop',
                 sizes: [[300, 250]],
             },
+            {
+                key: 'mobile-sticky',
+                sizes: [[320, 50]],
+            },
         ]);
     });
 
@@ -146,6 +150,16 @@ describe('slots', () => {
             {
                 key: 'top-above-nav',
                 sizes: [[300, 250]],
+            },
+        ]);
+    });
+
+    test('should return the correct mobile-sticky slot at breakpoint M', () => {
+        getBreakpointKey.mockReturnValue('M');
+        expect(slots('mobile-sticky', '')).toEqual([
+            {
+                key: 'mobile-sticky',
+                sizes: [[320, 50]],
             },
         ]);
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -1,12 +1,14 @@
 // @flow
 
 import config from 'lib/config';
+import { getCookie as getCookie_ } from 'lib/cookies';
 import { slots, _ } from './slot-config';
 import { getBreakpointKey as getBreakpointKey_ } from './utils';
 
 const { getSlots } = _;
 
 const getBreakpointKey: any = getBreakpointKey_;
+const getCookie: any = getCookie_;
 
 jest.mock('./utils', () => {
     // $FlowFixMe property requireActual is actually not missing Flow.
@@ -16,6 +18,10 @@ jest.mock('./utils', () => {
         getBreakpointKey: jest.fn(),
     };
 });
+
+jest.mock('lib/cookies', () => ({
+    getCookie: jest.fn(),
+}));
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 describe('getSlots', () => {
@@ -29,6 +35,34 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
+        getCookie.mockReturnValue('UK');
+        expect(getSlots('Article')).toEqual([
+            {
+                key: 'right',
+                sizes: [[300, 600], [300, 250]],
+            },
+            {
+                key: 'inline1',
+                sizes: [[300, 250]],
+            },
+            {
+                key: 'top-above-nav',
+                sizes: [[300, 250]],
+            },
+            {
+                key: 'inline',
+                sizes: [[300, 250]],
+            },
+            {
+                key: 'mostpop',
+                sizes: [[300, 250]],
+            },
+        ]);
+    });
+
+    test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
+        getBreakpointKey.mockReturnValue('M');
+        getCookie.mockReturnValue('NA');
         expect(getSlots('Article')).toEqual([
             {
                 key: 'right',
@@ -156,6 +190,7 @@ describe('slots', () => {
 
     test('should return the correct mobile-sticky slot at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
+        getCookie.mockReturnValue('NA');
         expect(slots('mobile-sticky', '')).toEqual([
             {
                 key: 'mobile-sticky',

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -70,7 +70,8 @@ export type PrebidSlot = {
         | 'inline1'
         | 'inline'
         | 'mostpop'
-        | 'comments',
+        | 'comments'
+        | 'mobile-sticky',
     sizes: PrebidSize[],
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -9,6 +9,7 @@ import { countryName } from 'common/modules/experiments/tests/contributions-epic
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
+import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -16,6 +17,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialOutbrainTesting,
     adblockTest,
     commercialConsentModalBanner,
+    prebidUsMobileSticky,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-us-mobile-sticky.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-us-mobile-sticky.js
@@ -1,0 +1,32 @@
+// @flow strict
+import { getCookie } from 'lib/cookies';
+import { isBreakpoint } from 'lib/detect';
+
+export const prebidUsMobileSticky: ABTest = {
+    id: 'PrebidUsMobileSticky',
+    start: '2019-06-11',
+    expiry: '2019-09-30',
+    author: 'Ioanna Kyprianou',
+    description: 'This asks prebid for a mobile sticky slot 320x50',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure:
+        'We can see an ad served by prebid for a mobile sticky slot',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'No significant impact to performance as well as higher ad yield',
+    canRun: () =>
+        (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA' &&
+        isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }),
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

Changes to add mobile sticky leaderboard slot (320x50) to prebid header bidding
Affecting only US and setting it on a 0% AB Test
Changed mobile sticky from lazy loading to eager loading


## Screenshots
Example of Prebid responding with a bid for 320x50 slot

![Screenshot 2019-07-11 at 11 18 32](https://user-images.githubusercontent.com/51630004/61214110-ed05e000-a6fe-11e9-9fa9-0a1a614b6f65.png)

### Tested

- [x] Locally
- [x] On CODE (optional)

