### PR TITLE
Better attribute name: commercialBundleUrl

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -110,6 +110,7 @@ case class Config(
   sentryHost: String,
   switches: Map[String, Boolean],
   dfpAccountId: String,
+  commercialBundleUrl: String,
   commercialUrl: String,
 )
 
@@ -520,7 +521,8 @@ object DotcomponentsDataModel {
       sentryHost = jsPageData.get("sentryHost").getOrElse(""),
       switches = switches,
       dfpAccountId = "", // TODO
-      commercialUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
+      commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
+      commercialUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
     )
 
     val author = Author(


### PR DESCRIPTION
## What does this change?

Give a better name for the attribute that carries the URL to the dotcom-rendering commercial bundle. The old one is kept while the dotcom-rendering side is migrated. Then another PR will remove the old name.
