### PR TITLE
Make byline optional

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -142,7 +142,7 @@ object SubMetaLink {
 }
 
 case class Author(
-  byline: String,
+  byline: Option[String],
   twitterHandle: Option[String],
 )
 
@@ -537,7 +537,7 @@ object DotcomponentsDataModel {
       pageType
     )
 
-    val byline = article.trail.byline.getOrElse("Guardian staff reporter")
+    val byline = article.trail.byline
 
     val config = Config(
       ajaxUrl = Configuration.ajax.url,

--- a/article/app/model/dotcomponents/LinkedData.scala
+++ b/article/app/model/dotcomponents/LinkedData.scala
@@ -40,19 +40,13 @@ object LinkedData {
     )
 
     val article = liveblog.article
-
-    val authors = article.tags.contributors.map(contributor => {
-      Person(
-        name = contributor.name,
-        sameAs = contributor.metadata.webUrl,
-      )
-    })
+    val authors = getAuthors(article)
 
     List(
       LiveBlogPosting(
         `@id` = baseURL + article.metadata.id,
         image = getImages(article, fallbackLogo),
-        author = authors,
+        author = getAuthors(article),
         datePublished = article.trail.webPublicationDate.toString(),
         dateModified = article.fields.lastModified.toString(),
         headline = article.trail.headline,
@@ -149,12 +143,17 @@ object LinkedData {
   }
 
   def getAuthors(article: Article): List[Person] = {
-    article.tags.contributors.map(contributor => {
+    val authors = article.tags.contributors.map(contributor => {
       Person(
         name = contributor.name,
-        sameAs = contributor.metadata.webUrl,
+        sameAs = Some(contributor.metadata.webUrl),
       )
     })
+
+    authors match {
+      case Nil => List(Person(name = "Guardian staff reporter", sameAs = None))
+      case _ => authors
+    }
   }
 }
 
@@ -247,7 +246,7 @@ object ListItem {
 case class Person(
   `@type`: String = "Person",
   name: String,
-  sameAs: String,
+  sameAs: Option[String],
 )
 
 object Person {


### PR DESCRIPTION
**WARNING - only merge after https://github.com/guardian/dotcom-rendering/pull/736.**

## What does this change?

Rather than defaulting to Guardian support staff, we should keep it empty and use a default for the structured data only (as Google requires an author value).

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
