### PR TITLE
Add weekly article counts to local storage

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,7 +31,7 @@ import {
     logHistory,
     logSummary,
     showInMegaNav,
-    incrementDailyArticleCount,
+    incrementDailyArticleCount, incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
 import { initTechFeedback } from 'common/modules/onward/tech-feedback';
 import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-prefs';
@@ -155,11 +155,12 @@ const updateHistory = (): void => {
     }
 };
 
-const updateDailyArticleCount = (): void => {
+const updateArticleCounts = (): void => {
     const page = config.get('page');
 
     if (page) {
         incrementDailyArticleCount(page);
+        incrementWeeklyArticleCount(page);
     }
 };
 
@@ -355,7 +356,7 @@ const init = (): void => {
         ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],
         ['c-banner-picker', initialiseBanner],
-        ['c-increment-daily-count', updateDailyArticleCount],
+        ['c-increment-article-counts', updateArticleCounts],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
     ]);
 };

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,7 +31,8 @@ import {
     logHistory,
     logSummary,
     showInMegaNav,
-    incrementDailyArticleCount, incrementWeeklyArticleCount,
+    incrementDailyArticleCount,
+    incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
 import { initTechFeedback } from 'common/modules/onward/tech-feedback';
 import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-prefs';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -6,14 +6,14 @@ import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
 } from 'lib/geolocation';
-import { getArticleViewCount } from 'common/modules/onward/history';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
 const articleCountDays = 30;
 
-const articleViewCount = getArticleViewCount(articleCountDays);
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
 const geolocation = geolocationGetSync();
 const isUSUKAU = ['GB', 'US', 'AU'].includes(geolocation);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -4,14 +4,14 @@ import {
     defaultButtonTemplate,
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
-import { getArticleViewCount } from 'common/modules/onward/history';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
 // User must have read at least 5 articles in last 14 days
 const minArticleViews = 5;
 const articleCountDays = 30;
 
-const articleViewCount = getArticleViewCount(articleCountDays);
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
 const highlightedText =
     'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -517,7 +517,7 @@ const incrementWeeklyArticleCount = (pageConfig: Object): void => {
             });
 
             // Remove any weeks older than a year
-            const cutOff = weeklyArticleCount - 365;
+            const cutOff = startOfThisWeek - 365;
             const firstOldWeekIndex = weeklyArticleCount.findIndex(
                 c => c.week && c.week < cutOff
             );

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -71,6 +71,7 @@ describe('history', () => {
     let mockContains;
     let mockSummary;
     let mockDailyArticleCount;
+    let mockWeeklyArticleCount;
 
     beforeEach(() => {
         mockContains = contains;
@@ -82,6 +83,8 @@ describe('history', () => {
                 return mockSummary;
             } else if (key === 'gu.history.dailyArticleCount') {
                 return mockDailyArticleCount;
+            } else if (key === 'gu.history.weeklyArticleCount') {
+                return mockWeeklyArticleCount;
             }
         });
 
@@ -92,6 +95,8 @@ describe('history', () => {
                 mockSummary = data;
             } else if (key === 'gu.history.dailyArticleCount') {
                 mockDailyArticleCount = data;
+            } else if (key === 'gu.history.weeklyArticleCount') {
+                mockWeeklyArticleCount = data;
             }
         });
     });
@@ -390,7 +395,7 @@ describe('history', () => {
         expect(getArticleViewCountForDays(1)).toEqual(2);
     });
 
