### PR TITLE
Rename DCR CommercialConfiguration into PageType

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -19,7 +19,7 @@ import renderers.RemoteRenderer
 
 import scala.concurrent.Future
 
-import model.dotcomponents.CommercialConfiguration
+import model.dotcomponents.PageType
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
@@ -56,11 +56,11 @@ class LiveBlogController(
         mapModel(path, range){
           (page, blocks) => {
             val isAmpSupported = page.article.content.shouldAmplify
-            val commercialConfiguration: CommercialConfiguration = CommercialConfiguration(page, request, context)
+            val pageType: PageType = PageType(page, request, context)
             (page, request.getRequestFormat) match {
               case (minute: MinutePage, HtmlFormat) => Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
               case (blog: LiveBlogPage, HtmlFormat) => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-              case (blog: LiveBlogPage, AmpFormat) if isAmpSupported => remoteRenderer.getAMPArticle(ws, path, page, blocks, commercialConfiguration)
+              case (blog: LiveBlogPage, AmpFormat) if isAmpSupported => remoteRenderer.getAMPArticle(ws, path, page, blocks, pageType)
               case (blog: LiveBlogPage, AmpFormat) => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case _ => Future.successful(NotFound)
             }
@@ -156,8 +156,8 @@ class LiveBlogController(
     blog: LiveBlogPage,
     blocks: Blocks
   )(implicit request: RequestHeader): Result = {
-    val commercialConfiguration: CommercialConfiguration = CommercialConfiguration(blog, request, context)
-    val model = DotcomponentsDataModel.fromArticle(blog, request, blocks, commercialConfiguration)
+    val pageType: PageType = PageType(blog, request, context)
+    val model = DotcomponentsDataModel.fromArticle(blog, request, blocks, pageType)
     val json = DataModelV3.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -79,7 +79,7 @@ case class Commercial(
   editionCommercialProperties: Map[String, EditionCommercialProperties],
   prebidIndexSites: List[PrebidIndexSite],
   commercialProperties: Option[CommercialProperties],
-  commercialConfiguration: CommercialConfiguration
+  pageType: PageType
 )
 
 object Block {
@@ -205,7 +205,7 @@ case class DataModelV3(
   beaconURL: String,
   isCommentable: Boolean,
   commercialProperties: Map[String, EditionCommercialProperties],
-  commercialConfiguration: CommercialConfiguration,
+  pageType: PageType,
   starRating: Option[Int],
   trailText: String,
   nav: Nav,
@@ -252,7 +252,7 @@ object DataModelV3 {
       "beaconURL" -> model.beaconURL,
       "isCommentable" -> model.isCommentable,
       "commercialProperties" -> model.commercialProperties,
-      "commercialConfiguration" -> model.commercialConfiguration,
+      "pageType" -> model.pageType,
       "starRating" -> model.starRating,
       "trailText" -> model.trailText,
       "nav" -> model.nav,
@@ -276,7 +276,7 @@ object DotcomponentsDataModel {
 
   val VERSION = 2
 
-  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, commercialConfiguration: CommercialConfiguration): DataModelV3 = {
+  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DataModelV3 = {
 
     val article = articlePage.article
     val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
@@ -520,7 +520,7 @@ object DotcomponentsDataModel {
         sites <- commercial.prebidIndexSites
       } yield sites.toList).getOrElse(List()),
       article.metadata.commercial,
-      commercialConfiguration
+      pageType
     )
 
     val byline = article.trail.byline.getOrElse("Guardian staff reporter")
@@ -576,7 +576,7 @@ object DotcomponentsDataModel {
       beaconURL = Configuration.debug.beaconUrl,
       isCommentable = article.trail.isCommentable,
       commercialProperties = commercial.editionCommercialProperties,
-      commercialConfiguration = commercialConfiguration,
+      pageType = pageType,
       starRating = article.content.starRating,
       trailText = article.trail.fields.trailText.getOrElse(""),
       nav = nav,

--- a/article/app/model/dotcomponents/PageType.scala
+++ b/article/app/model/dotcomponents/PageType.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.{JsBoolean, Json}
 import play.api.mvc.RequestHeader
 import views.support.JavaScriptPage.getMap
 
-case class CommercialConfiguration(
+case class PageType (
   hasShowcaseMainElement: Boolean,
   isFront: Boolean,
   isLiveblog: Boolean,
@@ -16,11 +16,11 @@ case class CommercialConfiguration(
   isSensitive: Boolean
 )
 
-object CommercialConfiguration {
-  implicit val writes = Json.writes[CommercialConfiguration]
+object PageType {
+  implicit val writes = Json.writes[PageType]
 
-  def apply(articlePage: PageWithStoryPackage, request: RequestHeader, context: ApplicationContext): CommercialConfiguration = {
-    CommercialConfiguration(
+  def apply(articlePage: PageWithStoryPackage, request: RequestHeader, context: ApplicationContext): PageType = {
+    PageType(
       getMap(articlePage, Edition(request), false).getOrElse("hasShowcaseMainElement", JsBoolean(false)).as[Boolean],
       getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean],
       getMap(articlePage, Edition(request), false).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -16,7 +16,7 @@ import play.twirl.api.Html
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import model.dotcomponents.CommercialConfiguration
+import model.dotcomponents.PageType
 
 class RemoteRenderer extends Logging {
 
@@ -66,9 +66,9 @@ class RemoteRenderer extends Logging {
     payload: String,
     page: PageWithStoryPackage,
     blocks: Blocks,
-    commercialConfiguration: CommercialConfiguration
+    pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, commercialConfiguration)
+    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
     val json = DataModelV3.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
   }
@@ -78,9 +78,9 @@ class RemoteRenderer extends Logging {
     path: String,
     page: PageWithStoryPackage,
     blocks: Blocks,
-    commercialConfiguration: CommercialConfiguration
+    pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, commercialConfiguration)
+    val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
     val json = DataModelV3.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.renderingEndpoint)
   }

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -3,7 +3,7 @@ package test
 import com.gu.contentapi.client.model.v1.Blocks
 import controllers.{ArticleController, ArticlePage}
 import model.Cached.RevalidatableResult
-import model.dotcomponents.CommercialConfiguration
+import model.dotcomponents.PageType
 import model.{ApplicationContext, Cached, PageWithStoryPackage}
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.mockito.MockitoSugar
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 // these
 
 class FakeRemoteRender(implicit context: ApplicationContext) extends renderers.RemoteRenderer {
-  override def getArticle(ws:WSClient, path: String, article: PageWithStoryPackage, blocks: Blocks, commercialConfiguration: CommercialConfiguration)(implicit request: RequestHeader): Future[Result] = {
+  override def getArticle(ws:WSClient, path: String, article: PageWithStoryPackage, blocks: Blocks, pageType: PageType)(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(Cached(article)(RevalidatableResult.Ok(Html("OK"))))
   }


### PR DESCRIPTION
## What does this change?

This PR, rename `CommercialConfiguration` into `PageType`.

`CommercialConfiguration` is an object that I introduced in the past and that is currently not being used on the DCR side, but that will be used as part of the complete set up of the commercial stack. It was incorrectly named for two reasons 

1. Metadata related to the ad stack is being put in the standard `DataModelV3.config`, along with other data that end up being exposed to the client side

2. The existing `CommercialConfiguration` contains page type information. 

The PR is aimed at reducing the confusion caused by the incorrect name.