### PR TITLE
Change dotcoom rendering parameter (?guui => ?dcr=true/false)

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -78,7 +78,7 @@ class ArticleController(
   }
 
   private def getJson(article: ArticlePage)(implicit request: RequestHeader): List[(String, Object)] = {
-    val contentFieldsJson = if (request.isGuuiJson) List(
+    val contentFieldsJson = if (request.forceDCR) List(
       "contentFields" -> Json.toJson(ContentFields(article.article)),
       "tags" -> Json.toJson(article.article.tags)) else List()
     List(("html", views.html.fragments.articleBody(article))) ++ contentFieldsJson
@@ -94,7 +94,7 @@ class ArticleController(
     val isAmpSupported = article.article.content.shouldAmplify
     val pageType: PageType = PageType(article, request, context)
     request.getRequestFormat match {
-      case JsonFormat if request.isGuui => Future.successful(common.renderJson(getGuuiJson(article, blocks), article).as("application/json"))
+      case JsonFormat if request.forceDCR => Future.successful(common.renderJson(getGuuiJson(article, blocks), article).as("application/json"))
       case JsonFormat => Future.successful(common.renderJson(getJson(article), article))
       case EmailFormat => Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(article), article))
       case HtmlFormat if tier == RemoteRender => remoteRenderer.getArticle(ws, path, article, blocks, pageType)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -88,7 +88,7 @@ class LiveBlogController(
 
       mapModel(path, range) {
         case (blog: LiveBlogPage, blocks) if rendered.contains(false) => getJsonForFronts(blog)
-        case (blog: LiveBlogPage, blocks) if request.isGuui => Future.successful(renderGuuiJson(path, blog, blocks))
+        case (blog: LiveBlogPage, blocks) if request.forceDCR => Future.successful(renderGuuiJson(path, blog, blocks))
         case (blog: LiveBlogPage, blocks) => getJson(path, blog, range, isLivePage, blocks)
         case (minute: MinutePage, blocks) => Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
         case _ => Future { Cached(600)(WithoutRevalidationResult(NotFound)) }

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -97,7 +97,7 @@ object ArticlePicker {
     val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
     val isBetaUser = ActiveExperiments.isParticipating(DotcomRenderingBeta)
 
-    val tier = if ((isSupported && isEnabled && isBetaUser) || request.isGuui) RemoteRender else LocalRenderArticle
+    val tier = if ((isSupported && isEnabled && isBetaUser && !request.forceDCROff) || request.forceDCR) RemoteRender else LocalRenderArticle
 
     // include features that we wish to log but not whitelist against
     val features = whitelistFeatures + ("isBetaUser" -> isBetaUser)

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -82,7 +82,7 @@ class DevParametersHttpRequestHandler(
     if (
       context.environment.mode != Prod &&
       !request.isJson &&
-      !request.isGuui &&
+      !request.forceDCR &&
       !request.isLazyLoad &&
       !request.uri.startsWith("/oauth2callback") &&
       !request.uri.startsWith("/px.gif")  && // diagnostics box

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -26,18 +26,13 @@ trait Requests {
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
 
-    def getRequestFormat: RequestFormat = if(isJson) JsonFormat else if (isEmail) EmailFormat else if(isAmp) AmpFormat else HtmlFormat
+    def getRequestFormat: RequestFormat = if (isJson) JsonFormat else if (isEmail) EmailFormat else if (isAmp) AmpFormat else HtmlFormat
 
     lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 
     lazy val isEmailJson: Boolean = r.path.endsWith(EMAIL_JSON_SUFFIX)
 
     lazy val isEmailTxt: Boolean = r.path.endsWith(EMAIL_TXT_SUFFIX)
-
-    lazy val isGuui: Boolean = r.getQueryString("guui").isDefined && !r.getQueryString("guui").contains("false")
-
-    // parameters for moon/guui new rendering layer project.
-    lazy val isGuuiJson: Boolean = isJson && isGuui
 
     lazy val isLazyLoad: Boolean = r.getQueryString("lazy-load").isDefined && !r.getQueryString("lazy-load").contains("false")
 
@@ -53,7 +48,7 @@ trait Requests {
 
     lazy val pathWithoutModifiers: String =
       if (isEmail) r.path.stripSuffix(EMAIL_SUFFIX)
-      else         r.path.stripSuffix("/all")
+      else r.path.stripSuffix("/all")
 
     lazy val hasParameters: Boolean = r.queryString.nonEmpty
 
@@ -71,7 +66,13 @@ trait Requests {
     lazy val isAdFree: Boolean = r.headers.keys.exists(_ equalsIgnoreCase "X-Gu-Commercial-Ad-Free")
 
     lazy val referrer: Option[String] = r.headers.get("referer")
+
+    // dotcom-rendering (DCR) parameters
+    lazy val forceDCR: Boolean = r.getQueryString("dcr").contains("true")
+    lazy val forceDCROff: Boolean = r.getQueryString("dcr").contains("false")
+
   }
+
 }
 
 object Requests extends Requests

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -68,8 +68,8 @@ trait Requests {
     lazy val referrer: Option[String] = r.headers.get("referer")
 
     // dotcom-rendering (DCR) parameters
-    lazy val forceDCR: Boolean = r.getQueryString("dcr").contains("true")
     lazy val forceDCROff: Boolean = r.getQueryString("dcr").contains("false")
+    lazy val forceDCR: Boolean = r.getQueryString("dcr").isDefined && !forceDCROff // don't check for .contains(true) so people can be lazy
 
   }
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -55,7 +55,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
 
       mostPopular match {
         case Nil => NotFound
-        case popular if request.isGuui => jsonResponse(popular)
+        case popular if request.forceDCR => jsonResponse(popular)
         case popular if !request.isJson => Cached(900) {
           RevalidatableResult.Ok(views.html.mostPopular(page, popular))
         }
@@ -86,7 +86,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
     val countryCode = headers.getOrElse("X-GU-GeoLocation","country:row").replace("country:","")
     val countryPopular = MostPopular("Across The&nbsp;Guardian", "", geoMostPopularAgent.mostPopular(countryCode).map(_.faciaContent))
 
-    if (request.isGuui) {
+    if (request.forceDCR) {
       jsonResponse(countryPopular, countryCode)
     } else {
       Cached(900) {

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -45,7 +45,7 @@ class RelatedController(
   private def renderRelated(trails: Seq[RelatedContentItem], containerTitle: String)(implicit request: RequestHeader): Result = Cached(30.minutes) {
     val relatedTrails = trails take 8
 
-    if (request.isGuui) {
+    if (request.forceDCR) {
       val data = OnwardCollectionResponse(
         heading = containerTitle,
         trails = trailsToItems(trails.map(_.faciaContent))


### PR DESCRIPTION
## What does this change?
Renames the parameter we use to force dotcom rendering. Currently we have `guui` and `guui=false`. In this bright new world we will have `dcr=true` and `dcr=false` which seems more sensible. 

It's still an acronym though so I'm happy for something else, just not sure `rendering=` would be that good either. I've stuck a comment in where the value is read from the query string, hopefully that should minimise confusion. 

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
