### PR TITLE
Bump @guardian/consent-management-platform to v0.3.0 and integrate into bannerPicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "files:../consent-management-platform",
+    "@guardian/consent-management-platform": "^0.3.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "^0.2.0",
+    "@guardian/consent-management-platform": "files:../consent-management-platform",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -302,6 +302,7 @@ const initialiseEmail = (): void => {
 };
 
 const initialiseBanner = (): void => {
+    // ordered by priority
     const bannerList = [
         consentManagementPlatformUi,
         firstPvConsentPlusEngagementBanner,

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -56,9 +56,12 @@ import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.li
 import ophan from 'ophan/ng';
 import { adFreeBanner } from 'common/modules/commercial/ad-free-banner';
 import { init as initReaderRevenueDevUtils } from 'common/modules/commercial/reader-revenue-dev-utils';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
-import { init as initCmpUi } from 'common/modules/ui/cmp-ui';
+// import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+// import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
+import {
+    consentManagementPlatformUi,
+    addPrivacySettingsLink,
+} from 'common/modules/ui/cmp-ui';
 
 const initialiseTopNavItems = (): void => {
     const header: ?HTMLElement = document.getElementById('header');
@@ -301,23 +304,19 @@ const initialiseEmail = (): void => {
 };
 
 const initialiseBanner = (): void => {
-    if (!isInVariantSynchronous(commercialIabCompliant, 'variant')) {
-        // ordered by priority
-        const bannerList = [
-            firstPvConsentPlusEngagementBanner,
-            firstPvConsentBanner,
-            breakingNews,
-            membershipBanner,
-            membershipEngagementBanner,
-            smartAppBanner,
-            adFreeBanner,
-            emailSignInBanner,
-        ];
+    const bannerList = [
+        consentManagementPlatformUi,
+        firstPvConsentPlusEngagementBanner,
+        firstPvConsentBanner,
+        breakingNews,
+        membershipBanner,
+        membershipEngagementBanner,
+        smartAppBanner,
+        adFreeBanner,
+        emailSignInBanner,
+    ];
 
-        initBannerPicker(bannerList);
-    } else {
-        initCmpUi();
-    }
+    initBannerPicker(bannerList);
 };
 
 const initialiseConsentCookieTracking = (): void =>
@@ -361,6 +360,7 @@ const init = (): void => {
         ['c-banner-picker', initialiseBanner],
         ['c-increment-article-counts', updateArticleCounts],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
+        ['c-add-privacy-settings-link', addPrivacySettingsLink],
     ]);
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -56,8 +56,6 @@ import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.li
 import ophan from 'ophan/ng';
 import { adFreeBanner } from 'common/modules/commercial/ad-free-banner';
 import { init as initReaderRevenueDevUtils } from 'common/modules/commercial/reader-revenue-dev-utils';
-// import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-// import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
 import {
     consentManagementPlatformUi,
     addPrivacySettingsLink,

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,11 +1,7 @@
 // @flow
-// import { cmpConfig, cmpUi } from '@guardian/consent-management-platform';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
-import {
-    cmpConfig,
-    cmpUi,
-} from '../../../../../../../../consent-management-platform';
+import { cmpConfig, cmpUi } from '@guardian/consent-management-platform';
 
 const CMP_READY_CLASS = 'cmp-iframe-ready';
 const OVERLAY_CLASS = 'cmp-overlay';
@@ -13,20 +9,20 @@ const IFRAME_CLASS = 'cmp-iframe';
 let container: ?HTMLElement;
 let uiPrepared: boolean = false;
 
-const onReadyCmp = () => {
+const onReadyCmp = (): void => {
     if (container && container.parentNode) {
         container.classList.add(CMP_READY_CLASS);
     }
 };
 
-const onCloseCmp = () => {
+const onCloseCmp = (): void => {
     if (container && container.parentNode) {
         container.classList.remove(CMP_READY_CLASS);
         container.remove();
     }
 };
 
-const prepareUi = () => {
+const prepareUi = (): void => {
     if (uiPrepared) {
         return;
     }
@@ -45,12 +41,14 @@ const prepareUi = () => {
     uiPrepared = true;
 };
 
-const show = () => {
+const show = (): Promise<boolean> => {
     prepareUi();
 
     if (document.body && container && !container.parentElement) {
         document.body.appendChild(container);
     }
+
+    return Promise.resolve(true);
 };
 
 const handlePrivacySettingsClick = (evt: Event): void => {
@@ -99,7 +97,7 @@ export const addPrivacySettingsLink = (): void => {
 
 export const consentManagementPlatformUi = {
     id: 'cmpUi',
-    canShow: () => {
+    canShow: (): Promise<boolean> => {
         if (isInVariantSynchronous(commercialIabCompliant, 'variant')) {
             return Promise.resolve(cmpUi.canShow());
         }
@@ -111,7 +109,7 @@ export const consentManagementPlatformUi = {
 
 // Exposed for testing purposes only
 export const _ = {
-    reset: () => {
+    reset: (): void => {
         if (container) {
             if (container.parentNode) {
                 container.remove();

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -120,6 +120,9 @@ export const _ = {
         }
         uiPrepared = false;
     },
+    CMP_READY_CLASS,
     OVERLAY_CLASS,
     IFRAME_CLASS,
+    onReadyCmp,
+    onCloseCmp,
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -8,6 +8,8 @@ import {
 } from '../../../../../../../../consent-management-platform';
 
 const CMP_READY_CLASS = 'cmp-iframe-ready';
+const OVERLAY_CLASS = 'cmp-overlay';
+const IFRAME_CLASS = 'cmp-iframe';
 let container: ?HTMLElement;
 let uiPrepared: boolean = false;
 
@@ -30,11 +32,11 @@ const prepareUi = () => {
     }
 
     container = document.createElement('div');
-    container.className = 'cmp-overlay';
+    container.className = OVERLAY_CLASS;
 
     const iframe = document.createElement('iframe');
     iframe.src = cmpConfig.CMP_URL;
-    iframe.className = 'cmp-iframe';
+    iframe.className = IFRAME_CLASS;
 
     container.appendChild(iframe);
 
@@ -105,4 +107,19 @@ export const consentManagementPlatformUi = {
         return Promise.resolve(false);
     },
     show,
+};
+
+// Exposed for testing purposes only
+export const _ = {
+    reset: () => {
+        if (container) {
+            if (container.parentNode) {
+                container.remove();
+            }
+            container = undefined;
+        }
+        uiPrepared = false;
+    },
+    OVERLAY_CLASS,
+    IFRAME_CLASS,
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,23 +1,19 @@
 // @flow
-import { consentManagementPlatformUi, _ } from './cmp-ui';
-import {
-    cmpUi as cmpUi_,
-    cmpConfig,
-} from '../../../../../../../../consent-management-platform';
+import { cmpUi as cmpUi_ } from '@guardian/consent-management-platform';
 import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
+import { consentManagementPlatformUi, _ } from './cmp-ui';
 
 const cmpUi: any = cmpUi_;
 const isInVariantSynchronous: any = isInVariantSynchronous_;
 
-jest.mock('../../../../../../../../consent-management-platform', () => ({
+jest.mock('@guardian/consent-management-platform', () => ({
     cmpUi: {
         canShow: jest.fn(),
         setupMessageHandlers: jest.fn(),
     },
     // $FlowFixMe property requireActual is actually not missing Flow.
-    cmpConfig: jest.requireActual(
-        '../../../../../../../../consent-management-platform'
-    ).cmpConfig,
+    cmpConfig: jest.requireActual('@guardian/consent-management-platform')
+        .cmpConfig,
 }));
 
 jest.mock('common/modules/experiments/ab', () => ({

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -97,6 +97,48 @@ describe('cmp-ui', () => {
                 );
                 expect(cmpUi.setupMessageHandlers).toHaveBeenCalledTimes(1);
             });
+
+            it('onReadyCmp adds the ready class to the container', () => {
+                consentManagementPlatformUi.show();
+
+                const container = document.querySelectorAll(overlaySelector)[0];
+
+                expect(container).toBeTruthy();
+
+                if (container) {
+                    expect(
+                        container.classList.contains(_.CMP_READY_CLASS)
+                    ).toBe(false);
+
+                    _.onReadyCmp();
+
+                    expect(
+                        container.classList.contains(_.CMP_READY_CLASS)
+                    ).toBe(true);
+                }
+            });
+
+            it('onCloseCmp removes the ready class from the container and the container from the page', () => {
+                consentManagementPlatformUi.show();
+
+                const container = document.querySelectorAll(overlaySelector)[0];
+
+                if (container) {
+                    _.onReadyCmp();
+
+                    expect(
+                        container.classList.contains(_.CMP_READY_CLASS)
+                    ).toBe(true);
+                    expect(container.parentNode).toBeTruthy();
+
+                    _.onCloseCmp();
+
+                    expect(
+                        container.classList.contains(_.CMP_READY_CLASS)
+                    ).toBe(false);
+                    expect(container.parentNode).toBeFalsy();
+                }
+            });
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,0 +1,52 @@
+// @flow
+import { consentManagementPlatformUi } from './cmp-ui';
+import { cmpUi as cmpUi_ } from '../../../../../../../../consent-management-platform';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
+
+const cmpUi: any = cmpUi_;
+const isInVariantSynchronous: any = isInVariantSynchronous_;
+
+jest.mock('../../../../../../../../consent-management-platform', () => ({
+    cmpUi: { canShow: jest.fn() },
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
+}));
+
+describe('cmp-ui', () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('consentManagementPlatformUi', () => {
+        describe('canShow', () => {
+            it('returns true if cmpUi.canShow true and in commercialIabCompliant test', () => {
+                cmpUi.canShow.mockReturnValue(true);
+                isInVariantSynchronous.mockReturnValue(true);
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(true);
+                });
+            });
+
+            it('returns false if cmpUi.canShow false', () => {
+                cmpUi.canShow.mockReturnValue(false);
+                isInVariantSynchronous.mockReturnValue(true);
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(false);
+                });
+            });
+
+            it('returns false if not in commercialIabCompliant test', () => {
+                cmpUi.canShow.mockReturnValue(true);
+                isInVariantSynchronous.mockReturnValue(false);
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(false);
+                });
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@files:../consent-management-platform":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.2.0.tgz#360dc3e9c602cc8421e2c5563d5b5bf238319430"
-  integrity sha512-NnzU8b1mP+FAyEfxzZulUQEA3xz+asgP7xgoO7rZIeo+QNgpm0dpGMh0QA6dA9sKn/+tXXoWj2/D5oT45UdnQA==
+"@guardian/consent-management-platform@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.3.0.tgz#eee7ffe7f33df38beac9740f4767c581de0960eb"
+  integrity sha512-JLJ5lprvdwVscSYAtxm+LF5YwydmayoGGYDn5qILHmgLNXWOs+Br9kD/FmlsRogfsYMJ4RvUC/uPCMZiS4EANg==
   dependencies:
     js-cookie "^2.2.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,7 +1082,7 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@^0.2.0":
+"@guardian/consent-management-platform@files:../consent-management-platform":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.2.0.tgz#360dc3e9c602cc8421e2c5563d5b5bf238319430"
   integrity sha512-NnzU8b1mP+FAyEfxzZulUQEA3xz+asgP7xgoO7rZIeo+QNgpm0dpGMh0QA6dA9sKn/+tXXoWj2/D5oT45UdnQA==


### PR DESCRIPTION
## What does this change?

This PR upgrades to `@guardian/consent-management-platform` [version 0.3.0](https://github.com/guardian/consent-management-platform/releases/tag/0.3.0) and integrates the `cmp-ui` into the `bannerPicker` logic.

`@guardian/consent-management-platform@v0.3.0` introduces a new interface `cmpUi` that contains a number useful functions for users who want to load the CMP UI on their site via an iframe. I've therefore started using these functions within `frontend` in this PR. Further details regarding `cmpUi` can be found here https://github.com/guardian/consent-management-platform/pull/30.

The new CMP UI is still behind a 0% A/B test, however I've replaced the temporary/simplistic way we were loading it before by integrating it into the `bannerPicker`, as this is how it'll be loaded going forward. This required exposing a new interface `consentManagementPlatformUi` from `cmp-ui`. 

## Screenshots

N/A

## What is the value of this and can you measure success?

Removes temporary code that was in `frontend` and replaces with the `'@guardian/consent-management-platform` package as we intend to use this going forward.