### PR TITLE
Decommission commercialUrl from DCR Config

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -110,8 +110,7 @@ case class Config(
   sentryHost: String,
   switches: Map[String, Boolean],
   dfpAccountId: String,
-  commercialBundleUrl: String,
-  commercialUrl: String,
+  commercialBundleUrl: String
 )
 
 object Config {
@@ -521,8 +520,7 @@ object DotcomponentsDataModel {
       sentryHost = jsPageData.get("sentryHost").getOrElse(""),
       switches = switches,
       dfpAccountId = "", // TODO
-      commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
-      commercialUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
+      commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js")
     )
 
     val author = Author(


### PR DESCRIPTION
## What does this change?

Decommission commercialUrl from DCR Config. Second part of https://github.com/guardian/frontend/pull/21669
