### PR TITLE
Default the "variant" for the article position test 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,7 +38,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-articles-viewed-month-moment-position",
+    "ab-contributions-epic-articles-viewed-month-moment-position-variant",
     "Moment epic which also states how many articles a user has viewed",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,7 +3,7 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
-import { articlesViewedMoment } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position';
+import { articlesViewedMomentVariant } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position';
 import { articlesViewedMoment60DaysVariant } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-moment-60-days';
 import { countryName } from 'common/modules/experiments/tests/contributions-epic-country-name';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
@@ -28,7 +28,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
-    articlesViewedMoment,
+    articlesViewedMomentVariant,
     articlesViewedMoment60DaysVariant,
     articlesViewed,
     learnMore,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position.js
@@ -27,17 +27,8 @@ const paragraphs = [
 
 const articleCountParagraph = `You’ve read ${articleViewCount} Guardian articles in the last month – made possible by our choice to keep Guardian journalism open to all. We do not have a paywall because we believe everyone deserves access to factual information, regardless of where they live or what they can afford.`;
 
-const controlParagraphs = paragraphs.slice();
-controlParagraphs.splice(3, 0, articleCountParagraph);
-
 const variantParagraphs = paragraphs.slice();
 variantParagraphs.splice(1, 0, articleCountParagraph);
-
-const controlCopy = {
-    heading,
-    paragraphs: controlParagraphs,
-    highlightedText,
-};
 
 const variantCopy = {
     heading,
@@ -73,16 +64,6 @@ export const articlesViewedMoment: EpicABTest = makeEpicABTest({
     canRun: () => articleViewCount >= minArticleViews,
 
     variants: [
-        {
-            id: 'control',
-            buttonTemplate: defaultButtonTemplate,
-            products: [],
-            copy: buildEpicCopy(controlCopy, false, geolocation),
-            classNames: [
-                'contributions__epic--2019-10-14_moment_climate_pledge',
-            ],
-            supportBaseURL: url,
-        },
         {
             id: 'variant',
             buttonTemplate: defaultButtonTemplate,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed-moment-position.js
@@ -40,9 +40,10 @@ const url = 'http://support.theguardian.com/contribute/climate-pledge-2019';
 
 const geolocation = geolocationGetSync();
 
-export const articlesViewedMoment: EpicABTest = makeEpicABTest({
-    id: 'ContributionsEpicArticlesViewedMonthMomentPosition',
-    campaignId: '2019-10-14_moment_climate_pledge_article_count_position',
+export const articlesViewedMomentVariant: EpicABTest = makeEpicABTest({
+    id: 'ContributionsEpicArticlesViewedMonthMomentPositionVariant',
+    campaignId:
+        '2019-10-14_moment_climate_pledge_article_count_position_variant',
 
     start: '2019-06-24',
     expiry: '2020-01-27',


### PR DESCRIPTION
## What does this change?
Assigns a winning variant to 100% of the audience

## Screenshots
<img width="642" alt="new epic" src="https://user-images.githubusercontent.com/3300789/67578788-2e038c80-f711-11e9-8786-9aaf360207e8.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
