### PR TITLE
Special report label link color

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-special-report.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-special-report.scss
@@ -36,7 +36,8 @@
     .content__labels {
         background-color: $highlight-main;
 
-        .content__series-label__link {
+        .content__series-label__link,
+        .content__label__link {
             color: $brightness-7;
         }
     }


### PR DESCRIPTION
## What does this change?
There is an issue on this article where the series label should be darker against the highlighted background.

https://www.theguardian.com/news/2016/apr/08/mossack-fonseca-law-firm-hide-money-panama-papers

## Screenshots

| Current | Expected |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/65959441-e52a2200-e449-11e9-87a8-353831efe31e.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/65959638-6f728600-e44a-11e9-9a0b-d98808609884.png" width="300px" />

## What is the value of this and can you measure success?
Make the label more accessible.
I haven't got the frontend project running locally so would need some help to test this.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
