### PR TITLE
Reverse the new CMP UI animation on close and slow it down

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -47,17 +47,19 @@ const onReadyCmp = (): Promise<void> =>
 
 const removeCmp = (): Promise<void> =>
     /**
-     *  Wait for trtansition duration (500ms)
+     *  Wait for transition duration (500ms)
      *  to end before removing container
      */
     new Promise(resolve => {
         setTimeout(() => {
-            if (container && container.parentNode) {
-                container.remove();
-                container.classList.remove(CMP_READY_CLASS);
-            }
-
-            resolve();
+            fastdom
+                .write(() => {
+                    if (container && container.parentNode) {
+                        container.remove();
+                        container.classList.remove(CMP_READY_CLASS);
+                    }
+                })
+                .then(resolve);
         }, 500);
     });
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -88,6 +88,7 @@ const prepareUi = (): void => {
     const iframe = document.createElement('iframe');
     iframe.src = cmpConfig.CMP_URL;
     iframe.className = IFRAME_CLASS;
+    iframe.tabIndex = 1;
 
     container.appendChild(iframe);
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -45,18 +45,35 @@ const onReadyCmp = (): Promise<void> =>
         })
         .then(animateCmp);
 
-const onCloseCmp = (): Promise<void> =>
-    fastdom.write(() => {
-        if (container && container.parentNode) {
-            // enable scrolling on body beneath overlay
-            if (document.body) {
-                document.body.classList.remove('no-scroll');
+const removeCmp = (): Promise<void> =>
+    /**
+     *  Wait for trtansition duration (500ms)
+     *  to end before removing container
+     */
+    new Promise(resolve => {
+        setTimeout(() => {
+            if (container && container.parentNode) {
+                container.remove();
+                container.classList.remove(CMP_READY_CLASS);
             }
-            container.classList.remove(CMP_READY_CLASS);
-            container.classList.remove(CMP_ANIMATE_CLASS);
-            container.remove();
-        }
+
+            resolve();
+        }, 500);
     });
+
+const onCloseCmp = (): Promise<void> =>
+    fastdom
+        .write(() => {
+            if (container && container.parentNode) {
+                // enable scrolling on body beneath overlay
+                if (document.body) {
+                    document.body.classList.remove('no-scroll');
+                }
+
+                container.classList.remove(CMP_ANIMATE_CLASS);
+            }
+        })
+        .then(removeCmp);
 
 const prepareUi = (): void => {
     if (uiPrepared) {

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -9,7 +9,7 @@
     z-index: 9999;
     display: none;
     transition: background-color;
-    transition-delay: .25s;
+    transition-delay: .5s;
 
     &.cmp-iframe-ready {
         display: block;
@@ -27,7 +27,7 @@
     width: 100%;
     max-width: 576px;
     transform: translateX(100vw);
-    transition: transform .25s ease-in;
+    transition: transform .5s ease-in;
 
     @include mq(mobileLandscape) {
         width: 30%;


### PR DESCRIPTION
## What does this change?

This PR reverses the new CMP UI animation when a user closes/saves so it slides off screen rather than disappearing immediately, I've also slowed the `transition-duration` from .25s to .5s.

## What is the value of this and can you measure success?

Better look and feel for the CMP UI.