### PR TITLE
Get single contribution date from attributes api

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -76,10 +76,7 @@ const persistResponse = (JsonResponse: () => void) => {
     if (JsonResponse.oneOffContributionDate) {
         const date = Date.parse(JsonResponse.oneOffContributionDate);
         if (!Number.isNaN(date)) {
-            addCookie(
-                SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-                Date.parse(JsonResponse.oneOffContributionDate).toString()
-            );
+            addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, date.toString());
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -170,6 +170,7 @@ const isPayingMember = (): boolean =>
     // If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
     isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
 
+// Expects milliseconds since epoch
 const getSupportFrontendOneOffContributionDate = (): number | null => {
     const supportFrontendCookie = getCookie(
         SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE
@@ -183,6 +184,7 @@ const getSupportFrontendOneOffContributionDate = (): number | null => {
     return null;
 };
 
+// Expects YYYY-MM-DD format
 const getAttributesOneOffContributionDate = (): number | null => {
     const attributesCookie = getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -23,6 +23,8 @@ const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
 const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
     'gu.contributions.recurring.contrib-timestamp.Annual';
 
+// This cookie is dropped by support frontend, but also set based
+// on the user attributes API if the user is signed in + verified
 const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
     'gu.contributions.contrib-timestamp';
 
@@ -71,6 +73,15 @@ const persistResponse = (JsonResponse: () => void) => {
         HIDE_SUPPORT_MESSAGING_COOKIE,
         !JsonResponse.showSupportMessaging
     );
+    if (JsonResponse.oneOffContributionDate) {
+        const date = Date.parse(JsonResponse.oneOffContributionDate);
+        if (!Number.isNaN(date)) {
+            addCookie(
+                SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+                Date.parse(JsonResponse.oneOffContributionDate).toString()
+            );
+        }
+    }
 
     removeCookie(ACTION_REQUIRED_FOR_COOKIE);
     if ('alertAvailableFor' in JsonResponse) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -442,9 +442,13 @@ const removeSupportFrontendOneOffContributionCookie = (): void =>
 const setAttributesOneOffContributionCookie = (value: any): void =>
     addCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE, value);
 
+const removeAttributesOneOffContributionCookie = (): void =>
+    removeCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE);
+
 describe('getting the last one-off contribution date of a user', () => {
     beforeEach(() => {
         removeSupportFrontendOneOffContributionCookie();
+        removeAttributesOneOffContributionCookie();
     });
 
     const contributionDate = '2018-01-06';
@@ -529,6 +533,7 @@ describe('getting the last recurring contribution date of a user', () => {
 describe('getting the days since last contribution', () => {
     beforeEach(() => {
         removeSupportFrontendOneOffContributionCookie();
+        removeAttributesOneOffContributionCookie();
     });
 
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
@@ -547,6 +552,7 @@ describe('getting the days since last contribution', () => {
 describe('isRecentOneOffContributor', () => {
     beforeEach(() => {
         removeSupportFrontendOneOffContributionCookie();
+        removeAttributesOneOffContributionCookie();
     });
 
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
@@ -577,6 +583,7 @@ describe('isRecentOneOffContributor', () => {
 describe('isPostAskPauseOneOffContributor', () => {
     beforeEach(() => {
         removeSupportFrontendOneOffContributionCookie();
+        removeAttributesOneOffContributionCookie();
     });
 
     const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');


### PR DESCRIPTION
## What does this change?
Currently support.theguardian.com drops a cookie when a single contribution is made with the timestamp.
For signed in/verified users, we can also get the date of the last single contribution from members-data-api.
This change sets a new cookie,`gu_one_off_contribution_date`, based on the members-data-api response. The existing `getLastOneOffContributionDate` function is updated to check both cookies.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
