### PR TITLE
Fix logging of failed DCR requests

### DIFF
--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -48,10 +48,10 @@ class RemoteRenderer extends Logging {
                 .withHeaders("X-GU-Dotcomponents" -> "true")
             case 400 =>
               // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
-              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error"))
+              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
                 .withHeaders("X-GU-Dotcomponents" -> "true")
             case _ =>
-              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer error"))
+              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer error (500)"))
                 .withHeaders("X-GU-Dotcomponents" -> "true")
           }
         })

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -8,7 +8,7 @@ import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
 import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
-import model.{Cached, PageWithStoryPackage}
+import model.{Cached, PageWithStoryPackage, NoCache}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
@@ -36,6 +36,7 @@ class RemoteRenderer extends Logging {
   )(implicit request: RequestHeader): Future[Result] = {
 
     def get(): Future[Result] = {
+
       ws.url(endpoint)
         .withRequestTimeout(Configuration.rendering.timeout)
         .addHttpHeaders("Content-Type" -> "application/json")
@@ -43,12 +44,15 @@ class RemoteRenderer extends Logging {
         .map(response => {
           response.status match {
             case 200 =>
-              Cached(article)(RevalidatableResult.OkDotcomponents(Html(response.body)))
+              Cached(article)(RevalidatableResult.Ok(Html(response.body)))
+                .withHeaders("X-GU-Dotcomponents" -> "true")
             case 400 =>
-              log.error("Remote renderer validation error: " + response.body)
-              throw new Exception(response.body)
+              // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
+              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error"))
+                .withHeaders("X-GU-Dotcomponents" -> "true")
             case _ =>
-              throw new Exception(response.body)
+              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer error"))
+                .withHeaders("X-GU-Dotcomponents" -> "true")
           }
         })
     }

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -60,9 +60,6 @@ object Cached extends implicits.Dates {
       apply(Results.Ok(content), content)
     }
 
-    def OkDotcomponents[C](content: C)(implicit writeable: Writeable[C]): RevalidatableResult = {
-      apply(Results.Ok(content).withHeaders("X-GU-Dotcomponents" -> "true"), content)
-    }
   }
 
 


### PR DESCRIPTION
## What does this change?

See these charts?

![image](https://user-images.githubusercontent.com/1218561/65612348-030c0880-dfac-11e9-9b29-4a4d2a6fb4c0.png)

The bottom-left one (DCR status codes) was only ever filled with 200s, even when DCR was failing.

We're *supposed* to add a header to the response that lets the request logger know it's being served by DCR. But when DCR fails, we just throw an exception, so the header is never added, so Kibana doesn't see it as a DCR request.

This PR makes it so that instead of just throwing an exception on failure, we return an explicit server error response, with the header added to it. This fixes the bug.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
