### PR TITLE
Activate the Commercial Ad Stack in DCR behind 0% AB Test

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -38,7 +38,8 @@ const commercialModules: Array<Array<any>> = [
 ];
 
 if (
-    config.get('tests.dotcomRenderingAdvertisementsVariant', false) === 'variant' &&
+    config.get('tests.dotcomRenderingAdvertisementsVariant', false) ===
+        'variant' &&
     !commercialFeatures.adFree
 ) {
     commercialModules.push(

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -38,7 +38,7 @@ const commercialModules: Array<Array<any>> = [
 ];
 
 if (
-    config.get('tests.dotcomRenderingAdvertisementsVariant') === 'variant' &&
+    config.get('tests.dotcomRenderingAdvertisementsVariant', false) === 'variant' &&
     !commercialFeatures.adFree
 ) {
     commercialModules.push(

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -37,7 +37,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-lotame-data-extract', initLotameDataExtract],
 ];
 
-if (false && !commercialFeatures.adFree) {
+if ((config.get('tests.dotcomRenderingAdvertisementsVariant')==="variant") && !commercialFeatures.adFree) {
     commercialModules.push(
         ['cm-prepare-prebid', preparePrebid],
         ['cm-prepare-googletag', prepareGoogletag],

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -37,7 +37,10 @@ const commercialModules: Array<Array<any>> = [
     ['cm-lotame-data-extract', initLotameDataExtract],
 ];
 
-if ((config.get('tests.dotcomRenderingAdvertisementsVariant')==="variant") && !commercialFeatures.adFree) {
+if (
+    config.get('tests.dotcomRenderingAdvertisementsVariant') === 'variant' &&
+    !commercialFeatures.adFree
+) {
     commercialModules.push(
         ['cm-prepare-prebid', preparePrebid],
         ['cm-prepare-googletag', prepareGoogletag],


### PR DESCRIPTION
## What does this change?

Activate the Commercial Ad Stack (import the relevant commercial modules in the dotcom-rendering commercial bundle) behind the same 0% AB test that activates the AdSlots in dotcom-rendering.

Tested On CODE

