### PR TITLE
Use actual byline

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -509,7 +509,7 @@ object DotcomponentsDataModel {
     )
 
     val byline = article.tags.contributors.map(_.name) match {
-      case Nil => "Guardian staff reporter"
+      case Nil => article.trail.byline.getOrElse("Guardian staff reporter")
       case contributors => contributors.mkString(",")
     }
 


### PR DESCRIPTION
## What does this change?

Use byline field rather than tags directly, as sometimes the tags are incomplete or incorrect. As an example, letters pages should have a byline of 'Letters' but currently display as 'Guardian staff reporter' (the fallback).
