### PR TITLE
Using an HTTPS domain for LiveIntent ads and trackers in The Guardian Today US email

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -248,24 +248,24 @@
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="margin-left:auto; margin-right:auto;">
         <tr>
             <td colspan="2">
-                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" style="display: block; width:100%; height:auto;" width="500">
+                <a href="https://li.guim.co.uk/click?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://li.guim.co.uk/imp?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" style="display: block; width:100%; height:auto;" width="500">
                 </a>
             </td>
         </tr>
         <tr style="display:block; height:1px; line-height:1px;">
-            <td><img height="1" src="https://sli.theguardian.com/imp?s=@{marquee.ids._2}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
-            <td><img height="1" src="https://sli.theguardian.com/imp?s=@{marquee.ids._3}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+            <td><img height="1" src="https://li.guim.co.uk/imp?s=@{marquee.ids._2}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+            <td><img height="1" src="https://li.guim.co.uk/imp?s=@{marquee.ids._3}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
         </tr>
         <tr>
             <td align="left">
-                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                <a href="https://li.guim.co.uk/click?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://li.guim.co.uk/imp?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                 </a>
             </td>
             <td align="right">
-                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                <a href="https://li.guim.co.uk/click?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://li.guim.co.uk/imp?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                 </a>
             </td>
         </tr>
@@ -283,24 +283,24 @@
                 <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
                         <td colspan="2">
-                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow" style="display: block; width: 300px; height: 250px;">
-                                <img border="0" height="250" src="https://sli.theguardian.com/imp?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="300">
+                            <a href="https://li.guim.co.uk/click?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow" style="display: block; width: 300px; height: 250px;">
+                                <img border="0" height="250" src="https://li.guim.co.uk/imp?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="300">
                             </a>
                         </td>
                     </tr>
                     <tr style="display:block; height:1px; line-height:1px;">
-                        <td><img height="1" src="https://sli.theguardian.com/imp?s=@{mpu.ids._2}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
-                        <td><img height="1" src="https://sli.theguardian.com/imp?s=@{mpu.ids._3}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+                        <td><img height="1" src="https://li.guim.co.uk/imp?s=@{mpu.ids._2}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+                        <td><img height="1" src="https://li.guim.co.uk/imp?s=@{mpu.ids._3}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
                     </tr>
                     <tr>
                         <td align="left">
-                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                                <img border="0" src="https://sli.theguardian.com/imp?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                            <a href="https://li.guim.co.uk/click?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                                <img border="0" src="https://li.guim.co.uk/imp?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                             </a>
                         </td>
                         <td align="right">
-                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                                <img border="0" src="https://sli.theguardian.com/imp?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                            <a href="https://li.guim.co.uk/click?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                                <img border="0" src="https://li.guim.co.uk/imp?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                             </a>
                         </td>
                     </tr>
@@ -316,7 +316,7 @@
         <tbody>
             <tr>
                 @safeRTB.ids.map { id =>
-                    <td><img border="0" height="6" src="https://sli.theguardian.com/imp?s=@id&sz=2x1&li@{safeRTB.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="2"></td>
+                    <td><img border="0" height="6" src="https://li.guim.co.uk/imp?s=@id&sz=2x1&li@{safeRTB.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="2"></td>
                 }
             </tr>
         </tbody>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -248,24 +248,24 @@
     <table align="center" border="0" cellpadding="0" cellspacing="0" style="margin-left:auto; margin-right:auto;">
         <tr>
             <td colspan="2">
-                <a href="http://li.theguardian.com/click?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="http://li.theguardian.com/imp?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" style="display: block; width:100%; height:auto;" width="500">
+                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._1}&layout=marquee&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" style="display: block; width:100%; height:auto;" width="500">
                 </a>
             </td>
         </tr>
         <tr style="display:block; height:1px; line-height:1px;">
-            <td><img height="1" src="http://li.theguardian.com/imp?s=@{marquee.ids._2}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
-            <td><img height="1" src="http://li.theguardian.com/imp?s=@{marquee.ids._3}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+            <td><img height="1" src="https://sli.theguardian.com/imp?s=@{marquee.ids._2}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+            <td><img height="1" src="https://sli.theguardian.com/imp?s=@{marquee.ids._3}&sz=1x1&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
         </tr>
         <tr>
             <td align="left">
