### PR TITLE
Add more `special-report` styling for card overriding

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -79,7 +79,7 @@ $pillars: (
         commentCount: $brightness-60,
         headlineIcon: $highlight-main,
         metaText: $brightness-60,
-        cutoutBackground: $highlight-main,  
+        cutoutBackground: $highlight-main,
         invertedKicker: $highlight-main,
         liveColour: #ffffff
     )
@@ -105,6 +105,14 @@ $pillars: (
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
             background-color: darken($opinion-faded, 3%);
+        }
+
+        &.fc-item--pillar-special-report {
+            .fc-item__timestamp,
+            .fc-trail__count--commentcount {
+                background-color: $special-report-dark;
+                color: $brightness-86;
+            }
         }
     }
 
@@ -356,7 +364,7 @@ $pillars: (
         }
 
         .fc-item__kicker {
-            color: $special-report-dark;
+            color: $highlight-main;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Fixes styling issues related with styling special report opinion articles. Namely kickers, comment counts and timestamps.

## Screenshots

### Before
<img width="317" alt="Screenshot 2019-10-09 at 17 44 51" src="https://user-images.githubusercontent.com/638051/66502261-d207f980-eabc-11e9-99c1-3676ebcc5ab2.png">
<img width="317" alt="Screenshot 2019-10-09 at 17 45 07" src="https://user-images.githubusercontent.com/638051/66502262-d207f980-eabc-11e9-9ea5-22b2c3b0cf9c.png">

### After

<img width="233" alt="Screenshot 2019-10-09 at 17 44 30" src="https://user-images.githubusercontent.com/638051/66502271-d59b8080-eabc-11e9-8a6a-c4c8ecf8f6f4.png">
<img width="317" alt="Screenshot 2019-10-09 at 17 44 42" src="https://user-images.githubusercontent.com/638051/66502272-d59b8080-eabc-11e9-8834-78b6927983cd.png">

