### PR TITLE
Make videos playable at additional sizes on fronts

### DIFF
--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -15,8 +15,10 @@ sealed trait CardType {
   }
 
   def youTubeMediaAtomPlayer: VideoPlayerMode = this match {
-    case FullMedia50 | FullMedia75 | FullMedia100 | ThreeQuarters | ThreeQuartersRight | Half =>
+    case FullMedia50 | FullMedia75 | FullMedia100 | ThreeQuarters | ThreeQuartersRight =>
       VideoPlayerMode(show = true, showEndSlate = true)
+    case Half | Third | Standard =>
+      VideoPlayerMode(show = true, showEndSlate = false)
     case _ =>
       VideoPlayerMode(show = false, showEndSlate = false)
   }


### PR DESCRIPTION
## What does this change?

Makes videos playable at additional sizes in fronts containers.

## Screenshots

![Screenshot 2019-10-29 at 17 52 23](https://user-images.githubusercontent.com/379839/67794661-ea908180-fa74-11e9-9102-3eec762be1f7.png)

## What is the value of this and can you measure success?

Following a request from editorial to have ready for the election.

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
