### PR TITLE
Enforce case in lat/long lookup functionality

### DIFF
--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -36,7 +36,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
 
     (maybeCity, maybeRegion, maybeCountry) match {
       case (Some(city), Some(region), Some(country)) =>
-        CitiesLookUp.getLatitudeLongitude(CityRef(city, region, country)) match {
+        CitiesLookUp.getLatitudeLongitude(CityRef(city.toLowerCase(), region.toLowerCase(), country)) match {
           case Some(latitudeLongitude) =>
             log.info(s"Matched $city, $region, $country to $latitudeLongitude")
 

--- a/onward/app/weather/geo/CitiesLookUp.scala
+++ b/onward/app/weather/geo/CitiesLookUp.scala
@@ -7,6 +7,13 @@ import scala.util.Try
 
 case class CityRef(city: String, region: String, country: String)
 
+object CityRef{
+  // see https://docs.fastly.com/vcl/geolocation/ - city and region should be lowercase, country is uppercase
+  // lets enforce this here for more reliable location lookup
+  def apply(city: String, region: String, country: String): CityRef =
+    CityRef(city.toLowerCase(), region.toLowerCase(), country)
+}
+
 object CitiesCsvLine {
   implicit class RichString(s: String) {
     def withoutQuotes: String = s.stripPrefix("\"").stripSuffix("\"")
@@ -71,7 +78,8 @@ object CitiesLookUp extends ResourcesHelper {
     getCsvLines.filter({ csvLine =>
       !csvLine.country.isEmpty && !csvLine.city.isEmpty
     }).map({ csvLine =>
-      CityRef(csvLine.city, csvLine.region, csvLine.country) -> LatitudeLongitude(csvLine.latitude, csvLine.longitude)
+      // see https://docs.fastly.com/vcl/geolocation/ - city and region should be lowercase, country is uppercase
+      CityRef(csvLine.city.toLowerCase(), csvLine.region.toLowerCase(), csvLine.country.toUpperCase()) -> LatitudeLongitude(csvLine.latitude, csvLine.longitude)
     }).foldLeft(Map.empty[CityRef, LatitudeLongitude]) {
       case (acc, kv) => acc + kv
     }


### PR DESCRIPTION
## What does this change?
Modifies the way we look up latitude/longitude locations so that `city` and `region` are always lower case, whilst `country` is always upper case. This is to prepare for migration to the new fastly geolocation namespace - see https://docs.fastly.com/guides/migrations/migrating-geolocation-variables-to-the-new-dataset#namespaces-differ-between-versions 

In particular - city and region have gone from being mixed case to always lower case. This code change aims to mirror that change. 

There's no real need to uppercase country_code/country as that hasn't changed, but I thought it might make sense to enforce case on everything anyway.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
