### PR TITLE
Moment banner -- final push test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -88,18 +88,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-banner-environment-moment-supporters",
-    "moment banner to be seen by current supporters",
-    owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 9, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-contributions-banner-environment-moment-non-supporters",
-    "moment banner to be seen by general audience",
+    "ab-contributions-banner-environment-moment-final-push",
+    "moment banner test for final push",
     owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 9, 30),

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-moment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-moment.js
@@ -94,7 +94,7 @@ export const acquisitionsBannerMomentTemplate = (
                 }
 
                 <div class="engagement-banner__cta">
-                    <a tabindex="3" class="button engagement-banner__button" href="${
+                    <a tabindex="3" class="button engagement-banner__button engagement-banner__button--moment-cta" href="${
                         params.linkUrl
                     }">
                     ${params.buttonCaption}${arrowWhiteRight.markup}

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,10 +10,7 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
 import { learnMore } from 'common/modules/experiments/tests/contributions-epic-learn-more-cta';
-import {
-    environmentMomentBannerNonSupporters,
-    environmentMomentBannerSupporters,
-} from 'common/modules/experiments/tests/contributions-moment-banner-environment';
+import { environmentMomentBannerFinalPush } from 'common/modules/experiments/tests/contributions-moment-banner-environment';
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
@@ -39,6 +36,5 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
     articlesViewedBanner,
-    environmentMomentBannerNonSupporters,
-    environmentMomentBannerSupporters,
+    environmentMomentBannerFinalPush,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
@@ -7,15 +7,10 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 const geolocation = geolocationGetSync();
 const campaignId = 'climate_pledge_2019';
 
-const stayQuietFinalPushCopy =
+const finalPushCopy =
     'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
-
-const thankYouFinalPushCopy =
-    'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
-
 const mobileFinalPushCopy =
     'The climate emergency is the defining issue of our times. Since we published our pledge, readers from more than 100 countries across the world have supported us. You have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism.';
-
 const closingSentenceFinalPush =
     'Your support is galvanising – it makes our work possible and is critical for our future. Thank you.';
 
@@ -56,7 +51,7 @@ export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
             id: 'stayquiet',
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
-                messageText: stayQuietFinalPushCopy,
+                messageText: finalPushCopy,
                 mobileMessageText: mobileFinalPushCopy,
                 closingSentence: closingSentenceFinalPush,
                 template: acquisitionsBannerMomentTemplate,
@@ -78,7 +73,7 @@ export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
             id: 'thankyou',
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
-                messageText: thankYouFinalPushCopy,
+                messageText: finalPushCopy,
                 mobileMessageText: mobileFinalPushCopy,
                 closingSentence: closingSentenceFinalPush,
                 template: acquisitionsBannerMomentTemplate,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
@@ -1,6 +1,5 @@
 // @flow
 
-// import { getSync } from 'lib/geolocation';
 import { acquisitionsBannerMomentTemplate } from 'common/modules/commercial/templates/acquisitions-banner-moment.js';
 import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
@@ -8,26 +7,14 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 const geolocation = geolocationGetSync();
 const campaignId = 'climate_pledge_2019';
 
-const defaultLeadSentence =
-    'The climate emergency is the defining issue of our times. ';
-const defaultCopy =
-    'This is the Guardian’s pledge: we will be truthful, resolute and undeterred in pursuing Guardian journalism on the environment. We will give global heating, wildlife extinction and pollution the urgent attention they demand. Our independence means we can interrogate inaction by those in power. It means Guardian reporting will always be driven by scientific facts, never by commercial or political interests. Support from our readers makes this work possible.';
-const defaultMobileCopy =
-    'This is the Guardian’s pledge: we will be truthful, resolute and undeterred in pursuing our journalism on the environment. Support from our readers makes this work possible.';
-
-const thankYouCopy =
-    'The climate emergency is the defining issue of our times. This is the Guardian’s pledge: we will be truthful, resolute and undeterred in pursuing Guardian journalism on the environment. We will give global heating, wildlife extinction and pollution the urgent attention they demand. Our independence means we can interrogate inaction by those in power. ';
-const thankYouMobileCopy =
-    'The climate emergency is the defining issue of our times. This is the Guardian’s pledge: we will be truthful, resolute and undeterred in pursuing our journalism on the environment. ';
-const thankYouClosingSentence =
-    'Thank you for supporting the Guardian – readers from around the world, like you, make this work possible.';
-const thankYouCTA = 'Support us again';
-
 const stayQuietFinalPushCopy =
     'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
 
 const thankYouFinalPushCopy =
     'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
+
+const mobileFinalPushCopy =
+    'The climate emergency is the defining issue of our times. Since we published our pledge, readers from more than 100 countries across the world have supported us. You have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism.';
 
 const closingSentenceFinalPush =
     'Your support is galvanising – it makes our work possible and is critical for our future. Thank you.';
