### PR TITLE
Identity -  Add MDAPI service

### DIFF
--- a/identity/app/conf/IdentityConfiguration.scala
+++ b/identity/app/conf/IdentityConfiguration.scala
@@ -11,6 +11,7 @@ class IdentityConfiguration(conf: GuardianConfiguration) extends IdConfig with S
   val domain: String = conf.id.domain
   val oauthUrl: String = conf.id.oauthUrl
   val url: String = conf.id.url
+  val membersDataApiUrl: String = conf.id.membersDataApiUrl
 }
 
 trait IdConfig {

--- a/identity/app/services/IdentityServices.scala
+++ b/identity/app/services/IdentityServices.scala
@@ -25,4 +25,5 @@ trait IdentityServices extends IdentityConfigurationComponents with IdApiCompone
   lazy val authenticationService = wire[AuthenticationService]
   lazy val torNodeLoggingIdRequestParser = wire[TorNodeLoggingIdRequestParser]
   lazy val emailService = wire[NewsletterService]
+  lazy val mdapiService = wire[MembersDataApiService]
 }

--- a/identity/app/services/MembersDataApiService.scala
+++ b/identity/app/services/MembersDataApiService.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import scala.concurrent.{ExecutionContext, Future}
 
-// Modeled on members-data-api Attributes - ConsentAccess
+// Modeled on members-data-api Attributes - ContentAccess
 // https://github.com/guardian/members-data-api/blob/master/membership-attribute-service/app/models/Attributes.scala
 case class ContentAccess(
   isMember: Boolean, // TODO a friend membership should not prevent auto-account deletion but currently does
@@ -19,6 +19,7 @@ case class ContentAccess(
 ) {
   def canProceedWithAutoDeletion: Boolean = !(isMember || isPaidMember || isRecurringContributor || hasDigitalPack || isPaperSubscriber || isGuardianWeeklySubscriber)
   def hasPaidProducts: Boolean = isPaidMember || isRecurringContributor || hasDigitalPack || isPaperSubscriber || isGuardianWeeklySubscriber
+  def hasSubscription: Boolean = hasDigitalPack || isPaperSubscriber || isGuardianWeeklySubscriber
 }
 
 object ContentAccess {

--- a/identity/app/services/MembersDataApiService.scala
+++ b/identity/app/services/MembersDataApiService.scala
@@ -1,10 +1,10 @@
 package services
 
-import common.Logging
-import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie}
+import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie, WSResponse}
 import play.api.mvc.{Cookie, Cookies}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import utils.SafeLogging
 import scala.concurrent.{ExecutionContext, Future}
 
 // Modeled on members-data-api Attributes - ContentAccess
@@ -32,9 +32,10 @@ object ContentAccess {
     ) (ContentAccess.apply _)
 }
 
-case class MdapiServiceException(message: String) extends Throwable
+// TODO trait and network vs parsing errors
+case class MdapiServiceException(message: String, userId: String) extends Throwable
 
-class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfiguration)(implicit executionContext: ExecutionContext) extends Logging {
+class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfiguration)(implicit executionContext: ExecutionContext) extends SafeLogging {
   private def toWSCookie(c: Cookie): WSCookie = {
     DefaultWSCookie(
       name = c.name,
@@ -47,15 +48,33 @@ class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfigurati
     )
   }
 
+  private def handleMdapiResponse(response: WSResponse, contentAccessResult: JsResult[ContentAccess]) = {
+    if(response.status != 200) {
+      val errorMsg = s"Network Error retrieving MDAPI content access: ${response.status} ${response.statusText} - ${response.json}"
+      logger.error(errorMsg)
+      Left(MdapiServiceException(errorMsg, "user?ID")) // get id from cookie
+    } else {
+      contentAccessResult.fold(
+        error => {
+          val errorMsg = s"Parsing Error retrieving MDAPI content access: ${error.toString()}"
+          logger.error(errorMsg)
+          Left(MdapiServiceException(errorMsg, "user?ID")) // get id from cookie
+        },
+        contentAccess => Right(contentAccess)
+      )
+    }
+  }
+
   def getUserContentAccess(cookies: Cookies): Future[Either[MdapiServiceException, ContentAccess]] = {
     val root = config.membersDataApiUrl
     val path = "/user-attributes/me"
-    for {
+    (for {
       response <- wsClient.url(s"$root$path").withCookies(cookies.map(c => toWSCookie(c)).toSeq: _*).get()
       contentAccessResult <- Future((response.json \ "contentAccess").validate[ContentAccess])
-    } yield contentAccessResult.fold(
-      error => Left(MdapiServiceException(error.toString())),
-      contentAccess => Right(contentAccess)
-    )
+    } yield {
+      handleMdapiResponse(response, contentAccessResult)
+    }) recover {
+      case f => Left(MdapiServiceException(s"Failed Future: $f", "user?id"))  // get id from cookie // Appropriate Error Message??
+    }
   }
 }

