### PR TITLE
Pick based on main elements as well as body

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -43,6 +43,18 @@ object ArticlePageChecks {
     !page.article.blocks.exists(_.body.exists(_.elements.exists(unsupportedElement)))
   }
 
+  def hasOnlySupportedMainElements(page: PageWithStoryPackage): Boolean = {
+    // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
+    def unsupportedElement(blockElement: BlockElement) = blockElement match {
+      case _: TextBlockElement => false
+      case _: ImageBlockElement => false
+      case _ => true
+    }
+
+    !page.article.blocks.exists(_.main.exists(_.elements.exists(unsupportedElement)))
+  }
+
+
   def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
 
   def isNotLiveBlog(page:PageWithStoryPackage): Boolean = ! page.item.isLiveBlog
@@ -75,6 +87,7 @@ object ArticlePicker {
       ("isSupportedType", ArticlePageChecks.isSupportedType(page)),
       ("hasBlocks", ArticlePageChecks.hasBlocks(page)),
       ("hasOnlySupportedElements", ArticlePageChecks.hasOnlySupportedElements(page)),
+      ("hasOnlySupportedMainElements", ArticlePageChecks.hasOnlySupportedMainElements(page)),
       ("isDiscussionDisabled", ArticlePageChecks.isDiscussionDisabled(page)),
       ("isAdFree", ArticlePageChecks.isAdFree(page, request)),
       ("isNotImmersive", ArticlePageChecks.isNotImmersive(page)),
@@ -87,8 +100,6 @@ object ArticlePicker {
       ("isNewsTone", ArticlePageChecks.isNewsTone(page)),
     )
   }
-
-
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
 


### PR DESCRIPTION
## What does this change?

Makes the picker apply element-whitelist logic to main elements as well as the body elements.

This is implemented as its own separate block of code because in theory there are occasions where we have supported something as a body element but not main yet, or vis versa, and I want to support that functionality.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
