### PR TITLE
Convert arts pillar to culture in DCR rich link controller.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -386,12 +386,14 @@ object DotcomponentsDataModel {
       relevantBlocks.filter(block => ids(block.id))
     }
 
+    // note: these two functions are duplicated in the onward service (DotcomponentsOnwardsModels - if duplicating again consider moving to common!)
     def isPaidContent(tags: List[Tag]): Boolean = tags.exists(tag => tag.`type` == "Tone" && tag.id == "tone/advertisement-features")
-
-    def findPillar(pillar: Pillar, tags: List[Tag]): String = {
-      if (isPaidContent(tags)) "labs"
-      else if (pillar.toString.toLowerCase == "arts") "culture"
-      else pillar.toString.toLowerCase()
+    def findPillar(pillar: Option[Pillar], tags: List[Tag]): String = {
+      pillar.map { pillar =>
+        if (isPaidContent(tags)) "labs"
+        else if (pillar.toString.toLowerCase == "arts") "culture"
+        else pillar.toString.toLowerCase()
+      }.getOrElse("news")
     }
 
     def findDesignType(designType: Option[DesignType], tags: List[Tag]): String = {
@@ -580,7 +582,7 @@ object DotcomponentsDataModel {
       editionId = Edition(request).id,
       pageId = article.metadata.id,
       tags = allTags,
-      pillar = article.metadata.pillar.map(pillar => findPillar(pillar, allTags)).getOrElse("news"),
+      pillar = findPillar(article.metadata.pillar, allTags),
       isImmersive = article.isImmersive,
       sectionLabel = article.content.sectionLabelName,
       sectionUrl = article.content.sectionLabelLink,

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -25,7 +25,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
             sponsorName = content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
             contributorImage = content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
             url = content.metadata.url,
-            pillar = content.metadata.pillar.nameOrDefault
+            pillar = RichLink.findPillar(content.metadata.pillar, content.tags.tags),
           )
           Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,6 +1,6 @@
 package models.dotcomponents
 
-import model.{DotcomContentType, Tag, Tags}
+import model.{DotcomContentType, Pillar, Tag, Tags}
 import play.api.libs.json.Json
 
 case class RichLink(
@@ -18,4 +18,15 @@ case class RichLink(
 
 object RichLink {
   implicit val writes = Json.writes[RichLink]
+
+
+  // note: these functions are duplicated in the article service (DotcomponentsDataModel - if duplicating again consider moving to common!)
+  def isPaidContent(tags: List[Tag]): Boolean = tags.exists(tag => tag.properties.tagType == "Tone" && tag.id == "tone/advertisement-features")
+  def findPillar(pillar: Option[Pillar], tags: List[Tag]): String = {
+    pillar.map { pillar =>
+      if (isPaidContent(tags)) "labs"
+      else if (pillar.toString.toLowerCase == "arts") "culture"
+      else pillar.toString.toLowerCase()
+    }.getOrElse("news")
+  }
 }


### PR DESCRIPTION
## What does this change?
Ensures that the capi 'arts' pillar gets rewritten to 'culture' on the dotcom rendering endpoint.

See [here](https://docs.google.com/document/d/1PLc-kGnO7aYJ-mkmsLctFK0etBNyHlWvHrS33hcLhtM/edit#heading=h.g7vssiekzolq) for details - arts has been deprecated. 

This change has involved duplicating functionality that previously only existed in the `article` service into `onward`. I decided to do this rather than sticking them in `common` cos there's only 2 apps that need the functionality so it seems a shame to have them included in every app.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
