### PR TITLE
Revert "Revert "Add openGraphData to the dotcomponentsDataModel""

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -210,6 +210,7 @@ case class DataModelV3(
   isAdFreeUser: Boolean,
   webURL: String,
   linkedData: List[LinkedData],
+  openGraphData: Map[String, String],
   config: JsObject,
   guardianBaseURL: String,
   contentType: String,
@@ -260,6 +261,7 @@ object DataModelV3 {
       "isAdFreeUser" -> model.isAdFreeUser,
       "webURL" -> model.webURL,
       "linkedData" -> model.linkedData,
+      "openGraphData" -> model.openGraphData,
       "config" -> model.config,
       "guardianBaseURL" -> model.guardianBaseURL,
       "contentType" -> model.contentType,
@@ -468,6 +470,8 @@ object DotcomponentsDataModel {
       }
     }
 
+    val openGraphData: Map[String, String] = articlePage.getOpenGraphProperties;
+
     val allTags = article.tags.tags.map(
       t => Tag(
         t.id,
@@ -594,6 +598,7 @@ object DotcomponentsDataModel {
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       webURL = article.metadata.webUrl,
       linkedData = linkedData,
+      openGraphData = openGraphData,
       config = combinedConfig,
       guardianBaseURL = Configuration.site.host,
       contentType = jsConfig("contentType").getOrElse(""),


### PR DESCRIPTION
Reverts guardian/frontend#21908 as we think it was unrelated to the issues with rendering we had last week. 