### PR TITLE
Add endpoint for dotcom-rendering to fetch rich link data.

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -11,6 +11,8 @@ import navigation.GuardianFoundationHelper
 
 object Tag {
 
+  def withoutCommercial(tag: Tag): Tag = tag.copy(properties = tag.properties.copy(commercial = None))
+
   def makeMetadata(tag: TagProperties, pagination: Option[Pagination]): MetaData = {
 
     val javascriptConfigOverrides: Map[String, JsValue] = Map(

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -16,15 +16,15 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
     contentType(path) map {
         case Some(content) if request.forceDCR =>
           val richLink = RichLink(
-            content.tags.tags.map(Tag.withoutCommercial), // throw away commercial data as we don't use it
-            content.content.cardStyle.toneString,
-            content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
-            content.trail.headline,
-            content.metadata.contentType,
-            content.content.starRating,
-            content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
-            content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
-            content.metadata.url
+            tags = content.tags.tags.map(Tag.withoutCommercial), // throw away commercial data as we don't use it
+            cardStyle = content.content.cardStyle.toneString,
+            thumbnailUrl = content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
+            headline = content.trail.headline,
+            contentType = content.metadata.contentType,
+            starRating = content.content.starRating,
+            sponsorName = content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
+            contributorImage = content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
+            url = content.metadata.url
           )
           Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -1,18 +1,32 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Logging}
 import contentapi.ContentApiClient
 import implicits.Requests
-import model.{ApplicationContext, Content, ContentType}
+import model.{ApplicationContext, Cached, Content, ContentType, Tag}
+import models.dotcomponents.RichLink
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html
+import views.support.{ImgSrc, Item460, RichLinkContributor}
 
 import scala.concurrent.Future
 
 class RichLinkController(contentApiClient: ContentApiClient, controllerComponents: ControllerComponents)(implicit context: ApplicationContext) extends OnwardContentCardController(contentApiClient, controllerComponents) with Paging with Logging with ImplicitControllerExecutionContext with Requests   {
-
   def render(path: String): Action[AnyContent] = Action.async { implicit request =>
     contentType(path) map {
+        case Some(content) if request.forceDCR =>
+          val richLink = RichLink(
+            content.tags.tags.map(Tag.withoutCommercial), // throw away commercial data as we don't use it
+            content.content.cardStyle.toneString,
+            content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
+            content.trail.headline,
+            content.metadata.contentType,
+            content.content.starRating,
+            content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
+            content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
+            content.metadata.url
+          )
+          Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))
         case None => NotFound
     }

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,0 +1,19 @@
+package models.dotcomponents
+
+import model.{DotcomContentType, Tag, Tags}
+import play.api.libs.json.Json
+
+case class RichLink(
+  tags: List[Tag],
+  cardStyle: String,
+  thumbnailUrl: Option[String],
+  headline: String,
+  contentType: Option[DotcomContentType],
+  starRating: Option[Int],
+  sponsorName: Option[String],
+  contributorImage: Option[String],
+  url: String)
+
+object RichLink {
+  implicit val writes = Json.writes[RichLink]
+}


### PR DESCRIPTION
## What does this change?
Modifies the rich link endpoint so that when the dotcom rendering parameter is included, it returns structured data for DCR to render a rich link with. 

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
