### PR TITLE
Get epic test data from new tool

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -238,11 +238,11 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val EpicTestsFromGoogleDocs = Switch(
+  val UseConfiguredEpicTests = Switch(
     Commercial,
-    "epic-tests-from-google-docs",
-    "Fetches epic tests from Google Docs. These take priority over hardcoded epic tests.",
-    owners = Seq(Owner.withGithub("joelochlann")),
+    "use-configured-epic-tests",
+    "Fetches epic tests a file created by the Epic Test tool. These take priority over hardcoded epic tests.",
+    owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
@@ -1,0 +1,14 @@
+// @flow
+import fetchJSON from 'lib/fetch-json';
+import config from 'lib/config';
+
+const prodEpicTestsDataFile = 'https://support.theguardian.com/epic-tests.json';
+const codeEpicTestsDataFile =
+    'https://support.code.dev-theguardian.com/epic-tests.json';
+
+export const getEpicTestData = (): Promise<any> => {
+    const url = config.get('page.isDev')
+        ? codeEpicTestsDataFile
+        : prodEpicTestsDataFile;
+    return fetchJSON(url, { mode: 'cors' });
+};

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-google-docs.js
@@ -6,9 +6,6 @@ export const epicControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
 export const bannerControlGoogleDocUrl: string =
     'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
-export const epicMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
-    ? 'https://interactive.guim.co.uk/docsdata-test/1THvo7I36Npb9GbKFAk6veIku3Hz5tBhpHobxrl0SoUc.json'
-    : 'https://interactive.guim.co.uk/docsdata/1VQ6yn2thnkFzjxIKt-AfOB_gJnX8omLNodkRyX7_Qbg.json';
 export const bannerMultipleTestsGoogleDocUrl: string = config.get('page.isDev')
     ? 'https://interactive.guim.co.uk/docsdata-test/19AGJYaPL8XpchykYlzqdKqNHxrHBILFktzM8vc5iShc.json'
     : 'https://interactive.guim.co.uk/docsdata/1IEVVHU5ZObCzyPV-BLQczaSzxe7pawLcH8_lvFD0Csk.json';

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -657,9 +657,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
     });
 };
 
