### PR TITLE
Add the googletagservice URL to the DCR data

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -115,6 +115,7 @@ case class Config(
   dfpAccountId: String,
   commercialBundleUrl: String,
   revisionNumber: String,
+  googletagUrl: String,
 )
 
 object Config {
@@ -532,6 +533,7 @@ object DotcomponentsDataModel {
       dfpAccountId = "", // TODO
       commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
       revisionNumber = ManifestData.revision.toString,
+      googletagUrl = Configuration.googletag.jsLocation,
     )
 
     val author = Author(


### PR DESCRIPTION
## What does this change?

Add the googletagservice URL to the DCR data. Gonna need it for rendering ads in DCR.

![Screenshot 2019-08-07 at 16 50 52](https://user-images.githubusercontent.com/6035518/62637992-74c4c000-b934-11e9-9e89-1ac7b02ffed1.png)

