### PR TITLE
Bypass mobile sticky conditions with param

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -19,7 +19,7 @@ const isInNA = (): boolean =>
 
 export const init = (): Promise<void> => {
     if (
-        window.location.hash.indexOf('#mobile-sticky-prebid') !== -1 ||
+        window.location.hash.indexOf('#mobile-sticky') !== -1 ||
         (config.get('switches.mobileStickyLeaderboard') &&
         isInNA() && // User is in North America
         isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -19,10 +19,11 @@ const isInNA = (): boolean =>
 
 export const init = (): Promise<void> => {
     if (
-        config.get('switches.mobileStickyLeaderboard') &&
+        window.location.hash.indexOf('#mobile-sticky-prebid') !== -1 ||
+        (config.get('switches.mobileStickyLeaderboard') &&
         isInNA() && // User is in North America
         isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) && // User is using a mobile device
-        config.get('page.contentType') === 'Article' // User is accessing an article
+            config.get('page.contentType') === 'Article') // User is accessing an article
     ) {
         const mobileStickyWrapper = createAdWrapper();
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -12,7 +12,7 @@ import { prebidUsMobileSticky } from 'common/modules/experiments/tests/prebid-us
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 const isMobileStickyPrebidTestOn = (): boolean =>
-    window.location.hash.indexOf('#mobile-sticky-prebid') !== -1 ||
+    window.location.hash.indexOf('#mobile-sticky') !== -1 ||
     (config.get('switches.mobileStickyLeaderboard') &&
         isInVariantSynchronous(prebidUsMobileSticky, 'variant'));
 


### PR DESCRIPTION
## What does this change?
Added a param to allow us testing mobile sticky without its conditions 


## What is the value of this and can you measure success?
Being able to test mobile sticky in UK

### Tested

- [x] Locally
- [ ] On CODE (optional)

