### PR TITLE
Paid For Videos - Hide Advertiser Logo and overlay for mobile landscape breakpoint

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -61,6 +61,9 @@
     bottom: 0;
     height: 85px;
     opacity: .5;
+    @include mq($until: mobileLandscape) {
+        display: none;
+    }
 }
 
 .youtube-media-atom__paid-for-label {
@@ -78,6 +81,9 @@
     bottom: 0 ;
     right: 0;
     width: auto;
+    @include mq($until: mobileLandscape) {
+        display: none;
+    }
 }
 
 .youtube-media-atom__paid-for-logo {
@@ -87,6 +93,9 @@
     bottom: 0;
     right: 0;
     margin-right: 10px;
+    @include mq($until: mobileLandscape) {
+        display: none;
+    }
 }
 
 .youtube-media-atom__iframe,


### PR DESCRIPTION
## What does this change?
Hides the advertiser logo and overlay on mobile landscape breakpoint as it was blocking the view of the actual video image

## Screenshots

**Before**
![Screenshot 2019-08-13 at 11 15 42](https://user-images.githubusercontent.com/51630004/62934182-de711e00-bdbb-11e9-9f30-a15623d1fa2f.png)

**After**
![Screenshot 2019-08-13 at 11 10 53](https://user-images.githubusercontent.com/51630004/62934136-c0a3b900-bdbb-11e9-91ed-5d55b8c9bd41.png)

## What is the value of this and can you measure success?
To be able to see the video image on mobiles

### Tested

- [x] Locally
- [ ] On CODE (optional)

