### PR TITLE
Activate all commercial modules in the DCR boot script

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -3,28 +3,28 @@ import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
-// import { init as initHighMerch } from 'commercial/modules/high-merch';
-// import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
-// import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
-// import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
+import { init as initHighMerch } from 'commercial/modules/high-merch';
+import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
+import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
+import { init as initMobileSticky } from 'commercial/modules/mobile-sticky';
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
 import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
 import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
 import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
-// import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
-// import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
-// import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
-// import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
-// import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
-// import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
-// import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
-// import { paidContainers } from 'commercial/modules/paid-containers';
+import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
+import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
+import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
+import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
+import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
+import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
+import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 // import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
-// import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
@@ -36,23 +36,22 @@ const commercialModules: Array<Array<any>> = [
     ['cm-lotame-data-extract', initLotameDataExtract, true], // Comes with a isDotcomRendering check
 ];
 
-if (!commercialFeatures.adFree) {
-    commercialModules
-        .push
-        // ['cm-prepare-prebid', preparePrebid],
-        // ['cm-prepare-googletag', prepareGoogletag],
-        // ['cm-thirdPartyTags', initThirdPartyTags],
-        // ['cm-prepare-adverification', prepareAdVerification],
-        // ['cm-mobileSticky', initMobileSticky],
-        // ['cm-highMerch', initHighMerch],
-        // ['cm-articleAsideAdverts', initArticleAsideAdverts],
-        // ['cm-articleBodyAdverts', initArticleBodyAdverts],
-        // ['cm-liveblogAdverts', initLiveblogAdverts],
-        // ['cm-stickyTopBanner', initStickyTopBanner],
-        // ['cm-paidContainers', paidContainers],
-        // ['cm-paidforBand', initPaidForBand],
-        // ['cm-commentAdverts', initCommentAdverts]
-        ();
+if (false && !commercialFeatures.adFree) {
+    commercialModules.push(
+        ['cm-prepare-prebid', preparePrebid],
+        ['cm-prepare-googletag', prepareGoogletag],
+        ['cm-thirdPartyTags', initThirdPartyTags],
+        ['cm-prepare-adverification', prepareAdVerification],
+        ['cm-mobileSticky', initMobileSticky],
+        ['cm-highMerch', initHighMerch],
+        ['cm-articleAsideAdverts', initArticleAsideAdverts],
+        ['cm-articleBodyAdverts', initArticleBodyAdverts],
+        ['cm-liveblogAdverts', initLiveblogAdverts],
+        ['cm-stickyTopBanner', initStickyTopBanner],
+        ['cm-paidContainers', paidContainers],
+        ['cm-paidforBand', initPaidForBand],
+        ['cm-commentAdverts', initCommentAdverts]
+    );
 }
 
 const loadHostedBundle = (): Promise<void> => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -1,6 +1,7 @@
 // @flow strict
 /* A regionalised container for all the commercial tags. */
 
+import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { imrWorldwide } from 'commercial/modules/third-party-tags/imr-worldwide';
@@ -60,12 +61,17 @@ const init = (): Promise<boolean> => {
         return Promise.resolve(false);
     }
 
+    // Section 1
     // Outbrain/Plista needs to be loaded before the first ad as it is checking
     // for the presence of high relevance component on page
     // I'm leaving this to check adFree state because while the thirdPartyTags
     // check above is now sensitive to ad-free, it could be changed independently
     // in the future - even by accident.  Justin.
-    if (!commercialFeatures.adFree) {
+
+    // Section 2
+    // For the moment, we are not attemtping to run Outbrain in dotcom-rendering
+    // But we want the other third party tags. Pascal.
+    if (!config.get('isDotcomRendering', false) && !commercialFeatures.adFree) {
         initPlistaOutbrainRenderer();
     }
 


### PR DESCRIPTION
## What does this change?

This uncomment all the commercial modules that are required for ad display. 

1. For the moment the code is actually prevented to run due to `false && !commercialFeatures.adFree`, this is because we are not ready yet to actually display ads. The interest here is that all the modules have been cleared for running on DCR rendered pages. The testing was simply done by replacing `false &&` by `true ||`. While doing so it was identified that...

2. We will not be initiating Outbrain for the moment as the DCR rendered pages do not currently have the right structure. For this we are adding `!config.get('isDotcomRendering', false)` where it would be initialised. 