### PR TITLE
Ensure initCheckMediator()

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -23,6 +23,7 @@ import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { initCheckMediator } from 'common/modules/check-mediator';
 // import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 
@@ -171,5 +172,11 @@ const bootCommercial = (): Promise<void> => {
             );
         });
 };
+
+// The function initCheckMediator() must run before the commercial modules are loaded,
+// notably before ['cm-checkDispatcher', initCheckDispatcher]
+// otherwise registeredChecks in check-mediator.js remains empty leading to pathological behaviors.
+// This is due to us inheriting the original split between main.js and commercial.js in frontend.
+initCheckMediator();
 
 bootCommercial();


### PR DESCRIPTION
## What does this change?

This PR simply ensures that the commercial module `['cm-checkDispatcher', initCheckDispatcher]` can initiate correctly. 

Module `['cm-checkDispatcher', initCheckDispatcher]` is currently commented out in the DCR commercial script but we will need soon to un-comment it out as part of preparing the way for Outbrain, and while investigating failures I discovered that, in frontend, `initCheckMediator();` is ran in `main.js`, before `commercial.js` runs.

`initCheckMediator()` set up the variable `registeredChecks` in check-mediator.js.

Adding it to the DCR commercial script is required because we do not have a DCR version of `main.js` with the required imports. So the easiest and most natural solution for the moment is to simply run it before `bootCommercial();` in DCR. 

Note: `initCheckMediator()` is idempotent, so we are not introducing future bugs by running it before `bootCommercial();` in DCR