### PR TITLE
Expand exemptions for blocking commercial scripts

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -260,7 +260,10 @@ final case class MetaData (
     DfpAgent.omitMPUsFromContainers(id, edition)
   } else false
 
-  val shouldBlockAnalytics: Boolean = id.contains("help/ng-interactive/2017/mar/17/contact-the-guardian-securely")
+  val shouldBlockAnalytics: Boolean = Set(
+      "help/ng-interactive/2017/mar/17/contact-the-guardian-securely",
+      "help/2016/sep/19/how-to-contact-the-guardian-securely"
+    ).contains(id)
 
   val requiresMembershipAccess: Boolean = membershipAccess.nonEmpty
 

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -29,7 +29,9 @@
     @InlineJs(prepareCmp().body, "prepareCmp.js")
 }
 
-@if(LotameSwitch.isSwitchedOn && !page.metadata.contentType.contains(DotcomContentType.Identity)) {
+@if(LotameSwitch.isSwitchedOn
+    && !page.metadata.contentType.contains(DotcomContentType.Identity)
+    && !page.metadata.shouldBlockAnalytics) {
     @InlineJs(prepareLotame().body, "prepareLotame.js")
 }
 

--- a/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
+++ b/static/src/javascripts/projects/commercial/modules/lotame-data-extract.js
@@ -1,4 +1,5 @@
 // @flow strict
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { loadScript } from 'lib/load-script';
 import config from 'lib/config';
 
@@ -20,7 +21,7 @@ const shouldLoadLotame = (): boolean => {
 // Fetches Lotame Data for the Ozone project
 // and stores in in window.OzoneLotameData
 const init = (): Promise<void> => {
-    if (!shouldLoadLotame) {
+    if (!shouldLoadLotame || commercialFeatures.shouldBlockAnalytics) {
         return Promise.resolve();
     }
     return loadScript('//ad.crwdcntrl.net/5/c=13271/pe=y/var=OzoneLotameData')

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -8,6 +8,7 @@ import userPrefs from 'common/modules/user-prefs';
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
     dfpAdvertising: boolean;
+    shouldBlockAnalytics: boolean;
     stickyTopBannerAd: boolean;
     articleBodyAdverts: boolean;
     articleAsideAdverts: boolean;
@@ -51,11 +52,11 @@ class CommercialFeatures {
         const newRecipeDesign =
             config.get('page.showNewRecipeDesign') &&
             config.get('tests.abNewRecipeDesign');
-        const isSecureContact = config
-            .get('page.pageId', '')
-            .includes(
-                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
-            );
+
+        const isSecureContact = [
+            'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+            'help/2016/sep/19/how-to-contact-the-guardian-securely',
+        ].includes(config.get('page.pageId', ''));
 
         // Feature switches
         this.adFree = !!forceAdFree || isAdFreeUser();
@@ -67,6 +68,8 @@ class CommercialFeatures {
                 !sensitiveContent &&
                 !isIdentityPage &&
                 !this.adFree);
+
+        this.shouldBlockAnalytics = isSecureContact;
 
         this.stickyTopBannerAd =
             !this.adFree &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -225,10 +225,20 @@ describe('Commercial features', () => {
             expect(features.thirdPartyTags).toBe(false);
         });
 
-        it('Does not run on secure contact pages', () => {
+        it('Does not run on the secure contact interactive', () => {
             config.set(
                 'page.pageId',
                 'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
+            );
+
+            const features = new CommercialFeatures();
+            expect(features.thirdPartyTags).toBe(false);
+        });
+
+        it('Does not run on secure contact help page', () => {
+            config.set(
+                'page.pageId',
+                'help/2016/sep/19/how-to-contact-the-guardian-securely'
             );
 
             const features = new CommercialFeatures();


### PR DESCRIPTION
## What does this change?

#### 👉 Remove external scripts from page

The article `help/2016/sep/19/how-to-contact-the-guardian-securely` [on this page](https://www.theguardian.com/help/2016/sep/19/how-to-contact-the-guardian-securely) has similar content to the [secure contact interactive](https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely), which we are already excluding third-party-tags from.

#### 👉Expand exemptions beyond scripts loaded via third party tags

Goodbye Lotame 👋...at least from a couple of pieces of content.

I have decided to add a more generic named `shouldBlockAnalytics` boolean to commercialFeatures. This is true if the page is one of the secure-contact pages, but may apply to other content. With Lotame and Confiant being loaded

I have not added a check for Confiant yet, happy to do so in the PR if it make sense? If a page has `shouldShowAdverts` to `false`, do we need to load `Confiant`? 🤔 

## Screenshots

#### Before:

<img width="1143" alt="Screenshot 2019-08-13 at 13 25 41" src="https://user-images.githubusercontent.com/8607683/62941826-e1293e80-bdce-11e9-9504-14c51b4a1ccc.png">

#### After:

<img width="1144" alt="Screenshot 2019-08-13 at 13 31 01" src="https://user-images.githubusercontent.com/8607683/62941860-f900c280-bdce-11e9-8c44-84f72ee7b9c5.png">


## What is the value of this and can you measure success?

I noticed that Privacy Badger flagged some trackers (!) on these two pages:

Therefore expanding the exemptions  🔐✨

Intended outcome is blocking scripts on two pieces of content, scripts should still load normally on all other pages. The 'blocklist' has therefore been made to be very specific and relies on the `pageIds`. 

## Checklist

### Does this affect other platforms?

Nope

### Does this affect GLabs Paid Content Pages? 

Nope

### Does this change break ad-free?

Nope

### Tested

- [x] Locally
- [ ] On CODE (optional)

