### PR TITLE
Update the date display in AMP liveblogs

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -45,6 +45,7 @@ case class Block(
     elements: List[PageElement],
     createdOn: Option[Long],
     createdOnDisplay: Option[String],
+    lastUpdated: Option[Long],
     lastUpdatedDisplay: Option[String],
     firstPublished: Option[Long],
     firstPublishedDisplay: Option[String],
@@ -297,6 +298,7 @@ object DotcomponentsDataModel {
 
       val createdOn = block.createdDate.map(_.dateTime)
       val createdOnDisplay = createdOn.map(dt => format(dt, edition))
+      val lastUpdated = block.lastModifiedDate.map(_.dateTime)
       val lastUpdatedDisplay = block.lastModifiedDate.map(dt => format(dt.dateTime, edition))
       val firstPublished = block.firstPublishedDate.orElse(block.createdDate).map(_.dateTime)
       val firstPublishedDisplay = firstPublished.map(dt => format(dt, edition))
@@ -306,6 +308,7 @@ object DotcomponentsDataModel {
         elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks),
         createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
+        lastUpdated = lastUpdated,
         lastUpdatedDisplay = lastUpdatedDisplay,
         title = block.title,
         firstPublished = firstPublished,

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -136,9 +136,7 @@ object GUDateTimeFormat {
     }
   }
   def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
-    // The reason for .toLowerCase is that I could not find the code for lowercase half day marker: am or pm
-    // So we "4.59 PM".toLowerCase
-    dateTime.toString(DateTimeFormat.forPattern("h.mm a").withZone(timezone)).toLowerCase
+    dateTime.toString(DateTimeFormat.forPattern("HH:mm z").withZone(timezone))
   }
 }
 


### PR DESCRIPTION
## What does this change?

This PR adds a missing attribute to the dotcom-rendering `Block` case class and update the (currently confusing) display of dates in the dotcom-rendered liveblog.

Note that the change was easy because there is a dedicated function to generate date displays for the liveblogs.

**Before**

![Screenshot 2019-07-30 at 13 40 30](https://user-images.githubusercontent.com/6035518/62129861-a0f69600-b2cf-11e9-8c97-5b51edd55c4b.png)


**After**

![Screenshot 2019-07-30 at 13 39 22](https://user-images.githubusercontent.com/6035518/62129787-77d60580-b2cf-11e9-88b3-dd2f5737ad06.png)

