### PR TITLE
Rugby world cup 2019 (WIP)

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -293,7 +293,7 @@ trait FeatureSwitches {
     "rugby-world-cup",
     "If this switch is on rugby world cup scores will be loaded in to rugby match reports and liveblogs",
     owners = Seq(Owner.withName("health team")),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false
   )

--- a/common/app/model/RugbyContent.scala
+++ b/common/app/model/RugbyContent.scala
@@ -29,4 +29,27 @@ object RugbyContent {
     ("sport/usarugby", "2950"),
     ("sport/japanrugby", "3000")
   )
+
+  val paTeamNameIds = Map (
+    ("sport/japanrugby", "73710"),
+    ("sport/russiarugby", "204077"), // TEST as new
+    ("sport/australia-rugby-union-team", "73752"),
+    ("sport/fiji-rugby-union-team", "73735"),
+    ("sport/france-rugby-union-team", "73743"),
+    ("sport/argentina-rugby-union-team", "73751"),
+    ("sport/new-zealand-rugby-union-team", "73739"),
+    ("sport/south-africa-rugby-team", "73730"),
+    ("sport/italy-rugby-union-team", "73750"),
+    ("sport/namibia-rugby-union-team", "73741"),
+    ("sport/ireland-rugby-union-team", "73734"),
+    ("sport/scotland-rugby-union-team", "73732"),
+    ("sport/england-rugby-union-team", "73738"),
+    ("sport/tonga-rugby-union-team", "73754"),
+    ("sport/wales-rugby-union-team", "73740"),
+    ("sport/georgia-rugby-union-team", "73736"),
+    ("sport/romaniarugbyunionteam", "73742"),
+    ("sport/samoa-rugby-union-team", "73711"),
+    ("sport/uruguay-rugby-union-team", "73737"),
+    ("sport/canadarugby", "73753")
+  )
 }

