### PR TITLE
Add openGraphData to the dotcomponentsDataModel

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -210,6 +210,7 @@ case class DataModelV3(
   isAdFreeUser: Boolean,
   webURL: String,
   linkedData: List[LinkedData],
+  openGraphData: Map[String, String],
   config: JsObject,
   guardianBaseURL: String,
   contentType: String,
@@ -260,6 +261,7 @@ object DataModelV3 {
       "isAdFreeUser" -> model.isAdFreeUser,
       "webURL" -> model.webURL,
       "linkedData" -> model.linkedData,
+      "openGraphData" -> model.openGraphData,
       "config" -> model.config,
       "guardianBaseURL" -> model.guardianBaseURL,
       "contentType" -> model.contentType,
@@ -468,6 +470,8 @@ object DotcomponentsDataModel {
       }
     }
 
+    val openGraphData: Map[String, String] = articlePage.getOpenGraphProperties;
+
     val allTags = article.tags.tags.map(
       t => Tag(
         t.id,
@@ -594,6 +598,7 @@ object DotcomponentsDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       webURL = article.metadata.webUrl,
       linkedData = linkedData,
+      openGraphData = openGraphData,
       config = combinedConfig,
       guardianBaseURL = Configuration.site.host,
       contentType = jsConfig("contentType").getOrElse(""),


### PR DESCRIPTION
## What does this change?

This adds openGraph Data to the DCR model to enable us to add it to pages in DCR.

*Why not pick and choose?*

Because, like some other fields, picking and choosing likely means we'll forget something, so IMO it's better to pass all the metadata and loop over it them in DCR. 

That way we can't *not* be in sync...

## Screenshots
![image](https://user-images.githubusercontent.com/638051/66578813-af84e780-eb73-11e9-87ce-f788b2023a40.png)


## What is the value of this and can you measure success?

Opengraph data is correct.

## Checklist
