### PR TITLE
Moment epic styles, new epic CTA

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
@@ -7,7 +7,7 @@ const codeEpicTestsDataFile =
     'https://support.code.dev-theguardian.com/epic-tests.json';
 
 export const getEpicTestData = (): Promise<any> => {
-    const url = !config.get('page.isDev')
+    const url = config.get('page.isDev')
         ? codeEpicTestsDataFile
         : prodEpicTestsDataFile;
     return fetchJSON(url, { mode: 'cors' });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-epic-test-data.js
@@ -7,7 +7,7 @@ const codeEpicTestsDataFile =
     'https://support.code.dev-theguardian.com/epic-tests.json';
 
 export const getEpicTestData = (): Promise<any> => {
-    const url = config.get('page.isDev')
+    const url = !config.get('page.isDev')
         ? codeEpicTestsDataFile
         : prodEpicTestsDataFile;
     return fetchJSON(url, { mode: 'cors' });

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons-learn-more.js
@@ -10,17 +10,37 @@ export const epicButtonsLearnMoreTemplate = (
     const applePayLogo = applePayApiAvailable ? applyPayMark.markup : '';
 
     const supportButtonSupport = `
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+            <a class="component-button component-button--primary component-button--hasicon-right contributions__contribute--epic-member"
               href="${supportUrl}"
               target="_blank">
-              ${ctaText}
+                ${ctaText}
+                <svg
+                class="svg-arrow-right-straight"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 17.89"
+                preserveAspectRatio="xMinYMid"
+                aria-hidden="true"
+                focusable="false"
+                >
+                    <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                </svg>
             </a>`;
 
     const learnMoreButton = `
-            <a class="contributions__option-button contributions__learn-more contributions__learn-more--epic contributions__contribute--epic-member"
+            <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--hasicon-right contributions__contribute--epic-member contributions__learn-more contributions__learn-more--epic"
               href="https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism?INTCMP=why_support_us"
               target="_blank">
               Why support matters
+              <svg
+                class="svg-arrow-right-straight"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 17.89"
+                preserveAspectRatio="xMinYMid"
+                aria-hidden="true"
+                focusable="false"
+                >
+                    <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                </svg>
             </a>`;
 
     const paymentLogos = `<div class="contributions__payment-logos contributions__contribute--epic-member">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -11,10 +11,20 @@ export const epicButtonsTemplate = (
 
     const supportButtonSupport = `
         <div>
-            <a class="component-button contributions__contribute--epic-member"
+            <a class="component-button component-button--primary component-button--hasicon-right contributions__contribute--epic-member"
               href="${supportUrl}"
               target="_blank">
-              ${ctaText}
+                ${ctaText}
+                <svg
+                class="svg-arrow-right-straight"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 17.89"
+                preserveAspectRatio="xMinYMid"
+                aria-hidden="true"
+                focusable="false"
+                >
+                    <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                </svg>
             </a>
         </div>`;
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -11,7 +11,7 @@ export const epicButtonsTemplate = (
 
     const supportButtonSupport = `
         <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+            <a class="component-button contributions__contribute--epic-member"
               href="${supportUrl}"
               target="_blank">
               ${ctaText}

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -37,6 +37,7 @@
 @import 'module/reader-revenue/epic-ticker';
 @import 'module/reader-revenue/banner-ticker';
 @import 'module/reader-revenue/reader-revenue-button';
+@import 'module/reader-revenue/moment-epic';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
 @import 'module/experiments/_update-account';

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -33,9 +33,10 @@
 @import 'module/crosswords/_main';
 @import 'module/email-signup/_main';
 @import 'module/_accessibility';
-@import 'module/experiments/embed';
+@import 'module/reader-revenue/epic';
 @import 'module/reader-revenue/epic-ticker';
 @import 'module/reader-revenue/banner-ticker';
+@import 'module/reader-revenue/reader-revenue-button';
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
 @import 'module/experiments/_update-account';

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -84,8 +84,7 @@
     svg, img { height: 100%; width: auto; }
 }
 
-.contributions__contribute,
-.contributions__learn-more {
+.contributions__contribute {
     background-color: $sport-dark;
     color: #ffffff;
     font-weight: bold;
@@ -114,7 +113,6 @@
 
 // Specificity needed to override an inline rule in _pillars.scss that's messing with the epic link colour.
 a[href].contributions__contribute.contributions__contribute--epic,
-a[href].contributions__learn-more.contributions__learn-more--epic,
 .contributions__adblock-button a {
     margin-top: 0;
     background-color: $highlight-main;
@@ -136,11 +134,6 @@ a[href].contributions__learn-more.contributions__learn-more--epic,
 
 a[href].contributions__learn-more.contributions__learn-more--epic {
     margin-top: $gs-baseline / 2;
-    background-color: $brightness-93;
-
-    &:hover {
-        background-color: $brightness-86;
-    }
 
     @include mq($from: mobileLandscape) {
         margin-top: 0;

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -1,4 +1,4 @@
-@import 'svg';
+@import '../experiments/svg';
 
 .contributions__embed  {
     border-top: 1px solid $sport-bright;

--- a/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
@@ -1,0 +1,8 @@
+// TBD: Add all moment epic class names here when they are available
+[class^="contributions__epic--2019-10_contribs_environment-pledge-moment"],
+.contributions__epic--2019-10_contribs_environment-pledge-moment_global_epic_hook {
+    .contributions__title {
+        font-size: 28px;
+        line-height: 1;
+    }
+}

--- a/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
@@ -1,5 +1,5 @@
 // TBD: Add all moment epic class names here when they are available
-[class^="contributions__epic--2019-10_contribs_environment-pledge-moment"],
+[class^='contributions__epic--2019-10_contribs_environment-pledge-moment'],
 .contributions__epic--2019-10_contribs_environment-pledge-moment_global_epic_hook {
     .contributions__title {
         font-size: 28px;

--- a/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
@@ -1,6 +1,5 @@
 // TBD: Add all moment epic class names here when they are available
-[class^='contributions__epic--2019-10_contribs_environment-pledge-moment'],
-.contributions__epic--2019-10_contribs_environment-pledge-moment_global_epic_hook {
+[class*='contributions__epic--2019-10_contribs_environment-pledge-moment'] {
     .contributions__title {
         font-size: 28px;
         line-height: 1;

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -11,7 +11,7 @@ $gu-cta-height: 42px;
     height: $gu-cta-height;
     min-height: $gu-cta-height;
     padding: 0 ($gu-cta-height / 2);
-    border: none;
+    border: 0;
     border-radius: $gu-cta-height / 2;
     box-sizing: border-box;
     background: transparent;

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -1,0 +1,125 @@
+$gu-transition: .3s ease-in-out;
+$gu-cta-height: 42px;
+
+.component-button {
+    @include fs-textSans(5);
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    font-weight: bold;
+    height: $gu-cta-height;
+    min-height: $gu-cta-height;
+    padding: 0 ($gu-cta-height / 2);
+    border: none;
+    border-radius: $gu-cta-height / 2;
+    box-sizing: border-box;
+    background: transparent;
+    cursor: pointer;
+    transition: $gu-transition;
+    justify-content: space-between;
+    position: relative;
+
+    &:hover, &:focus {
+        outline: 0;
+    }
+
+    &[data-disabled] {
+        pointer-events: none;
+    }
+}
+.component-button--non-interactive {
+    pointer-events: none;
+}
+
+.component-button--primary {
+    background-color: $highlight-main;
+    color: $brightness-7;
+    &:hover, &:focus {
+        background-color: $highlight-main;
+    }
+}
+
+.component-button--secondary {
+    color: $brightness-97;
+    background-color: $brightness-20;
+
+    &:hover, &:focus {
+        background-color: $brightness-7;
+    }
+}
+
+.component-button--green {
+    color: $brightness-97;
+    background-color: $green-bold;
+
+    &:hover, &:focus {
+        background-color: $green-dark;
+    }
+}
+
+.component-button--greenHollow {
+    color: $green-bold;
+    border: 1px solid $brightness-86;
+    &:hover, &:focus {
+        background: $brightness-97;
+    }
+}
+
+.component-button--greyHollow {
+    color: $brightness-7;
+    border: 1px solid $brightness-86;
+    &:hover, &:focus {
+        background: $brightness-97;
+    }
+}
+
+.component-button--disabled,
+.component-button[disabled],
+.component-button[data-disabled] {
+    color: $brightness-60;
+    background-color: $brightness-93;
+    border: 1px solid $brightness-86;
+    cursor: not-allowed;
+}
+
+.component-button__content,
+.component-button svg {
+    flex: 0 0 auto;
+    display: block;
+}
+
+.component-button svg {
+    fill: currentColor;
+    position: relative;
+    width: $gu-cta-height / 2;
+    height: auto;
+}
+
+.component-button--hasicon-left {
+    flex-direction: row-reverse;
+
+    svg {
+        margin: 0 ($gu-cta-height / 4) 0 (-$gu-cta-height / 8);
+    }
+}
+
+.component-button--hasicon-right {
+    svg {
+        margin: 0 (-$gu-cta-height / 8) 0 ($gu-cta-height / 4);
+    }
+}
+
+/* icon-specific animations & transitions */
+.component-button {
+    .svg-arrow-right-straight {
+        transition: $gu-transition transform;
+        will-change: transform;
+    }
+    &:hover .svg-arrow-right-straight, &:focus .svg-arrow-right-straight {
+        transform: translateX(20%);
+    }
+}
+
+.component-button--visited-white-text:visited {
+    color: $brightness-97;
+}

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -6,7 +6,8 @@ $gu-cta-height: 42px;
     display: inline-flex;
     align-items: center;
     text-decoration: none;
-    font-weight: bold;
+    font-weight: 700;
+    font-size: 17px;
     height: $gu-cta-height;
     min-height: $gu-cta-height;
     padding: 0 ($gu-cta-height / 2);
@@ -26,6 +27,11 @@ $gu-cta-height: 42px;
     &[data-disabled] {
         pointer-events: none;
     }
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
 }
 .component-button--non-interactive {
     pointer-events: none;
@@ -33,9 +39,9 @@ $gu-cta-height: 42px;
 
 .component-button--primary {
     background-color: $highlight-main;
-    color: $brightness-7;
+    color: $brightness-7 !important;
     &:hover, &:focus {
-        background-color: $highlight-main;
+        background-color: $highlight-dark;
     }
 }
 
@@ -66,10 +72,18 @@ $gu-cta-height: 42px;
 }
 
 .component-button--greyHollow {
-    color: $brightness-7;
+    color: $brightness-7 !important;
     border: 1px solid $brightness-86;
     &:hover, &:focus {
         background: $brightness-97;
+    }
+}
+
+.component-button--greyHollow--for-epic {
+    background-color: $brightness-93;
+
+    &:hover {
+        background-color: $brightness-86;
     }
 }
 


### PR DESCRIPTION
## What does this change?
I added in styles specific to the upcoming moment epic. The styles for this epic gave us the opportunity to switch over to using the CTA styles from the support site, so I've made them more universal. We can also implement them on the banner and elsewhere as we see appropriate.

## Screenshots
Moment epic styles (will need to be added to all moment epics once names are determined in the test machine):
<img width="695" alt="moment epic style" src="https://user-images.githubusercontent.com/3300789/66204052-d50c7f80-e6a1-11e9-85f1-ef667ba50ab3.png">

New CTAs on another relevant epic:
<img width="695" alt="epic new buttons" src="https://user-images.githubusercontent.com/3300789/66204059-da69ca00-e6a1-11e9-83fb-4b4c2bd7f13e.png">

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
