### PR TITLE
Introduce CMP library only

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -33,7 +33,6 @@ import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import { isBreakpoint } from 'lib/detect';
 import config from 'lib/config';
-import { init as initCmp } from 'lib/cmp';
 import { newHeaderInit } from 'common/modules/navigation/new-header';
 import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
@@ -205,9 +204,6 @@ const bootStandard = (): void => {
 
     // Set adtest query if url param declares it
     setAdTestCookie();
-
-    // Initialise the CMP library
-    initCmp();
 
     // set a short-lived cookie to trigger server-side ad-freeness
     // if the user is genuinely ad-free, this one will be overwritten

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -33,6 +33,7 @@ import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import { isBreakpoint } from 'lib/detect';
 import config from 'lib/config';
+import { init as initCmp } from 'lib/cmp';
 import { newHeaderInit } from 'common/modules/navigation/new-header';
 import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
@@ -204,6 +205,9 @@ const bootStandard = (): void => {
 
     // Set adtest query if url param declares it
     setAdTestCookie();
+
+    // Initialise the CMP library
+    initCmp();
 
     // set a short-lived cookie to trigger server-side ad-freeness
     // if the user is genuinely ad-free, this one will be overwritten

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -37,28 +37,7 @@ const triggerConsentNotification = (): void => {
     });
 };
 
-export const onConsentNotification = (
-    purposeName: PurposeEvent,
-    callback: PurposeCallback
-): void => {
-    const purpose = purposes[purposeName];
-
-    if (cmpIsReady) {
-        callback(purpose.state);
-    }
-
-    purpose.callbacks.push(callback);
-};
-
-export const consentState = (purposeName: PurposeEvent): boolean | null =>
-    purposes[purposeName].state;
-
-export const init = (): void => {
-    // do nothing if init has already been called
-    if (cmpIsReady) {
-        return;
-    }
-
+const init = (): void => {
     /**
      * These state assignments are temporary
      * and will eventually be replaced by values
@@ -71,8 +50,29 @@ export const init = (): void => {
     );
 
     cmpIsReady = true;
+};
 
-    triggerConsentNotification();
+export const onConsentNotification = (
+    purposeName: PurposeEvent,
+    callback: PurposeCallback
+): void => {
+    const purpose = purposes[purposeName];
+
+    if (!cmpIsReady) {
+        init();
+    }
+
+    callback(purpose.state);
+
+    purpose.callbacks.push(callback);
+};
+
+export const consentState = (purposeName: PurposeEvent): boolean | null => {
+    if (!cmpIsReady) {
+        init();
+    }
+
+    return purposes[purposeName].state;
 };
 
 // Exposed for testing purposes

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -1,0 +1,89 @@
+// @flow
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
+
+type PurposeEvent = 'functional' | 'performance' | 'advertisement';
+
+type PurposeCallback = (state: boolean | null) => void;
+
+type Purpose = {
+    state: boolean | null,
+    callbacks: Array<PurposeCallback>,
+};
+
+let cmpIsReady = false;
+
+const purposes: { [PurposeEvent]: Purpose } = {
+    functional: {
+        state: null,
+        callbacks: [],
+    },
+    performance: {
+        state: null,
+        callbacks: [],
+    },
+    advertisement: {
+        state: null,
+        callbacks: [],
+    },
+};
+
+const triggerConsentNotification = (): void => {
+    Object.keys(purposes).forEach(key => {
+        const purpose = purposes[key];
+        purpose.callbacks.forEach(callback => callback(purpose.state));
+    });
+};
+
+export const onConsentNotification = (
+    purposeName: PurposeEvent,
+    callback: PurposeCallback
+): void => {
+    const purpose = purposes[purposeName];
+
+    if (cmpIsReady) {
+        callback(purpose.state);
+    }
+
+    purpose.callbacks.push(callback);
+};
+
+export const consentState = (purposeName: PurposeEvent): boolean | null =>
+    purposes[purposeName].state;
+
+export const init = (): void => {
+    // do nothing if init has already been called
+    if (cmpIsReady) {
+        return;
+    }
+
+    /**
+     * These state assignments are temporary
+     * and will eventually be replaced by values
+     * read from the CMP cookie.
+     * */
+    purposes.functional.state = true;
+    purposes.performance.state = true;
+    purposes.advertisement.state = getAdConsentState(
+        thirdPartyTrackingAdConsent
+    );
+
+    cmpIsReady = true;
+
+    triggerConsentNotification();
+};
+
+// Exposed for testing purposes
+export const _ = {
+    triggerConsentNotification,
+    resetCmp: (): void => {
+        cmpIsReady = false;
+        Object.keys(purposes).forEach(key => {
+            const purpose = purposes[key];
+            purpose.state = null;
+            purpose.callbacks = [];
+        });
+    },
+};

--- a/static/src/javascripts/lib/cmp.js
+++ b/static/src/javascripts/lib/cmp.js
@@ -58,7 +58,7 @@ const triggerConsentNotification = (): void => {
     });
 };
 
