### PR TITLE
Block acquisitions asks on any page with sponsorship type  "paid-content'

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -147,7 +147,8 @@ const isCompatibleWithLiveBlogEpic = (page: Object): boolean =>
     isArticleWorthAnEpicImpression(page, defaultExclusionRules);
 
 const pageShouldHideReaderRevenue = () =>
-    config.get('page.shouldHideReaderRevenue');
+    config.get('page.shouldHideReaderRevenue') ||
+    config.get('page.sponsorshipType') === 'paid-content';
 
 const userIsInCorrectCohort = (
     userCohort: AcquisitionsComponentUserCohort


### PR DESCRIPTION
## What does this change?
Currently, it is only possible to set the "shouldHideReaderRevenue" flag on articles. But some fronts, for example, https://www.theguardian.com/modern-money, are tagged as "paid-content" and, as such, should not display the epic or the banner. 

This change prevents the epic or the banner from displaying on any page (Article or Front) that are tagged as "paid-content"