### PR TITLE
Wrap Google Remarketing with consent check

### DIFF
--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -18,12 +18,5 @@
                                 'Other' Analytics
     ******************************************************************************@
 
-    @* google remarketing fallback *@
-    <noscript>
-        <div style="display:inline;">
-            <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0"/>
-        </div>
-    </noscript>
-
     <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
 }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -43,7 +43,7 @@ const loadOther = (): void => {
     const services: Array<ThirdPartyTag> = [
         imrWorldwide,
         imrWorldwideLegacy,
-        remarketing,
+        remarketing(),
         simpleReach,
         krux,
         ias,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -1,5 +1,9 @@
 // @flow
 import config from 'lib/config';
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
 
 const onLoad = () => {
     window.google_trackConversion({
@@ -9,8 +13,12 @@ const onLoad = () => {
     });
 };
 
-export const remarketing: ThirdPartyTag = {
-    shouldRun: config.get('switches.remarketing'),
-    url: '//www.googleadservices.com/pagead/conversion_async.js',
-    onLoad,
+export const remarketing: () => ThirdPartyTag = () => {
+    const consent = getAdConsentState(thirdPartyTrackingAdConsent);
+    return {
+        shouldRun:
+            config.get('switches.remarketing') && (consent || consent == null),
+        url: '//www.googleadservices.com/pagead/conversion_async.js',
+        onLoad,
+    };
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -15,6 +15,8 @@ const onLoad = () => {
 
 export const remarketing: () => ThirdPartyTag = () => {
     const consent = getAdConsentState(thirdPartyTrackingAdConsent);
+    console.log('*** consent:', consent, config.get('switches.remarketing'));
+
     return {
         shouldRun:
             config.get('switches.remarketing') && (consent || consent == null),

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -15,7 +15,6 @@ const onLoad = () => {
 
 export const remarketing: () => ThirdPartyTag = () => {
     const consent = getAdConsentState(thirdPartyTrackingAdConsent);
-    console.log('*** consent:', consent, config.get('switches.remarketing'));
 
     return {
         shouldRun:

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -13,13 +13,10 @@ const onLoad = () => {
     });
 };
 
-export const remarketing: () => ThirdPartyTag = () => {
-    const consent = getAdConsentState(thirdPartyTrackingAdConsent);
-
-    return {
-        shouldRun:
-            config.get('switches.remarketing') && (consent || consent == null),
-        url: '//www.googleadservices.com/pagead/conversion_async.js',
-        onLoad,
-    };
-};
+export const remarketing: () => ThirdPartyTag = () => ({
+    shouldRun:
+        config.get('switches.remarketing') &&
+        !!getAdConsentState(thirdPartyTrackingAdConsent),
+    url: '//www.googleadservices.com/pagead/conversion_async.js',
+    onLoad,
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
@@ -29,16 +29,17 @@ describe('Remarketing', () => {
     });
 
     it('shouldRun returns false only if consent has been denied', () => {
-        getAdConsentState.mockReturnValueOnce(null);
         getAdConsentState.mockReturnValueOnce(true);
         getAdConsentState.mockReturnValueOnce(false);
-        const shouldRunNull = remarketing().shouldRun;
+        getAdConsentState.mockReturnValueOnce(null);
+
         const shouldRunTrue = remarketing().shouldRun;
         const shouldRunFalse = remarketing().shouldRun;
+        const shouldRunNull = remarketing().shouldRun;
 
-        expect(shouldRunNull).toEqual(true);
         expect(shouldRunTrue).toEqual(true);
         expect(shouldRunFalse).toEqual(false);
+        expect(shouldRunNull).toEqual(false);
     });
 
     it('should call google_trackConversion', () => {


### PR DESCRIPTION
## What does this change?
This PR wraps the remarketing tag around a consent check so that the script is only added is the consent state is true. Also adds tests.

## What is the value of this and can you measure success?
Prevents triggering this tracking tag when the user has not consented to it.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
