### PR TITLE
Add extra whitelisting for CORS requests

### DIFF
--- a/commercial/app/controllers/CmpDataController.scala
+++ b/commercial/app/controllers/CmpDataController.scala
@@ -9,7 +9,7 @@ import conf.Static
 class CmpDataController (val controllerComponents: ControllerComponents) (implicit context: ApplicationContext)
   extends BaseController with I18nSupport {
 
-  val cmpWhitelist = Seq("localhost", ".thegulocal.com", ".dev-theguardian.com", ".theguardian.com")
+  val cmpWhitelist = Seq("localhost", "thegulocal.com", "dev-theguardian.com", "theguardian.com")
 
   def renderVendorlist(): Action[AnyContent] = Action {
     implicit request =>

--- a/commercial/app/controllers/CmpDataController.scala
+++ b/commercial/app/controllers/CmpDataController.scala
@@ -6,10 +6,10 @@ import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 import conf.Static
 
-class CmpDataController (val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
+class CmpDataController (val controllerComponents: ControllerComponents) (implicit context: ApplicationContext)
   extends BaseController with I18nSupport {
 
-  val cmpWhitelist = List("http://localhost:3000", "http://localhost:9000", "https://www.thegulocal.com", "https://manage.thegulocal.com", "https://manage.theguardian.com")
+  val cmpWhitelist = Seq("localhost", ".thegulocal.com", ".dev-theguardian.com", ".theguardian.com")
 
   def renderVendorlist(): Action[AnyContent] = Action {
     implicit request =>

--- a/commercial/app/controllers/CmpDataController.scala
+++ b/commercial/app/controllers/CmpDataController.scala
@@ -8,14 +8,17 @@ import conf.Static
 
 class CmpDataController (val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
   extends BaseController with I18nSupport {
+
+  val cmpWhitelist = List("http://localhost:3000", "http://localhost:9000", "https://www.thegulocal.com", "https://manage.thegulocal.com", "https://manage.theguardian.com")
+
   def renderVendorlist(): Action[AnyContent] = Action {
     implicit request =>
-      Cors(Redirect(Static("data/vendor/cmp_vendorlist.json" )))
+      Cors(Redirect(Static("data/vendor/cmp_vendorlist.json" )), None, None, cmpWhitelist)
   }
 
   def renderShortVendorlist(): Action[AnyContent] = Action {
     implicit request =>
-      Cors(Redirect(Static("data/vendor/cmp_shortvendorlist.json" )))
+      Cors(Redirect(Static("data/vendor/cmp_shortvendorlist.json" )), None, None, cmpWhitelist)
   }
 
 }

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -1,5 +1,6 @@
 package model
 
+import java.net.URI
 import conf.Configuration.ajax
 import play.api.mvc.{RequestHeader, Results}
 import play.api.mvc.Result
@@ -8,11 +9,14 @@ object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
-  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None, extraWhitelist: List[String] = Nil) (implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None, extraWhitelist: Seq[String] = Nil) (implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
-    def isWhitelisted(origin: String): Boolean = ajax.corsOrigins.contains(origin) || extraWhitelist.contains(origin)
+    def isWhitelisted(origin: String): Boolean = {
+      val originUri = new URI(origin)
+      ajax.corsOrigins.contains(origin) || extraWhitelist.exists(originUri.getHost().endsWith(_))
+    }
 
     request.headers.get("Origin")
       .filter(isWhitelisted)

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -9,17 +9,12 @@ object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
-  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None, extraWhitelist: Seq[String] = Nil) (implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None, domainWhitelist: Seq[String] = Nil) (implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
-    def isWhitelisted(origin: String): Boolean = {
-      val originUri = new URI(origin)
-      ajax.corsOrigins.contains(origin) || extraWhitelist.exists(originUri.getHost().endsWith(_))
-    }
-
     request.headers.get("Origin")
-      .filter(isWhitelisted)
+      .filter(isWhitelisted(_, ajax.corsOrigins, domainWhitelist))
       .orElse(fallbackAllowOrigin) match {
 
       case Some(allowedOrigin) =>
@@ -31,5 +26,15 @@ object Cors extends Results with implicits.Requests {
         result.withHeaders(headers: _*)
       case None => result
     }
+  }
+
+  private[model] def isWhitelisted(origin: String, corsOrigins: Seq[String], extraWhitelist: Seq[String]): Boolean = {
+    val originHost = new URI(origin).getHost
+    corsOrigins.contains(origin) ||
+      extraWhitelist.contains(originHost) ||
+      extraWhitelist.exists { domain =>
+        if (domain == "localhost") false
+        else originHost.endsWith(s".$domain")
+      }
   }
 }

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -8,11 +8,11 @@ object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
-  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None)(implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None, fallbackAllowOrigin: Option[String] = None, extraWhitelist: List[String] = Nil) (implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
-    def isWhitelisted(origin: String): Boolean = ajax.corsOrigins.exists(_ == origin)
+    def isWhitelisted(origin: String): Boolean = ajax.corsOrigins.contains(origin) || extraWhitelist.contains(origin)
 
     request.headers.get("Origin")
       .filter(isWhitelisted)


### PR DESCRIPTION
## What does this change?
Allows passing an endpoint specific domain whitelist to check against a cors request.

For our new CMP we need to expose the IAB vendor list on Frontend. This is currently accessible through https://www.theguardian.com/commercial/cmp/vendorlist.json and will need to be accessible from most theguardian.com subdomains, guardian dev subdomains and localhost.
Currently we check the origin of cors requests against a whitelist located in AWS parameter store (`/frontend/prod/ajax.cors.origin`). The current approach would make us add all the needed domains to this parameter, effectively opening up all endpoints to any of those origins.
To void doing that this PR makes it possible to specify an extra whitelist on each the endpoint.

## Checklist
### Tested

- [ ] Locally
- [X] On CODE (optional)