--- a/common/app/model/RugbyContent.scala
+++ b/common/app/model/RugbyContent.scala
@@ -7,30 +7,51 @@ object RugbyContent {
   val timeFormatter: DateTimeFormatter = {
     DateTimeFormat.forPattern("YYYY/MM/dd")
   }
-  val teamNameIds = Map (
-    ("sport/australia-rugby-union-team", "100"),
-    ("sport/wales-rugby-union-team", "500"),
-    ("sport/england-rugby-union-team", "550"),
-    ("sport/ireland-rugby-union-team", "600"),
-    ("sport/france-rugby-union-team", "650"),
-    ("sport/scotland-rugby-union-team", "700"),
-    ("sport/tonga-rugby-union-team", "750"),
-    ("sport/argentina-rugby-union-team", "800"),
-    ("sport/new-zealand-rugby-union-team", "850"),
-    ("sport/south-africa-rugby-team", "900"),
-    ("sport/samoa-rugby-union-team", "950"),
-    ("sport/romaniarugbyunionteam", "951"),
-    ("sport/italy-rugby-union-team", "952"),
-    ("sport/canadarugby", "953"),
-    ("sport/fiji-rugby-union-team", "954"),
-    ("sport/uruguay-rugby-union-team", "2800"),
-    ("sport/georgia-rugby-union-team", "2850"),
-    ("sport/namibia-rugby-union-team", "2900"),
-    ("sport/usarugby", "2950"),
-    ("sport/japanrugby", "3000")
-  )
+//  val teamNameIds = Map (
+//    ("sport/australia-rugby-union-team", "100"),
+//    ("sport/wales-rugby-union-team", "500"),
+//    ("sport/england-rugby-union-team", "550"),
+//    ("sport/ireland-rugby-union-team", "600"),
+//    ("sport/france-rugby-union-team", "650"),
+//    ("sport/scotland-rugby-union-team", "700"),
+//    ("sport/tonga-rugby-union-team", "750"),
+//    ("sport/argentina-rugby-union-team", "800"),
+//    ("sport/new-zealand-rugby-union-team", "850"),
+//    ("sport/south-africa-rugby-team", "900"),
+//    ("sport/samoa-rugby-union-team", "950"),
+//    ("sport/romaniarugbyunionteam", "951"),
+//    ("sport/italy-rugby-union-team", "952"),
+//    ("sport/canadarugby", "953"),
+//    ("sport/fiji-rugby-union-team", "954"),
+//    ("sport/uruguay-rugby-union-team", "2800"),
+//    ("sport/georgia-rugby-union-team", "2850"),
+//    ("sport/namibia-rugby-union-team", "2900"),
+//    ("sport/usarugby", "2950"),
+//    ("sport/japanrugby", "3000")
+//  )
 
-  val paTeamNameIds = Map (
+//  2015/09/20/73734/73753 -> Ireland v Canada 2015-09-20T01:30:00.000+10:00
+//  2015/09/24/73752/73735 -> Australia v Fiji 2015-09-24T03:45:00.000+10:00
+//  2015/09/27/73730/73711 -> South Africa v Samoa 2015-09-27T03:45:00.000+10:00
+//  2015/09/19/73738/73735 -> England v Fiji 2015-09-19T07:00:00.000+10:00
+//  2015/09/19/73754/73736 -> Tonga v Georgia 2015-09-19T23:00:00.000+10:00
+//  2015/09/28/73734/73742 -> Ireland v Romania 2015-09-28T03:45:00.000+10:00
+//  2015/09/27/73738/73740 -> England v Wales 2015-09-27T07:00:00.000+10:00
+//  2015/09/21/73739/73751 -> New Zealand v Argentina 2015-09-21T03:45:00.000+10:00
+//  2015/09/20/73730/73710 -> South Africa v Japan 2015-09-20T03:45:00.000+10:00
+//  2015/09/30/73754/73741 -> Tonga v Namibia 2015-09-30T03:45:00.000+10:00
+//  2015/09/24/73743/73742 -> France v Romania 2015-09-24T07:00:00.000+10:0
+//  2015/09/20/73711/73733 -> Samoa v USA 2015-09-20T23:00:00.000+10:00
+//  2015/09/27/73752/73737 -> Australia v Uruguay 2015-09-27T23:00:00.000+10:00
+//  2015/09/20/73743/73750 -> France v Italy 2015-09-20T07:00:00.000+10:00
+//  2015/09/26/73751/73736 -> Argentina v Georgia 2015-09-26T03:45:00.000+10:00
+//  2015/09/25/73739/73741 -> New Zealand v Namibia 2015-09-25T07:00:00.000+10:00
+//  2015/09/28/73732/73733 -> Scotland v USA 2015-09-28T01:30:00.000+10:00
+//  2015/09/21/73740/73737 -> Wales v Uruguay 2015-09-21T01:30:00.000+10:00
+//  2015/09/27/73750/73753 -> Italy v Canada 2015-09-27T01:30:00.000+10:00
+//  2015/09/24/73732/73710 -> Scotland v Japan 2015-09-24T01:30:00.000+10:00
+
+  val teamNameIds = Map (
     ("sport/japanrugby", "73710"),
     ("sport/russiarugby", "204077"), // TEST as new
     ("sport/australia-rugby-union-team", "73752"),

--- a/common/app/model/RugbyContent.scala
+++ b/common/app/model/RugbyContent.scala
@@ -7,49 +7,6 @@ object RugbyContent {
   val timeFormatter: DateTimeFormatter = {
     DateTimeFormat.forPattern("YYYY/MM/dd")
   }
-//  val teamNameIds = Map (
-//    ("sport/australia-rugby-union-team", "100"),
-//    ("sport/wales-rugby-union-team", "500"),
-//    ("sport/england-rugby-union-team", "550"),
-//    ("sport/ireland-rugby-union-team", "600"),
-//    ("sport/france-rugby-union-team", "650"),
-//    ("sport/scotland-rugby-union-team", "700"),
-//    ("sport/tonga-rugby-union-team", "750"),
-//    ("sport/argentina-rugby-union-team", "800"),
-//    ("sport/new-zealand-rugby-union-team", "850"),
-//    ("sport/south-africa-rugby-team", "900"),
-//    ("sport/samoa-rugby-union-team", "950"),
-//    ("sport/romaniarugbyunionteam", "951"),
-//    ("sport/italy-rugby-union-team", "952"),
-//    ("sport/canadarugby", "953"),
-//    ("sport/fiji-rugby-union-team", "954"),
-//    ("sport/uruguay-rugby-union-team", "2800"),
-//    ("sport/georgia-rugby-union-team", "2850"),
-//    ("sport/namibia-rugby-union-team", "2900"),
-//    ("sport/usarugby", "2950"),
-//    ("sport/japanrugby", "3000")
-//  )
-
-//  2015/09/20/73734/73753 -> Ireland v Canada 2015-09-20T01:30:00.000+10:00
-//  2015/09/24/73752/73735 -> Australia v Fiji 2015-09-24T03:45:00.000+10:00
-//  2015/09/27/73730/73711 -> South Africa v Samoa 2015-09-27T03:45:00.000+10:00
-//  2015/09/19/73738/73735 -> England v Fiji 2015-09-19T07:00:00.000+10:00
-//  2015/09/19/73754/73736 -> Tonga v Georgia 2015-09-19T23:00:00.000+10:00
-//  2015/09/28/73734/73742 -> Ireland v Romania 2015-09-28T03:45:00.000+10:00
-//  2015/09/27/73738/73740 -> England v Wales 2015-09-27T07:00:00.000+10:00
-//  2015/09/21/73739/73751 -> New Zealand v Argentina 2015-09-21T03:45:00.000+10:00
-//  2015/09/20/73730/73710 -> South Africa v Japan 2015-09-20T03:45:00.000+10:00
-//  2015/09/30/73754/73741 -> Tonga v Namibia 2015-09-30T03:45:00.000+10:00
-//  2015/09/24/73743/73742 -> France v Romania 2015-09-24T07:00:00.000+10:0
-//  2015/09/20/73711/73733 -> Samoa v USA 2015-09-20T23:00:00.000+10:00
-//  2015/09/27/73752/73737 -> Australia v Uruguay 2015-09-27T23:00:00.000+10:00
-//  2015/09/20/73743/73750 -> France v Italy 2015-09-20T07:00:00.000+10:00
-//  2015/09/26/73751/73736 -> Argentina v Georgia 2015-09-26T03:45:00.000+10:00
-//  2015/09/25/73739/73741 -> New Zealand v Namibia 2015-09-25T07:00:00.000+10:00
-//  2015/09/28/73732/73733 -> Scotland v USA 2015-09-28T01:30:00.000+10:00
-//  2015/09/21/73740/73737 -> Wales v Uruguay 2015-09-21T01:30:00.000+10:00
-//  2015/09/27/73750/73753 -> Italy v Canada 2015-09-27T01:30:00.000+10:00
-//  2015/09/24/73732/73710 -> Scotland v Japan 2015-09-24T01:30:00.000+10:00
 
   val teamNameIds = Map (
     ("sport/japanrugby", "73710"),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -258,7 +258,7 @@ final case class Content(
 
   // Dynamic Meta Data may appear on the page for some content. This should be used for conditional metadata.
   def conditionalConfig: Map[String, JsValue] = {
-    val rugbyMeta = if (tags.isRugbyMatch && conf.switches.Switches.RugbyScoresSwitch.isSwitchedOn) {
+    val rugbyMeta = if (tags.isRugbyMatch) {
       val teamIds = tags.keywords.map(_.id).collect(RugbyContent.teamNameIds)
       val (team1, team2) = (teamIds.headOption.getOrElse(""), teamIds.lift(1).getOrElse(""))
       val date = RugbyContent.timeFormatter.withZoneUTC().print(trail.webPublicationDate)

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -26,7 +26,7 @@ import play.api.libs.ws.WSClient
 import rugby.conf.RugbyLifecycle
 import router.Routes
 import rugby.controllers.RugbyControllers
-import rugby.feed.{CapiFeed, OptaFeed}
+import rugby.feed.{CapiFeed, OptaFeed, PARugbyClient, PARugbyFeed}
 import rugby.jobs.RugbyStatsJob
 import services.OphanApi
 
@@ -49,7 +49,8 @@ trait SportServices {
   lazy val competitionsService = wire[CompetitionsService]
   lazy val cricketPaFeed = wire[PaFeed]
   lazy val cricketStatsJob = wire[CricketStatsJob]
-  lazy val rugbyFeed = wire[OptaFeed]
+  lazy val rugbyClient = wire[PARugbyClient]
+  lazy val rugbyFeed = wire[PARugbyFeed]
   lazy val rugbyStatsJob = wire[RugbyStatsJob]
   lazy val capiFeed = wire[CapiFeed]
   lazy val ophanApi = wire[OphanApi]

--- a/sport/app/conf/SportConfiguration.scala
+++ b/sport/app/conf/SportConfiguration.scala
@@ -11,6 +11,7 @@ object SportConfiguration {
     lazy val footballHost = "https://football-api.guardianapis.com/v1.5"
     lazy val footballKey = configuration.getMandatoryStringProperty("pa.api.key")
     lazy val cricketKey = configuration.getStringProperty("pa.cricket.api.key")
+    lazy val rugbyKey = configuration.getStringProperty("pa.rugby.api.key")
   }
 
   object optaRugby {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -21,12 +21,12 @@ class CricketLifecycle(
   }}
 
   private def scheduleJobs() {
-    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 15.seconds) {
-      Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
-    }
-    jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", 10.minutes) {
-      Future(cricketStatsJob.run(fromDate = LocalDate.now.minusMonths(2), matchesToFetch = 10))
-    }
+//    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 15.seconds) {
+//      Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
+//    }
+//    jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", 10.minutes) {
+//      Future(cricketStatsJob.run(fromDate = LocalDate.now.minusMonths(2), matchesToFetch = 10))
+//    }
   }
 
   private def descheduleJobs() {

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -23,28 +23,28 @@ class FootballLifecycle(
   }}
 
   private def scheduleJobs() {
-    competitionsService.competitionIds.zipWithIndex foreach { case (id, index) =>
-      //stagger fixtures and results refreshes to avoid timeouts
-      val seconds = index * 5 % 60
-      val minutes = index * 5 / 60 % 5
-      val cron = s"$seconds $minutes/5 * * * ?"
-
-      jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
-        competitionsService.refreshCompetitionAgent(id)
-      }
-    }
-
-    jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
-      competitionsService.refreshMatchDay()
-    }
-
-    jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
-      competitionsService.refreshCompetitionData()
-    }
-
-    jobs.schedule("TeamMapRefreshJob", "0 0/10 * * * ?") {
-      TeamMap.refresh()(contentApiClient, ec)
-    }
+//    competitionsService.competitionIds.zipWithIndex foreach { case (id, index) =>
+//      //stagger fixtures and results refreshes to avoid timeouts
+//      val seconds = index * 5 % 60
+//      val minutes = index * 5 / 60 % 5
+//      val cron = s"$seconds $minutes/5 * * * ?"
+//
+//      jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
+//        competitionsService.refreshCompetitionAgent(id)
+//      }
+//    }
+//
+//    jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
+//      competitionsService.refreshMatchDay()
+//    }
+//
+//    jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
+//      competitionsService.refreshCompetitionData()
+//    }
+//
+//    jobs.schedule("TeamMapRefreshJob", "0 0/10 * * * ?") {
+//      TeamMap.refresh()(contentApiClient, ec)
+//    }
   }
 
   private def descheduleJobs() {

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -23,9 +23,9 @@ class RugbyLifecycle(
     rugbyStatsJob.fetchFixturesAndResults()
 
     jobs.deschedule("FixturesAndResults")
-    jobs.schedule("FixturesAndResults", "30 * * * * ?") {
-      rugbyStatsJob.fetchFixturesAndResults()
-    }
+//    jobs.schedule("FixturesAndResults", "30 * * * * ?") {
+//      rugbyStatsJob.fetchFixturesAndResults()
+//    }
 
     jobs.deschedule("MatchNavArticles")
     jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -21,29 +21,11 @@ class RugbyLifecycle(
 
   override def start(): Unit = {
     rugbyStatsJob.fetchFixturesAndResults()
-//    rugbyStatsJob.fetchGroupTables()
 
     jobs.deschedule("FixturesAndResults")
     jobs.schedule("FixturesAndResults", "30 * * * * ?") {
       rugbyStatsJob.fetchFixturesAndResults()
     }
-
-//    jobs.deschedule("GroupTables")
-//    jobs.schedule("GroupTables", "10 0/30 * * * ?") {
-//      rugbyStatsJob.fetchGroupTables()
-//    }
-//
-//
-//    jobs.deschedule("PastEventScores")
-//    jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
-//      rugbyStatsJob.fetchPastScoreEvents()
-//    }
-
-//    jobs.deschedule("PastMatchesStat")
-//    jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
-//      rugbyStatsJob.fetchPastMatchesStat()
-//    }
-
 
     jobs.deschedule("MatchNavArticles")
     jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
@@ -53,14 +35,10 @@ class RugbyLifecycle(
 
     akkaAsync.after1s {
       rugbyStatsJob.fetchFixturesAndResults()
-      rugbyStatsJob.fetchGroupTables()
     }
 
     //delay to allow previous jobs to complete
     akkaAsync.after(initializationTimeout) {
-      rugbyStatsJob.fetchPastScoreEvents()
-//      rugbyStatsJob.fetchPastMatchesStat()
-
       val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -21,28 +21,28 @@ class RugbyLifecycle(
 
   override def start(): Unit = {
     rugbyStatsJob.fetchFixturesAndResults()
-    rugbyStatsJob.fetchGroupTables()
+//    rugbyStatsJob.fetchGroupTables()
 
     jobs.deschedule("FixturesAndResults")
-    jobs.schedule("FixturesAndResults", "5 0/30 * * * ?") {
+    jobs.schedule("FixturesAndResults", "30 * * * * ?") {
       rugbyStatsJob.fetchFixturesAndResults()
     }
 
-    jobs.deschedule("GroupTables")
-    jobs.schedule("GroupTables", "10 0/30 * * * ?") {
-      rugbyStatsJob.fetchGroupTables()
-    }
+//    jobs.deschedule("GroupTables")
+//    jobs.schedule("GroupTables", "10 0/30 * * * ?") {
+//      rugbyStatsJob.fetchGroupTables()
+//    }
+//
+//
+//    jobs.deschedule("PastEventScores")
+//    jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
+//      rugbyStatsJob.fetchPastScoreEvents()
+//    }
 
-
-    jobs.deschedule("PastEventScores")
-    jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
-      rugbyStatsJob.fetchPastScoreEvents()
-    }
-
-    jobs.deschedule("PastMatchesStat")
-    jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
-      rugbyStatsJob.fetchPastMatchesStat()
-    }
+//    jobs.deschedule("PastMatchesStat")
+//    jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
+//      rugbyStatsJob.fetchPastMatchesStat()
+//    }
 
 
     jobs.deschedule("MatchNavArticles")
@@ -59,7 +59,7 @@ class RugbyLifecycle(
     //delay to allow previous jobs to complete
     akkaAsync.after(initializationTimeout) {
       rugbyStatsJob.fetchPastScoreEvents()
-      rugbyStatsJob.fetchPastMatchesStat()
+//      rugbyStatsJob.fetchPastMatchesStat()
 
       val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -20,6 +20,9 @@ class RugbyLifecycle(
   protected val initializationTimeout: FiniteDuration = 10.seconds
 
   override def start(): Unit = {
+    rugbyStatsJob.fetchFixturesAndResults()
+    rugbyStatsJob.fetchGroupTables()
+
     jobs.deschedule("FixturesAndResults")
     jobs.schedule("FixturesAndResults", "5 0/30 * * * ?") {
       rugbyStatsJob.fetchFixturesAndResults()

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -27,6 +27,8 @@ class MatchesController(
 
     val matchOpt = rugbyStatsJob.getFixturesAndResultScore(year, month, day, team1, team2)
 
+    log.info(s"RUGBY - match opt is: ${matchOpt}")
+
     val currentPage = request.getParameter("page")
 
     matchOpt.map { aMatch =>

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -27,6 +27,7 @@ class MatchesController(
 
     val matchOpt = rugbyStatsJob.getFixturesAndResultScore(year, month, day, team1, team2)
 
+    log.info(s"RUGBY - matches are: ${rugbyStatsJob.getAllResults()}")
     log.info(s"RUGBY - match opt is: ${matchOpt}")
 
     val currentPage = request.getParameter("page")
@@ -34,25 +35,25 @@ class MatchesController(
     matchOpt.map { aMatch =>
       val matchNav = rugbyStatsJob.getMatchNavContent(aMatch).map(rugby.views.html.fragments.matchNav(_, currentPage).toString)
 
-      val scoreEvents = rugbyStatsJob.getScoreEvents(aMatch)
-      val (homeTeamScorers, awayTeamScorers) =  scoreEvents.partition(_.player.team.id == aMatch.homeTeam.id)
-
-      val matchStat = rugbyStatsJob.getMatchStat(aMatch)
-      val table = rugbyStatsJob.getGroupTable(aMatch)
+//      val scoreEvents = rugbyStatsJob.getScoreEvents(aMatch)
+//      val (homeTeamScorers, awayTeamScorers) =  scoreEvents.partition(_.player.team.id == aMatch.homeTeam.id)
+//
+//      val matchStat = rugbyStatsJob.getMatchStat(aMatch)
+//      val table = rugbyStatsJob.getGroupTable(aMatch)
 
       val page = MatchPage(aMatch)
       Cached(60){
         if (request.isJson)
           JsonComponent(
             "matchSummary" -> rugby.views.html.fragments.matchSummary(page, aMatch).toString,
-            "scoreEvents" -> rugby.views.html.fragments.scoreEvents(aMatch, homeTeamScorers, awayTeamScorers).toString,
+//            "scoreEvents" -> rugby.views.html.fragments.scoreEvents(aMatch, homeTeamScorers, awayTeamScorers).toString,
             "dropdown" -> views.html.fragments.dropdown("", isClientSideTemplate = true)(Html("")),
-            "nav" -> matchNav.getOrElse(""),
-            "matchStat" -> rugby.views.html.fragments.matchStats(aMatch, matchStat),
-            "groupTable" -> rugby.views.html.fragments.groupTable(aMatch, table)
+            "nav" -> matchNav.getOrElse("")
+//            "matchStat" -> rugby.views.html.fragments.matchStats(aMatch, matchStat),
+//            "groupTable" -> rugby.views.html.fragments.groupTable(aMatch, table)
           )
         else
-          RevalidatableResult.Ok(rugby.views.html.matchSummary(page, aMatch, homeTeamScorers, awayTeamScorers))
+          RevalidatableResult.Ok(rugby.views.html.matchSummary(page, aMatch))
       }
 
     }.getOrElse(NotFound)

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -26,31 +26,18 @@ class MatchesController(
   def score(year: String, month: String, day: String, team1: String, team2: String): Action[AnyContent] = Action { implicit request =>
 
     val matchOpt = rugbyStatsJob.getFixturesAndResultScore(year, month, day, team1, team2)
-
-    log.info(s"RUGBY - matches are: ${rugbyStatsJob.getAllResults()}")
-    log.info(s"RUGBY - match opt is: ${matchOpt}")
-
     val currentPage = request.getParameter("page")
 
     matchOpt.map { aMatch =>
       val matchNav = rugbyStatsJob.getMatchNavContent(aMatch).map(rugby.views.html.fragments.matchNav(_, currentPage).toString)
-
-//      val scoreEvents = rugbyStatsJob.getScoreEvents(aMatch)
-//      val (homeTeamScorers, awayTeamScorers) =  scoreEvents.partition(_.player.team.id == aMatch.homeTeam.id)
-//
-//      val matchStat = rugbyStatsJob.getMatchStat(aMatch)
-//      val table = rugbyStatsJob.getGroupTable(aMatch)
 
       val page = MatchPage(aMatch)
       Cached(60){
         if (request.isJson)
           JsonComponent(
             "matchSummary" -> rugby.views.html.fragments.matchSummary(page, aMatch).toString,
-//            "scoreEvents" -> rugby.views.html.fragments.scoreEvents(aMatch, homeTeamScorers, awayTeamScorers).toString,
             "dropdown" -> views.html.fragments.dropdown("", isClientSideTemplate = true)(Html("")),
             "nav" -> matchNav.getOrElse("")
-//            "matchStat" -> rugby.views.html.fragments.matchStats(aMatch, matchStat),
-//            "groupTable" -> rugby.views.html.fragments.groupTable(aMatch, table)
           )
         else
           RevalidatableResult.Ok(rugby.views.html.matchSummary(page, aMatch))

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -18,9 +18,16 @@ case object WorldCup2015 extends OptaEvent {
   override def hasGroupTable(stage: Stage.Value): Boolean = stage == Stage.Group
 }
 
+case object WorldCup2019 extends OptaEvent {
+  override val competition = "482"
+  override val season = "2019"
+  override def hasGroupTable(stage: Stage.Value): Boolean = stage == Stage.Group
+}
+
+
 case class RugbyOptaFeedException(message: String) extends RuntimeException(message)
 
-class OptaFeed(wsClient: WSClient) extends Logging {
+class OptaFeed(wsClient: WSClient) extends RugbyFeed with Logging {
 
   private def events = List(WorldCup2015)
 

--- a/sport/app/rugby/feed/PAFeed.scala
+++ b/sport/app/rugby/feed/PAFeed.scala
@@ -1,22 +1,15 @@
 package rugby.feed
 
-import java.util.concurrent.{ConcurrentLinkedDeque, ConcurrentLinkedQueue}
-import java.util.{Timer, TimerTask}
-import java.util.concurrent.atomic.AtomicBoolean
-
 import common.Logging
+import play.api.libs.json.{JsBoolean, Json}
 import play.api.libs.ws.WSClient
 import rugby.model._
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.Success
+import scala.concurrent.{ExecutionContext, Future}
 
 trait RugbyFeed {
   def getLiveScores()(implicit executionContext: ExecutionContext): Future[Seq[Match]]
   def getFixturesAndResults()(implicit executionContext: ExecutionContext): Future[Seq[Match]]
-  def getScoreEvents(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[Seq[ScoreEvent]]
-  def getMatchStat(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[MatchStat]
-  def getGroupTables()(implicit executionContext: ExecutionContext): Future[Map[OptaEvent, Seq[GroupTable]]]
 }
 
 trait RugbyClient {
@@ -24,14 +17,6 @@ trait RugbyClient {
   // (e.g. World Cup has seasons for 2019, 2015, etc.).
   // 'Events' are matches.
   def getEvents(seasonID: Int)(implicit executionContext: ExecutionContext): Future[PAMatchesResponse]
-
-  // Standings are league or group tables. A standing ID is
-  // a unique ID identifying a table-type and tournament
-  // season.
-  def getStanding(standingID: Int)(implicit executionContext: ExecutionContext): Future[PATableResponse]
-
-  // Actions are things like tries.
-  def getEventActions(eventID: Int)(implicit executionContext: ExecutionContext): Future[Seq[PAEvent]]
 }
 
 case class JsonParseException(msg: String) extends RuntimeException(msg)
@@ -66,31 +51,9 @@ class PARugbyFeed(rugbyClient: RugbyClient) extends RugbyFeed with Logging {
     rugbyClient.getEvents(worldCupSeasonID)
       .map(games => games.items.map(PAMatch.toMatch))
   }
-
-  def getScoreEvents(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[Seq[ScoreEvent]] = {
-    def eventsForGame(gameID: Int): Future[Seq[ScoreEvent]] = {
-      rugbyClient.getEventActions(gameID).map(_.flatMap(PAEvent.toScoreEvent))
-    }
-
-    eventsForGame(rugbyMatch.id.toInt)
-  }
-
-  def getMatchStat(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[MatchStat] = {
-    // WARNING PA -> Opta translation (MatchStat type) likely to be very difficult
-    // Perhaps we should see if we can avoid this endpoint?
-    ???
-  }
-
-  def getGroupTables()(implicit executionContext: ExecutionContext): Future[Map[OptaEvent, Seq[GroupTable]]] = {
-    val tables = worldCupGroupIDs.map(id => rugbyClient.getStanding(id))
-
-    for {
-      tables <- Future.sequence(tables)
-    } yield Map[OptaEvent, Seq[GroupTable]](WorldCup2019 -> tables.map(table => PATableResponse.toGroupTable(table)))
-  }
 }
 
-class PARugbyClient(wsClient: WSClient) extends RugbyClient {
+class PARugbyClient(wsClient: WSClient) extends RugbyClient with Logging {
 
   val apiKey = conf.SportConfiguration.pa.rugbyKey.getOrElse("")
   val basePath = "https://sport.api.press.net/v1"
@@ -98,119 +61,57 @@ class PARugbyClient(wsClient: WSClient) extends RugbyClient {
   override def getEvents(seasonID: Int)
     (implicit executionContext: ExecutionContext): Future[PAMatchesResponse] = {
 
-    val resp = requestMatches(wsClient, s"/event?season=$seasonID", Map.empty)
-    resp.map(items => PAMatchesResponse(hasNext = false, items = items)) // TODO fix .gets
-  }
-
-  override def getStanding(standingID: Int)
-    (implicit executionContext: ExecutionContext): Future[PATableResponse] = {
-
-    val resp = request(wsClient, s"/standing/$standingID", Map.empty)
-    resp.map(json => PATableResponse.fromJSON(json).get)
-  }
-
-  override def getEventActions(eventID: Int)
-    (implicit executionContext: ExecutionContext): Future[Seq[PAEvent]] = {
-
-    val resp = request(wsClient, s"/event/$eventID/actions", Map.empty)
-    resp.map(json => {
-      PAEvent
-        .fromJSONList(json)
-        .getOrElse(Nil)
-    })
+    val resp = request(wsClient, s"/event?season=$seasonID", Map.empty)
+    resp.map(json => PAMatchesResponse.fromJSON(json).get) // TODO fix .get
   }
 
   def request(
     client: WSClient,
     path: String,
     params: Map[String, String]
-  )(implicit executionContext: ExecutionContext): Future[String] = {
+  )(implicit executionContext: ExecutionContext): Future[List[String]] = {
     val headers = Map("apikey" -> apiKey, "Accept" -> "application/json")
 
     val request = client.url(basePath + path)
       .addHttpHeaders(headers.toSeq: _*)
       .addQueryStringParameters(params.toSeq: _*)
 
-    SimpleThrottler.run(() => request.get())
-      .map(resp => {
-        resp.status match {
-          case 200 => resp.body
-          case _ => throw PARugbyAPIException(s"request for $path failed (status: ${resp.status}, body: ${resp.body})")
-        }
-      })
-  }
+    def hasNext(json: String): Boolean = (Json.parse(json) \ "hasNext").getOrElse(JsBoolean(false)) == JsBoolean(true)
 
-  def requestMatches(
-    client: WSClient,
-    path: String,
-    params: Map[String, String]
-  )(implicit executionContext: ExecutionContext): Future[List[PAMatch]] = {
+    def req(page: Int): Future[(Boolean, String)] = {
+      val request = client.url(basePath + path)
+        .addHttpHeaders(headers.toSeq: _*)
+        .addQueryStringParameters(params.toSeq: _*, "page" -> page.toString)
 
-    def cycle(
-      fn: Int => Future[PAMatchesResponse],
-      acc: Future[List[PAMatch]],
-      page: Int
-    )(implicit executionContext: ExecutionContext): Future[List[PAMatch]] = {
+      val resp = request.get()
+        .map(resp => {
+          resp.status match {
+            case 200 => {
+              log.info(s"GET $path")
+              resp.body
+            }
+            case _ => {
+              log.info(s"GET FAILED $path")
+              throw PARugbyAPIException(s"request for $path failed (status: ${resp.status}, body: ${resp.body})")
+            }
+          }
+        })
 
-      val response = fn(page)
-
-      response.flatMap(resp => {
-        if (resp.hasNext) {
-          val newAcc = acc.map(_ ++ resp.items)
-          cycle(fn, newAcc, page + 1)
-        } else {
-          acc
-        }
-      })
+      resp.map(body => (hasNext(body), body))
     }
 
-    val getPage: Int => Future[PAMatchesResponse] = (page: Int) => {
-      val qps = params + ("page" -> page.toString)
-
-      request(client, path, qps)
-        .map(json => PAMatchesResponse.fromJSON(json).get)
-    }
-
-    cycle(getPage, Future.successful(Nil), 1)
-  }
-}
-
-// A simple throttler that leverages some Java components.
-// The timer runs on its own background thread so shouldn't block things.
-// Note, the queue is unbounded so it is possible for things to
-// grow and grow and grow...
-object SimpleThrottler {
-
-  private[this] val timer = new Timer()
-  private[this] val queue = new ConcurrentLinkedQueue[Promise[Unit]]()
-
-  def start(period: Long): Unit = {
-    val task = new TimerTask {
-      override def run(): Unit = {
-        val p = Option(queue.poll())
-        p.foreach(_.complete(Success(())))
-      }
-    }
-
-    timer.schedule(task, 0, period)
+    cycle(1, Nil, req)
   }
 
-  def run[A](task: () => Future[A])(implicit executionContext: ExecutionContext): Future[A] = {
-    val p: Promise[Unit] = Promise()
+  def cycle[A](
+    page: Int,
+    acc: List[A],
+    req: (Int) => Future[(Boolean, A)]
+  )(implicit executionContext: ExecutionContext): Future[List[A]] = {
 
-    if (queue.size > 20) {
-      Future.failed(new RuntimeException("Simple throttler has exceeded capacity, failing fast."))
-    } else {
-      queue.add(p)
-
-      for {
-        _ <- p.future
-        res <- task()
-      } yield res
-    }
+    req().flatMap({
+      case (hasNext, res) => cycle(page + 1, res :: acc, req)
+      case (_, res) => Future.successful(res :: acc)
+    })
   }
-
-  def stop(): Unit = timer.cancel()
-
-  start(1000)
 }

--- a/sport/app/rugby/feed/PAFeed.scala
+++ b/sport/app/rugby/feed/PAFeed.scala
@@ -1,0 +1,165 @@
+package rugby.feed
+
+import common.Logging
+import play.api.libs.ws.WSClient
+import rugby.model._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait RugbyFeed {
+  def getLiveScores()(implicit executionContext: ExecutionContext): Future[Seq[Match]]
+  def getFixturesAndResults()(implicit executionContext: ExecutionContext): Future[Seq[Match]]
+  def getScoreEvents(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[Seq[ScoreEvent]]
+  def getMatchStat(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[MatchStat]
+  def getGroupTables()(implicit executionContext: ExecutionContext): Future[Map[OptaEvent, Seq[GroupTable]]]
+}
+
+trait RugbyClient {
+  // Each tournament is associated with one or more 'seasons'
+  // (e.g. World Cup has seasons for 2019, 2015, etc.).
+  // 'Events' are matches.
+  def getEvents(seasonID: Int)(implicit executionContext: ExecutionContext): Future[PAMatchesResponse]
+
+  // Standings are league or group tables. A standing ID is
+  // a unique ID identifying a table-type and tournament
+  // season.
+  def getStanding(standingID: Int)(implicit executionContext: ExecutionContext): Future[PATableResponse]
+
+  // Actions are things like tries.
+  def getEventActions(eventID: Int)(implicit executionContext: ExecutionContext): Future[Seq[PAEvent]]
+}
+
+case class JsonParseException(msg: String) extends RuntimeException(msg)
+case class PARugbyAPIException(msg: String) extends RuntimeException(msg)
+
+object WorldCupPAIDs {
+  val rugbyID = 29
+  val worldCupTournamentID = 482 // ...which has 'seasons' for each competition year...
+  val worldCup2019SeasonID = 11421
+
+  // http://sport.api.press.net/v1/stage?season=11421, then e.g.
+  // http://sport.api.press.net/v1/standing?stage=849625 for each.
+  val worldCup2019GroupIDs = List(235175, 235176, 235178, 235180)
+}
+
+class PARugbyFeed(rugbyClient: RugbyClient) extends RugbyFeed with Logging {
+
+  import WorldCupPAIDs._
+
+  def getLiveScores()(implicit executionContext: ExecutionContext): Future[Seq[Match]] = {
+    val x = getFixturesAndResults().map(_.filter(_.isLive))
+    x.onComplete(foo => log.info("RUGBY " + foo.toString))
+    x
+  }
+
+  def getFixturesAndResults()(implicit executionContext: ExecutionContext): Future[Seq[Match]] = {
+    rugbyClient.getEvents(worldCup2019SeasonID)
+      .map(games => games.items.map(PAMatch.toMatch))
+  }
+
+  def getScoreEvents(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[Seq[ScoreEvent]] = {
+    def eventsForGame(gameID: Int): Future[Seq[ScoreEvent]] = {
+      rugbyClient.getEventActions(gameID).map(_.flatMap(PAEvent.toScoreEvent))
+    }
+
+    eventsForGame(rugbyMatch.id.toInt)
+  }
+
+  def getMatchStat(rugbyMatch: Match)(implicit executionContext: ExecutionContext): Future[MatchStat] = {
+    // WARNING PA -> Opta translation (MatchStat type) likely to be very difficult
+    // Perhaps we should see if we can avoid this endpoint?
+    ???
+  }
+
+  def getGroupTables()(implicit executionContext: ExecutionContext): Future[Map[OptaEvent, Seq[GroupTable]]] = {
+    val tables = worldCup2019GroupIDs.map(id => rugbyClient.getStanding(id))
+
+    for {
+      tables <- Future.sequence(tables)
+    } yield Map[OptaEvent, Seq[GroupTable]](WorldCup2019 -> tables.map(table => PATableResponse.toGroupTable(table)))
+  }
+}
+
+class PARugbyClient(wsClient: WSClient) extends RugbyClient {
+
+  val apiKey = conf.SportConfiguration.pa.rugbyKey.getOrElse("")
+  val basePath = "https://sport.api.press.net/v1"
+
+  override def getEvents(seasonID: Int)
+    (implicit executionContext: ExecutionContext): Future[PAMatchesResponse] = {
+
+    val resp = request(wsClient, s"/event?season=$seasonID", Map.empty)
+    resp.map(json => PAMatchesResponse.fromJSON(json).get) // TODO fix .gets
+  }
+
+  override def getStanding(standingID: Int)
+    (implicit executionContext: ExecutionContext): Future[PATableResponse] = {
+
+    val resp = request(wsClient, s"/standing/$standingID", Map.empty)
+    resp.map(json => PATableResponse.fromJSON(json).get)
+  }
+
+  override def getEventActions(eventID: Int)
+    (implicit executionContext: ExecutionContext): Future[Seq[PAEvent]] = {
+
+    val resp = request(wsClient, s"/event/$eventID/actions", Map.empty)
+    resp.map(json => {
+      PAEvent
+        .fromJSONList(json)
+        .getOrElse(Nil)
+    })
+  }
+
+  def request(
+    client: WSClient,
+    path: String,
+    params: Map[String, String]
+  )(implicit executionContext: ExecutionContext): Future[String] = {
+    val headers = Map("apikey" -> apiKey, "Accept" -> "application/json")
+
+    client.url(basePath + path)
+      .addHttpHeaders(headers.toSeq: _*)
+      .addQueryStringParameters(params.toSeq: _*)
+      .get()
+      .map(resp => {
+        resp.status match {
+          case 200 => resp.body
+          case _ => throw PARugbyAPIException(s"request for $path failed (status: ${resp.status}, body: ${resp.body})")
+        }
+      })
+  }
+
+  def requestMatches(
+    client: WSClient,
+    path: String,
+    params: Map[String, String]
+  )(implicit executionContext: ExecutionContext): Future[List[PAMatch]] = {
+
+    def cycle(
+      fn: Int => Future[PAMatchesResponse],
+      acc: Future[List[PAMatch]],
+      page: Int
+    )(implicit executionContext: ExecutionContext): Future[List[PAMatch]] = {
+
+      val response = fn(page)
+
+      response.flatMap(resp => {
+        if (resp.hasNext) {
+          val newAcc = acc.map(_ ++ resp.items)
+          cycle(fn, newAcc, page + 1)
+        } else {
+          acc
+        }
+      })
+    }
+
+    val getPage: Int => Future[PAMatchesResponse] = (page: Int) => {
+      val qps = params + ("page" -> page.toString)
+
+      request(client, path, qps)
+        .map(json => PAMatchesResponse.fromJSON(json).get)
+    }
+
+    cycle(getPage, Future.successful(Nil), 1)
+  }
+}

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -65,29 +65,29 @@ class RugbyStatsJob(feed: RugbyFeed) extends Logging {
     scoresEventsForMatchesFuture.map(_.toMap)
   }
 
-  def fetchPastMatchesStat()(implicit executionContext: ExecutionContext): Unit = {
-    val pastMatches = fixturesAndResultsMatches.get().values.filter(_.date.isBeforeNow).toList
-
-    fetchMatchesStat(pastMatches).map { statForMatches =>
-      statForMatches.foreach { case (aMatch, stat) =>
-        pastMatchesStat.alter { _ + (aMatch.key -> stat)}
-      }
-    }
-  }
-
-  private def fetchMatchesStat(matches: List[Match])(implicit executionContext: ExecutionContext): Future[Map[Match, MatchStat]] = {
-    val statForMatchesFuture = Future.sequence {
-      matches.map(rugbyMatch =>
-        feed.getMatchStat(rugbyMatch).map(matchStat => rugbyMatch -> matchStat)
-      )
-    }
-    statForMatchesFuture.onComplete {
-      case Success(result) => //do nothing
-      case Failure(t) => log.warn(s"Failed to fetch match stat with error: ${t.getMessage}", t)
-    }
-
-    statForMatchesFuture.map(_.toMap)
-  }
+//  def fetchPastMatchesStat()(implicit executionContext: ExecutionContext): Unit = {
+//    val pastMatches = fixturesAndResultsMatches.get().values.filter(_.date.isBeforeNow).toList
+//
+//    fetchMatchesStat(pastMatches).map { statForMatches =>
+//      statForMatches.foreach { case (aMatch, stat) =>
+//        pastMatchesStat.alter { _ + (aMatch.key -> stat)}
+//      }
+//    }
+//  }
+//
+//  private def fetchMatchesStat(matches: List[Match])(implicit executionContext: ExecutionContext): Future[Map[Match, MatchStat]] = {
+//    val statForMatchesFuture = Future.sequence {
+//      matches.map(rugbyMatch =>
+//        feed.getMatchStat(rugbyMatch).map(matchStat => rugbyMatch -> matchStat)
+//      )
+//    }
+//    statForMatchesFuture.onComplete {
+//      case Success(result) => //do nothing
+//      case Failure(t) => log.warn(s"Failed to fetch match stat with error: ${t.getMessage}", t)
+//    }
+//
+//    statForMatchesFuture.map(_.toMap)
+//  }
 
   def sendMatchArticles(navigationArticles: Future[Map[String, MatchNavigation]])(implicit executionContext: ExecutionContext): Future[immutable.Iterable[Map[String, MatchNavigation]]] = {
     navigationArticles.flatMap { matches =>
@@ -98,6 +98,8 @@ class RugbyStatsJob(feed: RugbyFeed) extends Logging {
   }
 
   def getFixturesAndResultScore(year: String, month: String, day: String, homeTeamId: String, awayTeamId: String): Option[Match] = {
+    log.info(s"RUGBY fixtures and results are ${fixturesAndResultsMatches.get}")
+
     fixturesAndResultsMatches.get.values.find { rugbyMatch =>
       isValidMatch(year, month, day, homeTeamId, awayTeamId, rugbyMatch)
     }

--- a/sport/app/rugby/model/paRugby.scala
+++ b/sport/app/rugby/model/paRugby.scala
@@ -1,0 +1,243 @@
+package rugby.feed
+
+import common.Logging
+import org.joda.time.DateTime
+import play.api.libs.json.{JsError, JsResult, JsSuccess, Json}
+import rugby.model.Stage.Stage
+import rugby.model._
+import PAReads._
+
+import scala.util.{Failure, Success, Try}
+
+case class PAResult(
+  code: String,
+  name: String,
+  value: String,
+)
+
+object PAReads {
+  implicit val dtReads = play.api.libs.json.JodaReads.DefaultJodaDateTimeReads
+
+  implicit val resultReads = Json.reads[PAResult]
+  implicit val playerReads = Json.reads[PAPlayer]
+  implicit val nestedParticipantReads = Json.reads[NestedParticipant]
+  implicit val participantReads = Json.reads[Participant]
+  implicit val teamReads = Json.reads[PATeam]
+  implicit val venueReads = Json.reads[Venue]
+  implicit val tournamentReads = Json.reads[Tournament]
+  implicit val matchReads = Json.reads[PAMatch]
+  implicit val matchesReads = Json.reads[PAMatchesResponse]
+  implicit val tableRowReads = Json.reads[PATableRow]
+  implicit val tableReads = Json.reads[PATableResponse]
+  implicit val reads = Json.reads[PAEvent]
+}
+
+case class PAPlayer(
+  id: Int,
+  name: String,
+)
+
+case class NestedParticipant(
+  id: Int,
+  name: String,
+  participants: Option[Seq[PAPlayer]]
+)
+
+case class Participant(
+  id: Int,
+  name: String,
+)
+
+case class PATeam(
+  id: Int,
+  participant: Participant,
+  results: Map[String, PAResult]
+)
+
+case class Venue(
+  name: String,
+)
+
+case class Tournament(
+  name: String,
+)
+
+
+case class PAMatch(
+  id: Int,
+  date: DateTime,
+  entrants: Seq[PATeam],
+  venue: Option[Venue],
+  tournament: Tournament,
+  status: String,
+)
+
+object PAMatch {
+  def getStage(item: PAMatch): Stage = {
+    Stage.Group // TODO figure out how to get stage from PA data as not obvious
+  }
+
+  // See https://sport.pressassociation.io/docs/status
+  def getStatus(item: PAMatch): Status = {
+    item.status match {
+      case "Not started" => Status.Fixture
+      case "Kick Off Delayed" => Status.Postponed
+      case "1st half" => Status.FirstHalf
+      case "Halftime" => Status.HalfTime
+      case "2nd half" => Status.SecondHalf
+      case "Finished" => Status.Result
+      case "Extra time" => Status.ExtraTimeFirstHalf // TODO not equivalent
+      case "Finished AET" => Status.Result
+      case "Interrupted" => Status.Postponed
+      case "Abandoned" => Status.Abandoned
+      case "Postponed" => Status.Postponed
+      case _ => Status.Fixture
+    }
+  }
+
+  def toMatch(item: PAMatch): Match = {
+    val homeTeam = item.entrants(0)
+    val awayTeam = item.entrants(1)
+    val stage = getStage(item)
+
+    Match(
+      date = item.date,
+      id = item.id.toString,
+      homeTeam = rugby.model.Team(
+        id = homeTeam.id.toString,
+        name = homeTeam.participant.name,
+        score = homeTeam.results.get("final-result").map(_.value.toInt)
+      ),
+      awayTeam = rugby.model.Team(
+        id = awayTeam.id.toString,
+        name = awayTeam.participant.name,
+        score = awayTeam.results.get("final-result").map(_.value.toInt)
+      ),
+      venue = item.venue.map(_.name),
+      competitionName = item.tournament.name,
+      status = getStatus(item),
+      event = WorldCup2019, // WARNING assumes we only have world cup 2019 info
+      stage = getStage(item),
+    )
+  }
+}
+
+case class PAMatchesResponse(
+  hasNext: Boolean,
+  items: List[PAMatch]
+)
+
+object PAMatchesResponse extends Logging {
+
+  def fromJSON(json: String): Try[PAMatchesResponse] = {
+    val jsvalue = Json.parse(json)
+    val read = Json.fromJson[PAMatchesResponse](jsvalue)
+    PAUtils.asTry(read)
+  }
+}
+
+case class PATableRow(
+  rank: Int,
+  participant: Participant,
+  standings: Map[String, PAResult]
+)
+
+case class PATableResponse(
+  tournament: Tournament,
+  entries: List[PATableRow]
+)
+
+object PATableResponse extends Logging {
+
+  // TODO put JSON elsewhere to re-use error behaviour etc.
+  def fromJSON(json: String): Try[PATableResponse] = {
+    val jsvalue = Json.parse(json)
+    val res = Json.fromJson[PATableResponse](jsvalue)
+    PAUtils.asTry(res)
+  }
+
+  def toGroupTable(table: PATableResponse): GroupTable = {
+    val ranks = table.entries.map(entry => {
+      TeamRank(
+        id = entry.participant.id.toString,
+        name = entry.participant.name,
+        rank = entry.rank,
+        played = entry.standings("played").value.toInt,
+        won = entry.standings("wins").value.toInt,
+        drawn = entry.standings("draws").value.toInt,
+        lost = entry.standings("defeits").value.toInt,
+        pointsdiff = 0, // TODO fixme or remove
+        points = entry.standings("points").value.toInt,
+      )
+    })
+
+    GroupTable(
+      table.tournament.name,
+      teams = ranks
+    )
+  }
+}
+
+case class PAEvent(
+  id: Int,
+  code: String,
+  `type`: String,
+  meta: Map[String, PAResult],
+  elapsed: Int,
+  participants: List[NestedParticipant],
+)
+
+object PAEvent extends Logging {
+
+  def fromJSON(json: String): Try[PAEvent] = {
+    val jsvalue = Json.parse(json)
+    val event = Json.fromJson[PAEvent](jsvalue)
+    PAUtils.asTry(event)
+  }
+
+  def fromJSONList(json: String): Try[List[PAEvent]] = {
+    val jsvalue = Json.parse(json)
+    val events = Json.fromJson[List[PAEvent]](jsvalue)
+    PAUtils.asTry(events)
+  }
+
+  def toScoreEvent(event: PAEvent): Option[ScoreEvent] = {
+    val scorers = event.participants.head.participants.headOption.flatMap(_.headOption)
+    val team = event.participants.headOption
+
+    // Filter to goal events with a team and scorer
+    for {
+      scorer <- scorers
+      team <- team
+      if event.code == "goal"
+    } yield {
+      val eventType = event.`type` match {
+        case "Try" => ScoreType.`Try`
+        case "Penalty Try" => ScoreType.PenaltyTry
+        case "Penalty" => ScoreType.Penalty
+        case "Conversion" => ScoreType.Conversion
+        case "Dropkick" => ScoreType.DropGoal
+        case _ =>
+          log.info(s"Unexpected action type (${event.`type`}.")
+          ScoreType.`Try`
+      }
+
+      ScoreEvent(
+        player = Player(
+          id = scorer.id.toString,
+          name = scorer.name,
+          team = Team(team.id.toString, team.name, None)
+        ),
+        minute = (event.elapsed / 60).toString, // TODO check
+        `type` = eventType
+      )
+    }
+  }
+}
+
+object PAUtils {
+  def asTry[A](jsres: JsResult[A]): Try[A] = jsres match {
+    case JsSuccess(events, _) => Success(events)
+    case JsError(errors) => Failure(JsonParseException(errors.toString))
+  }
+}

--- a/sport/app/rugby/model/paRugby.scala
+++ b/sport/app/rugby/model/paRugby.scala
@@ -98,7 +98,7 @@ object PAMatch {
     val stage = getStage(item)
 
     Match(
-      date = item.date,
+      date = item.date.toDateTimeISO,
       id = item.id.toString,
       homeTeam = rugby.model.Team(
         id = homeTeam.participant.id.toString,

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -13,7 +13,7 @@ case class Match(
   venue: Option[String],
   competitionName: String,
   status: Status,
-  event: OptaEvent,
+  event: OptaEvent, // TODO rename to just RugbyEvent (as will soon be PA)
   stage: Stage.Value
 ) {
   def hasTeam(teamId: String): Boolean = homeTeam.id == teamId || awayTeam.id == teamId

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -52,7 +52,7 @@ object Stage extends Enumeration(1) {
 }
 
 object Match {
-  val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy/MM/dd")
+  val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy/MM/dd").withZoneUTC()
 }
 
 case class Team(

--- a/sport/app/rugby/views/fragments/matchSummary.scala.html
+++ b/sport/app/rugby/views/fragments/matchSummary.scala.html
@@ -1,72 +1,52 @@
 @import model.Page
 @import rugby.model.Match
-@import rugby.model.Status.{FirstHalf, HalfTime, Result, SecondHalf}
+@import rugby.model.Status.{Result, FirstHalf, HalfTime, SecondHalf}
 @import views.support.RenderClasses
 @import conf.Configuration
 
-@(page: Page, theMatch: Match)
 
-@status() = {
-    @theMatch.status match {
-        case Result      => { <abbr class="m-status">FT</abbr> }
-        case HalfTime    => { <abbr class="m-status">HT</abbr> }
-        case FirstHalf   => { <abbr class="m-status">1st</abbr> }
-        case SecondHalf  => { <abbr class="m-status">2nd</abbr> }
-        case _ => {}
+@(page: Page, theMatch: Match)(implicit request: RequestHeader)
+
+@defining((theMatch.homeTeam, theMatch.awayTeam)){ case (homeTeam, awayTeam) =>
+ <div
+    data-component="big-match-special"
+    class="@RenderClasses(Map(
+        "match-summary" -> true,
+        "match-summary--fixture" -> theMatch.isFixture,
+        "match-summary--responsive" -> true
+    ))" data-match-id="@theMatch.id"
+ >
+
+    @if(theMatch.isLive || theMatch.status == Result){
+        <h1 class="u-h">@{homeTeam.name} @{homeTeam.score} - @{awayTeam.score} @{awayTeam.name}</h1>
+    }else{
+        <h1 class="u-h">@{homeTeam.name} v @{awayTeam.name}</h1>
     }
-}
 
-<div class="match-summary match-summary--responsive">
+    <div class="match-summary__teams">
+        <div class="match-summary__team match-summary__team--home">
+            <h2 class="team__name">@{homeTeam.name}</h2>
 
-    <div class="@RenderClasses(Map(
-        "match-summary__status" -> true,
-        "match-summary__status--live" -> theMatch.isLive))">
-        <div class="status__time">
-            @if(theMatch.isFixture){
-                @theMatch.date.toString("HH:mm")
-            }else{
-                @status()
+            <div class="team__crest-wrapper">
+                <img class="team__crest" src="@Configuration.staticSport.path/rugby/crests/200/pa/@{homeTeam.id}.png" />
+            </div>
+
+            @if(theMatch.isLive || theMatch.status == Result){
+                <div class="team__score"><span class="team__score__number">@homeTeam.score</span></div>
+            }
+        </div>
+
+        <div class="match-summary__team match-summary__team--away">
+            <h2 class="team__name">@{awayTeam.name}</h2>
+
+            <div class="team__crest-wrapper">
+                <img class="team__crest" src="@Configuration.staticSport.path/rugby/crests/200/pa/@{awayTeam.id}.png" />
+            </div>
+
+            @if(theMatch.isLive || theMatch.status == Result){
+                <div class="team__score"><span class="team__score__number">@awayTeam.score</span></div>
             }
         </div>
     </div>
-
-    <div class="match-info">
-        <div class="match-info__competition">@{theMatch.competitionName}</div>
-        <div class="match-info__venue">@{theMatch.venue}</div>
-    </div>
-    <div class="match-summary__teams">
-        <div class="match-summary__team match-summary__team--home u-cf">
-            <div class="team__crest team__crest--home">
-                <div class="team__crest__img-container">
-                    <span class="team__crest__img" style="background-image: url(@Configuration.staticSport.path/rugby/crests/200/@{theMatch.homeTeam.id}.png)"></span>
-                </div>
-            </div>
-            <div class="team__info">
-                <h2 class="team__heading">
-                    <span class="team__name">
-                        <span class="team__name-long">@theMatch.homeTeam.name</span>
-                    </span>
-                    <span class="team__score">@theMatch.homeTeam.score</span>
-                </h2>
-
-                <div class="team__battle-line"></div>
-            </div>
-        </div>
-
-        <div class="match-summary__team match-summary__team--away u-cf">
-            <div class="team__crest team__crest--away">
-                <div class="team__crest__img-container">
-                    <span class="team__crest__img" style="background-image: url(@Configuration.staticSport.path/rugby/crests/200/@{theMatch.awayTeam.id}.png)"></span>
-                </div>
-            </div>
-            <div class="team__info">
-                <h2 class="team__heading">
-                    <span class="team__name">
-                        <span class="team__name-long">@theMatch.awayTeam.name</span>
-                    </span>
-                    <span class="team__score">@theMatch.awayTeam.score</span>
-                </h2>
-            </div>
-        </div>
-    </div>
 </div>
+}

--- a/sport/app/rugby/views/matchSummary.scala.html
+++ b/sport/app/rugby/views/matchSummary.scala.html
@@ -1,7 +1,7 @@
 @import model.Page
 @import rugby.model.{Match, ScoreEvent}
 
-@(page: Page, theMatch: Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: Page, theMatch: Match)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page, Some("football")) { } {
     <div class="l-side-margins">

--- a/sport/test/resources/rugby/feed/pa-event-actions.json
+++ b/sport/test/resources/rugby/feed/pa-event-actions.json
@@ -1,0 +1,678 @@
+[
+    {
+        "id": 3602087,
+        "code": "goal",
+        "type": "Penalty",
+        "elapsed": 3,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 414646,
+                        "name": "George Ford",
+                        "firstName": "George",
+                        "lastName": "Ford",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "3"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "414646"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "George Ford"
+            }
+        },
+        "updated": "2015-09-18T21:06:32Z"
+    },
+    {
+        "id": 3602176,
+        "code": "goal",
+        "type": "Penalty Try",
+        "elapsed": 13,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                }
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "13"
+            }
+        },
+        "updated": "2017-10-20T05:59:31Z"
+    },
+    {
+        "id": 3602187,
+        "code": "goal",
+        "type": "Conversion",
+        "elapsed": 13,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 414646,
+                        "name": "George Ford",
+                        "firstName": "George",
+                        "lastName": "Ford",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "13"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "414646"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "George Ford"
+            }
+        },
+        "updated": "2015-09-18T22:04:25Z"
+    },
+    {
+        "id": 3803059,
+        "code": "card",
+        "type": "Yellow card",
+        "elapsed": 13,
+        "participants": [
+            {
+                "id": 73735,
+                "name": "Fiji",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 94,
+                    "name": "Fiji"
+                },
+                "participants": [
+                    {
+                        "id": 400665,
+                        "name": "Nikola Matawalu",
+                        "firstName": "Nikola",
+                        "lastName": "Matawalu",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 94,
+                            "name": "Fiji"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "13"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "400665"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Nikola Matawalu"
+            }
+        },
+        "updated": "2015-12-22T11:26:38Z"
+    },
+    {
+        "id": 3602310,
+        "code": "goal",
+        "type": "Try",
+        "elapsed": 22,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 470300,
+                        "name": "Mike Brown",
+                        "firstName": "Mike",
+                        "lastName": "Brown",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "22"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "470300"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Mike Brown"
+            }
+        },
+        "updated": "2015-09-18T21:31:46Z"
+    },
+    {
+        "id": 3602451,
+        "code": "goal",
+        "type": "Try",
+        "elapsed": 30,
+        "participants": [
+            {
+                "id": 73735,
+                "name": "Fiji",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 94,
+                    "name": "Fiji"
+                },
+                "participants": [
+                    {
+                        "id": 468501,
+                        "name": "Nemani Nadolo",
+                        "firstName": "Nemani",
+                        "lastName": "Nadolo",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 94,
+                            "name": "Fiji"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "30"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "468501"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Nemani Nasiganiyavi"
+            }
+        },
+        "updated": "2017-04-08T16:05:42Z"
+    },
+    {
+        "id": 3602482,
+        "code": "goal",
+        "type": "Penalty",
+        "elapsed": 34,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 414646,
+                        "name": "George Ford",
+                        "firstName": "George",
+                        "lastName": "Ford",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "34"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "414646"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "George Ford"
+            }
+        },
+        "updated": "2015-09-18T21:51:20Z"
+    },
+    {
+        "id": 3602507,
+        "code": "goal",
+        "type": "Penalty",
+        "elapsed": 37,
+        "participants": [
+            {
+                "id": 73735,
+                "name": "Fiji",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 94,
+                    "name": "Fiji"
+                },
+                "participants": [
+                    {
+                        "id": 468501,
+                        "name": "Nemani Nadolo",
+                        "firstName": "Nemani",
+                        "lastName": "Nadolo",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 94,
+                            "name": "Fiji"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "37"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "468501"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Nemani Nasiganiyavi"
+            }
+        },
+        "updated": "2017-04-08T16:05:37Z"
+    },
+    {
+        "id": 3602779,
+        "code": "goal",
+        "type": "Penalty",
+        "elapsed": 64,
+        "participants": [
+            {
+                "id": 73735,
+                "name": "Fiji",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 94,
+                    "name": "Fiji"
+                },
+                "participants": [
+                    {
+                        "id": 658199,
+                        "name": "Ben Volavola",
+                        "firstName": "Ben",
+                        "lastName": "Volavola",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 94,
+                            "name": "Fiji"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "64"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "658199"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Ben Volavola"
+            }
+        },
+        "updated": "2015-09-18T23:03:51Z"
+    },
+    {
+        "id": 3602790,
+        "code": "goal",
+        "type": "Penalty",
+        "elapsed": 68,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 324517,
+                        "name": "Owen Farrell",
+                        "firstName": "Owen",
+                        "lastName": "Farrell",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "68"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "324517"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Owen Farrell"
+            }
+        },
+        "updated": "2015-09-18T23:03:57Z"
+    },
+    {
+        "id": 3602802,
+        "code": "goal",
+        "type": "Try",
+        "elapsed": 72,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 470300,
+                        "name": "Mike Brown",
+                        "firstName": "Mike",
+                        "lastName": "Brown",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "72"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "470300"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Mike Brown"
+            }
+        },
+        "updated": "2015-09-18T23:04:04Z"
+    },
+    {
+        "id": 3602803,
+        "code": "goal",
+        "type": "Conversion",
+        "elapsed": 74,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 324517,
+                        "name": "Owen Farrell",
+                        "firstName": "Owen",
+                        "lastName": "Farrell",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "74"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "324517"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Owen Farrell"
+            }
+        },
+        "updated": "2015-09-18T23:04:12Z"
+    },
+    {
+        "id": 3602823,
+        "code": "goal",
+        "type": "Try",
+        "elapsed": 80,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 470254,
+                        "name": "Billy Vunipola",
+                        "firstName": "Billy",
+                        "lastName": "Vunipola",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "80"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "470254"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Billy Vunipola"
+            }
+        },
+        "updated": "2015-09-18T23:04:57Z"
+    },
+    {
+        "id": 3602824,
+        "code": "goal",
+        "type": "Conversion",
+        "elapsed": 80,
+        "participants": [
+            {
+                "id": 73738,
+                "name": "England",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 2,
+                    "name": "England"
+                },
+                "participants": [
+                    {
+                        "id": 324517,
+                        "name": "Owen Farrell",
+                        "firstName": "Owen",
+                        "lastName": "Farrell",
+                        "gender": "male",
+                        "type": "athlete",
+                        "country": {
+                            "id": 2,
+                            "name": "England"
+                        }
+                    }
+                ]
+            }
+        ],
+        "meta": {
+            "incident-minute": {
+                "code": "action:incident-minute",
+                "name": "Incident Minute",
+                "value": "80"
+            },
+            "player-fk": {
+                "code": "action:player-fk",
+                "name": "Player FK",
+                "value": "324517"
+            },
+            "player-name": {
+                "code": "action:player-name",
+                "name": "Player Name",
+                "value": "Owen Farrell"
+            }
+        },
+        "updated": "2015-09-18T23:02:54Z"
+    }
+]

--- a/sport/test/resources/rugby/feed/pa-events.json
+++ b/sport/test/resources/rugby/feed/pa-events.json
@@ -1,0 +1,1277 @@
+{
+  "offset": 0,
+  "limit": 20,
+  "hasNext": false,
+  "hasPrevious": false,
+  "items": [
+    {
+      "id": 3000315,
+      "name": "Wellington-Counties Manukau",
+      "status": "Finished",
+      "date": "2019-08-29T07:35:00Z",
+      "updated": "2019-08-29T11:43:41Z",
+      "entrants": [
+        {
+          "id": 10406409,
+          "number": 1,
+          "participant": {
+            "id": 468560,
+            "name": "Wellington",
+            "gender": "male",
+            "type": "team",
+            "country": {
+              "id": 93,
+              "name": "New Zealand"
+            },
+            "participants": [
+              {
+                "id": 959217,
+                "name": "Xavier Numia",
+                "firstName": "Xavier",
+                "lastName": "Numia",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "1"
+                  }
+                }
+              },
+              {
+                "id": 782747,
+                "name": "Asafo Aumua",
+                "firstName": "Asafo",
+                "lastName": "Aumua",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "2"
+                  }
+                }
+              },
+              {
+                "id": 782750,
+                "name": "Alex Fidow",
+                "firstName": "Alex",
+                "lastName": "Fidow",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "3"
+                  }
+                }
+              },
+              {
+                "id": 311037,
+                "name": "Joshua Furno",
+                "firstName": "Joshua",
+                "lastName": "Furno",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 4,
+                  "name": "Italy"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "4"
+                  }
+                }
+              },
+              {
+                "id": 735900,
+                "name": "James Blackwell",
+                "firstName": "James",
+                "lastName": "Blackwell",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "5"
+                  }
+                }
+              },
+              {
+                "id": 881038,
+                "name": "Mateaki Kafatolu",
+                "firstName": "Mateaki",
+                "lastName": "Kafatolu",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "6"
+                  }
+                }
+              },
+              {
+                "id": 873960,
+                "name": "Du'Plessis Kirifi",
+                "firstName": "Du'Plessis",
+                "lastName": "Kirifi",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "7"
+                  }
+                }
+              },
+              {
+                "id": 800023,
+                "name": "Teariki Ben-Nicholas",
+                "firstName": "Teariki",
+                "lastName": "Ben-Nicholas",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "8"
+                  }
+                }
+              },
+              {
+                "id": 857625,
+                "name": "Kemara Hauiti-Parapara",
+                "firstName": "Kemara",
+                "lastName": "Hauiti-Parapara",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "9"
+                  }
+                }
+              },
+              {
+                "id": 782754,
+                "name": "Jackson Garden-Bachop",
+                "firstName": "Jackson",
+                "lastName": "Garden-Bachop",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "10"
+                  }
+                }
+              },
+              {
+                "id": 960385,
+                "name": "Pepesana Patafilo",
+                "firstName": "Pepesana",
+                "lastName": "Patafilo",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "11"
+                  }
+                }
+              },
+              {
+                "id": 782783,
+                "name": "Peter Umaga-Jensen",
+                "firstName": "Peter",
+                "lastName": "Umaga-Jensen",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "12"
+                  }
+                }
+              },
+              {
+                "id": 727779,
+                "name": "Vince Aso",
+                "firstName": "Vince",
+                "lastName": "Aso",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "13"
+                  }
+                }
+              },
+              {
+                "id": 726119,
+                "name": "Wes Goosen",
+                "firstName": "Wes",
+                "lastName": "Goosen",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "14"
+                  }
+                }
+              },
+              {
+                "id": 883648,
+                "name": "Billy Proctor",
+                "firstName": "Billy",
+                "lastName": "Proctor",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "15"
+                  }
+                }
+              },
+              {
+                "id": 784623,
+                "name": "James O'Reilly",
+                "firstName": "James",
+                "lastName": "O'Reilly",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "16"
+                  }
+                }
+              },
+              {
+                "id": 1079782,
+                "name": "Morgan Poi",
+                "firstName": "Morgan",
+                "lastName": "Poi",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "17"
+                  }
+                }
+              },
+              {
+                "id": 957053,
+                "name": "Kaliopasi Uluilakepa",
+                "firstName": "Kaliopasi",
+                "lastName": "Uluilakepa",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "18"
+                  }
+                }
+              },
+              {
+                "id": 1079780,
+                "name": "Naitoa Ah Kuoi",
+                "firstName": "Naitoa",
+                "lastName": "Ah Kuoi",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "19"
+                  }
+                }
+              },
+              {
+                "id": 1082309,
+                "name": "Luke Tau'alupe",
+                "firstName": "Luke",
+                "lastName": "Tau'alupe",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "20"
+                  }
+                }
+              },
+              {
+                "id": 956687,
+                "name": "Connor Collins",
+                "firstName": "Connor",
+                "lastName": "Collins",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "21"
+                  }
+                }
+              },
+              {
+                "id": 780781,
+                "name": "Trent Renata",
+                "firstName": "Trent",
+                "lastName": "Renata",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "22"
+                  }
+                }
+              },
+              {
+                "id": 723742,
+                "name": "Ben Lam",
+                "firstName": "Ben",
+                "lastName": "Lam",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "23"
+                  }
+                }
+              }
+            ]
+          },
+          "results": {
+            "final-result": {
+              "code": "result:final-result",
+              "name": "Final Result",
+              "value": "29"
+            },
+            "halftime": {
+              "code": "result:halftime",
+              "name": "Halftime",
+              "value": "7"
+            },
+            "ordinary-time": {
+              "code": "result:ordinary-time",
+              "name": "Ordinary Time",
+              "value": "29"
+            },
+            "running-score": {
+              "code": "result:running-score",
+              "name": "Running Score",
+              "value": "29"
+            },
+            "tries": {
+              "code": "result:tries",
+              "name": "Tries",
+              "value": "4"
+            }
+          }
+        },
+        {
+          "id": 10406410,
+          "number": 2,
+          "participant": {
+            "id": 742019,
+            "name": "Counties Manukau",
+            "gender": "male",
+            "type": "team",
+            "country": {
+              "id": 93,
+              "name": "New Zealand"
+            },
+            "participants": [
+              {
+                "id": 784150,
+                "name": "Sean Bagshaw",
+                "firstName": "Sean",
+                "lastName": "Bagshaw",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "1"
+                  }
+                }
+              },
+              {
+                "id": 597509,
+                "name": "Joel Royal",
+                "firstName": "Joel",
+                "lastName": "Royal",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "2"
+                  }
+                }
+              },
+              {
+                "id": 735437,
+                "name": "Tim Metcher",
+                "firstName": "Tim",
+                "lastName": "Metcher",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "3"
+                  }
+                }
+              },
+              {
+                "id": 784164,
+                "name": "Viliame Rarasea",
+                "firstName": "Viliame",
+                "lastName": "Rarasea",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 94,
+                  "name": "Fiji"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "4"
+                  }
+                }
+              },
+              {
+                "id": 873738,
+                "name": "Daymon Leasuasu",
+                "firstName": "Daymon",
+                "lastName": "Leasuasu",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "5"
+                  }
+                }
+              },
+              {
+                "id": 851844,
+                "name": "Sikeli Nabou",
+                "firstName": "Sikeli",
+                "lastName": "Nabou",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 94,
+                  "name": "Fiji"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "6"
+                  }
+                }
+              },
+              {
+                "id": 727916,
+                "name": "Sam Henwood",
+                "firstName": "Sam",
+                "lastName": "Henwood",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "7"
+                  }
+                }
+              },
+              {
+                "id": 806510,
+                "name": "Malgene Ilaua",
+                "firstName": "Malgene",
+                "lastName": "Ilaua",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 25,
+                  "name": "Japan"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "8"
+                  }
+                }
+              },
+              {
+                "id": 784169,
+                "name": "Jonathan Taumateine",
+                "firstName": "Jonathan",
+                "lastName": "Taumateine",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "9"
+                  }
+                }
+              },
+              {
+                "id": 1079789,
+                "name": "Riley Hohepa",
+                "firstName": "Riley",
+                "lastName": "Hohepa",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "10"
+                  }
+                }
+              },
+              {
+                "id": 784766,
+                "name": "Kali Hala",
+                "firstName": "Kali",
+                "lastName": "Hala",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 171,
+                  "name": "Tonga"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "11"
+                  }
+                }
+              },
+              {
+                "id": 784159,
+                "name": "Orbyn Leger",
+                "firstName": "Orbyn",
+                "lastName": "Leger",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "12"
+                  }
+                }
+              },
+              {
+                "id": 777091,
+                "name": "Nathaniel Apa",
+                "firstName": "Nathaniel",
+                "lastName": "Apa",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "13"
+                  }
+                }
+              },
+              {
+                "id": 735847,
+                "name": "Chris Kuridrani",
+                "firstName": "Chris",
+                "lastName": "Kuridrani",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 39,
+                  "name": "Australia"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "14"
+                  }
+                }
+              },
+              {
+                "id": 735818,
+                "name": "Andrew Kellaway",
+                "firstName": "Andrew",
+                "lastName": "Kellaway",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 39,
+                  "name": "Australia"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Starter"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "15"
+                  }
+                }
+              },
+              {
+                "id": 873700,
+                "name": "Donald Maka",
+                "firstName": "Donald",
+                "lastName": "Maka",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "16"
+                  }
+                }
+              },
+              {
+                "id": 873364,
+                "name": "Mark Royal",
+                "firstName": "Mark",
+                "lastName": "Royal",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "17"
+                  }
+                }
+              },
+              {
+                "id": 710874,
+                "name": "Conan O'Donnell",
+                "firstName": "Conan",
+                "lastName": "O'Donnell",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 45,
+                  "name": "Ireland"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "18"
+                  }
+                }
+              },
+              {
+                "id": 879010,
+                "name": "Jonathan Kawau",
+                "firstName": "Jonathan",
+                "lastName": "Kawau",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "19"
+                  }
+                }
+              },
+              {
+                "id": 959767,
+                "name": "Dan Hyatt",
+                "firstName": "Dan",
+                "lastName": "Hyatt",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "20"
+                  }
+                }
+              },
+              {
+                "id": 880213,
+                "name": "Liam Daniela",
+                "firstName": "Liam",
+                "lastName": "Daniela",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 93,
+                  "name": "New Zealand"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "21"
+                  }
+                }
+              },
+              {
+                "id": 1082294,
+                "name": "Nikolai Foliaki",
+                "firstName": "Nikolai",
+                "lastName": "Foliaki",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 2,
+                  "name": "England"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "22"
+                  }
+                }
+              },
+              {
+                "id": 1082295,
+                "name": "Liam Fitzsimons",
+                "firstName": "Liam",
+                "lastName": "Fitzsimons",
+                "gender": "male",
+                "type": "athlete",
+                "country": {
+                  "id": 2,
+                  "name": "England"
+                },
+                "meta": {
+                  "lineup-type": {
+                    "code": "participant:lineup-type",
+                    "name": "Lineup Type",
+                    "value": "Substitute player"
+                  },
+                  "shirt-number": {
+                    "code": "participant:shirt-number",
+                    "name": "Shirt Number",
+                    "value": "23"
+                  }
+                }
+              }
+            ]
+          },
+          "results": {
+            "final-result": {
+              "code": "result:final-result",
+              "name": "Final Result",
+              "value": "22"
+            },
+            "halftime": {
+              "code": "result:halftime",
+              "name": "Halftime",
+              "value": "12"
+            },
+            "ordinary-time": {
+              "code": "result:ordinary-time",
+              "name": "Ordinary Time",
+              "value": "22"
+            },
+            "running-score": {
+              "code": "result:running-score",
+              "name": "Running Score",
+              "value": "22"
+            },
+            "tries": {
+              "code": "result:tries",
+              "name": "Tries",
+              "value": "4"
+            }
+          }
+        }
+      ],
+      "stage": {
+        "id": 860050,
+        "name": "Mitre 10 Cup",
+        "gender": "male",
+        "start": "2019-08-07",
+        "end": "2019-10-13",
+        "country": {
+          "id": 93,
+          "name": "New Zealand"
+        }
+      },
+      "season": {
+        "id": 13681,
+        "name": "2019"
+      },
+      "tournament": {
+        "id": 9564,
+        "name": "New Zealand Mitre 10 Cup",
+        "gender": "male"
+      },
+      "sport": {
+        "id": 29,
+        "name": "Rugby Union"
+      },
+      "venue": {
+        "id": 6994,
+        "name": "Westpac Stadium",
+        "type": "Stadium",
+        "country": {
+          "id": 93,
+          "name": "New Zealand"
+        }
+      },
+      "meta": {
+        "game-ended": {
+          "code": "event:game-ended",
+          "name": "Game Ended",
+          "value": "2019-08-29T13:32:07Z"
+        },
+        "live": {
+          "code": "event:live",
+          "name": "Live",
+          "value": "no"
+        },
+        "round": {
+          "code": "event:round",
+          "name": "Round",
+          "value": "4"
+        },
+        "venue-name": {
+          "code": "event:venue-name",
+          "name": "Venue Name",
+          "value": "Westpac Stadium"
+        },
+        "verified": {
+          "code": "event:verified",
+          "name": "Verified",
+          "value": "yes"
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "http://sport.api.press.net/v1/event/3000315"
+        },
+        {
+          "rel": "event-actions",
+          "href": "http://sport.api.press.net/v1/event/3000315/actions"
+        }
+      ]
+    }
+  ]
+}

