### PR TITLE
bump ophan/tracker-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.11",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.13",
+    "ophan-tracker-js": "1.3.18",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
     "prebid.js": "https://github.com/guardian/Prebid.js.git#64e1965",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7590,9 +7590,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.13.tgz#715aa8655c1ec4c8e45379bae55a95b535522ff6"
+ophan-tracker-js@1.3.18:
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.18.tgz#738e349c856b44a43e5279bedc9ff2490ad53856"
+  integrity sha512-IKeOUmw1LYGDpNWWt4OPDr1TLlaWFpsL/TIHw+f4Z9gt/CRFEO70Z9eEFu14ZBLNREklpSFjuZ9g0VaoJ4sZfQ==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

Bump the version of the ophan tracker-js dependency from `1.3.13` -> `1.3.18`
This bump will update a newer adblock detection, which we hope will fix the unreliable data for D&I. Currently there are different results for the same pageview, potentially caused by the synchronous nature of the previous adblock detection.

The only published version in between is the `1.3.17`, you can check out the changelog [here](https://github.com/guardian/ophan/blob/master/tracker-js/changes.md) 


## What is the value of this and can you measure success?
We will need to check with D&I in the near future to see if the data is more reliable and the problem solved.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
