### PR TITLE
Update xaxis placements ids

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -49,6 +49,7 @@ import {
     stripDfpAdPrefixFrom,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
+    containsWS,
 } from './utils';
 import { getAppNexusDirectBidParams, getAppNexusPlacementId } from './appnexus';
 
@@ -232,10 +233,21 @@ const getImproveSizeParam = (slotId: string): { w?: number, h?: number } => {
 };
 
 const getXaxisPlacementId = (sizes: PrebidSize[]): number => {
-    if (containsDmpu(sizes)) return 13663297;
-    if (containsMpu(sizes)) return 13663304;
-    if (containsBillboard(sizes)) return 13663284;
-    return 13663304;
+    // TODO check whether to return -1 or 13663304
+    switch (getBreakpointKey()) {
+        case 'D':
+            if (containsDmpu(sizes)) return 13663297;
+            if (containsMpu(sizes)) return 15900184;
+            if (containsBillboard(sizes)) return 13663284;
+            if (containsLeaderboard(sizes)) return 15900187;
+            if (containsWS(sizes)) return 16279905;
+            return -1;
+        case 'M':
+            if (containsMpu(sizes)) return 13663304;
+            return -1;
+        default:
+            return 13663304;
+    }
 };
 
 const getPangaeaPlacementId = (sizes: PrebidSize[]): number => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -233,20 +233,20 @@ const getImproveSizeParam = (slotId: string): { w?: number, h?: number } => {
 };
 
 const getXaxisPlacementId = (sizes: PrebidSize[]): number => {
-    // TODO check whether to return -1 or 13663304
+    const NO_MATCH_ID = 15900184;
     switch (getBreakpointKey()) {
         case 'D':
             if (containsDmpu(sizes)) return 13663297;
             if (containsMpu(sizes)) return 15900184;
+            if (containsWS(sizes)) return 16279905;
             if (containsBillboard(sizes)) return 13663284;
             if (containsLeaderboard(sizes)) return 15900187;
-            if (containsWS(sizes)) return 16279905;
-            return -1;
+            return NO_MATCH_ID;
         case 'M':
             if (containsMpu(sizes)) return 13663304;
-            return -1;
+            return NO_MATCH_ID;
         default:
-            return 13663304;
+            return NO_MATCH_ID;
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -62,6 +62,9 @@ export const containsLeaderboard = (sizes: PrebidSize[]): boolean =>
 export const containsBillboard = (sizes: PrebidSize[]): boolean =>
     contains(sizes, [970, 250]);
 
+export const containsWS = (sizes: PrebidSize[]): boolean =>
+    contains(sizes, [160, 600]);
+
 export const containsMpuOrDmpu = (sizes: PrebidSize[]): boolean =>
     containsMpu(sizes) || containsDmpu(sizes);
 


### PR DESCRIPTION
## What does this change?

This PR updates the Xaxis placement IDs and adds a new WideSky (WS) size.
Still need some clarification on whether we send one placement id or multiple ids when the sizes are more than one. 
I abandoned the idea of unit testing this as the `utils.js` is mocked and the whole function depends on a util function... so not much value of testing returned mocked values .. please enlighten me however if you think otherwise 😉

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
