### PR TITLE
Rework third-party-tags in preparation for the CMP Framework

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -15,8 +15,8 @@ import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-par
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
     const frag = document.createDocumentFragment();
-    while (services.length) {
-        const service = services.shift();
+
+    services.forEach(service => {
         // flowlint sketchy-null-bool:warn
         if (service.useImage) {
             new Image().src = service.url;
@@ -26,8 +26,9 @@ const insertScripts = (services: Array<ThirdPartyTag>): void => {
             script.onload = service.onLoad;
             frag.appendChild(script);
         }
-    }
-    if (ref && ref.parentNode) {
+    });
+
+    if (ref && ref.parentNode && frag.querySelectorAll('script').length) {
         ref.parentNode.insertBefore(frag, ref);
     }
 };
@@ -44,9 +45,7 @@ const loadOther = (): void => {
         fbPixel(),
     ].filter(_ => _.shouldRun);
 
-    if (services.length) {
-        insertScripts(services);
-    }
+    insertScripts(services);
 };
 
 const init = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -15,12 +15,14 @@ import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-par
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
     const frag = document.createDocumentFragment();
+    let insertedScripts = false;
 
     services.forEach(service => {
         // flowlint sketchy-null-bool:warn
         if (service.useImage) {
             new Image().src = service.url;
         } else {
+            insertedScripts = true;
             const script = document.createElement('script');
             script.src = service.url;
             script.onload = service.onLoad;
@@ -28,7 +30,7 @@ const insertScripts = (services: Array<ThirdPartyTag>): void => {
         }
     });
 
-    if (ref && ref.parentNode && frag.querySelectorAll('script').length) {
+    if (insertedScripts && ref && ref.parentNode) {
         ref.parentNode.insertBefore(frag, ref);
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -1,6 +1,7 @@
 // @flow strict
 /* A regionalised container for all the commercial tags. */
 
+import fastdom from 'lib/fastdom-promise';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { imrWorldwide } from 'commercial/modules/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from 'commercial/modules/third-party-tags/imr-worldwide-legacy';
@@ -30,9 +31,11 @@ const insertScripts = (services: Array<ThirdPartyTag>): void => {
         }
     });
 
-    if (insertedScripts && ref && ref.parentNode) {
-        ref.parentNode.insertBefore(frag, ref);
-    }
+    fastdom.write(() => {
+        if (insertedScripts && ref && ref.parentNode) {
+            ref.parentNode.insertBefore(frag, ref);
+        }
+    });
 };
 
 const loadOther = (): void => {


### PR DESCRIPTION
## What does this change?
This reworks ```third-party-tag.js``` in a way that isolates part of its logic into a ```insertScripts()```, allowing that function to be passed into the CMP Framework that's currently being developed. Also improved performance and code readability.

### Tested

- [X] Locally
- [ ] On CODE (optional)