### PR TITLE
Add publication to DCR data model.

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -225,7 +225,8 @@ case class DataModelV3(
   nav: Nav,
   designType: String,
   showBottomSocialButtons: Boolean,
-  pageFooter: PageFooter
+  pageFooter: PageFooter,
+  publication: String
 )
 
 object DataModelV3 {
@@ -273,7 +274,8 @@ object DataModelV3 {
       "nav" -> model.nav,
       "designType" -> model.designType,
       "showBottomSocialButtons" -> model.showBottomSocialButtons,
-      "pageFooter" -> model.pageFooter
+      "pageFooter" -> model.pageFooter,
+      "publication" -> model.publication
     )
   }
 
@@ -545,8 +547,8 @@ object DotcomponentsDataModel {
 
     val config = Config(
       ajaxUrl = Configuration.ajax.url,
-      sentryPublicApiKey = jsPageData.get("sentryPublicApiKey").getOrElse(""),
-      sentryHost = jsPageData.get("sentryHost").getOrElse(""),
+      sentryPublicApiKey = jsPageData.getOrElse("sentryPublicApiKey", ""),
+      sentryHost = jsPageData.getOrElse("sentryHost", ""),
       switches = switches,
       dfpAccountId = Configuration.commercial.dfpAccountId,
       abTests = ActiveExperiments.getJsMap(request),
@@ -606,7 +608,8 @@ object DotcomponentsDataModel {
       nav = nav,
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(article),
       designType = findDesignType(article.metadata.designType, allTags),
-      pageFooter = pageFooter
+      pageFooter = pageFooter,
+      publication = article.content.publication
     )
   }
 }

--- a/article/conf/schema/dotcomponentsDataModelV1.jsonschema
+++ b/article/conf/schema/dotcomponentsDataModelV1.jsonschema
@@ -138,6 +138,9 @@
                 },
                 "commissioningDesks": {
                     "type": "string"
+                },
+                "publication": {
+                    "type": "string"
                 }
             },
             "required": [


### PR DESCRIPTION
## What does this change?
Adds `publication` to the DCR model so that we can, for example. show the observer tag on content that's been published in the observer. For example, this piece https://www.theguardian.com/artanddesign/2019/sep/15/british-galleries-nazi-art-restorer should have 'The Observer' tag in place where a series tag would normally appear.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
