### PR TITLE
Reposition Page skin ads to start after the nav header

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -8,7 +8,7 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 const pageSkin = (): void => {
     const bodyEl = document.body;
     const hasPageSkin: boolean = config.get('page.hasPageSkin');
-    let topPosition: Number;
+    let topPosition: number = 0;
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
@@ -31,18 +31,25 @@ const pageSkin = (): void => {
         }
     };
 
-    const moveBackgroundVerticalPosition = (verticalPos: Number): void => {
-        bodyEl.style.backgroundPosition = `50% ${verticalPos}px`;
+    const moveBackgroundVerticalPosition = (verticalPos: number): void => {
+        if (bodyEl) {
+            bodyEl.style.backgroundPosition = `50% ${verticalPos}px`;
+        }
     };
 
-    //This is to reposition the Page Skin to start where the navigation header ends.
-    const repositionSkin = (): void => {
-        if (bodyEl && hasPageSkin) {
-            if (!topPosition) {
-                const navHeader = document.getElementsByClassName('new-header')[0];
+    const initTopPositionOnce = (): void => {
+        if (topPosition === 0) {
+            const navHeader = document.getElementsByClassName('new-header')[0];
+            if (navHeader) {
                 topPosition = navHeader.offsetTop + navHeader.offsetHeight;
             }
-            moveBackgroundVerticalPosition(topPosition);
+        }
+    };
+
+    // This is to reposition the Page Skin to start where the navigation header ends.
+    const repositionSkin = (): void => {
+        if (hasPageSkin) {
+            initTopPositionOnce();
             if (window.pageYOffset === 0) {
                 moveBackgroundVerticalPosition(topPosition);
             } else if (window.pageXOffset <= topPosition) {

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -8,7 +8,7 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 const pageSkin = (): void => {
     const bodyEl = document.body;
     const hasPageSkin: boolean = config.get('page.hasPageSkin');
-    const NAVMENU_END_POSITION: Number = 508;
+    let topPosition: Number;
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
@@ -32,26 +32,35 @@ const pageSkin = (): void => {
     };
 
     const moveBackgroundVerticalPosition = (verticalPos: Number): void => {
-        bodyEl.style.backgroundPosition = '50% ' + verticalPos + 'px';
+        bodyEl.style.backgroundPosition = `50% ${verticalPos}px`;
     };
 
+    //This is to reposition the Page Skin to start where the navigation header ends.
     const repositionSkin = (): void => {
         if (bodyEl && hasPageSkin) {
+            if (!topPosition) {
+                const navHeader = document.getElementsByClassName('new-header')[0];
+                topPosition = navHeader.offsetTop + navHeader.offsetHeight;
+            }
+            moveBackgroundVerticalPosition(topPosition);
             if (window.pageYOffset === 0) {
-                moveBackgroundVerticalPosition(NAVMENU_END_POSITION);
-            } else if (window.pageXOffset <= NAVMENU_END_POSITION) {
-                moveBackgroundVerticalPosition(NAVMENU_END_POSITION - window.pageYOffset);
-            } if (window.pageYOffset > NAVMENU_END_POSITION){
+                moveBackgroundVerticalPosition(topPosition);
+            } else if (window.pageXOffset <= topPosition) {
+                moveBackgroundVerticalPosition(
+                    topPosition - window.pageYOffset
+                );
+            }
+            if (window.pageYOffset > topPosition) {
                 moveBackgroundVerticalPosition(0);
             }
         }
     };
 
     togglePageSkin();
-    repositionSkin();
 
     mediator.on('window:throttledResize', togglePageSkin);
     mediator.on('window:throttledScroll', repositionSkin);
+    mediator.on('modules:commercial:dfp:rendered', repositionSkin);
 };
 
 export { pageSkin };

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -31,11 +31,13 @@ const pageSkin = (): void => {
     };
 
     const repositionSkin = (): void => {
-        console.log('reposition skin', bodyEl.scrollTop);
-        if (bodyEl.scrollTop === 0) {
-            bodyEl.style.backgroundPosition = '50% 507px';
-        } else {
-            bodyEl.style.backgroundPosition = '50% 0px';
+        if (bodyEl && hasPageSkin) {
+            console.log('reposition skin', bodyEl.scrollTop);
+            if (bodyEl.scrollTop === 0) {
+                bodyEl.style.backgroundPosition = '50% 507px';
+            } else {
+                bodyEl.style.backgroundPosition = '50% 0px';
+            }
         }
     };
 

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -8,6 +8,7 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 const pageSkin = (): void => {
     const bodyEl = document.body;
     const hasPageSkin: boolean = config.get('page.hasPageSkin');
+    const NAVMENU_END_POSITION: Number = 508;
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
@@ -30,13 +31,18 @@ const pageSkin = (): void => {
         }
     };
 
+    const moveBackgroundVerticalPosition = (verticalPos: Number): void => {
+        bodyEl.style.backgroundPosition = '50% ' + verticalPos + 'px';
+    };
+
     const repositionSkin = (): void => {
         if (bodyEl && hasPageSkin) {
-            console.log('reposition skin', bodyEl.scrollTop);
-            if (bodyEl.scrollTop === 0) {
-                bodyEl.style.backgroundPosition = '50% 507px';
-            } else {
-                bodyEl.style.backgroundPosition = '50% 0px';
+            if (window.pageYOffset === 0) {
+                moveBackgroundVerticalPosition(NAVMENU_END_POSITION);
+            } else if (window.pageXOffset <= NAVMENU_END_POSITION) {
+                moveBackgroundVerticalPosition(NAVMENU_END_POSITION - window.pageYOffset);
+            } if (window.pageYOffset > NAVMENU_END_POSITION){
+                moveBackgroundVerticalPosition(0);
             }
         }
     };

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -30,9 +30,20 @@ const pageSkin = (): void => {
         }
     };
 
+    const repositionSkin = (): void => {
+        console.log('reposition skin', bodyEl.scrollTop);
+        if (bodyEl.scrollTop === 0) {
+            bodyEl.style.backgroundPosition = '50% 507px';
+        } else {
+            bodyEl.style.backgroundPosition = '50% 0px';
+        }
+    };
+
     togglePageSkin();
+    repositionSkin();
 
     mediator.on('window:throttledResize', togglePageSkin);
+    mediator.on('window:throttledScroll', repositionSkin);
 };
 
 export { pageSkin };


### PR DESCRIPTION
## What does this change?
Fixes issue with Page skins ads which start at the top of the page and the part behind the navigation header is not visible
Solution: Repositioning to start after the navigation header

## Screenshots

### Before

![page-skin-before](https://user-images.githubusercontent.com/51630004/67885710-f85f0900-fb3f-11e9-8668-5f7abae5802f.gif)

### After

![page-skin-after](https://user-images.githubusercontent.com/51630004/67885723-fe54ea00-fb3f-11e9-8b58-20aa7f6d6be4.gif)


## What is the value of this and can you measure success?
Better user& advertiser experience 

### Tested

- [x] Locally
- [ ] On CODE (optional)

