### PR TITLE
Add pillar to rich link DCR endpoint.

### DIFF
--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -24,7 +24,8 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
             starRating = content.content.starRating,
             sponsorName = content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
             contributorImage = content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
-            url = content.metadata.url
+            url = content.metadata.url,
+            pillar = content.metadata.pillar.nameOrDefault
           )
           Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -12,7 +12,9 @@ case class RichLink(
   starRating: Option[Int],
   sponsorName: Option[String],
   contributorImage: Option[String],
-  url: String)
+  url: String,
+  pillar: String
+)
 
 object RichLink {
   implicit val writes = Json.writes[RichLink]


### PR DESCRIPTION
## What does this change?
Adds pillar to the richlink model used by dotcom rendering. This is needed so that the link can be styled according to the content it links to rather than the pillar of the page it is displayed on. 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
