### PR TITLE
 Get geolocation once in contributions-utilities 

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -62,7 +62,6 @@ declare type Runnable<T: ABTest> = T & {
 declare type AcquisitionsABTest = ABTest & {
     campaignId: string,
     componentType: OphanComponentType,
-    geolocation: ?string,
 };
 
 declare type MaxViews = {
@@ -131,7 +130,6 @@ declare type InitEpicABTest = {
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
-    geolocation: ?string,
     highPriority: boolean,
 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -55,7 +55,7 @@ import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy'
 import { initTicker } from 'common/modules/commercial/ticker';
 import once from 'lodash/once';
 
-export const currentGeoLocation = once((): string => geolocationGetSync());
+const currentGeoLocation = once((): string => geolocationGetSync());
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -775,7 +775,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                     const countryGroups = rowWithLocations
                         ? optionalSplitAndTrim(rowWithLocations.locations, ',')
                         : [];
-                    
+
                     return {
                         id: testName,
                         campaignId: testName,
@@ -813,7 +813,7 @@ export const getEngagementBannerTestsFromGoogleDoc = (): Promise<
                                 ? buildBannerCopy(
                                       row.leadSentence.trim(),
                                       testHasCountryName,
-                                    currentGeoLocation()
+                                      currentGeoLocation()
                                   )
                                 : undefined;
 
@@ -880,4 +880,5 @@ export {
     getVisitCount,
     buildEpicCopy,
     buildBannerCopy,
+    currentGeoLocation,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -3,13 +3,11 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
     campaignId: 'epic_always_ask_if_tagged',
 
-    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-05-23',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -4,10 +4,9 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 import {
     getCountryName,
     getLocalCurrencySymbol,
-    getSync as geolocationGetSync,
 } from 'lib/geolocation';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
+import { buildBannerCopy, currentGeoLocation } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
@@ -15,13 +14,12 @@ const articleCountDays = 30;
 
 const articleViewCount = getArticleViewCount(articleCountDays);
 
-const geolocation = geolocationGetSync();
-const isUSUKAU = ['GB', 'US', 'AU'].includes(geolocation);
+const isUSUKAU = ['GB', 'US', 'AU'].includes(currentGeoLocation());
 
 const messageText =
     'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
 const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
-    geolocation
+    currentGeoLocation()
 )}1</span>`;
 const USUKAUControlLeadSentence =
     'We chose a different approach. Will you support it?';
@@ -41,10 +39,9 @@ export const articlesViewedBanner: AcquisitionsABTest = {
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
     canRun: () =>
-        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
+        articleViewCount >= minArticleViews && !!getCountryName(currentGeoLocation()),
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    geolocation,
     variants: [
         {
             id: 'control',
@@ -55,7 +52,7 @@ export const articlesViewedBanner: AcquisitionsABTest = {
                         ? USUKAUControlLeadSentence
                         : ROWControlLeadSentence,
                     !isUSUKAU,
-                    geolocation
+                    currentGeoLocation()
                 ),
                 messageText,
                 ctaText,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -1,12 +1,12 @@
 // @flow
 
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
-import {
-    getCountryName,
-    getLocalCurrencySymbol,
-} from 'lib/geolocation';
+import { getCountryName, getLocalCurrencySymbol } from 'lib/geolocation';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { buildBannerCopy, currentGeoLocation } from 'common/modules/commercial/contributions-utilities';
+import {
+    buildBannerCopy,
+    currentGeoLocation,
+} from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
@@ -39,7 +39,8 @@ export const articlesViewedBanner: AcquisitionsABTest = {
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
     canRun: () =>
-        articleViewCount >= minArticleViews && !!getCountryName(currentGeoLocation()),
+        articleViewCount >= minArticleViews &&
+        !!getCountryName(currentGeoLocation()),
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -6,6 +6,7 @@ import {
     currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
+import { getCountryName } from 'lib/geolocation';
 
 // User must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -57,7 +58,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     highPriority: true,
 
     canRun: () =>
-        articleViewCount >= minArticleViews && !!getCountryName(currentGeoLocation()),
+        articleViewCount >= minArticleViews &&
+        !!getCountryName(currentGeoLocation()),
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -3,9 +3,9 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
     buildEpicCopy,
+    currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // User must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -36,8 +36,7 @@ const ROWControlCopy = {
     highlightedText,
 };
 
-const geolocation = geolocationGetSync();
-const isUSUK = ['GB', 'US'].includes(geolocation);
+const isUSUK = ['GB', 'US'].includes(currentGeoLocation());
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicArticlesViewedMonth',
@@ -55,11 +54,10 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
-    geolocation,
     highPriority: true,
 
     canRun: () =>
-        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
+        articleViewCount >= minArticleViews && !!getCountryName(currentGeoLocation()),
 
     variants: [
         {
@@ -69,7 +67,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             copy: buildEpicCopy(
                 isUSUK ? USUKControlCopy : ROWControlCopy,
                 !isUSUK,
-                geolocation
+                currentGeoLocation()
             ),
         },
         {
@@ -87,7 +85,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                     highlightedText,
                 },
                 false,
-                geolocation
+                currentGeoLocation()
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -3,13 +3,11 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
     campaignId: 'kr1_epic_ask_four_earning',
 
-    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-01-24',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -5,6 +5,7 @@ import {
     buildEpicCopy,
     currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
+import { getCountryName } from 'lib/geolocation';
 
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
@@ -22,7 +23,6 @@ export const countryName: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
-    geolocation,
     highPriority: true,
 
     canRun: () =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -3,10 +3,8 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
     buildEpicCopy,
+    currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
-import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
-
-const geolocation = geolocationGetSync();
 
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
@@ -28,9 +26,9 @@ export const countryName: EpicABTest = makeEpicABTest({
     highPriority: true,
 
     canRun: () =>
-        geolocation !== 'US' &&
-        geolocation !== 'GB' &&
-        !!getCountryName(geolocation),
+        currentGeoLocation() !== 'US' &&
+        currentGeoLocation() !== 'GB' &&
+        !!getCountryName(currentGeoLocation()),
 
     variants: [
         {
@@ -49,7 +47,7 @@ export const countryName: EpicABTest = makeEpicABTest({
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },
                 true,
-                geolocation
+                currentGeoLocation()
             ),
         },
     ],


### PR DESCRIPTION
## What does this change?
The Commercial team has noticed issues which may relate to geolocation selection since the day [this PR](https://github.com/guardian/frontend/pull/21622/files) was merged.
We're not certain what the cause is. One theory is that we're now trying to fetch the geolocation from local storage too many times at once.

This change reduces the number of times we get the geolocation when creating contributions tests.
Rather than fetching it at the point that we create each test, it uses `once` to only calculate the value once across all test.

We can determine if it fixes the issue by running a report after it's been live for a few hours.

## Screenshots
Country name tests:
<img width="729" alt="Screenshot 2019-08-02 at 10 14 20" src="https://user-images.githubusercontent.com/1513454/62359902-a80be700-b50f-11e9-8aad-00a93efb5ddf.png">
Articles viewed tests:
<img width="729" alt="Screenshot 2019-08-02 at 10 14 30" src="https://user-images.githubusercontent.com/1513454/62359907-ae9a5e80-b50f-11e9-98cf-2003eb152b1a.png">
Fall backs:
<img width="729" alt="Screenshot 2019-08-02 at 10 24 24" src="https://user-images.githubusercontent.com/1513454/62359928-b78b3000-b50f-11e9-88ae-02e74a4b80bb.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
