### PR TITLE
Update Ophan Tracker js

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.11",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.18",
+    "ophan-tracker-js": "1.3.19",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
     "prebid.js": "https://github.com/guardian/Prebid.js.git#71da9f1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,10 +7730,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.18:
-  version "1.3.18"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.18.tgz#738e349c856b44a43e5279bedc9ff2490ad53856"
-  integrity sha512-IKeOUmw1LYGDpNWWt4OPDr1TLlaWFpsL/TIHw+f4Z9gt/CRFEO70Z9eEFu14ZBLNREklpSFjuZ9g0VaoJ4sZfQ==
+ophan-tracker-js@1.3.19:
+  version "1.3.19"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.19.tgz#64b2b3be9cc1d9ff2fcd4492dedab8385d732a73"
+  integrity sha512-xzyscisPgTPwq6QerwwImmzT+/qxxAxhVdWq3eI5dKml6CkPnjO3JSliZEjDySW6lRJyakqVfEWMET6pNauLjg==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

Brings in https://github.com/guardian/ophan/pull/3455 that means we capture all renderedComponents

@guardian/dotcom-platform 