### PR TITLE
Mobile sticky support for DCR

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -3,29 +3,47 @@ import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { shouldIncludeMobileSticky } from 'commercial/modules/prebid/utils';
+import config from 'lib/config';
 
-const createAdWrapper = (): HTMLDivElement => {
-    const wrapper: HTMLDivElement = document.createElement('div');
-    wrapper.className = 'mobilesticky-container';
+const createAdWrapperClassic = () => {
+    const wrapper: HTMLElement = document.createElement('div');
+    wrapper.className = 'mobilesticky-container`';
     const adSlot = createSlots('mobile-sticky', {})[0];
     wrapper.appendChild(adSlot);
     return wrapper;
 };
 
+const createAdWrapperDCR = () => {
+    const wrapper = document.querySelector('.mobilesticky-container');
+    if (wrapper) {
+        const adSlot = createSlots('mobile-sticky', {})[0];
+        wrapper.appendChild(adSlot);
+    }
+    return wrapper;
+};
+
+const createAdWrapper = () => {
+    if (!config.get('isDotcomRendering', false)) {
+        return createAdWrapperClassic();
+    }
+    return createAdWrapperDCR();
+};
+
 export const init = (): Promise<void> => {
     if (shouldIncludeMobileSticky()) {
         const mobileStickyWrapper = createAdWrapper();
-
         return fastdom
             .write(() => {
-                if (document.body)
+                if (document.body && mobileStickyWrapper)
                     document.body.appendChild(mobileStickyWrapper);
             })
             .then(() => {
-                const mobileStickyAdSlot = mobileStickyWrapper.querySelector(
-                    '#dfp-ad--mobile-sticky'
-                );
-                if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, true);
+                if (mobileStickyWrapper) {
+                    const mobileStickyAdSlot = mobileStickyWrapper.querySelector(
+                        '#dfp-ad--mobile-sticky'
+                    );
+                    if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, true);
+                }
             });
     }
 

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -7,7 +7,7 @@ import config from 'lib/config';
 
 const createAdWrapperClassic = () => {
     const wrapper: HTMLElement = document.createElement('div');
-    wrapper.className = 'mobilesticky-container`';
+    wrapper.className = 'mobilesticky-container';
     const adSlot = createSlots('mobile-sticky', {})[0];
     wrapper.appendChild(adSlot);
     return wrapper;


### PR DESCRIPTION
## What does this change?

This enriches the `createAdWrapper` function in `mobile-sticky.js`, to support dotcom-rendering. In frontend classic the `mobilesticky-container` div is being created, but in DCR it will have been injected into the page server side (because we need to attach styles to it at that stage). 

Note that we have removed type information to deal with the fact that `document.querySelector` could return `null`. 