### PR TITLE
Convert twitter universal website tag code to third party integration

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -100,7 +100,7 @@ trait CommercialSwitches {
 
   val TwitterUwtSwitch = Switch(
     Commercial,
-    "twitterUwt",
+    "twitter-uwt",
     "Include the Twitter universal website tag code.",
     owners = group(Commercial),
     safeState = Off,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -88,10 +88,20 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-    val InizioSwitch = Switch(
+  val InizioSwitch = Switch(
     Commercial,
     "inizio",
     "Include the Inizio script on page so that creatives can show a survey.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val TwitterUwtSwitch = Switch(
+    Commercial,
+    "twitterUwt",
+    "Include the Twitter universal website tag code.",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -26,16 +26,4 @@
     </noscript>
 
     <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
-
-    <!-- Twitter universal website tag code -->
-    <script>
-    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
-    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
-    a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
-    // Insert Twitter Pixel ID and Standard Event data below
-    twq('init','nyl43');
-    twq('track','PageView');
-    </script>
-<!-- End Twitter universal website tag code -->
-
 }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -12,6 +12,7 @@ import { ias } from 'commercial/modules/third-party-tags/ias';
 import { inizio } from 'commercial/modules/third-party-tags/inizio';
 import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
 import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-party-tags/plista-outbrain-renderer';
+import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
@@ -48,6 +49,7 @@ const loadOther = (): void => {
         ias,
         inizio,
         fbPixel(),
+        twitterUwt(),
     ].filter(_ => _.shouldRun);
 
     insertScripts(services);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -1,0 +1,21 @@
+// @flow strict
+import config from 'lib/config';
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
+
+const onLoad = () => {
+    // Insert Twitter Pixel ID and Standard Event data below
+    window.twq('init', 'nyl43');
+    window.twq('track', 'PageView');
+};
+
+// Twitter universal website tag code
+export const twitterUwt: () => ThirdPartyTag = () => ({
+    shouldRun:
+        config.get('switches.twitterUwt', false) &&
+        !!getAdConsentState(thirdPartyTrackingAdConsent),
+    url: '//static.ads-twitter.com/uwt.js',
+    onLoad,
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -7,8 +7,10 @@ import {
 
 const onLoad = () => {
     // Insert Twitter Pixel ID and Standard Event data below
-    window.twq('init', 'nyl43');
-    window.twq('track', 'PageView');
+    if (window.twq) {
+        window.twq('init', 'nyl43');
+        window.twq('track', 'PageView');
+    }
 };
 
 // Twitter universal website tag code

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -8,26 +8,7 @@ jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
     getAdConsentState: jest.fn(),
 }));
 
-/**
- * we have to mock config like this because
- * loading twitterUwt has side affects
- * that are dependent on config.
- * */
-jest.mock('lib/config', () => {
-    const defaultConfig = {
-        switches: {
-            twitterUwt: true,
-        },
-    };
-
-    return Object.assign({}, defaultConfig, {
-        get: (path: string = '', defaultValue: any) =>
-            path
-                .replace(/\[(.+?)\]/g, '.$1')
-                .split('.')
-                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
-    });
-});
+jest.mock('lib/config', () => ({ get: () => true }));
 
 describe('twitterUwt', () => {
     afterEach(() => {
@@ -44,7 +25,17 @@ describe('twitterUwt', () => {
         expect(onLoad).toBeDefined();
     });
 
-    it('shouldRun to be false if ad consent not granted', () => {
+    it('shouldRun to be false if ad consent not granted or denied', () => {
+        getAdConsentState.mockReturnValueOnce(null);
+
+        const { shouldRun, url, onLoad } = twitterUwt();
+
+        expect(shouldRun).toEqual(false);
+        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
+        expect(onLoad).toBeDefined();
+    });
+
+    it('shouldRun to be false if ad consent denied', () => {
         getAdConsentState.mockReturnValueOnce(false);
 
         const { shouldRun, url, onLoad } = twitterUwt();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -1,0 +1,56 @@
+// @flow
+import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
+import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
+
+const getAdConsentState: any = _getAdConsentState;
+
+jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
+    getAdConsentState: jest.fn(),
+}));
+
+/**
+ * we have to mock config like this because
+ * loading twitterUwt has side affects
+ * that are dependent on config.
+ * */
+jest.mock('lib/config', () => {
+    const defaultConfig = {
+        switches: {
+            twitterUwt: true,
+        },
+    };
+
+    return Object.assign({}, defaultConfig, {
+        get: (path: string = '', defaultValue: any) =>
+            path
+                .replace(/\[(.+?)\]/g, '.$1')
+                .split('.')
+                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
+    });
+});
+
+describe('twitterUwt', () => {
+    afterEach(() => {
+        getAdConsentState.mockReset();
+    });
+
+    it('shouldRun to be true if ad consent granted', () => {
+        getAdConsentState.mockReturnValueOnce(true);
+
+        const { shouldRun, url, onLoad } = twitterUwt();
+
+        expect(shouldRun).toEqual(true);
+        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
+        expect(onLoad).toBeDefined();
+    });
+
+    it('shouldRun to be false if ad consent not granted', () => {
+        getAdConsentState.mockReturnValueOnce(false);
+
+        const { shouldRun, url, onLoad } = twitterUwt();
+
+        expect(shouldRun).toEqual(false);
+        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
+        expect(onLoad).toBeDefined();
+    });
+});


### PR DESCRIPTION
## What does this change?

Updated: This PR updates the  Twitter universal website tag code previously added inline within `base.scala.html` in this PR: https://github.com/guardian/frontend/pull/20876 to be a third party integration. 

The original implementation (inline within `base.scala.html`) was only agreed on the basis of this being a temporary addition, now that it's required beyond the initial period of it's use then an integration as per @katebee's comment https://github.com/guardian/frontend/pull/20876#discussion_r243815910 is the correct way to load this script, and this can now also include a check against whether the user has granted consent to personalised ads & tracking in the `shouldRun` check.

I've also put a switch in so we can turn this tracking script on/off at any given time.

## Screenshots

N/A

## What is the value of this and can you measure success?

Makes sure we're no longer firing tracking when consent hasn't been granted 