### PR TITLE
Change skimlinks bucket.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -7,7 +7,7 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
 import common.ManifestData
-import conf.Configuration.affiliatelinks
+import conf.Configuration.affiliateLinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import controllers.ArticlePage
@@ -300,9 +300,9 @@ object DotcomponentsDataModel {
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       section = article.metadata.sectionId,
       showAffiliateLinks =  article.content.fields.showAffiliateLinks,
-      supportedSections = affiliatelinks.affiliateLinkSections,
-      defaultOffTags = affiliatelinks.defaultOffTags,
-      alwaysOffTags = affiliatelinks.alwaysOffTags,
+      supportedSections = affiliateLinks.affiliateLinkSections,
+      defaultOffTags = affiliateLinks.defaultOffTags,
+      alwaysOffTags = affiliateLinks.alwaysOffTags,
       tagPaths = article.content.tags.tags.map(_.id)
     )
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -246,7 +246,9 @@ class GuardianConfiguration extends Logging {
     lazy val subscribeWithGoogleApiUrl = configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
   }
 
-  object affiliatelinks {
+  object affiliateLinks {
+    lazy val bucket = configuration.getMandatoryStringProperty("skimlinks.bucket")
+    lazy val domainsKey = "skimlinks/skimlinks-domains.csv"
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet
     lazy val defaultOffTags: Set[String] = configuration.getStringProperty("affiliatelinks.default.off.tags").getOrElse("").split(",").toSet
@@ -578,7 +580,7 @@ class GuardianConfiguration extends Logging {
   object aws {
 
     lazy val region = configuration.getMandatoryStringProperty("aws.region")
-    lazy val bucket = configuration.getMandatoryStringProperty("aws.bucket")
+    lazy val frontendStoreBucket = configuration.getMandatoryStringProperty("aws.bucket")
     lazy val notificationSns: String = configuration.getMandatoryStringProperty("sns.notification.topic.arn")
     lazy val videoEncodingsSns: String = configuration.getMandatoryStringProperty("sns.missing_video_encodings.topic.arn")
     lazy val frontPressSns: Option[String] = configuration.getStringProperty("frontpress.sns.topic")

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -247,7 +247,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object affiliateLinks {
-    lazy val bucket = configuration.getMandatoryStringProperty("skimlinks.bucket")
+    lazy val bucket: Option[String] = configuration.getStringProperty("skimlinks.bucket")
     lazy val domainsKey = "skimlinks/skimlinks-domains.csv"
     lazy val skimlinksId = configuration.getMandatoryStringProperty("skimlinks.id")
     lazy val affiliateLinkSections: Set[String] = configuration.getStringProperty("affiliatelinks.sections").getOrElse("").split(",").toSet

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -150,8 +150,8 @@ object S3 extends S3
 
 object S3FrontsApi extends S3 {
 
-  override lazy val bucket = Configuration.aws.frontendStoreBucket
-  lazy val stage = Configuration.facia.stage.toUpperCase
+  override lazy val bucket: String = Configuration.aws.frontendStoreBucket
+  lazy val stage: String = Configuration.facia.stage.toUpperCase
   val namespace = "frontsapi"
   lazy val location = s"$stage/$namespace"
 
@@ -163,14 +163,14 @@ object S3FrontsApi extends S3 {
 }
 
 object S3Archive extends S3 {
- override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code" else "aws-frontend-archive"
+ override lazy val bucket: String = if (Configuration.environment.isNonProd) "aws-frontend-archive-code" else "aws-frontend-archive"
  def getHtml(path: String): Option[String] = get(path)
 }
 
 object S3ArchiveOriginals extends S3 {
-  override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code-originals" else "aws-frontend-archive-originals"
+  override lazy val bucket: String = if (Configuration.environment.isNonProd) "aws-frontend-archive-code-originals" else "aws-frontend-archive-originals"
 }
 
 object S3Skimlinks extends S3 {
-  override lazy val bucket = Configuration.affiliateLinks.bucket
+  override lazy val bucket: String = Configuration.affiliateLinks.bucket.getOrElse(Configuration.aws.frontendStoreBucket)
 }

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -21,7 +21,7 @@ import scala.io.{Codec, Source}
 
 trait S3 extends Logging {
 
-  lazy val bucket = Configuration.aws.bucket
+  lazy val bucket = Configuration.aws.frontendStoreBucket
 
   lazy val client: Option[AmazonS3] = Configuration.aws.credentials.map{ credentials =>
     AmazonS3Client
@@ -150,7 +150,7 @@ object S3 extends S3
 
 object S3FrontsApi extends S3 {
 
-  override lazy val bucket = Configuration.aws.bucket
+  override lazy val bucket = Configuration.aws.frontendStoreBucket
   lazy val stage = Configuration.facia.stage.toUpperCase
   val namespace = "frontsapi"
   lazy val location = s"$stage/$namespace"
@@ -167,12 +167,10 @@ object S3Archive extends S3 {
  def getHtml(path: String): Option[String] = get(path)
 }
 
-object S3Infosec extends S3 {
-  override lazy val bucket = "aws-frontend-infosec"
-  val key = "blocked-email-domains.txt"
-  def getBlockedEmailDomains: Option[String] = get(key)
-}
-
 object S3ArchiveOriginals extends S3 {
   override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code-originals" else "aws-frontend-archive-originals"
+}
+
+object S3Skimlinks extends S3 {
+  override lazy val bucket = Configuration.affiliateLinks.bucket
 }

--- a/common/app/services/SkimLinksCache.scala
+++ b/common/app/services/SkimLinksCache.scala
@@ -17,7 +17,7 @@ object SkimLinksCache extends Logging {
   def populateSkimLinkDomains(): Unit = {
     log.info("Fetching and caching skimlinks")
     val domains = S3Skimlinks.get(affiliateLinks.domainsKey).getOrElse {
-      log.error(s"Failed to fetch skimlinks from S3: ${affiliateLinks.bucket}/${affiliateLinks.domainsKey}")
+      log.error(s"Failed to fetch skimlinks from S3: ${S3Skimlinks.bucket}/${affiliateLinks.domainsKey}")
       ""
     }
     skimLinkDomains.set(domains.split(",").toSet)

--- a/common/app/services/SkimLinksCache.scala
+++ b/common/app/services/SkimLinksCache.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import app.LifecycleComponent
 import common.Logging
+import conf.Configuration.affiliateLinks
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -15,8 +16,8 @@ object SkimLinksCache extends Logging {
 
   def populateSkimLinkDomains(): Unit = {
     log.info("Fetching and caching skimlinks")
-    val domains = S3.get("skimlinks/skimlinks-domains.csv").getOrElse{
-      log.error("Failed to fetch skimlinks from S3")
+    val domains = S3Skimlinks.get(affiliateLinks.domainsKey).getOrElse {
+      log.error(s"Failed to fetch skimlinks from S3: ${affiliateLinks.bucket}/${affiliateLinks.domainsKey}")
       ""
     }
     skimLinkDomains.set(domains.split(",").toSet)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -5,7 +5,7 @@ import java.util.regex.{Matcher, Pattern}
 
 import com.gu.contentatom.renderer.ArticleConfiguration
 import common.{Edition, LinkTo, Logging}
-import conf.Configuration.affiliatelinks._
+import conf.Configuration.affiliateLinks._
 import conf.Configuration.site.host
 import conf.switches.Switches
 import conf.switches.Switches._

--- a/onward/app/services/breakingnews/BreakingNewsApi.scala
+++ b/onward/app/services/breakingnews/BreakingNewsApi.scala
@@ -7,7 +7,7 @@ import play.api.{Environment, Mode}
 import services.S3
 
 class S3BreakingNews(environment: Environment) extends S3 {
-  override lazy val bucket = Configuration.aws.bucket
+  override lazy val bucket = Configuration.aws.frontendStoreBucket
   lazy val stage = if(environment.mode == Mode.Test) "TEST" else Configuration.environment.stage.toUpperCase
   val namespace = "notifications"
   lazy val location = s"$stage/$namespace"


### PR DESCRIPTION
## What does this change?
As part of the work to add [affiliate links to apps](https://github.com/guardian/mobile-apps-api/pull/1397) it made sense to move the list of supported affiliate links domains created by [skimlinks lambda](https://github.com/guardian/skimlinks-lambda) out of the main frontend store bucket and into a separate bucket to make cross account access less of a faff. 

This updates frontend to use this bucket, and removes some unnecessary infosec S3 code. I've also changed the names of a few things cos I'm that kind of rock star dev.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
