### PR TITLE
Remove browserId and PageViewID from GA request

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -84,8 +84,6 @@
         @***************************************************************************************
         * Custom dimensions common to all platforms across the whole Guardian estate           *
         ***************************************************************************************@
-        ga('@{trackerName}.set', 'dimension1', guardian.config.ophan.pageViewId);
-        ga('@{trackerName}.set', 'dimension2', guardian.config.ophan.browserId);
         ga('@{trackerName}.set', 'dimension3', 'theguardian.com'); @* Platform *@
 
         @***************************************************************************************


### PR DESCRIPTION
## What does this change?

Removes pageViewId and browserId from the GA request. 

See email chain starting 24 July 16:28.

@guardian/dotcom-platform 