### PR TITLE
Exclude recurring contributors from 'post-ask-pause' group

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -37,7 +37,6 @@ import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquis
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
-    isRecurringContributor,
 } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
@@ -160,7 +159,8 @@ const userIsInCorrectCohort = (
     switch (userCohort) {
         case 'PostAskPauseSingleContributors':
             return (
-                isPostAskPauseOneOffContributor() && !isRecurringContributor()
+                isPostAskPauseOneOffContributor() &&
+                !shouldHideSupportMessaging()
             );
         case 'AllExistingSupporters':
             return shouldHideSupportMessaging();

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -37,6 +37,7 @@ import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquis
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
+    isRecurringContributor,
 } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
@@ -158,7 +159,9 @@ const userIsInCorrectCohort = (
 ): boolean => {
     switch (userCohort) {
         case 'PostAskPauseSingleContributors':
-            return isPostAskPauseOneOffContributor();
+            return (
+                isPostAskPauseOneOffContributor() && !isRecurringContributor()
+            );
         case 'AllExistingSupporters':
             return shouldHideSupportMessaging();
         case 'AllNonSupporters':


### PR DESCRIPTION
## What does this change?
We use the 'PostAskPauseSingleContributors' cohort to target epic tests at people who have made one-off contributions in the past.
However, it's possible to be a recurring contributor in addition to having made one-off contributions. In this case, they should be excluded from this cohort.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
