### PR TITLE
First version of dotcom-rendering-commercial.js

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -1,35 +1,61 @@
 // @flow
-/*
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
-*/
-// import { init as initCmpService } from 'commercial/modules/cmp/cmp';
-// import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
-// import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
-// import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
-/*
-import {
-    defer,
-    wrap,
-    addStartTimeBaseline,
-    addEndTimeBaseline,
-    primaryBaseline,
-} from 'commercial/modules/dfp/performance-logging';
+import { init as initHighMerch } from 'commercial/modules/high-merch';
+import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
+import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
+import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
+import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
+import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
+import { init as initCmpService } from 'commercial/modules/cmp/cmp';
+import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
+import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
+import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
+import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
+import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
+import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
+import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
+import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
+import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
-*/
-/*
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
+import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+
 const commercialModules: Array<Array<any>> = [
-    //['cm-prepare-cmp', initCmpService],
-    //['cm-track-cmp-consent', trackCmpConsent],
-    //['cm-thirdPartyTags', initThirdPartyTags],
-    //['cm-prepare-googletag', prepareGoogletag, true],
+    ['cm-adFreeSlotRemove', adFreeSlotRemove],
+    ['cm-closeDisabledSlots', closeDisabledSlots],
+    ['cm-prepare-cmp', initCmpService],
+    ['cm-track-cmp-consent', trackCmpConsent],
+    ['cm-checkDispatcher', initCheckDispatcher],
+    ['cm-lotame-cmp', initLotameCmp],
+    ['cm-lotame-data-extract', initLotameDataExtract, true],
 ];
-*/
-/*
+
+if (!commercialFeatures.adFree) {
+    commercialModules.push(
+        ['cm-prepare-prebid', preparePrebid],
+        ['cm-prepare-googletag', prepareGoogletag],
+        ['cm-thirdPartyTags', initThirdPartyTags],
+        ['cm-prepare-adverification', prepareAdVerification],
+        ['cm-mobileSticky', initMobileSticky],
+        ['cm-highMerch', initHighMerch],
+        ['cm-articleAsideAdverts', initArticleAsideAdverts],
+        ['cm-articleBodyAdverts', initArticleBodyAdverts],
+        ['cm-liveblogAdverts', initLiveblogAdverts],
+        ['cm-stickyTopBanner', initStickyTopBanner],
+        ['cm-paidContainers', paidContainers],
+        ['cm-paidforBand', initPaidForBand],
+        ['cm-commentAdverts', initCommentAdverts]
+    );
+}
+
 const loadHostedBundle = (): Promise<void> => {
-    if (config.page.isHosted) {
+    if (config.get('page.isHosted')) {
         return new Promise(resolve => {
             require.ensure(
                 [],
@@ -41,16 +67,11 @@ const loadHostedBundle = (): Promise<void> => {
                     const loadOnwardComponent = require('commercial/modules/hosted/onward');
                     commercialModules.push(
                         ['cm-hostedAbout', hostedAbout.init],
-                        [
-                            'cm-hostedVideo',
-                            initHostedVideo.initHostedVideo,
-                            true,
-                        ],
+                        ['cm-hostedVideo', initHostedVideo.initHostedVideo],
                         ['cm-hostedGallery', hostedGallery.init],
                         [
                             'cm-hostedOnward',
                             loadOnwardComponent.loadOnwardComponent,
-                            true,
                         ],
                         [
                             'cm-hostedOJCarousel',
@@ -65,55 +86,52 @@ const loadHostedBundle = (): Promise<void> => {
     }
     return Promise.resolve();
 };
-const loadModules = (): Promise<void> => {
-    addStartTimeBaseline(primaryBaseline);
 
+const loadModules = (): Promise<any> => {
     const modulePromises = [];
 
     commercialModules.forEach(module => {
         const moduleName: string = module[0];
         const moduleInit: () => void = module[1];
-        const moduleDefer: boolean = module[2];
 
-        catchErrorsWithContext([
+        catchErrorsWithContext(
             [
-                moduleName,
-                function pushAfterComplete(): void {
-                    // These modules all have async init procedures which don't block, and return a promise purely for
-                    // perf logging, to time when their async work is done. The command buffer guarantees execution order,
-                    // so we don't use the returned promise to order the bootstrap's module invocations.
-                    const wrapped = moduleDefer
-                        ? defer(moduleName, moduleInit)
-                        : wrap(moduleName, moduleInit);
-                    const result = wrapped();
-                    modulePromises.push(result);
+                [
+                    moduleName,
+                    function pushAfterComplete(): void {
+                        const result = moduleInit();
+                        modulePromises.push(result);
+                    },
+                ],
+            ],
+            {
+                feature: 'commercial',
+            }
+        );
+    });
+
+    return Promise.all(modulePromises);
+};
+
+const bootCommercial = (): Promise<void> => {
+    markTime('commercial start');
+    catchErrorsWithContext(
+        [
+            [
+                'ga-user-timing-commercial-start',
+                function runTrackPerformance(): void {
+                    trackPerformance(
+                        'Javascript Load',
+                        'commercialStart',
+                        'Commercial start parse time'
+                    );
                 },
             ],
-        ]);
-    });
-    return Promise.all(modulePromises).then(
-        (): void => {
-            addEndTimeBaseline(primaryBaseline);
+        ],
+        {
+            feature: 'commercial',
         }
     );
-};
-*/
-const bootCommercial = () => {
-    /*
-    markTime('commercial start');
-
-    catchErrorsWithContext([
-        [
-            'ga-user-timing-commercial-start',
-            function runTrackPerformance(): void {
-                trackPerformance(
-                    'Javascript Load',
-                    'commercialStart',
-                    'Commercial start parse time'
-                );
-            },
-        ],
-    ]);
 
     // Stub the command queue
     window.googletag = {
@@ -124,27 +142,34 @@ const bootCommercial = () => {
         .then(loadModules)
         .then(() => {
             markTime('commercial end');
-            catchErrorsWithContext([
+            catchErrorsWithContext(
                 [
-                    'ga-user-timing-commercial-end',
-                    function runTrackPerformance(): void {
-                        trackPerformance(
-                            'Javascript Load',
-                            'commercialEnd',
-                            'Commercial end parse time'
-                        );
-                    },
+                    [
+                        'ga-user-timing-commercial-end',
+                        function runTrackPerformance(): void {
+                            trackPerformance(
+                                'Javascript Load',
+                                'commercialEnd',
+                                'Commercial end parse time'
+                            );
+                        },
+                    ],
                 ],
-            ]);
+                {
+                    feature: 'commercial',
+                }
+            );
         })
         .catch(err => {
-            // Just in case something goes wrong, we don't want it to
-            // prevent enhanced from loading
-            reportError(err, {
-                feature: 'commercial',
-            });
+            // report async errors in bootCommercial to Sentry with the commercial feature tag
+            reportError(
+                err,
+                {
+                    feature: 'commercial',
+                },
+                false
+            );
         });
-    */
 };
 
 bootCommercial();

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -7,7 +7,6 @@ import { queueAdvert } from 'commercial/modules/dfp/queue-advert';
 import { displayLazyAds } from 'commercial/modules/dfp/display-lazy-ads';
 import { displayAds } from 'commercial/modules/dfp/display-ads';
 import { setupPrebidOnce } from 'commercial/modules/dfp/prepare-prebid';
