### PR TITLE
Make footer data

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -95,7 +95,7 @@ object FooterLinks {
   val auListTwo = List(
     allTopics("au"),
     allWriters("au"),
-    FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses")
+    FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses"),
     digitalNewspaperArchive,
     facebook("au"),
     twitter("au")
@@ -139,7 +139,7 @@ object FooterLinks {
     discountCodes("au")
   )
 
-  val internationalListThree = List(
+  val intListThree = List(
     FooterLink("Advertise with us", "https://advertising.theguardian.com", "international : footer : advertise with us"),
     FooterLink("Search UK jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_INT_GU_JOBS", "international : footer : uk-jobs"),
     FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer", "international : footer : soulmates"),

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -11,11 +11,11 @@ object FooterLinks {
 
   // Footer column one
 
-  val complaintsAndCorrections = FooterLink("Complaints &amp; corrections", "/info/complaints-and-corrections", "complaints")
+  val complaintsAndCorrections = FooterLink("Complaints & corrections", "/info/complaints-and-corrections", "complaints")
   val secureDrop = FooterLink("SecureDrop", "https://www.theguardian.com/securedrop", "securedrop")
   val privacyPolicy = FooterLink("Privacy policy", "/info/privacy", "privacy")
   val cookiePolicy = FooterLink("Cookie policy", "/info/cookies", "cookie")
-  val termsAndConditions = FooterLink("Terms &amp; conditions", "/help/terms-of-service", "terms")
+  val termsAndConditions = FooterLink("Terms & conditions", "/help/terms-of-service", "terms")
 
   def help(edition: String): FooterLink = FooterLink("Help", "/help", s"${edition} : footer : tech feedback", "js-tech-feedback-report")
   def workForUs(edition: String): FooterLink = FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -1,0 +1,149 @@
+package navigation
+
+case class FooterLink(
+  text: String,
+  url: String,
+  dataLinkName: String,
+  extraClasses: String = ""
+)
+
+object FooterLinks {
+
+  // Footer column one
+
+  val complaintsAndCorrections = FooterLink("Complaints &amp; corrections", "/info/complaints-and-corrections", "complaints")
+  val secureDrop = FooterLink("SecureDrop", "https://www.theguardian.com/securedrop", "securedrop")
+  val privacyPolicy = FooterLink("Privacy policy", "/info/privacy", "privacy")
+  val cookiePolicy = FooterLink("Cookie policy", "/info/cookies", "cookie")
+  val termsAndConditions = FooterLink("Terms &amp; conditions", "/help/terms-of-service", "terms")
+
+  def help(edition: String): FooterLink = FooterLink("Help", "/help", s"${edition} : footer : tech feedback", "js-tech-feedback-report")
+  def workForUs(edition: String): FooterLink = FooterLink("Work for us", "https://workforus.theguardian.com", s"${edition} : footer : work for us")
+
+  val ukListOne = List(
+    FooterLink("About us", "/about", "uk : footer : about us"),
+    FooterLink("Contact us", "/help/contact-us", "uk : footer : contact us"),
+    complaintsAndCorrections,
+    secureDrop,
+    workForUs("uk"),
+    privacyPolicy,
+    cookiePolicy,
+    termsAndConditions,
+    help("uk"),
+  )
+
+  val usListOne = List(
+    FooterLink("About us", "/info/about-guardian-us", "us : footer : about us"),
+    FooterLink("Contact us", "/info/about-guardian-us/contact", "us : footer : contact us"),
+    complaintsAndCorrections,
+    secureDrop,
+    workForUs("us"),
+    privacyPolicy,
+    cookiePolicy,
+    termsAndConditions,
+    help("us"),
+  )
+
+  val auListOne = List(
+    FooterLink("About us", "/info/about-guardian-australia", "au : footer : about us"),
+    FooterLink("Information", "/info", "au : footer : information"),
+    FooterLink("Contact us", "/info/2013/may/26/contact-guardian-australia", "au : footer : contact us"),
+    secureDrop,
+    FooterLink("Vacancies","https://www.theguardian.com/info/2015/aug/04/guardian-australia-job-vacancies", "au : footer : vacancies"),
+    privacyPolicy,
+    cookiePolicy,
+    termsAndConditions,
+    help("au"),
+  )
+
+  val intListOne = List(
+    FooterLink("Contact us", "/help/contact-us", "international : footer : contact us"),
+    complaintsAndCorrections,
+    secureDrop,
+    workForUs("international"),
+    privacyPolicy,
+    cookiePolicy,
+    termsAndConditions,
+    help("international"),
+  )
+
+  // Footer column two
+
+  def allTopics(edition: String): FooterLink = FooterLink("All topics", "/index/subjects/a", s"${edition} : footer : all topics")
+  def allWriters(edition: String): FooterLink = FooterLink("All writers", "/index/contributors", s"${edition} : footer : all contributors")
+  val digitalNewspaperArchive = FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
+  def facebook(edition: String): FooterLink = FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
+  def twitter(edition: String): FooterLink = FooterLink("Twitter", "https://twitter.com/guardian", s"${edition}: footer : twitter")
+
+  val ukListTwo = List(
+    allTopics("uk"),
+    allWriters("uk"),
+    FooterLink("Modern Slavery Act", "/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT", "uk : footer : modern slavery act statement"),
+    digitalNewspaperArchive,
+    facebook("uk"),
+    twitter("uk")
+  )
+
+  val usListTwo = List(
+    allTopics("us"),
+    allWriters("us"),
+    digitalNewspaperArchive,
+    facebook("us"),
+    twitter("us")
+  )
+
+  val auListTwo = List(
+    allTopics("au"),
+    allWriters("au"),
+    FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses")
+    digitalNewspaperArchive,
+    facebook("au"),
+    twitter("au")
+  )
+
+  val intListTwo = List(
+    allTopics("international"),
+    allWriters("international"),
+    digitalNewspaperArchive,
+    facebook("international"),
+    twitter("international")
+  )
+
+  // Footer column three
+
+  def discountCodes(edition: String): FooterLink = FooterLink("Discount Codes", "https://discountcode.theguardian.com/", s"${edition}: footer : discount code", "js-discount-code-link")
+
+  val ukListThree = List(
+    FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
+    FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
+    FooterLink("Search jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_UK_GU_JOBS", "uk : footer : jobs"),
+    FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES", "uk : footer : soulmates"),
+    FooterLink("Patrons", "https://patrons.theguardian.com/?INTCMP=footer_patrons", "uk : footer : patrons"),
+    discountCodes("uk")
+  )
+
+  val usListThree = List(
+    FooterLink("Advertise with us", "https://advertising.theguardian.com/us/advertising", "us : footer : advertise with us"),
+    FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
+    FooterLink("Search jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_US_GU_JOBS", "us : footer : jobs"),
+    FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer", "us : footer : soulmates"),
+    discountCodes("us")
+  )
+
+  val auListThree = List(
+    FooterLink("Advertising", "/advertising/guardian-australia-advertising", "au : footer : advertising"),
+    FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
+    FooterLink("Advertise with us", "https://advertising.theguardian.com/", "au : footer : advertise with us"),
+    FooterLink("Search UK jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_AU_GU_JOBS", "au : footer : uk-jobs"),
+    FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer", "au : footer : soulmates"),
+    discountCodes("au")
+  )
+
+  val internationalListThree = List(
+    FooterLink("Advertise with us", "https://advertising.theguardian.com", "international : footer : advertise with us"),
+    FooterLink("Search UK jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_INT_GU_JOBS", "international : footer : uk-jobs"),
+    FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer", "international : footer : soulmates"),
+    discountCodes("international")
+  )
+
+}

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -1,5 +1,8 @@
 package navigation
 
+import common.{Edition, editions}
+
+
 case class FooterLink(
   text: String,
   url: String,
@@ -145,4 +148,14 @@ object FooterLinks {
     discountCodes("international")
   )
 
+  def getFooterByEdition(edition: Edition): Seq[Seq[FooterLink]] = edition match {
+    case editions.Uk => Seq(ukListOne, ukListTwo, ukListThree)
+    case editions.Us => Seq(usListOne, usListTwo, usListThree)
+    case editions.Au => Seq(auListOne, auListTwo, auListThree)
+    case editions.International => Seq(intListOne, intListTwo, intListThree)
+    case _ => Seq(intListOne, intListTwo, intListThree)
+  }
+
 }
+
+

--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -131,7 +131,6 @@ object FooterLinks {
   )
 
   val auListThree = List(
-    FooterLink("Advertising", "/advertising/guardian-australia-advertising", "au : footer : advertising"),
     FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
     FooterLink("Advertise with us", "https://advertising.theguardian.com/", "au : footer : advertise with us"),
     FooterLink("Search UK jobs", "https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_AU_GU_JOBS", "au : footer : uk-jobs"),

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -4,6 +4,7 @@
 @import common.Edition
 @import common.LinkTo
 @import navigation.NavMenu
+@import navigation.{FooterLinks, FooterLink}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
 @import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, AmpFooter}
 @import common.editions.{Au, Uk, Us, International}
@@ -12,6 +13,20 @@
 @import com.gu.identity.model.EmailNewsletters
 @import model.NoCache
 @import views.support.{RenderClasses}
+
+
+
+@footerListItem(link: FooterLink) = {
+    <li class="colophon__item">
+        <a
+        data-link-name="@link.dataLinkName"
+        href="@if(link.url.startsWith("/")) {@LinkTo{@link.url}} else {@link.url}"
+        class="@link.extraClasses"
+        >
+        @Html(link.text)
+        </a>
+    </li>
+}
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
 
@@ -65,79 +80,20 @@
                 <div class="@RenderClasses(Map(
                     "colophon__lists-container--foundation" ->  page.metadata.isFoundation,
                 ), "colophon__lists-container")">
+
                     @if(!page.metadata.isFoundation) {
                         @currentEdition match {
                             case Uk => {
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/about}">
-                                        About us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
-                                        Contact us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                                        Complaints &amp; corrections</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        SecureDrop</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : work for us" href="https://workforus.theguardian.com">
-                                        Work for us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                                        Privacy policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
-                                        Cookie policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                                        Terms &amp; conditions</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                        Help</a>
-                                    </li>
+                                    @FooterLinks.ukListOne.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="uk : footer : all topics" href="@LinkTo {/index/subjects/a}">
-                                        All topics</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : all contributors" href="@LinkTo {/index/contributors}">
-                                        All writers</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : modern slavery act statement" href="@LinkTo {/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT}">
-                                        Modern Slavery Act</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
-                                        Digital newspaper archive</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
-                                        Facebook</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
-                                        Twitter</a>
-                                    </li>
+                                    @FooterLinks.ukListTwo.map { link: FooterLink => @footerListItem(link)}
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="uk : footer : advertise with us" href="https://advertising.theguardian.com">
-                                        Advertise with us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                                        Guardian Labs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_UK_GU_JOBS">
-                                        Search jobs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
-                                        Dating</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="uk : footer : patrons" href="https://patrons.theguardian.com/?INTCMP=footer_patrons">
-                                        Patrons</a>
-                                    </li>
-                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="uk : footer : discount code" href="https://discountcode.theguardian.com/">
-                                        Discount Codes</a>
-                                    </li>
+                                    @FooterLinks.ukListThree.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 @readerRevenueLinks(Edition(request).id.toLowerCase())
@@ -145,70 +101,18 @@
 
                             case Us => {
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="us : footer : about us" href="@LinkTo {/info/about-guardian-us}">
-                                        About us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
-                                        Contact us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                                        Complaints &amp; corrections</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        SecureDrop</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : work for us" href="https://workforus.theguardian.com/">
-                                        Work for us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                                        Privacy policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
-                                        Cookie policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                                        Terms &amp; conditions</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                        Help</a>
-                                    </li>
+                                    @FooterLinks.usListOne.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="us : footer : all topics" href="@LinkTo {/index/subjects/a}">
-                                        All topics</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : all contributors" href="@LinkTo {/index/contributors}">
-                                        All writers</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
-                                        Digital newspaper archive</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
-                                        Facebook</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
-                                        Twitter</a>
-                                    </li>
+                                    @FooterLinks.usListTwo.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="us : footer : advertise with us" href="https://advertising.theguardian.com/us/advertising">
-                                        Advertise with us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
-                                        Guardian Labs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_US_GU_JOBS">
-                                        Search jobs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="us : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_us_web_footer">
-                                        Dating</a>
-                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="us : footer : discount code" href="https://discountcode.theguardian.com/">
-                                        Coupons</a>
-                                    </li>
+
+                                    @FooterLinks.usListThree.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 @readerRevenueLinks(Edition(request).id.toLowerCase())
@@ -217,71 +121,16 @@
 
                             case Au => {
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
-                                        About us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
-                                        Information</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
-                                        Contact us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        SecureDrop</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://www.theguardian.com/info/2015/aug/04/guardian-australia-job-vacancies">
-                                        Vacancies</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                                        Privacy policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
-                                        Cookie policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                                        Terms &amp; conditions</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/help}">
-                                        Help</a>
-                                    </li>
+                                    @FooterLinks.auListOne.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="au : footer : all topics" href="@LinkTo {/index/subjects/a}">
-                                        All topics</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : all contributors" href="@LinkTo {/index/contributors}">
-                                        All writers</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
-                                        Events</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
-                                        Digital newspaper archive</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
-                                        Facebook</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
-                                        Twitter</a>
-                                    </li>
+                                    @FooterLinks.auListTwo.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs-australia}">
-                                        Guardian Labs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : advertise with us" href="https://advertising.theguardian.com">
-                                        Advertise with us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_AU_GU_JOBS">
-                                        Search UK jobs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="au : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_au_web_footer">
-                                        Dating</a>
-                                    <li class="colophon__item"><a class="js-discount-code-link" data-link-name="au : footer : discount code" href="https://discountcode.theguardian.com/">
-                                        Discount Codes</a>
-                                    </li>
+
+                                    @FooterLinks.auListThree.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 @readerRevenueLinks(Edition(request).id.toLowerCase())
@@ -289,48 +138,11 @@
 
                             case International => {
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="international : footer : contact us" href="@LinkTo {/help/contact-us}">
-                                        Contact us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                                        Complaints &amp; corrections</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="securedrop" href="https://www.theguardian.com/securedrop">
-                                        SecureDrop</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : work for us" href="https://workforus.theguardian.com">
-                                        Work for us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                                        Privacy policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
-                                        Cookie policy</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                                        Terms &amp; conditions</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/help}">
-                                        Help</a>
-                                    </li>
+                                @FooterLinks.intListOne.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="international : footer : all topics" href="@LinkTo {/index/subjects/a}">
-                                        All topics</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : all contributors" href="@LinkTo {/index/contributors}">
-                                        All writers</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
-                                        Digital newspaper archive</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : facebook" href="https://www.facebook.com/theguardian">
-                                        Facebook</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : twitter" href="https://twitter.com/guardian">
-                                        Twitter</a>
-                                    </li>
+                                @FooterLinks.intListTwo.map { link: FooterLink => @footerListItem(link) }
                                 </ul>
 
                                 <ul class="colophon__list">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -334,17 +334,8 @@
                                 </ul>
 
                                 <ul class="colophon__list">
-                                    <li class="colophon__item"><a data-link-name="international : footer : advertise with us" href="https://advertising.theguardian.com">
-                                        Advertise with us</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : uk-jobs" href="https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_INT_GU_JOBS">
-                                        Search UK jobs</a>
-                                    </li>
-                                    <li class="colophon__item"><a data-link-name="international : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer">
-                                        Dating</a>
-                                    <li class="colophon__item js-discount-code-link"><a data-link-name="international : footer : discount code" href="https://discountcode.theguardian.com">
-                                        Discount Codes</a>
-                                    </li>
+                                @FooterLinks.intListThree.map { link: FooterLink => @footerListItem(link) }
+
                                 </ul>
 
                                 @readerRevenueLinks(Edition(request).id.toLowerCase())

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -82,77 +82,15 @@
                 ), "colophon__lists-container")">
 
                     @if(!page.metadata.isFoundation) {
-                        @currentEdition match {
-                            case Uk => {
-                                <ul class="colophon__list">
-                                    @FooterLinks.ukListOne.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
 
-                                <ul class="colophon__list">
-                                    @FooterLinks.ukListTwo.map { link: FooterLink => @footerListItem(link)}
-                                </ul>
-
-                                <ul class="colophon__list">
-                                    @FooterLinks.ukListThree.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                @readerRevenueLinks(Edition(request).id.toLowerCase())
-                            }
-
-                            case Us => {
-                                <ul class="colophon__list">
-                                    @FooterLinks.usListOne.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-
-                                <ul class="colophon__list">
-                                    @FooterLinks.usListTwo.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-
-                                <ul class="colophon__list">
-
-                                    @FooterLinks.usListThree.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                @readerRevenueLinks(Edition(request).id.toLowerCase())
-
-                            }
-
-                            case Au => {
-                                <ul class="colophon__list">
-                                    @FooterLinks.auListOne.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                <ul class="colophon__list">
-                                    @FooterLinks.auListTwo.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                <ul class="colophon__list">
-
-                                    @FooterLinks.auListThree.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                @readerRevenueLinks(Edition(request).id.toLowerCase())
+                        @FooterLinks.getFooterByEdition(currentEdition).map { linkGroup =>
+                            <ul class="colophon__list">
+                                @linkGroup.map { link: FooterLink => @footerListItem(link)}
+                            </ul>
                         }
 
-                            case International => {
-                                <ul class="colophon__list">
-                                @FooterLinks.intListOne.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
+                        @readerRevenueLinks(Edition(request).id.toLowerCase())
 
-                                <ul class="colophon__list">
-                                @FooterLinks.intListTwo.map { link: FooterLink => @footerListItem(link) }
-                                </ul>
-
-                                <ul class="colophon__list">
-                                @FooterLinks.intListThree.map { link: FooterLink => @footerListItem(link) }
-
-                                </ul>
-
-                                @readerRevenueLinks(Edition(request).id.toLowerCase())
-                            }
-                        }
                     } else {
                         <div class="colophon__list">
                             @fragments.inlineSvg("guardian-foundation", "logo")


### PR DESCRIPTION
## What does this change?
Moves the footer links from hardcoded HTML into data to loop over. 

## Screenshots
### UK

![image](https://user-images.githubusercontent.com/638051/63015825-ef886080-be89-11e9-81d9-f0efcdb889c9.png)

### US

![image](https://user-images.githubusercontent.com/638051/63015873-062eb780-be8a-11e9-8f21-a9b4a8a0a203.png)


### Australia

![image](https://user-images.githubusercontent.com/638051/63015729-a9330180-be89-11e9-87ad-0139403d9e18.png)

### International

![image](https://user-images.githubusercontent.com/638051/63015903-1c3c7800-be8a-11e9-8a7c-89a5eb1a1885.png)


## What is the value of this and can you measure success?
We can then share this with Dotcom-Rendering, as well as making it easier to edit on Frontend.