--- a/identity/app/services/MembersDataApiService.scala
+++ b/identity/app/services/MembersDataApiService.scala
@@ -1,0 +1,42 @@
+package services
+
+import common.{HttpStatusException, Logging}
+import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie, WSResponse}
+import play.api.mvc.{Cookie, Cookies}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// TODO model member data
+case class MemberData()
+
+class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfiguration)(implicit executionContext: ExecutionContext) extends Logging with implicits.WSRequests {
+
+  private def toWSCookie(c: Cookie): WSCookie = {
+    DefaultWSCookie(
+      name = c.name,
+      value = c.value,
+      domain = c.domain,
+      path = Option(c.path),
+      maxAge = c.maxAge.map[Long](i => i.toLong),
+      secure = c.secure,
+      httpOnly = c.httpOnly
+    )
+  }
+
+  def getMembersData(cookies: Cookies): Future[WSResponse] = {
+    val root = config.membersDataApiUrl
+    val path = "/user-attributes/me"
+    wsClient.url(s"$root$path").withCookies(cookies.map(c => toWSCookie(c)).toSeq: _*).get() flatMap { response =>
+      response.status match {
+        case 200 =>
+          println("200")
+          println(response.body)
+          Future.successful(response)
+        case _ =>
+          println(response.status)
+          println(response.statusText)
+          Future.failed(HttpStatusException(response.status, response.statusText))
+      }
+    }
+  }
+}

--- a/identity/app/services/MembersDataApiService.scala
+++ b/identity/app/services/MembersDataApiService.scala
@@ -1,16 +1,40 @@
 package services
 
 import common.{HttpStatusException, Logging}
-import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie, WSResponse}
+import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie}
 import play.api.mvc.{Cookie, Cookies}
-
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 import scala.concurrent.{ExecutionContext, Future}
 
-// TODO model member data
-case class MemberData()
+// Modeled on members-data-api Attributes - ConsentAccess
+// https://github.com/guardian/members-data-api/blob/master/membership-attribute-service/app/models/Attributes.scala
+case class ContentAccess(
+  isMember: Boolean, // TODO a friend membership should not prevent auto-account deletion but currently does
+  isPaidMember: Boolean,
+  isRecurringContributor: Boolean,
+  hasDigitalPack: Boolean,
+  isPaperSubscriber: Boolean,
+  isGuardianWeeklySubscriber: Boolean
+) {
+  def canProceedWithAutoDeletion: Boolean = !(isMember || isPaidMember || isRecurringContributor || hasDigitalPack || isPaperSubscriber || isGuardianWeeklySubscriber)
+  def hasPaidProducts: Boolean = isPaidMember || isRecurringContributor || hasDigitalPack || isPaperSubscriber || isGuardianWeeklySubscriber
+}
 
