### PR TITLE
Add DNT setting to Vimeo embeds

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -113,7 +113,11 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
         val someIframe = Option(element.select("iframe").first())
 
         someIframe match {
-          case Some(iframe) => wrapIframe(child, iframe)
+          case Some(iframe) =>
+            if (canonicalUrl.startsWith("https://player.vimeo.com")) {
+              addVimeoDntFlag(iframe)
+            }
+            wrapIframe(child, iframe)
           case None         => wrapHD(child)
         }
       }
@@ -126,6 +130,11 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
     }
 
     document
+  }
+
+  private def addVimeoDntFlag(iframe: Element) {
+    val src = iframe.attr("src")
+    iframe.attr("src", src ++ (if (src.contains("?")) "&" else "?") ++ "dnt=true")
   }
 
   private def wrapIframe(container: Element, iframe: Element) {


### PR DESCRIPTION
## What does this change?

Asks Vimeo not to track users who interact with their embeds on gu.com, as per [their docs](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Using-Player-Parameters).

## Screenshots

<img width="718" alt="Screen Shot 2019-08-06 at 15 08 35" src="https://user-images.githubusercontent.com/629976/62546968-5be8db80-b85c-11e9-9bb1-1aeed995562b.png">

## What is the value of this and can you measure success?

GPDRRRRRR

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
