### PR TITLE
AdStack loaded by default in DEV

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -38,8 +38,9 @@ const commercialModules: Array<Array<any>> = [
 ];
 
 if (
-    config.get('tests.dotcomRenderingAdvertisementsVariant', 'control') ===
-        'variant' &&
+    (config.get('tests.dotcomRenderingAdvertisementsVariant', 'control') ===
+        'variant' ||
+        config.get('stage', '') === 'DEV') &&
     !commercialFeatures.adFree
 ) {
     commercialModules.push(


### PR DESCRIPTION
## What does this change?

This enables ad modules loading by default in dotcom-rendering DEV.
