### PR TITLE
Track insert/view componentEvent for double banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -7,6 +7,7 @@ import {
     hideBanner as hideEngagementBanner,
     deriveBannerParams as deriveEngagementBannerParams,
     bannerParamsToHtml as engagementBannerParamsToHtml,
+    trackBanner,
 } from 'common/modules/commercial/membership-engagement-banner';
 import {
     track as trackFirstPvConsent,
@@ -147,6 +148,8 @@ const show = (): Promise<boolean> => {
                 }
                 bindFirstPvConsentClickHandlers(firstPvConsentMessage);
                 engagementMessage.bindCloseHandler(hideEngagementBanner);
+
+                trackBanner(paramsAndEngagementBannerHtml.params);
 
                 if (paramsAndEngagementBannerHtml.params.bannerShownCallback) {
                     paramsAndEngagementBannerHtml.params.bannerShownCallback();


### PR DESCRIPTION
## What does this change?
We send insert/view `componentEvent`s to ophan for the contributions banner. But these are not being fired for the combined contributions + consent banner.

## Screenshots
![Screenshot 2019-08-15 at 14 50 35](https://user-images.githubusercontent.com/1513454/63099015-0ef7ba00-bf6c-11e9-8434-bd626001b83e.png)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
