### PR TITLE
Prepare article-body-adverts for targeting DCR

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -72,13 +72,21 @@ const filterNearbyCandidates = (maximumAdHeight: number) => (
     return false;
 };
 
+const getBodySelector = (): string =>
+    !config.get('isDotcomRendering', false)
+        ? '.js-article__body'
+        : '.article-body-03f883b8';
+
+const getSlotSelector = (): string =>
+    !config.get('isDotcomRendering', false) ? ' > p' : ' > span';
+
 const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const isImmersive = config.get('page.isImmersive');
 
     // For inline1
     const defaultRules = {
-        bodySelector: '.js-article__body',
-        slotSelector: ' > p',
+        bodySelector: getBodySelector(),
+        slotSelector: getSlotSelector(),
         minAbove: isImmersive ? 700 : 300,
         minBelow: 700,
         selectors: {
@@ -101,8 +109,8 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
 
     // For any other inline
     const relaxedRules = {
-        bodySelector: '.js-article__body',
-        slotSelector: ' > p',
+        bodySelector: getBodySelector(),
+        slotSelector: getSlotSelector(),
         minAbove: isPaidContent ? 1600 : 1000,
         minBelow: 800,
         selectors: {
@@ -146,8 +154,8 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
 
 const addMobileInlineAds = (): Promise<number> => {
     const rules = {
-        bodySelector: '.js-article__body',
-        slotSelector: ' > p',
+        bodySelector: getBodySelector(),
+        slotSelector: getSlotSelector(),
         minAbove: 200,
         minBelow: 200,
         selectors: {
@@ -202,8 +210,8 @@ const addInlineAds = (): Promise<number> => {
 
 const attemptToAddInlineMerchAd = (): Promise<boolean> => {
     const rules = {
-        bodySelector: '.js-article__body',
-        slotSelector: ' > p',
+        bodySelector: getBodySelector(),
+        slotSelector: getSlotSelector(),
         minAbove: 300,
         minBelow: 0,
         selectors: {


### PR DESCRIPTION
## What does this change?

This PR does two things

1. Abstract away in a function the values of `bodySelector` and `slotSelector` inside article-body-adverts.js.

2. Set the correct values for CDR (while leaving the values for frontend) invariant. 
 
nb (1): The special class name 'article-body-03f883b8' was chosen by me here: https://github.com/guardian/dotcom-rendering/pull/751  and is the DCR equivalent of what `js-article__body` does for frontend generated articles. Otherwise DCR uses `span` as children of its article body (where frontend uses `p`). 

nb (2): It is not impossible that further refactoring of this file might be needed in the future. Notably if the SpaceFinder rules need more fine tuning for DCR.

nb (3): Using `!config.get('isDotcomRendering', false)` allows the "old" value to come first in the ternary expression :)

