### PR TITLE
Prepare to use latest @guardian/consent-management-platform with error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.5",
+    "@guardian/consent-management-platform": "1.0.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0",
+    "@guardian/consent-management-platform": "1.0.0-beta.5",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "^1.0.0",
+    "@guardian/consent-management-platform": "1.0.0-beta.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.4",
+    "@guardian/consent-management-platform": "1.0.0-beta.5",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.1",
+    "@guardian/consent-management-platform": "1.0.0-beta.2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.2",
+    "@guardian/consent-management-platform": "1.0.0-beta.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.3",
+    "@guardian/consent-management-platform": "1.0.0-beta.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "1.0.0-beta.5",
+    "@guardian/consent-management-platform": "1.0.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.0.4",
-    "@guardian/consent-management-platform": "^0.3.1",
+    "@guardian/consent-management-platform": "^1.0.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,8 +103,6 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
-            console.log('onIabConsentNotification --->', state);
-
             const consentState =
                 state[1] && state[2] && state[3] && state[4] && state[5];
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,6 +103,8 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
+            console.log('onIabConsentNotification --->', state);
+
             const consentState =
                 state[1] && state[2] && state[3] && state[4] && state[5];
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -3,6 +3,7 @@ import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
 import { cmpConfig, cmpUi } from '@guardian/consent-management-platform';
 import fastdom from 'lib/fastdom-promise';
+import reportError from 'lib/report-error';
 
 const CMP_READY_CLASS = 'cmp-iframe-ready';
 const CMP_ANIMATE_CLASS = 'cmp-animate';
@@ -78,6 +79,16 @@ const onCloseCmp = (): Promise<void> =>
         })
         .then(removeCmp);
 
+const onErrorCmp = (error: Error): void => {
+    reportError(
+        error,
+        {
+            feature: 'cmp',
+        },
+        false
+    );
+};
+
 const prepareUi = (): void => {
     if (uiPrepared) {
         return;
@@ -90,7 +101,7 @@ const prepareUi = (): void => {
         cmpConfig.CMP_URL
     }" class="${IFRAME_CLASS}" tabIndex="1"></iframe></div>`;
 
-    cmpUi.setupMessageHandlers(onReadyCmp, onCloseCmp);
+    cmpUi.setupMessageHandlers(onReadyCmp, onCloseCmp, onErrorCmp);
 
     uiPrepared = true;
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -20,6 +20,8 @@ jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),
 }));
 
