### PR TITLE
Triplelift Adapter - Remove 300x600 inventory code

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -334,9 +334,6 @@ const getTripleLiftInventoryCode = (
     if (containsLeaderboard(sizes))
         return 'theguardian_topbanner_728x90_prebid';
 
-    if (containsDmpu(sizes) && isArticle)
-        return 'theguardian_article_300x600_prebid';
-
     if (containsMpu(sizes))
         return isArticle
             ? 'theguardian_article_300x250_prebid'


### PR DESCRIPTION
## What does this change?
Continuation of https://github.com/guardian/frontend/pull/21706 it removes 300x600 Triplelift's inventory code as it's already picked up by mpu 


