### PR TITLE
Add ophan attention time tracking to youtube player

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -345,6 +345,7 @@ const onPlayerReady = (
         duration,
         youtubePlayer,
         paused: false,
+        playing: false,
         pendingTrackingCalls: [25, 50, 75],
     };
 
@@ -380,8 +381,18 @@ const onPlayerReady = (
     }
 };
 
-const isAnyPlayerPlaying = (): boolean =>{
-    return Object.values(players).filter(_=>_.playing).length>0;
+const isAnyPlayerPlaying = (): boolean =>
+    Object.values(players).filter(_ => _.playing).length > 0;
+
+const triggerVideoStateEvent = (isPlaying: boolean): void => {
+    if (isPlaying) {
+        const videoPlaying = new Event('videoPlaying');
+        document.body.dispatchEvent(videoPlaying);
+    } else {
+        // Use videoEnded until tracker-js updated to videoStopped.
+        const videoStopped = new Event('videoEnded');
+        document.body.dispatchEvent(videoStopped);
+    }
 };
 
 const onPlayerStateChange = (
@@ -396,6 +407,7 @@ const onPlayerStateChange = (
 
     if (stateKey) {
         STATES[stateKey](atomId);
+        triggerVideoStateEvent(isAnyPlayerPlaying());
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -382,16 +382,18 @@ const onPlayerReady = (
 };
 
 const isAnyPlayerPlaying = (): boolean =>
-    Object.values(players).filter(_ => _.playing).length > 0;
+    Object.keys(players)
+        .map(key => players[key])
+        .filter((p: AtomPlayer): boolean => p.playing).length > 0;
 
 const triggerVideoStateEvent = (isPlaying: boolean): void => {
     if (isPlaying) {
         const videoPlaying = new Event('videoPlaying');
-        document.body.dispatchEvent(videoPlaying);
+        document.dispatchEvent(videoPlaying);
     } else {
         // Use videoEnded until tracker-js updated to videoStopped.
         const videoStopped = new Event('videoEnded');
-        document.body.dispatchEvent(videoStopped);
+        document.dispatchEvent(videoStopped);
     }
 };
 


### PR DESCRIPTION
## What does this change?
Ophan can now track attention time spent watching videos. Prior to this change, the "playing" state of a video was not passed to Ophan meaning that video pages were often given very low attention times. The issue in which this was first raised is here: https://github.com/guardian/ophan/issues/3391

Note: https://github.com/guardian/frontend/blob/0030877e1ff32bc6b44623db7f3bd98e083ca894/static/src/javascripts/projects/common/modules/atoms/youtube.js#L394-L396 points out that at the moment the ophan codebase is looking for one of three DOM events: `videoPlaying`, `videoPaused` and `videoEnded`. In this change we're moving towards a video being either 'playing' or 'stopped' and so we'll potentially add a listener to tracker-js for a `videoStopped` event and then update this to reflect that. Functionally nothing changes, but semantically `videoStopped` makes more sense. 
## Screenshots

## What is the value of this and can you measure success?
Correct tracking of video attention times. If implemented correctly, attention times for videos should increase from the current of a few seconds to something on the scale of the video's length.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (please specify)
Ophan

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
