### PR TITLE
Update 'Support us' to 'Subscribe' on UK mobile header

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -65,7 +65,7 @@
                         <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                             data-link-name="nav2 : support-cta"
                             data-edition="@{editionId}"
-                            href="@getReaderRevenueUrl(Support, Header)">
+                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
                             Subscribe
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -66,7 +66,7 @@
                             data-link-name="nav2 : support-cta"
                             data-edition="@{editionId}"
                             href="@getReaderRevenueUrl(Support, Header)">
-                            Support us
+                            Subscribe
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
                     } else {


### PR DESCRIPTION
## What does this change?
This is a change in the mobile header cta from "support us" to "subscribe".
This change is part of improving traffic to the subscriptions pages, which is part of an overall initiative to improve the number of subscriptions purchased
This piece of work relates to the [Mobile Header](https://docs.google.com/presentation/d/1gUOtdVyeLFEBFZVbtdXVC4qZNjnLBViWWw0J9E8FszE/edit#slide=id.g5db0e82211_0_13) changes

[Trello Card](https://trello.com/c/bV9d6oM2/2527-change-uk-mobile-web-support-header-from-support-us-to-subscribe)


## What is the value of this and can you measure success
We can measure success by looking at the analytics for click through rates and the number of subscription purchases

## Screenshots
#### Old
![Screen Shot 2019-08-29 at 11 39 20](https://user-images.githubusercontent.com/45875444/63933870-f8fcf580-ca51-11e9-951f-1e17b2b2512a.png)

#### New
![Screen Shot 2019-08-29 at 11 37 03](https://user-images.githubusercontent.com/45875444/63933581-6f4d2800-ca51-11e9-9f44-8ad3a1bd4cb8.png)

## What is the value of this and can you measure success?
N/A

## Checklist
N/A

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
No visual changes

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
