### PR TITLE
Tweak logging behavior for amp requests in the picker

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -100,6 +100,7 @@ class ArticleController(
       case HtmlFormat if tier == RemoteRender => remoteRenderer.getArticle(ws, path, article, blocks, pageType)
       case HtmlFormat => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
       case AmpFormat if isAmpSupported => remoteRenderer.getAMPArticle(ws, path, article, blocks, pageType)
+      case AmpFormat if tier == RemoteRender => remoteRenderer.getArticle(ws, path, article, blocks, pageType)
       case AmpFormat => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
     }
   }

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -69,8 +69,6 @@ object ArticlePageChecks {
 
   def isNotAGallery(page:PageWithStoryPackage): Boolean = ! page.item.tags.isGallery
 
-  def isNotAMP(request: RequestHeader): Boolean = ! request.isAmp
-
   def isNotOpinion(page:PageWithStoryPackage): Boolean = ! page.item.tags.isComment
 
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = ! page.article.tags.isPaidContent
@@ -104,7 +102,6 @@ object ArticlePicker {
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAReview", ArticlePageChecks.isNotAReview(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
-      ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotOpinionP", ArticlePageChecks.isNotOpinion(page)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNewsTone", ArticlePageChecks.isNewsTone(page)),

--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -4,6 +4,7 @@ import common.Logging
 import common.LoggingField._
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
+import implicits.Requests._
 
 import scala.util.Random
 
@@ -15,7 +16,8 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
       List[LogField](
         "req.method" -> r.method,
         "req.url" -> r.uri,
-        "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString
+        "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString,
+        "req.isAmp" -> r.isAmp
       )
     }.getOrElse(Nil)
 


### PR DESCRIPTION
## What does this change?

While trying to make sense of the numbers, I've gone through the picker and article controller with a bit more care and found some potential quirks in how we do the handling and logging of amp requests.

I have made the following changes:

* Previously, if an AMP request comes in and we determine we don't support AMP for that article (via the shouldAmplify() function) we would *always* just defer it to the non-amp twirl templates. I have made a change in this PR that gives dotcom rendering a chance to render these articles as well, if it can support it as a normal web article (in practice  this will likely be rare, but I think most people would expect it to work this way)

* I have taken the isNotAMP check out of the picker feature whitelist. The article controller will forcibly use dotcom rendering for every AMP request that passes shouldAmplify() anyway regardless of what the picker thinks, and if we're going to start giving a chance for DCR to render those unsupportable amp pages (see change 1) then it should ignore the fact that it's amp or not.

* I added a new field to the DotcomponentsLogger which logs out whether the request is an AMP request or not. This makes it easier to ignore amp requests  when trying to get data out of Kibana wrt what % of normal articles we support.

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
