### PR TITLE
Fixed 'learn more cta' test priority

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -51,7 +51,7 @@ export const learnMore: EpicABTest = makeEpicABTest({
     audienceOffset: 0,
 
     geolocation,
-    highPriority: true,
+    highPriority: false,
 
     canRun: () => articleViewCount < maxArticleViews,
 


### PR DESCRIPTION
## What does this change?
Correctly labeling an epic test to be normal priority