-    it('removes old history while incrementing the article count', () => {
+    it('removes old daily history while incrementing the article count', () => {
         const counts = [{ day: today - 40, count: 9 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
@@ -422,7 +427,7 @@ describe('history', () => {
         expect(getArticleViewCountForWeeks(2)).toEqual(2);
     });
 
-    it('increments the daily article count', () => {
+    it('increments the weekly article count', () => {
         const counts = [{ week: startOfThisWeek, count: 1 }];
         localStorageStub.set('gu.history.weeklyArticleCount', counts);
 
@@ -431,14 +436,14 @@ describe('history', () => {
         expect(getArticleViewCountForWeeks(1)).toEqual(2);
     });
 
-    it('removes old history while incrementing the article count', () => {
-        const counts = [{ day: today - 400, count: 9 }];
+    it('removes old weekly history while incrementing the article count', () => {
+        const counts = [{ week: startOfThisWeek - 400, count: 9 }];
         localStorageStub.set('gu.history.weeklyArticleCount', counts);
 
         incrementWeeklyArticleCount(pageConfig);
 
         expect(localStorageStub.get('gu.history.weeklyArticleCount')).toEqual([
-            { day: today, count: 1 },
+            { week: startOfThisWeek, count: 1 },
         ]);
     });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -12,7 +12,10 @@ import {
     mostViewedSeries,
     getArticleViewCountForDays,
     _,
-    incrementDailyArticleCount, getMondayFromDate, getArticleViewCountForWeeks, incrementWeeklyArticleCount,
+    incrementDailyArticleCount,
+    getMondayFromDate,
+    getArticleViewCountForWeeks,
+    incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
 import { local as localStorageStub } from 'lib/storage';
 

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -10,9 +10,9 @@ import {
     reset,
     seriesSummary,
     mostViewedSeries,
-    getArticleViewCount,
+    getArticleViewCountForDays,
     _,
-    incrementDailyArticleCount,
+    incrementDailyArticleCount, getMondayFromDate, getArticleViewCountForWeeks, incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
 import { local as localStorageStub } from 'lib/storage';
 
@@ -34,6 +34,7 @@ jest.mock('fastdom');
 const contains = [['/p/3kvgc', 1], ['/p/3kx8f', 1], ['/p/3kx7e', 1]];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
+const startOfThisWeek = getMondayFromDate(new Date());
 
 const pageConfig = {
     pageId: '/p/3jbcb',
@@ -358,23 +359,32 @@ describe('history', () => {
         const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
-        expect(getArticleViewCount(1)).toEqual(1);
+        expect(getArticleViewCountForDays(1)).toEqual(1);
     });
 
     it('gets article count for 2 days', () => {
         const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
-        expect(getArticleViewCount(2)).toEqual(2);
+        expect(getArticleViewCountForDays(2)).toEqual(2);
     });
 
-    it('increments the article count', () => {
+    it('increments the daily article count', () => {
         const counts = [{ day: today, count: 1 }];
         localStorageStub.set('gu.history.dailyArticleCount', counts);
 
         incrementDailyArticleCount(pageConfig);
 
-        expect(getArticleViewCount(1)).toEqual(2);
+        expect(getArticleViewCountForDays(1)).toEqual(2);
+    });
+
+    it('increments the yearly article count', () => {
+        const counts = [{ day: today, count: 1 }];
+        localStorageStub.set('gu.history.dailyArticleCount', counts);
+
+        incrementDailyArticleCount(pageConfig);
+
+        expect(getArticleViewCountForDays(1)).toEqual(2);
     });
 
     it('removes old history while incrementing the article count', () => {
@@ -384,6 +394,47 @@ describe('history', () => {
         incrementDailyArticleCount(pageConfig);
 
         expect(localStorageStub.get('gu.history.dailyArticleCount')).toEqual([
+            { day: today, count: 1 },
+        ]);
+    });
+
+    // weeklyArticleCountB tests
+    it('gets weekly count for this week only', () => {
+        const counts = [
+            { week: startOfThisWeek, count: 1 },
+            { week: startOfThisWeek - 7, count: 1 },
+        ];
+        localStorageStub.set('gu.history.weeklyArticleCount', counts);
+
+        expect(getArticleViewCountForWeeks(1)).toEqual(1);
+    });
+
+    it('gets article count for 2 weeks', () => {
+        const counts = [
+            { week: startOfThisWeek, count: 1 },
+            { week: startOfThisWeek - 7, count: 1 },
+        ];
+        localStorageStub.set('gu.history.weeklyArticleCount', counts);
+
+        expect(getArticleViewCountForWeeks(2)).toEqual(2);
+    });
+
+    it('increments the daily article count', () => {
+        const counts = [{ week: startOfThisWeek, count: 1 }];
+        localStorageStub.set('gu.history.weeklyArticleCount', counts);
+
+        incrementWeeklyArticleCount(pageConfig);
+
+        expect(getArticleViewCountForWeeks(1)).toEqual(2);
+    });
+
+    it('removes old history while incrementing the article count', () => {
+        const counts = [{ day: today - 400, count: 9 }];
+        localStorageStub.set('gu.history.weeklyArticleCount', counts);
+
+        incrementWeeklyArticleCount(pageConfig);
+
+        expect(localStorageStub.get('gu.history.weeklyArticleCount')).toEqual([
             { day: today, count: 1 },
         ]);
     });


### PR DESCRIPTION
## What does this change?
In #21463, we started recording a users daily article count in their local storage, for the past 30 days.

This PR adds similar functionality, but weekly and going back a year. 

This is because, ultimately, we would like to be able to know how many articles a user has read in varying time periods, going back up to a year. 

We could have achieved  a similar outcome by simply extending the period we go back from 30 to 365, although that could result in quite a large object in the users localStorage. 

@guardian/contributions , I'd be interested in your thoughts on this, as if this isn't a genuine concern then we should just do that! It would be preferable from a code maintenance point of view. 