### PR TITLE
Only show CMP UI if IAB Cookie cookie not present

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,9 +1,11 @@
 // @flow
+import { getCookie } from 'lib/cookies';
 
 // TODO: this should be derived from config
 const CMP_DOMAIN = 'https://manage.theguardian.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
 const CMP_CLOSE_MSG = 'closeCmp';
+const IAB_COOKIE_NAME = 'euconsent';
 
 let container: ?HTMLElement;
 
@@ -21,6 +23,10 @@ const receiveMessage = (event: MessageEvent) => {
 };
 
 export const init = (): void => {
+    if (getCookie(IAB_COOKIE_NAME)) {
+        return;
+    }
+
     container = document.createElement('div');
     container.className = 'cmp-overlay';
 


### PR DESCRIPTION
## What does this change?

If the IAB Cookie `euconsent` has already been set don't show the new CMP UI.

## What is the value of this and can you measure success?

More realistic behaviour when viewing the new CMP UI as part of 0% A/B test.