### PR TITLE
Fix cookie domain on localhost

### DIFF
--- a/static/src/javascripts/lib/cookies.js
+++ b/static/src/javascripts/lib/cookies.js
@@ -13,7 +13,7 @@ const getShortDomain = ({
 }: { isCrossSubdomain: boolean } = {}): string => {
     const domain = document.domain || '';
 
-    if (config.get('page.isPreview')) {
+    if (domain === 'localhost' || config.get('page.isPreview')) {
         return domain;
     }
 


### PR DESCRIPTION
## What does this change?
Fixes an issue preventing us from saving cookie on localhost.

Previously the code on getShortDomain() was manipulating the domain string such that when running on localhost it returned '.localhost' instead of the expected 'localhost'. getDomainAttribute() would get this value and wrap it with a domain key ('domain=.localhost;') to be added to the cookie string. This domain however is considered invalid and the browser wouldn't save it. This PR fixes that bug. It was tested with the consent banner cookie but potentially fixes other issues as well.