### PR TITLE
1% experiment for the commercial features on DCR

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -28,7 +28,7 @@ object DotcomRenderingBeta extends Experiment(
   description = "Beta test for dotcom rendering version of site",
   owners = Seq(Owner.withGithub("nicl")),
   sellByDate = new LocalDate(2020, 12, 1),
-  participationGroup = Perc50 // see ArticlePicker.scala - our main filter mechanism is by page features
+  participationGroup = Perc1A // see ArticlePicker.scala - our main filter mechanism is by page features
 )
 
 object DotcomRenderingAdvertisements extends Experiment(

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,7 @@ import org.joda.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldTLSSupportDeprecation,
-    DotcomRenderingBeta
+    DotcomRenderingAdvertisements
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -22,10 +22,10 @@ object OldTLSSupportDeprecation extends Experiment(
   participationGroup = TLSSupport
 )
 
-object DotcomRenderingBeta extends Experiment(
-  name = "dotcom-rendering-beta",
-  description = "Beta test for dotcom rendering version of site",
-  owners = Seq(Owner.withGithub("nicl")),
+object DotcomRenderingAdvertisements extends Experiment(
+  name = "dotcom-rendering-advertisements",
+  description = "Activate the display of ads on DCR pages",
+  owners = Seq(Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc1A // see ArticlePicker.scala - our main filter mechanism is by page features
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,8 +7,7 @@ import org.joda.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldTLSSupportDeprecation,
-    DotcomRenderingBeta,
-    DotcomRenderingAdvertisements,
+    DotcomRenderingBeta
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -29,12 +28,4 @@ object DotcomRenderingBeta extends Experiment(
   owners = Seq(Owner.withGithub("nicl")),
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc1A // see ArticlePicker.scala - our main filter mechanism is by page features
-)
-
-object DotcomRenderingAdvertisements extends Experiment(
-  name = "dotcom-rendering-advertisements",
-  description = "Activate the display of ads on DCR pages",
-  owners = Seq(Owner.withGithub("shtukas")),
-  sellByDate = new LocalDate(2020, 12, 1),
-  participationGroup = Perc0A // see ArticlePicker.scala - our main filter mechanism is by page features
 )


### PR DESCRIPTION
## What does this change?

Swaps the 50% test for DCR beta into a 1% test, for use after we switch on commercial features.

After merging this PR:

- Pages with no commercial features will always be rendered in DCR as long as we support it. (i.e. the 50% abtest has been removed)
- Pages with commercial features will be subject to a 1% abtest

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
