### PR TITLE
Changing 'Discount Codes' to 'Discount Coupons' in the UK edition.

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -192,7 +192,7 @@ private object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodes = NavLink("Discount Codes", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
-  val discountCoupons = NavLink("Discount Coupons", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
+  val discountCoupons = NavLink("Coupons", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -192,6 +192,7 @@ private object NavLinks {
   val holidays = NavLink("Holidays", "https://holidays.theguardian.com")
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val discountCodes = NavLink("Discount Codes", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
+  val discountCoupons = NavLink("Discount Coupons", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),
@@ -526,7 +527,7 @@ private object NavLinks {
   val usBrandExtensions= List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
     digitalNewspaperArchive,
-    discountCodes
+    discountCoupons
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -207,7 +207,7 @@
                                     <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
                                         Dating</a>
                                     <li class="colophon__item"><a class="js-discount-code-link" data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
-                                        Discount Codes</a>
+                                        Coupons</a>
                                     </li>
                                 </ul>
 


### PR DESCRIPTION
## What does this change?

This changes 'Discount Codes' to 'Coupons' in both the navigation and footer when viewing the US edition.

## Screenshots

Before:
![Screen Shot 2019-07-31 at 16 50 25](https://user-images.githubusercontent.com/2051501/62227183-5cdcc180-b3b3-11e9-9d4e-063ee21aa3ad.png)

After:
![Screen Shot 2019-07-31 at 16 51 29](https://user-images.githubusercontent.com/2051501/62227273-7e3dad80-b3b3-11e9-8329-cae4e4e95999.png)

