### PR TITLE
Change links pointing to email prefs on profile to manage

### DIFF
--- a/identity/app/controllers/editprofile/tabs/EmailsTab.scala
+++ b/identity/app/controllers/editprofile/tabs/EmailsTab.scala
@@ -1,5 +1,6 @@
 package controllers.editprofile.tabs
 
+import conf.Configuration
 import controllers.editprofile._
 import play.api.mvc.{Action, AnyContent}
 
@@ -11,19 +12,15 @@ trait EmailsTab
 
   val emailFilter = emailValidationFilter
 
+  private def redirectToManage(path: String): Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      url = s"${Configuration.id.mmaUrl}/${path}",
+      MOVED_PERMANENTLY)
+  }
+
   /** GET /email-prefs */
-  def displayEmailPrefsForm(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] =
-    displayForm(EmailPrefsProfilePage, consentsUpdated, consentHint, emailValidationRequired = true)
+  def redirectToEmailPrefs: Action[AnyContent] = redirectToManage("email-prefs")
 
   /** GET /privacy/edit */
-  def displayPrivacyFormRedirect(
-    consentsUpdated: Boolean,
-    consentHint: Option[String]): Action[AnyContent] =
-    csrfAddToken {
-      recentFullAuthWithIdapiUserAction { implicit request =>
-        Redirect(
-          routes.EditProfileController.displayEmailPrefsForm(consentsUpdated, consentHint),
-          MOVED_PERMANENTLY)
-      }
-    }
+  def displayPrivacyFormRedirect: Action[AnyContent] = redirectToManage("email-prefs")
 }

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -25,7 +25,7 @@
     <section class="identity-forms-message">
         <h1 class="identity-title">Thank you! We've got your preferences</h1>
         <div class="identity-forms-message__body">
-            <p>You can change these anytime by going to My account > <a class="u-underline" data-link-name="complete-consents : to-email-prefs" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.displayEmailPrefsForm(false, None).url, idRequest)">
+            <p>You can change these anytime by going to My account > <a class="u-underline" data-link-name="complete-consents : to-email-prefs" href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.redirectToEmailPrefs.url, idRequest)">
                 Email Preferences
             </a>.</p>
             <br/>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -85,7 +85,7 @@
 
                     @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-contributions-tab", requiresValidation = requiresValidation, disableClientSideRouting = true)
 
-                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", requiresValidation = requiresValidation)
+                    @tab(6, "Emails & marketing", "/email-prefs", None, optionalClass="qa-privacy-tab", disableClientSideRouting = true)
                 </ol>
         </div>
     </div>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -56,7 +56,7 @@ GET         /membership/edit                        controllers.editprofile.Edit
 GET         /contribution/recurring/edit            controllers.editprofile.EditProfileController.redirectToManageContributions
 GET         /digitalpack/edit                       controllers.editprofile.EditProfileController.redirectToManageSubscriptions
 
-GET         /email-prefs                            controllers.editprofile.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
+GET         /email-prefs                            controllers.editprofile.EditProfileController.redirectToEmailPrefs
 
 ########################################################################################################################
 # PUBLIC EDIT PROFILE
@@ -81,4 +81,4 @@ GET         /complete-consents                      controllers.editprofile.Edit
 # Old routes
 ########################################################################################################################
 GET         /consents/staywithus                    controllers.editprofile.EditProfileController.redirectToConsentsJourney()
-GET         /privacy/edit                           controllers.editprofile.EditProfileController.displayPrivacyFormRedirect(consentsUpdated: Boolean ?= false, consentHint: Option[String])
+GET         /privacy/edit                           controllers.editprofile.EditProfileController.redirectToEmailPrefs

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -403,24 +403,5 @@ import scala.concurrent.Future
         userUpdate.privateFields.value.telephoneNumber.value should equal(TelephoneNumber(Some(telephoneNumberCountryCode), Some(telephoneNumberLocalNumber)))
       }
     }
-
-    "displayEmailPrefsForm method" should {
-      "display Guardian Today UK newsletter" in new EditProfileFixture {
-        override val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true), hasRepermissioned = Some(true)))
-        override val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
-        override val authenticatedUser = AuthenticatedUser(user, testAuth, true)
-        when(authService.fullyAuthenticatedUser(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
-        when(api.me(testAuth)) thenReturn Future.successful(Right(user))
-
-        val userEmailSubscriptions = List(EmailList(EmailNewsletters.guardianTodayUk.listId.toString))
-        when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
-          .thenReturn(Future.successful(Right(Subscriber("HTML", userEmailSubscriptions, "subscribed"))))
-
-        val result = controller.displayEmailPrefsForm(false, None).apply(FakeCSRFRequest(csrfAddToken))
-        status(result) should be(200)
-        contentAsString(result) should include (EmailNewsletters.guardianTodayUk.name)
-        contentAsString(result) should include ("Unsubscribe")
-      }
-    }
   }
 }


### PR DESCRIPTION
## What does this change?
This changes links to `profile.theguardian.com/email-prefs` to `manage.theguardian.com/email-prefs` as part of work to migrate all the profile management tabs that currently sit on Frontend to manage-frontend.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
