### PR TITLE
Escape text in og:title tag.

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -330,7 +330,7 @@ final case class Content(
   }
 
   val opengraphProperties: Map[String, String] = Map(
-    "og:title" -> metadata.webTitle,
+    "og:title" -> StripHtmlTagsAndUnescapeEntities(metadata.webTitle),
     "og:description" -> fields.trailText.map(StripHtmlTagsAndUnescapeEntities(_)).getOrElse(""),
     "og:image" -> openGraphImage
   ) ++ openGraphImageWidth.map("og:image:width" -> _.toString).toMap ++


### PR DESCRIPTION
## What does this change?
Ensures that any characters in the title of a page are properly escaped in the `og:title` tag. This is currently causing problems for pages like this one https://www.theguardian.com/global/video/2019/oct/10/he-said-id-break-the-law-for-you-i-was-13-calling-time-on-street-harassment - see https://cards-dev.twitter.com/validator to try some pages out

This was actually discovered by @gtrufitt , just thought I'd get a build running before the morning. I was able to test locally sort of by checking the source code of the page - the quotes got escaped.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
