### PR TITLE
Move Public Profile tab to Manage Frontend

### DIFF
--- a/identity/app/controllers/editprofile/tabs/PublicTab.scala
+++ b/identity/app/controllers/editprofile/tabs/PublicTab.scala
@@ -1,5 +1,6 @@
 package controllers.editprofile.tabs
 
+import conf.Configuration
 import controllers.editprofile.{EditProfileControllerComponents, EditProfileFormHandling, PublicEditProfilePage}
 import play.api.mvc.{Action, AnyContent}
 
@@ -7,10 +8,12 @@ trait PublicTab
     extends EditProfileControllerComponents
     with EditProfileFormHandling {
 
+  private def redirectToManage(path: String): Action[AnyContent] = Action { implicit request =>
+    Redirect(
+      url = s"${Configuration.id.mmaUrl}/${path}",
+      MOVED_PERMANENTLY)
+  }
   /** GET /public/edit */
-  def displayPublicProfileForm: Action[AnyContent] = displayForm(PublicEditProfilePage)
-
-  /** POST /public/edit */
-  def submitPublicProfileForm(): Action[AnyContent] = submitForm(PublicEditProfilePage)
+  def redirectToPublicSettings: Action[AnyContent] = redirectToManage("public-settings")
 
 }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -75,7 +75,7 @@
         <div class="identity-wrapper identity-wrapper--wide monocolumn-wrapper">
                 <h1 class="identity-title" data-test-id="edit-profile-header">Edit your profile</h1>
                 <ol class="tabs__container tabs__container--multiple js-tabs js-account-profile-tabs" id="js-account-profile-tabs" role="tablist" data-is-bound="true">
-                    @tab(1, "Public profile", "/public/edit", None)
+                    @tab(1, "Public profile", "/public/edit", None, disableClientSideRouting = true)
 
                     @tab(2, "Account details", "/account/edit", Some("edit-account-details"), optionalClass="qa-account-details-tab")
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -46,8 +46,7 @@ GET         /delete/confirm                         controllers.AccountDeletionC
 ########################################################################################################################
 # EDIT PROFILE
 ########################################################################################################################
-GET         /public/edit                            controllers.editprofile.EditProfileController.displayPublicProfileForm
-POST        /public/edit                            controllers.editprofile.EditProfileController.submitPublicProfileForm
+GET         /public/edit                            controllers.editprofile.EditProfileController.redirectToPublicSettings
 
 GET         /account/edit                           controllers.editprofile.EditProfileController.displayAccountForm
 POST        /account/edit                           controllers.editprofile.EditProfileController.submitAccountForm

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -90,48 +90,6 @@ import scala.concurrent.Future
   }
 
   "EditProfileController" when {
-    "submitPublicProfileForm method is called with a valid CSRF request" should {
-      val location = "Test location"
-      val aboutMe = "Interesting"
-      val interests = "Other interesting things"
-      val username = "usernametest1"
-
-      "save the user through the ID API" in new EditProfileFixture {
-
-        val fakeRequest = FakeCSRFRequest(csrfAddToken)
-          .withFormUrlEncodedBody(
-            "location" -> location,
-            "aboutMe" -> aboutMe,
-            "interests" -> interests,
-            "username" -> username
-          )
-
-        val updatedUser = user.copy(
-          publicFields = PublicFields(
-            location = Some(location),
-            aboutMe = Some(aboutMe),
-            interests = Some(interests),
-            username = Some(username),
-            displayName = Some(username)
-          )
-        )
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
-          .thenReturn(Future.successful(Right(updatedUser)))
-
-        val result = controller.submitPublicProfileForm().apply(fakeRequest)
-
-        status(result) should be(200)
-
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
-        verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
-        val userUpdate = userUpdateCapture.getValue
-
-        userUpdate.publicFields.value.location.value should equal(location)
-        userUpdate.publicFields.value.aboutMe.value should equal(aboutMe)
-        userUpdate.publicFields.value.interests.value should equal(interests)
-      }
-    }
-
     "The submitAccountForm method" should {
       object FakeRequestAccountData {
         val primaryEmailAddress = "john.smith@bobmail.com"


### PR DESCRIPTION
## What does this change?
Completes the movement of the public profile tab from frontend/identity to the Manage Frontend project.

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

