### PR TITLE
DCR Commercial, uncomment: cm-checkDispatcher

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -23,7 +23,7 @@ import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-
 // import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-// import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
+import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
 // import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 
 const commercialModules: Array<Array<any>> = [
@@ -31,7 +31,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-prepare-cmp', initCmpService],
     ['cm-track-cmp-consent', trackCmpConsent],
-    // ['cm-checkDispatcher', initCheckDispatcher],
+    ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract, true], // Comes with a isDotcomRendering check
 ];


### PR DESCRIPTION
## What does this change?

Uncomment the last Ad Free commercial module (`cm-checkDispatcher`), which wasn't required for Ad Free, but will help with performance testing.

Note:

- This required a tiny DCR change: https://github.com/guardian/dotcom-rendering/pull/685
- The updates in `check-dispatcher.js` are not specific to DCR, and are simply updates that should have been added for code robustness, the effect for DCR is no useless errors thrown at the console. 