@@ -45,96 +32,8 @@ const linkUrl =
     'https://support.theguardian.com/contribute/climate-pledge-2019';
 
 const secondaryLinkUrl =
-    geolocation === 'US'
-        ? 'https://www.theguardian.com/environment/2019/oct/16/climate-crisis-america-guardian-editor-john-mulholland?INTCMP=climate_pledge_2019'
-        : 'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=climate_pledge_2019';
-
+    'https://www.theguardian.com/environment/2019/oct/31/guardian-climate-pledge-thank-you-hope-change?INTCMP=climate_pledge_2019';
 const secondaryLinkLabel = 'Why support matters';
-
-export const environmentMomentBannerNonSupporters: AcquisitionsABTest = {
-    id: 'ContributionsBannerEnvironmentMomentNonSupporters',
-    start: '2019-01-01',
-    expiry: '2020-09-30',
-    author: 'Joshua Lieberman',
-    description: 'environment moment',
-    audience: 1,
-    audienceOffset: 0,
-    successMeasure: 'AV per impression',
-    audienceCriteria: 'All',
-    idealOutcome: 'best AV possible',
-    canRun: () => true,
-    showForSensitive: true,
-    campaignId,
-    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    geolocation,
-    variants: [
-        {
-            id: 'control',
-            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
-            engagementBannerParams: {
-                leadSentence: defaultLeadSentence,
-                messageText: defaultCopy,
-                mobileMessageText: defaultMobileCopy,
-                template: acquisitionsBannerMomentTemplate,
-                bannerModifierClass: 'moment-banner',
-                minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.momentBannerDefault,
-                titles: ['We will not stay quiet ', 'on the climate crisis'],
-                linkUrl,
-                secondaryLinkUrl,
-                secondaryLinkLabel,
-            },
-            canRun: () =>
-                canShowBannerSync(
-                    minArticlesBeforeShowingBanner,
-                    userCohortParam.momentBannerDefault
-                ),
-        },
-    ],
-};
-
-export const environmentMomentBannerSupporters: AcquisitionsABTest = {
-    id: 'ContributionsBannerEnvironmentMomentSupporters',
-    start: '2019-01-01',
-    expiry: '2020-09-30',
-    author: 'Joshua Lieberman',
-    description: 'environment moment',
-    audience: 1,
-    audienceOffset: 0,
-    successMeasure: 'AV per impression',
-    audienceCriteria: 'All',
-    idealOutcome: 'best AV possible',
-    canRun: () => true,
-    showForSensitive: true,
-    campaignId,
-    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    geolocation,
-    variants: [
-        {
-            id: 'control',
-            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
-            engagementBannerParams: {
-                messageText: thankYouCopy,
-                closingSentence: thankYouClosingSentence,
-                mobileMessageText: thankYouMobileCopy,
-                buttonCaption: thankYouCTA,
-                template: acquisitionsBannerMomentTemplate,
-                bannerModifierClass: 'moment-banner moment-banner-thank-you',
-                minArticlesBeforeShowingBanner,
-                userCohort: userCohortParam.momentBannerThankYou,
-                titles: ['We will not stay quiet ', 'on the climate crisis'],
-                linkUrl,
-                secondaryLinkUrl,
-                secondaryLinkLabel,
-            },
-            canRun: () =>
-                canShowBannerSync(
-                    minArticlesBeforeShowingBanner,
-                    userCohortParam.momentBannerThankYou
-                ),
-        },
-    ],
-};
 
 export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
     id: 'ContributionsBannerEnvironmentMomentFinalPush',
@@ -158,6 +57,7 @@ export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
                 messageText: stayQuietFinalPushCopy,
+                mobileMessageText: mobileFinalPushCopy,
                 closingSentence: closingSentenceFinalPush,
                 template: acquisitionsBannerMomentTemplate,
                 bannerModifierClass: 'moment-banner',
