### PR TITLE
Extend contributions cookie expiry

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -13,7 +13,10 @@ import interactionTracking from 'common/modules/analytics/interaction-tracking';
 import { initAnalyticsRegister } from 'common/modules/analytics/register';
 import { ScrollDepth } from 'common/modules/analytics/scrollDepth';
 import { requestUserSegmentsFromId } from 'common/modules/commercial/user-ad-targeting';
-import { refresh as refreshUserFeatures } from 'common/modules/commercial/user-features';
+import {
+    refresh as refreshUserFeatures,
+    extendContribsCookieExpiry,
+} from 'common/modules/commercial/user-features';
 import { initCommentCount } from 'common/modules/discussion/comment-count';
 import { init as initCookieRefresh } from 'common/modules/identity/cookierefresh';
 import { initNavigation } from 'common/modules/navigation/navigation';
@@ -340,6 +343,7 @@ const init = (): void => {
         ['c-history-nav', showHistoryInMegaNav],
         ['c-start-register', startRegister],
         ['c-cookies', cleanupCookies],
+        ['c-extend-contribs-expiry', extendContribsCookieExpiry],
         ['c-localStorage', cleanupLocalStorage],
         ['c-overlay', initOpenOverlayOnClick],
         ['c-public-api', initPublicApi],

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -275,6 +275,18 @@ const fakeOneOffContributor = (): void => {
 const isAdFreeUser = (): boolean =>
     isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
 
+//Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
+const extendContribsCookieExpiry = (): void => {
+    const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
+    if (cookie) {
+        const contributionDate = parseInt(cookie, 10);
+        if (Number.isInteger(contributionDate)) {
+            const newExpiry = 365 - dateDiffDays(contributionDate, Date.now());
+            addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, contributionDate, newExpiry)
+        }
+    }
+};
+
 export {
     accountDataUpdateWarning,
     isAdFreeUser,
@@ -291,4 +303,5 @@ export {
     readerRevenueRelevantCookies,
     fakeOneOffContributor,
     shouldNotBeShownSupportMessaging,
+    extendContribsCookieExpiry,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -284,7 +284,7 @@ const extendContribsCookieExpiry = (): void => {
             const newExpiry = 365 - dateDiffDays(contributionDate, Date.now());
             addCookie(
                 SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-                contributionDate,
+                contributionDate.toString(),
                 newExpiry
             );
         }

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -281,11 +281,11 @@ const extendContribsCookieExpiry = (): void => {
     if (cookie) {
         const contributionDate = parseInt(cookie, 10);
         if (Number.isInteger(contributionDate)) {
-            const newExpiry = 365 - dateDiffDays(contributionDate, Date.now());
+            const daysToLive = 365 - dateDiffDays(contributionDate, Date.now());
             addCookie(
                 SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
                 contributionDate.toString(),
-                newExpiry
+                daysToLive
             );
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -275,14 +275,18 @@ const fakeOneOffContributor = (): void => {
 const isAdFreeUser = (): boolean =>
     isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
 
-//Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
+// Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
 const extendContribsCookieExpiry = (): void => {
     const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
     if (cookie) {
         const contributionDate = parseInt(cookie, 10);
         if (Number.isInteger(contributionDate)) {
             const newExpiry = 365 - dateDiffDays(contributionDate, Date.now());
-            addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, contributionDate, newExpiry)
+            addCookie(
+                SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+                contributionDate,
+                newExpiry
+            );
         }
     }
 };


### PR DESCRIPTION
## What does this change?
We're updating the TTL of one-off contribution cookies to 1 year to enable longer term acquisitions strategies.
We also need to extend the TTL of any existing cookies.

Note - we can revert this change later once users have the correct expiries

## Screenshots
Given a cookie with an expiry 6 months after the contribution date:
<img width="654" alt="Screenshot 2019-08-12 at 13 51 27" src="https://user-images.githubusercontent.com/1513454/62866284-55e57580-bd08-11e9-9c68-518a3ec2ea16.png">

Extend to 12 months after the contribution date:
<img width="654" alt="Screenshot 2019-08-13 at 17 04 42" src="https://user-images.githubusercontent.com/1513454/62957324-7c7cdc80-bdec-11e9-9912-e855a4e8fffa.png">



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
