### PR TITLE
Add Switch to Mobile Sticky Banner and Test Param to Prebid Mobile Sticky

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -550,4 +550,14 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val mobileStickyLeaderboard: Switch = Switch(
+    group = Commercial,
+    name = "mobile-sticky-leaderboard",
+    description = "Include Mobile Sticky leaderboard banner",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -19,6 +19,7 @@ const isInNA = (): boolean =>
 
 export const init = (): Promise<void> => {
     if (
+        config.get('switches.mobileStickyLeaderboard') &&
         isInNA() && // User is in North America
         isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
         config.get('page.contentType') === 'Article' // User is accessing an article

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -11,10 +11,10 @@ import type { PrebidSlot } from 'commercial/modules/prebid/types';
 import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
-const isMobileStickyPrebidOn = (): boolean =>
-    window.location.hash.indexOf('#mobile-sticky-prebid') !== -1;
-const inMobileStickyPrebidTestOr = (liveClause: boolean): boolean =>
-    isMobileStickyPrebidOn() || liveClause;
+const inMobileStickyPrebidTestOn = (): boolean =>
+    window.location.hash.indexOf('#mobile-sticky-prebid') !== -1 ||
+    (config.get('switches.mobileStickyLeaderboard') &&
+        isInVariantSynchronous(prebidUsMobileSticky, 'variant'));
 
 const filterByAdvertId = (
     advertId: string,
@@ -107,10 +107,7 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
     switch (getBreakpointKey()) {
         case 'M':
             // Add Check if location is NA when A/B test gets removed
-            return inMobileStickyPrebidTestOr(
-                config.get('switches.mobileStickyLeaderboard') &&
-                    isInVariantSynchronous(prebidUsMobileSticky, 'variant')
-            )
+            return inMobileStickyPrebidTestOn()
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -106,6 +106,7 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
+            // Add Check if location is NA when A/B test gets removed
             return inMobileStickyPrebidTestOr(
                 config.get('switches.mobileStickyLeaderboard') &&
                     isInVariantSynchronous(prebidUsMobileSticky, 'variant')

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -11,7 +11,7 @@ import type { PrebidSlot } from 'commercial/modules/prebid/types';
 import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
-const inMobileStickyPrebidTestOn = (): boolean =>
+const isMobileStickyPrebidTestOn = (): boolean =>
     window.location.hash.indexOf('#mobile-sticky-prebid') !== -1 ||
     (config.get('switches.mobileStickyLeaderboard') &&
         isInVariantSynchronous(prebidUsMobileSticky, 'variant'));
@@ -107,7 +107,7 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
     switch (getBreakpointKey()) {
         case 'M':
             // Add Check if location is NA when A/B test gets removed
-            return inMobileStickyPrebidTestOn()
+            return isMobileStickyPrebidTestOn()
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -11,10 +11,10 @@ import type { PrebidSlot } from 'commercial/modules/prebid/types';
 import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
-const inMobileStickyPrebidOn = (): boolean =>
+const isMobileStickyPrebidOn = (): boolean =>
     window.location.hash.indexOf('#mobile-sticky-prebid') !== -1;
 const inMobileStickyPrebidTestOr = (liveClause: boolean): boolean =>
-    inMobileStickyPrebidOn() || liveClause;
+    isMobileStickyPrebidOn() || liveClause;
 
 const filterByAdvertId = (
     advertId: string,

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -101,8 +101,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
-            // Add Check if location is NA when A/B test gets removed
-            return isInVariantSynchronous(prebidUsMobileSticky, 'variant')
+            return (config.get('switches.mobileStickyLeaderboard') &&
+                    isInVariantSynchronous(prebidUsMobileSticky, 'variant'))
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -11,6 +11,11 @@ import type { PrebidSlot } from 'commercial/modules/prebid/types';
 import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us-mobile-sticky';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
+const inMobileStickyPrebidOn = (): boolean =>
+    window.location.hash.indexOf('#mobile-sticky-prebid') !== -1;
+const inMobileStickyPrebidTestOr = (liveClause: boolean): boolean =>
+    inMobileStickyPrebidOn() || liveClause;
+
 const filterByAdvertId = (
     advertId: string,
     slots: Array<PrebidSlot>
@@ -101,8 +106,10 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
-            return (config.get('switches.mobileStickyLeaderboard') &&
-                    isInVariantSynchronous(prebidUsMobileSticky, 'variant'))
+            return inMobileStickyPrebidTestOr(
+                config.get('switches.mobileStickyLeaderboard') &&
+                    isInVariantSynchronous(prebidUsMobileSticky, 'variant')
+            )
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -81,6 +81,7 @@ describe('getSlots', () => {
         isInVariantSynchronous.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         getCookie.mockReturnValue('NA');
+        config.set('switches.mobileStickyLeaderboard', true);
         expect(getSlots('Article')).toEqual([
             {
                 key: 'right',
@@ -209,6 +210,7 @@ describe('slots', () => {
     test('should return the correct mobile-sticky slot at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
         getCookie.mockReturnValue('NA');
+        config.set('switches.mobileStickyLeaderboard', true);
         isInVariantSynchronous.mockReturnValue(true);
         expect(slots('mobile-sticky', '')).toEqual([
             {


### PR DESCRIPTION
## What does this change?

- Adds a switch around the Mobile Sticky banner and Mobile Sticky Prebid demand. Default state: On
- Adds a testing parameter `#mobile-sticky-prebid` to allow bypassing all switches and conditions on asking mobile sticky on prebid 

## Screenshots
![Screenshot 2019-07-16 at 13 47 56](https://user-images.githubusercontent.com/51630004/61295615-5a357600-a7d0-11e9-91ed-b9126b24ef3e.png)

## What is the value of this and can you measure success?
Value is the ability to be able to switch on/off the mobile sticky and able to test mobile sticky on prebid irrespective of region 


### Tested

- [x] Locally
- [x] On CODE (optional)

