### PR TITLE
If sponsor name is 'no sponsor' hide badge.

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Commercial.{isPaidContent, isOnDarkBackground}
 
 @for(commercial <- page.metadata.commercial; branding <- commercial.branding(Edition(request))) {
-    @if(branding.sponsorName != "No Sponsor") {
+    @if(!branding.isUnsponsored) {
         @pageLogo(branding,
             content.tags.isInteractive,
             isOnDarkBackground(content, isPaidContent(page))

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -4,8 +4,10 @@
 @import views.support.Commercial.{isPaidContent, isOnDarkBackground}
 
 @for(commercial <- page.metadata.commercial; branding <- commercial.branding(Edition(request))) {
-    @pageLogo(branding,
-              content.tags.isInteractive,
-              isOnDarkBackground(content, isPaidContent(page))
-    )
+    @if(branding.sponsorName != "No Sponsor") {
+        @pageLogo(branding,
+            content.tags.isInteractive,
+            isOnDarkBackground(content, isPaidContent(page))
+        )
+    }
 }

--- a/common/app/views/fragments/commercial/cardLogo.scala.html
+++ b/common/app/views/fragments/commercial/cardLogo.scala.html
@@ -1,6 +1,8 @@
 @import com.gu.commercial.branding.Branding
 @(branding: Branding, isStandardSizeCard: Boolean, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
 
-<div class="badge @if(isStandardSizeCard){badge--branded}">
-    @logo(branding, onDarkBackground)
-</div>
+@if (branding.sponsorName != "No Sponsor") {
+    <div class="badge @if(isStandardSizeCard){badge--branded}">
+        @logo(branding, onDarkBackground)
+    </div>
+}

--- a/common/app/views/fragments/commercial/cardLogo.scala.html
+++ b/common/app/views/fragments/commercial/cardLogo.scala.html
@@ -1,7 +1,7 @@
 @import com.gu.commercial.branding.Branding
 @(branding: Branding, isStandardSizeCard: Boolean, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
 
-@if (branding.sponsorName != "No Sponsor") {
+@if(!branding.isUnsponsored) {
     <div class="badge @if(isStandardSizeCard){badge--branded}">
         @logo(branding, onDarkBackground)
     </div>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
   val targetingClient = "com.gu" %% "targeting-client-play26" % "0.14.7"
   val scanamo = "com.gu" %% "scanamo" % "0.9.5"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.12"
-  val commercialShared = "com.gu" %% "commercial-shared" % "6.1.2"
+  val commercialShared = "com.gu" %% "commercial-shared" % "6.1.3"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion


### PR DESCRIPTION
## What does this change?
We have a situation at the moment where content that is in e.g. global development is getting a badge indicating that it's been sponsored by the gates foundation. This happens when something used to have a sponsor which has since been removed - then the badge ends up being the badge of the sponsor of the section. 

Our solution to this is to change the sponsorship in tag manager to 'No sponsor' in cases where we don't want a piece of content to inherit the badge of the section that it's in. This change modifies dotcom to no add a badge in these cases

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
