### PR TITLE
Reduce sentry sample

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -57,7 +57,7 @@ const sentryOptions = {
         const isIgnored =
             typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
         const { enableSentryReporting } = config.get('switches');
-        const isInSample = Math.random() < 0.1;
+        const isInSample = Math.random() < 0.025; // 2.5%
 
         if (isDev && !isIgnored) {
             // Some environments don't support or don't always expose the console Object


### PR DESCRIPTION
## What does this change?

Reduces the sentry sample reporting to 2.5% down from 10%.

Saves 💰.

@guardian/dotcom-platform 