### PR TITLE
Refactor catchErrorsWithContext to return Promise

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -87,20 +87,10 @@ const loadHostedBundle = (): Promise<void> => {
     return Promise.resolve();
 };
 
-const loadModules = (): Promise<any> => {
-    const modulePromises = [];
-
-    commercialModules.forEach(module => {
-        const moduleName: string = module[0];
-        const moduleInit: () => void = module[1];
-        const result = catchErrorsWithContext([[moduleName, moduleInit]], {
-            feature: 'commercial',
-        });
-        modulePromises.push(result);
+const loadModules = (): Promise<any> =>
+    catchErrorsWithContext(commercialModules, {
+        feature: 'commercial',
     });
-
-    return Promise.all(modulePromises);
-};
 
 export const bootCommercial = (): Promise<void> => {
     markTime('commercial start');

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -99,8 +99,6 @@ const loadModules = (): Promise<any> => {
         modulePromises.push(result);
     });
 
-    console.log('loadModules --->', modulePromises);
-
     return Promise.all(modulePromises);
 };
 

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -93,22 +93,13 @@ const loadModules = (): Promise<any> => {
     commercialModules.forEach(module => {
         const moduleName: string = module[0];
         const moduleInit: () => void = module[1];
-
-        catchErrorsWithContext(
-            [
-                [
-                    moduleName,
-                    function pushAfterComplete(): void {
-                        const result = moduleInit();
-                        modulePromises.push(result);
-                    },
-                ],
-            ],
-            {
-                feature: 'commercial',
-            }
-        );
+        const result = catchErrorsWithContext([[moduleName, moduleInit]], {
+            feature: 'commercial',
+        });
+        modulePromises.push(result);
     });
+
+    console.log('loadModules --->', modulePromises);
 
     return Promise.all(modulePromises);
 };

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -39,7 +39,7 @@ const catchAndLogError = (
             logError(name, error, tags);
         });
     } catch (error) {
-        // sync errors end up here - catch and log them
+        // uncaught sync errors end up here - catch and log them
         logError(name, error, tags);
         return Promise.resolve();
     }

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -16,6 +16,8 @@ const logError = (
         window.console.warn('Caught error.', error.stack);
     }
 
