### PR TITLE
Fix epic button format on safari

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -19,6 +19,7 @@ $gu-cta-height: 42px;
     transition: $gu-transition;
     justify-content: space-between;
     position: relative;
+    white-space: nowrap;
 
     &:hover, &:focus {
         outline: 0;


### PR DESCRIPTION
## What does this change?
The epic button has a styling issue on safari 

## Screenshots
Before:
<img width="657" alt="Screenshot 2019-10-16 at 16 11 57" src="https://user-images.githubusercontent.com/1513454/66932613-cb830000-f02f-11e9-81a6-32f9ac4268c8.png">

After:
<img width="657" alt="Screenshot 2019-10-16 at 16 22 35" src="https://user-images.githubusercontent.com/1513454/66933565-2e28cb80-f031-11e9-848e-f92ad3900453.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
