### PR TITLE
Enable Youtube ads for readers who them

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -138,7 +138,9 @@ const setupPlayer = (
     );
 
     return new window.YT.Player(eltId, {
-        host: 'https://www.youtube-nocookie.com',
+        host: !wantPersonalisedAds
+            ? 'https://www.youtube-nocookie.com'
+            : 'https://www.youtube.com',
         videoId,
         width: '100%',
         height: '100%',

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -140,7 +140,7 @@ const setupPlayer = (
     return new window.YT.Player(elt.id, {
         host:
             commercialFeatures.adFree ||
-            elt.classList.contains('youtube-media-atom__iframe')
+            !elt.classList.contains('youtube-media-atom__iframe')
                 ? 'https://www.youtube-nocookie.com'
                 : 'https://www.youtube.com',
         videoId,

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -108,7 +108,7 @@ const createAdsConfig = (
 };
 
 const setupPlayer = (
-    eltId: string,
+    elt: HTMLElement,
     videoId: string,
     channelId?: string,
     onReady,
@@ -137,10 +137,12 @@ const setupPlayer = (
         inPfpAdTargetingVariant
     );
 
-    return new window.YT.Player(eltId, {
-        host: !wantPersonalisedAds
-            ? 'https://www.youtube-nocookie.com'
-            : 'https://www.youtube.com',
+    return new window.YT.Player(elt.id, {
+        host:
+            commercialFeatures.adFree ||
+            elt.classList.contains('youtube-media-atom__iframe')
+                ? 'https://www.youtube-nocookie.com'
+                : 'https://www.youtube.com',
         videoId,
         width: '100%',
         height: '100%',
@@ -188,7 +190,7 @@ export const initYoutubePlayer = (
         };
 
         return setupPlayer(
-            el.id,
+            el,
             videoId,
             channelId,
             onPlayerReady,


### PR DESCRIPTION
## What does this change?

The cookieless youtube domain does not display ads in the Youtube player—all ads drop chocolate cookies for tracking. This change restores the calorie-dense domain for readers who are not in the ad-free cohort, assuming the video is one of ours*.

\* this is done via a heuristic: media atoms have a particular class name. I assume media atoms are always used for videos we own, but I'm not 100% sure. In any case, this is the closest we can get as the rendering tier does not exploit blocks and their metadata.

## Screenshots

Random video:
![Screen Shot 2019-08-15 at 15 01 32](https://user-images.githubusercontent.com/629976/63099928-ea044680-bf6d-11e9-8e77-6f33e9953c6c.png)

Guardian video:
![Screen Shot 2019-08-15 at 15 03 27](https://user-images.githubusercontent.com/629976/63099937-eec8fa80-bf6d-11e9-8d00-24be339d7142.png)


## What is the value of this and can you measure success?

Mo' money.

