### PR TITLE
Revert "Revert 'Only fetch geolocation once for epic + banner tests #21622' "

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -62,6 +62,7 @@ declare type Runnable<T: ABTest> = T & {
 declare type AcquisitionsABTest = ABTest & {
     campaignId: string,
     componentType: OphanComponentType,
+    geolocation: ?string,
 };
 
 declare type MaxViews = {
@@ -129,7 +130,8 @@ declare type InitEpicABTest = {
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
     deploymentRules?: DeploymentRules,
-    hasCountryName?: boolean,
+    testHasCountryName?: boolean,
+    geolocation: ?string,
     highPriority: boolean,
 }
 

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -405,8 +405,17 @@ const extendedCurrencySymbol = {
     International: '$',
 };
 
-const getLocalCurrencySymbol = (): string =>
-    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] || '£';
+const defaultCurrencySymbol = '£';
+
+const getLocalCurrencySymbolSync = (): string =>
+    extendedCurrencySymbol[countryCodeToCountryGroupId(getSync())] ||
+    defaultCurrencySymbol;
+
+const getLocalCurrencySymbol = (geolocation: ?string): string =>
+    geolocation
+        ? extendedCurrencySymbol[countryCodeToCountryGroupId(geolocation)] ||
+          defaultCurrencySymbol
+        : defaultCurrencySymbol;
 
 // A limited set of country names for the test to add country name in the epic copy
 const countryNames = {
@@ -469,15 +478,19 @@ const countryNames = {
     PA: 'Panama',
 };
 
+const getCountryName = (geolocation: ?string): ?string =>
+    geolocation ? countryNames[geolocation] : undefined;
+
 export {
     get,
     countryCodeToCountryGroupId,
     countryCodeToSupportInternationalisationId,
     getFromStorage,
     getSync,
+    getLocalCurrencySymbolSync,
     getLocalCurrencySymbol,
     init,
     setGeolocation,
     extendedCurrencySymbol,
-    countryNames,
+    getCountryName,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -1,5 +1,5 @@
 // @flow
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import reportError from 'lib/report-error';
 import { getEpicControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 
@@ -20,7 +20,7 @@ const fallbackCopy = {
         controlCopyParagraphTwo,
         controlCopyParagraphThree,
     ],
-    highlightedText: `For as little as ${getLocalCurrencySymbol()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
+    highlightedText: `For as little as ${getLocalCurrencySymbolSync()}1, you can support the Guardian &ndash; and it only takes a minute. Thank you.`,
 };
 
 const getEpicParams = (
@@ -48,7 +48,7 @@ const getEpicParams = (
         paragraphs: rowsFromGoogleDoc.map(row => row.paragraphs),
         highlightedText: firstRow.highlightedText.replace(
             /%%CURRENCY_SYMBOL%%/g,
-            getLocalCurrencySymbol()
+            getLocalCurrencySymbolSync()
         ),
     };
 };

--- a/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/iframe-epic-utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import config from 'lib/config';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import { constructQuery as constructURLQuery } from 'lib/url';
 
 import {
@@ -119,7 +119,7 @@ const addEpicDataToUrl = (url: string): string => {
         pvid: config.get('ophan.pageViewId'),
         url: window.location.href.split('?')[0],
         // use to display pricing in local currency
-        lcs: getLocalCurrencySymbol(),
+        lcs: getLocalCurrencySymbolSync(),
     });
     return `${url}?${params}`;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -3,7 +3,7 @@ import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/tem
 import { getEngagementBannerControlFromGoogleDoc } from 'common/modules/commercial/contributions-google-docs';
 import config from 'lib/config';
 import reportError from 'lib/report-error';
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import {
     supportContributeURL,
     addCountryGroupToSupportLink,
@@ -36,7 +36,7 @@ const getAcquisitionsBannerParams = (
 
     const ctaText = `<span class="engagement-banner__highlight"> ${firstRow.ctaText.replace(
         /%%CURRENCY_SYMBOL%%/g,
-        getLocalCurrencySymbol()
+        getLocalCurrencySymbolSync()
     )}</span>`;
 
     return {
@@ -73,7 +73,7 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
 
             return {
                 messageText: fallbackCopy,
-                ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol()}1</span>`,
+                ctaText: `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbolSync()}1</span>`,
                 buttonCaption: 'Support The Guardian',
                 linkUrl: supportContributeURL(),
                 hasTicker: false,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -24,7 +24,7 @@ jest.mock('lib/url', () => ({
 }));
 jest.mock('lib/geolocation', () => ({
     getSync: jest.fn(() => 'GB'),
-    getLocalCurrencySymbol: () => '£',
+    getLocalCurrencySymbolSync: () => '£',
 }));
 jest.mock('common/modules/experiments/ab', () => ({
     getEngagementBannerTestToRun: jest.fn(() => {

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
@@ -1,18 +1,18 @@
 // @flow
 
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 
 export const acquisitionsBannerTickerTemplate = `
     <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker is-hidden">
         
         <div class="js-ticker-under-goal is-hidden">
             <div class="js-ticker-so-far engagement-banner-ticker__so-far">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">contributed</div>
             </div>
             
             <div class="js-ticker-goal engagement-banner-ticker__goal">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">our goal</div>
             </div>
         </div>
@@ -24,7 +24,7 @@ export const acquisitionsBannerTickerTemplate = `
             </div>
             
             <div class="js-ticker-exceeded engagement-banner-ticker__exceeded">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="engagement-banner-ticker__count-label">contributed</div>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 
 export const acquisitionsEpicTickerTemplate = `
     <div id="epic-ticker" class="js-epic-ticker epic-ticker is-hidden">
@@ -12,7 +12,7 @@ export const acquisitionsEpicTickerTemplate = `
             </div>
             
             <div class="js-ticker-goal epic-ticker__goal">
-                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbol()}0</div>
+                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbolSync()}0</div>
                 <div class="js-ticker-label epic-ticker__count-label">our goal</div>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,5 +1,5 @@
 // @flow
-import { getLocalCurrencySymbol } from 'lib/geolocation';
+import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import fetchJSON from 'lib/fetch-json';
 
 type TickerType = 'unlimited' | 'hardstop';
@@ -59,10 +59,10 @@ const increaseCounter = (
         newCount <= count[parentElementSelector] || newCount >= total; // either we've reached the total or the count isn't going up because total is too small
 
     if (finishedCounting) {
-        counterElement.innerHTML = `${getLocalCurrencySymbol()}${total.toLocaleString()}`;
+        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${total.toLocaleString()}`;
     } else {
         count[parentElementSelector] = newCount;
-        counterElement.innerHTML = `${getLocalCurrencySymbol()}${count[
+        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${count[
             parentElementSelector
         ].toLocaleString()}`;
 
@@ -109,7 +109,7 @@ const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
         if (countElement && labelElement) {
             const amount =
                 goalReached() && tickerType === 'unlimited' ? total : goal;
-            countElement.innerHTML = `${getLocalCurrencySymbol()}${amount.toLocaleString()}`;
+            countElement.innerHTML = `${getLocalCurrencySymbolSync()}${amount.toLocaleString()}`;
 
             if (goalReached()) {
                 labelElement.innerHTML = 'contributed';

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -7,6 +7,7 @@ import { articlesViewed } from 'common/modules/experiments/tests/contributions-e
 import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
+import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -22,4 +23,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
     acquisitionsEpicAlwaysAskIfTagged,
 ];
 
-export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [];
+export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    articlesViewedBanner,
+];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -3,11 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     id: 'AcquisitionsEpicAlwaysAskIfTagged',
     campaignId: 'epic_always_ask_if_tagged',
 
+    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-05-23',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -1,0 +1,76 @@
+// @flow
+
+import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
+import {
+    getCountryName,
+    getLocalCurrencySymbol,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+import { getArticleViewCount } from 'common/modules/onward/history';
+import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
+
+// User must have read at least 5 articles in last 30 days
+const minArticleViews = 5;
+const articleCountDays = 30;
+
+const articleViewCount = getArticleViewCount(articleCountDays);
+
+const geolocation = geolocationGetSync();
+const isUSUKAU = ['GB', 'US', 'AU'].includes(geolocation);
+
+const messageText =
+    'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
+const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
+    geolocation
+)}1</span>`;
+const USUKAUControlLeadSentence =
+    'We chose a different approach. Will you support it?';
+const ROWControlLeadSentence =
+    'More people in %%COUNTRY_NAME%%, like you, are reading and supporting The Guardian’s independent, investigative journalism.';
+
+export const articlesViewedBanner: AcquisitionsABTest = {
+    id: 'ContributionsBannerArticlesViewed',
+    campaignId: 'contributions_banner_articles_viewed',
+    start: '2019-07-10',
+    expiry: '2019-10-30',
+    author: 'Tom Forbes',
+    description: 'show number of articles viewed in contributions banner',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'variant design performs at least as well as control',
+    canRun: () =>
+        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence: buildBannerCopy(
+                    isUSUKAU
+                        ? USUKAUControlLeadSentence
+                        : ROWControlLeadSentence,
+                    !isUSUKAU,
+                    geolocation
+                ),
+                messageText,
+                ctaText,
+                template: acquisitionsBannerControlTemplate,
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence: `You’ve read ${articleViewCount} Guardian articles in the last month – if you’ve enjoyed reading, we hope you will consider supporting us today.`,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerControlTemplate,
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -5,7 +5,7 @@ import {
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCount } from 'common/modules/onward/history';
-import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // User must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
@@ -55,10 +55,11 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
+    geolocation,
     highPriority: true,
 
     canRun: () =>
-        articleViewCount >= minArticleViews && countryNames[geolocation],
+        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
 
     variants: [
         {
@@ -67,7 +68,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             products: [],
             copy: buildEpicCopy(
                 isUSUK ? USUKControlCopy : ROWControlCopy,
-                !isUSUK
+                !isUSUK,
+                geolocation
             ),
         },
         {
@@ -84,7 +86,8 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
                     highlightedText,
                 },
-                false
+                false,
+                geolocation
             ),
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -3,11 +3,13 @@ import {
     makeEpicABTest,
     defaultButtonTemplate,
 } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const askFourEarning: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicAskFourEarning',
     campaignId: 'kr1_epic_ask_four_earning',
 
+    geolocation: geolocationGetSync(),
     highPriority: false,
 
     start: '2017-01-24',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -4,7 +4,9 @@ import {
     defaultButtonTemplate,
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
-import { countryNames, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
+
+const geolocation = geolocationGetSync();
 
 export const countryName: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicCountryName',
@@ -22,16 +24,13 @@ export const countryName: EpicABTest = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
 
+    geolocation,
     highPriority: true,
 
-    canRun: () => {
-        const geolocation = geolocationGetSync();
-        return (
-            geolocation !== 'US' &&
-            geolocation !== 'GB' &&
-            countryNames[geolocation]
-        );
-    },
+    canRun: () =>
+        geolocation !== 'US' &&
+        geolocation !== 'GB' &&
+        !!getCountryName(geolocation),
 
     variants: [
         {
@@ -49,7 +48,8 @@ export const countryName: EpicABTest = makeEpicABTest({
                     highlightedText:
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },
-                true
+                true,
+                geolocation
             ),
         },
     ],


### PR DESCRIPTION
Reverts guardian/frontend#21701

Putting this change back in for now, while we wait to see if it made any difference for Commercial