### PR TITLE
Update to Identity/README

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -23,7 +23,7 @@ So to go into the Identity project:
 
 and then the following commands are equivalent:
 
-  `idrun` or `run 9009`
+  `run` or `run 9009`
 
 The former is encouraged, in case we ever need to change the port.
 


### PR DESCRIPTION
changed the `idrun` command to `run`, since `idrun` is no longer used
as noticed after trying to use it, while `run` works as expected
