### PR TITLE
Enforce upper case for weather lat/long lookups

### DIFF
--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -36,7 +36,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
 
     (maybeCity, maybeRegion, maybeCountry) match {
       case (Some(city), Some(region), Some(country)) =>
-        CitiesLookUp.getLatitudeLongitude(CityRef(city, region, country)) match {
+        CitiesLookUp.getLatitudeLongitude(CityRef.makeFixedCase(city, region, country)) match {
           case Some(latitudeLongitude) =>
             log.info(s"Matched $city, $region, $country to $latitudeLongitude")
 

--- a/onward/app/weather/geo/CitiesLookUp.scala
+++ b/onward/app/weather/geo/CitiesLookUp.scala
@@ -7,6 +7,11 @@ import scala.util.Try
 
 case class CityRef(city: String, region: String, country: String)
 
+object CityRef {
+  def makeFixedCase(city: String, region: String, country: String): CityRef =
+    CityRef(city.toUpperCase(), region.toUpperCase(), country.toUpperCase())
+}
+
 object CitiesCsvLine {
   implicit class RichString(s: String) {
     def withoutQuotes: String = s.stripPrefix("\"").stripSuffix("\"")
@@ -71,7 +76,8 @@ object CitiesLookUp extends ResourcesHelper {
     getCsvLines.filter({ csvLine =>
       !csvLine.country.isEmpty && !csvLine.city.isEmpty
     }).map({ csvLine =>
-      CityRef(csvLine.city, csvLine.region, csvLine.country) -> LatitudeLongitude(csvLine.latitude, csvLine.longitude)
+
+      CityRef.makeFixedCase(csvLine.city, csvLine.region, csvLine.country) -> LatitudeLongitude(csvLine.latitude, csvLine.longitude)
     }).foldLeft(Map.empty[CityRef, LatitudeLongitude]) {
       case (acc, kv) => acc + kv
     }


### PR DESCRIPTION
## What does this change?
This is attempt two at https://github.com/guardian/frontend/pull/21713 - making everything upper case when doing lookups for lat/long in our geo database to prepare for using the [new fastly geo functions](https://github.com/guardian/frontend/pull/21713) which are needed to support IPV6. 

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
