### PR TITLE
Change Mobile Sticky's location condition to be read from localStorage instead of cookie

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -570,4 +570,15 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val mobileStickyPrebid: Switch = Switch(
+    group = Commercial,
+    name = "mobile-sticky-prebid",
+    description = "Include Mobile Sticky leaderboard banner in Prebid",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -100,7 +100,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
 
     switch (getBreakpointKey()) {
         case 'M':
-            return shouldIncludeMobileSticky()
+            return shouldIncludeMobileSticky() &&
+                config.get('switches.mobileStickyPrebid')
                 ? commonSlots.concat([...mobileSlots, mobileStickySlot])
                 : commonSlots.concat(mobileSlots);
         case 'T':

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -78,6 +78,7 @@ describe('getSlots', () => {
 
     test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
         getBreakpointKey.mockReturnValue('M');
+        config.set('switches.mobileStickyPrebid', true);
         shouldIncludeMobileSticky.mockReturnValue(true);
         expect(getSlots('Article')).toEqual([
             {
@@ -206,6 +207,7 @@ describe('slots', () => {
 
     test('should return the correct mobile-sticky slot at breakpoint M', () => {
         getBreakpointKey.mockReturnValue('M');
+        config.set('switches.mobileStickyPrebid', true);
         shouldIncludeMobileSticky.mockReturnValue(true);
         expect(slots('mobile-sticky', '')).toEqual([
             {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -5,7 +5,6 @@ import { getBreakpoint, isBreakpoint } from 'lib/detect';
 import { pbTestNameMap } from 'lib/url';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
-import { getCookie } from 'lib/cookies';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { prebidTripleLiftAdapter } from 'common/modules/experiments/tests/prebid-triple-lift-adapter';
 import type { PrebidSize } from './types';
@@ -48,9 +47,6 @@ export const isInAuRegion = (): boolean =>
 
 export const isInRowRegion = (): boolean =>
     !isInUkRegion() && !isInUsRegion() && !isInAuRegion();
-
-export const isInNA = (): boolean =>
-    (getCookie('GU_geo_continent') || 'OTHER').toUpperCase() === 'NA';
 
 export const containsMpu = (sizes: PrebidSize[]): boolean =>
     contains(sizes, [300, 250]);
@@ -147,7 +143,7 @@ export const shouldIncludeMobileSticky = once(
         window.location.hash.indexOf('#mobile-sticky') !== -1 ||
         (config.get('switches.mobileStickyLeaderboard') &&
             isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) &&
-            isInNA() &&
+            isInUsRegion() &&
             config.get('page.contentType') === 'Article')
 );
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -5,7 +5,6 @@ import {
     isBreakpoint as isBreakpoint_,
 } from 'lib/detect';
 import config from 'lib/config';
-import { getCookie as getCookie_ } from 'lib/cookies';
 import {
     getLargestSize,
     getBreakpointKey,
@@ -29,16 +28,11 @@ import {
 const getSync: any = getSync_;
 const getBreakpoint: any = getBreakpoint_;
 const isBreakpoint: any = isBreakpoint_;
-const getCookie: any = getCookie_;
 
 jest.mock('lodash/once', () => a => a);
 
 jest.mock('lib/geolocation', () => ({
     getSync: jest.fn(() => 'GB'),
-}));
-
-jest.mock('lib/cookies', () => ({
-    getCookie: jest.fn(),
 }));
 
 jest.mock('lib/detect', () => ({
@@ -376,7 +370,7 @@ describe('Utils', () => {
         config.set('page.contentType', 'Network Front');
         config.set('switches.mobileStickyLeaderboard', true);
         isBreakpoint.mockReturnValue(true);
-        getCookie.mockReturnValue('NA');
+        getSync.mockReturnValue('US');
         expect(shouldIncludeMobileSticky()).toBe(false);
     });
 
@@ -384,7 +378,7 @@ describe('Utils', () => {
         config.set('page.contentType', 'Article');
         isBreakpoint.mockReturnValue(true);
         config.set('switches.mobileStickyLeaderboard', false);
-        getCookie.mockReturnValue('NA');
+        getSync.mockReturnValue('US');
         expect(shouldIncludeMobileSticky()).toBe(false);
     });
 
@@ -392,7 +386,7 @@ describe('Utils', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
         isBreakpoint.mockReturnValue(true);
-        getCookie.mockReturnValue('EU');
+        getSync.mockReturnValue('GB');
         expect(shouldIncludeMobileSticky()).toBe(false);
     });
 
@@ -400,7 +394,7 @@ describe('Utils', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
         isBreakpoint.mockReturnValue(false);
-        getCookie.mockReturnValue('EU');
+        getSync.mockReturnValue('US');
         expect(shouldIncludeMobileSticky()).toBe(false);
     });
 
@@ -408,7 +402,7 @@ describe('Utils', () => {
         config.set('page.contentType', 'Network Front');
         config.set('switches.mobileStickyLeaderboard', false);
         isBreakpoint.mockReturnValue(false);
-        getCookie.mockReturnValue('EU');
+        getSync.mockReturnValue('US');
         window.location.hash = '#mobile-sticky';
         expect(shouldIncludeMobileSticky()).toBe(true);
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -367,7 +367,7 @@ describe('Utils', () => {
     test('shouldIncludeMobileSticky should be true if location cookie is NA, switch is ON and content is Article on mobiles ', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
-        getCookie.mockReturnValue('NA');
+        getSync.mockReturnValue('US');
         isBreakpoint.mockReturnValue(true);
         expect(shouldIncludeMobileSticky()).toBe(true);
     });


### PR DESCRIPTION

## What does this change?

Changes the condition for when to show mobile sticky from cookie  `GU_geo_continent` to localStorage `gu.geolocation`
This is to try fix mobile sticky which still shows drop in impressions even after fixing Fastly issue with IPv6
Also introduces a switch to be able to turn on/off mobile sticky on Prebid with  `safeState = On`

## What is the value of this and can you measure success?
Will increase mobile sticky impressions if success.


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
