### PR TITLE
AB test dotcom-rendering-advertisements

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,6 +8,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldTLSSupportDeprecation,
     DotcomRenderingBeta,
+    DotcomRenderingAdvertisements,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -28,4 +29,12 @@ object DotcomRenderingBeta extends Experiment(
   owners = Seq(Owner.withGithub("nicl")),
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc50 // see ArticlePicker.scala - our main filter mechanism is by page features
+)
+
+object DotcomRenderingAdvertisements extends Experiment(
+  name = "dotcom-rendering-advertisements",
+  description = "Activate the display of ads on DCR pages",
+  owners = Seq(Owner.withGithub("shtukas")),
+  sellByDate = new LocalDate(2020, 12, 1),
+  participationGroup = Perc0A // see ArticlePicker.scala - our main filter mechanism is by page features
 )


### PR DESCRIPTION
## What does this change?

Add the 0% AB test `dotcom-rendering-advertisements`, to trigger advertisements in DCR