### PR TITLE
Ds change subs url on subs banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -28,7 +28,7 @@ const DISPLAY_EVENT_KEY = 'subscription-banner : display';
 const MESSAGE_CODE = 'subscription-banner';
 const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 const COMPONENT_TYPE = 'ACQUISITIONS_OTHER';
-const OPHAN_EVENT_ID = 'acquisitions-subscription-banner'
+const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -27,6 +27,8 @@ const ENTER_KEY_CODE = 'Enter';
 const DISPLAY_EVENT_KEY = 'subscription-banner : display';
 const MESSAGE_CODE = 'subscription-banner';
 const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
+const COMPONENT_TYPE = 'ACQUISITIONS_OTHER';
+const OPHAN_EVENT_ID = 'acquisitions-subscription-banner'
 
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
@@ -37,7 +39,7 @@ const subscriptionBannerSwitchIsOn: boolean = config.get(
 
 const pageviews: number = local.get('gu.alreadyVisited');
 
-const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22ACQUISITIONS_SUBSCRIPTIONS_BANNER%22%7D`;
+const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
 const fiveOrMorePageViews = (currentPageViews: number) => currentPageViews >= 5;
@@ -94,8 +96,8 @@ const bindClickHandler = (button, callback) => {
 const trackSubscriptionBannerView = () => {
     submitViewEvent({
         component: {
-            componentType: 'ACQUISITIONS_OTHER',
-            id: 'acquisitions-subscription-banner',
+            componentType: COMPONENT_TYPE,
+            id: OPHAN_EVENT_ID,
         },
     });
 };
@@ -103,8 +105,8 @@ const trackSubscriptionBannerView = () => {
 const trackSubscriptionBannerCtaClick = () => {
     submitClickEvent({
         component: {
-            componentType: 'ACQUISITIONS_OTHER',
-            id: 'acquisitions-subscription-banner',
+            componentType: COMPONENT_TYPE,
+            id: OPHAN_EVENT_ID,
         },
     });
 };


### PR DESCRIPTION
## What does this change?
this is an update to the subs banner url because it currently contains a ophan component type that does not exist, this PR will update the url to a component type that does exist "ACQUISITIONS_OTHER" 

## Screenshots
N/A

## What is the value of this and can you measure success?
N/A

## Checklist
N/A

### Does this affect other platforms?

- [x] No
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
