### PR TITLE
Removing 'Advertising' from the AU footer.

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -268,9 +268,6 @@
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
-                                        Advertising</a>
-                                    </li>
                                     <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs-australia}">
                                         Guardian Labs</a>
                                     </li>


### PR DESCRIPTION
## What does this change?

This removes the 'Advertising' link from the AU footer.

## Screenshots

Before:

![Screen Shot 2019-08-06 at 15 27 20](https://user-images.githubusercontent.com/2051501/62548461-bedb7200-b85e-11e9-85ce-f6fd01056917.png)

After:

![Screen Shot 2019-08-06 at 15 26 45](https://user-images.githubusercontent.com/2051501/62548460-bedb7200-b85e-11e9-9834-63f1d716307f.png)
