### PR TITLE
Epic for moment with article view count

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,6 +38,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-articles-viewed-month-moment",
+    "Moment epic which also states how many articles a user has viewed",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 27),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-learn-more-cta",
     "States how many articles a user has viewed in the epic in a month",
     owners = Seq(Owner.withGithub("jlieb10")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,6 +3,7 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { commercialIabCompliant } from 'common/modules/experiments/tests/commercial-iab-compliant';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
+import { articlesViewedMoment } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment';
 import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
@@ -26,6 +27,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
+    articlesViewedMoment,
     articlesViewed,
     learnMore,
     countryName,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -46,7 +46,7 @@ const geolocation = geolocationGetSync();
 
 export const articlesViewedMoment: EpicABTest = makeEpicABTest({
     id: 'ContributionsEpicArticlesViewedMonthMoment',
-    campaignId: '2019-10-14_moment_climate_pledge_2019_article_count',
+    campaignId: '2019-10-14_moment_climate_pledge_article_count',
 
     start: '2019-06-24',
     expiry: '2020-01-27',
@@ -72,12 +72,18 @@ export const articlesViewedMoment: EpicABTest = makeEpicABTest({
             buttonTemplate: defaultButtonTemplate,
             products: [],
             copy: buildEpicCopy(controlCopy, false, geolocation),
+            classNames: [
+                'contributions__epic--2019-10-14_moment_climate_pledge',
+            ],
         },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,
             products: [],
             copy: buildEpicCopy(variantCopy, false, geolocation),
+            classNames: [
+                'contributions__epic--2019-10-14_moment_climate_pledge',
+            ],
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -1,0 +1,83 @@
+// @flow
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+    buildEpicCopy,
+} from 'common/modules/commercial/contributions-utilities';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+// User must have read at least 5 articles in last 14 days
+const minArticleViews = 5;
+const articleCountDays = 30;
+
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
+
+const heading = 'As the climate crisis escalates...';
+
+const highlightedText =
+    'Support us from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
+
+const controlCopy = {
+    heading,
+    paragraphs: [
+        '... The Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power around the world. We will inform our readers about threats to our environment based on scientific facts, not on commercial or political interests. And we have made an important change to our style guide to ensure the language we use accurately describes the urgent environmental catastrophes facing the world.',
+        'The Guardian believes that the problems we face on the climate crisis are structural and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of our planet – and to inspire hope.',
+        'The Guardian made a choice: to keep our journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.',
+        'We hope you will consider supporting The Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+    ],
+    highlightedText,
+};
+
+const variantCopy = {
+    heading,
+    paragraphs: [
+        '... The Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power around the world. We will inform our readers about threats to our environment based on scientific facts, not on commercial or political interests. And we have made an important change to our style guide to ensure the language we use accurately describes the urgent environmental catastrophes facing the world.',
+        'The Guardian believes that the problems we face on the climate crisis are structural and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of our planet – and to inspire hope.',
+        `You’ve read ${articleViewCount} Guardian articles in the last month – made possible by our choice to keep Guardian journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.`,
+        'We hope you will consider supporting The Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+    ],
+    highlightedText,
+};
+
+const geolocation = geolocationGetSync();
+
+export const articlesViewedMoment: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicArticlesViewedMonthMoment',
+    campaignId: '2019-10-14_moment_climate_pledge_2019_article_count',
+
+    start: '2019-06-24',
+    expiry: '2020-01-27',
+
+    author: 'Tom Forbes',
+    description:
+        'Moment epic which also states how many articles a user has viewed',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    geolocation,
+    highPriority: true,
+
+    canRun: () => articleViewCount >= minArticleViews,
+
+    variants: [
+        {
+            id: 'control',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+            copy: buildEpicCopy(controlCopy, false, geolocation),
+        },
+        {
+            id: 'variant',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+            copy: buildEpicCopy(variantCopy, false, geolocation),
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -21,11 +21,11 @@ const highlightedText =
 const controlCopy = {
     heading,
     paragraphs: [
-        '... The Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
-        'Our independence means we are free to investigate and challenge inaction by those in power around the world. We will inform our readers about threats to our environment based on scientific facts, not on commercial or political interests. And we have made an important change to our style guide to ensure the language we use accurately describes the urgent environmental catastrophes facing the world.',
-        'The Guardian believes that the problems we face on the climate crisis are structural and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of our planet – and to inspire hope.',
+        '... the Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power. We will inform our readers about threats to the environment based on scientific facts, not driven by commercial or political interests. And we have made several important changes to our style guide to ensure the language we use accurately reflects the environmental catastrophe.',
+        'The Guardian believes that the problems we face on the climate crisis are systemic and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of human life on earth. We want their stories to inspire hope. We will also report back on our own progress as an organisation, as we take important steps to address our impact on the environment.',
         'The Guardian made a choice: to keep our journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.',
-        'We hope you will consider supporting The Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+        'We hope you will consider supporting the Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
     ],
     highlightedText,
 };
@@ -33,11 +33,11 @@ const controlCopy = {
 const variantCopy = {
     heading,
     paragraphs: [
-        '... The Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
-        'Our independence means we are free to investigate and challenge inaction by those in power around the world. We will inform our readers about threats to our environment based on scientific facts, not on commercial or political interests. And we have made an important change to our style guide to ensure the language we use accurately describes the urgent environmental catastrophes facing the world.',
-        'The Guardian believes that the problems we face on the climate crisis are structural and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of our planet – and to inspire hope.',
+        '... the Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power. We will inform our readers about threats to the environment based on scientific facts, not driven by commercial or political interests. And we have made several important changes to our style guide to ensure the language we use accurately reflects the environmental catastrophe.',
+        'The Guardian believes that the problems we face on the climate crisis are systemic and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of human life on earth. We want their stories to inspire hope. We will also report back on our own progress as an organisation, as we take important steps to address our impact on the environment.',
         `You’ve read ${articleViewCount} Guardian articles in the last month – made possible by our choice to keep Guardian journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.`,
-        'We hope you will consider supporting The Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+        'We hope you will consider supporting the Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
     ],
     highlightedText,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -63,6 +63,7 @@ export const articlesViewedMoment: EpicABTest = makeEpicABTest({
 
     geolocation,
     highPriority: true,
+    useLocalViewLog: true,
 
     canRun: () => articleViewCount >= minArticleViews,
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -7,7 +7,7 @@ import {
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
-// User must have read at least 5 articles in last 14 days
+// User must have read at least 5 articles in last 30 days
 const minArticleViews = 5;
 const articleCountDays = 30;
 

--- a/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_moment-epic.scss
@@ -1,5 +1,5 @@
 // TBD: Add all moment epic class names here when they are available
-[class*='contributions__epic--2019-10_contribs_environment-pledge-moment'] {
+[class*='contributions__epic--2019-10-14_moment_climate_pledge'] {
     .contributions__title {
         font-size: 28px;
         line-height: 1;


### PR DESCRIPTION
## What does this change?
Adds a new epic test for the upcoming moment. The test must be hardcoded because the tool does not currently support the 'articles viewed' feature.
The aim is to find out whether including the number of articles viewed in the last month performs better than the control moment copy.

## Screenshots
Control (without article count):
<img width="624" alt="Screenshot 2019-10-10 at 14 46 22" src="https://user-images.githubusercontent.com/1513454/66574822-cffd7380-eb6c-11e9-8f3e-15c3b86956b5.png">


Variant (with article count):
<img width="624" alt="Screenshot 2019-10-10 at 14 46 35" src="https://user-images.githubusercontent.com/1513454/66574835-d4c22780-eb6c-11e9-8975-23ccced1b2be.png">



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
