### PR TITLE
Add Branding to Paid For Videos in front video carousel for US

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -45,7 +45,7 @@
                 ""
             }){channelId: String =>
             <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
-                ("u-responsive-ratio", true),
+                ("u-responsive-ratio", !isPaidFor),
                 ("u-responsive-ratio--hd", sixteenByNine),
                 ("youtube-media-atom", true),
                 ("no-player", !playable || expired ),

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -70,7 +70,7 @@
                     @for(f <- faciaHeaderProperties) {
                         @*//TODO Add kicker inside f.header.kicker*@
                         @if(isPaidFor) {
-                            <div class="fc-item__kicker">Advertiser Content</div>
+                            <div class="fc-item__kicker">Advertiser content</div>
                         }
                         @title(f.header, 0, 0)
                         @if(f.showByline) {
@@ -114,7 +114,7 @@
                         @if(isPaidFor) {
                             <div class="youtube-media-atom--sponsored-container"></div>
                             <span class="youtube-media-atom__sponsored-label">
-                                Advertiser Content
+                                Advertiser content
                             </span>
                             @*TODO: use map to catch all cases *@
                             <div class="youtube-media-atom__sponsored-logo-container">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -64,7 +64,7 @@
             <div id="youtube-@asset.id" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
 
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
-                <div class="video-overlay">
+                <div class="video-overlay @if(isPaidFor) { video-overlay--paid-for }">
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
@@ -75,7 +75,7 @@
 
                     </div>
                         @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
-                            <span class="video-overlay__duration">
+                            <span class="video-overlay__duration @if(isPaidFor) { video-overlay__duration--paid-for }">
                                 @media.formattedDuration
                             </span>
                         }
@@ -98,7 +98,7 @@
                         <div class='gs-container'>
                             <div class='content__main-column'>
                                 <div class='youtube-media-atom__immersive-interface'>
-                                    <div class="youtube-media-atom__play-button vjs-control-text">
+                                    <div class="youtube-media-atom__play-button vjs-control-text @if(isPaidFor) { vjs-control-text__item--paid-for }">
                                         Play Video
                                         @fragments.inlineSvg("play", "icon")
                                     </div>
@@ -120,7 +120,7 @@
                                 }
                             }
                         }
-                        <div class="youtube-media-atom__play-button vjs-control-text">
+                        <div class="youtube-media-atom__play-button vjs-control-text @if(isPaidFor) { vjs-control-text__item--paid-for }">
                             Play Video @fragments.inlineSvg("play", "icon")
                         </div>
                         @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -116,11 +116,13 @@
                             <span class="youtube-media-atom__sponsored-label">
                                 Advertiser content
                             </span>
-                            @*TODO: use map to catch all cases *@
-                            <div class="youtube-media-atom__sponsored-logo-container">
-                                <img border="0"
-                                src="@PaidCard.fromPressedContent(pressedContent.get).branding.get.logo.src">
-                            </div>
+                            @pressedContent.map{ pc =>
+                                @PaidCard.fromPressedContent(pc).branding.map{ b =>
+                                    <div class="youtube-media-atom__sponsored-logo-container">
+                                        <img border="0" src="@b.logo.src">
+                                    </div>
+                                }
+                            }
                         }
                         <div class="youtube-media-atom__play-button vjs-control-text">
                             Play Video @fragments.inlineSvg("play", "icon")

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -118,9 +118,7 @@
                                         <span class="youtube-media-atom__paid-for-label">
                                             Advertiser content
                                         </span>
