### PR TITLE
Add debug information to window.guardian.config.debug for Outbrain

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
@@ -33,13 +33,23 @@ const renderWidget = (widgetType: string, init: any): Promise<void> => {
 };
 
 const init = (): Promise<void> => {
+    /*
+        The `config.set` instances in this function are injecting debuging information into window.guardian.config.debug
+        This will be used for investigations
+    */
+
     const edition = config.get('page.edition', '').toLowerCase();
     const isSwitchOn = config.get('switches.plistaForOutbrainAu');
-    const shouldServePlistaOrOutbrain: boolean = isSwitchOn && edition === 'au';
-    if (shouldServePlistaOrOutbrain) {
+    const shouldUseRandomWidget: boolean = isSwitchOn && edition === 'au';
+
+    config.set('debug.outbrain.shouldUseRandomWidget', shouldUseRandomWidget);
+
+    if (shouldUseRandomWidget) {
         const possibleWidgets = ['plista', 'outbrain'];
         const randomWidget =
             possibleWidgets[Math.floor(Math.random() * possibleWidgets.length)];
+
+        config.set('debug.outbrain.randomWidget', randomWidget);
 
         if (randomWidget === 'plista') {
             return renderWidget('plista', plista.init);


### PR DESCRIPTION
## What does this change?

This PR does two things:

1. Rename `shouldServePlistaOrOutbrain` into `shouldUseRandomWidget` in `plista-outbrain-renderer.js`

2. Add debug information in `plista-outbrain-renderer.js ` and `outbrain.js`. I will be needing this to understand in PROD, differences in rendering of the Outbrain widget. 

What it looks like on the console:

![Screenshot 2019-09-13 at 14 12 59](https://user-images.githubusercontent.com/6035518/64865181-acf4a800-d630-11e9-9444-2dfbf2679a1a.png)
