### PR TITLE
Fix /email endpoint for paths containing newspaper publication name

### DIFF
--- a/article/conf/routes
+++ b/article/conf/routes
@@ -18,10 +18,7 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/04/g2/features
 # single-part tag
 #  e.g. /theguardian/2015/nov/03/mainsection
-
-# do not match anything with /email in the last section as this should be processed by email endpoints in ArticleController
-# regex for this inspired by https://stackoverflow.com/questions/406230/regular-expression-to-match-a-line-that-doesnt-contain-a-word
-GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<^((?!\/email).)*$>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
+GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
 # liveblogs, minutes. 
 # NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -9,17 +9,6 @@ GET     /_healthcheck               controllers.HealthCheck.healthCheck()
 
 GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 
-# Newspaper pages paths
-# gallery format (?)
-#  e.g. /theobserver/gallery/2013/sep/14/the-10-best-fonts
-# article format
-#  e.g. /theobserver/2015/nov/01/the-big-issue-generation-gap-pensioners-young-people
-# multi-part tags
-#  e.g. /theguardian/2015/nov/04/g2/features
-# single-part tag
-#  e.g. /theguardian/2015/nov/03/mainsection
-GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
-
 # liveblogs, minutes. 
 # NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used
 # See https://github.com/guardian/fastly-cache-purger/blob/master/src/main/scala/com/gu/fastly/Lambda.scala 
@@ -39,4 +28,16 @@ GET     /*path/email                controllers.ArticleController.renderEmail(pa
 GET     /*path/email/headline.txt   controllers.ArticleController.renderHeadline(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailtxt       controllers.ArticleController.renderEmail(path)
+
+# Newspaper pages paths
+# gallery format (?)
+#  e.g. /theobserver/gallery/2013/sep/14/the-10-best-fonts
+# article format
+#  e.g. /theobserver/2015/nov/01/the-big-issue-generation-gap-pensioners-young-people
+# multi-part tags
+#  e.g. /theguardian/2015/nov/04/g2/features
+# single-part tag
+#  e.g. /theguardian/2015/nov/03/mainsection
+GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
+
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -18,7 +18,10 @@ GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 #  e.g. /theguardian/2015/nov/04/g2/features
 # single-part tag
 #  e.g. /theguardian/2015/nov/03/mainsection
-GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
+
+# do not match anything with /email in the last section as this should be processed by email endpoints in ArticleController
+# regex for this inspired by https://stackoverflow.com/questions/406230/regular-expression-to-match-a-line-that-doesnt-contain-a-word
+GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<^((?!\/email).)*$>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
 # liveblogs, minutes. 
 # NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used


### PR DESCRIPTION
## What does this change?
Currently the /email endpoint doesn't work for pages such as https://www.theguardian.com/theobserver/2018/aug/18/observer-archive-radwinter-21-august-1966 because the path matches the PublicationController, which then returns a 404 as it doesn't understand the /email suffix.

This change moves that route so that the email endpoints are tried first. This has the side effect of moving this route be low the liveblog routes. I've checked with Celine about this, she doesn't think it will cause problems. 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
