### PR TITLE
Set Epic css classes from test/variant names

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -648,7 +648,10 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
                   }
                 : {}),
             copy: buildEpicCopy(variant, test.hasCountryName, geolocation),
-            classNames: variant.classNames,
+            classNames: [
+                `contributions__epic--${test.name}`,
+                `contributions__epic--${test.name}-${variant.name}`,
+            ],
             showTicker: optionalStringToBoolean(variant.showTicker),
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -6,7 +6,7 @@ jest.mock('lib/raven');
 jest.mock('ophan/ng', () => null);
 
 const rawTest = {
-    name: 'My test',
+    name: 'my_test',
     isOn: true,
     locations: ['UnitedStates', 'Australia'],
     tagIds: ['football/football'],
@@ -30,7 +30,6 @@ const rawTest = {
                 maxViewsCount: 4,
                 minDaysBetweenViews: 0,
             },
-            classNames: ['test-class'],
         },
     ],
     highPriority: false,
@@ -40,7 +39,7 @@ const rawTest = {
 describe('buildConfiguredEpicTestFromJson', () => {
     it('Parses and constructs an epic test', () => {
         const test = buildConfiguredEpicTestFromJson(rawTest);
-        expect(test.id).toBe('My test');
+        expect(test.id).toBe('my_test');
         expect(test.useLocalViewLog).toBe(false);
         expect(test.userCohort).toBe('AllNonSupporters');
 
@@ -50,7 +49,10 @@ describe('buildConfiguredEpicTestFromJson', () => {
         expect(variant.id).toBe('Control');
         expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
         expect(variant.tagIds).toEqual(['football/football']);
-        expect(variant.classNames).toEqual(['test-class']);
+        expect(variant.classNames).toEqual([
+            'contributions__epic--my_test',
+            'contributions__epic--my_test-Control',
+        ]);
         expect(variant.copy).toEqual({
             heading: 'This was made using the new tool!',
             paragraphs: ['testing testing', 'this is a test'],


### PR DESCRIPTION
## What does this change?
With thanks to @jlieb10 for the idea.
Rather than setting css classes in the Epic tests tool (not user friendly!), just construct two classes based on the name:
`contributions__epic--test_name`
`contributions__epic--test_name-variant_name`

We can then define a class in the stylesheet for a specific test or variant.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