-const onConsentNotification = (
+export const onConsentNotification = (
     purposeName: PurposeEvent,
     callback: PurposeCallback
 ): void => {
@@ -70,14 +70,6 @@ const onConsentNotification = (
 
     purpose.callbacks.push(callback);
 };
-
-const consentState = (purposeName: PurposeEvent): boolean | null => {
-    checkCmpReady();
-
-    return purposes[purposeName].state;
-};
-
-export { onConsentNotification, consentState };
 
 // Exposed for testing purposes
 export const _ = {

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -66,30 +66,42 @@ describe('cmp', () => {
     });
 
     describe('onConsentNotification', () => {
+        const purposes = ['functional', 'performance', 'advertisement'];
+
         describe('if cmpIsReady is TRUE when onConsentNotification called', () => {
-            it('executes functional callback', () => {
+            purposes.forEach(purpose => {
+                it(`executes ${purpose} callback immediately`, () => {
+                    const myCallBack = jest.fn();
+
+                    init();
+
+                    onConsentNotification(purpose, myCallBack);
+
+                    expect(myCallBack).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            it('executes functional callback with initial functional state', () => {
                 const myCallBack = jest.fn();
 
                 init();
 
                 onConsentNotification('functional', myCallBack);
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('executes performance callback', () => {
+            it('executes performance callback with initial performance state', () => {
                 const myCallBack = jest.fn();
 
                 init();
 
                 onConsentNotification('performance', myCallBack);
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('executes advertisement callback with true if getAdConsentState true', () => {
+            it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
                 getAdConsentState.mockReturnValue(true);
 
                 const myCallBack = jest.fn();
@@ -98,11 +110,10 @@ describe('cmp', () => {
 
                 onConsentNotification('advertisement', myCallBack);
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('executes advertisement callback with true if getAdConsentState false', () => {
+            it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
                 getAdConsentState.mockReturnValue(false);
 
                 const myCallBack = jest.fn();
@@ -111,8 +122,19 @@ describe('cmp', () => {
 
                 onConsentNotification('advertisement', myCallBack);
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(false);
+            });
+
+            it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
+                getAdConsentState.mockReturnValue(null);
+
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toBeCalledWith(null);
             });
 
             it('executes advertisement callback each time consent nofication triggered', () => {
@@ -134,61 +156,75 @@ describe('cmp', () => {
             });
         });
 
-        describe('if cmpIsReady is FALSE when onConsentNotification called waits to', () => {
-            it('execute functional callback', () => {
+        describe('if cmpIsReady is FALSE when onConsentNotification', () => {
+            purposes.forEach(purpose => {
+                it(`waits to execute ${purpose} callback until cmpIsReady`, () => {
+                    const myCallBack = jest.fn();
+
+                    onConsentNotification(purpose, myCallBack);
+
+                    expect(myCallBack).not.toHaveBeenCalled();
+
+                    init();
+
+                    expect(myCallBack).toHaveBeenCalledTimes(1);
+                });
+            });
+
+            it('executes functional callback with initial functional state', () => {
                 const myCallBack = jest.fn();
 
                 onConsentNotification('functional', myCallBack);
 
-                expect(myCallBack).not.toBeCalled();
-
                 init();
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('execute performance callback', () => {
+            it('executes performance callback with initial performance state', () => {
                 const myCallBack = jest.fn();
 
                 onConsentNotification('performance', myCallBack);
 
-                expect(myCallBack).not.toBeCalled();
-
                 init();
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('execute advertisement callback with true if getAdConsentState true', () => {
+            it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
                 getAdConsentState.mockReturnValue(true);
 
                 const myCallBack = jest.fn();
 
                 onConsentNotification('advertisement', myCallBack);
 
-                expect(myCallBack).not.toBeCalled();
-
                 init();
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
                 expect(myCallBack).toBeCalledWith(true);
             });
 
-            it('execute advertisement callback with true if getAdConsentState false', () => {
+            it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
                 getAdConsentState.mockReturnValue(false);
 
                 const myCallBack = jest.fn();
 
                 onConsentNotification('advertisement', myCallBack);
 
-                expect(myCallBack).not.toBeCalled();
+                init();
+
+                expect(myCallBack).toBeCalledWith(false);
+            });
+
+            it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
+                getAdConsentState.mockReturnValue(null);
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
 
                 init();
 
-                expect(myCallBack).toHaveBeenCalledTimes(1);
-                expect(myCallBack).toBeCalledWith(false);
+                expect(myCallBack).toBeCalledWith(null);
             });
 
             it('execute advertisement callback each time consent nofication triggered', () => {

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { init, onConsentNotification, consentState, _ } from 'lib/cmp';
+import { onConsentNotification, consentState, _ } from 'lib/cmp';
 import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 
 const getAdConsentState: any = _getAdConsentState;
@@ -15,52 +15,19 @@ describe('cmp', () => {
         getAdConsentState.mockReset();
     });
 
-    it('does not re-trigger consent notifications if init called multiple times', () => {
-        const myCallBack = jest.fn();
-
-        init();
-
-        onConsentNotification('functional', myCallBack);
-
-        expect(myCallBack).toHaveBeenCalledTimes(1);
-
-        init();
-
-        expect(myCallBack).toHaveBeenCalledTimes(1);
-    });
-
     describe('consentState', () => {
-        it('returns null state if cmp lib has not been initialised', () => {
-            expect(consentState('functional')).toBeNull();
-            expect(consentState('performance')).toBeNull();
-            expect(consentState('advertisement')).toBeNull();
-        });
-
-        it('returns functional consent state', () => {
-            init();
-
+        it('returns initial functional consent state', () => {
             expect(consentState('functional')).toBe(true);
         });
-
-        it('returns performance consent state', () => {
-            init();
-
+        it('returns initial performance consent state', () => {
             expect(consentState('performance')).toBe(true);
         });
-
-        it('returns advertisement consent state with true if getAdConsentState true', () => {
+        it('returns initial advertisement consent state as true if getAdConsentState true', () => {
             getAdConsentState.mockReturnValue(true);
-
-            init();
-
             expect(consentState('advertisement')).toBe(true);
         });
-
-        it('returns advertisement consent state with false if getAdConsentState true', () => {
+        it('returns initial advertisement consent state as false if getAdConsentState true', () => {
             getAdConsentState.mockReturnValue(false);
-
-            init();
-
             expect(consentState('advertisement')).toBe(false);
         });
     });
@@ -73,8 +40,6 @@ describe('cmp', () => {
                 it(`executes ${purpose} callback immediately`, () => {
                     const myCallBack = jest.fn();
 
-                    init();
-
                     onConsentNotification(purpose, myCallBack);
 
                     expect(myCallBack).toHaveBeenCalledTimes(1);
@@ -84,8 +49,6 @@ describe('cmp', () => {
             it('executes functional callback with initial functional state', () => {
                 const myCallBack = jest.fn();
 
-                init();
-
                 onConsentNotification('functional', myCallBack);
 
                 expect(myCallBack).toBeCalledWith(true);
@@ -93,8 +56,6 @@ describe('cmp', () => {
 
             it('executes performance callback with initial performance state', () => {
                 const myCallBack = jest.fn();
-
-                init();
 
                 onConsentNotification('performance', myCallBack);
 
@@ -106,8 +67,6 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                init();
-
                 onConsentNotification('advertisement', myCallBack);
 
                 expect(myCallBack).toBeCalledWith(true);
@@ -118,8 +77,6 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                init();
-
                 onConsentNotification('advertisement', myCallBack);
 
                 expect(myCallBack).toBeCalledWith(false);
@@ -129,8 +86,6 @@ describe('cmp', () => {
                 getAdConsentState.mockReturnValue(null);
 
                 const myCallBack = jest.fn();
-
-                init();
 
                 onConsentNotification('advertisement', myCallBack);
 
@@ -142,101 +97,7 @@ describe('cmp', () => {
 
                 const myCallBack = jest.fn();
 
-                init();
-
                 onConsentNotification('advertisement', myCallBack);
-
-                _.triggerConsentNotification();
-
-                expect(myCallBack).toHaveBeenCalledTimes(2);
-                expect(myCallBack.mock.calls).toEqual([
-                    [true], // First call
-                    [true], // Second call
-                ]);
-            });
-        });
-
-        describe('if cmpIsReady is FALSE when onConsentNotification', () => {
-            purposes.forEach(purpose => {
-                it(`waits to execute ${purpose} callback until cmpIsReady`, () => {
-                    const myCallBack = jest.fn();
-
-                    onConsentNotification(purpose, myCallBack);
-
-                    expect(myCallBack).not.toHaveBeenCalled();
-
-                    init();
-
-                    expect(myCallBack).toHaveBeenCalledTimes(1);
-                });
-            });
-
-            it('executes functional callback with initial functional state', () => {
-                const myCallBack = jest.fn();
-
-                onConsentNotification('functional', myCallBack);
-
-                init();
-
-                expect(myCallBack).toBeCalledWith(true);
-            });
-
-            it('executes performance callback with initial performance state', () => {
-                const myCallBack = jest.fn();
-
-                onConsentNotification('performance', myCallBack);
-
-                init();
-
-                expect(myCallBack).toBeCalledWith(true);
-            });
-
-            it('executes advertisement callback with initial advertisement state true if getAdConsentState true', () => {
-                getAdConsentState.mockReturnValue(true);
-
-                const myCallBack = jest.fn();
-
-                onConsentNotification('advertisement', myCallBack);
-
-                init();
-
-                expect(myCallBack).toBeCalledWith(true);
-            });
-
-            it('executes advertisement callback with initial advertisement state false if getAdConsentState false', () => {
-                getAdConsentState.mockReturnValue(false);
-
-                const myCallBack = jest.fn();
-
-                onConsentNotification('advertisement', myCallBack);
-
-                init();
-
-                expect(myCallBack).toBeCalledWith(false);
-            });
-
-            it('executes advertisement callback with initial advertisement state null if getAdConsentState null', () => {
-                getAdConsentState.mockReturnValue(null);
-
-                const myCallBack = jest.fn();
-
-                onConsentNotification('advertisement', myCallBack);
-
-                init();
-
-                expect(myCallBack).toBeCalledWith(null);
-            });
-
-            it('execute advertisement callback each time consent nofication triggered', () => {
-                getAdConsentState.mockReturnValue(true);
-
-                const myCallBack = jest.fn();
-
-                onConsentNotification('advertisement', myCallBack);
-
-                expect(myCallBack).not.toBeCalled();
-
-                init();
 
                 _.triggerConsentNotification();
 

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -1,0 +1,215 @@
+// @flow
+import { init, onConsentNotification, consentState, _ } from 'lib/cmp';
+import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
+
+const getAdConsentState: any = _getAdConsentState;
+
+jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
+    getAdConsentState: jest.fn(),
+    thirdPartyTrackingAdConsent: jest.fn(),
+}));
+
+describe('cmp', () => {
+    beforeEach(() => {
+        _.resetCmp();
+        getAdConsentState.mockReset();
+    });
+
+    it('does not re-trigger consent notifications if init called multiple times', () => {
+        const myCallBack = jest.fn();
+
+        init();
+
+        onConsentNotification('functional', myCallBack);
+
+        expect(myCallBack).toHaveBeenCalledTimes(1);
+
+        init();
+
+        expect(myCallBack).toHaveBeenCalledTimes(1);
+    });
+
+    describe('consentState', () => {
+        it('returns null state if cmp lib has not been initialised', () => {
+            expect(consentState('functional')).toBeNull();
+            expect(consentState('performance')).toBeNull();
+            expect(consentState('advertisement')).toBeNull();
+        });
+
+        it('returns functional consent state', () => {
+            init();
+
+            expect(consentState('functional')).toBe(true);
+        });
+
+        it('returns performance consent state', () => {
+            init();
+
+            expect(consentState('performance')).toBe(true);
+        });
+
+        it('returns advertisement consent state with true if getAdConsentState true', () => {
+            getAdConsentState.mockReturnValue(true);
+
+            init();
+
+            expect(consentState('advertisement')).toBe(true);
+        });
+
+        it('returns advertisement consent state with false if getAdConsentState true', () => {
+            getAdConsentState.mockReturnValue(false);
+
+            init();
+
+            expect(consentState('advertisement')).toBe(false);
+        });
+    });
+
+    describe('onConsentNotification', () => {
+        describe('if cmpIsReady is TRUE when onConsentNotification called', () => {
+            it('executes functional callback', () => {
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('functional', myCallBack);
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes performance callback', () => {
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('performance', myCallBack);
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes advertisement callback with true if getAdConsentState true', () => {
+                getAdConsentState.mockReturnValue(true);
+
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('executes advertisement callback with true if getAdConsentState false', () => {
+                getAdConsentState.mockReturnValue(false);
+
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(false);
+            });
+
+            it('executes advertisement callback each time consent nofication triggered', () => {
+                getAdConsentState.mockReturnValue(true);
+
+                const myCallBack = jest.fn();
+
+                init();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                _.triggerConsentNotification();
+
+                expect(myCallBack).toHaveBeenCalledTimes(2);
+                expect(myCallBack.mock.calls).toEqual([
+                    [true], // First call
+                    [true], // Second call
+                ]);
+            });
+        });
+
+        describe('if cmpIsReady is FALSE when onConsentNotification called waits to', () => {
+            it('execute functional callback', () => {
+                const myCallBack = jest.fn();
+
+                onConsentNotification('functional', myCallBack);
+
+                expect(myCallBack).not.toBeCalled();
+
+                init();
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('execute performance callback', () => {
+                const myCallBack = jest.fn();
+
+                onConsentNotification('performance', myCallBack);
+
+                expect(myCallBack).not.toBeCalled();
+
+                init();
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('execute advertisement callback with true if getAdConsentState true', () => {
+                getAdConsentState.mockReturnValue(true);
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).not.toBeCalled();
+
+                init();
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(true);
+            });
+
+            it('execute advertisement callback with true if getAdConsentState false', () => {
+                getAdConsentState.mockReturnValue(false);
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).not.toBeCalled();
+
+                init();
+
+                expect(myCallBack).toHaveBeenCalledTimes(1);
+                expect(myCallBack).toBeCalledWith(false);
+            });
+
+            it('execute advertisement callback each time consent nofication triggered', () => {
+                getAdConsentState.mockReturnValue(true);
+
+                const myCallBack = jest.fn();
+
+                onConsentNotification('advertisement', myCallBack);
+
+                expect(myCallBack).not.toBeCalled();
+
+                init();
+
+                _.triggerConsentNotification();
+
+                expect(myCallBack).toHaveBeenCalledTimes(2);
+                expect(myCallBack.mock.calls).toEqual([
+                    [true], // First call
+                    [true], // Second call
+                ]);
+            });
+        });
+    });
+});

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -96,16 +96,27 @@ describe('cmp', () => {
                 getAdConsentState.mockReturnValue(true);
 
                 const myCallBack = jest.fn();
+                const expectedArguments = [[true]];
 
                 onConsentNotification('advertisement', myCallBack);
 
-                _.triggerConsentNotification();
+                const triggerCount = 5;
 
-                expect(myCallBack).toHaveBeenCalledTimes(2);
-                expect(myCallBack.mock.calls).toEqual([
-                    [true], // First call
-                    [true], // Second call
-                ]);
+                /**
+                 * TODO: Once the module under test handles
+                 * updates to state we should update this test
+                 * to handle 5 updates to state (with differing values)
+                 * rather than triggering consent notifications manually
+                 * so we can test the callback is receiving the correct
+                 * latest state.
+                 */
+                for (let i = 0; i < triggerCount; i += 1) {
+                    _.triggerConsentNotification();
+                    expectedArguments.push([true]);
+                }
+
+                expect(myCallBack).toHaveBeenCalledTimes(triggerCount + 1);
+                expect(myCallBack.mock.calls).toEqual(expectedArguments);
             });
         });
     });

--- a/static/src/javascripts/lib/cmp.spec.js
+++ b/static/src/javascripts/lib/cmp.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { onConsentNotification, consentState, _ } from 'lib/cmp';
+import { onConsentNotification, _ } from 'lib/cmp';
 import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 
 const getAdConsentState: any = _getAdConsentState;
@@ -13,23 +13,6 @@ describe('cmp', () => {
     beforeEach(() => {
         _.resetCmp();
         getAdConsentState.mockReset();
-    });
-
-    describe('consentState', () => {
-        it('returns initial functional consent state', () => {
-            expect(consentState('functional')).toBe(true);
-        });
-        it('returns initial performance consent state', () => {
-            expect(consentState('performance')).toBe(true);
-        });
-        it('returns initial advertisement consent state as true if getAdConsentState true', () => {
-            getAdConsentState.mockReturnValue(true);
-            expect(consentState('advertisement')).toBe(true);
-        });
-        it('returns initial advertisement consent state as false if getAdConsentState true', () => {
-            getAdConsentState.mockReturnValue(false);
-            expect(consentState('advertisement')).toBe(false);
-        });
     });
 
     describe('onConsentNotification', () => {


### PR DESCRIPTION
## What does this change?

I've pulled out `lib/cmp` and `lib/cmp.spec.js` into this PR from the original https://github.com/guardian/frontend/pull/21696. The module `lib/cmp.js` is initialised in `standard` in preparation for it to be used it, although it isn't used yet - subsequent PRs for this integration work to follow.