### PR TITLE
Add a small README for facia-press

### DIFF
--- a/facia-press/README.md
+++ b/facia-press/README.md
@@ -1,0 +1,10 @@
+# Facia Press
+
+Facia press is responsible for "pressing" content (fronts) configured by the
+fronts tool (part of editorial tools) and uploading the result to S3 where it
+is served by [facia]
+
+See [here] for a more detailed look at the architecture.
+
+[facia]: /facia
+[here]: /docs/02-architecture/02-fronts-architecture.md


### PR DESCRIPTION
## What does this change?

Adds a small README to facia-press. As a new developer to the project, I think it's useful to have a brief README for each of the components/apps which make up frontend. If folks think this is useful, I'll continue adding for other apps within this repo.

## What is the value of this and can you measure success?

Easier to get up to speed with the codebase.
