### PR TITLE
Make rules for DCR inline 1

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -87,16 +87,11 @@ const getBodySelector = (): string =>
 const getSlotSelector = (): string =>
     !config.get('isDotcomRendering', false) ? ' > p' : ' > span';
 
-const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
-    const isImmersive = config.get('page.isImmersive');
-
-    // For inline1
-    const defaultRules = {
-        bodySelector: getBodySelector(),
-        slotSelector: getSlotSelector(),
-        minAbove: isImmersive ? 700 : 300,
-        minBelow: 700,
-        selectors: {
+const getDefaultRulesSelectorsForDesktopInlineAds = (
+    isDotcomRendering: boolean
+): {} => {
+    if (!isDotcomRendering) {
+        return {
             ' > h2': {
                 minAbove: isInInlineAdABTest ? 5 : 0,
                 minBelow: isInInlineAdABTest ? 190 : 250,
@@ -110,7 +105,36 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minAbove: 0,
                 minBelow: 600,
             },
+        };
+    }
+    return {
+        ' > h2': {
+            minAbove: isInInlineAdABTest ? 5 : 0,
+            minBelow: isInInlineAdABTest ? 190 : 250,
         },
+        ' .ad-slot': adSlotClassSelectorSizes,
+        ' > :not(span):not(h2):not(.ad-slot)': {
+            minAbove: 35,
+            minBelow: 400,
+        },
+        ' figure.element--immersive': {
+            minAbove: 0,
+            minBelow: 600,
+        },
+    };
+};
+
+const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
+    const isImmersive = config.get('page.isImmersive');
+
+    const defaultRules = {
+        bodySelector: getBodySelector(),
+        slotSelector: getSlotSelector(),
+        minAbove: isImmersive ? 700 : 300,
+        minBelow: 700,
+        selectors: getDefaultRulesSelectorsForDesktopInlineAds(
+            config.get('isDotcomRendering', false)
+        ),
         filter: filterNearbyCandidates(adSizes.mpu.height),
     };
 


### PR DESCRIPTION
## What does this change?

Add Space Finder rules for DCR.

ps: The return type of `getDefaultRulesSelectorsForDesktopInlineAds` is left unspecified on purpose.