### PR TITLE
Activate cm-lotame-data-extract at DCR commercial

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -11,7 +11,7 @@ import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
 import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
-// import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
 import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
 // import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 // import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
@@ -33,7 +33,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-track-cmp-consent', trackCmpConsent],
     // ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
-    // ['cm-lotame-data-extract', initLotameDataExtract, true],
+    ['cm-lotame-data-extract', initLotameDataExtract, true], // Comes with a isDotcomRendering check
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
+++ b/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
@@ -25,6 +25,10 @@ const init = (): Promise<void> => {
     }
     return loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')
         .then(() => {
+            if (config.get('isDotcomRendering', false)) {
+                // We do not need the LOTCC initialization for dotcom-rendering Ad Free
+                return Promise.resolve();
+            }
             if ('LOTCC' in window && 'bcp' in window.LOTCC) {
                 Promise.resolve(window.LOTCC.bcp());
             } else {


### PR DESCRIPTION
## What does this change?

Towards Ad Free: Activate cm-lotame-data-extract at DCR commercial.

This one comes with an amendment in `lotame-data-extract.js` which disables the initialisation on dotcom-rendering. (Checked with Commercial Dev that this is OK).

When moving away from Ad Free, the check will be removed. Adding the check make the dotcom-rendering-commercial bundle closer to the regular commercial bundle, for performance testing. 


