### PR TITLE
Sonobi Migration - Change Pangaea IDs & move to Prebid

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 7, 30),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-pangaea-adapter",
+    "Test adding pangaea in prebid for US",
+    owners = Seq(Owner.withGithub("ioanna0")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 7, 30),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -591,4 +591,13 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+  val pangaeaUSBidder: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-pangaea-us",
+    description = "Include Pangaea adapter to US",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -51,6 +51,7 @@ import {
     shouldIncludeTripleLift,
     shouldIncludeXaxis,
     shouldUseOzoneAdaptor,
+    shouldIncludePangaea,
     stripDfpAdPrefixFrom,
     stripMobileSuffix,
     stripTrailingNumbersAbove1,
@@ -543,6 +544,19 @@ const adYouLikeBidder: PrebidBidder = {
     },
 };
 
+const pangaeaUSBidder: PrebidBidder = {
+    name: 'pangaea',
+    switchName: 'prebidPangaeaUs',
+    bidParams: (): PrebidAppNexusParams =>
+        Object.assign(
+            {},
+            {
+                placementId: 13892369, // currently only US placement ID supported
+                keywords: buildAppNexusTargetingObject(getPageTargeting()),
+            }
+        ),
+};
+
 // Dummy bidders for the whitehorse project (https://trello.com/c/KbeBLyYZ)
 const getDummyServerSideBidders = (): Array<PrebidBidder> => {
     const dummyServerSideBidders: Array<PrebidBidder> = [];
@@ -639,6 +653,7 @@ const currentBidders: (PrebidSize[]) => PrebidBidder[] = slotSizes => {
     const otherBidders: PrebidBidder[] = [
         ...(inPbTestOr(shouldIncludeSonobi()) ? [sonobiBidder] : []),
         ...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
+        ...(inPbTestOr(shouldIncludePangaea()) ? [pangaeaUSBidder] : []),
         ...(inPbTestOr(shouldIncludeTripleLift()) ? [tripleLiftBidder] : []),
         ...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
         ...(inPbTestOr(shouldIncludeImproveDigital())

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.js
@@ -551,7 +551,7 @@ const pangaeaUSBidder: PrebidBidder = {
         Object.assign(
             {},
             {
-                placementId: 13892369, // currently only US placement ID supported
+                placementId: '13892369', // currently only US placement ID supported
                 keywords: buildAppNexusTargetingObject(getPageTargeting()),
             }
         ),

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -28,6 +28,7 @@ import {
     shouldIncludeSonobi as shouldIncludeSonobi_,
     stripMobileSuffix as stripMobileSuffix_,
     shouldIncludeTripleLift as shouldIncludeTripleLift_,
+    shouldIncludePangaea,
 } from './utils';
 
 const containsBillboard: any = containsBillboard_;
@@ -733,6 +734,40 @@ describe('xaxis adapter', () => {
 
         expect(xaxisBids[1].params).toEqual({
             placementId: 15900184,
+        });
+    });
+});
+
+describe('pangaea adapter', () => {
+    beforeEach(() => {
+        resetConfig();
+        shouldIncludePangaea.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('should include pangaea adapter if condition is true ', () => {
+        config.set('switches.prebidPangaeaUs', true);
+        expect(getBidders()).toEqual(['ix', 'pangaea']);
+    });
+
+    test('should not include pangaea adapter if condition is false ', () => {
+        config.set('switches.prebidPangaeaUs', false);
+        expect(getBidders()).toEqual(['ix']);
+    });
+
+    test('should return correct pangaea adapter params for US', () => {
+        config.set('switches.prebidPangaeaUs', true);
+
+        const pangaeaBids = bids('dfp-ad--top-above-nav', [
+            [728, 90],
+            [970, 250],
+        ]);
+        expect(pangaeaBids[2].params).toEqual({
+            keywords: 'someAppNexusTargetingObject',
+            placementId: 13892369,
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -749,12 +749,12 @@ describe('pangaea adapter', () => {
         jest.resetAllMocks();
     });
 
-    test('should include pangaea adapter if condition is true ', () => {
+    test('should include pangaea adapter if switch is true ', () => {
         config.set('switches.prebidPangaeaUs', true);
         expect(getBidders()).toEqual(['ix', 'pangaea']);
     });
 
-    test('should not include pangaea adapter if condition is false ', () => {
+    test('should not include pangaea adapter if switch is false ', () => {
         config.set('switches.prebidPangaeaUs', false);
         expect(getBidders()).toEqual(['ix']);
     });

--- a/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/bid-config.spec.js
@@ -28,7 +28,7 @@ import {
     shouldIncludeSonobi as shouldIncludeSonobi_,
     stripMobileSuffix as stripMobileSuffix_,
     shouldIncludeTripleLift as shouldIncludeTripleLift_,
-    shouldIncludePangaea,
+    shouldIncludePangaea as shouldIncludePangaea_,
 } from './utils';
 
 const containsBillboard: any = containsBillboard_;
@@ -46,6 +46,7 @@ const shouldIncludeOzone: any = shouldIncludeOzone_;
 const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const shouldIncludeXaxis: any = shouldIncludeXaxis_;
 const shouldIncludeSonobi: any = shouldIncludeSonobi_;
+const shouldIncludePangaea: any = shouldIncludePangaea_;
 const shouldIncludeTripleLift: any = shouldIncludeTripleLift_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
@@ -767,7 +768,7 @@ describe('pangaea adapter', () => {
         ]);
         expect(pangaeaBids[2].params).toEqual({
             keywords: 'someAppNexusTargetingObject',
-            placementId: 13892369,
+            placementId: '13892369',
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -7,6 +7,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { prebidTripleLiftAdapter } from 'common/modules/experiments/tests/prebid-triple-lift-adapter';
+import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 import type { PrebidSize } from './types';
 
 const stripSuffix = (s: string, suffix: string): string => {
@@ -112,7 +113,8 @@ export const shouldIncludeOpenx = (): boolean => !isInUsRegion();
 
 export const shouldIncludeTrustX = (): boolean => isInUsRegion();
 
-export const shouldIncludePangaea = (): boolean => isInUsRegion();
+export const shouldIncludePangaea = (): boolean =>
+    isInVariantSynchronous(pangaeaAdapterTest, 'variant');
 
 export const shouldIncludeTripleLift = (): boolean =>
     isInVariantSynchronous(prebidTripleLiftAdapter, 'variant');

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -112,6 +112,8 @@ export const shouldIncludeOpenx = (): boolean => !isInUsRegion();
 
 export const shouldIncludeTrustX = (): boolean => isInUsRegion();
 
+export const shouldIncludePangaea = (): boolean => isInUsRegion();
+
 export const shouldIncludeTripleLift = (): boolean =>
     isInVariantSynchronous(prebidTripleLiftAdapter, 'variant');
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -14,6 +14,7 @@ import {
     environmentMomentBannerSupporters,
 } from 'common/modules/experiments/tests/contributions-moment-banner-environment';
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
+import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -21,6 +22,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     adblockTest,
     prebidTripleLiftAdapter,
     xaxisAdapterTest,
+    pangaeaAdapterTest,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import once from 'lodash/once';
+
+const currentGeoLocation = once((): string => geolocationGetSync());
+
+export const pangaeaAdapterTest: ABTest = {
+    id: 'CommercialPangaeaAdapter',
+    start: '2019-10-08',
+    expiry: '2020-07-30',
+    author: 'Ioanna Kyprianou',
+    description:
+        'Test adding pangaea in prebid for US',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'Pangaea adapter works in prebid for US',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Pangaea adapter delivers in prebid for US',
+    showForSensitive: true,
+    canRun: () => ['US', 'CA'].includes(currentGeoLocation()),
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
@@ -9,15 +9,13 @@ export const pangaeaAdapterTest: ABTest = {
     start: '2019-10-08',
     expiry: '2020-07-30',
     author: 'Ioanna Kyprianou',
-    description:
-        'Test adding pangaea in prebid for US',
+    description: 'Test adding pangaea in prebid for US',
     audience: 0.0,
     audienceOffset: 0.0,
     successMeasure: 'Pangaea adapter works in prebid for US',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
-    idealOutcome:
-        'Pangaea adapter delivers in prebid for US',
+    idealOutcome: 'Pangaea adapter delivers in prebid for US',
     showForSensitive: true,
     canRun: () => ['US', 'CA'].includes(currentGeoLocation()),
     variants: [


### PR DESCRIPTION
## What does this change?
Adds Pangaea adapter to Prebid in US in order to migrate it from Sonobi.
Adds it behind 0% AB test `#ab-CommercialPangaeaAdapter=control`

## Screenshots

![Screenshot 2019-10-08 at 14 15 08](https://user-images.githubusercontent.com/51630004/66398783-4a47bf80-e9d6-11e9-8f67-a1ae3c430caa.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

