### PR TITLE
Add `top: 0;` to top-bar to be explicit in position

### DIFF
--- a/static/src/stylesheets/layout/nav/_top-bar.scss
+++ b/static/src/stylesheets/layout/nav/_top-bar.scss
@@ -1,6 +1,7 @@
 .new-header__top-bar {
     position: absolute;
     left: $gs-gutter / 2;
+    top: 0;
 
     @include mq(mobileLandscape) {
         left: $gs-gutter;


### PR DESCRIPTION
## What does this change?

We're getting reports of the top bar crashing into the pillars.

![image](https://user-images.githubusercontent.com/638051/64424135-24aa5c00-d0a0-11e9-9599-2a92a34f4eb3.png)

While I couldn't work out what was causing the issue, this seems to be the CSS that *would* cause the issue so taking a stab in the dark to see whether this fixes it initially...

This makes it explicit that we want the top bar to be at the top.

