### PR TITLE
Uncomment initCheckDispatcher

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -24,7 +24,7 @@ import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCheckMediator } from 'common/modules/check-mediator';
-// import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
+import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 
 const commercialModules: Array<Array<any>> = [
@@ -32,7 +32,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-prepare-cmp', initCmpService],
     ['cm-track-cmp-consent', trackCmpConsent],
-    // ['cm-checkDispatcher', initCheckDispatcher],
+    ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
 ];


### PR DESCRIPTION
## What does this change?

This PR simply uncomments the initialisation of `['cm-checkDispatcher', initCheckDispatcher]`, the last remaining Commercial module for DCR. This comes after PR https://github.com/guardian/frontend/pull/21751 and paves the way for Outbrain activation.

