### PR TITLE
Engagement Banner Border

### DIFF
--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -1,4 +1,5 @@
 .site-message--engagement-banner {
+    border-top: 1px solid $brightness-7;
     background-color: $highlight-main;
     max-height: 80%;
 


### PR DESCRIPTION
## What does this change?
I added a border to the engagement banner so it can be differentiated from other yellow elements on the page

## Screenshots
contrived but demonstrative example:

![engagement banner border](https://user-images.githubusercontent.com/3300789/63789759-e4a0e780-c8ef-11e9-9d11-9f7658b923f8.png)