-                <a href="http://li.theguardian.com/click?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="http://li.theguardian.com/imp?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._4}&sz=116x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                 </a>
             </td>
             <td align="right">
-                <a href="http://li.theguardian.com/click?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                    <img border="0" src="http://li.theguardian.com/imp?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                <a href="https://sli.theguardian.com/click?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                    <img border="0" src="https://sli.theguardian.com/imp?s=@{marquee.ids._5}&sz=69x15&li=@{marquee.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                 </a>
             </td>
         </tr>
@@ -283,24 +283,24 @@
                 <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
                         <td colspan="2">
-                            <a href="http://li.theguardian.com/click?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow" style="display: block; width: 300px; height: 250px;">
-                                <img border="0" height="250" src="http://li.theguardian.com/imp?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="300">
+                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow" style="display: block; width: 300px; height: 250px;">
+                                <img border="0" height="250" src="https://sli.theguardian.com/imp?s=@{mpu.ids._1}&sz=300x250&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="300">
                             </a>
                         </td>
                     </tr>
                     <tr style="display:block; height:1px; line-height:1px;">
-                        <td><img height="1" src="http://li.theguardian.com/imp?s=@{mpu.ids._2}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
-                        <td><img height="1" src="http://li.theguardian.com/imp?s=@{mpu.ids._3}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+                        <td><img height="1" src="https://sli.theguardian.com/imp?s=@{mpu.ids._2}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
+                        <td><img height="1" src="https://sli.theguardian.com/imp?s=@{mpu.ids._3}&sz=1x1&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="10"></td>
                     </tr>
                     <tr>
                         <td align="left">
-                            <a href="http://li.theguardian.com/click?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                                <img border="0" src="http://li.theguardian.com/imp?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                                <img border="0" src="https://sli.theguardian.com/imp?s=@{mpu.ids._4}&sz=116x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                             </a>
                         </td>
                         <td align="right">
-                            <a href="http://li.theguardian.com/click?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
-                                <img border="0" src="http://li.theguardian.com/imp?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
+                            <a href="https://sli.theguardian.com/click?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" rel="nofollow">
+                                <img border="0" src="https://sli.theguardian.com/imp?s=@{mpu.ids._5}&sz=69x15&li=@{mpu.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%">
                             </a>
                         </td>
                     </tr>
@@ -316,7 +316,7 @@
         <tbody>
             <tr>
                 @safeRTB.ids.map { id =>
-                    <td><img border="0" height="6" src="http://li.theguardian.com/imp?s=@id&sz=2x1&li@{safeRTB.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="2"></td>
+                    <td><img border="0" height="6" src="https://sli.theguardian.com/imp?s=@id&sz=2x1&li@{safeRTB.newsletterId}&m=%%=v(@@hashedEmail)=%%&p=%%jobid%%" width="2"></td>
                 }
             </tr>
         </tbody>


### PR DESCRIPTION
Using an HTTPS link for LiveIntent ads and trackers in The Guardian Today US email, for typical https reasons, but also to try and fix the issue that tracking pixels are appearing as 404 in Gmail, when in fact they work fine when not going via Google's image proxy (that all images in gmail are wrapped with) - see image.

## What does this change?
The URL to the LiveIntent brokering system.

## Screenshots

Before (see the squares just above the support ask section):

<img width="553" alt="Screen Shot 2019-11-21 at 13 51 01" src="https://user-images.githubusercontent.com/1515970/69343711-03e8b000-0c66-11ea-8616-21b419a3366c.png">

After: 
Same! The same 2 pixels didn't show, but the rest and the advert did just fine.
Ok so this change didn't fix the issue - it must therefore be Google proxy related - I think it's because there are about 4 redirects, and the proxy won't follow that many. However, I feel we should still move forward as using HTTPS and a cookie-free domain is better than HTTP and li.theguardian.com.

## What is the value of this and can you measure success?
No tracking pixels 404-ing and ads showing fine.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify) - [x] Email

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (TBC)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
