### PR TITLE
Epic test: Learn More CTA 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,6 +38,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-learn-more-cta",
+    "States how many articles a user has viewed in the epic in a month",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 27),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-country-name",
     "Displays country name in the epic",
     owners = Seq(Owner.withGithub("tomrf1")),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -32,7 +32,6 @@ import {
 } from 'lib/string-utils';
 import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
-import { epicButtonsLearnMoreTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons-learn-more';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -94,6 +94,11 @@ const defaultButtonTemplate: (CtaUrls, ctaText?: string) => string = (
     ctaText?: string
 ) => epicButtonsTemplate(url, ctaText);
 
+const learnMoreButtonTemplate: (CtaUrls, ctaText?: string) => string = (
+    url: CtaUrls,
+    ctaText?: string
+) => epicButtonsTemplate(url, ctaText);
+
 const controlTemplate: EpicTemplate = (
     variant: EpicVariant,
     copy: AcquisitionsEpicTemplateCopy
@@ -890,6 +895,7 @@ export {
     shouldShowEpic,
     makeEpicABTest,
     defaultButtonTemplate,
+    learnMoreButtonTemplate,
     defaultMaxViews,
     getReaderRevenueRegion,
     userIsInCorrectCohort,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -32,6 +32,7 @@ import {
 } from 'lib/string-utils';
 import { throwIfEmptyArray } from 'lib/array-utils';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
+import { epicButtonsLearnMoreTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons-learn-more';
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import {
@@ -97,7 +98,7 @@ const defaultButtonTemplate: (CtaUrls, ctaText?: string) => string = (
 const learnMoreButtonTemplate: (CtaUrls, ctaText?: string) => string = (
     url: CtaUrls,
     ctaText?: string
-) => epicButtonsTemplate(url, ctaText);
+) => epicButtonsLearnMoreTemplate(url, ctaText);
 
 const controlTemplate: EpicTemplate = (
     variant: EpicVariant,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -95,11 +95,6 @@ const defaultButtonTemplate: (CtaUrls, ctaText?: string) => string = (
     ctaText?: string
 ) => epicButtonsTemplate(url, ctaText);
 
-const learnMoreButtonTemplate: (CtaUrls, ctaText?: string) => string = (
-    url: CtaUrls,
-    ctaText?: string
-) => epicButtonsLearnMoreTemplate(url, ctaText);
-
 const controlTemplate: EpicTemplate = (
     variant: EpicVariant,
     copy: AcquisitionsEpicTemplateCopy
@@ -896,7 +891,6 @@ export {
     shouldShowEpic,
     makeEpicABTest,
     defaultButtonTemplate,
-    learnMoreButtonTemplate,
     defaultMaxViews,
     getReaderRevenueRegion,
     userIsInCorrectCohort,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { applePayApiAvailable } from 'lib/detect';
 import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
 
-export const epicButtonsTemplate = (
+export const epicButtonsLearnMoreTemplate = (
     { supportUrl = '' }: CtaUrls,
     ctaText?: string = 'Support The Guardian'
 ) => {

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
@@ -1,0 +1,44 @@
+// @flow
+import config from 'lib/config';
+import { applePayApiAvailable } from 'lib/detect';
+import applyPayMark from 'svgs/acquisitions/apple-pay-mark.svg';
+
+export const epicButtonsTemplate = (
+    { supportUrl = '' }: CtaUrls,
+    ctaText?: string = 'Support The Guardian'
+) => {
+    const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
+
+    const supportButtonSupport = `
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+              href="${supportUrl}"
+              target="_blank">
+              ${ctaText}
+            </a>
+        </div>`;
+
+    const learnMoreButton = `
+        <div>
+            <a class="contributions__option-button contributions__learn-more contributions__learn-more--epic"
+              href="https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism"
+              target="_blank">
+              Why support matters
+            </a>
+        </div>`;
+
+    const paymentLogos = `<div class="contributions__payment-logos contributions__contribute--epic-member">
+        <img src="${config.get(
+            'images.acquisitions.payment-methods',
+            ''
+        )}" alt="Accepted payment methods: Visa, Mastercard, American Express and Paypal">
+        ${applePayLogo}
+    </div>`;
+
+    return `
+        <div class="contributions__buttons">
+            ${supportButtonSupport}
+            ${learnMoreButton}
+            ${paymentLogos}
+        </div>`;
+};

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
@@ -10,22 +10,18 @@ export const epicButtonsLearnMoreTemplate = (
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 
     const supportButtonSupport = `
-        <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
               href="${supportUrl}"
               target="_blank">
               ${ctaText}
-            </a>
-        </div>`;
+            </a>`;
 
     const learnMoreButton = `
-        <div>
-            <a class="contributions__option-button contributions__learn-more contributions__learn-more--epic"
-              href="https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism"
+            <a class="contributions__option-button contributions__learn-more contributions__learn-more--epic contributions__contribute--epic-member"
+              href="https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism?INTCMP=why_support_us"
               target="_blank">
               Why support matters
-            </a>
-        </div>`;
+            </a>`;
 
     const paymentLogos = `<div class="contributions__payment-logos contributions__contribute--epic-member">
         <img src="${config.get(

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -9,6 +9,7 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
 import { prebidTripleLiftAdapter } from 'common/modules/experiments/tests/prebid-triple-lift-adapter';
+import { learnMore } from 'common/modules/experiments/tests/contributions-epic-learn-more-cta';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -20,6 +21,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
     articlesViewed,
+    learnMore,
     countryName,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -53,13 +53,13 @@ export const learnMore: EpicABTest = makeEpicABTest({
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(copy),
+            copy: buildEpicCopy(copy, false, geolocation),
         },
         {
             id: 'variant',
             buttonTemplate: learnMoreButtonTemplate,
             products: [],
-            copy: buildEpicCopy(copy),
+            copy: buildEpicCopy(copy, false, geolocation),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -1,0 +1,50 @@
+// @flow
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+    buildEpicCopy,
+} from 'common/modules/commercial/contributions-utilities';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
+
+// User must not have read fewer than 5 articles in the last 30 days
+const maxArticleViews = 5;
+const articleCountDays = 30;
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
+
+const geolocation = geolocationGetSync();
+
+export const learnMore: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicLearnMoreCTA',
+    campaignId: 'epic_articles_viewed_month',
+
+    start: '2019-06-24',
+    expiry: '2020-01-27',
+
+    author: 'Joshua Lieberman',
+    description: 'States how many articles a user has viewed in the epic',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    geolocation,
+    highPriority: true,
+
+    canRun: () => articleViewCount < maxArticleViews,
+
+    variants: [
+        {
+            id: 'control',
+            products: [],
+            template
+        },
+        {
+            id: 'variant',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -2,11 +2,11 @@
 import {
     makeEpicABTest,
     defaultButtonTemplate,
-    learnMoreButtonTemplate,
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { epicButtonsLearnMoreTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons-learn-more';
 
 // User must not have read fewer than 5 articles in the last 30 days
 const maxArticleViews = 5;
@@ -27,6 +27,11 @@ const copy = {
         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
     highlightedText,
 };
+
+const learnMoreButtonTemplate: (CtaUrls, ctaText?: string) => string = (
+    url: CtaUrls,
+    ctaText?: string
+) => epicButtonsLearnMoreTemplate(url, ctaText);
 
 export const learnMore: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicLearnMoreCta',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -2,7 +2,8 @@
 import {
     makeEpicABTest,
     defaultButtonTemplate,
-    learnMoreButtonTemplate, buildEpicCopy,
+    learnMoreButtonTemplate,
+    buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
@@ -37,7 +38,8 @@ export const learnMore: EpicABTest = makeEpicABTest({
     author: 'Joshua Lieberman',
     description: 'Encourages users ',
     successMeasure: 'AV & CTA click-through rate',
-    idealOutcome: 'Acquires many Supporters and audience demonstrating engagement',
+    idealOutcome:
+        'Acquires many Supporters and audience demonstrating engagement',
 
     audienceCriteria: 'All',
     audience: 1,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -29,7 +29,7 @@ const copy = {
 };
 
 export const learnMore: EpicABTest = makeEpicABTest({
-    id: 'ContributionsEpicLearnMoreCTA',
+    id: 'ContributionsEpicLearnMoreCta',
     campaignId: 'epic_learn_more_cta',
 
     start: '2019-06-24',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -2,10 +2,10 @@
 import {
     makeEpicABTest,
     defaultButtonTemplate,
-    buildEpicCopy,
+    learnMoreButtonTemplate, buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
-import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 // User must not have read fewer than 5 articles in the last 30 days
 const maxArticleViews = 5;
@@ -14,17 +14,30 @@ const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
 const geolocation = geolocationGetSync();
 
+const highlightedText =
+    'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
+
+const copy = {
+    heading: 'Since you’re here...',
+    paragraphs:
+        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+    highlightedText,
+};
+
 export const learnMore: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicLearnMoreCTA',
-    campaignId: 'epic_articles_viewed_month',
+    campaignId: 'epic_learn_more_cta',
 
     start: '2019-06-24',
     expiry: '2020-01-27',
 
     author: 'Joshua Lieberman',
-    description: 'States how many articles a user has viewed in the epic',
-    successMeasure: 'Conversion rate',
-    idealOutcome: 'Acquires many Supporters',
+    description: 'Encourages users ',
+    successMeasure: 'AV & CTA click-through rate',
+    idealOutcome: 'Acquires many Supporters and audience demonstrating engagement',
 
     audienceCriteria: 'All',
     audience: 1,
@@ -38,13 +51,15 @@ export const learnMore: EpicABTest = makeEpicABTest({
     variants: [
         {
             id: 'control',
+            buttonTemplate: defaultButtonTemplate,
             products: [],
-            template
+            copy: buildEpicCopy(copy),
         },
         {
             id: 'variant',
-            buttonTemplate: defaultButtonTemplate,
+            buttonTemplate: learnMoreButtonTemplate,
             products: [],
+            copy: buildEpicCopy(copy),
         },
     ],
 });

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -84,7 +84,8 @@
     svg, img { height: 100%; width: auto; }
 }
 
-.contributions__contribute {
+.contributions__contribute,
+.contributions__learn-more {
     background-color: $sport-dark;
     color: #ffffff;
     font-weight: bold;
@@ -93,6 +94,7 @@
     padding-left: $gs-gutter * (3 / 4);;
     padding-right: 0;
     margin-left: 0;
+
     &:hover {
         background-color: darken($sport-dark, 5%);
         text-decoration: none;
@@ -100,7 +102,6 @@
 
     &:after {
         content: '';
-
         display: inline-block;
         background-repeat: no-repeat;
         width: 30px;
@@ -113,6 +114,7 @@
 
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic,
+a[href].contributions__learn-more.contributions__learn-more--epic,
 .contributions__adblock-button a {
     margin-top: 0;
     background-color: $highlight-main;
@@ -130,6 +132,25 @@ a[href].contributions__contribute.contributions__contribute--epic,
     &:after {
         background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="$black" stroke="$black" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
     }
+}
+
+a[href].contributions__learn-more.contributions__learn-more--epic {
+    margin-top: $gs-baseline / 2;
+    background-color: $brightness-93;
+
+    &:hover {
+        background-color: $brightness-86;
+    }
+
+    @include mq($from: mobileLandscape) {
+        margin-top: 0;
+    }
+}
+
+.contributions__learn-more + .contributions__payment-logos {
+    width: 100%;
+    margin-top: $gs-baseline / 2;
+    margin-left: $gs-baseline / 2;
 }
 
 .contributions__contribute--epic-member {


### PR DESCRIPTION
## What does this change?
We are adding an epic test

## Screenshots
Variant, desktop:
<img width="709" alt="learn more variant" src="https://user-images.githubusercontent.com/3300789/64790502-1a8bd000-d56e-11e9-9bd7-b4154949451e.png">

Variant, mobile:
<img width="477" alt="learn more variant mobile" src="https://user-images.githubusercontent.com/3300789/64790559-3000fa00-d56e-11e9-953e-bdc54a377a23.png">

Control, desktop:
<img width="707" alt="learn more control" src="https://user-images.githubusercontent.com/3300789/64790585-342d1780-d56e-11e9-9988-6ef4b1af49b5.png">

Control, mobile:
<img width="479" alt="learn more control mobile" src="https://user-images.githubusercontent.com/3300789/64790595-38f1cb80-d56e-11e9-8600-3ab758e6bac3.png">

## What is the value of this and can you measure success?
This is an epic test which will have its success measured by AV and clickthrough rate to the 'learn more' article.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
