### PR TITLE
Add a tag blacklist to the picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -55,7 +55,7 @@ object ArticlePageChecks {
   }
 
   private[this] val tagsBlacklist: Set[String] = Set(
-    "info/about-guardian-australia"
+    "tracking/platformfunctional/dcrblacklist"
   )
 
   def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -54,6 +54,9 @@ object ArticlePageChecks {
     !page.article.blocks.exists(_.main.exists(_.elements.exists(unsupportedElement)))
   }
 
+  private[this] val tagsBlacklist: Set[String] = Set(
+    "info/about-guardian-australia"
+  )
 
   def isNotImmersive(page: PageWithStoryPackage): Boolean = ! page.item.isImmersive
 
@@ -72,6 +75,11 @@ object ArticlePageChecks {
   def isNewsTone(page: PageWithStoryPackage): Boolean = {
     page.article.tags.tones.headOption.exists(_.id == "tone/news") || page.article.tags.tones.isEmpty
   }
+
+  def isNotBlackListed(page: PageWithStoryPackage): Boolean = {
+    !page.item.tags.tags.exists(s=>tagsBlacklist(s.id))
+  }
+
 }
 
 object ArticlePicker {
@@ -98,6 +106,7 @@ object ArticlePicker {
       ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNewsTone", ArticlePageChecks.isNewsTone(page)),
+      ("isNotBlackListed", ArticlePageChecks.isNotBlackListed(page)),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Add a tag blacklist to the picker

>>>>> Do not merge until we've put the right tag in

## Screenshots

## What is the value of this and can you measure success?

Gives editorial/cp a way to block broken articles from rendering in dcr

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