-export const getConfigueredEpicTests = (): Promise<
-    $ReadOnlyArray<EpicABTest>
-> =>
+export const getConfiguredEpicTests = (): Promise<$ReadOnlyArray<EpicABTest>> =>
     getEpicTestData()
         .then(epicTestData => {
             if (epicTestData.tests) {
@@ -672,7 +670,7 @@ export const getConfigueredEpicTests = (): Promise<
         .catch((err: Error) => {
             reportError(
                 new Error(
-                    `Error getting multiple configuered epic tests. ${
+                    `Error getting multiple configured epic tests. ${
                         err.message
                     }. Stack: ${err.stack}`
                 ),

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -657,7 +657,9 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
     });
 };
 
-export const getEpicTestsFromTool = (): Promise<$ReadOnlyArray<EpicABTest>> =>
+export const getConfigueredEpicTests = (): Promise<
+    $ReadOnlyArray<EpicABTest>
+> =>
     getEpicTestData()
         .then(epicTestData => {
             if (epicTestData.tests) {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -24,10 +24,8 @@ import {
     getCountryName,
 } from 'lib/geolocation';
 import {
-    splitAndTrim,
     optionalSplitAndTrim,
     optionalStringToBoolean,
-    throwIfEmptyString,
     filterEmptyString,
 } from 'lib/string-utils';
 import { throwIfEmptyArray } from 'lib/array-utils';
@@ -531,45 +529,7 @@ const makeEpicABTest = ({
     return test;
 };
 
-// TODO - migrate hardcoded tests
 const buildEpicCopy = (
-    row: any,
-    testHasCountryName: boolean,
-    geolocation: ?string
-) => {
-    const heading = throwIfEmptyString('heading', row.heading);
-
-    const paragraphs: string[] = throwIfEmptyArray(
-        'paragraphs',
-        splitAndTrim(row.paragraphs, '\n')
-    );
-
-    const countryName: ?string = testHasCountryName
-        ? getCountryName(geolocation)
-        : undefined;
-
-    return {
-        heading:
-            heading && countryName
-                ? replaceCountryName(heading, countryName)
-                : heading,
-        paragraphs:
-            paragraphs && countryName
-                ? paragraphs.map<string>(para =>
-                      replaceCountryName(para, countryName)
-                  )
-                : paragraphs,
-        highlightedText: row.highlightedText
-            ? row.highlightedText.replace(
-                  /%%CURRENCY_SYMBOL%%/g,
-                  getLocalCurrencySymbol(geolocation)
-              )
-            : undefined,
-        footer: optionalSplitAndTrim(row.footer, '\n'),
-    };
-};
-
-const buildEpicCopyNew = (
     row: any,
     testHasCountryName: boolean,
     geolocation: ?string
@@ -683,7 +643,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
                       supportBaseURL: variant.cta.baseURL,
                   }
                 : {}),
-            copy: buildEpicCopyNew(variant, test.hasCountryName, geolocation),
+            copy: buildEpicCopy(variant, test.hasCountryName, geolocation),
             showTicker: optionalStringToBoolean(variant.showTicker),
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -278,6 +278,7 @@ const makeEpicABTestVariant = (
         copy: initVariant.copy,
         showTicker: initVariant.showTicker || false,
         backgroundImageUrl: initVariant.backgroundImageUrl,
+        deploymentRules,
 
         countryGroups: initVariant.countryGroups || [],
         tagIds: initVariant.tagIds || [],
@@ -587,15 +588,16 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
     const excludedTagIds = test.excludedTagIds;
     const excludedSections = test.excludedSections;
 
-    const deploymentRules = test.alwaysAsk
-        ? 'AlwaysAsk'
-        : ({
-              days: parseInt(test.maxViewsDays, 10) || defaultMaxViews.days,
-              count: parseInt(test.maxViewsCount, 10) || defaultMaxViews.count,
-              minDaysBetweenViews:
-                  parseInt(test.minDaysBetweenViews, 10) ||
-                  defaultMaxViews.minDaysBetweenViews,
-          }: MaxViews);
+    const parseMaxViews = (): MaxViews =>
+        test.maxViews
+            ? ({
+                  days: test.maxViewsDays,
+                  count: test.maxViewsCount,
+                  minDaysBetweenViews: test.minDaysBetweenViews,
+              }: MaxViews)
+            : defaultMaxViews;
+
+    const deploymentRules = test.alwaysAsk ? 'AlwaysAsk' : parseMaxViews();
 
     return makeEpicABTest({
         id: test.name,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -591,9 +591,9 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
     const parseMaxViews = (): MaxViews =>
         test.maxViews
             ? ({
-                  days: test.maxViewsDays,
-                  count: test.maxViewsCount,
-                  minDaysBetweenViews: test.minDaysBetweenViews,
+                  days: test.maxViews.maxViewsDays,
+                  count: test.maxViews.maxViewsCount,
+                  minDaysBetweenViews: test.maxViews.minDaysBetweenViews,
               }: MaxViews)
             : defaultMaxViews;
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -660,9 +660,10 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
 export const getConfiguredEpicTests = (): Promise<$ReadOnlyArray<EpicABTest>> =>
     getEpicTestData()
         .then(epicTestData => {
+            const showDrafts = window.location.hash === '#show-draft-epics';
             if (epicTestData.tests) {
                 return epicTestData.tests
-                    .filter(test => test.isOn)
+                    .filter(test => test.isOn || showDrafts)
                     .map(buildConfiguredEpicTestFromJson);
             }
             return [];

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -604,7 +604,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
         highPriority: test.highPriority,
 
         start: '2018-01-01',
-        expiry: '2020-01-01',
+        expiry: '2025-01-01',
 
         author: 'Epic test tool',
         description: 'Epic test tool',

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -13,7 +13,7 @@ const rawTest = {
     sections: [],
     excludedTagIds: [],
     excludedSections: [],
-    alwaysAsk: true,
+    alwaysAsk: false,
     isLiveBlog: false,
     hasCountryName: false,
     variants: [
@@ -25,17 +25,20 @@ const rawTest = {
             footer: '',
             showTicker: false,
             backgroundImageUrl: '',
+            maxViews: {
+                maxViewsDays: 30,
+                maxViewsCount: 4,
+                minDaysBetweenViews: 0,
+            },
         },
     ],
     highPriority: false,
-    maxViewsCount: 4,
     useLocalViewLog: false,
 };
 
 describe('buildConfiguredEpicTestFromJson', () => {
     it('Parses and constructs an epic test', () => {
         const test = buildConfiguredEpicTestFromJson(rawTest);
-        console.log(test);
         expect(test.id).toBe('My test');
         expect(test.useLocalViewLog).toBe(false);
         expect(test.userCohort).toBe('AllNonSupporters');
@@ -51,6 +54,12 @@ describe('buildConfiguredEpicTestFromJson', () => {
             paragraphs: ['testing testing', 'this is a test'],
             footer: [],
             highlightedText: 'Some highlighted text',
+        });
+
+        expect(variant.deploymentRules).toEqual({
+            days: 30,
+            count: 4,
+            minDaysBetweenViews: 0,
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -1,0 +1,54 @@
+// @flow
+
+import { buildConfiguredEpicTestFromJson } from './contributions-utilities';
+
+jest.mock('lib/raven');
+jest.mock('ophan/ng', () => null);
+
+const rawTest = {
+    name: 'My test',
+    isOn: true,
+    locations: ['UnitedStates', 'Australia'],
+    tagIds: ['football/football'],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    isLiveBlog: false,
+    hasCountryName: false,
+    variants: [
+        {
+            name: 'Control',
+            heading: 'This was made using the new tool!',
+            paragraphs: ['testing testing', 'this is a test'],
+            highlightedText: 'Some highlighted text',
+            footer: '',
+            showTicker: false,
+            backgroundImageUrl: '',
+        },
+    ],
+    highPriority: false,
+    maxViewsCount: 4,
+    useLocalViewLog: false,
+};
+
+describe('buildConfiguredEpicTestFromJson', () => {
+    it('Parses and constructs an epic test', () => {
+        const test = buildConfiguredEpicTestFromJson(rawTest);
+        console.log(test);
+        expect(test.id).toBe('My test');
+        expect(test.useLocalViewLog).toBe(false);
+        expect(test.userCohort).toBe('AllNonSupporters');
+
+        // $ExpectError
+        const variant = (test.variants[0]: EpicVariant); // have to cast because type is `Variant`
+        expect(variant.id).toBe('Control');
+        expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
+        expect(variant.tagIds).toEqual(['football/football']);
+        expect(variant.copy.heading).toBe('This was made using the new tool!');
+        expect(variant.copy.paragraphs).toEqual([
+            'testing testing',
+            'this is a test',
+        ]);
+    });
+});

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -40,8 +40,9 @@ describe('buildConfiguredEpicTestFromJson', () => {
         expect(test.useLocalViewLog).toBe(false);
         expect(test.userCohort).toBe('AllNonSupporters');
 
-        // $ExpectError
-        const variant = (test.variants[0]: EpicVariant); // have to cast because type is `Variant`
+        // Have to cast here because type is `Variant`
+        // $FlowFixMe
+        const variant = (test.variants[0]: EpicVariant);
         expect(variant.id).toBe('Control');
         expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
         expect(variant.tagIds).toEqual(['football/football']);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -46,10 +46,11 @@ describe('buildConfiguredEpicTestFromJson', () => {
         expect(variant.id).toBe('Control');
         expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
         expect(variant.tagIds).toEqual(['football/football']);
-        expect(variant.copy.heading).toBe('This was made using the new tool!');
-        expect(variant.copy.paragraphs).toEqual([
-            'testing testing',
-            'this is a test',
-        ]);
+        expect(variant.copy).toEqual({
+            heading: 'This was made using the new tool!',
+            paragraphs: ['testing testing', 'this is a test'],
+            footer: [],
+            highlightedText: 'Some highlighted text',
+        });
     });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -27,7 +27,7 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getEpicTestsFromTool,
+    getConfigueredEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
 
 export const getEpicTestToRun = memoize(
@@ -40,7 +40,7 @@ export const getEpicTestToRun = memoize(
         );
 
         if (config.get('switches.epicTestsFromGoogleDocs')) {
-            return getEpicTestsFromTool().then(configuredEpicTests => {
+            return getConfigueredEpicTests().then(configuredEpicTests => {
                 configuredEpicTests.forEach(test =>
                     config.set(`switches.ab${test.id}`, true)
                 );

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -39,7 +39,7 @@ export const getEpicTestToRun = memoize(
             test => !test.highPriority
         );
 
-        if (config.get('switches.epicTestsFromGoogleDocs')) {
+        if (config.get('switches.useConfiguredEpicTests')) {
             return getConfigueredEpicTests().then(configuredEpicTests => {
                 configuredEpicTests.forEach(test =>
                     config.set(`switches.ab${test.id}`, true)

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -27,7 +27,7 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getConfigueredEpicTests,
+    getConfiguredEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
 
 export const getEpicTestToRun = memoize(
@@ -40,7 +40,7 @@ export const getEpicTestToRun = memoize(
         );
 
         if (config.get('switches.useConfiguredEpicTests')) {
-            return getConfigueredEpicTests().then(configuredEpicTests => {
+            return getConfiguredEpicTests().then(configuredEpicTests => {
                 configuredEpicTests.forEach(test =>
                     config.set(`switches.ab${test.id}`, true)
                 );

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -27,7 +27,7 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getEpicTestsFromGoogleDoc,
+    getEpicTestsFromTool,
 } from 'common/modules/commercial/contributions-utilities';
 
 export const getEpicTestToRun = memoize(
@@ -40,7 +40,7 @@ export const getEpicTestToRun = memoize(
         );
 
         if (config.get('switches.epicTestsFromGoogleDocs')) {
-            return getEpicTestsFromGoogleDoc().then(configuredEpicTests => {
+            return getEpicTestsFromTool().then(configuredEpicTests => {
                 configuredEpicTests.forEach(test =>
                     config.set(`switches.ab${test.id}`, true)
                 );

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -18,9 +18,9 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import { NOT_IN_TEST } from 'common/modules/experiments/ab-constants';
 import { runnableTestsToParticipations } from 'common/modules/experiments/ab-utils';
-import { getEpicTestsFromGoogleDoc as getEpicTestsFromGoogleDoc_ } from 'common/modules/commercial/contributions-utilities';
+import { getEpicTestsFromTool as getEpicTestsFromTool_ } from 'common/modules/commercial/contributions-utilities';
 
-const getEpicTestsFromGoogleDoc: any = getEpicTestsFromGoogleDoc_;
+const getEpicTestsFromTool: any = getEpicTestsFromTool_;
 
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
@@ -31,7 +31,7 @@ jest.mock('common/modules/experiments/ab-ophan', () => ({
     buildOphanPayload: () => {},
 }));
 jest.mock('common/modules/commercial/contributions-utilities', () => ({
-    getEpicTestsFromGoogleDoc: jest.fn(),
+    getEpicTestsFromTool: jest.fn(),
 }));
 
 jest.mock('lodash/memoize', () => f => f);
@@ -51,7 +51,7 @@ describe('A/B', () => {
         overwriteMvtCookie(1234);
         window.location.hash = '';
         setParticipationsInLocalStorage({});
-        getEpicTestsFromGoogleDoc.mockReturnValue(Promise.resolve(null));
+        getEpicTestsFromTool.mockReturnValue(Promise.resolve(null));
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -18,9 +18,9 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import { NOT_IN_TEST } from 'common/modules/experiments/ab-constants';
 import { runnableTestsToParticipations } from 'common/modules/experiments/ab-utils';
-import { getConfigueredEpicTests as getConfigueredEpicTests_ } from 'common/modules/commercial/contributions-utilities';
+import { getConfiguredEpicTests as getConfiguredEpicTests_ } from 'common/modules/commercial/contributions-utilities';
 
-const getConfigueredEpicTests: any = getConfigueredEpicTests_;
+const getConfiguredEpicTests: any = getConfiguredEpicTests_;
 
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
@@ -31,7 +31,7 @@ jest.mock('common/modules/experiments/ab-ophan', () => ({
     buildOphanPayload: () => {},
 }));
 jest.mock('common/modules/commercial/contributions-utilities', () => ({
-    getConfigueredEpicTests: jest.fn(),
+    getConfiguredEpicTests: jest.fn(),
 }));
 
 jest.mock('lodash/memoize', () => f => f);
@@ -51,7 +51,7 @@ describe('A/B', () => {
         overwriteMvtCookie(1234);
         window.location.hash = '';
         setParticipationsInLocalStorage({});
-        getConfigueredEpicTests.mockReturnValue(Promise.resolve(null));
+        getConfiguredEpicTests.mockReturnValue(Promise.resolve(null));
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -18,7 +18,7 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import { NOT_IN_TEST } from 'common/modules/experiments/ab-constants';
 import { runnableTestsToParticipations } from 'common/modules/experiments/ab-utils';
-import { getEpicTestsFromTool as getEpicTestsFromTool_ } from 'common/modules/commercial/contributions-utilities';
+import { getConfigueredEpicTests as getEpicTestsFromTool_ } from 'common/modules/commercial/contributions-utilities';
 
 const getEpicTestsFromTool: any = getEpicTestsFromTool_;
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -18,9 +18,9 @@ import {
 } from 'common/modules/experiments/ab-tests';
 import { NOT_IN_TEST } from 'common/modules/experiments/ab-constants';
 import { runnableTestsToParticipations } from 'common/modules/experiments/ab-utils';
-import { getConfigueredEpicTests as getEpicTestsFromTool_ } from 'common/modules/commercial/contributions-utilities';
+import { getConfigueredEpicTests as getConfigueredEpicTests_ } from 'common/modules/commercial/contributions-utilities';
 
-const getEpicTestsFromTool: any = getEpicTestsFromTool_;
+const getConfigueredEpicTests: any = getConfigueredEpicTests_;
 
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
@@ -31,7 +31,7 @@ jest.mock('common/modules/experiments/ab-ophan', () => ({
     buildOphanPayload: () => {},
 }));
 jest.mock('common/modules/commercial/contributions-utilities', () => ({
-    getEpicTestsFromTool: jest.fn(),
+    getConfigueredEpicTests: jest.fn(),
 }));
 
 jest.mock('lodash/memoize', () => f => f);
@@ -51,7 +51,7 @@ describe('A/B', () => {
         overwriteMvtCookie(1234);
         window.location.hash = '';
         setParticipationsInLocalStorage({});
-        getEpicTestsFromTool.mockReturnValue(Promise.resolve(null));
+        getConfigueredEpicTests.mockReturnValue(Promise.resolve(null));
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -18,7 +18,7 @@ import {
 } from 'common/modules/experiments/ab-local-storage';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getEpicTestsFromTool,
+    getConfigueredEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
 
 const selectRadios = () => {
@@ -85,7 +85,7 @@ const appendOverlay = (): Promise<void> => {
         isExpired: isExpired(expiry),
     });
     return Promise.all([
-        getEpicTestsFromTool(),
+        getConfigueredEpicTests(),
         getEngagementBannerTestsFromGoogleDoc(),
     ]).then(([asyncEpicTests, asyncBannerTests]) => {
         const data = {

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -18,7 +18,7 @@ import {
 } from 'common/modules/experiments/ab-local-storage';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getEpicTestsFromGoogleDoc,
+    getEpicTestsFromTool,
 } from 'common/modules/commercial/contributions-utilities';
 
 const selectRadios = () => {
@@ -85,7 +85,7 @@ const appendOverlay = (): Promise<void> => {
         isExpired: isExpired(expiry),
     });
     return Promise.all([
-        getEpicTestsFromGoogleDoc(),
+        getEpicTestsFromTool(),
         getEngagementBannerTestsFromGoogleDoc(),
     ]).then(([asyncEpicTests, asyncBannerTests]) => {
         const data = {

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -18,7 +18,7 @@ import {
 } from 'common/modules/experiments/ab-local-storage';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getConfigueredEpicTests,
+    getConfiguredEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
 
 const selectRadios = () => {
@@ -85,7 +85,7 @@ const appendOverlay = (): Promise<void> => {
         isExpired: isExpired(expiry),
     });
     return Promise.all([
-        getConfigueredEpicTests(),
+        getConfiguredEpicTests(),
         getEngagementBannerTestsFromGoogleDoc(),
     ]).then(([asyncEpicTests, asyncBannerTests]) => {
         const data = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -18,21 +18,23 @@ const highlightedText =
 
 const USUKControlCopy = {
     heading: 'Since you’re here...',
-    paragraphs:
-        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+    paragraphs: [
+        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+    ],
     highlightedText,
 };
 
 const ROWControlCopy = {
     heading: 'More people in %%COUNTRY_NAME%%...',
-    paragraphs:
-        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+    paragraphs: [
+        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+    ],
     highlightedText,
 };
 
@@ -79,11 +81,12 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
             copy: buildEpicCopy(
                 {
                     heading: `You’ve read ${articleViewCount} articles...`,
-                    paragraphs:
-                        '... in the last month. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+                    paragraphs: [
+                        '... in the last month. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+                    ],
                     highlightedText,
                 },
                 false,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-country-name.js
@@ -40,11 +40,12 @@ export const countryName: EpicABTest = makeEpicABTest({
             copy: buildEpicCopy(
                 {
                     heading: 'More people in %%COUNTRY_NAME%%…',
-                    paragraphs:
-                        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.\n',
+                    paragraphs: [
+                        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
+                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+                    ],
                     highlightedText:
                         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
                 },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-learn-more-cta.js
@@ -20,11 +20,12 @@ const highlightedText =
 
 const copy = {
     heading: 'Since you’re here...',
-    paragraphs:
-        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.\n' +
-        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.\n' +
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.\n' +
-        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable. \n',
+    paragraphs: [
+        '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+    ],
     highlightedText,
 };
 


### PR DESCRIPTION
## What does this change?
So far we've been configuring epic tests from a google spreadsheet, from which a json file is created. The browser requests this json after page load.

We have a new tool to replace the spreadsheet. This PR changes frontend to request a new file (behind fastly). The model published by the tool is much closer to the model in frontend so the parsing is simpler.

It's behind a switch, but I've removed support for the google spreadsheet so we'd have to revert this change if we need to go back.

E.g.
<img width="650" alt="Screenshot 2019-09-18 at 14 20 00" src="https://user-images.githubusercontent.com/1513454/65152250-7dbeac00-da1f-11e9-8421-fd95bfde192e.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
