### PR TITLE
Bump @guardian/consent-management-platform to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "^0.3.0",
+    "@guardian/consent-management-platform": "^0.3.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.3.0.tgz#eee7ffe7f33df38beac9740f4767c581de0960eb"
-  integrity sha512-JLJ5lprvdwVscSYAtxm+LF5YwydmayoGGYDn5qILHmgLNXWOs+Br9kD/FmlsRogfsYMJ4RvUC/uPCMZiS4EANg==
+"@guardian/consent-management-platform@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.3.1.tgz#146eb41982d6637e8884712db429ecc7bc5d0771"
+  integrity sha512-CE9QvnrXK8obbS9W6n/gwusuAu3++JTE4Pyit7BEwpFY9GOHKNIiLM1hDIKj3Y9yT5AHzEemO1iSkfK4Wzyamw==
   dependencies:
     js-cookie "^2.2.1"
 


### PR DESCRIPTION
This PR bumps `@guardian/consent-management-platform` to [v0.3.1](https://github.com/guardian/consent-management-platform/releases/tag/0.3.1), this update corrects the domains

## What is the value of this and can you measure success?

Better dev experience, we can now see the CMP UI when running frontend locally.