### PR TITLE
Update how cookie persistent is derived

### DIFF
--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -124,10 +124,16 @@ class ReauthenticationController(
 
     def onSuccess(password: String): Future[Result] = {
         logger.trace("reauthenticating with ID API")
-        val persistent = request.user.auth match {
-          case ScGuU(_, v) => v.isPersistent
-          case _ => false
-        }
+
+        // Previously derived from the data within the GU_U cookie.
+        // However, the functionality of verifying the GU_U cookie
+        // and decoding data from within it has been deprecated
+        // (with the change to authentication in identity).
+        // Instead determine whether the cookie should be a session cookie
+        // by looking at whether the current SC_GU_U is a session cookie.
+        // From the Play docs: if maxAge is `None` then the cookie is transient.
+        val persistent = request.cookies.get("SC_GU_U").fold(false)(_.maxAge.isDefined)
+
         val auth = EmailPassword(request.user.primaryEmailAddress, password, idRequest.clientIp)
         val authResponse = api.authBrowser(auth, idRequest.trackingData, Some(persistent))
 


### PR DESCRIPTION
## What does this change?

Changes how cookie persistent type is derived. Previously it was derived from the value of the GU_U cookie; this change derives it directly from the SC_GU_U cookie's expiry time. See inline comment for more context.

This change is in preparation for the work to replace identity-cookie with identity-auth-play. I deemed it significant enough a change to merit a separate PR.