### PR TITLE
Update LiveBlog time display logic, basing it on publishedDate

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -124,7 +124,6 @@ class ArticleController(
       case Right(r) => Right(r)
       case _ => Right(NotFound)
     }
-
   }
 
 }

--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -22,7 +22,7 @@ object KeyEventData {
     val bodyBlocks = (latestSummary.toSeq ++ keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
 
     bodyBlocks.map { bodyBlock =>
-      KeyEventData(bodyBlock.id, bodyBlock.publishedCreatedDate(timezone), bodyBlock.title)
+      KeyEventData(bodyBlock.id, bodyBlock.publishedDate.map(LiveBlogDate(_, timezone)), bodyBlock.title)
     }
   }
 

--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -2,8 +2,8 @@
 
 @(date: Option[LiveBlogDate])
 
-@date.map { case LiveBlogDate(createdDate, hhmm, ampm, gmt) =>
-    <time datetime="@createdDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
+@date.map { case LiveBlogDate(publishedDate, hhmm, ampm, gmt) =>
+    <time datetime="@publishedDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
     <span class="block-time__absolute">@hhmm</span>
 }
 

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -34,7 +34,7 @@
 
         <p class="block-time published-time">
                 <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-                    @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
+                    @views.html.liveblog.dateBlock(block.publishedDate.map(LiveBlogDate(_, timezone)))
                 </a>
         </p>
 


### PR DESCRIPTION
## What does this change?

This is the same PR that was made here: https://github.com/guardian/frontend/pull/20036  , and made to resolve the obvious problem on this page ( https://www.theguardian.com/science/live/2019/oct/07/nobel-prize-in-physiology-or-medicine-live ), where the block was made few days before the event started. 

This time, if there is a side effect, we will investigate it first before reverting.

*Before*

![Screenshot 2019-11-11 at 12 47 45](https://user-images.githubusercontent.com/6035518/68588583-cfb10a80-0481-11ea-86ff-77e788b6bddd.png)

*After*

![Screenshot 2019-11-11 at 12 48 24](https://user-images.githubusercontent.com/6035518/68588603-d770af00-0481-11ea-8ce1-27c017c2c28a.png)

