### PR TITLE
Set frontendAssetsFullURL in DCR data object

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -121,6 +121,7 @@ case class Config(
   revisionNumber: String,
   googletagUrl: String,
   stage: String,
+  frontendAssetsFullURL: String,
 )
 
 object Config {
@@ -556,6 +557,7 @@ object DotcomponentsDataModel {
       revisionNumber = ManifestData.revision.toString,
       googletagUrl = Configuration.googletag.jsLocation,
       stage = common.Environment.stage,
+      frontendAssetsFullURL = s"${Configuration.site.host}${Configuration.assets.path}",
     )
 
     val author = Author(


### PR DESCRIPTION
## What does this change?

Pass the full URL to frontend's assets.  We pass the full url instead of just the path component to make working on local possible (where DCR and frontend have different URLs).

![Screenshot 2019-09-18 at 12 13 43](https://user-images.githubusercontent.com/6035518/65143851-d8e7a300-da0d-11e9-93dc-b4ce72b0a46d.png)

