### PR TITLE
Moment epic test for 5 or more views in 2 months

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,6 +48,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-articles-viewed-month-moment-60-days",
+    "Moment epic which also states how many articles a user has viewed",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 27),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-learn-more-cta",
     "States how many articles a user has viewed in the epic in a month",
     owners = Seq(Owner.withGithub("jlieb10")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,6 +4,7 @@ import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
 import { articlesViewedMoment } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-variant';
+import { articlesViewedMoment60Days } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days';
 import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
@@ -28,6 +29,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
     articlesViewedMoment,
+    articlesViewedMoment60Days,
     articlesViewed,
     learnMore,
     countryName,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
@@ -18,6 +18,18 @@ const heading = 'As the climate crisis escalates...';
 const highlightedText =
     'Support us from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
 
+const controlCopy = {
+    heading,
+    paragraphs: [
+        '... the Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power. We will inform our readers about threats to the environment based on scientific facts, not driven by commercial or political interests. And we have made several important changes to our style guide to ensure the language we use accurately reflects the environmental catastrophe.',
+        'The Guardian believes that the problems we face on the climate crisis are systemic and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of human life on earth. We want their stories to inspire hope. We will also report back on our own progress as an organisation, as we take important steps to address our impact on the environment.',
+        'The Guardian made a choice: to keep our journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.',
+        'We hope you will consider supporting the Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+    ],
+    highlightedText,
+};
+
 const variantCopy = {
     heading,
     paragraphs: [
@@ -58,6 +70,16 @@ export const articlesViewedMoment60Days: EpicABTest = makeEpicABTest({
     canRun: () => articleViewCount >= minArticleViews,
 
     variants: [
+        {
+            id: 'control',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+            copy: buildEpicCopy(controlCopy, false, geolocation),
+            classNames: [
+                'contributions__epic--2019-10-14_moment_climate_pledge',
+            ],
+            supportBaseURL: url,
+        },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
@@ -1,0 +1,72 @@
+// @flow
+import {
+    makeEpicABTest,
+    defaultButtonTemplate,
+    buildEpicCopy,
+} from 'common/modules/commercial/contributions-utilities';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+// User must have read at least 5 articles in last 60 days
+const minArticleViews = 5;
+const articleCountDays = 60;
+
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
+
+const heading = 'As the climate crisis escalates...';
+
+const highlightedText =
+    'Support us from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
+
+const variantCopy = {
+    heading,
+    paragraphs: [
+        '... the Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
+        'Our independence means we are free to investigate and challenge inaction by those in power. We will inform our readers about threats to the environment based on scientific facts, not driven by commercial or political interests. And we have made several important changes to our style guide to ensure the language we use accurately reflects the environmental catastrophe.',
+        'The Guardian believes that the problems we face on the climate crisis are systemic and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of human life on earth. We want their stories to inspire hope. We will also report back on our own progress as an organisation, as we take important steps to address our impact on the environment.',
+        `You’ve read ${articleViewCount} Guardian articles in the last two months – made possible by our choice to keep Guardian journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.`,
+        'We hope you will consider supporting the Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
+    ],
+    highlightedText,
+};
+
+const url = 'http://support.theguardian.com/contribute/climate-pledge-2019';
+
+const geolocation = geolocationGetSync();
+
+export const articlesViewedMoment60Days: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicArticlesViewedMonthMoment60Days',
+    campaignId: '2019-10-14_moment_climate_pledge_article_count_60_days',
+
+    start: '2019-06-24',
+    expiry: '2020-01-27',
+
+    author: 'Tom Forbes',
+    description:
+        'Moment epic which also states how many articles a user has viewed',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    geolocation,
+    highPriority: true,
+    useLocalViewLog: true,
+
+    canRun: () => articleViewCount >= minArticleViews,
+
+    variants: [
+        {
+            id: 'variant',
+            buttonTemplate: defaultButtonTemplate,
+            products: [],
+            copy: buildEpicCopy(variantCopy, false, geolocation),
+            classNames: [
+                'contributions__epic--2019-10-14_moment_climate_pledge',
+            ],
+            supportBaseURL: url,
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
We're currently running a moment-specific epic test for people who have viewed 5 or more articles in 30 days. We want to catch more people with a test for 5 or more in 60 days.
The test is almost identical to the original 30 days test.

## Screenshots
Control (no article count):
<img width="657" alt="Screenshot 2019-10-17 at 14 10 36" src="https://user-images.githubusercontent.com/1513454/67011693-034d7e80-f0e8-11e9-9d1d-b5ded9f30101.png">


Variant (with article count):
<img width="657" alt="Screenshot 2019-10-17 at 11 08 49" src="https://user-images.githubusercontent.com/1513454/67011660-f4ff6280-f0e7-11e9-8ad3-397cbc4a5753.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
