### PR TITLE
Add showForSensitive flag to AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-compliant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-compliant.js
@@ -12,6 +12,7 @@ export const commercialIabCompliant: ABTest = {
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome: 'CMP is compliant',
+    showForSensitive: true,
     canRun: () => true,
     variants: [
         {


### PR DESCRIPTION
## What does this change?
Add the `showForSensitive` flag to the `ab-CommercialIabCompliant` so that user will not be removed from the variant when visited an article with sensitive content.