### PR TITLE
Only show CMP UI once ready message received from iframe

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,24 +1,37 @@
 // @flow
 import { getCookie } from 'lib/cookies';
 
-// TODO: this should be derived from config
-const CMP_DOMAIN = 'https://manage.theguardian.com';
+// TODO: this should be derived from config or imported from new lib
+const CMP_DOMAIN = 'https://manage.thegulocal.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
+const CMP_READY_MSG = 'readyCmp';
 const CMP_CLOSE_MSG = 'closeCmp';
 const IAB_COOKIE_NAME = 'euconsent';
+const CMP_READY_CLASS = 'cmp-iframe-ready';
 
 let container: ?HTMLElement;
 
 const receiveMessage = (event: MessageEvent) => {
     const { origin, data } = event;
 
-    if (
-        origin === CMP_DOMAIN &&
-        data === CMP_CLOSE_MSG &&
-        container &&
-        container.parentNode
-    ) {
-        container.remove();
+    if (origin !== CMP_DOMAIN) {
+        return;
+    }
+
+    switch (data) {
+        case CMP_READY_MSG:
+            if (container && container.parentNode) {
+                container.classList.add(CMP_READY_CLASS);
+            }
+            break;
+        case CMP_CLOSE_MSG:
+            if (container && container.parentNode) {
+                container.classList.remove(CMP_READY_CLASS);
+                container.remove();
+            }
+            break;
+        default:
+            break;
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -2,7 +2,7 @@
 import { getCookie } from 'lib/cookies';
 
 // TODO: this should be derived from config or imported from new lib
-const CMP_DOMAIN = 'https://manage.thegulocal.com';
+const CMP_DOMAIN = 'https://manage.theguardian.com';
 const CMP_URL = `${CMP_DOMAIN}/consent`;
 const CMP_READY_MSG = 'readyCmp';
 const CMP_CLOSE_MSG = 'closeCmp';

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -8,6 +8,11 @@
     padding: 0;
     margin: 0;
     z-index: 9999;
+    display: none;
+
+    &.cmp-iframe-ready {
+        display: block;
+    }
 }
 
 .cmp-iframe {


### PR DESCRIPTION
## What does this change?

Currently when we load the CMP UI in an iframe in frontend we see the first re-render of the React application on `manage-frontend` that's triggered after we've fetched the vendor list and updated the state accordingly. 

This PR adds a listener for a new `postMessage` sent from the iframe notifying it that the vendor list has been fetched and the state updated and the UI is ready to show. 

The related PR on manage-frontend is here: https://github.com/guardian/manage-frontend/pull/258

## What is the value of this and can you measure success?

We only show the CMP UI once it's ready, so we no longer see the nasty re-render.

## Screenshots

**Before...**
![CMP-OLD](https://user-images.githubusercontent.com/1590704/63592454-869b9980-c5a9-11e9-8adb-68309699a98e.gif)

**After...**
![CMP-NEU](https://user-images.githubusercontent.com/1590704/63592474-90250180-c5a9-11e9-8b5b-1084745a6d01.gif)

