### PR TITLE
Remove control from moment epic with 'two months' message

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,7 +48,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-articles-viewed-month-moment-60-days",
+    "ab-contributions-epic-articles-viewed-month-moment-60-days-variant",
     "Moment epic which also states how many articles a user has viewed",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,7 +4,7 @@ import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
 import { articlesViewedMoment } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position';
-import { articlesViewedMoment60Days } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days';
+import { articlesViewedMoment60DaysVariant } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days';
 import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
@@ -29,7 +29,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
     articlesViewedMoment,
-    articlesViewedMoment60Days,
+    articlesViewedMoment60DaysVariant,
     articlesViewed,
     learnMore,
     countryName,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days.js
@@ -18,18 +18,6 @@ const heading = 'As the climate crisis escalates...';
 const highlightedText =
     'Support us from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
 
-const controlCopy = {
-    heading,
-    paragraphs: [
-        '... the Guardian will not stay quiet. This is our pledge: we will continue to give global heating, wildlife extinction and pollution the urgent attention and prominence they demand. The Guardian recognises the climate emergency as the defining issue of our times.',
-        'Our independence means we are free to investigate and challenge inaction by those in power. We will inform our readers about threats to the environment based on scientific facts, not driven by commercial or political interests. And we have made several important changes to our style guide to ensure the language we use accurately reflects the environmental catastrophe.',
-        'The Guardian believes that the problems we face on the climate crisis are systemic and that fundamental societal change is needed. We will keep reporting on the efforts of individuals and communities around the world who are fearlessly taking a stand for future generations and the preservation of human life on earth. We want their stories to inspire hope. We will also report back on our own progress as an organisation, as we take important steps to address our impact on the environment.',
-        'The Guardian made a choice: to keep our journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.',
-        'We hope you will consider supporting the Guardian’s open, independent reporting today. Every contribution from our readers, however big or small, is so valuable.',
-    ],
-    highlightedText,
-};
-
 const variantCopy = {
     heading,
     paragraphs: [
@@ -46,9 +34,10 @@ const url = 'http://support.theguardian.com/contribute/climate-pledge-2019';
 
 const geolocation = geolocationGetSync();
 
-export const articlesViewedMoment60Days: EpicABTest = makeEpicABTest({
-    id: 'ContributionsEpicArticlesViewedMonthMoment60Days',
-    campaignId: '2019-10-14_moment_climate_pledge_article_count_60_days',
+export const articlesViewedMoment60DaysVariant: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicArticlesViewedMonthMoment60DaysVariant',
+    campaignId:
+        '2019-10-14_moment_climate_pledge_article_count_60_days_variant',
 
     start: '2019-06-24',
     expiry: '2020-01-27',
@@ -70,16 +59,6 @@ export const articlesViewedMoment60Days: EpicABTest = makeEpicABTest({
     canRun: () => articleViewCount >= minArticleViews,
 
     variants: [
-        {
-            id: 'control',
-            buttonTemplate: defaultButtonTemplate,
-            products: [],
-            copy: buildEpicCopy(controlCopy, false, geolocation),
-            classNames: [
-                'contributions__epic--2019-10-14_moment_climate_pledge',
-            ],
-            supportBaseURL: url,
-        },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,


### PR DESCRIPTION
## What does this change?
Removes the control from an epic test because the variant is doing very well. This epic has 'the Pledge' theme, with an article count for the last 60 day. The 30 day epic is still running as a separate 'test' - we may try to combine them later but not now.

## Screenshots
<img width="628" alt="Screenshot 2019-10-21 at 08 54 20" src="https://user-images.githubusercontent.com/1513454/67187520-4b1f1f00-f3e2-11e9-92cb-b7e564ba04aa.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
