### PR TITLE
Ds change subs url on subs banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -42,13 +42,12 @@ const pageviews: number = local.get('gu.alreadyVisited');
 const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
-
 const fiveOrMorePageViews = (currentPageViews: number) => currentPageViews >= 5;
 
 const isAustralianEdition = (currentEdition: string) => currentEdition === 'AU';
 
 const closedAt = (lastClosedAtKey: string) =>
-userPrefs.set(lastClosedAtKey, new Date().toISOString());
+    userPrefs.set(lastClosedAtKey, new Date().toISOString());
 
 const bannerHasBeenAcknowledged = (): void => {
     const messageStates = userPrefs.get('messages') || [];
@@ -171,7 +170,6 @@ const show: () => Promise<boolean> = async () => {
 };
 
 const canShow: () => Promise<boolean> = () => {
-
     const can = Promise.resolve(
         fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -172,8 +172,6 @@ const show: () => Promise<boolean> = async () => {
 
 const canShow: () => Promise<boolean> = () => {
 
-    bannerDismissedOverOneMonthAgo()
-
     const can = Promise.resolve(
         fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -39,15 +39,16 @@ const subscriptionBannerSwitchIsOn: boolean = config.get(
 
 const pageviews: number = local.get('gu.alreadyVisited');
 
-const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%7D`;
+const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
+
 
 const fiveOrMorePageViews = (currentPageViews: number) => currentPageViews >= 5;
 
 const isAustralianEdition = (currentEdition: string) => currentEdition === 'AU';
 
 const closedAt = (lastClosedAtKey: string) =>
-    userPrefs.set(lastClosedAtKey, new Date().toISOString());
+userPrefs.set(lastClosedAtKey, new Date().toISOString());
 
 const bannerHasBeenAcknowledged = (): void => {
     const messageStates = userPrefs.get('messages') || [];
@@ -170,6 +171,9 @@ const show: () => Promise<boolean> = async () => {
 };
 
 const canShow: () => Promise<boolean> = () => {
+
+    bannerDismissedOverOneMonthAgo()
+
     const can = Promise.resolve(
         fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&


### PR DESCRIPTION
## What does this change?
The subscriptions banner url has been changed because the Ophan is not receiving the component_type, which means we can't track conversion in Ophan. The PR also adds componentID to the banner

## Screenshots
N/A

## What is the value of this and can you measure success?
This is a fix which which will allow us to track the subscription banner

## Checklist

### Does this affect other platforms?
- [x] No
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
