### PR TITLE
Add classNames parameter to epic variants

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -29,6 +29,7 @@ declare type EpicVariant = Variant & {
     subscribeURL: string,
     componentName: string,
     template: EpicTemplate,
+    classNames: string[],
     showTicker: boolean,
 
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
@@ -97,6 +98,7 @@ declare type InitEpicABTestVariant = {
     buttonTemplate?: (CtaUrls, ctaText?: string) => string,
     ctaText?: string,
     copy?: AcquisitionsEpicTemplateCopy,
+    classNames?: string[],
     showTicker?: boolean,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -108,6 +108,7 @@ const controlTemplate: EpicTemplate = (
                   variant.ctaText
               )
             : undefined,
+        epicClassNames: variant.classNames,
         showTicker: variant.showTicker,
         backgroundImageUrl: variant.backgroundImageUrl,
     });
@@ -276,6 +277,7 @@ const makeEpicABTestVariant = (
         buttonTemplate: initVariant.buttonTemplate,
         ctaText: initVariant.ctaText,
         copy: initVariant.copy,
+        classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,
         backgroundImageUrl: initVariant.backgroundImageUrl,
         deploymentRules,
@@ -646,6 +648,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
                   }
                 : {}),
             copy: buildEpicCopy(variant, test.hasCountryName, geolocation),
+            classNames: variant.classNames,
             showTicker: optionalStringToBoolean(variant.showTicker),
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -30,6 +30,7 @@ const rawTest = {
                 maxViewsCount: 4,
                 minDaysBetweenViews: 0,
             },
+            classNames: ['test-class'],
         },
     ],
     highPriority: false,
@@ -49,6 +50,7 @@ describe('buildConfiguredEpicTestFromJson', () => {
         expect(variant.id).toBe('Control');
         expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
         expect(variant.tagIds).toEqual(['football/football']);
+        expect(variant.classNames).toEqual(['test-class']);
         expect(variant.copy).toEqual({
             heading: 'This was made using the new tool!',
             paragraphs: ['testing testing', 'this is a test'],

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -29,9 +29,10 @@ export const acquisitionsEpicControlTemplate = ({
     showTicker: boolean,
     backgroundImageUrl?: string,
 }) => {
-    const extraClasses = epicClassNames
-        .concat([backgroundImageUrl ? 'contributions__epic--with-image' : ''])
-        .join(' ');
+    const extraClasses = (backgroundImageUrl
+        ? epicClassNames.concat(['contributions__epic--with-image'])
+        : epicClassNames
+    ).join(' ');
 
     return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -15,6 +15,7 @@ const buildImage = (url: string): string =>
 export const acquisitionsEpicControlTemplate = ({
     copy: { heading = '', paragraphs, highlightedText, footer },
     componentName,
+    epicClassNames = [],
     buttonTemplate,
     wrapperClass = '',
     showTicker = false,
@@ -22,14 +23,15 @@ export const acquisitionsEpicControlTemplate = ({
 }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
+    epicClassNames: string[],
     buttonTemplate?: string,
     wrapperClass?: string,
     showTicker: boolean,
     backgroundImageUrl?: string,
 }) => {
-    const extraClasses = backgroundImageUrl
-        ? 'contributions__epic--with-image'
-        : '';
+    const extraClasses = epicClassNames
+        .concat([backgroundImageUrl ? 'contributions__epic--with-image' : ''])
+        .join(' ');
 
     return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">


### PR DESCRIPTION
## What does this change?
Adds the ability to pass css class names into Epic test variants, to add custom styling to the epic.
We used to have this functionality, but I removed it [here](https://github.com/guardian/frontend/pull/21424/files) when we began using a template.
So this PR adds that logic back in.

Next up, we'll need to add support in the Epic tests tool to allow users to set it.
We expect to use custom css for the upcoming Moment.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
