### PR TITLE
Bump atom-renderer to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "@guardian/atom-renderer": "1.0.3",
+    "@guardian/atom-renderer": "1.0.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.183" 
+  val identityLibVersion = "3.183"
   val awsVersion = "1.11.240"
   val capiVersion = "14.1"
   val faciaVersion = "3.0.2"
@@ -71,7 +71,7 @@ object Dependencies {
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "1.0.3"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "1.0.4"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,9 +1063,10 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
-"@guardian/atom-renderer@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.0.3.tgz#f8027bca91256a220bf75e8d0ebfa3ebecfa8f58"
+"@guardian/atom-renderer@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.0.4.tgz#52a43f977ab4b6f6e8d070ca387b3280cb546f90"
+  integrity sha512-dAFVBXUqllChlHpez1XO5wTY/uGctsWuwLUvZ/kL3nKWsIjDoTL6cNVTaNO4GnX1JiXN6TE2HT/NuTOsaC4Zsw==
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
## What does this change?

Fix the issue in Firefox where snippet would not open/close when people clicked on the "show/hide" button.

![Untitled](https://user-images.githubusercontent.com/629976/63871637-2a26e880-c9b4-11e9-9e4c-25eb9a5c118d.gif)


## What is the value of this and can you measure success?

No more complaints.
