### PR TITLE
Introduced a stable URL for the full vendorlist.json

### DIFF
--- a/commercial/app/controllers/CmpDataController.scala
+++ b/commercial/app/controllers/CmpDataController.scala
@@ -1,0 +1,15 @@
+package commercial.controllers
+
+import model.ApplicationContext
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+import conf.Static
+
+class CmpDataController (val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
+  extends BaseController with I18nSupport {
+  def renderVendorlist(): Action[AnyContent] = Action {
+    implicit request =>
+      Redirect(Static("data/vendor/cmp_vendorlist.json" ))
+  }
+}

--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -32,6 +32,7 @@ trait CommercialControllers {
   lazy val travelOffersController = wire[TravelOffersController]
   lazy val trafficDriverController = wire[TrafficDriverController]
   lazy val piggybackPixelController = wire[PiggybackPixelController]
+  lazy val cmpDataController = wire[CmpDataController]
   lazy val adsDotTextFileController = wire[AdsDotTextViewController]
   lazy val prebidAnalyticsController = wire[PrebidAnalyticsController]
   lazy val pageViewAnalyticsController = wire[PageViewAnalyticsController]

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -38,6 +38,8 @@ GET         /advertiser-content/:campaignName/:pageName                     comm
 GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET         /advertiser-content/:campaignName/:pageName/autoplay.json       commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
 
+# AIB / CMP / TCF vendorlist.json
+GET         /commercial/cmp/vendorlist.json                                            commercial.controllers.CmpDataController.renderVendorlist()
 
 # ADS.TXT + APP-ADS.txt Standard
 GET         /ads.txt                                                        commercial.controllers.AdsDotTextViewController.renderTextFile()

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -60,7 +60,7 @@
         },
         "libs": {
             "googletag": "@{Configuration.javascript.config("googletagJsUrl")}",
-            "cmp": { "fullVendorDataUrl": "@Static("data/vendor/cmp_vendorlist.json")" },
+            "cmp": { "fullVendorDataUrl": "/commercial/cmp/vendorlist.json" },
             "facebookAccountId": "@FBPixel.account"
         }
     }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -272,6 +272,8 @@ GET            /advertiser-content/:campaignName/:pageName                      
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
 GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize
+GET            /commercial/cmp/vendorlist.json                                            commercial.controllers.CmpDataController.renderVendorlist()
+
 GET            /ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderTextFile()
 GET            /app-ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderAppTextFile()
 GET            /commercial/prebid/revenue                                                                                        controllers.admin.commercial.TeamKPIController.renderPrebidDashboard()


### PR DESCRIPTION
This introduces a stable URL to access the latest vendor list we have: 

https://www.theguardian.com/commercial/cmp/vendorlist.json (also works on localhost for dev).

