### PR TITLE
CMP UI - remove no-scroll restrictions

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -89,11 +89,18 @@ const prepareUi = (): void => {
     const container: HTMLElement = document.createElement('div');
     container.className = CONTAINER_CLASS;
 
+    /**
+     * We found a bug where scrolling was
+     * sometimes not picked up on the iframe once it had animated in.
+     * Only forcing a reflow would correct this, so now when
+     * on the container transitionend we force a reflow.
+     */
     container.addEventListener('transitionend', () => {
-        if (overlay && overlay.parentNode) {
-            console.log('*** FORCE REFLOW ***');
-            overlay.style.width = '100%';
-        }
+        fastdom.write(() => {
+            if (overlay && overlay.parentNode) {
+                overlay.style.width = '100%';
+            }
+        });
     });
 
     overlay.appendChild(container);

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -41,8 +41,10 @@ const onReadyCmp = (): Promise<void> =>
         })
         .then(animateCmp)
         .then(() => {
-            console.log('*** FORCE REFLOW ***');
-            overlay.style.width = '100%';
+            if (overlay && overlay.parentNode) {
+                console.log('*** FORCE REFLOW ***');
+                overlay.style.width = '100%';
+            }
         });
 
 const removeCmp = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -39,7 +39,11 @@ const onReadyCmp = (): Promise<void> =>
                 overlay.classList.add(CMP_READY_CLASS);
             }
         })
-        .then(animateCmp);
+        .then(animateCmp)
+        .then(() => {
+            console.log('*** FORCE REFLOW ***');
+            overlay.style.width = '100%';
+        });
 
 const removeCmp = (): Promise<void> =>
     /**

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -39,13 +39,7 @@ const onReadyCmp = (): Promise<void> =>
                 overlay.classList.add(CMP_READY_CLASS);
             }
         })
-        .then(animateCmp)
-        .then(() => {
-            if (overlay && overlay.parentNode) {
-                console.log('*** FORCE REFLOW ***');
-                overlay.style.width = '100%';
-            }
-        });
+        .then(animateCmp);
 
 const removeCmp = (): Promise<void> =>
     /**
@@ -93,8 +87,14 @@ const prepareUi = (): void => {
     overlay.className = OVERLAY_CLASS;
 
     const container: HTMLElement = document.createElement('div');
-
     container.className = CONTAINER_CLASS;
+
+    container.addEventListener('transitionend', () => {
+        if (overlay && overlay.parentNode) {
+            console.log('*** FORCE REFLOW ***');
+            overlay.style.width = '100%';
+        }
+    });
 
     overlay.appendChild(container);
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -26,12 +26,6 @@ const animateCmp = (): Promise<void> =>
             fastdom.write(() => {
                 if (overlay && overlay.parentNode) {
                     overlay.classList.add(CMP_ANIMATE_CLASS);
-
-                    // disable scrolling on body beneath overlay
-                    if (document.body) {
-                        document.body.classList.add('no-scroll');
-                    }
-
                     resolve();
                 }
             });
@@ -69,11 +63,6 @@ const onCloseCmp = (): Promise<void> =>
     fastdom
         .write(() => {
             if (overlay && overlay.parentNode) {
-                // enable scrolling on body beneath overlay
-                if (document.body) {
-                    document.body.classList.remove('no-scroll');
-                }
-
                 overlay.classList.remove(CMP_ANIMATE_CLASS);
             }
         })
@@ -97,9 +86,26 @@ const prepareUi = (): void => {
     overlay = document.createElement('div');
     overlay.className = OVERLAY_CLASS;
 
-    overlay.innerHTML = `<div class="${CONTAINER_CLASS}"><iframe src="${
-        cmpConfig.CMP_URL
-    }" class="${IFRAME_CLASS}" tabIndex="1"></iframe></div>`;
+    const container: HTMLElement = document.createElement('div');
+
+    container.className = CONTAINER_CLASS;
+
+    overlay.appendChild(container);
+
+    const iframe: HTMLIFrameElement = document.createElement('iframe');
+
+    iframe.className = IFRAME_CLASS;
+    iframe.src = cmpConfig.CMP_URL;
+    iframe.tabIndex = 1;
+    iframe.addEventListener(
+        'touchmove',
+        (evt: Event) => {
+            evt.preventDefault();
+        },
+        false
+    );
+
+    container.appendChild(iframe);
 
     cmpUi.setupMessageHandlers(onReadyCmp, onCloseCmp, onErrorCmp);
 

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -21,7 +21,7 @@
 
     &.cmp-animate {
         @include mq(mobileLandscape) {
-            background-color: rgba(#000000, .5);
+            background-color: rgba(#000000, .6);
         }
     }
 }

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -55,11 +55,3 @@
     width: 100%;
     border: 0;
 }
-
-// Prevent body scrolling behind overlay
-body.no-scroll {
-    overflow: hidden;
-    position: fixed;
-    left: 0;
-    right: 0;
-}


### PR DESCRIPTION
## What does this change?

Currently when the new CMP UI is displayed we disable scrolling on the article beneath the overlay. We achieved this by adding a `no-scroll` class that fixes the position of the body and hides any overflow. The issue we found was applying this class forces the body to jump to the top if a user has scrolled the page. To remove this jump we're allowing the user to scroll the content beneath the overlay now, by no longer adding the `no-scroll` class.

Removing this class had a side affect on mobile where the body beneath the `iframe` scrolls on `touchmove` on the `iframe`. To get around this we capture `touchmove` on the `iframe` and `preventDefault`.

There's also a fix for a bug that we were seeing in Chrome where scroll events on the iframe were not being picked up until the page had reflowed.