### PR TITLE
Fix email freetextimage

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -49,10 +49,10 @@ object EmailHelpers {
 
   def imgForFront: (String, Option[String]) => Html = img(width=EmailImageParams.fullWidth) _
 
-  def imgFromCard(card: ContentCard, colWidth: Int = 12)(implicit requestHeader: RequestHeader): Option[Html] = {
+  def imgFromCard(card: ContentCard, colWidth: Int = 12, altTextOverride: Option[String] = None)(implicit requestHeader: RequestHeader): Option[Html] = {
     val width = ((colWidth.toDouble / 12.toDouble) * EmailImageParams.fullWidth).toInt
     imageUrlFromCard(card, width).map { url => Html {
-        s"""<a ${card.header.url.hrefWithRel}>${img(width)(url, Some(card.header.headline))}</a>"""
+        s"""<a ${card.header.url.hrefWithRel}>${img(width)(url, Some(altTextOverride.getOrElse(card.header.headline)))}</a>"""
       }
     }
   }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -131,6 +131,7 @@
 
 @freeTextWithImage(card: ContentCard, collectionName: String) = {
     @faciaCard(classesForCard(card)) {
+@*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
         @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
         @row(Seq("free-text"))(Html(card.header.headline))
     }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -129,9 +129,9 @@
     }
 }
 
-@freeTextWithImage(card: ContentCard) = {
+@freeTextWithImage(card: ContentCard, collectionName: String) = {
     @faciaCard(classesForCard(card)) {
-        @row(Seq("no-pad")){@imgFromCard(card)}
+        @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
         @row(Seq("free-text"))(Html(card.header.headline))
     }
 }
@@ -140,14 +140,14 @@
     @fullRow(Seq("free-text"))(Html(text))
 }
 
-@renderCard(card: ContentCard, cardStyle: EmailCardStyle, isBranded: Boolean) = {
+@renderCard(card: ContentCard, cardStyle: EmailCardStyle, isBranded: Boolean, collectionName: String) = {
     @cardStyle match {
         case EmailHidden => { }
         case EmailFreeText if card.displayElement.isEmpty => {
             @freeText(card.header.headline)
         }
         case EmailFreeText => {
-            @freeTextWithImage(card)
+            @freeTextWithImage(card, collectionName)
         }
         case layoutStyle: EmailFaciaCard => {
             @card.cardStyle match {
@@ -205,9 +205,9 @@
 
     @collection.cards.zipWithIndex.map { case (card, cardIndex) =>
         @if(cardIndex == 0) {
-            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).firstCard, collection.branding.isDefined)
+            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).firstCard, collection.branding.isDefined, collection.displayName)
         } else {
-            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).otherCards, collection.branding.isDefined)
+            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).otherCards, collection.branding.isDefined, collection.displayName)
         }
     }
 }


### PR DESCRIPTION
## What does this change?
Allows the alt text for an image in a fonts card to be overridden, and overrides it for free text front cards.

## What is the value of this and can you measure success?
Currently people are using `free-text` with HTML in the headline field to make nice text happen on emails. Unfortunately when this HTML gets injected into the `alt` field of an image tag it messes up the markup big time. 


## Before
![Screenshot 2019-10-22 at 17 05 46](https://user-images.githubusercontent.com/3606555/67306044-3e87ed00-f4ee-11e9-9b77-1d90527a7585.png)
## After
![Screenshot 2019-10-22 at 17 05 25](https://user-images.githubusercontent.com/3606555/67306057-4182dd80-f4ee-11e9-8ed3-5a228c3abeaa.png)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
