### PR TITLE
Use byline only for byline

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -509,10 +509,7 @@ object DotcomponentsDataModel {
       commercialConfiguration
     )
 
-    val byline = article.tags.contributors.map(_.name) match {
-      case Nil => article.trail.byline.getOrElse("Guardian staff reporter")
-      case contributors => contributors.mkString(",")
-    }
+    val byline = article.trail.byline.getOrElse("Guardian staff reporter")
 
     val config = Config(
       ajaxUrl = Configuration.ajax.url,


### PR DESCRIPTION
## What does this change?

Fixes byline for AMP in cases where byline and contributor tags do not match up.

before/after:

![Screenshot 2019-07-23 at 13 43 13](https://user-images.githubusercontent.com/858402/61713168-d5a6a280-ad4f-11e9-94c4-e20ea923ef81.png)
![Screenshot 2019-07-23 at 13 43 08](https://user-images.githubusercontent.com/858402/61713178-da6b5680-ad4f-11e9-9aa3-9f54e75dd4da.png)
