### PR TITLE
Sonobi Migration - Change Appnexus US IDs & move to Prebid

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -145,4 +145,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 7, 30),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-appnexus-us-adapter",
+    "Test new us placement id for appnexus in US",
+    owners = Seq(Owner.withGithub("ioanna0")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 7, 30),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -431,16 +431,6 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
-  val prebidAppNexusUKROW: Switch = Switch(
-    group = CommercialPrebid,
-    name = "prebid-appnexus-uk-row",
-    description = "Include AppNexus adapter in Prebid auctions in UK/ROW",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-  )
-
   val prebidAppNexusInvcode: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-appnexus-invcode",

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -5,8 +5,6 @@ import {
     getPageTargeting,
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
-import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 import {
     getLargestSize,
@@ -20,9 +18,6 @@ import {
 } from './utils';
 
 import type { PrebidAppNexusParams, PrebidSize } from './types';
-
-const isInAppnexusUSAdapterTestVariant = (): boolean =>
-    isInVariantSynchronous(appnexusUSAdapter, 'variant');
 
 const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
     const device: string = getBreakpointKey() === 'M' ? 'M' : 'D';
@@ -74,7 +69,7 @@ export const getAppNexusDirectPlacementId = (sizes: PrebidSize[]): string => {
         return '11016434';
     }
 
-    if (isInUsRegion() && isInAppnexusUSAdapterTestVariant()) {
+    if (isInUsRegion()) {
         return '4848330';
     }
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -64,12 +64,13 @@ export const getAppNexusPlacementId = (sizes: PrebidSize[]): string => {
     }
 };
 
-export const getAppNexusDirectPlacementId = (
-    sizes: PrebidSize[],
-    isAuRegion: boolean
-): string => {
-    if (isAuRegion) {
+export const getAppNexusDirectPlacementId = (sizes: PrebidSize[]): string => {
+    if (isInAuRegion()) {
         return '11016434';
+    }
+
+    if (isInUsRegion()) {
+        return '4848330';
     }
 
     const defaultPlacementId: string = '9251752';
@@ -101,10 +102,9 @@ export const getAppNexusDirectPlacementId = (
 };
 
 export const getAppNexusDirectBidParams = (
-    sizes: PrebidSize[],
-    isAuRegion: boolean
+    sizes: PrebidSize[]
 ): PrebidAppNexusParams => {
-    if (isAuRegion && config.get('switches.prebidAppnexusInvcode')) {
+    if (isInAuRegion() && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
         if (invCode) {
@@ -119,7 +119,7 @@ export const getAppNexusDirectBidParams = (
         }
     }
     return {
-        placementId: getAppNexusDirectPlacementId(sizes, isAuRegion),
+        placementId: getAppNexusDirectPlacementId(sizes),
         keywords: buildAppNexusTargetingObject(getPageTargeting()),
     };
 };

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.js
@@ -5,6 +5,8 @@ import {
     getPageTargeting,
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
+import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 import {
     getLargestSize,
@@ -18,6 +20,9 @@ import {
 } from './utils';
 
 import type { PrebidAppNexusParams, PrebidSize } from './types';
+
+const isInAppnexusUSAdapterTestVariant = (): boolean =>
+    isInVariantSynchronous(appnexusUSAdapter, 'variant');
 
 const getAppNexusInvCode = (sizes: Array<PrebidSize>): ?string => {
     const device: string = getBreakpointKey() === 'M' ? 'M' : 'D';
@@ -69,7 +74,7 @@ export const getAppNexusDirectPlacementId = (sizes: PrebidSize[]): string => {
         return '11016434';
     }
 
-    if (isInUsRegion()) {
+    if (isInUsRegion() && isInAppnexusUSAdapterTestVariant()) {
         return '4848330';
     }
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -141,6 +141,13 @@ describe('getAppNexusDirectPlacementId', () => {
         ).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
     });
 
+    test('should return the expected values when in US  and desktop device', () => {
+        isInUsRegion.mockReturnValue(true);
+        expect(
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
+        ).toEqual(['4848330', '4848330', '4848330', '4848330', '4848330']);
+    });
+
     test('should return the expected values for ROW when on desktop device', () => {
         isInAuRegion.mockReturnValue(false);
         getBreakpointKey.mockReturnValue('D');

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -1,5 +1,6 @@
 // @flow
 import config from 'lib/config';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import {
     _,
     getAppNexusDirectBidParams,
@@ -52,6 +53,7 @@ const {
 const getBreakpointKey: any = getBreakpointKey_;
 const isInAuRegion: any = isInAuRegion_;
 const isInUsRegion: any = isInUsRegion_;
+const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
@@ -143,6 +145,9 @@ describe('getAppNexusDirectPlacementId', () => {
 
     test('should return the expected values when in US  and desktop device', () => {
         isInUsRegion.mockReturnValue(true);
+        isInVariantSynchronous.mockImplementation(
+            (testId, variantId) => variantId === 'variant'
+        );
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['4848330', '4848330', '4848330', '4848330', '4848330']);

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -269,7 +269,7 @@ describe('getAppNexusDirectBidParams', () => {
     test('should include placementId for AU region when invCode switch is off', () => {
         getBreakpointKey.mockReturnValue('M');
         isInAuRegion.mockReturnValue(true);
-        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
+        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
         });
@@ -279,7 +279,7 @@ describe('getAppNexusDirectBidParams', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
         isInAuRegion.mockReturnValueOnce(true);
-        expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
+        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: {
                 edition: 'UK',
                 sens: 'f',
@@ -294,7 +294,7 @@ describe('getAppNexusDirectBidParams', () => {
     test('should include placementId and not include invCode if outside AU region', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]], false)).toEqual({
+        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '4298191',
         });

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -1,6 +1,5 @@
 // @flow
 import config from 'lib/config';
-import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import {
     _,
     getAppNexusDirectBidParams,
@@ -53,7 +52,6 @@ const {
 const getBreakpointKey: any = getBreakpointKey_;
 const isInAuRegion: any = isInAuRegion_;
 const isInUsRegion: any = isInUsRegion_;
-const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
@@ -145,9 +143,6 @@ describe('getAppNexusDirectPlacementId', () => {
 
     test('should return the expected values when in US  and desktop device', () => {
         isInUsRegion.mockReturnValue(true);
-        isInVariantSynchronous.mockImplementation(
-            (testId, variantId) => variantId === 'variant'
-        );
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['4848330', '4848330', '4848330', '4848330', '4848330']);

--- a/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/appnexus.spec.js
@@ -135,22 +135,25 @@ describe('getAppNexusDirectPlacementId', () => {
     ];
 
     test('should return the expected values when in AU region and desktop device', () => {
+        isInAuRegion.mockReturnValue(true);
         expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size, true))
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
     });
 
     test('should return the expected values for ROW when on desktop device', () => {
+        isInAuRegion.mockReturnValue(false);
         getBreakpointKey.mockReturnValue('D');
         expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size, false))
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['9251752', '9251752', '9926678', '9926678', '9251752']);
     });
 
     test('should return the expected values for ROW when on tablet device', () => {
         getBreakpointKey.mockReturnValue('T');
+        isInAuRegion.mockReturnValue(false);
         expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size, false))
+            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['4371641', '9251752', '9251752', '4371640', '9251752']);
     });
 });
@@ -265,6 +268,7 @@ describe('getAppNexusDirectBidParams', () => {
 
     test('should include placementId for AU region when invCode switch is off', () => {
         getBreakpointKey.mockReturnValue('M');
+        isInAuRegion.mockReturnValue(true);
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
@@ -274,6 +278,7 @@ describe('getAppNexusDirectBidParams', () => {
     test('should exclude placementId for AU region when including member and invCode', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
+        isInAuRegion.mockReturnValueOnce(true);
         expect(getAppNexusDirectBidParams([[300, 250]], true)).toEqual({
             keywords: {
                 edition: 'UK',

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -387,7 +387,7 @@ const appNexusBidder: PrebidBidder = {
     name: 'and',
     switchName: 'prebidAppnexus',
     bidParams: (slotId: string, sizes: PrebidSize[]): PrebidAppNexusParams =>
-        getAppNexusDirectBidParams(sizes, isInAuRegion()),
+        getAppNexusDirectBidParams(sizes),
 };
 
 const openxClientSideBidder: PrebidBidder = {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -136,8 +136,8 @@ export const shouldUseOzoneAdaptor = (): boolean =>
 export const shouldIncludeAppNexus = (): boolean =>
     isInAuRegion() ||
     (isInUsRegion() && isInAppnexusUSAdapterTestVariant()) ||
-    (config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
-    !!pbTestNameMap().and;
+    ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
+        !!pbTestNameMap().and);
 
 export const shouldIncludeXaxis = (): boolean =>
     // 10% of UK page views

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -7,8 +7,12 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { prebidTripleLiftAdapter } from 'common/modules/experiments/tests/prebid-triple-lift-adapter';
+import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 import type { PrebidSize } from './types';
+
+const isInAppnexusUSAdapterTestVariant = (): boolean =>
+    isInVariantSynchronous(appnexusUSAdapter, 'variant');
 
 const stripSuffix = (s: string, suffix: string): string => {
     const re = new RegExp(`${suffix}$`);
@@ -131,8 +135,9 @@ export const shouldUseOzoneAdaptor = (): boolean =>
 
 export const shouldIncludeAppNexus = (): boolean =>
     isInAuRegion() ||
-    isInUsRegion() ||
-    (config.get('switches.prebidAppnexusUkRow') || !!pbTestNameMap().and);
+    (isInUsRegion() && isInAppnexusUSAdapterTestVariant()) ||
+    (config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
+    !!pbTestNameMap().and;
 
 export const shouldIncludeXaxis = (): boolean =>
     // 10% of UK page views

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -2,7 +2,6 @@
 
 import once from 'lodash/once';
 import { getBreakpoint, isBreakpoint } from 'lib/detect';
-import { pbTestNameMap } from 'lib/url';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
@@ -134,10 +133,7 @@ export const shouldUseOzoneAdaptor = (): boolean =>
     !isInUsRegion() && !isInAuRegion() && config.get('switches.prebidOzone');
 
 export const shouldIncludeAppNexus = (): boolean =>
-    isInAuRegion() ||
-    (isInUsRegion() && isInAppnexusUSAdapterTestVariant()) ||
-    ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
-        !!pbTestNameMap().and);
+    isInAppnexusUSAdapterTestVariant() || !isInUsRegion();
 
 export const shouldIncludeXaxis = (): boolean =>
     // 10% of UK page views

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -131,8 +131,8 @@ export const shouldUseOzoneAdaptor = (): boolean =>
 
 export const shouldIncludeAppNexus = (): boolean =>
     isInAuRegion() ||
-    ((config.get('switches.prebidAppnexusUkRow') && !isInUsRegion()) ||
-        !!pbTestNameMap().and);
+    isInUsRegion() ||
+    (config.get('switches.prebidAppnexusUkRow') || !!pbTestNameMap().and);
 
 export const shouldIncludeXaxis = (): boolean =>
     // 10% of UK page views

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -1,5 +1,6 @@
 // @flow
 import { getSync as getSync_ } from 'lib/geolocation';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import {
     getBreakpoint as getBreakpoint_,
     isBreakpoint as isBreakpoint_,
@@ -28,6 +29,7 @@ import {
 const getSync: any = getSync_;
 const getBreakpoint: any = getBreakpoint_;
 const isBreakpoint: any = isBreakpoint_;
+const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 jest.mock('lodash/once', () => a => a);
 
@@ -110,13 +112,33 @@ describe('Utils', () => {
         expect(results).toEqual(['M', 'T', 'T', 'D', 'D']);
     });
 
-    ['AU', 'NZ', 'US', 'CA', 'GB'].forEach(region => {
-        test(`houldIncludeAppNexus should return true if geolocation is ${region}`, () => {
+    ['AU', 'NZ', 'GB'].forEach(region => {
+        test(`shouldIncludeAppNexus should return true if geolocation is ${region}`, () => {
             config.switches.prebidAppnexusUkRow = true;
             getSync.mockReturnValue(region);
             expect(shouldIncludeAppNexus()).toBe(true);
         });
     });
+
+    ['US', 'CA'].forEach(region => {
+        test(`shouldIncludeAppNexus should return false if geolocation is ${region} and not in variant`, () => {
+            config.switches.prebidAppnexusUkRow = true;
+            getSync.mockReturnValue(region);
+            expect(shouldIncludeAppNexus()).toBe(false);
+        });
+    });
+
+    ['US', 'CA'].forEach(region => {
+        test(`shouldIncludeAppNexus should return true if geolocation is ${region} and in variant`, () => {
+            config.switches.prebidAppnexusUkRow = true;
+            isInVariantSynchronous.mockImplementationOnce(
+                (testId, variantId) => variantId === 'variant'
+            );
+            getSync.mockReturnValue(region);
+            expect(shouldIncludeAppNexus()).toBe(true);
+        });
+    });
+
 
     test('shouldIncludeAppNexus should otherwise return false', () => {
         config.switches.prebidAppnexusUkRow = true;

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -139,7 +139,6 @@ describe('Utils', () => {
         });
     });
 
-
     test('shouldIncludeAppNexus should otherwise return false', () => {
         config.switches.prebidAppnexusUkRow = true;
         const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -122,16 +122,16 @@ describe('Utils', () => {
         expect(shouldIncludeAppNexus()).toBe(true);
     });
 
-    test('shouldIncludeAppNexus should return false if geolocation is US', () => {
+    test('shouldIncludeAppNexus should return true if geolocation is US', () => {
         config.switches.prebidAppnexusUkRow = true;
         getSync.mockReturnValue('US');
-        expect(shouldIncludeAppNexus()).toBe(false);
+        expect(shouldIncludeAppNexus()).toBe(true);
     });
 
-    test('shouldIncludeAppNexus should return false if geolocation is CA', () => {
+    test('shouldIncludeAppNexus should return true if geolocation is CA', () => {
         config.switches.prebidAppnexusUkRow = true;
         getSync.mockReturnValue('CA');
-        expect(shouldIncludeAppNexus()).toBe(false);
+        expect(shouldIncludeAppNexus()).toBe(true);
     });
 
     test('shouldIncludeAppNexus should return true if geolocation is GB', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -53,7 +53,6 @@ jest.mock('common/modules/experiments/ab-tests');
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
-    config.set('switches.prebidAppnexusUkRow', undefined);
     config.set('switches.prebidAppnexus', true);
     config.set('switches.prebidAppnexusInvcode', false);
     config.set('switches.prebidOpenx', true);
@@ -114,7 +113,6 @@ describe('Utils', () => {
 
     ['AU', 'NZ', 'GB'].forEach(region => {
         test(`shouldIncludeAppNexus should return true if geolocation is ${region}`, () => {
-            config.switches.prebidAppnexusUkRow = true;
             getSync.mockReturnValue(region);
             expect(shouldIncludeAppNexus()).toBe(true);
         });
@@ -122,7 +120,6 @@ describe('Utils', () => {
 
     ['US', 'CA'].forEach(region => {
         test(`shouldIncludeAppNexus should return false if geolocation is ${region} and not in variant`, () => {
-            config.switches.prebidAppnexusUkRow = true;
             getSync.mockReturnValue(region);
             expect(shouldIncludeAppNexus()).toBe(false);
         });
@@ -130,7 +127,6 @@ describe('Utils', () => {
 
     ['US', 'CA'].forEach(region => {
         test(`shouldIncludeAppNexus should return true if geolocation is ${region} and in variant`, () => {
-            config.switches.prebidAppnexusUkRow = true;
             isInVariantSynchronous.mockImplementationOnce(
                 (testId, variantId) => variantId === 'variant'
             );
@@ -140,39 +136,11 @@ describe('Utils', () => {
     });
 
     test('shouldIncludeAppNexus should otherwise return false', () => {
-        config.switches.prebidAppnexusUkRow = true;
         const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
         for (let i = 0; i < testGeos.length; i += 1) {
             getSync.mockReturnValue(testGeos[i]);
             expect(shouldIncludeAppNexus()).toBe(true);
         }
-    });
-
-    test('shouldIncludeAppNexus should return false for UK region if UK switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('GB');
-        expect(shouldIncludeAppNexus()).toBe(false);
-    });
-
-    test('shouldIncludeAppNexus should return false for UK region if UK switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeAppNexus()).toBe(false);
-        }
-    });
-
-    test('shouldIncludeAppNexus should return true for AU region if UK region is switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('AU');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true for NZ region if UK region is switched off', () => {
-        config.switches.prebidAppnexusUkRow = false;
-        getSync.mockReturnValue('NZ');
-        expect(shouldIncludeAppNexus()).toBe(true);
     });
 
     test('shouldIncludeOpenx should return true if geolocation is GB', () => {

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.spec.js
@@ -110,34 +110,12 @@ describe('Utils', () => {
         expect(results).toEqual(['M', 'T', 'T', 'D', 'D']);
     });
 
-    test('shouldIncludeAppNexus should return true if geolocation is AU', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('AU');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true if geolocation is NZ', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('NZ');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true if geolocation is US', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('US');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true if geolocation is CA', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('CA');
-        expect(shouldIncludeAppNexus()).toBe(true);
-    });
-
-    test('shouldIncludeAppNexus should return true if geolocation is GB', () => {
-        config.switches.prebidAppnexusUkRow = true;
-        getSync.mockReturnValue('GB');
-        expect(shouldIncludeAppNexus()).toBe(true);
+    ['AU', 'NZ', 'US', 'CA', 'GB'].forEach(region => {
+        test(`houldIncludeAppNexus should return true if geolocation is ${region}`, () => {
+            config.switches.prebidAppnexusUkRow = true;
+            getSync.mockReturnValue(region);
+            expect(shouldIncludeAppNexus()).toBe(true);
+        });
     });
 
     test('shouldIncludeAppNexus should otherwise return false', () => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -14,6 +14,7 @@ import {
     environmentMomentBannerSupporters,
 } from 'common/modules/experiments/tests/contributions-moment-banner-environment';
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
+import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -22,6 +23,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     adblockTest,
     prebidTripleLiftAdapter,
     xaxisAdapterTest,
+    appnexusUSAdapter,
     pangaeaAdapterTest,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
@@ -1,4 +1,8 @@
 // @flow strict
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import once from 'lodash/once';
+
+const currentGeoLocation = once((): string => geolocationGetSync());
 
 export const appnexusUSAdapter: ABTest = {
     id: 'CommercialAppnexusUsAdapter',
@@ -13,7 +17,7 @@ export const appnexusUSAdapter: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome: 'Appnexus adapter delivers in US',
     showForSensitive: true,
-    canRun: () => true,
+    canRun: () => ['US', 'CA'].includes(currentGeoLocation()),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
@@ -1,0 +1,27 @@
+// @flow strict
+
+export const appnexusUSAdapter: ABTest = {
+    id: 'CommercialAppnexusUsAdapter',
+    start: '2019-10-7',
+    expiry: '2020-07-30',
+    author: 'Ioanna Kyprianou',
+    description: 'Test new us placement id for appnexus in US',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'Appnexus adapter works in US',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'Appnexus adapter delivers in US',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

- Adds Appnexus (`and`) adapter to Prebid in US in order to migrate it from Sonobi.
- Adds it behind 0% AB test `#ab-CommercialAppnexusUsAdapter=variant`

## Screenshots

![Screenshot 2019-10-07 at 14 24 21](https://user-images.githubusercontent.com/51630004/66317380-4dc54300-e911-11e9-9083-91bfffbd380d.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

