### PR TITLE
Simplify tag model used for DCR rich link endpoint

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -11,8 +11,6 @@ import navigation.GuardianFoundationHelper
 
 object Tag {
 
-  def withoutCommercial(tag: Tag): Tag = tag.copy(properties = tag.properties.copy(commercial = None))
-
   def makeMetadata(tag: TagProperties, pagination: Option[Pagination]): MetaData = {
 
     val javascriptConfigOverrides: Map[String, JsValue] = Map(

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -4,7 +4,7 @@ import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Loggi
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, Content, ContentType, Tag}
-import models.dotcomponents.RichLink
+import models.dotcomponents.{RichLink, RichLinkTagTag}
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html
 import views.support.{ImgSrc, Item460, RichLinkContributor}
@@ -16,7 +16,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
     contentType(path) map {
         case Some(content) if request.forceDCR =>
           val richLink = RichLink(
-            tags = content.tags.tags.map(Tag.withoutCommercial), // throw away commercial data as we don't use it
+            tags = content.tags.tags.map(t => RichLinkTagTag(t.properties.id, t.properties.tagType, t.properties.webTitle)),
             cardStyle = content.content.cardStyle.toneString,
             thumbnailUrl = content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
             headline = content.trail.headline,

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -4,7 +4,7 @@ import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Loggi
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, Content, ContentType, Tag}
-import models.dotcomponents.{RichLink, RichLinkTagTag}
+import models.dotcomponents.{RichLink, RichLinkTag}
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html
 import views.support.{ImgSrc, Item460, RichLinkContributor}
@@ -16,7 +16,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
     contentType(path) map {
         case Some(content) if request.forceDCR =>
           val richLink = RichLink(
-            tags = content.tags.tags.map(t => RichLinkTagTag(t.properties.id, t.properties.tagType, t.properties.webTitle)),
+            tags = content.tags.tags.map(t => RichLinkTag(t.properties.id, t.properties.tagType, t.properties.webTitle)),
             cardStyle = content.content.cardStyle.toneString,
             thumbnailUrl = content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
             headline = content.trail.headline,

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -4,7 +4,7 @@ import model.{DotcomContentType, Pillar, Tag, Tags}
 import play.api.libs.json.Json
 
 case class RichLink(
-  tags: List[Tag],
+  tags: List[RichLinkTagTag],
   cardStyle: String,
   thumbnailUrl: Option[String],
   headline: String,
@@ -30,3 +30,10 @@ object RichLink {
     }.getOrElse("news")
   }
 }
+
+// duplicated in dotcomponentsdatamodel
+case class RichLinkTagTag(
+  id: String,
+  `type`: String,
+  title: String,
+)

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -4,7 +4,7 @@ import model.{DotcomContentType, Pillar, Tag, Tags}
 import play.api.libs.json.Json
 
 case class RichLink(
-  tags: List[RichLinkTagTag],
+  tags: List[RichLinkTag],
   cardStyle: String,
   thumbnailUrl: Option[String],
   headline: String,
@@ -32,8 +32,12 @@ object RichLink {
 }
 
 // duplicated in dotcomponentsdatamodel
-case class RichLinkTagTag(
+case class RichLinkTag(
   id: String,
   `type`: String,
   title: String,
 )
+
+object RichLinkTag {
+  implicit val writes = Json.writes[RichLinkTag]
+}


### PR DESCRIPTION
## What does this change?
Rather than using the dotcom `Tag` model, which is [rather large](https://github.com/guardian/frontend/blob/master/common/app/model/Tag.scala#L154) let's use a much simplified tag model with only the fields required for rendering rich links.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
