### PR TITLE
Update appearance of shady pie for daily and app

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblock-ask.js
@@ -11,21 +11,16 @@ const askHtml = `
     <div class="contributions__adblock-content">
         <div class="contributions__adblock-header">
             <h2>
-                Editorially<br>
-                independent,<br>
-                open to everyone
+                Read The<br>
+                Guardian without<br>
+                interruption on all<br>
+                your devices
             </h2>
         </div>
-        <div class="contributions__adblock-sub">
-            We chose a different approach —<br>
-            will you support it?
-        </div>
         <a class="contributions__adblock-button" href="${supportUrl}">
-            <span class="component-button__content">Find out more</span>
-            <svg class="svg-arrow-right-straight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 17.89" preserveAspectRatio="xMinYMid">
-                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z"></path>
-            </svg>
+            <span class="component-button__content">Subscribe now</span>
         </a>
+        <img src="https://media.guim.co.uk/b437f809d9fa4c72336ccbead1730b6bb0965239/0_0_432_503/432.png" class="contributions__adblock-image" alt="" />
     </div>
 </div>
 `;

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -228,14 +228,10 @@ a[href].contributions__learn-more.contributions__learn-more--epic {
 
 .contributions__adblock {
     position: absolute;
-    top: 0;
+    top: 5px;
     padding-top: $gs-baseline/2;
-    width: 100%;
-
-    .contributions__adblock-content {
-        border-top: 5px solid $highlight-main;
-        margin-right: 20px;
-    }
+    width: 94%;
+    background-color: $highlight-main;
 
     .contributions__adblock-header {
         padding-left: 10px;
@@ -244,6 +240,8 @@ a[href].contributions__learn-more.contributions__learn-more--epic {
         h2 {
             @include fs-headline(6);
             font-weight: 700;
+            font-size: 28px;
+            line-height: 30px;
         }
     }
 
@@ -253,10 +251,9 @@ a[href].contributions__learn-more.contributions__learn-more--epic {
     }
 
     .contributions__adblock-button {
-        margin-top: 10px;
-        margin-left: 5px;
-        background-color: $highlight-main;
-        color: $brightness-7 !important;
+        margin: 25px 0 80px 10px;
+        background-color: $brightness-7 !important;
+        color: $brightness-100 !important;
         font-size: 16px;
         line-height: 22px;
         font-family: $f-sans-serif-text;
@@ -285,19 +282,13 @@ a[href].contributions__learn-more.contributions__learn-more--epic {
             flex: 0 0 auto;
             display: block;
         }
+    }
 
-        svg {
-            flex: 0 0 auto;
-            display: block;
-
-            transition: .3s ease-in-out transform;
-            will-change: transform;
-            margin: 0 -5px 0 10px;
-            fill: currentColor;
-            position: relative;
-            width: 21px;
-            height: auto;
-        }
+    .contributions__adblock-image {
+        height: 150px;
+        position: absolute;
+        bottom: 0;
+        right: 0;
     }
 }
 


### PR DESCRIPTION
## What does this change?
This changes the appearance of the shady pie, which is the widget that appears in the right column of article pages above the 'most viewed' list when a user has an adblocker switched on.

## Screenshots
![Screen Shot 2019-10-22 at 17 35 42](https://user-images.githubusercontent.com/16781258/67309624-1a2f0f00-f4f4-11e9-9269-2b1849d0d267.png)

## What is the value of this and can you measure success?
The value will be measured in the analytics reporting, the change is an attempt to improve the number of subscription purchases, so number of conversions will be an important measurement

## Checklist

### Does this affect other platforms?
No

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [x] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
