### PR TITLE
Use Fastly Geodetected Latitude/Longitude for Weather

### DIFF
--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -20,8 +20,8 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
   }
 
   val CityHeader: String = "X-GU-GeoCity"
-  val RegionHeader: String = "X-GU-GeoRegion"
   val CountryHeader: String = "X-GU-GeoCountry"
+  val LatLongHeader: String = "X-GU-GeoLatLong"
 
   def whatIsMyCity(): Action[AnyContent] = Action.async { implicit request =>
 
@@ -31,34 +31,32 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
       request.headers.get(key).map(java.net.URLDecoder.decode(_, "latin1"))
 
     val maybeCity = getEncodedHeader(CityHeader).filter(_.nonEmpty)
-    val maybeRegion = getEncodedHeader(RegionHeader).filter(_.nonEmpty)
     val maybeCountry = getEncodedHeader(CountryHeader).filter(_.nonEmpty)
+    val maybeLatLong = getEncodedHeader(LatLongHeader)
+      .flatMap(LatitudeLongitude.fromString)
+      .map(LatitudeLongitude.toCityAccuracy)
 
-    (maybeCity, maybeRegion, maybeCountry) match {
-      case (Some(city), Some(region), Some(country)) =>
-        CitiesLookUp.getLatitudeLongitude(CityRef.makeFixedCase(city, region, country)) match {
-          case Some(latitudeLongitude) =>
-            log.info(s"Matched $city, $region, $country to $latitudeLongitude")
+    (maybeLatLong, maybeCity, maybeCountry) match {
+      case (Some(latitudeLongitude), _, _) =>
+        weatherApi.getNearestCity(latitudeLongitude).map {
+          location => Cached(1 hour)(JsonComponent(CityResponse.fromLocationResponse(location)))
+        }.recover {
+          case _ =>
+            log.warn(s"Failed to get nearest city with lat/long")
+            Cached(CacheTime.NotFound)(JsonNotFound())
+        }
 
-            weatherApi.getNearestCity(latitudeLongitude) map { location =>
-              Cached(1 hour)(JsonComponent(CityResponse.fromLocationResponse(location).copy(
-                // Prefer the city name in MaxMind - the one Accuweather returns is a bit more granular than we'd like,
-                // given how fuzzy geolocation by IP is.
-                city = city
-              )))
-            }
+      case (_, Some(city), Some(country)) =>
+        log.warn(s"Latitude/longitude not available, trying text search")
 
-          case None =>
-            log.warn(s"Could not find $city, $region, $country in database, trying text search")
-            weatherApi.searchForLocations(city) map { locations =>
-              val cities = CityResponse.fromLocationResponses(locations.filter(_.Country.ID == country).toList)
+        weatherApi.searchForLocations(city) map { locations =>
+          val cities = CityResponse.fromLocationResponses(locations.filter(_.Country.ID == country).toList)
 
-              cities.headOption.fold {
-                Cached(CacheTime.NotFound)(JsonNotFound())
-              } { weatherCity =>
-                Cached(1 hour)(JsonComponent(weatherCity))
-              }
-            }
+          cities.headOption.fold {
+            Cached(CacheTime.NotFound)(JsonNotFound())
+          } { weatherCity =>
+            Cached(1 hour)(JsonComponent(weatherCity))
+          }
         }
 
       case (_, _, _) =>

--- a/onward/app/weather/geo/LatitudeLongitude.scala
+++ b/onward/app/weather/geo/LatitudeLongitude.scala
@@ -1,5 +1,32 @@
 package weather.geo
 
+import scala.util.Try
+
 case class LatitudeLongitude(latitude: Double, longitude: Double) {
   override def toString: String = s"$latitude,$longitude"
+}
+
+object LatitudeLongitude {
+  def fromString(latLong: String): Option[LatitudeLongitude] = {
+    val splitLatLong = latLong.split(",")
+
+    if (splitLatLong.length != 2) {
+      None
+    } else {
+      Try {
+        val latitude = splitLatLong(0).toDouble
+        val longitude = splitLatLong(1).toDouble
+
+        LatitudeLongitude(latitude, longitude)
+      }.toOption
+    }
+  }
+
+  def toCityAccuracy(latLong: LatitudeLongitude): LatitudeLongitude = {
+    val roundTo2dp = (value: Double) => BigDecimal(value)
+      .setScale(2, BigDecimal.RoundingMode.HALF_UP)
+      .toDouble
+
+    LatitudeLongitude(roundTo2dp(latLong.latitude), roundTo2dp(latLong.longitude))
+  }
 }

--- a/onward/test/weather/geo/LatitudeLongitudeTest.scala
+++ b/onward/test/weather/geo/LatitudeLongitudeTest.scala
@@ -1,0 +1,43 @@
+package weather.geo
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+class LatitudeLongitudeTest
+  extends FlatSpec
+    with Matchers
+    with OptionValues {
+
+  behavior of "LatitudeLongitude"
+
+  it should "successfully parse a valid lat/long string" in {
+    val latLongString = "51.498,-0.102"
+
+    val latLong = LatitudeLongitude.fromString(latLongString)
+
+    latLong.value should be(LatitudeLongitude(51.498, -0.102))
+  }
+
+  it should "return None for a nonsense lat/long string" in {
+    val badLatLongString = "blah blah"
+
+    val latLong = LatitudeLongitude.fromString(badLatLongString)
+
+    latLong should be(None)
+  }
+
+  it should "return None for an invalid lat/long string" in {
+    val badLatLongString = "51.498,-0.102,45.123"
+
+    val latLong = LatitudeLongitude.fromString(badLatLongString)
+
+    latLong should be(None)
+  }
+
+  it should "set the accuracy to city level (2 d.p.)" in {
+    val latLong = LatitudeLongitude(51.468, -0.112)
+
+    val lessGranularLatLong = LatitudeLongitude.toCityAccuracy(latLong)
+
+    lessGranularLatLong should be(LatitudeLongitude(51.47, -0.11))
+  }
+}


### PR DESCRIPTION
## What does this change?

In order to support IPv6 we have to move to a new geo detection API in Fastly (the API we're using currently doesn't support IPv6). As part of this we're switching to using latitude/longitude as the primary way of deciding which weather info to show to a user (we'll also fall back on city/country if lat/long isn't available).

Note that we're still [varying the cache for responses to this endpoint on country, region and city](https://github.com/guardian/fastly-edge-cache/blob/master/services_guardian_apps/src/main/resources/varnish/main.vcl#L243) even though the data will generally be fetched from accuweather based on lat/long. We don't want to vary based on lat/long as it will fragment the cache too much.

## Screenshots

![Screenshot 2019-10-31 at 16 38 21](https://user-images.githubusercontent.com/379839/67967216-222a3580-fbfd-11e9-88a9-a9a7507e65b1.png)

In this screenshot we've spoofed the lat long header which Fastly will add for us.

## What is the value of this and can you measure success?

The value is that it unblocks us enabling IPv6 for the domain this API is served from.

We can verify this change has worked by continuing the see weather information after migrating to the new Fastly geolocation API.

### Tested

- [x] Locally
- [x] On CODE (optional)