+jest.mock('lib/report-error', () => jest.fn());
+
 describe('cmp-ui', () => {
     afterEach(() => {
         jest.resetAllMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,11 +1082,12 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.3.1.tgz#146eb41982d6637e8884712db429ecc7bc5d0771"
-  integrity sha512-CE9QvnrXK8obbS9W6n/gwusuAu3++JTE4Pyit7BEwpFY9GOHKNIiLM1hDIKj3Y9yT5AHzEemO1iSkfK4Wzyamw==
+"@guardian/consent-management-platform@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0.tgz#0d2e763a1aa5887cdb4644033dfcfbb53799c697"
+  integrity sha512-U6d/ve7WZzhWtPx6nNc4XkI0P8Z1hvFTR9bEKZ2F/ykVNtiKWKNMwxiTVKGCcvwXJkQHqVpCpFVsa3kTEMVYYA==
   dependencies:
+    consent-string "^1.5.1"
     js-cookie "^2.2.1"
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
@@ -2055,6 +2056,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+
 base62@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/base62/-/base62-1.1.2.tgz#22ced6a49913565bc0b8d9a11563a465c084124c"
@@ -2966,6 +2972,13 @@ connect@3.6.6:
     finalhandler "1.1.0"
     parseurl "~1.3.2"
     utils-merge "1.0.1"
+
+consent-string@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.2.tgz#cd3615f406a1d7649ebc9722960b5e451cf6a685"
+  integrity sha512-xzfHnFzHQSupiamNY93UGn8FggPajHYExI45pzadhVpXVaj3ztnhnA7lYjKXl09pKRQKCT4hvjytt+2eoH7Jaw==
+  dependencies:
+    base-64 "^0.1.0"
 
 console-browserify@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.3.tgz#eb934b948bf27fefcbc44ffe6a2f9d8ea39e14d6"
-  integrity sha512-1TRDiWzbHDP3IangWRX7SXSwzi6t1oWri8oiK2Gcx+tW1Y2nnmIfEuQUqKkhx+bnd3W2HY+zAsFWRq7OEarbqQ==
+"@guardian/consent-management-platform@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.4.tgz#f98399e05f06ae4eab97ab863481c0d9b3848d33"
+  integrity sha512-BwN6fdxs4563K0qKNwXDee3HWMVaktK3qW/wnPVj28lzVQL+H0yb2OijcQ69H+CaLNGJCi5AVnhNREOjWoH0bA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.1.tgz#04869d4042a0b1df455d77ec4b7c030981f8e1d0"
-  integrity sha512-TzsSAn3LqCq+Fk8Rz6eyxY1exQLAm3V4sFdwUmTQsa0x4gri3qduOYAPfAguXtCU9B47Q6NA+Hf3B3tuC5iQdw==
+"@guardian/consent-management-platform@1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.2.tgz#ea72c3f2f04bff7e5465821e2784bfa91afc57a5"
+  integrity sha512-ZFrSJi0klOBZnUhdAP+VqQEp+o6z42bBPBCE+CQ/m8AIRfPmQA26OyeQOJMBhEYHju5j36DziEWg66Ih6808YA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.0-beta.5":
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.5.tgz#bc910838cb8fbf3a456101eb167297fb0207d561"
-  integrity sha512-ZpnEDISKaRD6rafVLgc7OHRbvrNCKhONVA1WaTM0vyElTQZwKRBiNy7bFSa+LZ7QLhQNE83KjKGdhlx1wFjsyQ==
+"@guardian/consent-management-platform@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.1.tgz#3faf970a78746323015f95c5cbbdb2daa015508c"
+  integrity sha512-Mgn4GbbNIY+ADRpDgXrAtCffemg3wfA0730dtCbM7D6Em5/2pcx3RQzYvUFMLeB4TAi9ALytIFzM4FRmRCt+Sw==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.0-beta.4":
-  version "1.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.4.tgz#f98399e05f06ae4eab97ab863481c0d9b3848d33"
-  integrity sha512-BwN6fdxs4563K0qKNwXDee3HWMVaktK3qW/wnPVj28lzVQL+H0yb2OijcQ69H+CaLNGJCi5AVnhNREOjWoH0bA==
+"@guardian/consent-management-platform@1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.5.tgz#bc910838cb8fbf3a456101eb167297fb0207d561"
+  integrity sha512-ZpnEDISKaRD6rafVLgc7OHRbvrNCKhONVA1WaTM0vyElTQZwKRBiNy7bFSa+LZ7QLhQNE83KjKGdhlx1wFjsyQ==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0.tgz#0d2e763a1aa5887cdb4644033dfcfbb53799c697"
-  integrity sha512-U6d/ve7WZzhWtPx6nNc4XkI0P8Z1hvFTR9bEKZ2F/ykVNtiKWKNMwxiTVKGCcvwXJkQHqVpCpFVsa3kTEMVYYA==
+"@guardian/consent-management-platform@1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.1.tgz#04869d4042a0b1df455d77ec4b7c030981f8e1d0"
+  integrity sha512-TzsSAn3LqCq+Fk8Rz6eyxY1exQLAm3V4sFdwUmTQsa0x4gri3qduOYAPfAguXtCU9B47Q6NA+Hf3B3tuC5iQdw==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "0.23.1"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.0-beta.2":
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.2.tgz#ea72c3f2f04bff7e5465821e2784bfa91afc57a5"
-  integrity sha512-ZFrSJi0klOBZnUhdAP+VqQEp+o6z42bBPBCE+CQ/m8AIRfPmQA26OyeQOJMBhEYHju5j36DziEWg66Ih6808YA==
+"@guardian/consent-management-platform@1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.0-beta.3.tgz#eb934b948bf27fefcbc44ffe6a2f9d8ea39e14d6"
+  integrity sha512-1TRDiWzbHDP3IangWRX7SXSwzi6t1oWri8oiK2Gcx+tW1Y2nnmIfEuQUqKkhx+bnd3W2HY+zAsFWRq7OEarbqQ==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
## What does this change?

Prepares `frontend` to use the latest version of `@guardian/consent-management-platform`.

This new  version of `@guardian/consent-management-platform` accepts a 3rd argument in `setupMessageHandlers` called `onErrorCmp`, this a callback that is executed when an Error is thrown, it allows users of the library to catch errors and handle them with their own custom reporting tools, eg. Raven in frontend.

Related PR on `@guardian/consent-management-platform`: https://github.com/guardian/consent-management-platform/pull/37