-
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -7,6 +7,7 @@ import { queueAdvert } from 'commercial/modules/dfp/queue-advert';
 import { displayLazyAds } from 'commercial/modules/dfp/display-lazy-ads';
 import { displayAds } from 'commercial/modules/dfp/display-ads';
 import { setupPrebidOnce } from 'commercial/modules/dfp/prepare-prebid';
+
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -1,14 +1,12 @@
 // @flow
 
 import qwery from 'qwery';
-
 import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 import { loadScript } from 'lib/load-script';
 import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
 import { session } from 'lib/storage';
-
 import {
     getAdConsentState,
     thirdPartyTrackingAdConsent,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -17,7 +17,7 @@ const isGoogleProxy: () => boolean = () =>
 
 let moduleLoadResult = Promise.resolve();
 
-if (!isGoogleProxy()) {
+if (!isGoogleProxy() && !config.get('isDotcomRendering', false)) {
     moduleLoadResult = import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid');
 }
 


### PR DESCRIPTION
## What does this change?

This introduce the first version of `dotcom-rendering-commercial.js`. 

`dotcom-rendering-commercial.js` is essentially identical to today's version of `commercial.js` with few lines commented out. This is mostly to demonstrate that the imports have all behaved correctly. Note that one file needed to be updated for this to happen smoothly: `prepare-prebid.js`. The added check take advantage of the work that has been done in those two PRs: https://github.com/guardian/frontend/pull/21673 and  https://github.com/guardian/dotcom-rendering/pull/681 . 
