### PR TITLE
Fix setting of vary header for targeted collections.

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -125,23 +125,23 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
 
   import PressedPage.pressedPageFormat
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader) = {
-    val futureFaciaPage: Future[Option[PressedPage]] = frontJsonFapi.get(path, liteRequestType).flatMap {
+    val futureFaciaPage: Future[Option[(PressedPage, Boolean)]] = frontJsonFapi.get(path, liteRequestType).flatMap {
         case Some(faciaPage: PressedPage) =>
           val regionalFaciaPage = TargetedCollections.processTargetedCollections(faciaPage, request.territories, context.isPreview)
           if (conf.Configuration.environment.stage == "CODE") {
             logInfoWithCustomFields(s"Rendering front $path, frontjson: ${Json.stringify(Json.toJson(faciaPage)(pressedPageFormat))}", List())
           }
           if(faciaPage.collections.isEmpty && liteRequestType == LiteAdFreeType) {
-            frontJsonFapi.get(path, LiteType)
+            frontJsonFapi.get(path, LiteType).map(_.map(f => (f, false)))
           }
-          else Future.successful(Some(regionalFaciaPage))
+          else Future.successful(Some(regionalFaciaPage, true))
         case None => Future.successful(None)
     }
 
     val futureResult = futureFaciaPage.flatMap {
-      case Some(faciaPage) if nonHtmlEmail(request) =>
+      case Some((faciaPage, _)) if nonHtmlEmail(request) =>
         successful(Cached(CacheTime.RecentlyUpdated)(renderEmail(faciaPage)))
-      case Some(faciaPage: PressedPage) =>
+      case Some((faciaPage: PressedPage, targetedTerritories)) =>
         val result = successful(Cached(CacheTime.Facia)(
           if (request.isRss) {
             val body = TrailsToRss.fromPressedPage(faciaPage)
@@ -158,7 +158,7 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
         ))
         // setting Vary header can be expensive (https://www.fastly.com/blog/best-practices-using-vary-header)
         // only set it for fronts with targeted collections
-        if (TargetedCollections.pageContainsTargetedCollections(faciaPage)) {
+        if (targetedTerritories) {
           result.map(_.withHeaders(("Vary", GUHeaders.TERRITORY_HEADER)))
         } else result
       case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))}

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -34,8 +34,12 @@ object TargetedCollections {
   def pageContainsTargetedCollections(faciaPage: PressedPage): Boolean =
     faciaPage.collections.exists(c => c.targetedTerritory.isDefined)
 
-  def processTargetedCollections(faciaPage: PressedPage, allowedContainerTerritories: List[TargetedTerritory], isPreview: Boolean): PressedPage = {
-    if (pageContainsTargetedCollections(faciaPage)) {
+  def processTargetedCollections(
+    faciaPage: PressedPage,
+    allowedContainerTerritories: List[TargetedTerritory],
+    isPreview: Boolean,
+    targetedCollections: Boolean): PressedPage = {
+    if (targetedCollections) {
       if (isPreview) {
         markCollections(faciaPage)
       } else {


### PR DESCRIPTION
## What does this change?
Ensures that we add X-GU-Territory to the Vary header on responses when a front contains targeted territories.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
