### PR TITLE
Add correct rendering platform param

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -226,7 +226,9 @@ const buildPageTargetting = (
                 : undefined,
             cc: geolocationGetSync(),
             s: page.section, // for reference in a macro, so cannot be extracted from ad unit
-            pr: 'dotcom-platform', // rendering platform
+            rp: config.get('isDotcomRendering', false)
+                ? 'dotcom-rendering'
+                : 'dotcom-platform', // rendering platform
             inskin: inskinTargetting(),
         },
         page.sharedAdTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -162,7 +162,7 @@ describe('Build Page Targeting', () => {
         expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
         expect(pageTargeting.pa).toEqual('f');
         expect(pageTargeting.cc).toEqual('US');
-        expect(pageTargeting.pr).toEqual('dotcom-platform');
+        expect(pageTargeting.rp).toEqual('dotcom-platform');
     });
 
     it('should set correct personalized ad (pa) param', () => {
@@ -235,7 +235,7 @@ describe('Build Page Targeting', () => {
             inskin: 'f',
             pa: 'f',
             cc: 'US',
-            pr: 'dotcom-platform',
+            rp: 'dotcom-platform',
         });
     });
 


### PR DESCRIPTION
## What does this change?

DFP expects the field `rp` not `pr` and should vary between `dotcom-platform` and `dotcom-rendering`. This will allow us to differentiate page views between platforms.

## What is the value of this and can you measure success?

Tracking and reporting.

