### PR TITLE
Adapt detect.js' adblockInUse for DCR

### DIFF
--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -1,5 +1,6 @@
 // @flow
 
+import config from 'lib/config';
 import mediator from 'lib/mediator';
 
 declare class MediaQueryListEvent extends Event {
@@ -290,15 +291,22 @@ const pageVisible = (): boolean => pageVisibility === 'visible';
 
 const isEnhanced = (): boolean => window.guardian.isEnhanced;
 
-const adblockInUse: Promise<?boolean> = new Promise(resolve => {
-    if (window.guardian.adBlockers.hasOwnProperty('active')) {
-        // adblock detection has completed
-        resolve(window.guardian.adBlockers.active);
-    } else {
-        // Push a listener for when the JS loads
-        window.guardian.adBlockers.onDetect.push(resolve);
+const getAdblockInUse = () => {
+    if (config.get('isDotcomRendering', false)) {
+        return Promise.resolve(false);
     }
-});
+    return new Promise(resolve => {
+        if (window.guardian.adBlockers.hasOwnProperty('active')) {
+            // adblock detection has completed
+            resolve(window.guardian.adBlockers.active);
+        } else {
+            // Push a listener for when the JS loads
+            window.guardian.adBlockers.onDetect.push(resolve);
+        }
+    });
+};
+
+const adblockInUse: Promise<?boolean> = getAdblockInUse();
 
 const getReferrer = (): string => document.referrer || '';
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -10,6 +10,9 @@ jest.mock('lib/config', () => ({
         if (key === 'page.adUnit') {
             return 'adunit';
         }
+        if (key === 'isDotcomRendering') {
+            return false;
+        }
         throw new Error(
             `Unexpected config lookup '${key}', check the mock is still correct`
         );


### PR DESCRIPTION
## What does this change?

This makes it so that `adblockInUse` which is used as part of the initialisation of Outbrain always resolves to `false` when running in DCR. The reason being that the existing code breaks in DCR preventing any Outbrain widget on DCR pages. Until the underlying problem with `adblockInUse` is fixed (work planned), I want to be able to display Outbrain widget on DCR pages (when it is allowed).