### PR TITLE
Show new CMP UI when in 0% A/B test

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -56,6 +56,9 @@ import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.li
 import ophan from 'ophan/ng';
 import { adFreeBanner } from 'common/modules/commercial/ad-free-banner';
 import { init as initReaderRevenueDevUtils } from 'common/modules/commercial/reader-revenue-dev-utils';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
+import { init as initCmpUi } from 'common/modules/ui/cmp-ui';
 
 const initialiseTopNavItems = (): void => {
     const header: ?HTMLElement = document.getElementById('header');
@@ -302,18 +305,23 @@ const initialiseEmail = (): void => {
 };
 
 const initialiseBanner = (): void => {
-    // ordered by priority
-    const bannerList = [
-        firstPvConsentPlusEngagementBanner,
-        firstPvConsentBanner,
-        breakingNews,
-        membershipBanner,
-        membershipEngagementBanner,
-        smartAppBanner,
-        adFreeBanner,
-        emailSignInBanner,
-    ];
-    initBannerPicker(bannerList);
+    if (!isInVariantSynchronous(commercialIabCompliant, 'variant')) {
+        // ordered by priority
+        const bannerList = [
+            firstPvConsentPlusEngagementBanner,
+            firstPvConsentBanner,
+            breakingNews,
+            membershipBanner,
+            membershipEngagementBanner,
+            smartAppBanner,
+            adFreeBanner,
+            emailSignInBanner,
+        ];
+
+        initBannerPicker(bannerList);
+    } else {
+        initCmpUi();
+    }
 };
 
 const initialiseConsentCookieTracking = (): void =>

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,9 +1,21 @@
 // @flow
-const CMP_URL = 'https://manage.thegulocal.com/consent';
+
+// TODO: this should be derived from config
+const CMP_DOMAIN = 'https://manage.theguardian.com';
+const CMP_URL = `${CMP_DOMAIN}/consent`;
+
+let container: ?HTMLElement;
+
+const receiveMessage = (event: MessageEvent) => {
+    if (event.origin === CMP_DOMAIN && container && container.parentNode) {
+        container.remove();
+    }
+};
 
 export const init = (): void => {
-    const container = document.createElement('div');
+    container = document.createElement('div');
     container.className = 'cmp-overlay';
+
     const iframe = document.createElement('iframe');
     iframe.src = CMP_URL;
     iframe.className = 'cmp-iframe';
@@ -13,4 +25,6 @@ export const init = (): void => {
     if (document.body) {
         document.body.appendChild(container);
     }
+
+    window.addEventListener('message', receiveMessage, false);
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -3,11 +3,19 @@
 // TODO: this should be derived from config
 const CMP_DOMAIN = 'https://manage.theguardian.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
+const CMP_CLOSE_MSG = 'closeCmp';
 
 let container: ?HTMLElement;
 
 const receiveMessage = (event: MessageEvent) => {
-    if (event.origin === CMP_DOMAIN && container && container.parentNode) {
+    const { origin, data } = event;
+
+    if (
+        origin === CMP_DOMAIN &&
+        data === CMP_CLOSE_MSG &&
+        container &&
+        container.parentNode
+    ) {
         container.remove();
     }
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,0 +1,12 @@
+// @flow
+const CMP_URL = 'https://manage.thegulocal.com/consent';
+
+export const init = (): void => {
+    const iframe = document.createElement('iframe');
+    iframe.src = CMP_URL;
+    iframe.className = 'cmp-iframe';
+
+    if (document.body) {
+        document.body.appendChild(iframe);
+    }
+};

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -2,11 +2,15 @@
 const CMP_URL = 'https://manage.thegulocal.com/consent';
 
 export const init = (): void => {
+    const container = document.createElement('div');
+    container.className = 'cmp-overlay';
     const iframe = document.createElement('iframe');
     iframe.src = CMP_URL;
     iframe.className = 'cmp-iframe';
 
+    container.appendChild(iframe);
+
     if (document.body) {
-        document.body.appendChild(iframe);
+        document.body.appendChild(container);
     }
 };

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -16,6 +16,7 @@
 @import 'module/site-messages/_engagement-banner';
 @import 'module/site-messages/_fiv-banner';
 @import 'module/site-messages/_ad-free-banner';
+@import 'module/site-messages/_cmp-iframe';
 @import 'module/tls-warning';
 @import 'module/onward-garnett/_breaking-news';
 @import 'module/onward-garnett/_feedback';

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -1,3 +1,15 @@
+.cmp-overlay {
+    background-color: rgba(black, .5);
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    z-index: 9999;
+}
+
 .cmp-iframe {
     position: fixed;
     left: 0;

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -16,7 +16,12 @@
     bottom: 0;
     top: 0;
     height: 100%;
-    width: 30%;
+    width: 100%;
     z-index: 9999;
     border: 0;
+
+    @include mq(phablet) {
+        min-width: 576px;
+        width: 30%;
+    }
 }

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -1,5 +1,5 @@
 .cmp-overlay {
-    background-color: rgba(black, .5);
+    background-color: rgba(#000000, .5);
     position: fixed;
     top: 0;
     right: 0;

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -1,0 +1,10 @@
+.cmp-iframe {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    top: 0;
+    height: 100%;
+    width: 30%;
+    z-index: 9999;
+    border: 0;
+}


### PR DESCRIPTION
## What does this change?

When a user is in the 0% A/B test to show the new CMP UI we don't initialise any of the normal banner picker logic, instead we call `initCmpUi()`.

`initCmpUi` adds an iframe (pointing to the new CMP UI) and overlay to the page. It also sets up an event listener for `postMessage` events emitted from iframes. It acts upon a close message from the CMP UI and removes the iframe and the container.

The logic to send the `postMessage` is in the corresponding PR on `manage-frontend`: https://github.com/guardian/manage-frontend/pull/254