### PR TITLE
Remove whitelist for articles on DCR

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -24,6 +24,7 @@ import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
 import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, GUDateTimeFormat, ImgSrc, Item300}
 import controllers.ArticlePage
+import experiments.ActiveExperiments
 import org.joda.time.DateTime
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
@@ -112,6 +113,7 @@ case class Config(
   sentryPublicApiKey: String,
   sentryHost: String,
   switches: Map[String, Boolean],
+  abTests: Map[String, String],
   dfpAccountId: String,
   commercialBundleUrl: String,
   revisionNumber: String,
@@ -531,6 +533,7 @@ object DotcomponentsDataModel {
       sentryHost = jsPageData.get("sentryHost").getOrElse(""),
       switches = switches,
       dfpAccountId = Configuration.commercial.dfpAccountId,
+      abTests = ActiveExperiments.getJsMap(request),
       commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
       revisionNumber = ManifestData.revision.toString,
       googletagUrl = Configuration.googletag.jsLocation,

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -69,50 +69,6 @@ object ArticlePicker {
     logger.withRequestHeaders(request).results(msg, results, page)
   }
 
-  private[this] val whitelist = Set(
-    "world/2018/oct/14/british-man-shot-dead-by-hunter-in-france",
-    "politics/2018/oct/14/brexit-dominic-raab-rushes-to-brussels-before-eu-crunch-talks",
-    "politics/2018/oct/14/eu-leaders-line-up-no-deal-emergency-brexit-summit-for-november",
-    "world/2018/oct/01/palu-earthquake-and-tsunami-what-we-know-so-far",
-    "info/2018/may/09/why-sign-in-to-the-guardian",
-    "society/2018/oct/14/folic-acid-to-be-added-to-flour-in-effort-to-reduce-serious-birth-defects",
-    "film/2017/dec/08/bryan-singer-denies-sexually-assaulting-17-year-old-boy-at-yacht-party-in-2003",
-    "business/2018/oct/14/china-ambassador-cui-tiankai-stumped-on-who-aides-trump-on-trade",
-    "world/2018/oct/14/bavaria-poll-humiliation-for-angela-merkel-conservative-allies",
-    "world/2017/dec/31/at-least-10-tourists-and-two-pilots-killed-as-plane-crashes-in-costa-rica",
-    "us-news/2017/nov/28/new-york-truck-attack-suspect-sayfullo-saipov",
-    "australia-news/2018/oct/15/us-embassy-apologises-after-mistakenly-sending-cookie-monster-cat-invitation",
-    "politics/2018/oct/15/foreign-office-left-disoriented-and-demoralised-by-brexit-say-diplomats",
-    "film/2018/aug/03/harvey-weinstein-lawyers-new-york-court-sexual-assault-charges",
-    "politics/2018/oct/14/local-welfare-schemes-in-england-on-brink-of-collapse-survey-finds",
-    "society/2018/sep/01/children-social-care-services-councils-austerity",
-    "uk-news/2018/oct/15/mi5-believed-black-people-posed-security-risk-papers-reveal",
-    "info/2018/sep/07/removed-video",
-    "world/2018/aug/24/more-than-25-children-and-four-women-killed-in-air-strikes-in-yemen",
-    "help/2018/may/29/why-do-i-need-to-upgrade-my-browser",
-    "world/2017/oct/23/syria-shocking-images-of-starving-baby-reveal-impact-of-food-crisis",
-    "business/2018/oct/14/saudi-shares-drop-on-fallout-journalists-disappearance-trump",
-    "commentisfree/2018/may/27/royal-wedding-celebration-black-excellence-letters",
-    "uk-news/2018/sep/05/child-sexual-exploitation-18-people-appear-in-huddersfield-court",
-    "us-news/2018/aug/18/colorado-bodies-crude-oil-murder-case",
-    "business/2018/oct/14/uk-scientists-turn-coffee-waste-electricity-fuel-cell-colombia",
-    "info/2018/sep/20/article-removed",
-    "money/2018/oct/15/three-quarters-of-uk-workers-do-not-receive-same-pay-each-month",
-    "info/2018/aug/10/article-removed",
-    "help/2018/apr/18/subscriptions",
-    "uk-news/2018/oct/14/met-police-damian-collins-no-investigation-leave-campaigners-data-misuse",
-    "world/2018/oct/14/nine-climbers-killed-in-storm-in-himalayas-mount-gurja-nepal-south-korea",
-    "help/2017/mar/15/computer-security-tips-for-whistleblowers-and-sources",
-    "uk-news/2018/oct/15/cornwall-murder-lyn-bryant-police-new-dna-evidence",
-    "uk-news/2018/oct/18/man-beaten-to-death-in-south-west-london",
-    "science/2018/oct/17/chinese-city-plans-to-launch-artificial-moon-to-replace-streetlights",
-    "uk-news/2018/oct/17/no-retrial-for-teacher-accused-of-having-sex-with-student-on-plane-eleanor-wilson",
-    "australia-news/2018/oct/18/queensland-man-charged-with-raping-young-english-woman-on-working-holiday",
-    "business/2018/oct/17/man-falls-from-top-floor-of-westfield-stratford-on-to-another-shopper",
-    "uk-news/2018/oct/17/elizabeth-isherwood-wales-death-locked-cupboard-macdonald-resorts-sued",
-    "us-news/2018/oct/17/high-school-cookies-teen-grandfather-ashes"
-  )
-
   private[this] def featureWhitelist(page: PageWithStoryPackage, request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("isSupportedType", ArticlePageChecks.isSupportedType(page)),
@@ -135,10 +91,9 @@ object ArticlePicker {
 
     val features = featureWhitelist(page, request)
     val isSupported = features.forall({ case (test, isMet) => isMet})
-    val isWhitelisted = whitelist(page.metadata.id)
     val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
 
-    val tier = if ((isSupported && isWhitelisted && isEnabled) || request.isGuui) RemoteRender else LocalRenderArticle
+    val tier = if ((isSupported  && isEnabled) || request.isGuui) RemoteRender else LocalRenderArticle
 
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -1,9 +1,10 @@
 package services.dotcomponents
 
 import controllers.ArticlePage
+import experiments.{ActiveExperiments, DotcomRenderingBeta}
 import model.PageWithStoryPackage
 import implicits.Requests._
-import model.liveblog.{BlockElement, TextBlockElement, ImageBlockElement}
+import model.liveblog.{BlockElement, ImageBlockElement, TextBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -83,7 +84,10 @@ object ArticlePicker {
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
-      ("isNewsTone", ArticlePageChecks.isNewsTone(page))
+      ("isNewsTone", ArticlePageChecks.isNewsTone(page)),
+
+      // A/B testing, not a page feature as such but useful to include here to benefit from logging
+      ("isBetaUser", ActiveExperiments.isParticipating(DotcomRenderingBeta)(request))
     )
   }
 
@@ -93,7 +97,7 @@ object ArticlePicker {
     val isSupported = features.forall({ case (test, isMet) => isMet})
     val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
 
-    val tier = if ((isSupported  && isEnabled) || request.isGuui) RemoteRender else LocalRenderArticle
+    val tier = if ((isSupported && isEnabled) || request.isGuui) RemoteRender else LocalRenderArticle
 
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)
@@ -102,7 +106,5 @@ object ArticlePicker {
     }
 
     tier
-
   }
-
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,6 +7,7 @@ import org.joda.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldTLSSupportDeprecation,
+    DotcomRenderingBeta,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -19,4 +20,12 @@ object OldTLSSupportDeprecation extends Experiment(
   sellByDate = new LocalDate(2020, 1, 20),
   // Custom group based on header set in Fastly
   participationGroup = TLSSupport
+)
+
+object DotcomRenderingBeta extends Experiment(
+  name = "dotcom-rendering-beta",
+  description = "Beta test for dotcom rendering version of site",
+  owners = Seq(Owner.withGithub("nicl")),
+  sellByDate = new LocalDate(2020, 12, 1),
+  participationGroup = Perc50 // see ArticlePicker.scala - our main filter mechanism is by page features
 )

--- a/common/app/experiments/ExperimentsDefinition.scala
+++ b/common/app/experiments/ExperimentsDefinition.scala
@@ -17,7 +17,7 @@ trait ExperimentsDefinition {
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     allExperiments
-      .filter(e => isParticipating(e) || isControl(e))
+    .filter(e => isParticipating(e) || isControl(e))
       .toSeq.sortBy(_.name)
       .map { e =>
         val value = e.value

--- a/common/app/experiments/ExperimentsDefinition.scala
+++ b/common/app/experiments/ExperimentsDefinition.scala
@@ -15,15 +15,27 @@ trait ExperimentsDefinition {
   val allExperiments: Set[Experiment]
   implicit val canCheckExperiment: CanCheckExperiment
 
-  def getJavascriptConfig(implicit request: RequestHeader): String = {
+  def getJsMap(implicit request: RequestHeader): Map[String, String] = {
+   allExperiments.foreach(exp => {
+     println(s"name:${exp.name} switch:${exp.switch.isSwitchedOn} value:${exp.value}")
+   })
+
     allExperiments
-    .filter(e => isParticipating(e) || isControl(e))
+      .filter(e => isParticipating(e) || isControl(e))
       .toSeq.sortBy(_.name)
       .map { e =>
         val value = e.value
         val nameWithValue = s"${e.name}-${value}" // Each experiment variant needs to have a unique name for Ophan
-        s""""${CamelCase.fromHyphenated(nameWithValue)}":"${value}""""
+        CamelCase.fromHyphenated(nameWithValue) -> value
       }
+      .toMap
+  }
+
+
+  def getJavascriptConfig(implicit request: RequestHeader): String = {
+    getJsMap
+      .toList
+      .map({case (key, value) => s""""${CamelCase.fromHyphenated(key)}":"${value}""""})
       .mkString(",")
   }
 


### PR DESCRIPTION
## What does this change?

Removes whitelist from the Article Picker.

Note that there is already a feature switch in place, so we can still turn DCR off (since there is no picker for AMP, this will *only* turn off the article picker).

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
