### PR TITLE
Fix issues with IabCompliant AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Test the IAB compliant version of our CMP",
     owners = Seq(Owner.withGithub("ripecosta")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 9, 30),
+    sellByDate = new LocalDate(2019, 10, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -165,6 +165,7 @@ describe('DFP', () => {
             enableSingleRequest: jest.fn(),
             collapseEmptyDivs: jest.fn(),
             refresh: jest.fn(),
+            setRequestNonPersonalizedAds: jest.fn(),
         };
         const sizeMapping = {
             sizes: [],
@@ -404,7 +405,13 @@ describe('DFP', () => {
     describe('keyword targeting', () => {
         it('should send page level keywords', () => {
             onIabConsentNotification.mockImplementation(callback =>
-                callback({ '1': null })
+                callback({
+                    '1': true,
+                    '2': true,
+                    '3': true,
+                    '4': true,
+                    '5': true,
+                })
             );
             prepareGoogletag().then(() => {
                 expect(

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,15 +103,14 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
-            const consentState = state[1];
+            const consentState =
+                state[1] && state[2] && state[3] && state[4] && state[5];
 
-            if (consentState !== null) {
-                window.googletag.cmd.push(() => {
-                    window.googletag
-                        .pubads()
-                        .setRequestNonPersonalizedAds(consentState ? 0 : 1);
-                });
-            }
+            window.googletag.cmd.push(() => {
+                window.googletag
+                    .pubads()
+                    .setRequestNonPersonalizedAds(consentState ? 0 : 1);
+            });
         });
 
         // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -19,12 +19,10 @@ let scriptsInserted: boolean = false;
 
 const insertScripts = (services: Array<ThirdPartyTag>): void => {
     onIabConsentNotification(state => {
-        const consentState = state[1];
+        const consentState =
+            state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (
-            !scriptsInserted &&
-            (consentState === true || consentState === null)
-        ) {
+        if (!scriptsInserted && consentState) {
             scriptsInserted = true;
 
             const ref = document.scripts[0];

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,10 +1,16 @@
 // @flow
+import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
+
+const onIabConsentNotification: any = onIabConsentNotification_;
 
 const { insertScripts, loadOther } = _;
 
 jest.mock('lib/raven');
+jest.mock('@guardian/consent-management-platform', () => ({
+    onIabConsentNotification: jest.fn(),
+}));
 
 beforeEach(() => {
     const firstScript = document.createElement('script');
@@ -84,8 +90,18 @@ describe('third party tags', () => {
         };
         it('should add a script to the document', () => {
             _.reset();
+            onIabConsentNotification.mockImplementation(callback =>
+                callback({
+                    '1': true,
+                    '2': true,
+                    '3': true,
+                    '4': true,
+                    '5': true,
+                })
+            );
+            console.log('*** before: ', document.scripts);
             insertScripts([fakeThirdPartyTag]);
-
+            console.log('*** after: ', document.scripts);
             expect(document.scripts.length).toBe(2);
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -99,9 +99,7 @@ describe('third party tags', () => {
                     '5': true,
                 })
             );
-            console.log('*** before: ', document.scripts);
             insertScripts([fakeThirdPartyTag]);
-            console.log('*** after: ', document.scripts);
             expect(document.scripts.length).toBe(2);
         });
     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -86,13 +86,14 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
 
 const createAdsConfig = (
     adFree: boolean,
+    wantPersonalisedAds: boolean,
     isPfpAdTargetingSwitchedOn: boolean
 ): Object => {
     if (adFree) {
         return { disableAds: true };
     } else if (isPfpAdTargetingSwitchedOn) {
         return {
-            nonPersonalizedAd: !consentState,
+            nonPersonalizedAd: !wantPersonalisedAds,
             adTagParameters: {
                 iu: config.get('page.adUnit'),
                 cust_params: encodeURIComponent(
@@ -101,7 +102,7 @@ const createAdsConfig = (
             },
         };
     }
-    return { nonPersonalizedAd: !consentState };
+    return { nonPersonalizedAd: !wantPersonalisedAds };
 };
 
 const setupPlayer = (
@@ -129,6 +130,7 @@ const setupPlayer = (
 
     const adsConfig = createAdsConfig(
         commercialFeatures.adFree,
+        !!consentState,
         isPfpAdTargetingSwitchedOn
     );
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -34,7 +34,7 @@ type Handlers = {
 
 let consentState;
 onIabConsentNotification(state => {
-    consentState = state[1];
+    consentState = state[1] && state[2] && state[3] && state[4] && state[5];
 });
 
 const onPlayerStateChangeEvent = (
@@ -86,14 +86,13 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
 
 const createAdsConfig = (
     adFree: boolean,
-    wantPersonalisedAds: boolean,
     isPfpAdTargetingSwitchedOn: boolean
 ): Object => {
     if (adFree) {
         return { disableAds: true };
     } else if (isPfpAdTargetingSwitchedOn) {
         return {
-            nonPersonalizedAd: !wantPersonalisedAds,
+            nonPersonalizedAd: !consentState,
             adTagParameters: {
                 iu: config.get('page.adUnit'),
                 cust_params: encodeURIComponent(
@@ -102,7 +101,7 @@ const createAdsConfig = (
             },
         };
     }
-    return { nonPersonalizedAd: !wantPersonalisedAds };
+    return { nonPersonalizedAd: !consentState };
 };
 
 const setupPlayer = (
@@ -113,7 +112,6 @@ const setupPlayer = (
     onStateChange,
     onError
 ) => {
-    const wantPersonalisedAds: boolean = consentState !== false;
     const isPfpAdTargetingSwitchedOn: boolean = config.get(
         'switches.commercialYoutubePfpAdTargeting',
         false
@@ -131,7 +129,6 @@ const setupPlayer = (
 
     const adsConfig = createAdsConfig(
         commercialFeatures.adFree,
-        wantPersonalisedAds,
         isPfpAdTargetingSwitchedOn
     );
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -204,8 +204,8 @@ const buildPageTargetting = (
 ): { [key: string]: mixed } => {
     const page = config.get('page');
     // personalised ads targeting
-    const paTargeting: {} =
-        adConsentState !== null ? { pa: adConsentState ? 't' : 'f' } : {};
+    // flowlint-next-line sketchy-null-bool:off
+    const paTargeting: {} = { pa: adConsentState ? 't' : 'f' };
     const adFreeTargeting: {} = commercialFeatures.adFree ? { af: 't' } : {};
     const pageTargets: PageTargeting = Object.assign(
         {
@@ -256,7 +256,8 @@ const getPageTargeting = (): { [key: string]: mixed } => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
     onIabConsentNotification(state => {
-        const consentState = state[1];
+        const consentState =
+            state[1] && state[2] && state[3] && state[4] && state[5];
 
         if (consentState !== latestConsentState) {
             myPageTargetting = buildPageTargetting(consentState);

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -69,6 +69,8 @@ const falseConsentMock = (callback): void =>
     callback({ '1': false, '2': false, '3': false, '4': false, '5': false });
 const nullConsentMock = (callback): void =>
     callback({ '1': null, '2': null, '3': null, '4': null, '5': null });
+const mixedConsentMock = (callback): void =>
+    callback({ '1': false, '2': true, '3': true, '4': false, '5': true });
 
 describe('Build Page Targeting', () => {
     beforeEach(() => {
@@ -169,6 +171,14 @@ describe('Build Page Targeting', () => {
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(falseConsentMock);
+        expect(getPageTargeting().pa).toBe('f');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(nullConsentMock);
+        expect(getPageTargeting().pa).toBe('f');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(mixedConsentMock);
         expect(getPageTargeting().pa).toBe('f');
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -63,9 +63,12 @@ jest.mock('@guardian/consent-management-platform', () => ({
     onIabConsentNotification: jest.fn(),
 }));
 
-const trueConsentMock = (callback): void => callback({ '1': true });
-const falseConsentMock = (callback): void => callback({ '1': false });
-const nullConsentMock = (callback): void => callback({ '1': null });
+const trueConsentMock = (callback): void =>
+    callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
+const falseConsentMock = (callback): void =>
+    callback({ '1': false, '2': false, '3': false, '4': false, '5': false });
+const nullConsentMock = (callback): void =>
+    callback({ '1': null, '2': null, '3': null, '4': null, '5': null });
 
 describe('Build Page Targeting', () => {
     beforeEach(() => {
@@ -155,7 +158,7 @@ describe('Build Page Targeting', () => {
         expect(pageTargeting.tn).toEqual(['news']);
         expect(pageTargeting.vl).toEqual('90');
         expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
-        expect(pageTargeting.pa).toEqual(undefined);
+        expect(pageTargeting.pa).toEqual('f');
         expect(pageTargeting.cc).toEqual('US');
         expect(pageTargeting.pr).toEqual('dotcom-platform');
     });
@@ -220,6 +223,7 @@ describe('Build Page Targeting', () => {
             pv: '123456',
             fr: '0',
             inskin: 'f',
+            pa: 'f',
             cc: 'US',
             pr: 'dotcom-platform',
         });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-compliant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-compliant.js
@@ -3,7 +3,7 @@
 export const commercialIabCompliant: ABTest = {
     id: 'CommercialIabCompliant',
     start: '2018-08-13',
-    expiry: '2019-09-30',
+    expiry: '2019-10-30',
     author: 'Ricardo Costa',
     description: '0% participation AB test for the IAB compliant CMP',
     audience: 0,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -12,6 +12,8 @@ import ophan from 'ophan/ng';
 import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
 
 type Template = {
     heading: string,
@@ -101,7 +103,9 @@ const trackInteraction = (interaction: string): void => {
 
 const canShow = (): Promise<boolean> =>
     Promise.resolve(
-        hasUnsetAdChoices() && !hasUserAcknowledgedBanner(messageCode)
+        hasUnsetAdChoices() &&
+            !hasUserAcknowledgedBanner(messageCode) &&
+            !isInVariantSynchronous(commercialIabCompliant, 'variant')
     );
 
 const track = (): void => {


### PR DESCRIPTION
## What does this change?
Fixes 3 issues with the IabCompliant AB test:
- Extend the test until the end of October
- Prevent the regular banner from showing when users are on the variant
- Change the way consent is checked (use all 5 IAB purposes instead of just one)