### PR TITLE
Revert " Get geolocation once in contributions-utilities "

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -62,6 +62,7 @@ declare type Runnable<T: ABTest> = T & {
 declare type AcquisitionsABTest = ABTest & {
     campaignId: string,
     componentType: OphanComponentType,
+    geolocation: ?string,
 };
 
 declare type MaxViews = {
@@ -130,6 +131,7 @@ declare type InitEpicABTest = {
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
+    geolocation: ?string,
     highPriority: boolean,
 }
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -3,11 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
     campaignId: 'epic_always_ask_if_tagged',
 
+    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-05-23',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -1,12 +1,13 @@
 // @flow
 
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
-import { getCountryName, getLocalCurrencySymbol } from 'lib/geolocation';
-import { getArticleViewCount } from 'common/modules/onward/history';
 import {
-    buildBannerCopy,
-    currentGeoLocation,
-} from 'common/modules/commercial/contributions-utilities';
+    getCountryName,
+    getLocalCurrencySymbol,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+import { getArticleViewCount } from 'common/modules/onward/history';
+import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
@@ -14,12 +15,13 @@ const articleCountDays = 30;
 
 const articleViewCount = getArticleViewCount(articleCountDays);
 
-const isUSUKAU = ['GB', 'US', 'AU'].includes(currentGeoLocation());
+const geolocation = geolocationGetSync();
+const isUSUKAU = ['GB', 'US', 'AU'].includes(geolocation);
 
 const messageText =
     'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
 const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
-    currentGeoLocation()
+    geolocation
 )}1</span>`;
 const USUKAUControlLeadSentence =
     'We chose a different approach. Will you support it?';
@@ -39,10 +41,10 @@ export const articlesViewedBanner: AcquisitionsABTest = {
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
     canRun: () =>
-        articleViewCount >= minArticleViews &&
-        !!getCountryName(currentGeoLocation()),
+        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    geolocation,
     variants: [
         {
             id: 'control',
@@ -53,7 +55,7 @@ export const articlesViewedBanner: AcquisitionsABTest = {
                         ? USUKAUControlLeadSentence
                         : ROWControlLeadSentence,
                     !isUSUKAU,
-                    currentGeoLocation()
+                    geolocation
                 ),
                 messageText,
                 ctaText,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -3,10 +3,9 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
     buildEpicCopy,
-    currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { getCountryName } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // User must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -37,7 +36,8 @@ const ROWControlCopy = {
     highlightedText,
 };
 
-const isUSUK = ['GB', 'US'].includes(currentGeoLocation());
+const geolocation = geolocationGetSync();
+const isUSUK = ['GB', 'US'].includes(geolocation);
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicArticlesViewedMonth',
@@ -55,11 +55,11 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
+    geolocation,
     highPriority: true,
 
     canRun: () =>
-        articleViewCount >= minArticleViews &&
-        !!getCountryName(currentGeoLocation()),
+        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
 
     variants: [
         {
@@ -69,7 +69,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             copy: buildEpicCopy(
                 isUSUK ? USUKControlCopy : ROWControlCopy,
                 !isUSUK,
-                currentGeoLocation()
+                geolocation
             ),
         },
         {
@@ -87,7 +87,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                     highlightedText,
                 },
                 false,
-                currentGeoLocation()
+                geolocation
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -3,11 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
     campaignId: 'kr1_epic_ask_four_earning',
 
+    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-01-24',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -3,9 +3,10 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
     buildEpicCopy,
-    currentGeoLocation,
 } from 'common/modules/commercial/contributions-utilities';
-import { getCountryName } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
+
+const geolocation = geolocationGetSync();
 
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
@@ -23,12 +24,13 @@ export const countryName: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
+    geolocation,
     highPriority: true,
 
     canRun: () =>
-        currentGeoLocation() !== 'US' &&
-        currentGeoLocation() !== 'GB' &&
-        !!getCountryName(currentGeoLocation()),
+        geolocation !== 'US' &&
+        geolocation !== 'GB' &&
+        !!getCountryName(geolocation),
 
     variants: [
         {
@@ -47,7 +49,7 @@ export const countryName: EpicABTest = makeEpicABTest({
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },
                 true,
-                currentGeoLocation()
+                geolocation
             ),
         },
     ],


### PR DESCRIPTION
Reverts guardian/frontend#21702

This doesn't appear to have affected the numbers for commercial, so we're going to try reverting the original change and see if that makes a difference