### PR TITLE
Add mobile sticky placement id to trust x adapter

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -103,6 +103,8 @@ const getTrustXAdUnitId = (
             return '2963';
         case 'dfp-ad--comments':
             return '3840';
+        case 'dfp-ad--mobile-sticky':
+            return '8519';
         default:
             // for inline10 and onwards just use same IDs as inline9
             if (slotId.startsWith('dfp-ad--inline')) {

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -359,6 +359,10 @@ describe('getTrustXAdUnitId', () => {
         expect(getTrustXAdUnitId('dfp-ad--inline10', true)).toBe('3840');
         expect(getTrustXAdUnitId('dfp-ad--inline10', false)).toBe('3841');
     });
+
+    test('should return the expected values for dfp-ad--mobile-sticky', () => {
+        expect(getTrustXAdUnitId('dfp-ad--mobile-sticky', true)).toBe('8519');
+    });
 });
 
 describe('indexExchangeBidders', () => {


### PR DESCRIPTION
## What does this change?
Adds mobile sticky placement id to trust x adapter

## Screenshots
![Screenshot 2019-09-16 at 15 58 46](https://user-images.githubusercontent.com/51630004/64968962-f21c1280-d89a-11e9-9fad-cad5780b394d.png)

## What is the value of this and can you measure success?
Should pass correct placement id to TrustX adapter in Prebid for mobile sticky. 

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)
