### PR TITLE
Add AdvertisementFeature designType to articles with paidContent

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -377,8 +377,6 @@ object DotcomponentsDataModel {
       else designType.map(_.toString).getOrElse("Article")
     }
 
-    article.metadata.designType.map(_.toString).getOrElse("Article")
-
     val bodyBlocksRaw = articlePage match {
       case lb: LiveBlogPage => blocksForLiveblogPage(lb, blocks)
       case article => blocks.body.getOrElse(Nil)


### PR DESCRIPTION
## What does this change?
In order to get DC updated to use designTypes instead of tones, we need to model the AdvertismentFeature as a designType. We will do this in the [Scala Capi Client]( https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala) but in the meantime we'll do it in the model here.

Note: There are other updates to the capi client that are not reflected here but 'Advertisement Features' are the only current implementation that is required in DC but missing from the capi client.

## What is the value of this and can you measure success?

Clearer model in DCR.

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [X] Apps (In the long run, recommendation to client changes incoming...)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] Yes (please give details)

It's specifically to support this.

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No

### Does this change update the version of CAPI we're using?


### Tested

- [X] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/dotcom-platform 