### PR TITLE
Improve visibility of environment in secondary nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -212,8 +212,8 @@ private object NavLinks {
       world,
       ukBusiness,
       football,
-      politics,
       ukEnvironment,
+      politics,
       education,
       society,
       science,
@@ -254,13 +254,13 @@ private object NavLinks {
     children = List(
       world,
       ukNews,
+      ukEnvironment,
       science,
       cities,
       globalDevelopment,
       football,
       tech,
       ukBusiness,
-      ukEnvironment,
       obituaries
     )
   )

--- a/static/src/stylesheets/layout/nav/_subnav-link.scss
+++ b/static/src/stylesheets/layout/nav/_subnav-link.scss
@@ -1,13 +1,18 @@
 .subnav-link {
-    @include fs-textSans(5);
+    @include fs-textSans(2);
     color: $brightness-7;
     display: block;
     height: $pillar-height - $gs-baseline / 2;
     line-height: $pillar-height - $gs-baseline / 2;
-    padding: 0 ($gs-gutter / 4);
+    padding: 0 4px;
     position: relative;
 
+    @include mq(mobileMedium) {
+        font-size: 14px;
+    }
+
     @include mq(tablet) {
+        @include fs-textSans(5, true);
         height: $pillar-height;
         line-height: $pillar-height;
     }

--- a/static/src/stylesheets/layout/nav/_subnav-link.scss
+++ b/static/src/stylesheets/layout/nav/_subnav-link.scss
@@ -1,5 +1,5 @@
 .subnav-link {
-    @include fs-textSans(2);
+    @include fs-textSans(1);
     color: $brightness-7;
     display: block;
     height: $pillar-height - $gs-baseline / 2;

--- a/static/src/stylesheets/layout/nav/_subnav.scss
+++ b/static/src/stylesheets/layout/nav/_subnav.scss
@@ -78,9 +78,12 @@
         content: '';
         display: block;
         height: 13px;
-        border: 1px solid $brightness-86;
-        border-top: 0;
-        border-bottom: 0;
+        
+        @include mq(tablet) {
+            border: 1px solid $brightness-86;
+            border-top: 0;
+            border-bottom: 0;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/nav/_subnav.scss
+++ b/static/src/stylesheets/layout/nav/_subnav.scss
@@ -11,9 +11,12 @@
     .gs-container {
         @include clearfix();
         box-sizing: border-box;
-        border: 1px solid $brightness-86;
-        border-top: 0;
-        border-bottom: 0;
+
+        @include mq(tablet) {
+            border: 1px solid $brightness-86;
+            border-top: 0;
+            border-bottom: 0;
+        }
 
         .footer__primary & {
             border-top: 1px solid $brightness-86;


### PR DESCRIPTION
## What does this change?
Environment has increased prominence in the secondary nav at mobile breakpoints. 

Also I have removed lines from the side of the pillars at mobile, and had to reduce the font sizes of the secondary nav to acomodate visibility of "environment".

## Screenshots
![unnamed-1](https://user-images.githubusercontent.com/14570016/66112806-71138980-e5c3-11e9-8bee-f5f930d209e6.png)
![unnamed](https://user-images.githubusercontent.com/14570016/66112808-71138980-e5c3-11e9-8421-9fb9f5eb0e11.png)


## What is the value of this and can you measure success?
Illustrates our commitment to the environment in our coverage.

## Checklist

- [ ] 

- [ ] 

- [ ] 

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ 💯 ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ 👍 ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ 🔢 ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [👍  ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
