### PR TITLE
Introducing CMP library

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -38,6 +38,7 @@ import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
 import debounce from 'lodash/debounce';
 import ophan from 'ophan/ng';
+import { init as initCmp } from 'lib/cmp';
 import { initAtoms } from './atoms';
 
 const setAdTestCookie = (): void => {
@@ -204,6 +205,9 @@ const bootStandard = (): void => {
 
     // Set adtest query if url param declares it
     setAdTestCookie();
+
+    // Initialise the CMP library
+    initCmp();
 
     // set a short-lived cookie to trigger server-side ad-freeness
     // if the user is genuinely ad-free, this one will be overwritten

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -51,7 +51,7 @@ export const triggerConsentNotification = () => {
     });
 };
 
-export const consent = (purposeName: PurposeEvent): boolean | null =>
+export const consentState = (purposeName: PurposeEvent): boolean | null =>
     purposes[purposeName].state;
 
 export const init = () => {

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -43,6 +43,14 @@ export const onConsentNotification = (
     purpose.callbacks.push(callback);
 };
 
+// Exporting for testing purposes only
+export const triggerConsentNotification = () => {
+    Object.keys(purposes).forEach(key => {
+        const purpose = purposes[key];
+        purpose.callbacks.forEach(callback => callback(purpose.state));
+    });
+};
+
 export const consent = (purposeName: PurposeEvent): boolean | null =>
     purposes[purposeName].state;
 
@@ -55,8 +63,5 @@ export const init = () => {
 
     cmpIsReady = true;
 
-    Object.keys(purposes).forEach(key => {
-        const purpose = purposes[key];
-        purpose.callbacks.forEach(callback => callback(purpose.state));
-    });
+    triggerConsentNotification();
 };

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -30,6 +30,13 @@ const purposes: { [PurposeEvent]: Purpose } = {
     },
 };
 
+const triggerConsentNotification = () => {
+    Object.keys(purposes).forEach(key => {
+        const purpose = purposes[key];
+        purpose.callbacks.forEach(callback => callback(purpose.state));
+    });
+};
+
 export const onConsentNotification = (
     purposeName: PurposeEvent,
     callback: PurposeCallback
@@ -41,14 +48,6 @@ export const onConsentNotification = (
     }
 
     purpose.callbacks.push(callback);
-};
-
-// Exporting for testing purposes only
-export const triggerConsentNotification = () => {
-    Object.keys(purposes).forEach(key => {
-        const purpose = purposes[key];
-        purpose.callbacks.forEach(callback => callback(purpose.state));
-    });
 };
 
 export const consentState = (purposeName: PurposeEvent): boolean | null =>
@@ -64,4 +63,8 @@ export const init = () => {
     cmpIsReady = true;
 
     triggerConsentNotification();
+};
+
+export const _ = {
+    triggerConsentNotification,
 };

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -1,4 +1,8 @@
 // @flow
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
 
 type PurposeEvent = 'functional' | 'performance' | 'advertisement';
 