--- a/sport/test/resources/rugby/feed/pa-standing.json
+++ b/sport/test/resources/rugby/feed/pa-standing.json
@@ -1,0 +1,843 @@
+{
+    "id": 235174,
+    "name": "League Table",
+    "type": "Standard League Table 1",
+    "sport": {
+        "id": 29,
+        "name": "Rugby Union"
+    },
+    "tournament": {
+        "id": 482,
+        "name": "World Cup",
+        "gender": "male"
+    },
+    "season": {
+        "id": 11421,
+        "name": "2019"
+    },
+    "stage": {
+        "id": 849622,
+        "name": "World Cup Pool A",
+        "gender": "male",
+        "start": "2019-09-19",
+        "end": "2019-10-13",
+        "country": {
+            "id": 11,
+            "name": "International"
+        }
+    },
+    "updated": "2018-08-17T11:13:28Z",
+    "entries": [
+        {
+            "id": 2679928,
+            "rank": 1,
+            "participant": {
+                "id": 73734,
+                "name": "Ireland",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 45,
+                    "name": "Ireland"
+                }
+            },
+            "standings": {
+                "triesforaway": {
+                    "code": "result:triesforaway",
+                    "name": "Triesforaway",
+                    "value": "0"
+                },
+                "pointsfor": {
+                    "code": "result:pointsfor",
+                    "name": "Points For",
+                    "value": "0"
+                },
+                "triesagainstaway": {
+                    "code": "result:triesagainstaway",
+                    "name": "Triesagainstaway",
+                    "value": "0"
+                },
+                "pointshome": {
+                    "code": "result:pointshome",
+                    "name": "Points Home",
+                    "value": "0"
+                },
+                "pointsforaway": {
+                    "code": "result:pointsforaway",
+                    "name": "Away Points For",
+                    "value": "0"
+                },
+                "drawsaway": {
+                    "code": "result:drawsaway",
+                    "name": "Away Draws",
+                    "value": "0"
+                },
+                "points": {
+                    "code": "result:points",
+                    "name": "Points",
+                    "value": "0"
+                },
+                "triesfor": {
+                    "code": "result:triesfor",
+                    "name": "Triesfor",
+                    "value": "0"
+                },
+                "winsaway": {
+                    "code": "result:winsaway",
+                    "name": "Away Win",
+                    "value": "0"
+                },
+                "triesforhome": {
+                    "code": "result:triesforhome",
+                    "name": "Triesforhome",
+                    "value": "0"
+                },
+                "defeitshome": {
+                    "code": "result:defeitshome",
+                    "name": "Home Lost",
+                    "value": "0"
+                },
+                "pointsagainst": {
+                    "code": "result:pointsagainst",
+                    "name": "Points Against",
+                    "value": "0"
+                },
+                "rank": {
+                    "code": "result:rank",
+                    "name": "Rank",
+                    "value": "1"
+                },
+                "draws": {
+                    "code": "result:draws",
+                    "name": "Draw",
+                    "value": "0"
+                },
+                "pointsaway": {
+                    "code": "result:pointsaway",
+                    "name": "Points Away",
+                    "value": "0"
+                },
+                "drawshome": {
+                    "code": "result:drawshome",
+                    "name": "Home Draws",
+                    "value": "0"
+                },
+                "defeitsaway": {
+                    "code": "result:defeitsaway",
+                    "name": "Away Lost",
+                    "value": "0"
+                },
+                "playedhome": {
+                    "code": "result:playedhome",
+                    "name": "Home Played",
+                    "value": "0"
+                },
+                "pointsforhome": {
+                    "code": "result:pointsforhome",
+                    "name": "Home Points For",
+                    "value": "0"
+                },
+                "pointsagainsthome": {
+                    "code": "result:pointsagainsthome",
+                    "name": "Home Points Against",
+                    "value": "0"
+                },
+                "wins": {
+                    "code": "result:wins",
+                    "name": "Won",
+                    "value": "0"
+                },
+                "winshome": {
+                    "code": "result:winshome",
+                    "name": "Home Win",
+                    "value": "0"
+                },
+                "triesagainsthome": {
+                    "code": "result:triesagainsthome",
+                    "name": "Triesagainsthome",
+                    "value": "0"
+                },
+                "triesagainst": {
+                    "code": "result:triesagainst",
+                    "name": "Triesagainst",
+                    "value": "0"
+                },
+                "pointsagainstaway": {
+                    "code": "result:pointsagainstaway",
+                    "name": "Away Points Against",
+                    "value": "0"
+                },
+                "playedaway": {
+                    "code": "result:playedaway",
+                    "name": "Away Played",
+                    "value": "0"
+                },
+                "played": {
+                    "code": "result:played",
+                    "name": "Games Played",
+                    "value": "0"
+                },
+                "defeits": {
+                    "code": "result:defeits",
+                    "name": "Lost",
+                    "value": "0"
+                },
+                "pointsbonus": {
+                    "code": "result:pointsbonus",
+                    "name": "Bonus Points",
+                    "value": "0"
+                }
+            }
+        },
+        {
+            "id": 2679929,
+            "rank": 2,
+            "participant": {
+                "id": 73710,
+                "name": "Japan",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 25,
+                    "name": "Japan"
+                }
+            },
+            "standings": {
+                "triesforaway": {
+                    "code": "result:triesforaway",
+                    "name": "Triesforaway",
+                    "value": "0"
+                },
+                "pointsfor": {
+                    "code": "result:pointsfor",
+                    "name": "Points For",
+                    "value": "0"
+                },
+                "triesagainstaway": {
+                    "code": "result:triesagainstaway",
+                    "name": "Triesagainstaway",
+                    "value": "0"
+                },
+                "pointshome": {
+                    "code": "result:pointshome",
+                    "name": "Points Home",
+                    "value": "0"
+                },
+                "pointsforaway": {
+                    "code": "result:pointsforaway",
+                    "name": "Away Points For",
+                    "value": "0"
+                },
+                "drawsaway": {
+                    "code": "result:drawsaway",
+                    "name": "Away Draws",
+                    "value": "0"
+                },
+                "points": {
+                    "code": "result:points",
+                    "name": "Points",
+                    "value": "0"
+                },
+                "triesfor": {
+                    "code": "result:triesfor",
+                    "name": "Triesfor",
+                    "value": "0"
+                },
+                "winsaway": {
+                    "code": "result:winsaway",
+                    "name": "Away Win",
+                    "value": "0"
+                },
+                "triesforhome": {
+                    "code": "result:triesforhome",
+                    "name": "Triesforhome",
+                    "value": "0"
+                },
+                "defeitshome": {
+                    "code": "result:defeitshome",
+                    "name": "Home Lost",
+                    "value": "0"
+                },
+                "pointsagainst": {
+                    "code": "result:pointsagainst",
+                    "name": "Points Against",
+                    "value": "0"
+                },
+                "rank": {
+                    "code": "result:rank",
+                    "name": "Rank",
+                    "value": "2"
+                },
+                "draws": {
+                    "code": "result:draws",
+                    "name": "Draw",
+                    "value": "0"
+                },
+                "pointsaway": {
+                    "code": "result:pointsaway",
+                    "name": "Points Away",
+                    "value": "0"
+                },
+                "drawshome": {
+                    "code": "result:drawshome",
+                    "name": "Home Draws",
+                    "value": "0"
+                },
+                "defeitsaway": {
+                    "code": "result:defeitsaway",
+                    "name": "Away Lost",
+                    "value": "0"
+                },
+                "playedhome": {
+                    "code": "result:playedhome",
+                    "name": "Home Played",
+                    "value": "0"
+                },
+                "pointsforhome": {
+                    "code": "result:pointsforhome",
+                    "name": "Home Points For",
+                    "value": "0"
+                },
+                "pointsagainsthome": {
+                    "code": "result:pointsagainsthome",
+                    "name": "Home Points Against",
+                    "value": "0"
+                },
+                "wins": {
+                    "code": "result:wins",
+                    "name": "Won",
+                    "value": "0"
+                },
+                "winshome": {
+                    "code": "result:winshome",
+                    "name": "Home Win",
+                    "value": "0"
+                },
+                "triesagainsthome": {
+                    "code": "result:triesagainsthome",
+                    "name": "Triesagainsthome",
+                    "value": "0"
+                },
+                "triesagainst": {
+                    "code": "result:triesagainst",
+                    "name": "Triesagainst",
+                    "value": "0"
+                },
+                "pointsagainstaway": {
+                    "code": "result:pointsagainstaway",
+                    "name": "Away Points Against",
+                    "value": "0"
+                },
+                "playedaway": {
+                    "code": "result:playedaway",
+                    "name": "Away Played",
+                    "value": "0"
+                },
+                "played": {
+                    "code": "result:played",
+                    "name": "Games Played",
+                    "value": "0"
+                },
+                "defeits": {
+                    "code": "result:defeits",
+                    "name": "Lost",
+                    "value": "0"
+                },
+                "pointsbonus": {
+                    "code": "result:pointsbonus",
+                    "name": "Bonus Points",
+                    "value": "0"
+                }
+            }
+        },
+        {
+            "id": 2896787,
+            "rank": 3,
+            "participant": {
+                "id": 204077,
+                "name": "Russia",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 22,
+                    "name": "Russia"
+                }
+            },
+            "standings": {
+                "triesforaway": {
+                    "code": "result:triesforaway",
+                    "name": "Triesforaway",
+                    "value": "0"
+                },
+                "pointsfor": {
+                    "code": "result:pointsfor",
+                    "name": "Points For",
+                    "value": "0"
+                },
+                "triesagainstaway": {
+                    "code": "result:triesagainstaway",
+                    "name": "Triesagainstaway",
+                    "value": "0"
+                },
+                "pointshome": {
+                    "code": "result:pointshome",
+                    "name": "Points Home",
+                    "value": "0"
+                },
+                "pointsforaway": {
+                    "code": "result:pointsforaway",
+                    "name": "Away Points For",
+                    "value": "0"
+                },
+                "drawsaway": {
+                    "code": "result:drawsaway",
+                    "name": "Away Draws",
+                    "value": "0"
+                },
+                "points": {
+                    "code": "result:points",
+                    "name": "Points",
+                    "value": "0"
+                },
+                "triesfor": {
+                    "code": "result:triesfor",
+                    "name": "Triesfor",
+                    "value": "0"
+                },
+                "winsaway": {
+                    "code": "result:winsaway",
+                    "name": "Away Win",
+                    "value": "0"
+                },
+                "triesforhome": {
+                    "code": "result:triesforhome",
+                    "name": "Triesforhome",
+                    "value": "0"
+                },
+                "defeitshome": {
+                    "code": "result:defeitshome",
+                    "name": "Home Lost",
+                    "value": "0"
+                },
+                "pointsagainst": {
+                    "code": "result:pointsagainst",
+                    "name": "Points Against",
+                    "value": "0"
+                },
+                "rank": {
+                    "code": "result:rank",
+                    "name": "Rank",
+                    "value": "3"
+                },
+                "draws": {
+                    "code": "result:draws",
+                    "name": "Draw",
+                    "value": "0"
+                },
+                "pointsaway": {
+                    "code": "result:pointsaway",
+                    "name": "Points Away",
+                    "value": "0"
+                },
+                "drawshome": {
+                    "code": "result:drawshome",
+                    "name": "Home Draws",
+                    "value": "0"
+                },
+                "defeitsaway": {
+                    "code": "result:defeitsaway",
+                    "name": "Away Lost",
+                    "value": "0"
+                },
+                "playedhome": {
+                    "code": "result:playedhome",
+                    "name": "Home Played",
+                    "value": "0"
+                },
+                "pointsforhome": {
+                    "code": "result:pointsforhome",
+                    "name": "Home Points For",
+                    "value": "0"
+                },
+                "pointsagainsthome": {
+                    "code": "result:pointsagainsthome",
+                    "name": "Home Points Against",
+                    "value": "0"
+                },
+                "wins": {
+                    "code": "result:wins",
+                    "name": "Won",
+                    "value": "0"
+                },
+                "winshome": {
+                    "code": "result:winshome",
+                    "name": "Home Win",
+                    "value": "0"
+                },
+                "triesagainsthome": {
+                    "code": "result:triesagainsthome",
+                    "name": "Triesagainsthome",
+                    "value": "0"
+                },
+                "triesagainst": {
+                    "code": "result:triesagainst",
+                    "name": "Triesagainst",
+                    "value": "0"
+                },
+                "pointsagainstaway": {
+                    "code": "result:pointsagainstaway",
+                    "name": "Away Points Against",
+                    "value": "0"
+                },
+                "playedaway": {
+                    "code": "result:playedaway",
+                    "name": "Away Played",
+                    "value": "0"
+                },
+                "played": {
+                    "code": "result:played",
+                    "name": "Games Played",
+                    "value": "0"
+                },
+                "defeits": {
+                    "code": "result:defeits",
+                    "name": "Lost",
+                    "value": "0"
+                },
+                "pointsbonus": {
+                    "code": "result:pointsbonus",
+                    "name": "Bonus Points",
+                    "value": "0"
+                }
+            }
+        },
+        {
+            "id": 2969705,
+            "rank": 4,
+            "participant": {
+                "id": 73711,
+                "name": "Samoa",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 224,
+                    "name": "Samoa"
+                }
+            },
+            "standings": {
+                "triesforaway": {
+                    "code": "result:triesforaway",
+                    "name": "Triesforaway",
+                    "value": "0"
+                },
+                "pointsfor": {
+                    "code": "result:pointsfor",
+                    "name": "Points For",
+                    "value": "0"
+                },
+                "triesagainstaway": {
+                    "code": "result:triesagainstaway",
+                    "name": "Triesagainstaway",
+                    "value": "0"
+                },
+                "pointshome": {
+                    "code": "result:pointshome",
+                    "name": "Points Home",
+                    "value": "0"
+                },
+                "pointsforaway": {
+                    "code": "result:pointsforaway",
+                    "name": "Away Points For",
+                    "value": "0"
+                },
+                "drawsaway": {
+                    "code": "result:drawsaway",
+                    "name": "Away Draws",
+                    "value": "0"
+                },
+                "points": {
+                    "code": "result:points",
+                    "name": "Points",
+                    "value": "0"
+                },
+                "triesfor": {
+                    "code": "result:triesfor",
+                    "name": "Triesfor",
+                    "value": "0"
+                },
+                "winsaway": {
+                    "code": "result:winsaway",
+                    "name": "Away Win",
+                    "value": "0"
+                },
+                "triesforhome": {
+                    "code": "result:triesforhome",
+                    "name": "Triesforhome",
+                    "value": "0"
+                },
+                "defeitshome": {
+                    "code": "result:defeitshome",
+                    "name": "Home Lost",
+                    "value": "0"
+                },
+                "pointsagainst": {
+                    "code": "result:pointsagainst",
+                    "name": "Points Against",
+                    "value": "0"
+                },
+                "rank": {
+                    "code": "result:rank",
+                    "name": "Rank",
+                    "value": "4"
+                },
+                "draws": {
+                    "code": "result:draws",
+                    "name": "Draw",
+                    "value": "0"
+                },
+                "pointsaway": {
+                    "code": "result:pointsaway",
+                    "name": "Points Away",
+                    "value": "0"
+                },
+                "drawshome": {
+                    "code": "result:drawshome",
+                    "name": "Home Draws",
+                    "value": "0"
+                },
+                "defeitsaway": {
+                    "code": "result:defeitsaway",
+                    "name": "Away Lost",
+                    "value": "0"
+                },
+                "playedhome": {
+                    "code": "result:playedhome",
+                    "name": "Home Played",
+                    "value": "0"
+                },
+                "pointsforhome": {
+                    "code": "result:pointsforhome",
+                    "name": "Home Points For",
+                    "value": "0"
+                },
+                "pointsagainsthome": {
+                    "code": "result:pointsagainsthome",
+                    "name": "Home Points Against",
+                    "value": "0"
+                },
+                "wins": {
+                    "code": "result:wins",
+                    "name": "Won",
+                    "value": "0"
+                },
+                "winshome": {
+                    "code": "result:winshome",
+                    "name": "Home Win",
+                    "value": "0"
+                },
+                "triesagainsthome": {
+                    "code": "result:triesagainsthome",
+                    "name": "Triesagainsthome",
+                    "value": "0"
+                },
+                "triesagainst": {
+                    "code": "result:triesagainst",
+                    "name": "Triesagainst",
+                    "value": "0"
+                },
+                "pointsagainstaway": {
+                    "code": "result:pointsagainstaway",
+                    "name": "Away Points Against",
+                    "value": "0"
+                },
+                "playedaway": {
+                    "code": "result:playedaway",
+                    "name": "Away Played",
+                    "value": "0"
+                },
+                "played": {
+                    "code": "result:played",
+                    "name": "Games Played",
+                    "value": "0"
+                },
+                "defeits": {
+                    "code": "result:defeits",
+                    "name": "Lost",
+                    "value": "0"
+                },
+                "pointsbonus": {
+                    "code": "result:pointsbonus",
+                    "name": "Bonus Points",
+                    "value": "0"
+                }
+            }
+        },
+        {
+            "id": 2679931,
+            "rank": 5,
+            "participant": {
+                "id": 73732,
+                "name": "Scotland",
+                "gender": "male",
+                "type": "team",
+                "country": {
+                    "id": 15,
+                    "name": "Scotland"
+                }
+            },
+            "standings": {
+                "triesforaway": {
+                    "code": "result:triesforaway",
+                    "name": "Triesforaway",
+                    "value": "0"
+                },
+                "pointsfor": {
+                    "code": "result:pointsfor",
+                    "name": "Points For",
+                    "value": "0"
+                },
+                "triesagainstaway": {
+                    "code": "result:triesagainstaway",
+                    "name": "Triesagainstaway",
+                    "value": "0"
+                },
+                "pointshome": {
+                    "code": "result:pointshome",
+                    "name": "Points Home",
+                    "value": "0"
+                },
+                "pointsforaway": {
+                    "code": "result:pointsforaway",
+                    "name": "Away Points For",
+                    "value": "0"
+                },
+                "drawsaway": {
+                    "code": "result:drawsaway",
+                    "name": "Away Draws",
+                    "value": "0"
+                },
+                "points": {
+                    "code": "result:points",
+                    "name": "Points",
+                    "value": "0"
+                },
+                "triesfor": {
+                    "code": "result:triesfor",
+                    "name": "Triesfor",
+                    "value": "0"
+                },
+                "winsaway": {
+                    "code": "result:winsaway",
+                    "name": "Away Win",
+                    "value": "0"
+                },
+                "triesforhome": {
+                    "code": "result:triesforhome",
+                    "name": "Triesforhome",
+                    "value": "0"
+                },
+                "defeitshome": {
+                    "code": "result:defeitshome",
+                    "name": "Home Lost",
+                    "value": "0"
+                },
+                "pointsagainst": {
+                    "code": "result:pointsagainst",
+                    "name": "Points Against",
+                    "value": "0"
+                },
+                "rank": {
+                    "code": "result:rank",
+                    "name": "Rank",
+                    "value": "5"
+                },
+                "draws": {
+                    "code": "result:draws",
+                    "name": "Draw",
+                    "value": "0"
+                },
+                "pointsaway": {
+                    "code": "result:pointsaway",
+                    "name": "Points Away",
+                    "value": "0"
+                },
+                "drawshome": {
+                    "code": "result:drawshome",
+                    "name": "Home Draws",
+                    "value": "0"
+                },
+                "defeitsaway": {
+                    "code": "result:defeitsaway",
+                    "name": "Away Lost",
+                    "value": "0"
+                },
+                "playedhome": {
+                    "code": "result:playedhome",
+                    "name": "Home Played",
+                    "value": "0"
+                },
+                "pointsforhome": {
+                    "code": "result:pointsforhome",
+                    "name": "Home Points For",
+                    "value": "0"
+                },
+                "pointsagainsthome": {
+                    "code": "result:pointsagainsthome",
+                    "name": "Home Points Against",
+                    "value": "0"
+                },
+                "wins": {
+                    "code": "result:wins",
+                    "name": "Won",
+                    "value": "0"
+                },
+                "winshome": {
+                    "code": "result:winshome",
+                    "name": "Home Win",
+                    "value": "0"
+                },
+                "triesagainsthome": {
+                    "code": "result:triesagainsthome",
+                    "name": "Triesagainsthome",
+                    "value": "0"
+                },
+                "triesagainst": {
+                    "code": "result:triesagainst",
+                    "name": "Triesagainst",
+                    "value": "0"
+                },
+                "pointsagainstaway": {
+                    "code": "result:pointsagainstaway",
+                    "name": "Away Points Against",
+                    "value": "0"
+                },
+                "playedaway": {
+                    "code": "result:playedaway",
+                    "name": "Away Played",
+                    "value": "0"
+                },
+                "played": {
+                    "code": "result:played",
+                    "name": "Games Played",
+                    "value": "0"
+                },
+                "defeits": {
+                    "code": "result:defeits",
+                    "name": "Lost",
+                    "value": "0"
+                },
+                "pointsbonus": {
+                    "code": "result:pointsbonus",
+                    "name": "Bonus Points",
+                    "value": "0"
+                }
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": "self",
+            "href": "http://sport.api.press.net/v1/standing/235174"
+        }
+    ]
+}

