### PR TITLE
CMP UI - show on IE11

### DIFF
--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -27,10 +27,12 @@
     height: 100%;
     width: 100%;
     max-width: 576px;
-    transform: translateX(100vw);
+    position: absolute;
+    top: 0;
+    left: 100%;
+    transform: translateX(0);
     transition: transform .6s ease-in;
     will-change: transform;
-    position: relative;
 
     @include mq(mobileLandscape) {
         width: 30%;
@@ -38,7 +40,7 @@
     }
 
     .cmp-animate & {
-        transform: translateX(calc(100vw - 100%));
+        transform: translateX(-100%);
     }
 }
 
@@ -51,8 +53,10 @@
 
 // Prevent body scrolling behind overlay
 body.no-scroll {
-    overflow: hidden;
-    position: fixed;
-    left: 0;
-    right: 0;
+    @include mq(mobileLandscape) {
+        overflow: hidden;
+        position: fixed;
+        left: 0;
+        right: 0;
+    }
 }

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -58,10 +58,8 @@
 
 // Prevent body scrolling behind overlay
 body.no-scroll {
-    @include mq(mobileLandscape) {
-        overflow: hidden;
-        position: fixed;
-        left: 0;
-        right: 0;
-    }
+    overflow: hidden;
+    position: fixed;
+    left: 0;
+    right: 0;
 }

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -8,16 +8,21 @@
     margin: 0;
     z-index: 9999;
     display: none;
-    transition: background-color;
-    transition-delay: .6s;
-    will-change: background-color;
+
+    @include mq(mobileLandscape) {
+        transition: background-color;
+        transition-delay: .6s;
+        will-change: background-color;
+    }
 
     &.cmp-iframe-ready {
         display: block;
     }
 
     &.cmp-animate {
-        background-color: rgba(#000000, .5);
+        @include mq(mobileLandscape) {
+            background-color: rgba(#000000, .5);
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

1. Fixes a bug that was preventing the CMP UI from animating into view on IE, fixed by replacing viewport units with standard units. Thanks to @faresite for spotting the issue and helping debug on IE/Browserstack!

2. Only show the semi-opaque background colour on the overlay when the CMP UI is not 100% the viewport width - `mobileLandscape` and greater.