### PR TITLE
bump identitylibver to 3.189

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.189-M1"
+  val identityLibVersion = "3.189"
   val awsVersion = "1.11.240"
   val capiVersion = "15.0"
   val faciaVersion = "3.0.2"


### PR DESCRIPTION
## What does this change?

Bump the identity lib version to 1.389 which I forgot to include in the https://github.com/guardian/frontend/pull/21932 PR