### PR TITLE
Avoid special project label links being overriden

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -638,8 +638,9 @@
         }
     }
 
-    .content__label__link {
+    &:not(.content--pillar-special-report) .content__label__link {
         color: #ffffff;
+
     }
 
     .immersive-main-media__headline-container {


### PR DESCRIPTION
## What does this change?

Ensures the immersive label for special projects is the correct colour

## Screenshots

### Before


![image](https://user-images.githubusercontent.com/638051/66467849-0bb91000-ea7d-11e9-81db-0366081b2f28.png)
### After

<img width="260" alt="Screenshot 2019-10-09 at 09 23 15" src="https://user-images.githubusercontent.com/638051/66467809-fcd25d80-ea7c-11e9-9bbd-11ca6cb0f3a0.png">


## What is the value of this and can you measure success?
Styling

