### PR TITLE
Add desktop breakpoint to commercialInline1Headings AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -15,8 +15,7 @@ export const commercialInline1Headings: ABTest = {
     idealOutcome:
         'No significant impact to performance as well as higher ad yield',
     showForSensitive: true,
-    canRun: () =>
-        isBreakpoint({ min: 'desktop' }),
+    canRun: () => isBreakpoint({ min: 'desktop' }),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-inline1-headings.js
@@ -1,4 +1,5 @@
 // @flow strict
+import { isBreakpoint } from 'lib/detect';
 
 export const commercialInline1Headings: ABTest = {
     id: 'CommercialInline1Headings',
@@ -14,7 +15,8 @@ export const commercialInline1Headings: ABTest = {
     idealOutcome:
         'No significant impact to performance as well as higher ad yield',
     showForSensitive: true,
-    canRun: () => true,
+    canRun: () =>
+        isBreakpoint({ min: 'desktop' }),
     variants: [
         {
             id: 'control',


### PR DESCRIPTION
## What does this change?
Adds desktop breakpoint to commercialInline1Headings AB test. The functionality is only been changed for desktop devices
