### PR TITLE
Set url in moment epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment.js
@@ -42,6 +42,8 @@ const variantCopy = {
     highlightedText,
 };
 
+const url = 'http://support.theguardian.com/contribute/climate-pledge-2019';
+
 const geolocation = geolocationGetSync();
 
 export const articlesViewedMoment: EpicABTest = makeEpicABTest({
@@ -76,6 +78,7 @@ export const articlesViewedMoment: EpicABTest = makeEpicABTest({
             classNames: [
                 'contributions__epic--2019-10-14_moment_climate_pledge',
             ],
+            supportBaseURL: url,
         },
         {
             id: 'variant',
@@ -85,6 +88,7 @@ export const articlesViewedMoment: EpicABTest = makeEpicABTest({
             classNames: [
                 'contributions__epic--2019-10-14_moment_climate_pledge',
             ],
+            supportBaseURL: url,
         },
     ],
 });


### PR DESCRIPTION
## What does this change?
We have a hard-coded epic test for the moment.
This change is probably unnecessary because we're going to be showing the moment-specific landing page to all users, but I'm adding the special url just in case something changes .