@@ -179,6 +79,7 @@ export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
             test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
             engagementBannerParams: {
                 messageText: thankYouFinalPushCopy,
+                mobileMessageText: mobileFinalPushCopy,
                 closingSentence: closingSentenceFinalPush,
                 template: acquisitionsBannerMomentTemplate,
                 bannerModifierClass: 'moment-banner',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
@@ -23,12 +23,14 @@ const thankYouClosingSentence =
     'Thank you for supporting the Guardian – readers from around the world, like you, make this work possible.';
 const thankYouCTA = 'Support us again';
 
-const stayQuietFinalPushCopy = 'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
+const stayQuietFinalPushCopy =
+    'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
 
-const thankYouFinalPushCopy = 'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
+const thankYouFinalPushCopy =
+    'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
 
-const closingSentenceFinalPush = 'Your support is galvanising – it makes our work possible and is critical for our future. Thank you.';
-
+const closingSentenceFinalPush =
+    'Your support is galvanising – it makes our work possible and is critical for our future. Thank you.';
 
 // These test params must be set on engagementBannerParams *and* passed into canShowBannerSync
 // TODO - we need to rethink how banner tests are selected/displayed
@@ -182,7 +184,10 @@ export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
                 bannerModifierClass: 'moment-banner',
                 minArticlesBeforeShowingBanner,
                 userCohort: userCohortParam.momentBannerEveryone,
-                titles: ['Thank you for supporting ', 'our environmental pledge'],
+                titles: [
+                    'Thank you for supporting ',
+                    'our environmental pledge',
+                ],
                 linkUrl,
                 secondaryLinkUrl,
                 secondaryLinkLabel,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-moment-banner-environment.js
@@ -23,11 +23,19 @@ const thankYouClosingSentence =
     'Thank you for supporting the Guardian – readers from around the world, like you, make this work possible.';
 const thankYouCTA = 'Support us again';
 
+const stayQuietFinalPushCopy = 'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
+
+const thankYouFinalPushCopy = 'The climate emergency is the defining issue of our times. Since we published our environmental pledge, Guardian readers from more than 100 countries across the world have supported us. Many of you have told us how much you value our commitment: to be truthful, resolute and undeterred in pursuing this important journalism. ';
+
+const closingSentenceFinalPush = 'Your support is galvanising – it makes our work possible and is critical for our future. Thank you.';
+
+
 // These test params must be set on engagementBannerParams *and* passed into canShowBannerSync
 // TODO - we need to rethink how banner tests are selected/displayed
 const userCohortParam = {
     momentBannerDefault: 'AllNonSupporters',
     momentBannerThankYou: 'AllExistingSupporters',
+    momentBannerEveryone: 'Everyone',
 };
 const minArticlesBeforeShowingBanner = 0;
 
@@ -39,8 +47,7 @@ const secondaryLinkUrl =
         ? 'https://www.theguardian.com/environment/2019/oct/16/climate-crisis-america-guardian-editor-john-mulholland?INTCMP=climate_pledge_2019'
         : 'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=climate_pledge_2019';
 
-const secondaryLinkLabel =
-    geolocation === 'US' ? 'Hear from our editor' : 'Read our pledge';
+const secondaryLinkLabel = 'Why support matters';
 
 export const environmentMomentBannerNonSupporters: AcquisitionsABTest = {
     id: 'ContributionsBannerEnvironmentMomentNonSupporters',
@@ -122,6 +129,68 @@ export const environmentMomentBannerSupporters: AcquisitionsABTest = {
                 canShowBannerSync(
                     minArticlesBeforeShowingBanner,
                     userCohortParam.momentBannerThankYou
+                ),
+        },
+    ],
+};
+
+export const environmentMomentBannerFinalPush: AcquisitionsABTest = {
+    id: 'ContributionsBannerEnvironmentMomentFinalPush',
+    start: '2019-01-01',
+    expiry: '2020-09-30',
+    author: 'Thalia Silver',
+    description: 'environment moment',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'best AV possible',
+    canRun: () => true,
+    showForSensitive: true,
+    campaignId,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    geolocation,
+    variants: [
+        {
+            id: 'stayquiet',
+            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
+            engagementBannerParams: {
+                messageText: stayQuietFinalPushCopy,
+                closingSentence: closingSentenceFinalPush,
+                template: acquisitionsBannerMomentTemplate,
+                bannerModifierClass: 'moment-banner',
+                minArticlesBeforeShowingBanner,
+                userCohort: userCohortParam.momentBannerEveryone,
+                titles: ['We will not stay quiet ', 'on the climate crisis'],
+                linkUrl,
+                secondaryLinkUrl,
+                secondaryLinkLabel,
+            },
+            canRun: () =>
+                canShowBannerSync(
+                    minArticlesBeforeShowingBanner,
+                    userCohortParam.momentBannerEveryone
+                ),
+        },
+        {
+            id: 'thankyou',
+            test: (): void => {}, // banner tests look at the bucket and vary the copy themselves
+            engagementBannerParams: {
+                messageText: thankYouFinalPushCopy,
+                closingSentence: closingSentenceFinalPush,
+                template: acquisitionsBannerMomentTemplate,
+                bannerModifierClass: 'moment-banner',
+                minArticlesBeforeShowingBanner,
+                userCohort: userCohortParam.momentBannerEveryone,
+                titles: ['Thank you for supporting ', 'our environmental pledge'],
+                linkUrl,
+                secondaryLinkUrl,
+                secondaryLinkLabel,
+            },
+            canRun: () =>
+                canShowBannerSync(
+                    minArticlesBeforeShowingBanner,
+                    userCohortParam.momentBannerEveryone
                 ),
         },
     ],

--- a/static/src/stylesheets/module/site-messages/_moment-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_moment-banner.scss
@@ -8,12 +8,13 @@
 }
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
+$moment-blue: '#1570A6';
 
 .site-message--moment-banner {
     overflow: visible;
     border: 0;
     position: relative;
-    background-color: $highlight-main;
+    background-color: $moment-blue
 }
 
 .moment-banner__container {

--- a/static/src/stylesheets/module/site-messages/_moment-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_moment-banner.scss
@@ -8,7 +8,7 @@
 }
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
-$moment-blue: #1570A6;
+$moment-blue: #1570a6;
 
 .site-message--moment-banner {
     overflow: visible;
@@ -62,8 +62,6 @@ $moment-blue: #1570A6;
 
 .moment-banner__titles {
     margin-bottom: $gs-baseline;
-    // Magic number to get desired line breaks on mobile
-    //width: 270px;
 
     @include mq($from: tablet) {
         width: initial;

--- a/static/src/stylesheets/module/site-messages/_moment-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_moment-banner.scss
@@ -8,13 +8,13 @@
 }
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
-$moment-blue: '#1570A6';
+$moment-blue: #1570A6;
 
 .site-message--moment-banner {
     overflow: visible;
     border: 0;
     position: relative;
-    background-color: $moment-blue
+    background-color: $moment-blue;
 }
 
 .moment-banner__container {
@@ -63,7 +63,7 @@ $moment-blue: '#1570A6';
 .moment-banner__titles {
     margin-bottom: $gs-baseline;
     // Magic number to get desired line breaks on mobile
-    width: 270px;
+    //width: 270px;
 
     @include mq($from: tablet) {
         width: initial;
@@ -72,18 +72,24 @@ $moment-blue: '#1570A6';
 
 .moment-banner__title-one,
 .moment-banner__title-two {
-    font-size: 42px;
+    font-size: 36px;
     font-family: $title;
-    line-height: 40px;
+    line-height: 36px;
+
 
     @include mq($from: tablet) {
         display: block;
+        font-size: 42px;
         line-height: 40px;
     }
 }
 
+.moment-banner__title-one {
+    color: $brightness-97;
+}
+
 .moment-banner__title-two {
-    color: $sport-main;
+    color: $highlight-main;
 }
 
 .moment-banner__copy {
@@ -91,6 +97,7 @@ $moment-blue: '#1570A6';
     font-size: 17px;
     line-height: 21px;
     margin-bottom: $gs-baseline;
+    color: $brightness-97
 }
 
 .moment-banner__title-two,
@@ -107,13 +114,24 @@ $moment-blue: '#1570A6';
     font-weight: 700;
 }
 
+// Secondary Button / Link to editorial content
 .engagement-banner__button--moment-link {
-    color: $brightness-7;
-    background-color: $brightness-97;
-    border-color: $brightness-97;
+    color: $brightness-97;
+    background-color: $brightness-7;
+    border-color: $brightness-7;
     padding-right: 18px;
 }
 
+// Primary Support CTA
+.engagement-banner__button--moment-cta {
+    color: $brightness-7;
+    background-color: $highlight-main;
+    border-color: $highlight-main;
+
+    .inline-arrow-white-right path {
+        fill: $brightness-7;
+    }
+}
 
 // Color of the "G" inside the roundel logo
 .site-message--moment-banner .inline-marque-36 {


### PR DESCRIPTION
## What does this change?
New banner copy and styles for final push on moment

## Screenshot
Not quiet variant (Desktop)
![not-quiet-moment-desktop](https://user-images.githubusercontent.com/3300789/67951647-dae37b00-fbe3-11e9-9b4e-27f237f3c0bd.png)

Thank you variant (Desktop)
![thank-you-moment-desktop](https://user-images.githubusercontent.com/3300789/67951650-dae37b00-fbe3-11e9-9ab5-c820eceb2688.png)

Not quiet variant (Tablet)
![not-quiet-moment-tablet](https://user-images.githubusercontent.com/3300789/67951649-dae37b00-fbe3-11e9-9ac8-0247a512ef6c.png)

Thank you variant (Tablet)
![thank-you-moment-tablet](https://user-images.githubusercontent.com/3300789/67951652-db7c1180-fbe3-11e9-85be-f97bbc1b1fb6.png)

Not quiet variant (Mobile)
![not-quiet-moment-mobile](https://user-images.githubusercontent.com/3300789/67951648-dae37b00-fbe3-11e9-85af-c5f070fbeb6c.png)

Thank you variant (Mobile)
![thank-you-moment-mobile](https://user-images.githubusercontent.com/3300789/67951651-dae37b00-fbe3-11e9-80f9-c79630931834.png)

## What is the value of this and can you measure success?
All contributions are being measured

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
