### PR TITLE
fix layout issues with the CMP UI

### DIFF
--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -9,37 +9,43 @@
     z-index: 9999;
     display: none;
     transition: background-color;
-    transition-delay: .5s;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    -webkit-overflow-scrolling: touch;
+    transition-delay: .6s;
+    will-change: background-color;
 
     &.cmp-iframe-ready {
         display: block;
     }
 
-    &.cmp-iframe-animate {
+    &.cmp-animate {
         background-color: rgba(#000000, .5);
     }
 }
 
-.cmp-iframe {
+.cmp-container {
     z-index: 9999;
     border: 0;
     height: 100%;
     width: 100%;
     max-width: 576px;
     transform: translateX(100vw);
-    transition: transform .5s ease-in;
+    transition: transform .6s ease-in;
+    will-change: transform;
+    position: relative;
 
     @include mq(mobileLandscape) {
         width: 30%;
         min-width: 480px;
     }
 
-    .cmp-iframe-animate & {
+    .cmp-animate & {
         transform: translateX(calc(100vw - 100%));
     }
+}
+
+.cmp-iframe {
+    position: absolute;
+    height: 100%;
+    width: 100%;
 }
 
 // Prevent body scrolling behind overlay

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -46,6 +46,7 @@
     position: absolute;
     height: 100%;
     width: 100%;
+    border: 0;
 }
 
 // Prevent body scrolling behind overlay


### PR DESCRIPTION
## What does this change?

Fixes layout issues caused by these rules being added to the overlay:

```css
overflow-y: scroll;
overflow-x: hidden;	
-webkit-overflow-scrolling: touch;
```

They were added to enable scrolling on iOS but they're no longer required. 

We're also now wrapping the `iframe` in a containing `div` and we've also added `will-change` css properties to the overlay and the iframe container.
