### PR TITLE
Remove unused check: isUserInEmailAbTest

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/commercial/modules/check-dispatcher.js
@@ -143,7 +143,6 @@ const checksToDispatch = {
 
     emailCanRunPostCheck(): Promise<boolean> {
         const dependentChecks = [
-            waitForCheck('isUserInEmailAbTest'),
             waitForCheck('isOutbrainMerchandiseCompliantOrBlockedByAds'),
             waitForCheck('isOutbrainDisabled'),
             waitForCheck('isStoryQuestionsOnPage'),

--- a/static/src/javascripts/projects/common/modules/check-mediator-checks.js
+++ b/static/src/javascripts/projects/common/modules/check-mediator-checks.js
@@ -4,7 +4,6 @@ export const checks = [
     'isOutbrainDisabled',
     'isUserInContributionsAbTest',
     'isUserNotInContributionsAbTest',
-    'isUserInEmailAbTest',
     'emailCanRunPreCheck',
     'listCanRun',
     'emailInArticleOutbrainEnabled',


### PR DESCRIPTION
## What does this change?

The `isUserInEmailAbTest` check, which is registered in `check-mediator-checks.js` is actually never resolved (one can check this by doing a search string over the entire codebase, and see that it is never used, in particular never `registerCheck`'ed or `resolveCheck`'ed). This implies that its presence in `check-dispatcher.js`'s `emailCanRunPostCheck` is unnecessary (and does prevent `emailCanRunPostCheck` from ever completing).

This might have never been noticed before because `emailCanRunPostCheck` is only used in `email-article.js`.