@@ -42,7 +46,9 @@ export const onConsentNotification = (
 export const init = () => {
     purposes.functional.state = true;
     purposes.performance.state = true;
-    purposes.advertisement.state = true;
+    purposes.advertisement.state = getAdConsentState(
+        thirdPartyTrackingAdConsent
+    );
 
     cmpIsReady = true;
 

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -73,7 +73,12 @@ export const init = (): void => {
 // Exposed for testing purposes
 export const _ = {
     triggerConsentNotification,
-    resetCmpIsReady: (): void => {
+    resetCmp: (): void => {
         cmpIsReady = false;
+        Object.keys(purposes).forEach(key => {
+            const purpose = purposes[key];
+            purpose.state = null;
+            purpose.callbacks = [];
+        });
     },
 };

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -30,7 +30,7 @@ const purposes: { [PurposeEvent]: Purpose } = {
     },
 };
 
-const triggerConsentNotification = () => {
+const triggerConsentNotification = (): void => {
     Object.keys(purposes).forEach(key => {
         const purpose = purposes[key];
         purpose.callbacks.forEach(callback => callback(purpose.state));
@@ -40,7 +40,7 @@ const triggerConsentNotification = () => {
 export const onConsentNotification = (
     purposeName: PurposeEvent,
     callback: PurposeCallback
-) => {
+): void => {
     const purpose = purposes[purposeName];
 
     if (cmpIsReady) {
@@ -53,7 +53,12 @@ export const onConsentNotification = (
 export const consentState = (purposeName: PurposeEvent): boolean | null =>
     purposes[purposeName].state;
 
-export const init = () => {
+export const init = (): void => {
+    // do nothing if init has already been called
+    if (cmpIsReady) {
+        return;
+    }
+
     purposes.functional.state = true;
     purposes.performance.state = true;
     purposes.advertisement.state = getAdConsentState(
@@ -65,6 +70,10 @@ export const init = () => {
     triggerConsentNotification();
 };
 
+// Exposed for testing purposes
 export const _ = {
     triggerConsentNotification,
+    resetCmpIsReady: (): void => {
+        cmpIsReady = false;
+    },
 };

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -59,6 +59,11 @@ export const init = (): void => {
         return;
     }
 
+    /**
+     * These state assignments are temporary
+     * and will eventually be replaced by values
+     * read from the CMP cookie.
+     * */
     purposes.functional.state = true;
     purposes.performance.state = true;
     purposes.advertisement.state = getAdConsentState(

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -43,6 +43,9 @@ export const onConsentNotification = (
     purpose.callbacks.push(callback);
 };
 
+export const consent = (purposeName: PurposeEvent): boolean | null =>
+    purposes[purposeName].state;
+
 export const init = () => {
     purposes.functional.state = true;
     purposes.performance.state = true;

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -5,7 +5,7 @@ import { getAdConsentState as _getAdConsentState } from 'common/modules/commerci
 const getAdConsentState: any = _getAdConsentState;
 
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(() => true),
+    getAdConsentState: jest.fn(),
     thirdPartyTrackingAdConsent: jest.fn(),
 }));
 

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -1,0 +1,85 @@
+// @flow
+import { init, onConsentNotification, _ } from 'lib/cmp';
+import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
+
+const getAdConsentState: any = _getAdConsentState;
+
+jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
+    getAdConsentState: jest.fn(() => true),
+    thirdPartyTrackingAdConsent: jest.fn(),
+}));
+
+describe('cmp', () => {
+    beforeEach(() => {
+        _.resetCmpIsReady();
+        getAdConsentState.mockReset();
+    });
+
+    describe('onConsentNotification', () => {
+        it('executes functional callback', () => {
+            const myCallBack = jest.fn();
+
+            init();
+
+            onConsentNotification('functional', myCallBack);
+
+            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toBeCalledWith(true);
+        });
+
+        it('executes performance callback', () => {
+            const myCallBack = jest.fn();
+
+            init();
+
+            onConsentNotification('performance', myCallBack);
+
+            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toBeCalledWith(true);
+        });
+
+        it('executes advertisement callback with true if getAdConsentState true', () => {
+            getAdConsentState.mockReturnValue(true);
+
+            const myCallBack = jest.fn();
+
+            init();
+
+            onConsentNotification('advertisement', myCallBack);
+
+            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toBeCalledWith(true);
+        });
+
+        it('executes advertisement callback with true if getAdConsentState false', () => {
+            getAdConsentState.mockReturnValue(false);
+
+            const myCallBack = jest.fn();
+
+            init();
+
+            onConsentNotification('advertisement', myCallBack);
+
+            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toBeCalledWith(false);
+        });
+
+        it('executes advertisement callback each time consent nofication triggered', () => {
+            getAdConsentState.mockReturnValue(true);
+
+            const myCallBack = jest.fn();
+
+            init();
+
+            onConsentNotification('advertisement', myCallBack);
+
+            _.triggerConsentNotification();
+
+            expect(myCallBack).toBeCalledTimes(2);
+            expect(myCallBack.mock.calls).toEqual([
+                [true], // First call
+                [true], // Second call
+            ]);
+        });
+    });
+});

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { init, onConsentNotification, _ } from 'lib/cmp';
+import { init, onConsentNotification, consentState, _ } from 'lib/cmp';
 import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 
 const getAdConsentState: any = _getAdConsentState;
@@ -15,6 +15,36 @@ describe('cmp', () => {
         getAdConsentState.mockReset();
     });
 
+    describe('consentState', () => {
+        it('returns functional consent state', () => {
+            init();
+
+            expect(consentState('functional')).toBe(true);
+        });
+
+        it('returns performance consent state', () => {
+            init();
+
+            expect(consentState('performance')).toBe(true);
+        });
+
+        it('returns advertisement consent state with true if getAdConsentState true', () => {
+            getAdConsentState.mockReturnValue(true);
+
+            init();
+
+            expect(consentState('advertisement')).toBe(true);
+        });
+
+        it('returns advertisement consent state with false if getAdConsentState true', () => {
+            getAdConsentState.mockReturnValue(false);
+
+            init();
+
+            expect(consentState('advertisement')).toBe(false);
+        });
+    });
+
     describe('onConsentNotification', () => {
         it('executes functional callback', () => {
             const myCallBack = jest.fn();
@@ -23,7 +53,7 @@ describe('cmp', () => {
 
             onConsentNotification('functional', myCallBack);
 
-            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toHaveBeenCalledTimes(1);
             expect(myCallBack).toBeCalledWith(true);
         });
 
@@ -34,7 +64,7 @@ describe('cmp', () => {
 
             onConsentNotification('performance', myCallBack);
 
-            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toHaveBeenCalledTimes(1);
             expect(myCallBack).toBeCalledWith(true);
         });
 
@@ -47,7 +77,7 @@ describe('cmp', () => {
 
             onConsentNotification('advertisement', myCallBack);
 
-            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toHaveBeenCalledTimes(1);
             expect(myCallBack).toBeCalledWith(true);
         });
 
@@ -60,7 +90,7 @@ describe('cmp', () => {
 
             onConsentNotification('advertisement', myCallBack);
 
-            expect(myCallBack).toBeCalledTimes(1);
+            expect(myCallBack).toHaveBeenCalledTimes(1);
             expect(myCallBack).toBeCalledWith(false);
         });
 
@@ -75,7 +105,7 @@ describe('cmp', () => {
 
             _.triggerConsentNotification();
 
-            expect(myCallBack).toBeCalledTimes(2);
+            expect(myCallBack).toHaveBeenCalledTimes(2);
             expect(myCallBack.mock.calls).toEqual([
                 [true], // First call
                 [true], // Second call

--- a/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
@@ -1,13 +1,10 @@
 // @flow
 import config from 'lib/config';
 import fetch from 'lib/fetch';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 import { CMP_GLOBAL_NAME } from 'commercial/modules/cmp/cmp-env';
 import type { ConsentDataResponse } from 'commercial/modules/cmp/types';
 import { getRandomIntInclusive } from 'commercial/modules/prebid/utils';
+import { consentState } from 'lib/cmp';
 
 declare type ConsentPayload = {
     pv: string, // page view ID
@@ -30,7 +27,7 @@ const buildPayload = (
 ): ConsentPayload => ({
     pv: pageViewId,
     cs: consent.consentData,
-    cc: getAdConsentState(thirdPartyTrackingAdConsent),
+    cc: consentState('advertisement'),
 });
 
 const postConsent = (payload: ConsentPayload): void => {

--- a/static/src/javascripts/projects/commercial/modules/cmp/lib/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/lib/cmp.js
@@ -1,0 +1,53 @@
+// @flow
+
+type PurposeEvent = 'functional' | 'performance' | 'advertisement';
+
+type PurposeCallback = (state: boolean | null) => void;
+
+type Purpose = {
+    state: boolean | null,
+    callbacks: Array<PurposeCallback>,
+};
+
+let cmpIsReady = false;
+
+const purposes: { [PurposeEvent]: Purpose } = {
+    functional: {
+        state: null,
+        callbacks: [],
+    },
+    performance: {
+        state: null,
+        callbacks: [],
+    },
+    advertisement: {
+        state: null,
+        callbacks: [],
+    },
+};
+
+export const onConsentNotification = (
+    purposeName: PurposeEvent,
+    callback: PurposeCallback
+) => {
+    const purpose = purposes[purposeName];
+
+    if (cmpIsReady) {
+        callback(purpose.state);
+    }
+
+    purpose.callbacks.push(callback);
+};
+
+export const init = () => {
+    purposes.functional.state = true;
+    purposes.performance.state = true;
+    purposes.advertisement.state = true;
+
+    cmpIsReady = true;
+
+    Object.keys(purposes).forEach(key => {
+        const purpose = purposes[key];
+        purpose.callbacks.forEach(callback => callback(purpose.state));
+    });
+};

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -2,7 +2,6 @@
 import $ from 'lib/$';
 import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import config from 'lib/config';
-
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { getAdverts } from 'commercial/modules/dfp/get-adverts';
 import { getCreativeIDs } from 'commercial/modules/dfp/get-creative-ids';
@@ -10,6 +9,7 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { fillAdvertSlots as fillAdvertSlots_ } from 'commercial/modules/dfp/fill-advert-slots';
+import { onConsentNotification as onConsentNotification_ } from 'lib/cmp';
 
 // $FlowFixMe property requireActual is actually not missing Flow.
 const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
@@ -18,6 +18,7 @@ const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
 
 const getBreakpoint: any = getBreakpoint_;
 const fillAdvertSlots: any = fillAdvertSlots_;
+const onConsentNotification: any = onConsentNotification_;
 
 jest.mock('commercial/modules/dfp/fill-advert-slots', () => ({
     fillAdvertSlots: jest.fn(),
@@ -92,6 +93,10 @@ jest.mock('commercial/modules/third-party-tags/outbrain', () => ({
 }));
 jest.mock('commercial/modules/dfp/load-advert', () => ({
     loadAdvert: jest.fn(),
+}));
+jest.mock('lib/cmp', () => ({
+    onConsentNotification: jest.fn(),
+    consentState: jest.fn(() => null),
 }));
 
 let $style;
@@ -398,11 +403,15 @@ describe('DFP', () => {
     });
 
     describe('keyword targeting', () => {
-        it('should send page level keywords', () =>
+        it('should send page level keywords', () => {
+            onConsentNotification.mockImplementation((purpose, callback) =>
+                callback(null)
+            );
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setTargeting
                 ).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
-            }));
+            });
+        });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -7,7 +7,7 @@ import { loadScript } from 'lib/load-script';
 import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
 import { session } from 'lib/storage';
-import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
+import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -22,7 +22,7 @@ import { init as initMessenger } from 'commercial/modules/messenger';
 import { init as background } from 'commercial/modules/messenger/background';
 import { init as sendClick } from 'commercial/modules/messenger/click';
 import { init as disableRefresh } from 'commercial/modules/messenger/disable-refresh';
-import { init as getPageTargeting } from 'commercial/modules/messenger/get-page-targeting';
+import { init as initGetPageTargeting } from 'commercial/modules/messenger/get-page-targeting';
 import { init as getStyles } from 'commercial/modules/messenger/get-stylesheet';
 import { init as hide } from 'commercial/modules/messenger/hide';
 import { init as resize } from 'commercial/modules/messenger/resize';
@@ -34,7 +34,7 @@ import { onConsentNotification } from 'lib/cmp';
 initMessenger(
     type,
     getStyles,
-    getPageTargeting,
+    initGetPageTargeting,
     resize,
     hide,
     scroll,
@@ -61,7 +61,7 @@ const setDfpListeners = (): void => {
 const setPageTargeting = (): void => {
     const pubads = window.googletag.pubads();
     // because commercialFeatures may export itself as {} in the event of an exception during construction
-    const targeting = buildPageTargeting();
+    const targeting = getPageTargeting();
     Object.keys(targeting).forEach(key => {
         pubads.setTargeting(key, targeting[key]);
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,13 +103,11 @@ export const init = (): Promise<void> => {
         );
 
         onConsentNotification('advertisement', state => {
-            if (state === true) {
+            if (state !== null) {
                 window.googletag.cmd.push(() => {
-                    window.googletag.pubads().setRequestNonPersonalizedAds(0);
-                });
-            } else if (state === false) {
-                window.googletag.cmd.push(() => {
-                    window.googletag.pubads().setRequestNonPersonalizedAds(1);
+                    window.googletag
+                        .pubads()
+                        .setRequestNonPersonalizedAds(state ? 1 : 0);
                 });
             }
         });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -104,14 +104,14 @@ export const init = (): Promise<void> => {
 
         onConsentNotification('advertisement', state => {
             if (state === true) {
-                window.googletag.cmd.push(
-                    window.googletag.pubads().setRequestNonPersonalizedAds(0)
-                );
+                window.googletag.cmd.push(() => {
+                    window.googletag.pubads().setRequestNonPersonalizedAds(0);
+                });
             }
             if (state === false) {
-                window.googletag.cmd.push(
-                    window.googletag.pubads().setRequestNonPersonalizedAds(1)
-                );
+                window.googletag.cmd.push(() => {
+                    window.googletag.pubads().setRequestNonPersonalizedAds(1);
+                });
             }
         });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -107,8 +107,7 @@ export const init = (): Promise<void> => {
                 window.googletag.cmd.push(() => {
                     window.googletag.pubads().setRequestNonPersonalizedAds(0);
                 });
-            }
-            if (state === false) {
+            } else if (state === false) {
                 window.googletag.cmd.push(() => {
                     window.googletag.pubads().setRequestNonPersonalizedAds(1);
                 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -2,7 +2,7 @@
 
 import config from 'lib/config';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
+import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import once from 'lodash/once';
 import prebid from 'commercial/modules/prebid/prebid';
@@ -30,7 +30,7 @@ const setupPrebid: () => Promise<void> = () =>
             !config.get('page.hasPageSkin') &&
             !isGoogleProxy()
         ) {
-            buildPageTargeting();
+            getPageTargeting();
             prebid.initialise(window);
         }
         return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -21,7 +21,7 @@ jest.mock('commercial/modules/dfp/Advert', () =>
 );
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
-    buildPageTargeting: jest.fn(),
+    getPageTargeting: jest.fn(),
 }));
 
 jest.mock('commercial/modules/prebid/bid-config', () => ({

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -2,7 +2,7 @@
 
 import config from 'lib/config';
 import {
-    buildPageTargeting,
+    getPageTargeting,
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
 
@@ -113,14 +113,14 @@ export const getAppNexusDirectBidParams = (
                 member: '7012',
                 keywords: {
                     invc: [invCode],
-                    ...buildAppNexusTargetingObject(buildPageTargeting()),
+                    ...buildAppNexusTargetingObject(getPageTargeting()),
                 },
             };
         }
     }
     return {
         placementId: getAppNexusDirectPlacementId(sizes, isAuRegion),
-        keywords: buildAppNexusTargetingObject(buildPageTargeting()),
+        keywords: buildAppNexusTargetingObject(getPageTargeting()),
     };
 };
 
@@ -131,7 +131,7 @@ export const getAppNexusServerSideBidParams = (
         {},
         {
             placementId: getAppNexusPlacementId(sizes),
-            keywords: buildAppNexusTargetingObject(buildPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+            keywords: buildAppNexusTargetingObject(getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
         },
         window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
     );

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -21,7 +21,7 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
         sens: 'f',
         edition: 'UK',
     }),
-    buildPageTargeting: () => 'pageTargeting',
+    getPageTargeting: () => 'pageTargeting',
 }));
 
 jest.mock('./utils', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -6,7 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 import {
     buildAppNexusTargeting,
     buildAppNexusTargetingObject,
-    buildPageTargeting,
+    getPageTargeting,
 } from 'common/modules/commercial/build-page-targeting';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
@@ -52,7 +52,7 @@ import {
 } from './utils';
 import { getAppNexusDirectBidParams, getAppNexusPlacementId } from './appnexus';
 
-const PAGE_TARGETING: {} = buildAppNexusTargetingObject(buildPageTargeting());
+const PAGE_TARGETING: {} = buildAppNexusTargetingObject(getPageTargeting());
 
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');
@@ -344,25 +344,21 @@ const openxClientSideBidder: PrebidBidder = {
             return {
                 delDomain: 'guardian-us-d.openx.net',
                 unit: '540279544',
-                customParams: buildAppNexusTargetingObject(
-                    buildPageTargeting()
-                ),
+                customParams: buildAppNexusTargetingObject(getPageTargeting()),
             };
         }
         if (isInAuRegion()) {
             return {
                 delDomain: 'guardian-aus-d.openx.net',
                 unit: '540279542',
-                customParams: buildAppNexusTargetingObject(
-                    buildPageTargeting()
-                ),
+                customParams: buildAppNexusTargetingObject(getPageTargeting()),
             };
         }
         // UK and ROW
         return {
             delDomain: 'guardian-d.openx.net',
             unit: '540279541',
-            customParams: buildAppNexusTargetingObject(buildPageTargeting()),
+            customParams: buildAppNexusTargetingObject(getPageTargeting()),
         };
     },
 };
@@ -398,7 +394,7 @@ const sonobiBidder: PrebidBidder = {
             {
                 ad_unit: config.get('page.adUnit'),
                 dom_id: slotId,
-                appNexusTargeting: buildAppNexusTargeting(buildPageTargeting()),
+                appNexusTargeting: buildAppNexusTargeting(getPageTargeting()),
                 pageViewId: config.get('ophan.pageViewId'),
             },
             isInSafeframeTestVariant() ? { render: 'safeframe' } : {}
@@ -494,9 +490,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {},
                 {
                     placementId: getAppNexusPlacementId(sizes),
-                    keywords: buildAppNexusTargetingObject(
-                        buildPageTargeting()
-                    ), // Ok to duplicate call. Lodash 'once' is used.
+                    keywords: buildAppNexusTargetingObject(getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
             ),
@@ -512,7 +506,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                     delDomain: 'guardian-d.openx.net',
                     unit: '539997090',
                     customParams: buildAppNexusTargetingObject(
-                        buildPageTargeting()
+                        getPageTargeting()
                     ),
                 }))(),
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
@@ -530,9 +524,7 @@ const getDummyServerSideBidders = (): Array<PrebidBidder> => {
                 {},
                 {
                     placementId: getPangaeaPlacementId(sizes).toString(),
-                    keywords: buildAppNexusTargetingObject(
-                        buildPageTargeting()
-                    ), // Ok to duplicate call. Lodash 'once' is used.
+                    keywords: buildAppNexusTargetingObject(getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
                 },
                 window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
             ),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -63,7 +63,7 @@ const {
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
     buildAppNexusTargetingObject: () => 'someAppNexusTargetingObject',
-    buildPageTargeting: () => 'bla',
+    getPageTargeting: () => 'bla',
 }));
 
 jest.mock('common/modules/commercial/ad-prefs.lib', () => ({

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -12,28 +12,35 @@ import { ias } from 'commercial/modules/third-party-tags/ias';
 import { inizio } from 'commercial/modules/third-party-tags/inizio';
 import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
 import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-party-tags/plista-outbrain-renderer';
+import { onConsentNotification } from 'lib/cmp';
+
+let isInitialised: boolean = false;
 
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
-    const ref = document.scripts[0];
-    const frag = document.createDocumentFragment();
-    let insertedScripts = false;
+    onConsentNotification('advertisement', state => {
+        if (!isInitialised && (state === true || state === null)) {
+            isInitialised = true;
+            const ref = document.scripts[0];
+            const frag = document.createDocumentFragment();
+            let insertedScripts = false;
 
-    services.forEach(service => {
-        // flowlint sketchy-null-bool:warn
-        if (service.useImage) {
-            new Image().src = service.url;
-        } else {
-            insertedScripts = true;
-            const script = document.createElement('script');
-            script.src = service.url;
-            script.onload = service.onLoad;
-            frag.appendChild(script);
-        }
-    });
+            services.forEach(service => {
+                if (service.useImage === true) {
+                    new Image().src = service.url;
+                } else {
+                    insertedScripts = true;
+                    const script = document.createElement('script');
+                    script.src = service.url;
+                    script.onload = service.onLoad;
+                    frag.appendChild(script);
+                }
+            });
 
-    fastdom.write(() => {
-        if (insertedScripts && ref && ref.parentNode) {
-            ref.parentNode.insertBefore(frag, ref);
+            fastdom.write(() => {
+                if (insertedScripts && ref && ref.parentNode) {
+                    ref.parentNode.insertBefore(frag, ref);
+                }
+            });
         }
     });
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -14,21 +14,22 @@ import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
 import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-party-tags/plista-outbrain-renderer';
 import { onConsentNotification } from 'lib/cmp';
 
-let isInitialised: boolean = false;
+let scriptsInserted: boolean = false;
 
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     onConsentNotification('advertisement', state => {
-        if (!isInitialised && (state === true || state === null)) {
-            isInitialised = true;
+        if (!scriptsInserted && (state === true || state === null)) {
+            scriptsInserted = true;
+
             const ref = document.scripts[0];
             const frag = document.createDocumentFragment();
-            let insertedScripts = false;
+            let hasScriptsToInsert = false;
 
             services.forEach(service => {
                 if (service.useImage === true) {
                     new Image().src = service.url;
                 } else {
-                    insertedScripts = true;
+                    hasScriptsToInsert = true;
                     const script = document.createElement('script');
                     script.src = service.url;
                     script.onload = service.onLoad;
@@ -36,11 +37,13 @@ const insertScripts = (services: Array<ThirdPartyTag>): void => {
                 }
             });
 
-            fastdom.write(() => {
-                if (insertedScripts && ref && ref.parentNode) {
-                    ref.parentNode.insertBefore(frag, ref);
-                }
-            });
+            if (hasScriptsToInsert) {
+                fastdom.write(() => {
+                    if (ref && ref.parentNode) {
+                        ref.parentNode.insertBefore(frag, ref);
+                    }
+                });
+            }
         }
     });
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { init, _ } from './third-party-tags';
 import { triggerConsentNotification } from 'lib/cmp';
+import { init, _ } from './third-party-tags';
 
 const { insertScripts, loadOther } = _;
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
+import { triggerConsentNotification } from 'lib/cmp';
 
 const { insertScripts, loadOther } = _;
 
@@ -84,12 +85,7 @@ describe('third party tags', () => {
         };
         it('should add a script to the document', () => {
             insertScripts([fakeThirdPartyTag]);
-            expect(document.scripts.length).toBe(2);
-        });
-    });
-    describe('loadOther', () => {
-        it('should call insert scripts', () => {
-            loadOther();
+            triggerConsentNotification();
             expect(document.scripts.length).toBe(2);
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { triggerConsentNotification } from 'lib/cmp';
+import { _ as cmp } from 'lib/cmp';
 import { init, _ } from './third-party-tags';
 
 const { insertScripts, loadOther } = _;
@@ -85,7 +85,7 @@ describe('third party tags', () => {
         };
         it('should add a script to the document', () => {
             insertScripts([fakeThirdPartyTag]);
-            triggerConsentNotification();
+            cmp.triggerConsentNotification();
             expect(document.scripts.length).toBe(2);
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -1,19 +1,10 @@
 // @flow
 import config from 'lib/config';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 
-export const fbPixel: () => ThirdPartyTag = () => {
-    const consent = getAdConsentState(thirdPartyTrackingAdConsent);
-    return {
-        shouldRun:
-            config.get('switches.facebookTrackingPixel') &&
-            (consent == null || consent),
-        url: `https://www.facebook.com/tr?id=${config.get(
-            'libs.facebookAccountId'
-        )}&ev=PageView&noscript=1`,
-        useImage: true,
-    };
-};
+export const fbPixel: () => ThirdPartyTag = () => ({
+    shouldRun: config.get('switches.facebookTrackingPixel'),
+    url: `https://www.facebook.com/tr?id=${config.get(
+        'libs.facebookAccountId'
+    )}&ev=PageView&noscript=1`,
+    useImage: true,
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -32,20 +32,8 @@ describe('Facebook tracking pixel', () => {
         expect(result.shouldRun).toBe(false);
     });
 
-    it('should not load if consent has been denied', () => {
-        setup({ consent: false, switchedOn: true });
-        const result = fbPixel();
-        expect(result.shouldRun).toBe(false);
-    });
-
-    it('should load if consent is available and the switch enabled', () => {
+    it('should load if the switch enabled', () => {
         setup({ consent: true, switchedOn: true });
-        const result = fbPixel();
-        expect(result.shouldRun).toBe(true);
-    });
-
-    it('if the switch is enabled and consent is null, treat consent as true', () => {
-        setup({ consent: null, switchedOn: true });
         const result = fbPixel();
         expect(result.shouldRun).toBe(true);
     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -3,10 +3,7 @@ import fastdom from 'fastdom';
 
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
+import { consentState } from 'lib/cmp';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
@@ -89,7 +86,7 @@ const setupPlayer = (
     onError
 ) => {
     const wantPersonalisedAds: boolean =
-        getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+        consentState('advertisement') !== false;
     const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
     // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
     const relatedChannels = [];

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -201,7 +201,6 @@ const buildAppNexusTargeting = once(
 
 const buildPageTargetting = (adConsentState: boolean | null): {} => {
     const page = config.get('page');
-    console.log('*** consent state', adConsentState);
     // personalised ads targeting
     const paTargeting: {} =
         adConsentState !== null ? { pa: adConsentState ? 't' : 'f' } : {};

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -12,7 +12,7 @@ import { getUrlVars } from 'lib/url';
 import { getKruxSegments } from 'common/modules/commercial/krux';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
-import { onConsentNotification } from 'lib/cmp';
+import { onConsentNotification, consentState } from 'lib/cmp';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 import { removeFalseyValues } from 'commercial/modules/prebid/utils';
@@ -264,8 +264,17 @@ const getPageTargeting = (): {} => {
     return myPageTargetting;
 };
 
+const resetPageTargeting = (): void => {
+    myPageTargetting = {};
+    latestConsentState = undefined;
+};
+
 export {
     getPageTargeting,
     buildAppNexusTargeting,
     buildAppNexusTargetingObject,
+};
+
+export const _ = {
+    resetPageTargeting,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,4 +1,4 @@
-// @flow strict
+// @flow
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import {
@@ -12,7 +12,7 @@ import { getUrlVars } from 'lib/url';
 import { getKruxSegments } from 'common/modules/commercial/krux';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
-import { onConsentNotification, consentState } from 'lib/cmp';
+import { onConsentNotification } from 'lib/cmp';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 import { removeFalseyValues } from 'commercial/modules/prebid/utils';
@@ -199,7 +199,7 @@ const buildAppNexusTargeting = once(
         formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting))
 );
 
-const buildPageTargetting = (adConsentState: boolean | null): {} => {
+const buildPageTargetting = (adConsentState: boolean | null): Object => {
     const page = config.get('page');
     // personalised ads targeting
     const paTargeting: {} =
@@ -250,7 +250,7 @@ const buildPageTargetting = (adConsentState: boolean | null): {} => {
     return pageTargeting;
 };
 
-const getPageTargeting = (): {} => {
+const getPageTargeting = (): Object => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
     onConsentNotification('advertisement', state => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -208,12 +208,12 @@ const buildPageTargetting = (adConsentState: boolean | null): Object => {
     const pageTargets: PageTargeting = Object.assign(
         {
             sens: page.isSensitive ? 't' : 'f',
-            x: getKruxSegments(),
+            x: getKruxSegments(adConsentState),
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,
             si: isUserLoggedIn() ? 't' : 'f',
-            gdncrm: getUserSegments(),
+            gdncrm: getUserSegments(adConsentState),
             ab: abParam(),
             ref: getReferrer(),
             ms: formatTarget(page.source),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -2,9 +2,8 @@
 import { local } from 'lib/storage';
 
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
+import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import config from 'lib/config';
-import { getCookie as getCookie_ } from 'lib/cookies';
 import {
     getReferrer as getReferrer_,
     getBreakpoint as getBreakpoint_,
@@ -16,9 +15,9 @@ import { getSynchronousParticipations as getSynchronousParticipations_ } from 'c
 import { getKruxSegments as getKruxSegments_ } from 'common/modules/commercial/krux';
 
 import { getAdConsentState as getAdConsentState_ } from 'common/modules/commercial/ad-prefs.lib';
+import { onConsentNotification as onConsentNotification_ } from 'lib/cmp';
 
 const getAdConsentState: any = getAdConsentState_;
-const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
 const getSynchronousParticipations: any = getSynchronousParticipations_;
 const getKruxSegments: any = getKruxSegments_;
@@ -26,6 +25,7 @@ const getReferrer: any = getReferrer_;
 const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
+const onConsentNotification: any = onConsentNotification_;
 
 jest.mock('lib/storage');
 jest.mock('lib/config');
@@ -61,6 +61,10 @@ jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures() {},
+}));
+
+jest.mock('lib/cmp', () => ({
+    onConsentNotification: jest.fn(),
 }));
 
 describe('Build Page Targeting', () => {
@@ -99,10 +103,6 @@ describe('Build Page Targeting', () => {
 
         commercialFeatures.adFree = false;
 
-        // Reset mocking to default values.
-        getAdConsentState.mockReturnValue(null);
-        getCookie.mockReturnValue('ng101');
-
         getBreakpoint.mockReturnValue('mobile');
         getReferrer.mockReturnValue('');
 
@@ -129,11 +129,15 @@ describe('Build Page Targeting', () => {
     });
 
     it('should exist', () => {
-        expect(buildPageTargeting).toBeDefined();
+        expect(getPageTargeting).toBeDefined();
     });
 
     it('should build correct page targeting', () => {
-        const pageTargeting = buildPageTargeting();
+        onConsentNotification.mockImplementation((purpose, callback) => {
+            callback(null);
+        });
+
+        const pageTargeting = getPageTargeting();
 
         expect(pageTargeting.sens).toBe('f');
         expect(pageTargeting.edition).toBe('us');
@@ -157,22 +161,22 @@ describe('Build Page Targeting', () => {
 
     it('should set correct personalized ad (pa) param', () => {
         getAdConsentState.mockReturnValueOnce(true);
-        expect(buildPageTargeting().pa).toBe('t');
+        expect(getPageTargeting().pa).toBe('t');
 
         getAdConsentState.mockReturnValueOnce(false);
-        expect(buildPageTargeting().pa).toBe('f');
+        expect(getPageTargeting().pa).toBe('f');
     });
 
     it('should set correct edition param', () => {
-        expect(buildPageTargeting().edition).toBe('us');
+        expect(getPageTargeting().edition).toBe('us');
     });
 
     it('should set correct se param', () => {
-        expect(buildPageTargeting().se).toEqual(['filmweekly']);
+        expect(getPageTargeting().se).toEqual(['filmweekly']);
     });
 
     it('should set correct k param', () => {
-        expect(buildPageTargeting().k).toEqual([
+        expect(getPageTargeting().k).toEqual([
             'prince-charles-letters',
             'uk/uk',
             'prince-charles',
@@ -180,27 +184,23 @@ describe('Build Page Targeting', () => {
     });
 
     it('should set correct ab param', () => {
-        expect(buildPageTargeting().ab).toEqual(['MtMaster-variantName']);
+        expect(getPageTargeting().ab).toEqual(['MtMaster-variantName']);
     });
 
     it('should set correct krux params', () => {
-        expect(buildPageTargeting().x).toEqual([
-            'E012712',
-            'E012390',
-            'E012478',
-        ]);
+        expect(getPageTargeting().x).toEqual(['E012712', 'E012390', 'E012478']);
     });
 
     it('should set Observer flag for Observer content', () => {
-        expect(buildPageTargeting().ob).toEqual('t');
+        expect(getPageTargeting().ob).toEqual('t');
     });
 
     it('should set correct branding param for paid content', () => {
-        expect(buildPageTargeting().br).toEqual('p');
+        expect(getPageTargeting().br).toEqual('p');
     });
 
     it('should not contain an ad-free targeting value', () => {
-        expect(buildPageTargeting().af).toBeUndefined();
+        expect(getPageTargeting().af).toBeUndefined();
     });
 
     it('should remove empty values', () => {
@@ -209,7 +209,7 @@ describe('Build Page Targeting', () => {
         getUserSegments.mockReturnValue([]);
         getKruxSegments.mockReturnValue([]);
 
-        expect(buildPageTargeting()).toEqual({
+        expect(getPageTargeting()).toEqual({
             sens: 'f',
             bp: 'mobile',
             at: 'ng101',
@@ -226,71 +226,71 @@ describe('Build Page Targeting', () => {
     describe('Breakpoint targeting', () => {
         it('should set correct breakpoint targeting for a mobile device', () => {
             getBreakpoint.mockReturnValue('mobile');
-            expect(buildPageTargeting().bp).toEqual('mobile');
+            expect(getPageTargeting().bp).toEqual('mobile');
         });
 
         it('should set correct breakpoint targeting for a medium mobile device', () => {
             getBreakpoint.mockReturnValue('mobileMedium');
-            expect(buildPageTargeting().bp).toEqual('mobile');
+            expect(getPageTargeting().bp).toEqual('mobile');
         });
 
         it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
             getBreakpoint.mockReturnValue('mobileLandscape');
-            expect(buildPageTargeting().bp).toEqual('mobile');
+            expect(getPageTargeting().bp).toEqual('mobile');
         });
 
         it('should set correct breakpoint targeting for a phablet device', () => {
             getBreakpoint.mockReturnValue('phablet');
-            expect(buildPageTargeting().bp).toEqual('tablet');
+            expect(getPageTargeting().bp).toEqual('tablet');
         });
 
         it('should set correct breakpoint targeting for a tablet device', () => {
             getBreakpoint.mockReturnValue('tablet');
-            expect(buildPageTargeting().bp).toEqual('tablet');
+            expect(getPageTargeting().bp).toEqual('tablet');
         });
 
         it('should set correct breakpoint targeting for a desktop device', () => {
             getBreakpoint.mockReturnValue('desktop');
-            expect(buildPageTargeting().bp).toEqual('desktop');
+            expect(getPageTargeting().bp).toEqual('desktop');
         });
 
         it('should set correct breakpoint targeting for a leftCol device', () => {
             getBreakpoint.mockReturnValue('leftCol');
-            expect(buildPageTargeting().bp).toEqual('desktop');
+            expect(getPageTargeting().bp).toEqual('desktop');
         });
 
         it('should set correct breakpoint targeting for a wide device', () => {
             getBreakpoint.mockReturnValue('wide');
-            expect(buildPageTargeting().bp).toEqual('desktop');
+            expect(getPageTargeting().bp).toEqual('desktop');
         });
     });
 
     describe('Build Page Targeting (ad-free)', () => {
         it('should set the ad-free param to t when enabled', () => {
             commercialFeatures.adFree = true;
-            expect(buildPageTargeting().af).toBe('t');
+            expect(getPageTargeting().af).toBe('t');
         });
     });
 
     describe('Already visited frequency', () => {
         it('can pass a value of five or less', () => {
             local.set('gu.alreadyVisited', 5);
-            expect(buildPageTargeting().fr).toEqual('5');
+            expect(getPageTargeting().fr).toEqual('5');
         });
 
         it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
             local.set('gu.alreadyVisited', 18);
-            expect(buildPageTargeting().fr).toEqual('16-19');
+            expect(getPageTargeting().fr).toEqual('16-19');
         });
 
         it('over thirty, includes it in the bucket "30plus"', () => {
             local.set('gu.alreadyVisited', 300);
-            expect(buildPageTargeting().fr).toEqual('30plus');
+            expect(getPageTargeting().fr).toEqual('30plus');
         });
 
         it('passes a value of 0 if the value is not stored', () => {
             local.remove('gu.alreadyVisited');
-            expect(buildPageTargeting().fr).toEqual('0');
+            expect(getPageTargeting().fr).toEqual('0');
         });
     });
 
@@ -299,33 +299,33 @@ describe('Build Page Targeting', () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'
             );
-            expect(buildPageTargeting().ref).toEqual('facebook');
+            expect(getPageTargeting().ref).toEqual('facebook');
         });
 
         it('should set ref to Twitter', () => {
             getReferrer.mockReturnValue(
                 'https://www.t.co/you-must-unlearn-what-you-have-learned'
             );
-            expect(buildPageTargeting().ref).toEqual('twitter');
+            expect(getPageTargeting().ref).toEqual('twitter');
         });
 
         it('should set ref to reddit', () => {
             getReferrer.mockReturnValue(
                 'https://www.reddit.com/its-not-my-fault'
             );
-            expect(buildPageTargeting().ref).toEqual('reddit');
+            expect(getPageTargeting().ref).toEqual('reddit');
         });
 
         it('should set ref to google', () => {
             getReferrer.mockReturnValue(
                 'https://www.google.com/i-find-your-lack-of-faith-distrubing'
             );
-            expect(buildPageTargeting().ref).toEqual('google');
+            expect(getPageTargeting().ref).toEqual('google');
         });
 
         it('should set ref empty string if referrer does not match', () => {
             getReferrer.mockReturnValue('https://theguardian.com');
-            expect(buildPageTargeting().ref).toEqual(undefined);
+            expect(getPageTargeting().ref).toEqual(undefined);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -16,10 +16,7 @@ import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
 import { getKruxSegments as getKruxSegments_ } from 'common/modules/commercial/krux';
-import {
-    onConsentNotification as onConsentNotification_,
-    consentState as consentState_,
-} from 'lib/cmp';
+import { onConsentNotification as onConsentNotification_ } from 'lib/cmp';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
@@ -30,7 +27,6 @@ const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
 const onConsentNotification: any = onConsentNotification_;
-const consentState: any = consentState_;
 
 jest.mock('lib/storage');
 jest.mock('lib/config');
@@ -66,20 +62,12 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 
 jest.mock('lib/cmp', () => ({
     onConsentNotification: jest.fn(),
-    consentState: jest.fn(),
+    consentState: jest.fn(() => null),
 }));
 
-const trueConsentMock = (purpose, callback): void => {
-    callback(true);
-};
-
-const falseConsentMock = (purpose, callback): void => {
-    callback(false);
-};
-
-const nullConsentMock = (purpose, callback): void => {
-    callback(null);
-};
+const trueConsentMock = (purpose, callback): void => callback(true);
+const falseConsentMock = (purpose, callback): void => callback(false);
+const nullConsentMock = (purpose, callback): void => callback(null);
 
 describe('Build Page Targeting', () => {
     beforeEach(() => {

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -3,6 +3,7 @@ import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import reportError from 'lib/report-error';
 import { local } from 'lib/storage';
+import { consent } from 'lib/cmp';
 import {
     getAdConsentState,
     thirdPartyTrackingAdConsent,
@@ -60,8 +61,7 @@ const retrieve = (n: string): string => {
 };
 
 export const getKruxSegments = (): Array<string> => {
-    const wantPersonalisedAds: boolean =
-        getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    const wantPersonalisedAds: boolean = consent('advertisement') !== false;
     const segments: string = wantPersonalisedAds ? retrieve('segs') : '';
     return segments ? segments.split(',') : [];
 };

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import reportError from 'lib/report-error';
 import { local } from 'lib/storage';
-import { consent } from 'lib/cmp';
+import { consentState } from 'lib/cmp';
 
 let numRetries = 0;
 
@@ -57,7 +57,8 @@ const retrieve = (n: string): string => {
 };
 
 export const getKruxSegments = (): Array<string> => {
-    const wantPersonalisedAds: boolean = consent('advertisement') !== false;
+    const wantPersonalisedAds: boolean =
+        consentState('advertisement') !== false;
     const segments: string = wantPersonalisedAds ? retrieve('segs') : '';
     return segments ? segments.split(',') : [];
 };

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -11,9 +11,9 @@ const configureSegments = () => {
     if (window.Krux) {
         // For flag values, see https://konsole.zendesk.com/hc/en-us/articles/360000754674-JavaScript-Consent-Tag-Spec
         const consentFlags = {
-            dc: false,
-            al: false,
-            tg: false,
+            dc: true,
+            al: true,
+            tg: true,
             cd: false,
             sh: false,
             re: false,

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -4,10 +4,6 @@ import { getCookie } from 'lib/cookies';
 import reportError from 'lib/report-error';
 import { local } from 'lib/storage';
 import { consent } from 'lib/cmp';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 
 let numRetries = 0;
 

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -8,63 +8,38 @@ import {
     thirdPartyTrackingAdConsent,
 } from 'common/modules/commercial/ad-prefs.lib';
 
-// For flag values, see https://konsole.zendesk.com/hc/en-us/articles/360000754674-JavaScript-Consent-Tag-Spec
-const setConsentFlags = consentFlags => {
-    window.Krux('consent:set', consentFlags, ex => {
-        if (ex) {
-            switch (ex.idv) {
-                case 'no identifier found for user':
-                case 'user opted out via (optout or dnt)':
-                    break; // swallow these as they're harmless
-                default: {
-                    const exStr = Object.keys(ex)
-                        .map(prop => `${prop} -> '${ex[prop]}'`)
-                        .join(', ');
-                    const msg = `KRUX: ${exStr}`;
-                    reportError(new Error(msg), {
-                        feature: 'krux:consent:set',
-                        consentFlags,
-                    });
-                }
-            }
-        }
-    });
-};
-
-const enableSegments = () => {
-    setConsentFlags({
-        dc: true,
-        al: true,
-        tg: true,
-        cd: false,
-        sh: false,
-        re: false,
-    });
-};
-
-const disableSegments = () => {
-    setConsentFlags({
-        dc: false,
-        al: false,
-        tg: false,
-        cd: false,
-        sh: false,
-        re: false,
-    });
-};
-
 let numRetries = 0;
 
 const configureSegments = () => {
     if (window.Krux) {
-        // everything except an explicit denial of consent gives segments
-        const consentToSegments =
-            getAdConsentState(thirdPartyTrackingAdConsent) !== false;
-        if (consentToSegments) {
-            enableSegments();
-        } else {
-            disableSegments();
-        }
+        // For flag values, see https://konsole.zendesk.com/hc/en-us/articles/360000754674-JavaScript-Consent-Tag-Spec
+        const consentFlags = {
+            dc: false,
+            al: false,
+            tg: false,
+            cd: false,
+            sh: false,
+            re: false,
+        };
+        window.Krux('consent:set', consentFlags, ex => {
+            if (ex) {
+                switch (ex.idv) {
+                    case 'no identifier found for user':
+                    case 'user opted out via (optout or dnt)':
+                        break; // swallow these as they're harmless
+                    default: {
+                        const exStr = Object.keys(ex)
+                            .map(prop => `${prop} -> '${ex[prop]}'`)
+                            .join(', ');
+                        const msg = `KRUX: ${exStr}`;
+                        reportError(new Error(msg), {
+                            feature: 'krux:consent:set',
+                            consentFlags,
+                        });
+                    }
+                }
+            }
+        });
     } else if (numRetries < 20) {
         // give up to 2s for slow networks
         numRetries += 1;

--- a/static/src/javascripts/projects/common/modules/commercial/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/krux.js
@@ -3,7 +3,6 @@ import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import reportError from 'lib/report-error';
 import { local } from 'lib/storage';
-import { consentState } from 'lib/cmp';
 
 let numRetries = 0;
 
@@ -56,10 +55,10 @@ const retrieve = (n: string): string => {
     return local.getRaw(k) || getCookie(`${k}=([^;]*)`) || '';
 };
 
-export const getKruxSegments = (): Array<string> => {
-    const wantPersonalisedAds: boolean =
-        consentState('advertisement') !== false;
-    const segments: string = wantPersonalisedAds ? retrieve('segs') : '';
+export const getKruxSegments = (
+    adConsentState: boolean | null
+): Array<string> => {
+    const segments: string = adConsentState !== false ? retrieve('segs') : '';
     return segments ? segments.split(',') : [];
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
@@ -1,11 +1,12 @@
 // @flow
 import { local } from 'lib/storage';
 import { getUserFromCookie, getUserFromApi } from 'common/modules/identity/api';
+import { consentState } from 'lib/cmp';
 
 const userSegmentsKey = 'gu.ads.userSegmentsData';
 
-const getUserSegments = function(): Array<any> {
-    if (local.isAvailable()) {
+const getUserSegments = (): Array<any> => {
+    if (local.isAvailable() && consentState('advertisement') !== false) {
         let userCookieData;
         const userSegmentsData = local.get(userSegmentsKey);
 
@@ -25,11 +26,12 @@ const getUserSegments = function(): Array<any> {
     return [];
 };
 
-const requestUserSegmentsFromId = function(): void {
+const requestUserSegmentsFromId = (): void => {
     if (
         local.isAvailable() &&
         local.get(userSegmentsKey) === null &&
-        getUserFromCookie()
+        getUserFromCookie() &&
+        consentState('advertisement') !== false
     ) {
         getUserFromApi(user => {
             if (user && user.adData) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
@@ -5,8 +5,8 @@ import { consentState } from 'lib/cmp';
 
 const userSegmentsKey = 'gu.ads.userSegmentsData';
 
-const getUserSegments = (): Array<any> => {
-    if (local.isAvailable() && consentState('advertisement') !== false) {
+const getUserSegments = (adConsentState: boolean | null): Array<any> => {
+    if (local.isAvailable() && adConsentState !== false) {
         const userSegmentsData = local.get(userSegmentsKey);
 
         if (userSegmentsData) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
@@ -7,11 +7,10 @@ const userSegmentsKey = 'gu.ads.userSegmentsData';
 
 const getUserSegments = (): Array<any> => {
     if (local.isAvailable() && consentState('advertisement') !== false) {
-        let userCookieData;
         const userSegmentsData = local.get(userSegmentsKey);
 
         if (userSegmentsData) {
-            userCookieData = getUserFromCookie();
+            const userCookieData = getUserFromCookie();
 
             if (
                 userCookieData &&

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.spec.js
@@ -42,8 +42,7 @@ describe('User Ad Targeting', () => {
             userHash: 123,
             segments: 'something',
         });
-        consentState.mockImplementation(() => false);
-        expect(getUserSegments().length).toBe(0);
+        expect(getUserSegments(false).length).toBe(0);
     });
 
     it('should return user segments data from local storage when consent is true', () => {
@@ -52,7 +51,7 @@ describe('User Ad Targeting', () => {
             userHash: 123,
             segments: 'something',
         });
-        expect(getUserSegments()).toBe('something');
+        expect(getUserSegments(true)).toBe('something');
     });
 
     it('should return user segments data from local storage when consent is null', () => {
@@ -61,7 +60,7 @@ describe('User Ad Targeting', () => {
             userHash: 123,
             segments: 'something',
         });
-        expect(getUserSegments()).toBe('something');
+        expect(getUserSegments(null)).toBe('something');
     });
 
     it('should remove user segments belonging to another user from local storage', () => {
@@ -70,7 +69,7 @@ describe('User Ad Targeting', () => {
             userHash: 456,
             segments: 'anything',
         });
-        expect(getUserSegments().length).toBe(0);
+        expect(getUserSegments(true).length).toBe(0);
         expect(local.get(userSegmentsKey)).toBeFalsy();
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
+++ b/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
@@ -1,13 +1,13 @@
 // @flow
 import config from 'lib/config';
 import { constructQuery } from 'lib/url';
-import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
+import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 
 const videoAdUrl = (): string => {
     const queryParams = {
         ad_rule: 1,
         correlator: new Date().getTime(),
-        cust_params: encodeURIComponent(constructQuery(buildPageTargeting())),
+        cust_params: encodeURIComponent(constructQuery(getPageTargeting())),
         env: 'vp',
         gdfp_req: 1,
         impl: 's',


### PR DESCRIPTION
## What does this change?
This PR introduces the new CMP library that will contain all consent related logic. All it currently does is change the way Commercial modules work with consent, but the library itself gets the consent state the same way we previous did (through `ad-prefs.lib.js`).
Although this PR only change Commercial modules to work with the new library other teams are encouraged to use it as well.

### A little context
We want to improve the way we handle consent on *.theguardian.com.
One of the things we need to do to achieve that is have our consent-dependant modules change their behaviour when the consent state changes, which can happen at any time during runtime. This means that based on the consent state modules should activate or deactivate themselves or change the way they run, which is what we're trying to achieve with this PR.
Other things we need to do to improve the way we handle consent is having a better consent UI and have a more complex consent cookie to reflect that improved consent UI. These two points aren't in scope for this PR.

### The CMP library
The idea for the library is that it should be used as an event listener so that a component can register a callback to be run when the consent state they subscribe to changes. The only difference from a regular event listener is that the callback will also be called after library initialisation (after reading the consent cookie) or immediately after registering the callback if the library has already been initialised.
However in certain cases the event listener approach by itself isn't enough. For those cases we expose a function that returns consent state at the time it's called. Note: This approach should not be used to decide whether a module should run or not as it would mean the module would not be able to react to consent state changes. (If you want to see an example where this approach is needed take a look at the exposed function `getKruxSegments()` in `krux.js` that is used to build the page targeting.)


The CMP library exposes the following functions:

1. `init()`: Initialises the library. Runs all callbacks.
1. `onConsentNotification(purposeName, callback)`: Acts like an event listener. Is used to set a callback function to be run whenever the consent state of the provided purpose is changed. The callback is also run immediately if the library is already initialised. The consent state  (boolean or null) of the indicated purpose is passed  to the callback as an argument.
1. `consentState(purposeName)`: Returns the consent state (boolean or null) of the indicated purpose.

### Future work
1. The logic to read the consent cookie will be replaced to read a more complex cookie
1. The library will be extracted into it's our external library and will be imported into frontend as a dependancy

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [X] Locally
- [X] On CODE (optional)