### PR TITLE
Update smartAppBanner.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -23,8 +23,7 @@ const DATA = {
         LOGO: 'https://assets.guim.co.uk/images/apps/app-logo.png',
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-        LINK:
-            'https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8',
+        LINK: 'https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8',
         STORE: 'on the App Store',
     },
     ANDROID: {

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -24,7 +24,7 @@ const DATA = {
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK:
-            'https://apps.apple.com/gb/app/the-guardian-live-world-news/id409128287',
+            'https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8',
         STORE: 'on the App Store',
     },
     ANDROID: {

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -24,7 +24,7 @@ const DATA = {
         SCREENSHOTS:
             'https://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
         LINK:
-            'https://app.adjust.com/w97upi?deep_link=gnmguardian://root?contenttype=front&source=adjust',
+            'https://apps.apple.com/gb/app/the-guardian-live-world-news/id409128287',
         STORE: 'on the App Store',
     },
     ANDROID: {


### PR DESCRIPTION
## What does this change?

Safari uses a different banner but it looks like the facebook browser is using this link, which leads to a blank webpage.

There's more style issues (View is half offscreen) and the Android equivalent has very outdated styles.

## Screenshots

![IMG_0235](https://user-images.githubusercontent.com/11618797/63420276-48ae4200-c3fe-11e9-9559-51e78f1f541b.PNG)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
