### PR TITLE
Bump ophan-tracker-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.11",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.19",
+    "ophan-tracker-js": "1.3.20",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
     "prebid.js": "https://github.com/guardian/Prebid.js.git#71da9f1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,10 +7730,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.19:
-  version "1.3.19"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.19.tgz#64b2b3be9cc1d9ff2fcd4492dedab8385d732a73"
-  integrity sha512-xzyscisPgTPwq6QerwwImmzT+/qxxAxhVdWq3eI5dKml6CkPnjO3JSliZEjDySW6lRJyakqVfEWMET6pNauLjg==
+ophan-tracker-js@1.3.20:
+  version "1.3.20"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.20.tgz#eaa76de7b860fa3254986f9783c8f404d0e412c7"
+  integrity sha512-Rc2DUbfGvZgraKoKg/p2btnTN/ugu2axI3bcn59jz8kVyyrauegP+zgmtFFnW0gU154IvHDw/Zd+8oRQ1O0xrg==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?
Following work to update how video attention time is tracked, as per
https://github.com/guardian/frontend/pull/21924, `ophan-tracker-js`
needed updating to listen in the right location. This has now been
done and the changes published to npm (https://github.com/guardian/ophan/pull/3470)

`package.json` and `yarn.lock` have both been updated to use the new
version which was bumped from `1.3.19` to `1.3.20`.

## Screenshots

## What is the value of this and can you measure success?
Ophan attention time tracking should be updated in both network traffic and the dashboard.
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (please specify)
Ophan
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
