### PR TITLE
Better DCR Ads Dev Experience during tests

### DIFF
--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -37,11 +37,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-lotame-data-extract', initLotameDataExtract],
 ];
 
-if (
-    config.get('tests.dotcomRenderingAdvertisementsVariant', 'control') ===
-        'variant' &&
-    !commercialFeatures.adFree
-) {
+if (!commercialFeatures.adFree) {
     commercialModules.push(
         ['cm-prepare-prebid', preparePrebid],
         ['cm-prepare-googletag', prepareGoogletag],

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -38,9 +38,8 @@ const commercialModules: Array<Array<any>> = [
 ];
 
 if (
-    (config.get('tests.dotcomRenderingAdvertisementsVariant', 'control') ===
-        'variant' ||
-        config.get('stage', '') === 'DEV') &&
+    config.get('tests.dotcomRenderingAdvertisementsVariant', 'control') ===
+        'variant' &&
     !commercialFeatures.adFree
 ) {
     commercialModules.push(


### PR DESCRIPTION
## What does this change?

This resolve a tiny problem we had recently of not being able to display ads on a locally running instance of DCR talking to frontend PROD. 

Turns out that, until now there were two mechanisms in place to prevent accidental display of ads on a DCR rendered page. The first was two tests on the frontend generated DCR commercial init script and the other is within the code of DCR. The nature of the former meant that querying PROD from local would have an incorrect value for `config.get('stage', '')` (would be `PROD` instead of `DEV`) as well as an incorrectly set AB test variant, resulting in the required modules not being loaded. This change gets rid of the former check and solely relying on the DCR checks. 

