### PR TITLE
Introduce flag window.guardian.config.isDotcomRendering

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -9,6 +9,7 @@
 
 @defining(Edition(request)) { edition =>
     {
+        "isDotcomRendering": false,
         "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview)))),
         "nav": @JavaScript(Json.stringify(Json.toJson(NavMenu(item, edition)))),
         "switches" : { @{JavaScript(conf.switches.Switches.all.filter(_.exposeClientSide).map{ switch =>


### PR DESCRIPTION
## What does this change?

This is the frontend PR companion of this one: https://github.com/guardian/dotcom-rendering/pull/681

Both together simply ensures that the flag `window.guardian.config.isDotcomRendering` is set on standard frontend generated pages and dotcom-rendering rendered pages with the relevant value. This is a step towards re-using commercial JavaScript code between the two systems.
