### PR TITLE
Add Mobile sticky ad to Australia and New Zealand

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -143,7 +143,7 @@ export const shouldIncludeMobileSticky = once(
         window.location.hash.indexOf('#mobile-sticky') !== -1 ||
         (config.get('switches.mobileStickyLeaderboard') &&
             isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) &&
-            isInUsRegion() &&
+            (isInUsRegion() || isInAuRegion()) &&
             config.get('page.contentType') === 'Article')
 );
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -358,7 +358,7 @@ describe('Utils', () => {
         }
     });
 
-    test('shouldIncludeMobileSticky should be true if location cookie is NA, switch is ON and content is Article on mobiles ', () => {
+    test('shouldIncludeMobileSticky should be true if geolocation is NA, switch is ON and content is Article on mobiles ', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
         getSync.mockReturnValue('US');
@@ -366,7 +366,7 @@ describe('Utils', () => {
         expect(shouldIncludeMobileSticky()).toBe(true);
     });
 
-    test('should include mobile sticky if location cookie is AUS, switch is ON and content is Article on mobiles ', () => {
+    test('should include mobile sticky if geolocation is AUS, switch is ON and content is Article on mobiles ', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
         getSync.mockReturnValue('AU');
@@ -374,7 +374,7 @@ describe('Utils', () => {
         expect(shouldIncludeMobileSticky()).toBe(true);
     });
 
-    test('should include mobile sticky if location cookie is NZ, switch is ON and content is Article on mobiles ', () => {
+    test('should include mobile sticky if geolocation is NZ, switch is ON and content is Article on mobiles ', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);
         getSync.mockReturnValue('NZ');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -358,28 +358,14 @@ describe('Utils', () => {
         }
     });
 
-    test('shouldIncludeMobileSticky should be true if geolocation is NA, switch is ON and content is Article on mobiles ', () => {
-        config.set('page.contentType', 'Article');
-        config.set('switches.mobileStickyLeaderboard', true);
-        getSync.mockReturnValue('US');
-        isBreakpoint.mockReturnValue(true);
-        expect(shouldIncludeMobileSticky()).toBe(true);
-    });
-
-    test('should include mobile sticky if geolocation is AUS, switch is ON and content is Article on mobiles ', () => {
-        config.set('page.contentType', 'Article');
-        config.set('switches.mobileStickyLeaderboard', true);
-        getSync.mockReturnValue('AU');
-        isBreakpoint.mockReturnValue(true);
-        expect(shouldIncludeMobileSticky()).toBe(true);
-    });
-
-    test('should include mobile sticky if geolocation is NZ, switch is ON and content is Article on mobiles ', () => {
-        config.set('page.contentType', 'Article');
-        config.set('switches.mobileStickyLeaderboard', true);
-        getSync.mockReturnValue('NZ');
-        isBreakpoint.mockReturnValue(true);
-        expect(shouldIncludeMobileSticky()).toBe(true);
+    ['US', 'CA', 'AU', 'NZ'].forEach(region => {
+        test(`should include mobile sticky if geolocation is ${region}, switch is ON and content is Article on mobiles`, () => {
+            config.set('page.contentType', 'Article');
+            config.set('switches.mobileStickyLeaderboard', true);
+            getSync.mockReturnValue(region);
+            isBreakpoint.mockReturnValue(true);
+            expect(shouldIncludeMobileSticky()).toBe(true);
+        });
     });
 
     test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -366,6 +366,22 @@ describe('Utils', () => {
         expect(shouldIncludeMobileSticky()).toBe(true);
     });
 
+    test('should include mobile sticky if location cookie is AUS, switch is ON and content is Article on mobiles ', () => {
+        config.set('page.contentType', 'Article');
+        config.set('switches.mobileStickyLeaderboard', true);
+        getSync.mockReturnValue('AU');
+        isBreakpoint.mockReturnValue(true);
+        expect(shouldIncludeMobileSticky()).toBe(true);
+    });
+
+    test('should include mobile sticky if location cookie is NZ, switch is ON and content is Article on mobiles ', () => {
+        config.set('page.contentType', 'Article');
+        config.set('switches.mobileStickyLeaderboard', true);
+        getSync.mockReturnValue('NZ');
+        isBreakpoint.mockReturnValue(true);
+        expect(shouldIncludeMobileSticky()).toBe(true);
+    });
+
     test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {
         config.set('page.contentType', 'Network Front');
         config.set('switches.mobileStickyLeaderboard', true);


### PR DESCRIPTION
## What does this change?

- Adds Mobile sticky ad to Australia and New Zealand 

## Screenshots
![Screenshot 2019-10-02 at 14 56 38](https://user-images.githubusercontent.com/51630004/66050497-3c50f500-e525-11e9-8a7c-7281b53cf800.png)

### Tested

- [x] Locally
- [x] On CODE (optional)


