### PR TITLE
Strip header and footer from /privacy-settings on profile subdomain

### DIFF
--- a/identity/app/controllers/AdvertsManager.scala
+++ b/identity/app/controllers/AdvertsManager.scala
@@ -24,7 +24,7 @@ class AdvertsManager(
   with Mappings
   with Forms {
 
-  val page = IdentityPage("/privacy-settings", "Cookies and advertising settings", usesGuardianHeader = true)
+  val page = IdentityPage("/privacy-settings", "Cookies and advertising settings", isFlow = true)
 
   def renderAdvertsManager(returnUrl: Option[String]): Action[AnyContent] = Action { implicit request =>
 


### PR DESCRIPTION
The profile subdomain does not set the "X-GU-EDITION" header, meaning that all links on the profile subdomain redirect to the default edition (UK). So a user from say the US on this page ([https://profile.theguardian.com/privacy-settings](https://profile.theguardian.com/privacy-settings)) would be linked to the UK version of the site.

This particular page will be moved over to manage at some point in the future. For now stripping out the header and footer brings it in line with other pages on the profile subdomain, until this gets moved over.

To get to this privacy-settings page, a user would have to click "More Options" on the consent banner. AFAIK this page isn't linked to from anywhere else.

### Tested
- [X] Locally
- [ ] On CODE (optional)