### PR TITLE
Correct import of cm-lotame-data-extract

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -33,7 +33,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-track-cmp-consent', trackCmpConsent],
     // ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
-    ['cm-lotame-data-extract', initLotameDataExtract, true], // Comes with a isDotcomRendering check
+    ['cm-lotame-data-extract', initLotameDataExtract],
 ];
 
 if (false && !commercialFeatures.adFree) {


### PR DESCRIPTION
## What does this change?

Tiny change which correct a minor difference between the regular commercial boot script and the DCR one.


