### PR TITLE
Add merchandising-high Slot to /theguardian and /theobserver

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -21,6 +21,15 @@ import views.html.stacked
 
 object ContentHtmlPage extends HtmlPage[Page] {
 
+  def cleanedFrontBody(html: Html, page: Page)(implicit request: RequestHeader, context: ApplicationContext): Html = {
+    import views.support.`package`.withJsoup
+    import views.support.{BulletCleaner, CommercialComponentHigh}
+    val edition = Edition(request)
+    withJsoup(BulletCleaner(html.toString))(
+      CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.metadata.hasPageSkin(edition)),
+    )
+  }
+
   def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
     override def criticalCssLink: Html = criticalStyleLink(ContentCSSFile)
     override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
@@ -68,7 +77,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),
-        content,
+        if (page.metadata.url == "/theguardian") cleanedFrontBody(content, page) else content,
         footer(),
         message(),
         inlineJSNonBlocking(),

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -61,6 +61,8 @@ object ContentHtmlPage extends HtmlPage[Page] {
       case unsupported => throw new RuntimeException(s"Type of content '${unsupported.getClass.getName}' is not supported by ${this.getClass.getName}")
     }
 
+    val shouldAddMerchSlot: Boolean = page.metadata.sectionId == "todayspaper" || page.metadata.sectionId == "theobserver"
+
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
@@ -77,7 +79,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),
-        if (page.metadata.url == "/theguardian") cleanedFrontBody(content, page) else content,
+        if (shouldAddMerchSlot) cleanedFrontBody(content, page) else content,
         footer(),
         message(),
         inlineJSNonBlocking(),


### PR DESCRIPTION
## What does this change?

Adds merchandising-high Slot to /theguardian and /theobserver

## Screenshots

### **Before**
no merchandising high slot in /theguardian and /theobserver

### **After**

**/theguardian**
![Screenshot 2019-09-09 at 17 11 15](https://user-images.githubusercontent.com/51630004/64548332-52a0d200-d326-11e9-9eb3-24482514ed08.png)

**/theobserver**
![Screenshot 2019-09-09 at 17 18 12](https://user-images.githubusercontent.com/51630004/64548333-52a0d200-d326-11e9-863b-45c4dae78dd6.png)


## What is the value of this and can you measure success?
value: additional digital subscriptions per week
measure: Conversions in the data lake/GA

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

