### PR TITLE
increase opacity on cmp-overlay

### DIFF
--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -21,7 +21,7 @@
 
     &.cmp-animate {
         @include mq(mobileLandscape) {
-            background-color: rgba(#000000, .6);
+            background-color: rgba(#000000, .7);
         }
     }
 }


### PR DESCRIPTION
## What does this change?

This PR increases the opacity on `cmp-overlay` for the new CMP UI to `0.7` now we're allowing scrolling beneath, as per UX recommendations.