### PR TITLE
Automate TIF holidays

### DIFF
--- a/common/app/conf/audio/FlagshipContainer.scala
+++ b/common/app/conf/audio/FlagshipContainer.scala
@@ -9,13 +9,14 @@ trait FlagshipContainer {
   val londonTimezone = ZoneId.of("Europe/London")
 
   // Aug 17 at 3am
-  private val tifOnHolsStart = ZonedDateTime.of(2019, 8, 17, 3, 0, 0, 0, londonTimezone)
+  private val tifOnHolsStart = ZonedDateTime.of(2019, 8, 17, 3, 15, 0, 0, londonTimezone)
   // Sep 2 at 2am
-  private val tifOnHolsEnd = ZonedDateTime.of(2019, 9, 2, 2, 0, 0, 0, londonTimezone)
+  private val tifOnHolsEnd = ZonedDateTime.of(2019, 9, 2, 3, 15, 0, 0, londonTimezone)
 
   //The container should appear at 02:00 on Monday, and disappear at 03:00 on Saturday
-  private def isWeekend(dateTime: ZonedDateTime): Boolean =
-    dateTime.getDayOfWeek == DayOfWeek.SATURDAY && dateTime.getHour >= 3 || dateTime.getDayOfWeek == DayOfWeek.MONDAY && dateTime.getHour < 2
+  private val threeHoursFifteenMinutes = Duration.ofHours(3) plus Duration.ofMinutes(15)
+  private val weekend = Set(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+  private def isWeekend(dateTime: ZonedDateTime): Boolean = weekend(dateTime.minus(threeHoursFifteenMinutes).getDayOfWeek())
 
   protected val switch: Switch
 

--- a/common/app/conf/audio/FlagshipContainer.scala
+++ b/common/app/conf/audio/FlagshipContainer.scala
@@ -13,7 +13,7 @@ trait FlagshipContainer {
   // Sep 2 at 2am
   private val tifOnHolsEnd = ZonedDateTime.of(2019, 9, 2, 3, 15, 0, 0, londonTimezone)
 
-  //The container should appear at 02:00 on Monday, and disappear at 03:00 on Saturday
+  //The container should appear at 03:15 on Monday, and disappear at 03:15 on Saturday
   private val threeHoursFifteenMinutes = Duration.ofHours(3) plus Duration.ofMinutes(15)
   private val weekend = Set(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
   private def isWeekend(dateTime: ZonedDateTime): Boolean = weekend(dateTime.minus(threeHoursFifteenMinutes).getDayOfWeek())

--- a/common/app/conf/audio/FlagshipContainer.scala
+++ b/common/app/conf/audio/FlagshipContainer.scala
@@ -1,21 +1,21 @@
 package conf.audio
 import conf.switches.Switch
-import org.joda.time.DateTime
-import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
-import org.joda.time.format.DateTimeFormat
 
 import scala.concurrent.duration._
+import java.time.{ Duration,  ZonedDateTime, ZoneId, ZoneOffset, DayOfWeek }
 
 trait FlagshipContainer {
 
-  private val GoLiveDateTime = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm").parseDateTime("2018/11/01 03:15")
+  val londonTimezone = ZoneId.of("Europe/London")
 
-  //The container should appear at 03:15 on Monday, and disappear at 03:15 on Saturday
-  private val threeHoursFifteenMinutes: Long = (3.hours + 15.minutes).toMillis
-  private def isWeekend(dateTime: DateTime): Boolean = {
-    val day = dateTime.minus(threeHoursFifteenMinutes).getDayOfWeek
-    day == SATURDAY || day == SUNDAY
-  }
+  // Aug 17 at 3am
+  private val tifOnHolsStart = ZonedDateTime.of(2019, 8, 17, 3, 0, 0, 0, londonTimezone)
+  // Sep 2 at 2am
+  private val tifOnHolsEnd = ZonedDateTime.of(2019, 9, 2, 2, 0, 0, 0, londonTimezone)
+
+  //The container should appear at 02:00 on Monday, and disappear at 03:00 on Saturday
+  private def isWeekend(dateTime: ZonedDateTime): Boolean =
+    dateTime.getDayOfWeek == DayOfWeek.SATURDAY && dateTime.getHour >= 3 || dateTime.getDayOfWeek == DayOfWeek.MONDAY && dateTime.getHour < 2
 
   protected val switch: Switch
 
@@ -23,8 +23,8 @@ trait FlagshipContainer {
 
   def isFlagshipContainer(id: String): Boolean = containerIds.contains(id)
 
-  def displayFlagshipContainer(now: DateTime = DateTime.now): Boolean =
+  def displayFlagshipContainer(now: ZonedDateTime = ZonedDateTime.now(londonTimezone)): Boolean =
     switch.isSwitchedOn &&
-      now.isAfter(GoLiveDateTime) &&
+      (now.isBefore(tifOnHolsStart) || now.isAfter(tifOnHolsEnd)) &&
       !isWeekend(now)
 }

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -12,22 +12,22 @@ class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAf
   }
 
   it should "return true if the team is on not holiday yet" in {
-    val dateTime = ZonedDateTime.parse("2019/08/17 02:59", formatter)
+    val dateTime = ZonedDateTime.parse("2019/08/17 03:14", formatter)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
   it should "return false if the team is on holiday" in {
-    val dateTime = ZonedDateTime.parse("2019/08/17 03:00", formatter)
+    val dateTime = ZonedDateTime.parse("2019/08/17 03:15", formatter)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
   it should "return false if the team is still on holiday" in {
-    val dateTime = ZonedDateTime.parse("2019/09/02 02:00", formatter)
+    val dateTime = ZonedDateTime.parse("2019/09/02 03:15", formatter)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
   it should "return true if the team is not on holiday anymore" in {
-    val dateTime = ZonedDateTime.parse("2019/09/02 02:01", formatter)
+    val dateTime = ZonedDateTime.parse("2019/09/02 03:16", formatter)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
@@ -43,14 +43,14 @@ class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAf
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
-  it should "return true if Saturday and before 03:00" in {
-    val dateTime = ZonedDateTime.parse("2018/11/10 02:59", formatter)
+  it should "return true if Saturday and before 03:15" in {
+    val dateTime = ZonedDateTime.parse("2018/11/10 03:14", formatter)
     dateTime.getDayOfWeek should be(DayOfWeek.SATURDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Saturday at 03:00" in {
-    val dateTime = ZonedDateTime.parse("2018/11/10 03:00", formatter)
+  it should "return false if Saturday at 03:15" in {
+    val dateTime = ZonedDateTime.parse("2018/11/10 03:15", formatter)
     dateTime.getDayOfWeek should be(DayOfWeek.SATURDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
@@ -61,14 +61,14 @@ class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAf
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Monday and before 02:00" in {
-    val dateTime = ZonedDateTime.parse("2018/11/05 01:59", formatter)
+  it should "return false if Monday and before 03:15" in {
+    val dateTime = ZonedDateTime.parse("2018/11/05 02:14", formatter)
     dateTime.getDayOfWeek should be(DayOfWeek.MONDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
-  it should "return true if Monday at 02:00" in {
-    val dateTime = ZonedDateTime.parse("2018/11/05 02:00", formatter)
+  it should "return true if Monday at 03:15" in {
+    val dateTime = ZonedDateTime.parse("2018/11/05 03:15", formatter)
     dateTime.getDayOfWeek should be(DayOfWeek.MONDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -1,49 +1,75 @@
 package conf.audio
 import conf.switches.Switches.FlagshipFrontContainerSwitch
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.DateTimeConstants._
+import java.time.{ZonedDateTime, DayOfWeek}
+import java.time.format.DateTimeFormatter
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
-  private val formatter = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm")
+class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+  private val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").withZone(FlagshipFrontContainer.londonTimezone)
 
   override def beforeAll {
     FlagshipFrontContainerSwitch.switchOn()
   }
 
-  it should "return false if Tuesday but before 2018/11/01" in {
-    val dateTime = formatter.parseDateTime("2018/10/02 00:00")
-    dateTime.getDayOfWeek should be(TUESDAY)
+  it should "return true if the team is on not holiday yet" in {
+    val dateTime = ZonedDateTime.parse("2019/08/17 02:59", formatter)
+    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
+  it should "return false if the team is on holiday" in {
+    val dateTime = ZonedDateTime.parse("2019/08/17 03:00", formatter)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
+  it should "return false if the team is still on holiday" in {
+    val dateTime = ZonedDateTime.parse("2019/09/02 02:00", formatter)
+    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
+  }
+
+  it should "return true if the team is not on holiday anymore" in {
+    val dateTime = ZonedDateTime.parse("2019/09/02 02:01", formatter)
+    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
   it should "return true if Tuesday" in {
-    val dateTime = formatter.parseDateTime("2018/11/06 00:00")
-    dateTime.getDayOfWeek should be(TUESDAY)
+    val dateTime = ZonedDateTime.parse("2018/11/06 00:00", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.TUESDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
   it should "return false if Saturday and after 03:15" in {
-    val dateTime = formatter.parseDateTime("2018/11/10 04:00")
-    dateTime.getDayOfWeek should be(SATURDAY)
+    val dateTime = ZonedDateTime.parse("2018/11/10 04:00", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.SATURDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
-  it should "return true if Saturday and before 03:15" in {
-    val dateTime = formatter.parseDateTime("2018/11/10 03:00")
-    dateTime.getDayOfWeek should be(SATURDAY)
+  it should "return true if Saturday and before 03:00" in {
+    val dateTime = ZonedDateTime.parse("2018/11/10 02:59", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.SATURDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
+  }
+
+  it should "return false if Saturday at 03:00" in {
+    val dateTime = ZonedDateTime.parse("2018/11/10 03:00", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.SATURDAY)
+    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
   }
 
   it should "return true if Monday and after 03:15" in {
-    val dateTime = formatter.parseDateTime("2018/11/05 04:00")
-    dateTime.getDayOfWeek should be(MONDAY)
+    val dateTime = ZonedDateTime.parse("2018/11/05 04:00", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.MONDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 
-  it should "return false if Monday and before 03:15" in {
-    val dateTime = formatter.parseDateTime("2018/11/05 03:00")
-    dateTime.getDayOfWeek should be(MONDAY)
+  it should "return false if Monday and before 02:00" in {
+    val dateTime = ZonedDateTime.parse("2018/11/05 01:59", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.MONDAY)
     FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(false)
+  }
+
+  it should "return true if Monday at 02:00" in {
+    val dateTime = ZonedDateTime.parse("2018/11/05 02:00", formatter)
+    dateTime.getDayOfWeek should be(DayOfWeek.MONDAY)
+    FlagshipFrontContainer.displayFlagshipContainer(dateTime) should be(true)
   }
 }


### PR DESCRIPTION
The Today in Focus podcast won't published episodes between Aug 16 and Sep 2, so we're taking off the container on network fronts between Aug 17 3am and Sep 2 2am (London time).