### PR TITLE
Use lat/long coords from fastly to get weather location

### DIFF
--- a/onward/app/weather/geo/LatitudeLongitude.scala
+++ b/onward/app/weather/geo/LatitudeLongitude.scala
@@ -3,3 +3,12 @@ package weather.geo
 case class LatitudeLongitude(latitude: Double, longitude: Double) {
   override def toString: String = s"$latitude,$longitude"
 }
+
+object LatitudeLongitude {
+  def fromStringAnonymised(latLong: String): Option[LatitudeLongitude] = {
+    val coords = latLong.split(",").map(value => Math.round(value.toDouble * 100)/100.0)
+    if (coords.length == 2) {
+      Some(LatitudeLongitude(coords(0), coords(1)))
+    } else None
+  }
+}


### PR DESCRIPTION
## What does this change?
Modifies the fallback for when a location is not in our maxmind locations database - instead of using 'city' which doesn't work for any city with a non-ascii character in it - e.g. koln doesn't exist, only köln - a problem as we're using the non-unicode values from fastly - let's use the lat/long values provided by fastly geo - see https://github.com/guardian/fastly-edge-cache/pull/863

## What is the value of this and can you measure success?
One step closer to being able to re-enable IPV6

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
