### PR TITLE
Add type Coercion inside Number.isNaN

### DIFF
--- a/static/src/javascripts/projects/common/modules/user-prefs.js
+++ b/static/src/javascripts/projects/common/modules/user-prefs.js
@@ -63,7 +63,9 @@ const isOff = (
     { type }: StorageOptions = defaultOptions
 ): boolean => storage[type].get(`${storagePrefix}switch.${name}`) === false;
 
-const isNumeric = (str: string): boolean => !Number.isNaN(str);
+// Note 'false' !== Number.isNaN so we have to type coerce
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
+const isNumeric = (str: string): boolean => !Number.isNaN(Number(str));
 
 const isBoolean = (str: string): boolean => str === 'true' || str === 'false';
 


### PR DESCRIPTION
## What does this change?

http://localhost:9000/uk#gu.prefs.enhanced=true would save `{"value":null}` to localstorage. Now it saves `{"value":true}` because it actually gets to the boolean checker.

## Screenshots

![image](https://user-images.githubusercontent.com/638051/63839095-866b1780-c976-11e9-9624-fb0a7df5c902.png)


![image](https://user-images.githubusercontent.com/638051/63839292-e366cd80-c976-11e9-9da6-bbeddd0c5212.png)


![image](https://user-images.githubusercontent.com/638051/63839310-ec579f00-c976-11e9-99e7-6ae76a73be8e.png)



## What is the value of this and can you measure success?

User prefs work correctly.

@guardian/dotcom-platform 