### PR TITLE
Add picture and | Letters suffix to rich links to letters.

### DIFF
--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -5,6 +5,7 @@
 @import views.support.{BulletCleaner, ImgSrc, Item460, RenderClasses, RichLinkContributor}
 
 @import model.DotcomContentType
+@import model.pressed.Letters
 @(content: ContentType)(implicit request: RequestHeader)
 
 
@@ -29,7 +30,8 @@
     ))">
 
     <div class="rich-link__container">
-        @if(content.content.cardStyle == Media || content.content.cardStyle == Feature || content.content.cardStyle == DefaultCardstyle) {
+        @if(content.content.cardStyle == Media || content.content.cardStyle == Feature ||
+            content.content.cardStyle == DefaultCardstyle || content.content.cardStyle == Letters) {
             @content.trail.trailPicture.map { trailPictureContainer =>
                 @Item460.bestSrcFor(trailPictureContainer).map { imgSrc =>
 
@@ -46,7 +48,10 @@
                     @fragments.inlineSvg("garnett-quote", "icon")
                 }
                 <a class="rich-link__link">
-                    @Html(content.trail.headline)
+                    @{content.content.cardStyle match {
+                        case Letters => Html(content.trail.headline + " | Letters")
+                        case _ => Html(content.trail.headline)
+                        }}
                 </a>
             </h2>
             @if(!content.tags.isMedia && (


### PR DESCRIPTION
## What does this change?
Following from an email from Rory Foster requesting for Letters rich links to look a bit nicer. I shouldn't really have done this as rich links are rarely used, but it's such a quick change I figured we might as well bring letters links into parity with other rich links - looks like just an accident that there's no picture shown. 

## Screenshots
**Before**
![Screenshot 2019-07-18 at 12 59 47](https://user-images.githubusercontent.com/3606555/61455665-11aac380-a95c-11e9-9ac9-90f582ad44c8.png)
**After**
![Screenshot 2019-07-18 at 12 59 38](https://user-images.githubusercontent.com/3606555/61455664-11122d00-a95c-11e9-8a71-829e6f26d5ea.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
