### PR TITLE
Expand the consent banner to run everywhere

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/prepareCmp.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/prepareCmp.scala.js
@@ -59,7 +59,7 @@ try {
                     storeConsentGlobally: false,
                     storePublisherData: false,
                     logging: false,
-                    gdprApplies: false,
+                    gdprApplies: true,
                 }
                 return cmp;
             }());

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp-env.js
@@ -80,7 +80,7 @@ export const defaultConfig = {
     storeConsentGlobally: false,
     storePublisherData: false,
     logging: false,
-    gdprApplies: false,
+    gdprApplies: true,
 };
 
 export const vendorVersionList = [vendorVersion];

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -76,11 +76,6 @@ const generateStore = (isInTest: boolean): CmpStore => {
     return store;
 };
 
-const isInNA = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
-
-const gdprApplies = (): boolean => !isInNA();
-
 class CmpService {
     isLoaded: boolean;
     cmpReady: boolean;
@@ -102,9 +97,6 @@ class CmpService {
         if (getUrlVars().cmpdebug) {
             this.cmpConfig.logging = 'debug';
             log.info('Set logging level to DEBUG');
-        }
-        if (gdprApplies()) {
-            this.cmpConfig.gdprApplies = true;
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -1,6 +1,5 @@
 // @flow
 import config from 'lib/config';
-import { getCookie } from 'lib/cookies';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
 import checkIcon from 'svgs/icon/tick.svg';
 import {
@@ -81,11 +80,6 @@ const makeHtml = (): string => `
     </div>
 `;
 
-const isInNA = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
-
-const gdprApplies = (): boolean => !isInNA();
-
 const hasUnsetAdChoices = (): boolean =>
     allAdConsents.some((_: AdConsent) => getAdConsentState(_) === null);
 
@@ -107,9 +101,7 @@ const trackInteraction = (interaction: string): void => {
 
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
-        hasUnsetAdChoices() &&
-            gdprApplies() &&
-            !hasUserAcknowledgedBanner(messageCode)
+        hasUnsetAdChoices() && !hasUserAcknowledgedBanner(messageCode)
     );
 
 const track = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -1,5 +1,4 @@
 // @flow
-import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import {
     firstPvConsentBanner as banner,
     _ as test,
@@ -19,7 +18,6 @@ const passingCookies = _ => {
     if (_ === 'GU_country') return 'NO';
     else if (_ === 'GU_geo_continent') return 'EU';
 };
-const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -101,52 +99,6 @@ describe('First PV consents banner', () => {
             return banner.canShow().then(showable => {
                 expect(showable).toBe(false);
             });
-        });
-    });
-
-    describe('With location', () => {
-        it('should render in EU', async () => {
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'EU';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(true);
-        });
-        it('should render in AS', async () => {
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'AS';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(true);
-        });
-        it('should render in OC', async () => {
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'OC';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(true);
-        });
-        it('should render in AF', async () => {
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'AF';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(true);
-        });
-        it('should render in SA', async () => {
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'SA';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(true);
-        });
-        it('should not render in NA', async () => {
-            isInVariantSynchronous.mockImplementation(() => false);
-            getCookie.mockImplementation(_ => {
-                if (_ === 'GU_geo_continent') return 'NA';
-                return null;
-            });
-            return expect(await banner.canShow()).toBe(false);
         });
     });
 


### PR DESCRIPTION
## What does this change?
This PR expands the consent banner to run everywhere (was previously running everywhere except North America).

### Tested

- [x] Locally
- [x] On CODE (optional)