### PR TITLE
Change copy for the tablet daily edition help

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -50,7 +50,7 @@
                                                 <option value="feedback-form-android">Android news app help</option>
                                                 <option value="feedback-form-ios">iOS news app help</option>
                                                 <option value="feedback-form-daily">iPad daily edition help</option>
-                                                <option value="feedback-form-tablet">Android/Kindle Fire tablet daily edition help</option>
+                                                <option value="feedback-form-tablet">The Daily help</option>
                                                 <option value="feedback-form-editorial">Comment or query about an article</option>
                                                 <option value="feedback-form-discussion">Commenting/Moderation/Community help</option>
                                                 <option value="feedback-form-other">Other</option>

--- a/onward/app/views/fragments/feedbackForms.scala.html
+++ b/onward/app/views/fragments/feedbackForms.scala.html
@@ -68,7 +68,9 @@
 </div>
 
 <div id="feedback-form-tablet" class="feedback__blurb">
-    <p>From 31 January 2018, The Guardian Daily Edition app on Android and Kindle Fire devices will no longer be supported. For more information please follow this <a href="https://www.theguardian.com/help/insideguardian/2018/jan/31/service-update-changes-to-daily-edition-app-on-android-and-kindle-fire">link</a></p>
+    <p>Please ensure that you are on the latest version of the app.</p>
+    <p>If you are, and your problem persists, please contact us from within the app if you can (from edition picker screen press settings icon > Help > Contact Us ).</p>
+    <p>If you cannot use the app at all, can you please use this form and let us know which device you are using, the version of the operating system you are running, and the version number of The Daily app?</p>
 </div>
 
 <div id="feedback-form-windows" class="feedback__blurb">


### PR DESCRIPTION
## What does this change?

Change copy for the tablet daily edition help on feedback form

## Screenshots

## What is the value of this and can you measure success?

Replaced product

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