--- a/sport/test/rugby/feed/PAFeedTest.scala
+++ b/sport/test/rugby/feed/PAFeedTest.scala
@@ -66,11 +66,11 @@ object StubClient extends RugbyClient {
   }
 
   override def getEvents(seasonID: Int)
-    (implicit executionContext: ExecutionContext): Future[PAMatchesResponse] = {
+    (implicit executionContext: ExecutionContext): Future[List[PAMatch]] = {
 
     store.get(s"events/$seasonID") match {
       case Some(json) =>
-        toFut(PAMatchesResponse.fromJSON(json))
+        toFut(PAMatchesResponse.fromJSON(json)).map(_.items)
       case None =>
         Future.failed(new Exception("Item not found"))
     }

--- a/sport/test/rugby/feed/PAFeedTest.scala
+++ b/sport/test/rugby/feed/PAFeedTest.scala
@@ -44,18 +44,6 @@ class PAFeedTest extends AsyncFlatSpec with Matchers {
     val games = feed.getFixturesAndResults()
     games.map(matches => matches.size shouldBe 1)
   }
-
-  it should "get score events" in {
-    val scoreEvents = feed.getScoreEvents(exampleMatch)
-    scoreEvents.map(goals => goals.size shouldBe 12)
-  }
-
-  it should "get match stats" ignore _
-
-  it should "get group tables" in {
-    val tables = feed.getGroupTables()
-    tables.map(tables => tables(WorldCup2019).size shouldBe 4)
-  }
 }
 
 object StubClient extends RugbyClient {
@@ -83,28 +71,6 @@ object StubClient extends RugbyClient {
     store.get(s"events/$seasonID") match {
       case Some(json) =>
         toFut(PAMatchesResponse.fromJSON(json))
-      case None =>
-        Future.failed(new Exception("Item not found"))
-    }
-  }
-
-  override def getStanding(standingID: Int)
-    (implicit executionContext: ExecutionContext): Future[PATableResponse] = {
-
-    store.get(s"standing/$standingID") match {
-      case Some(json) =>
-        toFut(PATableResponse.fromJSON(json))
-      case None =>
-        Future.failed(new Exception("Item not found"))
-    }
-  }
-
-  override def getEventActions(eventID: Int)
-    (implicit executionContext: ExecutionContext): Future[Seq[PAEvent]] = {
-
-    store.get(s"actions/$eventID") match {
-      case Some(json) =>
-        toFut(PAEvent.fromJSONList(json))
       case None =>
         Future.failed(new Exception("Item not found"))
     }

--- a/sport/test/rugby/model/PAMatchParserTest.scala
+++ b/sport/test/rugby/model/PAMatchParserTest.scala
@@ -1,0 +1,46 @@
+package rugby.model
+
+import org.scalatest.{FlatSpec, Matchers}
+import rugby.feed.{JsonParseException, PAEvent, PAMatchesResponse, PATableResponse}
+
+import scala.io.Source
+import scala.util.Try
+
+class PAMatchParserTest extends FlatSpec with Matchers {
+
+  behavior of "PA Match parser"
+
+  it should "parse a PA events response" in {
+    val json = Source
+      .fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/pa-events.json"))
+      .mkString
+
+    checkJsonResult(PAMatchesResponse.fromJSON(json))
+  }
+
+  it should "parse a PA standings (tables) response" in {
+    val json = Source
+      .fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/pa-standing.json"))
+      .mkString
+
+    checkJsonResult(PATableResponse.fromJSON(json))
+  }
+
+  it should "parse a PA event actions response" in {
+    val json = Source
+      .fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/pa-event-actions.json"))
+      .mkString
+
+    checkJsonResult(PAEvent.fromJSONList(json))
+  }
+
+  def checkJsonResult[A](res: Try[A]): Unit = {
+    val clue = res.failed.toOption.collect {
+      case JsonParseException(msg) => msg
+    }.getOrElse("")
+
+    withClue(clue) {
+      res.isSuccess shouldBe true
+    }
+  }
+}

--- a/sport/test/rugby/model/PAMatchParserTest.scala
+++ b/sport/test/rugby/model/PAMatchParserTest.scala
@@ -1,7 +1,7 @@
 package rugby.model
 
 import org.scalatest.{FlatSpec, Matchers}
-import rugby.feed.{JsonParseException, PAEvent, PAMatchesResponse, PATableResponse}
+import rugby.feed.{JsonParseException, PAMatchesResponse}
 
 import scala.io.Source
 import scala.util.Try
@@ -16,22 +16,6 @@ class PAMatchParserTest extends FlatSpec with Matchers {
       .mkString
 
     checkJsonResult(PAMatchesResponse.fromJSON(json))
-  }
-
-  it should "parse a PA standings (tables) response" in {
-    val json = Source
-      .fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/pa-standing.json"))
-      .mkString
-
-    checkJsonResult(PATableResponse.fromJSON(json))
-  }
-
-  it should "parse a PA event actions response" in {
-    val json = Source
-      .fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/pa-event-actions.json"))
-      .mkString
-
-    checkJsonResult(PAEvent.fromJSONList(json))
   }
 
   def checkJsonResult[A](res: Try[A]): Unit = {

--- a/static/src/javascripts/bootstraps/enhanced/sport.js
+++ b/static/src/javascripts/bootstraps/enhanced/sport.js
@@ -81,6 +81,12 @@ const rugby = (): void => {
         // $FlowFixMe
         scoreBoard.fetched = (resp: Object): void => {
             fastdom
+                .read(() => document.querySelector('article'))
+                .then(liveblog => {
+                    liveblog.classList.add('content--has-scores');
+                });
+
+            fastdom
                 .read(() => document.querySelector('.content--liveblog'))
                 .then(liveblog => {
                     liveblog.classList.add('content--liveblog--rugby');

--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -127,6 +127,21 @@
         height: $garnett-x-large-button-size;
     }
 
+    // Technically this is not football-related but for rugby
+    .team__score__number {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: auto;
+        height: 51px;
+        font-size: 30px;
+        display: block;
+        text-align: center;
+        font-weight: bold;
+    }
+
     svg {
         position: absolute;
         top: 0;


### PR DESCRIPTION
**DO NOT MERGE YET.**

## What does this change?

Adds support for match info and group tables for the Rugby World Cup 2019.

The strategy has been to create an interface (`RugbyFeed`) that mirrors the Opta class and then re-implement for the new API, so that we can re-use the rest of the code.

This is not yet ready, but is sizeable so review is definitely welcome!

## Screenshots

n/a