-class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfiguration)(implicit executionContext: ExecutionContext) extends Logging with implicits.WSRequests {
+object ContentAccess {
+  implicit val jsRead: Reads[ContentAccess] = (
+    (JsPath \ "member").read[Boolean] and
+      (JsPath \ "paidMember").read[Boolean] and
+      (JsPath \ "recurringContributor").read[Boolean] and
+      (JsPath \ "digitalPack").read[Boolean] and
+      (JsPath \ "paperSubscriber").read[Boolean] and
+      (JsPath \ "guardianWeeklySubscriber").read[Boolean]
+    ) (ContentAccess.apply _)
+}
 
+class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfiguration)(implicit executionContext: ExecutionContext) extends Logging {
+
+  // TODO is there an alternative to converting to WSCookie?
   private def toWSCookie(c: Cookie): WSCookie = {
     DefaultWSCookie(
       name = c.name,
@@ -23,19 +47,15 @@ class MembersDataApiService(wsClient: WSClient, config: conf.IdentityConfigurati
     )
   }
 
-  def getMembersData(cookies: Cookies): Future[WSResponse] = {
+  def getUserContentAccess(cookies: Cookies): Future[ContentAccess] = {
     val root = config.membersDataApiUrl
     val path = "/user-attributes/me"
     wsClient.url(s"$root$path").withCookies(cookies.map(c => toWSCookie(c)).toSeq: _*).get() flatMap { response =>
       response.status match {
         case 200 =>
-          println("200")
-          println(response.body)
-          Future.successful(response)
-        case _ =>
-          println(response.status)
-          println(response.statusText)
-          Future.failed(HttpStatusException(response.status, response.statusText))
+          val contentAccess = response.json \ "contentAccess"
+          Future.successful(contentAccess.as[ContentAccess])
+        case _ => Future.failed(HttpStatusException(response.status, response.statusText))
       }
     }
   }

--- a/identity/test/services/MembersDataApiServiceTest.scala
+++ b/identity/test/services/MembersDataApiServiceTest.scala
@@ -10,7 +10,6 @@ import org.mockito.Matchers._
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.{Cookie, Cookies}
 import play.api.libs.json.Json
-
 import scala.concurrent.Future
 
 class MembersDataApiServiceTest
@@ -59,7 +58,6 @@ class MembersDataApiServiceTest
       |}
     """.stripMargin
 
-
   private val config = mock[IdentityConfiguration]
   private val cookies = Cookies(Seq(Cookie("Cookie1", "hash", None, "/", None, false, true, None), Cookie("Cookie2", "hash", None, "/", None, false, true, None)))
 
@@ -70,65 +68,55 @@ class MembersDataApiServiceTest
 
   when(wsMock.url(any[String])).thenReturn(wsRequestMock)
   when(wsRequestMock.withCookies(any())).thenReturn(wsRequestMock)
+  when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
 
   "getUserContentAccess" should
     "return ContentAccess data for user with valid cookies" in {
-    when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
     when(wsResponseMock.json).thenReturn(Json.parse(validMdapiResponseJsonString))
     when(wsResponseMock.status).thenReturn(200)
     when(wsResponseMock.statusText).thenReturn("OK")
 
     val futureEither = MdapiService.getUserContentAccess(cookies)
     futureEither map { either => either.isRight shouldBe true }
-    futureEither map { either => either.right.value shouldEqual ContentAccess(true,true,false,true,false,true) }
+    futureEither map { either => either.right.value shouldEqual ContentAccess(true, true, false, true, false, true) }
   }
 
   it should "return MdapiServiceException if unable to extract ContentAccess from json response" in {
-    when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
     when(wsResponseMock.json).thenReturn(Json.parse(invalidMdapiResponseJsonString))
     when(wsResponseMock.status).thenReturn(200)
 
     val futureEither = MdapiService.getUserContentAccess(cookies)
     futureEither map { either => either.isLeft shouldBe true }
-    futureEither map { either => either.left.value.message should include ("Failed to parse MDAPI response")}
+    futureEither map { either => either.left.value.message should include("Failed to parse MDAPI response") }
   }
 
   it should "return MdapiServiceException if service returns 404 status" in {
-    when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
     when(wsResponseMock.json).thenReturn(Json.parse(valid404ResponseJsonString))
     when(wsResponseMock.status).thenReturn(404)
     when(wsResponseMock.statusText).thenReturn("Not Found")
 
     val futureEither = MdapiService.getUserContentAccess(cookies)
     futureEither map { either => either.isLeft shouldBe true }
-    futureEither map { either => either.left.value.message should include ("Failed to getUserContentAccess")}
+    futureEither map { either => either.left.value.message should include("Failed to getUserContentAccess") }
   }
 
   "ContentAccess.canProceedWithAutoDeletion" should
     "return true when all cases are false" in {
-    val contentAccess = ContentAccess(false, false, false, false, false, false)
-    contentAccess.canProceedWithAutoDeletion shouldBe true
+    ContentAccess(false, false, false, false, false, false).canProceedWithAutoDeletion shouldBe true
   }
-    it should "return false if any cases are true" in {
-      val contentAccess1 = ContentAccess(true, false, false, false, false, false)
-      val contentAccess2 = ContentAccess(false, false, false, false, false, true)
-      val contentAccess3 = ContentAccess(true, false, true, false, true, false)
-      val contentAccess4 = ContentAccess(true, true, true, true, true, true)
-      contentAccess1.canProceedWithAutoDeletion shouldBe false
-      contentAccess2.canProceedWithAutoDeletion shouldBe false
-      contentAccess3.canProceedWithAutoDeletion shouldBe false
-      contentAccess4.canProceedWithAutoDeletion shouldBe false
-    }
+  it should "return false if any cases are true" in {
+    ContentAccess(true, false, false, false, false, false).canProceedWithAutoDeletion shouldBe false
+    ContentAccess(false, false, false, false, false, true).canProceedWithAutoDeletion shouldBe false
+    ContentAccess(true, false, true, false, true, false).canProceedWithAutoDeletion shouldBe false
+    ContentAccess(true, true, true, true, true, true).canProceedWithAutoDeletion shouldBe false
+  }
 
   "ContentAccess.hasSubscription" should
     "return false when all cases are false" in {
-    val contentAccess = ContentAccess(false, false, false, false, false, false)
-    contentAccess.hasSubscription shouldBe false
+    ContentAccess(false, false, false, false, false, false).hasSubscription shouldBe false
   }
   it should "return true if any cases are true" in {
-    val contentAccess1 = ContentAccess(false, false, false, true, true, true)
-    val contentAccess2 = ContentAccess(false, false, false, false, false, true)
-    contentAccess1.hasSubscription shouldBe true
-    contentAccess2.hasSubscription shouldBe true
+    ContentAccess(false, false, false, true, true, true).hasSubscription shouldBe true
+    ContentAccess(false, false, false, false, false, true).hasSubscription shouldBe true
   }
 }

--- a/identity/test/services/MembersDataApiServiceTest.scala
+++ b/identity/test/services/MembersDataApiServiceTest.scala
@@ -1,0 +1,109 @@
+package services
+
+import conf.IdentityConfiguration
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.AsyncFlatSpec
+import org.scalatest.Matchers._
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import play.api.mvc.{Cookie, Cookies}
+import play.api.libs.json.Json
+import scala.concurrent.Future
+
+class MembersDataApiServiceTest
+  extends AsyncFlatSpec
+  with MockitoSugar {
+
+  val mdapiApiRoot = "https://mdapimock.com"
+  val testUserId = "10000001"
+
+  val valid404ResponseJsonString =
+    """
+      |{
+      |  "message":"Not found",
+      |  "details":"Could not find user in the database",
+      |  "statusCode":404
+      |}
+    """.stripMargin
+
+  val validMdapiResponseJsonString =
+    """
+      |{
+      |"userId": "10000001",
+      |"membershipJoinDate": "2020-12-11",
+      |"guardianWeeklyExpiryDate": "2020-12-12",
+      |"digitalSubscriptionExpiryDate": "2020-12-12",
+      |"showSupportMessaging": false,
+      |"contentAccess": {
+      |"member": true,
+      |"paidMember": true,
+      |"recurringContributor": false,
+      |"digitalPack": true,
+      |"paperSubscriber": false,
+      |"guardianWeeklySubscriber": true
+      |}
+      |}
+    """.stripMargin
+
+  private val config = mock[IdentityConfiguration]
+  private val cookies = Cookies(Seq(Cookie("Cookie1", "hash", None, "/", None, false, true, None), Cookie("Cookie2", "hash", None, "/", None, false, true, None)))
+
+  private val wsThrow = mock[Throwable]
+  private val wsMock = mock[WSClient]
+  private val wsRequestMock = mock[WSRequest]
+  private val wsResponseMock = mock[WSResponse]
+  private val MdapiService = new MembersDataApiService(wsMock, config)
+
+  when(wsMock.url(anyString())).thenReturn(wsRequestMock)
+  when(wsRequestMock.withCookies(any())).thenReturn(wsRequestMock)
+
+  "getUserContentAccess" should
+    "return ContentAccess data for user with valid cookies" in {
+    when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
+    when(wsResponseMock.json).thenReturn(Json.parse(validMdapiResponseJsonString))
+    when(wsResponseMock.status).thenReturn(200)
+    when(wsResponseMock.statusText).thenReturn("OK")
+
+    val futureResult = MdapiService.getUserContentAccess(cookies)
+    futureResult map {
+      result =>
+        result.fold(l => println(s"left error:${l.message}"), r => (println(s"right: $r")))
+        result.isRight shouldBe true
+    }
+  }
+
+  // returns json validation error
+  it should "return MdapiServiceException if service returns 404 status" in {
+    when(wsRequestMock.get()).thenReturn(Future.successful(wsResponseMock))
+    when(wsResponseMock.json).thenReturn(Json.parse(valid404ResponseJsonString))
+    when(wsResponseMock.status).thenReturn(404)
+    when(wsResponseMock.statusText).thenReturn("Not Found")
+
+    val futureResult = MdapiService.getUserContentAccess(cookies)
+    futureResult map {
+      result =>
+        result.fold(l => println(s"left error:${l.message}"), r => (println(s"right: $r")))
+        result.isLeft shouldBe true
+    }
+  }
+
+  it should "return MdapiServiceException if service is unavailable" in {
+    when(wsRequestMock.get()).thenReturn(Future.failed(wsThrow))
+
+    val futureResult = MdapiService.getUserContentAccess(cookies)
+    futureResult map {
+      result =>
+        result.fold(l => println(s"left error:${l.message}"), r => (println(s"right: $r")))
+        result.isLeft shouldBe true
+    }
+  }
+
+  //    it should  "return MdapiServiceException if unable to extract ContentAccess from json response" in {
+  //      ???
+  //    }
+  //    it should "??? if user does not have valid cookies" in {
+  //      ???
+  //    }
+
+}


### PR DESCRIPTION
## What does this change?

Adds a service within the Identity Project to call the Members-Data-API. This will be use in the the`AccountDeletionController` in #21786  

## What is the value of this and can you measure success?

Currently, when a user tries to delete their account, the request will fail and instead notify User Help requesting a manual deletion. No feedback is provided to the user why the request failed. By calling MDAPI, we can get user's ContentAccess data and advise them what they need to do first before they can delete their online account, thus avoiding frustrating account deletion failures for the user and extra work for User Help. This service is required to do this. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
