### PR TITLE
Lower the ask-pause period from 6 to 3 months

### DIFF
--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -23,10 +23,10 @@ declare type EngagementBannerTemplateParams = {
 };
 
 /**
- * AllExistingSupporters - all recurring, all one-offs in last 6 months
- * AllNonSupporters - no recurring, no one-offs in last 6 months
+ * AllExistingSupporters - all recurring, all one-offs in last 3 months
+ * AllNonSupporters - no recurring, no one-offs in last 3 months
  * Everyone
- * PostAskPauseSingleContributors - people who made a contribution more than 6 months ago
+ * PostAskPauseSingleContributors - people who made a contribution more than 3 months ago
  *
  * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
  */

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -234,8 +234,8 @@ const getDaysSinceLastOneOffContribution = (): number | null => {
     return dateDiffDays(lastContributionDate, Date.now());
 };
 
-// defaults to last six months
-const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
+// defaults to last three months
+const isRecentOneOffContributor = (askPauseDays: number = 90): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {
         return false;
@@ -245,7 +245,7 @@ const isRecentOneOffContributor = (askPauseDays: number = 180): boolean => {
 
 // true if the user has completed their ask-free period
 const isPostAskPauseOneOffContributor = (
-    askPauseDays: number = 180
+    askPauseDays: number = 90
 ): boolean => {
     const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
     if (daysSinceLastContribution === null) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -573,7 +573,7 @@ describe('isRecentOneOffContributor', () => {
         expect(isRecentOneOffContributor()).toBe(true);
     });
 
-    it('returns false if the one-off contribution was more than 6 months ago', () => {
+    it('returns false if the one-off contribution was more than 3 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
         setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
         expect(isRecentOneOffContributor()).toBe(false);
@@ -598,7 +598,7 @@ describe('isPostAskPauseOneOffContributor', () => {
         expect(isPostAskPauseOneOffContributor()).toBe(false);
     });
 
-    it('returns true if the one-off contribution was between 6 and 7 months ago', () => {
+    it('returns true if the one-off contribution was more than 3 months ago', () => {
         global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
         setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
         expect(isPostAskPauseOneOffContributor()).toBe(true);


### PR DESCRIPTION
## What does this change?
Currently users do not see contributions messages for 6 months after their last single contribution.
We are changing this to 3 months.

Rather than testing the change, we can compare the impact using the datalake by looking at users who gave 6 months ago vs 3 months.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
