### PR TITLE
Add new adslot size for Google Outstream

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-sizes.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-sizes.js
@@ -30,6 +30,7 @@ const adSizes: Object = {
     // guardian proprietary ad sizes
     video: getAdSize(620, 1),
     outstreamDesktop: getAdSize(620, 350),
+    outstreamGoogleDesktop: getAdSize(550, 310),
     outstreamMobile: getAdSize(300, 197),
     merchandisingHighAdFeature: getAdSize(88, 89),
     merchandisingHigh: getAdSize(88, 87),

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -91,13 +91,13 @@ describe('createCommentSlots', () => {
         const commentMpu: HTMLElement = createCommentSlots(false)[0];
         const commentDmpu: HTMLElement = createCommentSlots(true)[0];
         expect(commentMpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|300,274|620,1|620,350|fluid'
+            '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid'
         );
         expect(commentMpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
         );
         expect(commentDmpu.getAttribute('data-desktop')).toBe(
-            '1,1|2,2|300,250|300,274|620,1|620,350|fluid|300,600|160,600'
+            '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid|300,600|160,600'
         );
         expect(commentDmpu.getAttribute('data-mobile')).toBe(
             '1,1|2,2|300,197|300,250|300,274|fluid'
@@ -252,7 +252,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|300,274|620,1|620,350|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -270,7 +270,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|300,274|620,1|620,350|fluid|300,600|160,600'
+                    '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid|300,600|160,600'
                 );
                 done();
             });
@@ -288,7 +288,7 @@ describe('initCommentAdverts', () => {
                 ): any);
                 expect(addSlot).toHaveBeenCalledTimes(1);
                 expect(adSlot.getAttribute('data-desktop')).toBe(
-                    '1,1|2,2|300,250|300,274|620,1|620,350|fluid'
+                    '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid'
                 );
                 done();
             });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -18,6 +18,7 @@ const inlineDefinition = {
             adSizes.mpu,
             adSizes.googleCard,
             adSizes.outstreamDesktop,
+            adSizes.outstreamGoogleDesktop,
             adSizes.fluid,
         ],
         desktop: [
@@ -27,6 +28,7 @@ const inlineDefinition = {
             adSizes.googleCard,
             adSizes.video,
             adSizes.outstreamDesktop,
+            adSizes.outstreamGoogleDesktop,
             adSizes.fluid,
         ],
     },

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -21,8 +21,8 @@ const inline1Html = `
     data-name="inline1"
     aria-hidden="true"
     data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
-    data-phablet="1,1|2,2|300,197|300,250|300,274|620,350|fluid"
-    data-desktop="1,1|2,2|300,250|300,274|620,1|620,350|fluid">
+    data-phablet="1,1|2,2|300,197|300,250|300,274|620,350|550,310|fluid"
+    data-desktop="1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid">
 </div>
 `;
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -90,12 +90,8 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
         }
         // Set refresh field based on the outcome of the slot render.
         const sizeString = advert.size && advert.size.toString();
-        console.log('SIZE STRING');
-        console.log(sizeString);
         const isNotFluid = sizeString !== '0,0';
         const isOutstream = outstreamSizes.includes(sizeString);
-        console.log('isOutstream');
-        console.log(isOutstream);
         const isNonRefreshableLineItem =
             event.lineItemId &&
             config

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -52,6 +52,7 @@ const reportEmptyResponse = (
 const outstreamSizes = [
     adSizes.outstreamDesktop.toString(),
     adSizes.outstreamMobile.toString(),
+    adSizes.outstreamGoogleDesktop.toString()
 ];
 
 export const onSlotRender = (event: SlotRenderEndedEvent): void => {
@@ -89,8 +90,12 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
         }
         // Set refresh field based on the outcome of the slot render.
         const sizeString = advert.size && advert.size.toString();
+        console.log("SIZE STRING");
+        console.log(sizeString);
         const isNotFluid = sizeString !== '0,0';
         const isOutstream = outstreamSizes.includes(sizeString);
+        console.log("isOutstream");
+        console.log(isOutstream);
         const isNonRefreshableLineItem =
             event.lineItemId &&
             config

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -52,7 +52,7 @@ const reportEmptyResponse = (
 const outstreamSizes = [
     adSizes.outstreamDesktop.toString(),
     adSizes.outstreamMobile.toString(),
-    adSizes.outstreamGoogleDesktop.toString()
+    adSizes.outstreamGoogleDesktop.toString(),
 ];
 
 export const onSlotRender = (event: SlotRenderEndedEvent): void => {
@@ -90,11 +90,11 @@ export const onSlotRender = (event: SlotRenderEndedEvent): void => {
         }
         // Set refresh field based on the outcome of the slot render.
         const sizeString = advert.size && advert.size.toString();
-        console.log("SIZE STRING");
+        console.log('SIZE STRING');
         console.log(sizeString);
         const isNotFluid = sizeString !== '0,0';
         const isOutstream = outstreamSizes.includes(sizeString);
-        console.log("isOutstream");
+        console.log('isOutstream');
         console.log(isOutstream);
         const isNonRefreshableLineItem =
             event.lineItemId &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -116,6 +116,11 @@ sizeCallbacks[adSizes.outstreamDesktop] = (_, advert) =>
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });
 
+sizeCallbacks[adSizes.outstreamGoogleDesktop] = (_, advert) =>
+    fastdom.write(() => {
+        advert.updateExtraSlotClasses('ad-slot--outstream');
+    });
+
 sizeCallbacks[adSizes.outstreamMobile] = (_, advert) =>
     fastdom.write(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');


### PR DESCRIPTION
## What does this change?
- Adds new adslot size (550x310) for Google Outstream
- Existing outstream size (620x350) is bigger than google's videos breaking the ad slot layout (see the Before image)

## Screenshots
**Before**

![image](https://user-images.githubusercontent.com/51630004/67488212-546ced80-f667-11e9-985d-5ccedf346335.png)

**After** 

![Screenshot 2019-10-24 at 14 00 23](https://user-images.githubusercontent.com/51630004/67488127-2ab3c680-f667-11e9-86ba-2d7955db3340.png)

## What is the value of this and can you measure success?
Ability to run google video ads without breaking the layout 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
