### PR TITLE
Remove overriding styling for opinion articles on special reports

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -77,9 +77,9 @@ $pillars: (
         featureHeadline: #ffffff,
         byline: $special-report-dark,
         commentCount: $brightness-60,
-        headlineIcon: $special-report-dark,
+        headlineIcon: $highlight-main,
         metaText: $brightness-60,
-        cutoutBackground: $highlight-main,
+        cutoutBackground: $highlight-main,  
         invertedKicker: $highlight-main,
         liveColour: #ffffff
     )
@@ -267,7 +267,7 @@ $pillars: (
         background-color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-comment {
+    &.fc-item--type-comment:not(.fc-item--pillar-special-report) {
         &.fc-item--pillar-news,
         &.fc-item--pillar-opinion,
         &.fc-item--pillar-sport,
@@ -275,6 +275,7 @@ $pillars: (
         &.fc-item--pillar-lifestyle {
             background-color: $opinion-faded;
         }
+
 
         .fc-item__container.u-faux-block-link--hover {
             background-color: darken($opinion-faded, 2%);
@@ -348,15 +349,10 @@ $pillars: (
     }
 
     &.fc-item--type-comment {
-        .fc-item__headline,
-        .fc-item__standfirst {
-            color: $special-report-dark;
-        }
 
         .fc-item__byline {
-            color: $special-report-dark;
-            background-color: $highlight-main;
             display: inline;
+            color: $highlight-main;
         }
 
         .fc-item__kicker {


### PR DESCRIPTION
## What does this change?

Makes special report styling match between fronts and onwards containers.

## Screenshots

Onwards
![Screenshot 2019-10-09 at 11 25 58](https://user-images.githubusercontent.com/638051/66473762-d49c2c00-ea87-11e9-88bd-92951d6a7e95.png)

Fronts

![Screenshot 2019-10-09 at 11 26 07](https://user-images.githubusercontent.com/638051/66473764-d665ef80-ea87-11e9-90ac-d3f24abaef51.png)

