### PR TITLE
Add transforms to new CMP UI 

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -13,13 +13,9 @@ let uiPrepared: boolean = false;
 
 const onReadyCmp = (): void => {
     if (container && container.parentNode) {
-        fastdom
-            .write(() => {
-                if (container && container.parentNode) {
-                    container.classList.add(CMP_READY_CLASS);
-                }
-            })
-            .then(() => {
+        fastdom.write(() => {
+            if (container && container.parentNode) {
+                container.classList.add(CMP_READY_CLASS);
                 /**
                  * Adding CMP_READY_CLASS changes display: none to display: block
                  * on the overlay. You can't update this display property and transition
@@ -32,13 +28,22 @@ const onReadyCmp = (): void => {
                         container.classList.add(CMP_ANIMATE_CLASS);
                     }
                 }, 0);
-            });
+                // disable scrolling on body beneath overlay
+                if (document.body) {
+                    document.body.classList.add('no-scroll');
+                }
+            }
+        });
     }
 };
 
 const onCloseCmp = (): void => {
     fastdom.write(() => {
         if (container && container.parentNode) {
+            // enable scrolling on body beneath overlay
+            if (document.body) {
+                document.body.classList.remove('no-scroll');
+            }
             container.classList.remove(CMP_READY_CLASS);
             container.classList.remove(CMP_ANIMATE_CLASS);
             container.remove();

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -106,11 +106,31 @@ describe('cmp-ui', () => {
                         container.classList.contains(_.CMP_READY_CLASS)
                     ).toBe(false);
 
-                    _.onReadyCmp();
+                    return _.onReadyCmp().then(() => {
+                        expect(
+                            container.classList.contains(_.CMP_READY_CLASS)
+                        ).toBe(true);
+                    });
+                }
+            });
 
+            it('onReadyCmp adds the animate class to the container', () => {
+                consentManagementPlatformUi.show();
+
+                const container = document.querySelectorAll(overlaySelector)[0];
+
+                expect(container).toBeTruthy();
+
+                if (container) {
                     expect(
-                        container.classList.contains(_.CMP_READY_CLASS)
-                    ).toBe(true);
+                        container.classList.contains(_.CMP_ANIMATE_CLASS)
+                    ).toBe(false);
+
+                    return _.onReadyCmp().then(() => {
+                        expect(
+                            container.classList.contains(_.CMP_ANIMATE_CLASS)
+                        ).toBe(true);
+                    });
                 }
             });
 
@@ -120,19 +140,23 @@ describe('cmp-ui', () => {
                 const container = document.querySelectorAll(overlaySelector)[0];
 
                 if (container) {
-                    _.onReadyCmp();
+                    return _.onReadyCmp()
+                        .then(() => {
+                            expect(
+                                container.classList.contains(_.CMP_READY_CLASS)
+                            ).toBe(true);
 
-                    expect(
-                        container.classList.contains(_.CMP_READY_CLASS)
-                    ).toBe(true);
-                    expect(container.parentNode).toBeTruthy();
+                            expect(container.parentNode).toBeTruthy();
 
-                    _.onCloseCmp();
+                            return _.onCloseCmp();
+                        })
+                        .then(() => {
+                            expect(
+                                container.classList.contains(_.CMP_READY_CLASS)
+                            ).toBe(false);
 
-                    expect(
-                        container.classList.contains(_.CMP_READY_CLASS)
-                    ).toBe(false);
-                    expect(container.parentNode).toBeFalsy();
+                            expect(container.parentNode).toBeFalsy();
+                        });
                 }
             });
         });

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -38,3 +38,11 @@
         transform: translateX(calc(100vw - 100%));
     }
 }
+
+// Prevent body scrolling behind overlay
+body.no-scroll {
+    overflow: hidden;
+    position: fixed;
+    left: 0;
+    right: 0;
+}

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -1,32 +1,40 @@
 .cmp-overlay {
-    background-color: rgba(#000000, .5);
     position: fixed;
     top: 0;
     right: 0;
-    width: 100%;
-    height: 100%;
+    left: 0;
+    bottom: 0;
     padding: 0;
     margin: 0;
     z-index: 9999;
     display: none;
+    transition: background-color;
+    transition-delay: .25s;
 
     &.cmp-iframe-ready {
         display: block;
     }
+
+    &.cmp-iframe-animate {
+        background-color: rgba(#000000, .5);
+    }
 }
 
 .cmp-iframe {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    top: 0;
-    height: 100%;
-    width: 100%;
     z-index: 9999;
     border: 0;
+    height: 100%;
+    width: 100%;
+    max-width: 576px;
+    transform: translateX(100vw);
+    transition: transform .25s ease-in;
 
-    @include mq(phablet) {
-        min-width: 576px;
+    @include mq(mobileLandscape) {
         width: 30%;
+        min-width: 480px;
+    }
+
+    .cmp-iframe-animate & {
+        transform: translateX(calc(100vw - 100%));
     }
 }


### PR DESCRIPTION
## What does this change?

The new CMP UI is still behind a 0% A/B test. This PR updates the way the CMP UI appears on the page. By default it is positioned just off the righthand side of the screen, when the `CMP_READY_CLASS` and `CMP_ANIMATE_CLASS`  have been added to the overlay we slide it into view. Once it has transitioned into view we add the opacity to the overlay and prevent the body beneath the overlay from being scrollable.

## Screenshots

**Mobile...**

![cmp-animate-mobile](https://user-images.githubusercontent.com/1590704/65524505-cd045100-dee5-11e9-8f50-b6efb5cd9ffc.gif)

**Desktop...**

![cmp-animate-desktop](https://user-images.githubusercontent.com/1590704/65524559-ec02e300-dee5-11e9-8f4a-7666b4ad6301.gif)