### PR TITLE
Add a subject field to the userhelp feedback form

### DIFF
--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -22,6 +22,7 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
     val feedbackForm = Form(
       tuple(
         "category" -> text,
+        "subject" -> text,
         "body" -> text,
         "user" -> text,
         "extra" -> text,
@@ -29,19 +30,22 @@ class TechFeedbackController(ws: WSClient, val controllerComponents: ControllerC
       )
     )
 
-    val (category, body, user, extra, name) = feedbackForm.bindFromRequest.get
+    val (category, subject, body, user, extra, name) = feedbackForm.bindFromRequest.get
 
     log.info(s"feedback submitted for category: $category")
 
+    val payload = Json.obj(
+      "category" -> java.net.URLEncoder.encode(category, "UTF-8"),
+      "subject" -> java.net.URLEncoder.encode(subject, "UTF-8"),
+      "body" -> java.net.URLEncoder.encode(body, "UTF-8"),
+      "user" -> java.net.URLEncoder.encode(user, "UTF-8"),
+      "extra" -> java.net.URLEncoder.encode(extra, "UTF-8"),
+      "name" -> java.net.URLEncoder.encode(name, "UTF-8")
+    )
+
     ws.url(Configuration.feedback.feedpipeEndpoint)
       .withRequestTimeout(6000.millis)
-      .post(Json.obj(
-        "category" -> java.net.URLEncoder.encode(category, "UTF-8"),
-        "body" -> java.net.URLEncoder.encode(body, "UTF-8"),
-        "user" -> java.net.URLEncoder.encode(user, "UTF-8"),
-        "extra" -> java.net.URLEncoder.encode(extra, "UTF-8"),
-        "name" -> java.net.URLEncoder.encode(name, "UTF-8")
-      ))
+      .post(payload)
 
     val page = model.SimplePage(MetaData.make(
       request.path,

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -66,8 +66,12 @@
                                         <input class="feedback__element" name="extra" type="hidden" value="none available"/>
 
                                         <div class="feedback__element">
+                                            <label for="fb-subject-entry">Subject</label>
+                                            <input name="subject" class="feedback__entry feedback__input--wide" id="fb-subject-entry" type="text" value="" placeholder="A short description of your problem/feedback" required>
+                                        </div>
+                                        <div class="feedback__element">
                                             <label for="fb-desc-entry">Description</label>
-                                            <textarea name="body" id="fb-desc-entry" class="feedback__entry feedback__input--wide feedback__textarea" placeholder="Please provide a description of your problem or feedback" required></textarea>
+                                            <textarea name="body" id="fb-desc-entry" class="feedback__entry feedback__input--wide feedback__textarea" placeholder="Please provide a complete description of your problem or feedback" required></textarea>
                                         </div>
                                         <div class="feedback__element">
                                             <label for="fb-name-entry">Name</label>


### PR DESCRIPTION
## What does this change?

Adds a subject field to the userhelp feedback to reduce the amount of work they have to do. I've promised I'd get this done for a long time now.

**Do not merge this until the associated PR on the feedpipe API has been merged**

## Screenshots

![image](https://user-images.githubusercontent.com/1218561/66043055-13753380-e516-11e9-9be9-516d5d26d2a1.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