-                                        <div>
-                                            <img class="youtube-media-atom__paid-for-logo" border="0" src="@b.logo.src">
-                                        </div>
+                                        <img class="youtube-media-atom__paid-for-logo" border="0" src="@b.logo.src">
                                     </div>
                                 }
                             }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -108,7 +108,7 @@
                         </div>
                     } else {
                         @if(isPaidFor) {
-                            <div class="youtube-media-atom__paid-for-container"></div>
+                            <div class="youtube-media-atom__paid-for-overlay"></div>
                             @pressedContent.map{ pc =>
                                 @PaidCard.fromPressedContent(pc).branding.map{ b =>
                                     <div class="youtube-media-atom__paid-for-logo-container">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -68,7 +68,6 @@
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
-                        @*//TODO Add kicker inside f.header.kicker*@
                         @if(isPaidFor) {
                             <div class="fc-item__kicker">Advertiser content</div>
                         }
@@ -112,13 +111,13 @@
                         </div>
                     } else {
                         @if(isPaidFor) {
-                            <div class="youtube-media-atom--sponsored-container"></div>
-                            <span class="youtube-media-atom__sponsored-label">
+                            <div class="youtube-media-atom__paid-for-container"></div>
+                            <span class="youtube-media-atom__paid-for-label">
                                 Advertiser content
                             </span>
                             @pressedContent.map{ pc =>
                                 @PaidCard.fromPressedContent(pc).branding.map{ b =>
-                                    <div class="youtube-media-atom__sponsored-logo-container">
+                                    <div class="youtube-media-atom__paid-for-logo-container">
                                         <img border="0" src="@b.logo.src">
                                     </div>
                                 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -11,7 +11,8 @@
 @import conf.switches.Switches.YouTubeRelatedVideos
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
-
+@import layout.PaidCard
+@import model.pressed.PressedContent
 @(
     media: model.content.MediaAtom,
     displayCaption: Boolean,
@@ -21,7 +22,9 @@
     posterImageOverride: Option[ImageMedia] = None,
     cardStyle: Option[CardStyle] = None,
     mediaWrapper: Option[MediaWrapper] = None,
-    faciaHeaderProperties: Option[VideoFaciaProperties] = None
+    faciaHeaderProperties: Option[VideoFaciaProperties] = None,
+    isPaidFor: Boolean = false,
+    pressedContent: Option[PressedContent] = None
 )(implicit request: RequestHeader)
 
 @videoJsError() = @{
@@ -65,6 +68,10 @@
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
+                        @*//TODO Add kicker inside f.header.kicker*@
+                        @if(isPaidFor) {
+                            <div class="fc-item__kicker">Advertiser Content</div>
+                        }
                         @title(f.header, 0, 0)
                         @if(f.showByline) {
                             <div class="fc-item__byline">@f.byline</div>
@@ -104,7 +111,20 @@
                             </div>
                         </div>
                     } else {
-                        <div class="youtube-media-atom__play-button vjs-control-text">Play Video @fragments.inlineSvg("play", "icon")</div>
+                        @if(isPaidFor) {
+                            <div class="youtube-media-atom--sponsored-container"></div>
+                            <span class="youtube-media-atom__sponsored-label">
+                                Advertiser Content
+                            </span>
+                            @*TODO: use map to catch all cases *@
+                            <div class="youtube-media-atom__sponsored-logo-container">
+                                <img border="0"
+                                src="@PaidCard.fromPressedContent(pressedContent.get).image.get.allImages.toStream.head.url">
+                            </div>
+                        }
+                        <div class="youtube-media-atom__play-button vjs-control-text">
+                            Play Video @fragments.inlineSvg("play", "icon")
+                        </div>
                         @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {
                             @if(duration != "0:00") {
                                 <div class="youtube-media-atom__bottom-bar">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -112,13 +112,15 @@
                     } else {
                         @if(isPaidFor) {
                             <div class="youtube-media-atom__paid-for-container"></div>
-                            <span class="youtube-media-atom__paid-for-label">
-                                Advertiser content
-                            </span>
                             @pressedContent.map{ pc =>
                                 @PaidCard.fromPressedContent(pc).branding.map{ b =>
                                     <div class="youtube-media-atom__paid-for-logo-container">
-                                        <img border="0" src="@b.logo.src">
+                                        <span class="youtube-media-atom__paid-for-label">
+                                            Advertiser content
+                                        </span>
+                                        <div>
+                                            <img class="youtube-media-atom__paid-for-logo" border="0" src="@b.logo.src">
+                                        </div>
                                     </div>
                                 }
                             }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -119,7 +119,7 @@
                             @*TODO: use map to catch all cases *@
                             <div class="youtube-media-atom__sponsored-logo-container">
                                 <img border="0"
-                                src="@PaidCard.fromPressedContent(pressedContent.get).image.get.allImages.toStream.head.url">
+                                src="@PaidCard.fromPressedContent(pressedContent.get).branding.get.logo.src">
                             </div>
                         }
                         <div class="youtube-media-atom__play-button vjs-control-text">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -68,10 +68,7 @@
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
-                        @if(isPaidFor) {
-                            <div class="fc-item__kicker">Advertiser content</div>
-                        }
-                        @title(f.header, 0, 0)
+                        @title(f.header, 0, 0, "u-faux-block-link__cta", None, isPaidFor)
                         @if(f.showByline) {
                             <div class="fc-item__byline">@f.byline</div>
                         }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -64,7 +64,7 @@
             <div id="youtube-@asset.id" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
 
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
-                <div class="video-overlay @if(isPaidFor) { video-overlay--paid-for }">
+                <div class="video-overlay">
                     <div class="video-overlay__headline">
 
                     @for(f <- faciaHeaderProperties) {
@@ -75,7 +75,7 @@
 
                     </div>
                         @if(media.formattedDuration.getOrElse("0:00") != "0:00") {
-                            <span class="video-overlay__duration @if(isPaidFor) { video-overlay__duration--paid-for }">
+                            <span class="video-overlay__duration">
                                 @media.formattedDuration
                             </span>
                         }
@@ -98,7 +98,7 @@
                         <div class='gs-container'>
                             <div class='content__main-column'>
                                 <div class='youtube-media-atom__immersive-interface'>
-                                    <div class="youtube-media-atom__play-button vjs-control-text @if(isPaidFor) { vjs-control-text__item--paid-for }">
+                                    <div class="youtube-media-atom__play-button vjs-control-text">
                                         Play Video
                                         @fragments.inlineSvg("play", "icon")
                                     </div>
@@ -120,7 +120,7 @@
                                 }
                             }
                         }
-                        <div class="youtube-media-atom__play-button vjs-control-text @if(isPaidFor) { vjs-control-text__item--paid-for }">
+                        <div class="youtube-media-atom__play-button vjs-control-text">
                             Play Video @fragments.inlineSvg("play", "icon")
                         </div>
                         @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -40,7 +40,7 @@
         </li>
 
         @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
-           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault">
+           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault @if(item.isPaidFor) { video-playlist__item--paid-for }">
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
                         @youTubeAtom.map { youTubeAtom =>

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -40,11 +40,19 @@
         </li>
 
         @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
-           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault">
+           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault @if(item.isPaidFor) { video-playlist__item--paid-for }">
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
                         @youTubeAtom.map { youTubeAtom =>
-                            @youtube(media = youTubeAtom, displayCaption = false, mediaWrapper = Some(VideoContainer), displayEndSlate = false, displayDuration = false, faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None), showByline = item.properties.showByline, item.properties.byline)))
+                            @youtube(media = youTubeAtom,
+                                displayCaption = false,
+                                mediaWrapper = Some(VideoContainer),
+                                displayEndSlate = false,
+                                displayDuration = false,
+                                faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None),
+                                    showByline = item.properties.showByline, item.properties.byline)),
+                                isPaidFor = item.isPaidFor,
+                                pressedContent = Some(item))
                         }
                     }
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -40,7 +40,7 @@
         </li>
 
         @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
-           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault @if(item.isPaidFor) { video-playlist__item--paid-for }">
+           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first} fc-item--pillar-@item.maybePillar.nameOrDefault">
                 @item.properties.maybeContent.map { content =>
                     @defining(content.elements.mediaAtoms.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))) { youTubeAtom =>
                         @youTubeAtom.map { youTubeAtom =>

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -18,7 +18,7 @@
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @if(isPaidFor) {
-        @articleLink{<div class="fc-item__kicker">Advertiser content</div> @headline()}
+        @articleLink{<span class="fc-item__kicker">Advertiser content</span> @headline()}
     } else {
         @header.kicker match {
             case Some(kicker) => {

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -18,7 +18,7 @@
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @if(isPaidFor) {
-        @articleLink{<span class="fc-item__kicker fc-item__kicker--video-paid-for">Advertiser content</span> @headline()}
+        @articleLink{<span class="fc-item__kicker">Advertiser content</span> @headline()}
     } else {
         @header.kicker match {
             case Some(kicker) => {

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -1,4 +1,4 @@
-@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None)(implicit request: RequestHeader)
+@(header: layout.FaciaCardHeader, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta", snapType: Option[layout.SnapType] = None, isPaidFor: Boolean = false)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._
@@ -17,12 +17,16 @@
 @articleLink(html: Html) = {<a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>}
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
-    @header.kicker match {
-        case Some(kicker) => {
-            @articleLink{<span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span> @headline()}
-        }
-        case _ => {
-            @articleLink{@headline()}
+    @if(isPaidFor) {
+        @articleLink{<div class="fc-item__kicker">Advertiser content</div> @headline()}
+    } else {
+        @header.kicker match {
+            case Some(kicker) => {
+                @articleLink{<span class="@kicker.linkClasses.mkString(" ")">@Html(kicker.kickerHtml)</span> @headline()}
+            }
+            case _ => {
+                @articleLink{@headline()}
+            }
         }
     }
 }

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -18,7 +18,7 @@
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
     @if(isPaidFor) {
-        @articleLink{<span class="fc-item__kicker">Advertiser content</span> @headline()}
+        @articleLink{<span class="fc-item__kicker fc-item__kicker--video-paid-for">Advertiser content</span> @headline()}
     } else {
         @header.kicker match {
             case Some(kicker) => {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -54,7 +54,7 @@
     position: relative;
 }
 
-.youtube-media-atom__paid-for-container {
+.youtube-media-atom__paid-for-overlay {
     background-color: #ffffff;
     width: 100%;
     position: absolute;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -72,6 +72,7 @@
     height: 3.125rem;
     font-size: 16px;
     color: #000000;
+    margin-right: 10px;
 }
 
 .youtube-media-atom__sponsored-logo-container {
@@ -80,6 +81,7 @@
     height: 85px;
     bottom: 0;
     right: 0;
+    margin-right: 10px;
 }
 
 .youtube-media-atom__iframe,

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -64,25 +64,28 @@
 }
 
 .youtube-media-atom__paid-for-label {
-    position: absolute;
-    bottom: 2rem;
-    right: 8rem;
-    display: block;
-    width: 11.5rem;
-    height: 3.125rem;
     font-size: 16px;
     color: #000000;
+    margin: 5px 10px 0 0;
     @include mq($until: 590px) {
         display: none;
     }
 }
 
 .youtube-media-atom__paid-for-logo-container {
+    display: flex;
     position: absolute;
-    width: 130px;
-    height: 85px;
-    bottom: 0;
+    bottom: 0 ;
     right: 0;
+    width: auto;
+}
+
+.youtube-media-atom__paid-for-logo {
+    width: auto !important;
+    height: 86px !important;
+    position: relative !important;
+    bottom: 0 !important;
+    right: 0 !important;
     margin-right: 10px;
 }
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -72,6 +72,9 @@
     height: 3.125rem;
     font-size: 16px;
     color: #000000;
+    @include mq($until: 590px) {
+        display: none;
+    }
 }
 
 .youtube-media-atom__sponsored-logo-container {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -55,23 +55,23 @@
 }
 
 .youtube-media-atom--sponsored-container {
-    background-color: white;
+    background-color: #ffffff;
     width: 100%;
     position: absolute;
     bottom: 0;
     height: 85px;
-    opacity: 0.5;
+    opacity: .5;
 }
 
 .youtube-media-atom__sponsored-label {
     position: absolute;
-    bottom: 2.00rem;
-    right: 4.00rem;
+    bottom: 2rem;
+    right: 4rem;
     display: block;
     width: 12.5rem;
     height: 3.125rem;
     font-size: 16px;
-    color: black;
+    color: #000000;
 }
 
 .youtube-media-atom__sponsored-logo-container {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -81,11 +81,11 @@
 }
 
 .youtube-media-atom__paid-for-logo {
-    width: auto !important;
-    height: 86px !important;
-    position: relative !important;
-    bottom: 0 !important;
-    right: 0 !important;
+    width: auto;
+    height: 86px;
+    position: relative;
+    bottom: 0;
+    right: 0;
     margin-right: 10px;
 }
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -54,6 +54,34 @@
     position: relative;
 }
 
+.youtube-media-atom--sponsored-container {
+    background-color: white;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    height: 85px;
+    opacity: 0.5;
+}
+
+.youtube-media-atom__sponsored-label {
+    position: absolute;
+    bottom: 2.00rem;
+    right: 4.00rem;
+    display: block;
+    width: 12.5rem;
+    height: 3.125rem;
+    font-size: 16px;
+    color: black;
+}
+
+.youtube-media-atom__sponsored-logo-container {
+    position: absolute;
+    width: 85px;
+    height: 85px;
+    bottom: 0;
+    right: 0;
+}
+
 .youtube-media-atom__iframe,
 .youtube-media-atom__overlay {
     height: 100%;
@@ -133,6 +161,7 @@ youtube-media-atom:not(.youtube-related-videos) .youtube-media-atom__iframe.yout
     overflow: hidden !important;
     display: inline-block;
     z-index: 2;
+    opacity: 1;
 }
 
 .no-player .youtube-media-atom__play-button.vjs-control-text {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -72,12 +72,12 @@
     height: 3.125rem;
     font-size: 16px;
     color: #000000;
-    margin-right: 10px;
+    margin-right: 15px;
 }
 
 .youtube-media-atom__sponsored-logo-container {
     position: absolute;
-    width: 110px;
+    width: 130px;
     height: 85px;
     bottom: 0;
     right: 0;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -66,13 +66,12 @@
 .youtube-media-atom__sponsored-label {
     position: absolute;
     bottom: 2rem;
-    right: 6rem;
+    right: 8rem;
     display: block;
     width: 11.5rem;
     height: 3.125rem;
     font-size: 16px;
     color: #000000;
-    margin-right: 15px;
 }
 
 .youtube-media-atom__sponsored-logo-container {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -66,9 +66,9 @@
 .youtube-media-atom__sponsored-label {
     position: absolute;
     bottom: 2rem;
-    right: 4rem;
+    right: 6rem;
     display: block;
-    width: 12.5rem;
+    width: 11.5rem;
     height: 3.125rem;
     font-size: 16px;
     color: #000000;
@@ -76,7 +76,7 @@
 
 .youtube-media-atom__sponsored-logo-container {
     position: absolute;
-    width: 85px;
+    width: 110px;
     height: 85px;
     bottom: 0;
     right: 0;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -54,7 +54,7 @@
     position: relative;
 }
 
-.youtube-media-atom--sponsored-container {
+.youtube-media-atom__paid-for-container {
     background-color: #ffffff;
     width: 100%;
     position: absolute;
@@ -63,7 +63,7 @@
     opacity: .5;
 }
 
-.youtube-media-atom__sponsored-label {
+.youtube-media-atom__paid-for-label {
     position: absolute;
     bottom: 2rem;
     right: 8rem;
@@ -77,7 +77,7 @@
     }
 }
 
-.youtube-media-atom__sponsored-logo-container {
+.youtube-media-atom__paid-for-logo-container {
     position: absolute;
     width: 130px;
     height: 85px;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -55,7 +55,7 @@
 }
 
 .youtube-media-atom__paid-for-overlay {
-    background-color: #ffffff;
+    background-color: $brightness-100;
     width: 100%;
     position: absolute;
     bottom: 0;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -67,7 +67,7 @@
     font-size: 16px;
     color: #000000;
     margin: 5px 10px 0 0;
-    @include mq($until: 590px) {
+    @include mq($until: phablet) {
         display: none;
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -301,16 +301,16 @@ $video-width-desktop: 700px;
     }
 }
 
-.fc-item--pillar-news.video-playlist__item .fc-item__kicker.fc-item__kicker--video-paid-for,
-.fc-item--pillar-news.video-playlist__item .video-overlay__duration.video-overlay__duration--paid-for {
+.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .fc-item__kicker,
+.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .video-overlay__duration{
     color: $labs-main;
 }
 
-.fc-item--pillar-news .vjs-big-play-button .vjs-control-text.vjs-control-text__item--paid-for {
+.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .vjs-big-play-button .vjs-control-text {
     background-color: $labs-main;
 }
 
-.fc-item--pillar-news.video-playlist__item .video-overlay.video-overlay--paid-for {
+.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .video-overlay {
     border-top-color: $labs-main;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -301,6 +301,19 @@ $video-width-desktop: 700px;
     }
 }
 
+.video-playlist__item--paid-for.video-playlist__item .fc-item__kicker,
+.video-playlist__item--paid-for.video-playlist__item .video-overlay__duration {
+    color: $labs-main !important;
+}
+
+.video-playlist__item--paid-for.video-playlist__item .vjs-big-play-button .vjs-control-text {
+    background-color: $labs-main !important;
+}
+
+.video-playlist__item--paid-for.video-playlist__item .video-overlay{
+    border-top-color: $labs-main !important;
+}
+
 .vjs-big-play-button .vjs-control-text,
 .youtube-media-atom__play-button.vjs-control-text {
     // Sets a base play button/icon size for all video players

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -310,7 +310,7 @@ $video-width-desktop: 700px;
     background-color: $labs-main !important;
 }
 
-.video-playlist__item--paid-for.video-playlist__item .video-overlay{
+.video-playlist__item--paid-for.video-playlist__item .video-overlay {
     border-top-color: $labs-main !important;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -301,17 +301,17 @@ $video-width-desktop: 700px;
     }
 }
 
-.video-playlist__item--paid-for.video-playlist__item .fc-item__kicker,
-.video-playlist__item--paid-for.video-playlist__item .video-overlay__duration {
-    color: $labs-main !important;
+.fc-item--pillar-news.video-playlist__item .fc-item__kicker.fc-item__kicker--video-paid-for,
+.fc-item--pillar-news.video-playlist__item .video-overlay__duration.video-overlay__duration--paid-for {
+    color: $labs-main;
 }
 
-.video-playlist__item--paid-for.video-playlist__item .vjs-big-play-button .vjs-control-text {
-    background-color: $labs-main !important;
+.fc-item--pillar-news .vjs-big-play-button .vjs-control-text.vjs-control-text__item--paid-for {
+    background-color: $labs-main;
 }
 
-.video-playlist__item--paid-for.video-playlist__item .video-overlay {
-    border-top-color: $labs-main !important;
+.fc-item--pillar-news.video-playlist__item .video-overlay.video-overlay--paid-for {
+    border-top-color: $labs-main;
 }
 
 .vjs-big-play-button .vjs-control-text,

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -302,7 +302,7 @@ $video-width-desktop: 700px;
 }
 
 .fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .fc-item__kicker,
-.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .video-overlay__duration{
+.fc-item--pillar-news.video-playlist__item.video-playlist__item--paid-for .video-overlay__duration {
     color: $labs-main;
 }
 


### PR DESCRIPTION
## What does this change?

Allowing The US team to offer Advertisers the ability to run video ads within the front page video Carousel

- "Advertiser Content" appears as kicker and text on an overlay
- Font and coloring are  Guardian Labs blue 
- Added branding logo 

## Screenshots

![Screenshot 2019-07-18 at 16 02 31](https://user-images.githubusercontent.com/51630004/61794871-0ce18600-ae1a-11e9-8693-5fafba4e0f00.png)

### Tested

- [x] Locally
- [x] On CODE (optional)