+    console.log('logError --->', tags);
+
     if (tags) {
         reportError(error, Object.assign({ module }, tags), false);
     } else {
@@ -68,4 +70,3 @@ const catchErrorsWithContext = (
 };
 
 export { catchErrorsWithContext, logError };
-export const _ = { catchAndLogError };

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -7,18 +7,6 @@
 
 import reportError from 'lib/report-error';
 
-const catchErrors = (fn: Function): ?Error => {
-    let error;
-
-    try {
-        fn();
-    } catch (e) {
-        error = e;
-    }
-
-    return error;
-};
-
 const logError = (
     module: string,
     error: Error,
@@ -39,19 +27,44 @@ const catchAndLogError = (
     name: string,
     fn: Function,
     tags: ?{ [key: string]: string }
-): void => {
-    const error = catchErrors(fn);
-
-    if (error) {
+): Promise<any> => {
+    try {
+        /*
+         * fn could be sync/async we therefore use Promise.all as
+         * this will only resolve once a sync function returns or an async
+         * function resolves.
+         */
+        return Promise.all([fn()]).catch(error => {
+            // uncaught async errors end up here - catch and log them
+            logError(name, error, tags);
+        });
+    } catch (error) {
+        // sync errors end up here - catch and log them
         logError(name, error, tags);
+        return Promise.resolve();
     }
 };
 
 const catchErrorsWithContext = (
     modules: Array<any>,
     tags: ?{ [key: string]: string }
-): void => {
-    modules.forEach(([name, fn]) => catchAndLogError(name, fn, tags));
+): Promise<any> => {
+    const pendingModules = [];
+
+    modules.forEach(([name, fn]) => {
+        pendingModules.push(catchAndLogError(name, fn, tags));
+    });
+
+    /*
+     * The modules array can contain sync and async functions.
+     * Returning a Promise.all means we can wait for all the sync
+     * functions to have returned and all the async functions to have resolved.
+     */
+    return Promise.all(pendingModules).then(results => {
+        const flattenedResults = [].concat(...results);
+
+        return Promise.resolve(flattenedResults);
+    });
 };
 
 export { catchErrorsWithContext, logError };

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -16,8 +16,6 @@ const logError = (
         window.console.warn('Caught error.', error.stack);
     }
 
-    console.log('logError --->', tags);
-
     if (tags) {
         reportError(error, Object.assign({ module }, tags), false);
     } else {

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -58,7 +58,8 @@ const catchErrorsWithContext = (
     /*
      * The modules array can contain sync and async functions.
      * Returning a Promise.all means we can wait for all the sync
-     * functions to have returned and all the async functions to have resolved.
+     * functions to have returned and all the async functions to have
+     * resolved before catchErrorsWithContext resolves.
      */
     return Promise.all(pendingModules).then(results => {
         const flattenedResults = [].concat(...results);

--- a/static/src/javascripts/lib/robust.spec.js
+++ b/static/src/javascripts/lib/robust.spec.js
@@ -88,7 +88,7 @@ describe('robust', () => {
 
             const testModules = [...modules, ['my-test-1', asyncFunc]];
 
-            return catchErrorsWithContext(testModules).then(res => {
+            return catchErrorsWithContext(testModules).then(() => {
                 expect(runner).toHaveBeenCalledTimes(modules.length);
                 expect(asyncFunc).toHaveBeenCalledTimes(1);
                 expect(reportError).not.toHaveBeenCalled();

--- a/static/src/javascripts/lib/robust.spec.js
+++ b/static/src/javascripts/lib/robust.spec.js
@@ -1,66 +1,145 @@
 // @flow
+import reportError_ from 'lib/report-error';
+import { catchErrorsWithContext } from './robust';
 
-import { catchErrorsWithContext, _ } from './robust';
+const reportError: any = reportError_;
 
-const { catchAndLogError } = _;
+// const { catchAndLogError } = _;
 
-// #? Refactor this into a test utility with lots of magic?
 jest.mock('lib/report-error', () => jest.fn());
-const reportErrorMock: any = require('lib/report-error');
-
-let origConsoleWarn;
-
-beforeEach(() => {
-    origConsoleWarn = window.console.warn;
-    window.console.warn = jest.fn();
-});
-
-afterEach(() => {
-    window.console.warn = origConsoleWarn;
-});
 
 describe('robust', () => {
     const ERROR = new Error('Something broke.');
-    const META = { module: 'test' };
-
-    const noError = () => true;
-
     const throwError = () => {
         throw ERROR;
     };
 
-    test('catchAndLogError()', () => {
-        expect(() => {
-            catchAndLogError('test', noError);
-        }).not.toThrowError();
+    let origConsoleWarn;
 
-        expect(() => {
-            catchAndLogError('test', throwError);
-        }).not.toThrowError(ERROR);
-
-        expect(window.console.warn).toHaveBeenCalledTimes(1);
+    beforeEach(() => {
+        origConsoleWarn = window.console.warn;
+        window.console.warn = jest.fn();
     });
 
-    test('catchAndLogError() - default reporter', () => {
-        reportErrorMock.mockClear();
-        catchAndLogError('test', noError);
-        expect(reportErrorMock).not.toHaveBeenCalled();
-
-        reportErrorMock.mockClear();
-        catchAndLogError('test', throwError);
-        expect(reportErrorMock).toHaveBeenCalledWith(ERROR, META, false);
+    afterEach(() => {
+        window.console.warn = origConsoleWarn;
+        reportError.mockReset();
     });
 
-    test('catchErrorsWithContext()', () => {
+    describe('catchErrorsWithContext()', () => {
+        let modules;
+
         const runner = jest.fn();
 
-        const MODULES = [
-            ['test-1', runner],
-            ['test-2', runner],
-            ['test-3', runner],
-        ];
+        beforeEach(() => {
+            modules = [
+                ['test-1', runner],
+                ['test-2', runner],
+                ['test-3', runner],
+            ];
+        });
 
-        catchErrorsWithContext(MODULES);
-        expect(runner).toHaveBeenCalledTimes(MODULES.length);
+        afterEach(() => {
+            runner.mockReset();
+        });
+
+        it('executes all modules passed to it', () =>
+            catchErrorsWithContext(modules).then(() => {
+                expect(runner).toHaveBeenCalledTimes(modules.length);
+            }));
+
+        it('reports single error and resolves', () => {
+            const testModules = [...modules, ['my-test-1', throwError]];
+            return catchErrorsWithContext(testModules).then(() => {
+                expect(runner).toHaveBeenCalledTimes(modules.length);
+                expect(reportError).toHaveBeenCalledTimes(1);
+                expect(reportError).toHaveBeenCalledWith(
+                    ERROR,
+                    { module: 'my-test-1' },
+                    false
+                );
+                expect(window.console.warn).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        it('reports multiple errors and resolves', () => {
+            const testModules = [
+                ['my-test-1', throwError],
+                ...modules,
+                ['my-test-2', throwError],
+            ];
+            return catchErrorsWithContext(testModules).then(() => {
+                expect(runner).toHaveBeenCalledTimes(modules.length);
+                expect(reportError).toHaveBeenCalledTimes(2);
+                expect(reportError).toHaveBeenCalledWith(
+                    ERROR,
+                    { module: 'my-test-1' },
+                    false
+                );
+                expect(reportError).toHaveBeenCalledWith(
+                    ERROR,
+                    { module: 'my-test-2' },
+                    false
+                );
+                expect(window.console.warn).toHaveBeenCalledTimes(2);
+            });
+        });
+
+        it('accepts and executes async functions and resolves', () => {
+            const asyncFunc = jest.fn(() => Promise.resolve());
+
+            const testModules = [...modules, ['my-test-1', asyncFunc]];
+
+            return catchErrorsWithContext(testModules).then(res => {
+                expect(runner).toHaveBeenCalledTimes(modules.length);
+                expect(asyncFunc).toHaveBeenCalledTimes(1);
+                expect(reportError).not.toHaveBeenCalled();
+            });
+        });
+
+        it('catches async unhandled async errors and resolves', () => {
+            const asyncFunc = jest.fn(
+                () =>
+                    new Promise(() => {
+                        throw ERROR;
+                    })
+            );
+
+            const testModules = [['my-test-1', asyncFunc], ...modules];
+
+            return catchErrorsWithContext(testModules).then(() => {
+                expect(runner).toHaveBeenCalledTimes(modules.length);
+                expect(asyncFunc).toHaveBeenCalledTimes(1);
+                expect(reportError).toHaveBeenCalledWith(
+                    ERROR,
+                    { module: 'my-test-1' },
+                    false
+                );
+            });
+        });
     });
+
+    describe('logError', () => {});
+
+    // const META = { module: 'test' };
+    // const noError = () => true;
+    // test('catchAndLogError()', () => {
+    //     expect(() => {
+    //         catchAndLogError('test', noError);
+    //     }).not.toThrowError();
+
+    //     expect(() => {
+    //         catchAndLogError('test', throwError);
+    //     }).toThrowError(ERROR);
+
+    //     expect(window.console.warn).toHaveBeenCalledTimes(1);
+    // });
+    // test('catchAndLogError() - default reporter', () => {
+    //     reportErrorMock.mockClear();
+    //     catchAndLogError('test', noError);
+    //     expect(reportErrorMock).not.toHaveBeenCalled();
+    //     reportErrorMock.mockClear();
+    //     catchAndLogError('test', throwError);
+    //     expect(reportErrorMock).toHaveBeenCalledWith(ERROR, META, false);
+    // });
 });

--- a/static/src/javascripts/lib/robust.spec.js
+++ b/static/src/javascripts/lib/robust.spec.js
@@ -1,10 +1,8 @@
 // @flow
 import reportError_ from 'lib/report-error';
-import { catchErrorsWithContext } from './robust';
+import { catchErrorsWithContext, logError } from './robust';
 
 const reportError: any = reportError_;
-
-// const { catchAndLogError } = _;
 
 jest.mock('lib/report-error', () => jest.fn());
 
@@ -97,7 +95,7 @@ describe('robust', () => {
             });
         });
 
-        it('catches async unhandled async errors and resolves', () => {
+        it('catches unhandled async errors and resolves', () => {
             const asyncFunc = jest.fn(
                 () =>
                     new Promise(() => {
@@ -119,27 +117,35 @@ describe('robust', () => {
         });
     });
 
-    describe('logError', () => {});
+    describe('logError', () => {
+        it('calls report error if tags provided', () => {
+            const testId = 'my-test-1';
 
-    // const META = { module: 'test' };
-    // const noError = () => true;
-    // test('catchAndLogError()', () => {
-    //     expect(() => {
-    //         catchAndLogError('test', noError);
-    //     }).not.toThrowError();
+            logError(testId, ERROR, {
+                module: testId,
+            });
 
-    //     expect(() => {
-    //         catchAndLogError('test', throwError);
-    //     }).toThrowError(ERROR);
+            expect(window.console.warn).toHaveBeenCalledTimes(1);
+            expect(reportError).toHaveBeenCalledWith(
+                ERROR,
+                { module: testId },
+                false
+            );
+        });
 
-    //     expect(window.console.warn).toHaveBeenCalledTimes(1);
-    // });
-    // test('catchAndLogError() - default reporter', () => {
-    //     reportErrorMock.mockClear();
-    //     catchAndLogError('test', noError);
-    //     expect(reportErrorMock).not.toHaveBeenCalled();
-    //     reportErrorMock.mockClear();
-    //     catchAndLogError('test', throwError);
-    //     expect(reportErrorMock).toHaveBeenCalledWith(ERROR, META, false);
-    // });
+        it('does not call report error if tags provided', () => {
+            const testId = 'my-test-1';
+
+            logError(testId, ERROR, {
+                module: testId,
+            });
+
+            expect(window.console.warn).toHaveBeenCalledTimes(1);
+            expect(reportError).toHaveBeenCalledWith(
+                ERROR,
+                { module: testId },
+                false
+            );
+        });
+    });
 });

--- a/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
@@ -1,8 +1,8 @@
 // @flow
 
-import { _ as robust } from 'lib/robust';
+// import { _ as robust } from 'lib/robust';
 import fastdom from 'lib/fastdom-promise';
-
+import { catchErrorsWithContext } from 'lib/robust';
 /* TODO:Improve type checking here */
 
 const loadEnhancers = (loaders: Array<Array<any>>): void => {
@@ -13,9 +13,14 @@ const loadEnhancers = (loaders: Array<Array<any>>): void => {
             .read(() => Array.from(document.querySelectorAll(classname)))
             .then(elements =>
                 elements.forEach((element: HTMLElement) => {
-                    robust.catchAndLogError(classname, () => {
-                        action(element);
-                    });
+                    catchErrorsWithContext([
+                        [
+                            classname,
+                            () => {
+                                action(element);
+                            },
+                        ],
+                    ]);
                 })
             );
     });

--- a/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
@@ -1,6 +1,4 @@
 // @flow
-
-// import { _ as robust } from 'lib/robust';
 import fastdom from 'lib/fastdom-promise';
 import { catchErrorsWithContext } from 'lib/robust';
 /* TODO:Improve type checking here */


### PR DESCRIPTION
## What does this change?

The function `catchErrorsWithContext` currently returns `void`, this PR updates this function to return a `Promise` that resolves once all the modules in the `modules` array passed to it have either resolved/returned.

Why are we doing this? Within `commercial.js` we execute stacks of modules `init` functions, these `init` calls are all wrapped in and executed via a `catchErrorsWithContext` call. As part of CMP phase 2 works we'll be passing these stacks to a library that will iterate through and execute them based on the user's consent preferences. We want this library function to return a `Promise` once all the functions in a stack have have either resolved/returned. We therefore need `catchErrorsWithContext` to return a resolved `Promise` once the methods passed to it have all resolved/returned.

## Screenshots

N/A

## What is the value of this and can you measure success?

Preparation for  CMP Phase 2 library.

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)