### PR TITLE
Introduce CMP lib to youtube player

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -34,8 +34,7 @@ type Handlers = {
     onPlayerStateChange: (event: Object) => void,
 };
 
-let consentState = null;
-
+let consentState = '';
 onConsentNotification('advertisement', state => {
     consentState = state;
 });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -34,7 +34,7 @@ type Handlers = {
     onPlayerStateChange: (event: Object) => void,
 };
 
-let consentState = '';
+let consentState;
 onConsentNotification('advertisement', state => {
     consentState = state;
 });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -5,13 +5,10 @@ import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { constructQuery } from 'lib/url';
 import { buildPageTargeting } from 'common/modules/commercial/build-page-targeting';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { commercialYoutubePfpAdTargeting } from 'common/modules/experiments/tests/commercial-youtube-pfp-ad-targeting';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { onConsentNotification } from 'lib/cmp';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {
@@ -36,6 +33,12 @@ type Handlers = {
     onPlayerReady: (event: Object) => void,
     onPlayerStateChange: (event: Object) => void,
 };
+
+let consentState = null;
+
+onConsentNotification('advertisement', state => {
+    consentState = state;
+});
 
 const onPlayerStateChangeEvent = (
     event,
@@ -113,8 +116,7 @@ const setupPlayer = (
     onStateChange,
     onError
 ) => {
-    const wantPersonalisedAds: boolean =
-        getAdConsentState(thirdPartyTrackingAdConsent) !== false;
+    const wantPersonalisedAds: boolean = consentState !== false;
     const inPfpAdTargetingVariant: boolean = isInVariantSynchronous(
         commercialYoutubePfpAdTargeting,
         'variant'

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -16,9 +16,8 @@ jest.mock('lib/config', () => ({
     }),
 }));
 
-jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(),
-    thirdPartyTrackingAdConsent: jest.fn(),
+jest.mock('lib/cmp', () => ({
+    onConsentNotification: jest.fn((purposeName, callback) => callback(true)),
 }));
 
 jest.mock('common/modules/commercial/commercial-features', () => ({


### PR DESCRIPTION
## What does this change?
Reworks the youtube-player.js to get the consent state from the newly introduced CMP lib (https://github.com/guardian/frontend/pull/21705).

## What is the value of this and can you measure success?
Just a rework. Success means everything works exactly like it did before but uses the new consent lib instead.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
