### PR TITLE
Update Guns and Lies in America to Article Email

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -403,7 +403,8 @@ object EmailAddons {
     TheUpsideWeeklyReport,
     AnimalsFarmed,
     USMorningBriefing,
-    ObserverPictureArchive)
+    ObserverPictureArchive,
+    GunsAndLiesInAmerica)
   private val frontEmails = Seq(
     SocialCareNetwork,
     GuardianUniversities,
@@ -441,7 +442,6 @@ object EmailAddons {
     SportAu,
     FirstDogOnTheMoon,
     GreenLight,
-    GunsAndLiesInAmerica,
     WordOfMouth
   )
 

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -190,6 +190,12 @@ case object ObserverPictureArchive extends ArticleEmailMetadata {
   def test(c: ContentPage): Boolean = c.item.tags.series.exists(_.id == "theobserver/series/observer-picture-archive")
 }
 
+case object GunsAndLiesInAmerica extends ArticleEmailMetadata {
+  val name = "Guns And Lies In America"
+  override val banner = Some("guns_and_lies.png")
+   def test(c: ContentPage): Boolean = c.item.tags.series.exists(_.id == "us-news/series/guns-and-lies-in-america-newsletter")
+}
+
 case object TheFlyer extends FrontEmailMetadata {
   val name = "The Flyer"
   override val banner = Some("the-flyer.png")
@@ -358,11 +364,6 @@ case object FirstDogOnTheMoon extends FrontEmailMetadata {
 case object GreenLight extends FrontEmailMetadata {
   val name = "Green Light"
   override val banner = Some("green-light.png")
-}
-
-case object GunsAndLiesInAmerica extends FrontEmailMetadata {
-  val name = "Guns And Lies In America"
-  override val banner = Some("guns_and_lies.png")
 }
 
 case object WordOfMouth extends FrontEmailMetadata {


### PR DESCRIPTION
## What does this change?

Changes the Guns and Lies in America email from a front email to an article email.

## What is the value of this and can you measure success?

The Guns and Lies in America email is currently coded as a front email, but the content has been created as an article. This change ensures the article email gets the correct branding for this series tag.
