### PR TITLE
Add ability to resurface the new CMP UI

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,7 +1,7 @@
 // @flow
 
 // TODO: this should be derived from config
-const CMP_DOMAIN = 'https://manage.thegulocal.com';
+const CMP_DOMAIN = 'https://manage.theguardian.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
 const CMP_CLOSE_MSG = 'closeCmp';
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,7 +1,7 @@
 // @flow
 
 // TODO: this should be derived from config
-const CMP_DOMAIN = 'https://manage.theguardian.com';
+const CMP_DOMAIN = 'https://manage.thegulocal.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
 const CMP_CLOSE_MSG = 'closeCmp';
 
@@ -45,7 +45,7 @@ const addPrivacySettingsLink = (): void => {
 
             newPrivacyLink.dataset.linkName = 'privacy-settings';
             newPrivacyLink.removeAttribute('href');
-            newPrivacyLink.innerText = 'Privacy Settings';
+            newPrivacyLink.innerText = 'Privacy settings';
 
             const newPrivacyLinkListItem: Element = privacyLinkListItem.cloneNode(
                 false

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,7 +1,7 @@
 // @flow
 
 // TODO: this should be derived from config
-const CMP_DOMAIN = 'https://manage.theguardian.com';
+const CMP_DOMAIN = 'https://manage.thegulocal.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
 const CMP_CLOSE_MSG = 'closeCmp';
 
@@ -20,6 +20,52 @@ const receiveMessage = (event: MessageEvent) => {
     }
 };
 
+const addContainerToPage = (): void => {
+    if (document.body && container && !container.parentElement) {
+        document.body.appendChild(container);
+    }
+};
+
+const handlePrivacySettingsClick = (evt: Event) => {
+    evt.preventDefault();
+
+    addContainerToPage();
+};
+
+const addPrivacySettingsLink = (): void => {
+    const privacyLink: ?HTMLElement = document.querySelector(
+        'a[data-link-name=privacy]'
+    );
+
+    if (privacyLink) {
+        const privacyLinkListItem: ?Element = privacyLink.parentElement;
+
+        if (privacyLinkListItem) {
+            const newPrivacyLink: HTMLElement = privacyLink.cloneNode(false);
+
+            newPrivacyLink.dataset.linkName = 'privacy-settings';
+            newPrivacyLink.removeAttribute('href');
+            newPrivacyLink.innerText = 'Privacy Settings';
+
+            const newPrivacyLinkListItem: Element = privacyLinkListItem.cloneNode(
+                false
+            );
+
+            newPrivacyLinkListItem.appendChild(newPrivacyLink);
+
+            privacyLinkListItem.insertAdjacentElement(
+                'afterend',
+                newPrivacyLinkListItem
+            );
+
+            newPrivacyLink.addEventListener(
+                'click',
+                handlePrivacySettingsClick
+            );
+        }
+    }
+};
+
 export const init = (): void => {
     container = document.createElement('div');
     container.className = 'cmp-overlay';
@@ -30,9 +76,13 @@ export const init = (): void => {
 
     container.appendChild(iframe);
 
-    if (document.body) {
-        document.body.appendChild(container);
-    }
+    addContainerToPage();
+
+    /**
+     * Temporarily add a Privacy Settings
+     * link in the footer for resurfacing the CMP UI.
+     * */
+    addPrivacySettingsLink();
 
     window.addEventListener('message', receiveMessage, false);
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -26,7 +26,7 @@ const addContainerToPage = (): void => {
     }
 };
 
-const handlePrivacySettingsClick = (evt: Event) => {
+const handlePrivacySettingsClick = (evt: Event): void => {
     evt.preventDefault();
 
     addContainerToPage();


### PR DESCRIPTION
## What does this change?

Users in the `CommercialIabCompliant` 0% A/B test need to be able to resurface the CMP UI after closing it. This PR introduces a temporary solution to that whilst a more suitable solution is defined. This **temporary** solution adds a new link in the footer using JavaScript labelled "Privacy settings". Clicking this link resurfaces the CMP UI.

## What is the value of this and can you measure success?

IAB compliance criteria met