### PR TITLE
Disable commercial modules loading in dotcom-rendering-commercial

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -3,55 +3,56 @@ import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
-import { init as initHighMerch } from 'commercial/modules/high-merch';
-import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
-import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
-import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
-import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
-import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
-import { init as initCmpService } from 'commercial/modules/cmp/cmp';
-import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
-import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
-import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
-import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
-import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
-import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
-import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
-import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
-import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
-import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
-import { paidContainers } from 'commercial/modules/paid-containers';
+// import { init as initHighMerch } from 'commercial/modules/high-merch';
+// import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
+// import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
+// import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
+// import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
+// import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
+// import { init as initCmpService } from 'commercial/modules/cmp/cmp';
+// import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
+// import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+// import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
+// import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
+// import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+// import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
+// import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
+// import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
+// import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
+// import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
+// import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
-import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+// import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
+// import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 
 const commercialModules: Array<Array<any>> = [
-    ['cm-adFreeSlotRemove', adFreeSlotRemove],
-    ['cm-closeDisabledSlots', closeDisabledSlots],
-    ['cm-prepare-cmp', initCmpService],
-    ['cm-track-cmp-consent', trackCmpConsent],
-    ['cm-checkDispatcher', initCheckDispatcher],
-    ['cm-lotame-cmp', initLotameCmp],
-    ['cm-lotame-data-extract', initLotameDataExtract, true],
+    // ['cm-adFreeSlotRemove', adFreeSlotRemove],
+    // ['cm-closeDisabledSlots', closeDisabledSlots],
+    // ['cm-prepare-cmp', initCmpService],
+    // ['cm-track-cmp-consent', trackCmpConsent],
+    // ['cm-checkDispatcher', initCheckDispatcher],
+    // ['cm-lotame-cmp', initLotameCmp],
+    // ['cm-lotame-data-extract', initLotameDataExtract, true],
 ];
 
 if (!commercialFeatures.adFree) {
-    commercialModules.push(
-        ['cm-prepare-prebid', preparePrebid],
-        ['cm-prepare-googletag', prepareGoogletag],
-        ['cm-thirdPartyTags', initThirdPartyTags],
-        ['cm-prepare-adverification', prepareAdVerification],
-        ['cm-mobileSticky', initMobileSticky],
-        ['cm-highMerch', initHighMerch],
-        ['cm-articleAsideAdverts', initArticleAsideAdverts],
-        ['cm-articleBodyAdverts', initArticleBodyAdverts],
-        ['cm-liveblogAdverts', initLiveblogAdverts],
-        ['cm-stickyTopBanner', initStickyTopBanner],
-        ['cm-paidContainers', paidContainers],
-        ['cm-paidforBand', initPaidForBand],
-        ['cm-commentAdverts', initCommentAdverts]
-    );
+    commercialModules
+        .push
+        // ['cm-prepare-prebid', preparePrebid],
+        // ['cm-prepare-googletag', prepareGoogletag],
+        // ['cm-thirdPartyTags', initThirdPartyTags],
+        // ['cm-prepare-adverification', prepareAdVerification],
+        // ['cm-mobileSticky', initMobileSticky],
+        // ['cm-highMerch', initHighMerch],
+        // ['cm-articleAsideAdverts', initArticleAsideAdverts],
+        // ['cm-articleBodyAdverts', initArticleBodyAdverts],
+        // ['cm-liveblogAdverts', initLiveblogAdverts],
+        // ['cm-stickyTopBanner', initStickyTopBanner],
+        // ['cm-paidContainers', paidContainers],
+        // ['cm-paidforBand', initPaidForBand],
+        // ['cm-commentAdverts', initCommentAdverts]
+        ();
 }
 
 const loadHostedBundle = (): Promise<void> => {


### PR DESCRIPTION
## What does this change?

For some reasons had forgotten to disable modules loading here: https://github.com/guardian/frontend/pull/21675
