### PR TITLE
Add @guardian/dotcom-platform to Commercial codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # See https://help.github.com/articles/about-codeowners/
 
 # Commercial Dev code
-/static/src/javascripts/projects/common/modules/commercial/ @guardian/commercial-dev
-/static/src/javascripts/projects/commercial/ @guardian/commercial-dev
-/commercial/ @guardian/commercial-dev
+/static/src/javascripts/projects/common/modules/commercial/ @guardian/commercial-dev @guardian/dotcom-platform
+/static/src/javascripts/projects/commercial/ @guardian/commercial-dev @guardian/dotcom-platform
+/commercial/ @guardian/commercial-dev @guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

This adds @guardian/dotcom-platform to the CODEOWNERS for Commercial code so that we're made aware of changes that might need reflecting or be affecting Dotcom Rendering.

This is likely temp as could be too noisy for Dotcom Platform...

@guardian/commercial-dev 