### PR TITLE
Add dcrCouldRender to Google Analytics to allow better like-for-like tracking

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -110,14 +110,19 @@ object ArticlePicker {
     )
   }
 
-  def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
-
+  def dcrCouldRender(page: PageWithStoryPackage, request: RequestHeader): Boolean = {
     val whitelistFeatures = featureWhitelist(page, request)
     val isSupported = whitelistFeatures.forall({ case (test, isMet) => isMet})
+
+    isSupported
+  }
+
+  def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
+    val whitelistFeatures = featureWhitelist(page, request)
     val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
     val isBetaUser = ActiveExperiments.isParticipating(DotcomRenderingBeta)
 
-    val tier = if ((isSupported && isEnabled && isBetaUser && !request.forceDCROff) || request.forceDCR) RemoteRender else LocalRenderArticle
+    val tier = if ((dcrCouldRender(page, request) && isEnabled && isBetaUser && !request.forceDCROff) || request.forceDCR) RemoteRender else LocalRenderArticle
 
     // include features that we wish to log but not whitelist against
     val features = whitelistFeatures + ("isBetaUser" -> isBetaUser)

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -46,7 +46,11 @@
     // Please email Dotcom Platform before changing this value
     function getExperienceValue() {
         // return 'none' if you're not testing anything
-        return 'none';
+        if (guardian.config.page.dcrCouldRender) {
+            return 'dcrCouldRender';
+        } else {
+            return 'none';
+        }
     }
 
     var identityId = null;


### PR DESCRIPTION
## What does this change?

Adds `dcrCouldRender` to the GA `experience` Custom Dimension if the page is rendered with Frontend but would have been renderered with DCR if it was in the Variant of the AB test.

## Screenshots

GA request CD43 - Experiences and the window config.

This page locally (can't be rendered DCR): http://localhost:9000/commentisfree/2019/jan/25/children-commit-crimes-james-bulger-murder-film

![Screenshot 2019-09-16 at 17 10 05](https://user-images.githubusercontent.com/638051/64975661-74aacf00-d8a7-11e9-8ec7-be12e73dbf7f.png)
![Screenshot 2019-09-16 at 17 11 04](https://user-images.githubusercontent.com/638051/64975663-74aacf00-d8a7-11e9-9a68-44c2473682e1.png)


This page locally (Can be rendered DCR): https://www.theguardian.com/business/2019/sep/16/demand-brexit-advice-pwc-profit

![Screenshot 2019-09-16 at 17 09 52](https://user-images.githubusercontent.com/638051/64975617-5cd34b00-d8a7-11e9-9c6c-7fc3f16baa5e.png)

![Screenshot 2019-09-16 at 17 09 31](https://user-images.githubusercontent.com/638051/64975616-5cd34b00-d8a7-11e9-933f-3dc57a6b269a.png)


## What is the value of this and can you measure success?

We can test like-for-like performance of pages across Frontend vs DCR. In GA we can segment Frontend pages down to this variable. 

