### PR TITLE
Mobile Sticky Prebid - A/B Switch name fix

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -98,7 +98,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-prebid-mobile-sticky",
+    "ab-prebid-us-mobile-sticky",
     "Test asking prebid for mobile sticky slots in US",
     owners = Owner.group(Commercial),
     safeState = Off,


### PR DESCRIPTION
## What does this change?

Fixed server side switch name to match client side one