### PR TITLE
Disable dotcom rendering when main media is show case.

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -75,6 +75,8 @@ object ArticlePageChecks {
 
   def isNotPaidContent(page: PageWithStoryPackage): Boolean = ! page.article.tags.isPaidContent
 
+  def mainMediaIsNotShowcase(page: PageWithStoryPackage): Boolean = ! page.article.elements.mainPicture.flatMap(_.images.masterImage.flatMap(_.role)).contains("showcase")
+
   def isNewsTone(page: PageWithStoryPackage): Boolean = {
     page.article.tags.tones.headOption.exists(_.id == "tone/news") || page.article.tags.tones.isEmpty
   }
@@ -109,6 +111,7 @@ object ArticlePicker {
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNewsTone", ArticlePageChecks.isNewsTone(page)),
       ("isNotBlackListed", ArticlePageChecks.isNotBlackListed(page)),
+      ("mainMediaIsNotShowcase", ArticlePageChecks.mainMediaIsNotShowcase(page))
     )
   }
 


### PR DESCRIPTION
## What does this change?
currently this page is rendered in dotcom rendering: https://www.theguardian.com/environment/2019/oct/16/ivory-coast-law-could-see-chocolate-industry-wipe-out-protected-forests but it doesn't look great as it has showcase main media. Let's stop rendering these types of articles in DCR.

cc @oliverlloyd 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
