### PR TITLE
Drop caps regex should ignore HTML tags

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -518,10 +518,12 @@ case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
 
 case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: Boolean = false) extends HtmlCleaner {
   private def setDropCap(p: Element): String = {
-    p.text.replaceFirst(
-      "^([\"'“‘]*[a-zA-Z])(.{199,})",
-      """<span class="drop-cap"><span class="drop-cap__inner">$1</span></span>$2"""
-    )
+    if (p.text.length > 199) {
+      p.html.replaceFirst(
+        "^([\"'“‘]*[a-zA-Z])(.{199,})",
+        """<span class="drop-cap"><span class="drop-cap__inner">$1</span></span>$2"""
+      )
+    } else p.html
   }
 
   override def clean(document: Document): Document = {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -518,7 +518,7 @@ case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
 
 case class DropCaps(isFeature: Boolean, isImmersive: Boolean, isRecipeArticle: Boolean = false) extends HtmlCleaner {
   private def setDropCap(p: Element): String = {
-    p.html.replaceFirst(
+    p.text.replaceFirst(
       "^([\"'“‘]*[a-zA-Z])(.{199,})",
       """<span class="drop-cap"><span class="drop-cap__inner">$1</span></span>$2"""
     )

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -108,7 +108,7 @@ class TemplatesTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
     body should include ("""<span class="drop-cap__inner">""")
   }
 
-  it should "not add the dropcap span when the paragraph is does not begin with a letter" in {
+  it should "not add the dropcap span when the paragraph does not begin with a letter" in {
     val body = withJsoup(bodyWithMarkup)(DropCaps(true, false)).body.trim
     body should not include """<span class="drop-cap__inner">"""
   }


### PR DESCRIPTION
## What does this change?
Modifies the regex that checks whether a html paragraph is suitable for adding a drop cap to so that it ignores HTML chars - currently if there is a link in the first paragraph this adds a good 20 characters or so (with all the css class names etc.) This is currently causing a problem for theguardian.com/food/2019/aug/16/cocktail-of-the-week-aizle-sazerac-recipe (not currently published)
## Screenshots
<img width="754" alt="Screenshot 2019-08-15 at 15 46 42" src="https://user-images.githubusercontent.com/3606555/63102895-e70c5480-bf73-11e9-9566-a822adf3f805.png">


## What is the value of this and can you measure success?
It looks a bit odd at the moment

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
