### PR TITLE
Prevent double MPUs on mobile after most-viewed

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -749,6 +749,9 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
     def hasAdjacentThrasher(element: Element): Boolean =
       Option(element.nextElementSibling()).exists(_.hasClass("fc-container--thrasher"))
 
+    def isMostViewedContainer(element: Element): Boolean =
+      Option(element.id()).contains("most-viewed")
+
     val sliceSlot = views.html.fragments.items.facia_cards.sliceSlot
 
     val containers: List[Element] = document.getElementsByClass("fc-container").asScala.toList
@@ -758,7 +761,7 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
     // we also exclude any containers that are directly before a thrasher
     // then we take every other container, up to a maximum of 10, for targeting MPU insertion
     val containersForCommercialMPUs = containers.zipWithIndex.collect {
-      case (x, i) if !hasFirstContainerThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) => x
+      case (x, i) if !hasFirstContainerThrasher(x, i) && !hasAdjacentCommercialContainer(x) && !hasAdjacentThrasher(x) && !isMostViewedContainer(x) => x
     }.zipWithIndex.collect {
       case (x, i) if i % 2 == 0 => x
     }.take(10)


### PR DESCRIPTION
## What does this change?
The most viewed container has its own inner ad and this commit
will prevent appending an ad slot after it thus preventing two MPUs
on top of each other on mobile.

To test, load the page in mobile view as the DOM element gets removed client side on desktop. 

## Screenshots
#### Before commit:
![Screenshot 2019-08-14 at 16 03 09](https://user-images.githubusercontent.com/12860328/63032948-b8787600-beae-11e9-81cb-38e7e469b05d.png)
#### After commit:
![Screenshot 2019-08-14 at 16 03 34](https://user-images.githubusercontent.com/12860328/63032984-c928ec00-beae-11e9-9460-117165f09865.png)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
