### PR TITLE
Fix live blog teads ad alignment

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -17,6 +17,9 @@ const normalise = (length: string): string => {
     return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
 };
 
+const isLiveBlogInlineAdSlot = (adSlot: ?HTMLElement): boolean =>
+    !!adSlot && adSlot.classList.contains('ad-slot--liveblog-inline');
+
 const resize = (
     specs: Specs,
     iframe: HTMLElement,
@@ -34,7 +37,7 @@ const resize = (
 
     const styles = {};
 
-    if (specs.width) {
+    if (specs.width && !isLiveBlogInlineAdSlot(adSlot)) {
         styles.width = normalise(specs.width);
     }
 
@@ -65,6 +68,7 @@ const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
             const adSlot = iframe && iframe.closest('.js-ad-slot');
+
             if (
                 adSlot &&
                 (adSlot.classList.contains('ad-slot--mostpop') ||


### PR DESCRIPTION
## What does this change?
This should fix the issue with teads ad passback alignment issue. Currently when we receive a teads passback it will override it's DOM element style attributes with the height and width received from the passback. It made the ad look as if it was aligned left but the fact is that the ad container was the size of the passback hence it looked as if it shifted to the left. 

There is a different way of achieving the fix by blacklisting the liveblog class from resizing but this would leave the dom element in its outstream width unless you strip those classes away. That would fix it somewhat but then the ad height wouldn't be adjusted and it would look inconsistent and too boxy (attaching a screenshot of this fix too).

The fix I've chosen isn't without its drawback, you will notice a resize shift during the passback, but that will make it consistent with the other inline ads.

## Screenshots

### The issue
<img width="769" alt="Screenshot 2019-08-28 at 16 21 07" src="https://user-images.githubusercontent.com/12860328/63869957-ee3e5400-c9b0-11e9-87c6-657cb1716158.png">

### The boxy solution (disregarded)
<img width="1380" alt="Screenshot 2019-08-28 at 13 54 34" src="https://user-images.githubusercontent.com/12860328/63869979-f8f8e900-c9b0-11e9-97dd-f20ea1e49e7e.png">

### This solution
<img width="733" alt="Screenshot 2019-08-28 at 16 21 40" src="https://user-images.githubusercontent.com/12860328/63869992-00b88d80-c9b1-11e9-93cd-ead8e2d5cdbd.png">


### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally **Impossible to test a teads passback locally**
- [x] On CODE 

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
