### PR TITLE
Add all page config (for the JS window.guardian.config.page) and remove duplicate fields

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -209,7 +209,7 @@ case class DataModelV3(
   shouldHideAds: Boolean,
   webURL: String,
   linkedData: List[LinkedData],
-  config: Config,
+  config: JsObject,
   guardianBaseURL: String,
   contentType: String,
   hasRelated: Boolean,
@@ -224,8 +224,7 @@ case class DataModelV3(
   designType: String,
   showBottomSocialButtons: Boolean,
   pageFooter: PageFooter,
-  publication: String,
-  jsPageConfig: Map[String, JsValue]
+  publication: String
 )
 
 object DataModelV3 {
@@ -274,8 +273,7 @@ object DataModelV3 {
       "designType" -> model.designType,
       "showBottomSocialButtons" -> model.showBottomSocialButtons,
       "pageFooter" -> model.pageFooter,
-      "publication" -> model.publication,
-      "jsPageConfig" -> model.jsPageConfig
+      "publication" -> model.publication
     )
   }
 
@@ -554,6 +552,9 @@ object DotcomponentsDataModel {
       frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage)
     )
 
+    val jsPageConfig = JavaScriptPage.getMap(articlePage, Edition(request), false)
+    val combinedConfig = Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
+
     val author = Author(
       byline = byline,
       twitterHandle = article.tags.contributors.headOption.flatMap(_.properties.twitterHandle)
@@ -590,7 +591,7 @@ object DotcomponentsDataModel {
       shouldHideAds = article.content.shouldHideAdverts,
       webURL = article.metadata.webUrl,
       linkedData = linkedData,
-      config = config,
+      config = combinedConfig,
       guardianBaseURL = Configuration.site.host,
       contentType = jsConfig("contentType").getOrElse(""),
       hasRelated = article.content.showInRelated,
@@ -606,7 +607,6 @@ object DotcomponentsDataModel {
       designType = findDesignType(article.metadata.designType, allTags),
       pageFooter = pageFooter,
       publication = article.content.publication,
-      jsPageConfig = JavaScriptPage.getMap(articlePage, Edition(request), false)
     )
   }
 }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -28,6 +28,7 @@ import controllers.ArticlePage
 import experiments.ActiveExperiments
 import org.joda.time.DateTime
 import common.Environment.stage
+import views.support.JavaScriptPage
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -111,17 +112,13 @@ object Pagination {
 }
 
 case class Config(
-  ajaxUrl: String,
-  sentryPublicApiKey: String,
-  sentryHost: String,
   switches: Map[String, Boolean],
   abTests: Map[String, String],
-  dfpAccountId: String,
   commercialBundleUrl: String,
-  revisionNumber: String,
   googletagUrl: String,
   stage: String,
   frontendAssetsFullURL: String,
+
 )
 
 object Config {
@@ -227,7 +224,8 @@ case class DataModelV3(
   designType: String,
   showBottomSocialButtons: Boolean,
   pageFooter: PageFooter,
-  publication: String
+  publication: String,
+  jsPageConfig: Map[String, JsValue]
 )
 
 object DataModelV3 {
@@ -276,7 +274,8 @@ object DataModelV3 {
       "designType" -> model.designType,
       "showBottomSocialButtons" -> model.showBottomSocialButtons,
       "pageFooter" -> model.pageFooter,
-      "publication" -> model.publication
+      "publication" -> model.publication,
+      "jsPageConfig" -> model.jsPageConfig
     )
   }
 
@@ -547,17 +546,12 @@ object DotcomponentsDataModel {
     val byline = article.trail.byline
 
     val config = Config(
-      ajaxUrl = Configuration.ajax.url,
-      sentryPublicApiKey = jsPageData.getOrElse("sentryPublicApiKey", ""),
-      sentryHost = jsPageData.getOrElse("sentryHost", ""),
       switches = switches,
-      dfpAccountId = Configuration.commercial.dfpAccountId,
       abTests = ActiveExperiments.getJsMap(request),
       commercialBundleUrl = buildFullCommercialUrl("javascripts/graun.dotcom-rendering-commercial.js"),
-      revisionNumber = ManifestData.revision.toString,
       googletagUrl = Configuration.googletag.jsLocation,
       stage = common.Environment.stage,
-      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
+      frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage)
     )
 
     val author = Author(
@@ -611,7 +605,8 @@ object DotcomponentsDataModel {
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(article),
       designType = findDesignType(article.metadata.designType, allTags),
       pageFooter = pageFooter,
-      publication = article.content.publication
+      publication = article.content.publication,
+      jsPageConfig = JavaScriptPage.getMap(articlePage, Edition(request), false)
     )
   }
 }


### PR DESCRIPTION
@shtukas is going to kindly give this a once over before merging. ❤️ 

## What does this change?

Passes all page values through to DCR. 

The following fields exist in the existing object so have been removed from DCR Config (but exist with the same names on DCR so *shouldn't* break anything!)

- "ajaxUrl": "http://localhost:9000", - Exists
- "sentryPublicApiKey": "344003a8d11c41d8800fbad8383fdc50", - Exists
- "sentryHost": "app.getsentry.com/35463", -Exists
- "dfpAccountId": "59666047", - Exists
- "revisionNumber": "DEV", -Exists

## Screenshots

![image](https://user-images.githubusercontent.com/638051/65241180-dacb6800-dada-11e9-8a64-2fd9d97e4126.png)

## What is the value of this and can you measure success?

All page fields added to DCR, in particular missing page targeting fields available for ads. It does also mean we won't miss any fields between Frontend and DCR in the future.

## Checklist

https://trello.com/c/X4W3aIQY/683-page-and-user-targeting