### PR TITLE
Remove the DotcomRendering switch

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -123,16 +123,13 @@ object ArticlePicker {
   }
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
-
     val whitelistFeatures = featureWhitelist(page, request)
-    val isEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
     val isAdFree = ArticlePageChecks.isAdFree(page, request)
     val isCommercialBetaUser = ActiveExperiments.isParticipating(DotcomRenderingAdvertisements)
 
     // add free pages always go through DCR provided it's turned on and we support its article features.
     // pages with commercial aspects require the request to go through the DotcomRenderingAdvertisements abtest
-
-    val tier = if ((dcrCouldRender(page, request) && isEnabled && (isAdFree || isCommercialBetaUser) && !request.forceDCROff) || request.forceDCR) RemoteRender else LocalRenderArticle
+    val tier = if ((dcrCouldRender(page, request) && (isAdFree || isCommercialBetaUser) && !request.forceDCROff) || request.forceDCR) RemoteRender else LocalRenderArticle
 
     // include features that we wish to log but not whitelist against
     val features = whitelistFeatures + ("isCommercialBetaUser" -> isCommercialBetaUser)

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -7,16 +7,6 @@ import conf.switches.SwitchGroup.Commercial
 
 trait FeatureSwitches {
 
-  val DotcomRendering = Switch(
-    SwitchGroup.Feature,
-    "dotcom-rendering",
-    "If this switch is on, we will use the dotcom rendering tier for articles which are supported by it",
-    owners = Seq(Owner.withGithub("MatthewJWalls")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = false
-  )
-
   val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",


### PR DESCRIPTION
## What does this change?

Remove the DotcomRendering switch. (It is henceforth no longer possible to turn DCR web article off).

