### PR TITLE
Move imrWorldwide from advertising consent check into performance consent check

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -104,6 +104,6 @@ export const _ = {
     insertScripts,
     loadOther,
     reset: () => {
-        scriptsInserted = false;
+        adScriptsInserted = false;
     },
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -15,47 +15,53 @@ import { init as initPlistaOutbrainRenderer } from 'commercial/modules/third-par
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 
-let scriptsInserted: boolean = false;
+let adScriptsInserted: boolean = false;
 
-const insertScripts = (services: Array<ThirdPartyTag>): void => {
+const addScripts = (services: Array<ThirdPartyTag>): void => {
+    const ref = document.scripts[0];
+    const frag = document.createDocumentFragment();
+    let hasScriptsToInsert = false;
+
+    services.forEach(service => {
+        if (service.useImage === true) {
+            new Image().src = service.url;
+        } else {
+            hasScriptsToInsert = true;
+            const script = document.createElement('script');
+            script.src = service.url;
+            script.onload = service.onLoad;
+            frag.appendChild(script);
+        }
+    });
+
+    if (hasScriptsToInsert) {
+        fastdom.write(() => {
+            if (ref && ref.parentNode) {
+                ref.parentNode.insertBefore(frag, ref);
+            }
+        });
+    }
+};
+
+const insertScripts = (
+    adServices: Array<ThirdPartyTag>,
+    nonAdServices: Array<ThirdPartyTag>
+): void => {
+    addScripts(nonAdServices);
+
     onIabConsentNotification(state => {
         const consentState =
             state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (!scriptsInserted && consentState) {
-            scriptsInserted = true;
-
-            const ref = document.scripts[0];
-            const frag = document.createDocumentFragment();
-            let hasScriptsToInsert = false;
-
-            services.forEach(service => {
-                if (service.useImage === true) {
-                    new Image().src = service.url;
-                } else {
-                    hasScriptsToInsert = true;
-                    const script = document.createElement('script');
-                    script.src = service.url;
-                    script.onload = service.onLoad;
-                    frag.appendChild(script);
-                }
-            });
-
-            if (hasScriptsToInsert) {
-                fastdom.write(() => {
-                    if (ref && ref.parentNode) {
-                        ref.parentNode.insertBefore(frag, ref);
-                    }
-                });
-            }
+        if (!adScriptsInserted && consentState) {
+            addScripts(adServices);
+            adScriptsInserted = true;
         }
     });
 };
 
 const loadOther = (): void => {
-    const services: Array<ThirdPartyTag> = [
-        imrWorldwide,
-        imrWorldwideLegacy,
+    const adServices: Array<ThirdPartyTag> = [
         remarketing(),
         simpleReach,
         krux,
@@ -65,7 +71,12 @@ const loadOther = (): void => {
         twitterUwt(),
     ].filter(_ => _.shouldRun);
 
-    insertScripts(services);
+    const nonAdServices: Array<ThirdPartyTag> = [
+        imrWorldwide,
+        imrWorldwideLegacy,
+    ].filter(_ => _.shouldRun);
+
+    insertScripts(adServices, nonAdServices);
 };
 
 const init = (): Promise<boolean> => {


### PR DESCRIPTION
## What does this change?

The `imrWorldwide` and `imrWorldwideLegacy` tags are currently grouped in with a list of third party tag that are only added to the page when the user's advertising consent state is `true`.

This PR splits the current list of the third party tag scripts into 2: `advertisingServices` and `performanceServices`, and moves the `imrWorldwide` and `imrWorldwideLegacy` tags into the `performanceServices` list.

The tags in this new `performanceServices` list will only be added to the page when the user's performance consent state is `true`. Currently all users performance consent state is `true`, however once the new CMP goes live with PECR purposes this boolean will be derived from the consent granted using that.