### PR TITLE
Epic tests priority parameter

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -81,6 +81,7 @@ declare type EpicABTest = AcquisitionsABTest & {
     useTargetingTool: boolean,
     insertEvent: string,
     viewEvent: string,
+    highPriority: boolean,
 };
 
 declare type InitEpicABTestVariant = {
@@ -131,6 +132,7 @@ declare type InitEpicABTest = {
     deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
     geolocation: ?string,
+    highPriority: boolean,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -462,6 +462,8 @@ const makeEpicABTest = ({
     successMeasure,
     audienceCriteria,
     variants,
+    geolocation,
+    highPriority,
 
     // optional params
     campaignPrefix = 'gdnwb_copts_memco',
@@ -472,13 +474,13 @@ const makeEpicABTest = ({
     pageCheck = isCompatibleWithArticleEpic,
     template = controlTemplate,
     canRun = () => true,
-    geolocation,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
         // to disable contributions asks for a particular piece of content
         showForSensitive: true,
         geolocation,
+        highPriority,
         canRun() {
             return (
                 canRun() &&
@@ -616,10 +618,15 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
 
                     const geolocation = geolocationGetSync();
 
+                    const highPriority = rows.some(row =>
+                        optionalStringToBoolean(row.highPriority)
+                    );
+
                     return makeEpicABTest({
                         id: testName,
                         campaignId: testName,
                         geolocation,
+                        highPriority,
 
                         start: '2018-01-01',
                         expiry: '2020-01-01',

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -32,6 +32,8 @@ import {
 
 export const getEpicTestToRun = memoize(
     (): Promise<?Runnable<EpicABTest>> => {
+        // The syncEpicTests are the hard-coded tests, and asyncEpicTests are fetched from config
+
         const highPrioritySyncTests = syncEpicTests.filter(
             test => test.highPriority
         );

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -10,6 +10,7 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     campaignId: 'epic_always_ask_if_tagged',
 
     geolocation: geolocationGetSync(),
+    highPriority: false,
 
     start: '2017-05-23',
     expiry: '2020-01-27',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -56,6 +56,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audienceOffset: 0,
 
     geolocation,
+    highPriority: true,
 
     canRun: () =>
         articleViewCount >= minArticleViews && !!getCountryName(geolocation),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -10,6 +10,7 @@ export const askFourEarning: EpicABTest = makeEpicABTest({
     campaignId: 'kr1_epic_ask_four_earning',
 
     geolocation: geolocationGetSync(),
+    highPriority: false,
 
     start: '2017-01-24',
     expiry: '2020-01-27',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -25,6 +25,7 @@ export const countryName: EpicABTest = makeEpicABTest({
     audienceOffset: 0,
 
     geolocation,
+    highPriority: true,
 
     canRun: () =>
         geolocation !== 'US' &&


### PR DESCRIPTION
## What does this change?
This is necessary because we have hard-coded tests as well as configured tests.
Currently all configured tests have priority over hard-coded tests.

This change adds a `highPriority` field to the `EpicABTest` model.
It means that tests have the following priority:
1. configured highPriority=true
2. hard-coded highPriority=true
3. configured highPriority=false
4. hard-coded highPriority=false

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
