### PR TITLE
Fix cookie domain if preview

### DIFF
--- a/static/src/javascripts/lib/cookies.js
+++ b/static/src/javascripts/lib/cookies.js
@@ -1,5 +1,6 @@
 // @flow
 import reportError from 'lib/report-error';
+import config from 'lib/config';
 
 const ERR_INVALID_COOKIE_NAME = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;
 
@@ -11,6 +12,11 @@ const getShortDomain = ({
     isCrossSubdomain = false,
 }: { isCrossSubdomain: boolean } = {}): string => {
     const domain = document.domain || '';
+
+    if (config.get('page.isPreview')) {
+        return domain;
+    }
+
     // Trim any possible subdomain (will be shared with supporter, identity, etc)
     if (isCrossSubdomain) {
         return ['', ...domain.split('.').slice(-2)].join('.');


### PR DESCRIPTION
## What does this change?

Ensure we set the domain correctly for cookies on preview.

## What is the value of this and can you measure success?

Fixes current (buggy) behaviour where consent banner appears on every page load as cookie to store consent is not set.

relates to https://github.com/guardian/frontend/pull/21640