### PR TITLE
 Epic tests: add PostAskPauseSingleContributors cohort 

### DIFF
--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -22,7 +22,13 @@ declare type EngagementBannerTemplateParams = {
     signInUrl?: string,
 };
 
-declare type AcquisitionsComponentUserCohort = 'OnlyExistingSupporters' | 'OnlyNonSupporters' | 'Everyone';
+/**
+ * AllExistingSupporters - all recurring, all one-offs in last 6 months
+ * AllNonSupporters - no recurring, no one-offs in last 6 months
+ * Everyone
+ * PostHolidayOneOffContributors - people who made a contribution between 6-7 months ago
+ */
+declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostHolidayOneOffContributors';
 
 declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     campaignCode: string,

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -27,6 +27,8 @@ declare type EngagementBannerTemplateParams = {
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
  * PostHolidayOneOffContributors - people who made a contribution between 6-7 months ago
+ *
+ * Note - PostHolidayOneOffContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */
 declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostHolidayOneOffContributors';
 

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -26,11 +26,11 @@ declare type EngagementBannerTemplateParams = {
  * AllExistingSupporters - all recurring, all one-offs in last 6 months
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
- * PostHolidaySingleContributors - people who made a contribution between 6-7 months ago
+ * PostAskPauseSingleContributors - people who made a contribution between 6-7 months ago
  *
- * Note - PostHolidaySingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
+ * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */
-declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostHolidaySingleContributors';
+declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostAskPauseSingleContributors';
 
 declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     campaignCode: string,

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -26,11 +26,11 @@ declare type EngagementBannerTemplateParams = {
  * AllExistingSupporters - all recurring, all one-offs in last 6 months
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
- * PostHolidayOneOffContributors - people who made a contribution between 6-7 months ago
+ * PostHolidaySingleContributors - people who made a contribution between 6-7 months ago
  *
- * Note - PostHolidayOneOffContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
+ * Note - PostHolidaySingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */
-declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostHolidayOneOffContributors';
+declare type AcquisitionsComponentUserCohort = 'AllExistingSupporters' | 'AllNonSupporters' | 'Everyone' | 'PostHolidaySingleContributors';
 
 declare type EngagementBannerParams = EngagementBannerTemplateParams & {
     campaignCode: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -157,7 +157,7 @@ const userIsInCorrectCohort = (
     userCohort: AcquisitionsComponentUserCohort
 ): boolean => {
     switch (userCohort) {
-        case 'PostHolidayOneOffContributors':
+        case 'PostHolidaySingleContributors':
             return isPostHolidayOneOffContributor();
         case 'AllExistingSupporters':
             return shouldHideSupportMessaging();
@@ -174,7 +174,7 @@ const isValidCohort = (cohort: string): boolean =>
         'AllExistingSupporters',
         'AllNonSupporters',
         'Everyone',
-        'PostHolidayOneOffContributors',
+        'PostHolidaySingleContributors',
     ].includes(cohort);
 
 const shouldShowEpic = (test: EpicABTest): boolean => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -157,7 +157,7 @@ const userIsInCorrectCohort = (
     userCohort: AcquisitionsComponentUserCohort
 ): boolean => {
     switch (userCohort) {
-        case 'PostHolidaySingleContributors':
+        case 'PostAskPauseSingleContributors':
             return isPostHolidayOneOffContributor();
         case 'AllExistingSupporters':
             return shouldHideSupportMessaging();
@@ -174,7 +174,7 @@ const isValidCohort = (cohort: string): boolean =>
         'AllExistingSupporters',
         'AllNonSupporters',
         'Everyone',
-        'PostHolidaySingleContributors',
+        'PostAskPauseSingleContributors',
     ].includes(cohort);
 
 const shouldShowEpic = (test: EpicABTest): boolean => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -36,7 +36,7 @@ import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templ
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import {
     shouldHideSupportMessaging,
-    isPostHolidayOneOffContributor,
+    isPostAskPauseOneOffContributor,
 } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
@@ -158,7 +158,7 @@ const userIsInCorrectCohort = (
 ): boolean => {
     switch (userCohort) {
         case 'PostAskPauseSingleContributors':
-            return isPostHolidayOneOffContributor();
+            return isPostAskPauseOneOffContributor();
         case 'AllExistingSupporters':
             return shouldHideSupportMessaging();
         case 'AllNonSupporters':

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -34,7 +34,10 @@ import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
-import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
+import {
+    shouldHideSupportMessaging,
+    isPostHolidayOneOffContributor,
+} from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
     supportSubscribeGeoRedirectURL,
@@ -154,9 +157,11 @@ const userIsInCorrectCohort = (
     userCohort: AcquisitionsComponentUserCohort
 ): boolean => {
     switch (userCohort) {
-        case 'OnlyExistingSupporters':
+        case 'PostHolidayOneOffContributors':
+            return isPostHolidayOneOffContributor();
+        case 'AllExistingSupporters':
             return shouldHideSupportMessaging();
-        case 'OnlyNonSupporters':
+        case 'AllNonSupporters':
             return !shouldHideSupportMessaging();
         case 'Everyone':
         default:
@@ -165,9 +170,12 @@ const userIsInCorrectCohort = (
 };
 
 const isValidCohort = (cohort: string): boolean =>
-    ['OnlyExistingSupporters', 'OnlyNonSupporters', 'Everyone'].includes(
-        cohort
-    );
+    [
+        'AllExistingSupporters',
+        'AllNonSupporters',
+        'Everyone',
+        'PostHolidayOneOffContributors',
+    ].includes(cohort);
 
 const shouldShowEpic = (test: EpicABTest): boolean => {
     const onCompatiblePage = test.pageCheck(config.get('page'));
@@ -470,7 +478,7 @@ const makeEpicABTest = ({
     campaignPrefix = 'gdnwb_copts_memco',
     useLocalViewLog = false,
     useTargetingTool = false,
-    userCohort = 'OnlyNonSupporters',
+    userCohort = 'AllNonSupporters',
     testHasCountryName = false,
     pageCheck = isCompatibleWithArticleEpic,
     template = controlTemplate,
@@ -609,7 +617,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                     );
                     const userCohort = rowWithUserCohort
                         ? rowWithUserCohort.userCohort
-                        : 'OnlyNonSupporters';
+                        : 'AllNonSupporters';
 
                     // If testHasCountryName is true but a country name is not available for this user then
                     // they will be excluded from this test
@@ -654,7 +662,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
                               }),
                         ...(isThankYou
                             ? {
-                                  userCohort: 'OnlyExistingSupporters',
+                                  userCohort: 'AllExistingSupporters',
                                   useLocalViewLog: true,
                               }
                             : {}),
@@ -734,7 +742,7 @@ export const getEpicTestsFromGoogleDoc = (): Promise<
 // TODO - banner testing needs a refactor, as currently both canRun and canShow need to call this
 export const canShowBannerSync = (
     minArticlesBeforeShowingBanner: number = 3,
-    userCohort: AcquisitionsComponentUserCohort = 'OnlyNonSupporters'
+    userCohort: AcquisitionsComponentUserCohort = 'AllNonSupporters'
 ): boolean => {
     const userHasSeenEnoughArticles: boolean =
         getVisitCount() >= minArticlesBeforeShowingBanner;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -51,7 +51,7 @@ const getAcquisitionsBannerParams = (
         isHardcodedFallback: false,
         template: acquisitionsBannerControlTemplate,
         minArticlesBeforeShowingBanner: 3,
-        userCohort: 'OnlyNonSupporters',
+        userCohort: 'AllNonSupporters',
     };
 };
 
@@ -83,6 +83,6 @@ export const getControlEngagementBannerParams = (): Promise<EngagementBannerPara
                 isHardcodedFallback: true,
                 template: acquisitionsBannerControlTemplate,
                 minArticlesBeforeShowingBanner: 3,
-                userCohort: 'OnlyNonSupporters',
+                userCohort: 'AllNonSupporters',
             };
         });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -225,25 +225,25 @@ const getDaysSinceLastOneOffContribution = (): number | null => {
 };
 
 // defaults to last six months
-const isRecentOneOffContributor = (holidayDays: number = 180): boolean => {
+const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;
     }
-    return daysSinceLastContribution <= holidayDays;
+    return daysSinceLastContribution <= askPauseDays;
 };
 
-// true if the user is in the first month after ask-free holiday
+// true if the user is in the first month after ask-free period
 const isPostAskPauseOneOffContributor = (
-    holidayDays: number = 180
+    askPauseDays: number = 180
 ): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;
     }
     return (
-        daysSinceLastContribution > holidayDays &&
-        daysSinceLastContribution < holidayDays + 30
+        daysSinceLastContribution > askPauseDays &&
+        daysSinceLastContribution < askPauseDays + 30
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -234,7 +234,7 @@ const isRecentOneOffContributor = (holidayDays: number = 180): boolean => {
 };
 
 // true if the user is in the first month after ask-free holiday
-const isPostHolidayOneOffContributor = (holidayDays: number = 180): boolean => {
+const isPostAskPauseOneOffContributor = (holidayDays: number = 180): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;
@@ -300,7 +300,7 @@ export {
     getLastOneOffContributionDate,
     getLastRecurringContributionDate,
     getDaysSinceLastOneOffContribution,
-    isPostHolidayOneOffContributor,
+    isPostAskPauseOneOffContributor,
     readerRevenueRelevantCookies,
     fakeOneOffContributor,
     shouldNotBeShownSupportMessaging,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -224,13 +224,25 @@ const getDaysSinceLastOneOffContribution = (): number | null => {
     return dateDiffDays(lastContributionDate, Date.now());
 };
 
-// in last six months
-const isRecentOneOffContributor = (): boolean => {
+// defaults to last six months
+const isRecentOneOffContributor = (holidayDays: number = 180): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;
     }
-    return daysSinceLastContribution <= 180;
+    return daysSinceLastContribution <= holidayDays;
+};
+
+// true if the user is in the first month after ask-free holiday
+const isPostHolidayOneOffContributor = (holidayDays: number = 180): boolean => {
+    const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
+    if (daysSinceLastContribution === null) {
+        return false;
+    }
+    return (
+        daysSinceLastContribution > holidayDays &&
+        daysSinceLastContribution < holidayDays + 30
+    );
 };
 
 const isRecurringContributor = (): boolean =>
@@ -288,6 +300,7 @@ export {
     getLastOneOffContributionDate,
     getLastRecurringContributionDate,
     getDaysSinceLastOneOffContribution,
+    isPostHolidayOneOffContributor,
     readerRevenueRelevantCookies,
     fakeOneOffContributor,
     shouldNotBeShownSupportMessaging,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -234,7 +234,9 @@ const isRecentOneOffContributor = (holidayDays: number = 180): boolean => {
 };
 
 // true if the user is in the first month after ask-free holiday
-const isPostAskPauseOneOffContributor = (holidayDays: number = 180): boolean => {
+const isPostAskPauseOneOffContributor = (
+    holidayDays: number = 180
+): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -16,6 +16,7 @@ import {
     isRecentOneOffContributor,
     shouldNotBeShownSupportMessaging,
     getLastRecurringContributionDate,
+    isPostHolidayOneOffContributor,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -564,5 +565,35 @@ describe('isRecentOneOffContributor', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
         expect(isRecentOneOffContributor()).toBe(false);
+    });
+});
+
+describe('isPostHolidayOneOffContributor', () => {
+    beforeEach(() => {
+        removeOneOffContributionCookie();
+    });
+
+    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
+
+    it('returns false if there is no one-off contribution cookie', () => {
+        expect(isPostHolidayOneOffContributor()).toBe(false);
+    });
+
+    it('returns false if there are 5 days between the last contribution date and now', () => {
+        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isPostHolidayOneOffContributor()).toBe(false);
+    });
+
+    it('returns false if the one-off contribution was more than 7 months ago', () => {
+        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isPostHolidayOneOffContributor()).toBe(false);
+    });
+
+    it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
+        global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
+        setOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isPostHolidayOneOffContributor()).toBe(true);
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -16,7 +16,7 @@ import {
     isRecentOneOffContributor,
     shouldNotBeShownSupportMessaging,
     getLastRecurringContributionDate,
-    isPostHolidayOneOffContributor,
+    isPostAskPauseOneOffContributor,
 } from './user-features.js';
 
 jest.mock('lib/raven');
@@ -568,7 +568,7 @@ describe('isRecentOneOffContributor', () => {
     });
 });
 
-describe('isPostHolidayOneOffContributor', () => {
+describe('isPostAskPauseOneOffContributor', () => {
     beforeEach(() => {
         removeOneOffContributionCookie();
     });
@@ -576,24 +576,24 @@ describe('isPostHolidayOneOffContributor', () => {
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
     it('returns false if there is no one-off contribution cookie', () => {
-        expect(isPostHolidayOneOffContributor()).toBe(false);
+        expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
     it('returns false if there are 5 days between the last contribution date and now', () => {
         global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostHolidayOneOffContributor()).toBe(false);
+        expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
     it('returns false if the one-off contribution was more than 7 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostHolidayOneOffContributor()).toBe(false);
+        expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
     it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
         setOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostHolidayOneOffContributor()).toBe(true);
+        expect(isPostAskPauseOneOffContributor()).toBe(true);
     });
 });


### PR DESCRIPTION
## What does this change?
For contributions messaging we can target a specific `userCohort`, based on their existing financial relationship with the guardian. This change adds a new cohort for users who are in the first month after their 6-month ask-free holiday, following a single contribution.
This is because we want to test custom messages encouraging them to contribute again.

Also renamed the existing cohorts for clarity

## Screenshots
Variant 1
<img width="629" alt="Screenshot 2019-08-16 at 09 39 51" src="https://user-images.githubusercontent.com/1513454/63155106-e1f9e480-c009-11e9-8224-7dbcdcc1bfc3.png">


Variant 2
<img width="629" alt="Screenshot 2019-08-16 at 09 40 10" src="https://user-images.githubusercontent.com/1513454/63155114-e6be9880-c009-11e9-82ce-6d2b5af5d8de.png">


Control
<img width="629" alt="Screenshot 2019-08-16 at 09 39 28" src="https://user-images.githubusercontent.com/1513454/63155128-eaeab600-c009-11e9-8230-fdcaaaa8d82a.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
