### PR TITLE
Epic tests: do not limit PostAskPauseSingleContributors to 1 month

### DIFF
--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -26,7 +26,7 @@ declare type EngagementBannerTemplateParams = {
  * AllExistingSupporters - all recurring, all one-offs in last 6 months
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
- * PostAskPauseSingleContributors - people who made a contribution between 6 and 12 months ago
+ * PostAskPauseSingleContributors - people who made a contribution more than 6 months ago
  *
  * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -26,7 +26,7 @@ declare type EngagementBannerTemplateParams = {
  * AllExistingSupporters - all recurring, all one-offs in last 6 months
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
- * PostAskPauseSingleContributors - people who made a contribution more than 6 months ago
+ * PostAskPauseSingleContributors - people who made a contribution between 6 and 12 months ago
  *
  * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -26,7 +26,7 @@ declare type EngagementBannerTemplateParams = {
  * AllExistingSupporters - all recurring, all one-offs in last 6 months
  * AllNonSupporters - no recurring, no one-offs in last 6 months
  * Everyone
- * PostAskPauseSingleContributors - people who made a contribution between 6-7 months ago
+ * PostAskPauseSingleContributors - people who made a contribution more than 6 months ago
  *
  * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -243,7 +243,7 @@ const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
     return daysSinceLastContribution <= askPauseDays;
 };
 
-// true if the user is in the first month after ask-free period
+// true if the user has completed their ask-free period
 const isPostAskPauseOneOffContributor = (
     askPauseDays: number = 180
 ): boolean => {
@@ -251,10 +251,7 @@ const isPostAskPauseOneOffContributor = (
     if (daysSinceLastContribution === null) {
         return false;
     }
-    return (
-        daysSinceLastContribution > askPauseDays &&
-        daysSinceLastContribution < askPauseDays + 30
-    );
+    return daysSinceLastContribution > askPauseDays;
 };
 
 const isRecurringContributor = (): boolean =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -243,7 +243,7 @@ const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
     return daysSinceLastContribution <= askPauseDays;
 };
 
-// true if the user has completed their ask-free period
+// true if the user is in the first 6 months after ask-free period
 const isPostAskPauseOneOffContributor = (
     askPauseDays: number = 180
 ): boolean => {
@@ -251,7 +251,10 @@ const isPostAskPauseOneOffContributor = (
     if (daysSinceLastContribution === null) {
         return false;
     }
-    return daysSinceLastContribution > askPauseDays;
+    return (
+        daysSinceLastContribution > askPauseDays &&
+        daysSinceLastContribution < askPauseDays + 180
+    );
 };
 
 const isRecurringContributor = (): boolean =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -243,7 +243,7 @@ const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
     return daysSinceLastContribution <= askPauseDays;
 };
 
-// true if the user is in the first 6 months after ask-free period
+// true if the user has completed their ask-free period
 const isPostAskPauseOneOffContributor = (
     askPauseDays: number = 180
 ): boolean => {
@@ -251,10 +251,7 @@ const isPostAskPauseOneOffContributor = (
     if (daysSinceLastContribution === null) {
         return false;
     }
-    return (
-        daysSinceLastContribution > askPauseDays &&
-        daysSinceLastContribution < askPauseDays + 180
-    );
+    return daysSinceLastContribution > askPauseDays;
 };
 
 const isRecurringContributor = (): boolean =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -598,6 +598,12 @@ describe('isPostAskPauseOneOffContributor', () => {
         expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
+    it('returns false if the one-off contribution was more than 12 months ago', () => {
+        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+        expect(isPostAskPauseOneOffContributor()).toBe(false);
+    });
+
     it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
         setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -598,12 +598,6 @@ describe('isPostAskPauseOneOffContributor', () => {
         expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
-    it('returns false if the one-off contribution was more than 12 months ago', () => {
-        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostAskPauseOneOffContributor()).toBe(false);
-    });
-
     it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
         setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -598,12 +598,6 @@ describe('isPostAskPauseOneOffContributor', () => {
         expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
-    it('returns false if the one-off contribution was more than 7 months ago', () => {
-        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostAskPauseOneOffContributor()).toBe(false);
-    });
-
     it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
         setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/frontend/pull/21742 added a test cohort for contributors in the first month after their 6 month 'ask pause'. We've decided to remove the 1 month limit.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
