### PR TITLE
Add totalSizeCap to local logging config for all frontend applications.

### DIFF
--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-admin.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-admin.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-admin.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-admin.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-admin.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-admin.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-applications.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-applications.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-applications.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-applications.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/applications/conf/logback.xml
+++ b/applications/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-applications.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-applications.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-archive.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-archive.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-archive.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/archive/conf/logback.xml
+++ b/archive/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-archive.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-archive.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-archive.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-article.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-article.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-article.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-article.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-article.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/article/conf/logback.xml
+++ b/article/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-article.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-commercial.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-commercial.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-commercial.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-commercial.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-commercial.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/commercial/conf/logback.xml
+++ b/commercial/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-commercial.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-test.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-test.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/common/test/resources/logback.xml
+++ b/common/test/resources/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-dev-build.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-dev-build.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-dev-build.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-dev-build.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-dev-build.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/dev-build/conf/logback.xml
+++ b/dev-build/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-dev-build.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/diagnostics/conf/logback.xml
+++ b/diagnostics/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-diagnostics.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-diagnostics.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/diagnostics/conf/logback.xml
+++ b/diagnostics/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-diagnostics.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-diagnostics.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-diagnostics.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/diagnostics/conf/logback.xml
+++ b/diagnostics/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-diagnostics.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-discussion.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-discussion.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-discussion.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-discussion.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/discussion/conf/logback.xml
+++ b/discussion/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-discussion.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-discussion.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia-press.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-facia-press.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia-press.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/facia-press/conf/logback.xml
+++ b/facia-press/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-facia-press.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-facia-press.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-facia-press.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-facia.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-facia.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-facia.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/facia/conf/logback.xml
+++ b/facia/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-facia.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-identity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-identity.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-identity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/identity/conf/logback.xml
+++ b/identity/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-identity.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-identity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-identity.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-onward.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-onward.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-onward.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-onward.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/onward/conf/logback.xml
+++ b/onward/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-onward.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-onward.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-preview.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-preview.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-preview.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-preview.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-preview.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/preview/conf/logback.xml
+++ b/preview/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-preview.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-rss.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-rss.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-rss.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-rss.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/rss/conf/logback.xml
+++ b/rss/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-rss.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-rss.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -5,9 +5,9 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend-sport.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-sport.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 
         <encoder>

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -6,7 +6,7 @@
         <file>logs/frontend-sport.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-sport.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/frontend-sport.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap><maxFileSize>256MB</maxFileSize>
         </rollingPolicy>
 

--- a/sport/conf/logback.xml
+++ b/sport/conf/logback.xml
@@ -7,7 +7,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-sport.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
+            <maxHistory>7</maxHistory><totalSizeCap>512MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>


### PR DESCRIPTION
## What does this change?
Switches our local logging config to SizeAndTimeBasedRollingPolicy and adds `totalSizeCap` and `maxFileSize` properties (see https://logback.qos.ch/manual/appenders.html#tbrpTotalSizeCap) to all apps, following an incident on CAPI as a result of disks getting filled up with logs.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
