### PR TITLE
Move Teads ads between paragraphs 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -105,4 +105,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 7, 30),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-inline1-before-headings",
+    "Test inline1 ads to be placed above headings",
+    owners = Seq(Owner.withGithub("ioanna0")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 7, 30),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -108,8 +108,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-commercial-inline1-before-headings",
-    "Test inline1 ads to be placed above headings",
+    "ab-commercial-inline1-headings",
+    "Test inline1 ads to not be placed right after h2 headings",
     owners = Seq(Owner.withGithub("ioanna0")),
     safeState = On,
     sellByDate = new LocalDate(2020, 7, 30),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -111,7 +111,7 @@ trait ABTestSwitches {
     "ab-commercial-inline1-headings",
     "Test inline1 ads to not be placed right after h2 headings",
     owners = Seq(Owner.withGithub("ioanna0")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 7, 30),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,6 +10,11 @@ import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialInline1BeforeHeadings } from 'common/modules/experiments/tests/commercial-inline1-before-headings';
+
+const commercialInline1BeforeHeadings = (): boolean =>
+    isInVariantSynchronous(commercialInline1BeforeHeadings, 'variant');
 
 type AdSize = {
     width: number,
@@ -89,13 +94,13 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     // For inline1
     const defaultRules = {
         bodySelector: getBodySelector(),
-        slotSelector: getSlotSelector(),
-        minAbove: 400,
-        minBelow: 700,
-        selectors: {
+        slotSelector: getSlotSelector(), //candidates = bodySelector + slotSelector
+        minAbove: isImmersive ? 700 : 400, //candidate should be farEnoughFromTopOfBody
+        minBelow: 700, //candidate should be farEnoughFromBottomOfBody
+        selectors: {  // test each selector against each candidate
             ' > h2': {
                 minAbove: 0,
-                minBelow: 0,
+                minBelow: 250,
             },
             ' .ad-slot': adSlotClassSelectorSizes,
             ' > :not(p):not(h2):not(.ad-slot)': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -268,8 +268,8 @@ export const init = (): Promise<boolean> => {
     im.then((inlineMerchAdded: boolean) =>
         inlineMerchAdded ? trackAdRender('dfp-ad--im') : Promise.resolve()
     )
-        .then(addInlineAds)
-        .then(initCarrot);
+        .then(isInInlineAdABTest ? addInlineAds : initCarrot)
+        .then(isInInlineAdABTest ? initCarrot : addInlineAds);
 
     return im;
 };

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -13,7 +13,7 @@ import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialInline1BeforeHeadings } from 'common/modules/experiments/tests/commercial-inline1-before-headings';
 
-const commercialInline1BeforeHeadings = (): boolean =>
+const isInInlineBeforeHeadingsABTest = (): boolean =>
     isInVariantSynchronous(commercialInline1BeforeHeadings, 'variant');
 
 type AdSize = {
@@ -48,7 +48,7 @@ const insertAdAtPara = (
         .write(() =>
             ads.forEach(ad => {
                 if (para.parentNode) {
-                    para.parentNode.insertBefore(ad, para.nextSibling);
+                    para.parentNode.insertBefore(ad, para);
                 }
             })
         )
@@ -82,9 +82,6 @@ const getBodySelector = (): string =>
         ? '.js-article__body'
         : '.article-body-03f883b8';
 
-//1. if 620x320 AND has h2
-//2. put it at the bottom of the paragraph!
-
 const getSlotSelector = (): string =>
     !config.get('isDotcomRendering', false) ? ' > p' : ' > span';
 
@@ -94,13 +91,13 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     // For inline1
     const defaultRules = {
         bodySelector: getBodySelector(),
-        slotSelector: getSlotSelector(), //candidates = bodySelector + slotSelector
-        minAbove: isImmersive ? 700 : 400, //candidate should be farEnoughFromTopOfBody
-        minBelow: 700, //candidate should be farEnoughFromBottomOfBody
-        selectors: {  // test each selector against each candidate
+        slotSelector: getSlotSelector(),
+        minAbove: isImmersive ? 700 : 400,
+        minBelow: 700,
+        selectors: {
             ' > h2': {
-                minAbove: 0,
-                minBelow: 250,
+                minAbove: isInInlineBeforeHeadingsABTest ? 5 : 0,
+                minBelow: isInInlineBeforeHeadingsABTest ? 190 : 250,
             },
             ' .ad-slot': adSlotClassSelectorSizes,
             ' > :not(p):not(h2):not(.ad-slot)': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -268,8 +268,8 @@ export const init = (): Promise<boolean> => {
     im.then((inlineMerchAdded: boolean) =>
         inlineMerchAdded ? trackAdRender('dfp-ad--im') : Promise.resolve()
     )
-        .then(initCarrot)
-        .then(addInlineAds);
+        .then(addInlineAds)
+        .then(initCarrot);
 
     return im;
 };

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -13,7 +13,7 @@ import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialInline1Headings } from 'common/modules/experiments/tests/commercial-inline1-headings';
 
-const isInInlineAdABTest = (): boolean =>
+const isInInlineAdABTest: boolean =
     isInVariantSynchronous(commercialInline1Headings, 'variant');
 
 type AdSize = {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -92,7 +92,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const defaultRules = {
         bodySelector: getBodySelector(),
         slotSelector: getSlotSelector(),
-        minAbove: isImmersive ? 700 : 400,
+        minAbove: isImmersive ? 700 : 300,
         minBelow: 700,
         selectors: {
             ' > h2': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -43,7 +43,7 @@ const insertAdAtPara = (
         .write(() =>
             ads.forEach(ad => {
                 if (para.parentNode) {
-                    para.parentNode.insertBefore(ad, para);
+                    para.parentNode.insertBefore(ad, para.nextSibling);
                 }
             })
         )
@@ -77,6 +77,9 @@ const getBodySelector = (): string =>
         ? '.js-article__body'
         : '.article-body-03f883b8';
 
+//1. if 620x320 AND has h2
+//2. put it at the bottom of the paragraph!
+
 const getSlotSelector = (): string =>
     !config.get('isDotcomRendering', false) ? ' > p' : ' > span';
 
@@ -87,12 +90,12 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const defaultRules = {
         bodySelector: getBodySelector(),
         slotSelector: getSlotSelector(),
-        minAbove: isImmersive ? 700 : 300,
+        minAbove: 400,
         minBelow: 700,
         selectors: {
             ' > h2': {
                 minAbove: 0,
-                minBelow: 250,
+                minBelow: 0,
             },
             ' .ad-slot': adSlotClassSelectorSizes,
             ' > :not(p):not(h2):not(.ad-slot)': {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -13,8 +13,10 @@ import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialInline1Headings } from 'common/modules/experiments/tests/commercial-inline1-headings';
 
-const isInInlineAdABTest: boolean =
-    isInVariantSynchronous(commercialInline1Headings, 'variant');
+const isInInlineAdABTest: boolean = isInVariantSynchronous(
+    commercialInline1Headings,
+    'variant'
+);
 
 type AdSize = {
     width: number,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -11,10 +11,10 @@ import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { commercialInline1BeforeHeadings } from 'common/modules/experiments/tests/commercial-inline1-before-headings';
+import { commercialInline1Headings } from 'common/modules/experiments/tests/commercial-inline1-headings';
 
-const isInInlineBeforeHeadingsABTest = (): boolean =>
-    isInVariantSynchronous(commercialInline1BeforeHeadings, 'variant');
+const isInInlineAdABTest = (): boolean =>
+    isInVariantSynchronous(commercialInline1Headings, 'variant');
 
 type AdSize = {
     width: number,
@@ -96,8 +96,8 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
         minBelow: 700,
         selectors: {
             ' > h2': {
-                minAbove: isInInlineBeforeHeadingsABTest ? 5 : 0,
-                minBelow: isInInlineBeforeHeadingsABTest ? 190 : 250,
+                minAbove: isInInlineAdABTest ? 5 : 0,
+                minBelow: isInInlineAdABTest ? 190 : 250,
             },
             ' .ad-slot': adSlotClassSelectorSizes,
             ' > :not(p):not(h2):not(.ad-slot)': {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -9,12 +9,14 @@ import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
 import { prebidTripleLiftAdapter } from 'common/modules/experiments/tests/prebid-triple-lift-adapter';
 import { learnMore } from 'common/modules/experiments/tests/contributions-epic-learn-more-cta';
+import { commercialInline1Headings } from 'common/modules/experiments/tests/commercial-inline1-headings';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialIabCompliant,
     adblockTest,
     prebidTripleLiftAdapter,
+    commercialInline1Headings,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
@@ -8,7 +8,8 @@ export const commercialInline1BeforeHeadings: ABTest = {
     description: 'Test inline1 ads to be placed above h2 headings',
     audience: 0.01,
     audienceOffset: 0.0,
-    successMeasure: 'We can see inline1 ads in desktop and top-above-nav in mobiles, before headings',
+    successMeasure:
+        'We can see inline1 ads in desktop and top-above-nav in mobiles, before headings',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
@@ -1,5 +1,4 @@
 // @flow strict
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 export const commercialInline1BeforeHeadings: ABTest = {
     id: 'CommercialInline1BeforeHeadings',
@@ -7,14 +6,14 @@ export const commercialInline1BeforeHeadings: ABTest = {
     expiry: '2020-07-30',
     author: 'Ioanna Kyprianou',
     description: 'Test inline1 ads to be placed above h2 headings',
-    audience: 0.0,
+    audience: 0.01,
     audienceOffset: 0.0,
     successMeasure: 'We can see inline1 ads in desktop and top-above-nav in mobiles, before headings',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome:
         'No significant impact to performance as well as higher ad yield',
-    canRun: () => ['US', 'CA'].includes(geolocationGetSync()),
+    canRun: () => true,
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-before-headings.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+export const commercialInline1BeforeHeadings: ABTest = {
+    id: 'CommercialInline1BeforeHeadings',
+    start: '2019-07-30',
+    expiry: '2020-07-30',
+    author: 'Ioanna Kyprianou',
+    description: 'Test inline1 ads to be placed above h2 headings',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'We can see inline1 ads in desktop and top-above-nav in mobiles, before headings',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'No significant impact to performance as well as higher ad yield',
+    canRun: () => ['US', 'CA'].includes(geolocationGetSync()),
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -2,7 +2,7 @@
 
 export const commercialInline1Headings: ABTest = {
     id: 'CommercialInline1Headings',
-    start: '2019-07-30',
+    start: '2019-09-13',
     expiry: '2020-07-30',
     author: 'Ioanna Kyprianou',
     description: 'Test inline1 ads to not be placed right after h2 headings',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -13,6 +13,7 @@ export const commercialInline1Headings: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome:
         'No significant impact to performance as well as higher ad yield',
+    showForSensitive: true,
     canRun: () => true,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -8,8 +8,7 @@ export const commercialInline1Headings: ABTest = {
     description: 'Test inline1 ads to not be placed right after h2 headings',
     audience: 0.01,
     audienceOffset: 0.0,
-    successMeasure:
-        'We can see inline1 ads in desktop between paragraphs',
+    successMeasure: 'We can see inline1 ads in desktop between paragraphs',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -1,15 +1,15 @@
 // @flow strict
 
-export const commercialInline1BeforeHeadings: ABTest = {
-    id: 'CommercialInline1BeforeHeadings',
+export const commercialInline1Headings: ABTest = {
+    id: 'CommercialInline1Headings',
     start: '2019-07-30',
     expiry: '2020-07-30',
     author: 'Ioanna Kyprianou',
-    description: 'Test inline1 ads to be placed above h2 headings',
+    description: 'Test inline1 ads to not be placed right after h2 headings',
     audience: 0.01,
     audienceOffset: 0.0,
     successMeasure:
-        'We can see inline1 ads in desktop and top-above-nav in mobiles, before headings',
+        'We can see inline1 ads in desktop between paragraphs',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome:


### PR DESCRIPTION
## What does this change?

For desktop articles with h2 headings Teads ads are appearing between h2 and p (check the Before screenshot) making the article hard to read. 
This is an attempt to fix it by changing the spacefinder rules on desktop's inline1 slots.
Sets it to 1% AB test to check all edge cases and measure the impact on ads impressions

## Screenshots

### **Before**

![Screenshot 2019-09-13 at 16 53 49](https://user-images.githubusercontent.com/51630004/64876701-a32a6f00-d647-11e9-8d35-fc3dc6e9f551.png)

### **After**
![Screenshot 2019-09-13 at 16 53 31](https://user-images.githubusercontent.com/51630004/64876710-a58cc900-d647-11e9-924f-47f11243e8b4.png)

## What is the value of this and can you measure success?
Will improve readability of articles with headings

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

