### PR TITLE
Make epic article count configurable

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -72,6 +72,12 @@ declare type MaxViews = {
     minDaysBetweenViews: number,
 };
 
+declare type ArticlesViewedSettings = {
+    minViews?: number,
+    maxViews?: number,
+    count: number,
+}
+
 declare type DeploymentRules = 'AlwaysAsk' | MaxViews
 
 declare type EpicABTest = AcquisitionsABTest & {
@@ -135,6 +141,8 @@ declare type InitEpicABTest = {
     testHasCountryName?: boolean,
     geolocation: ?string,
     highPriority: boolean,
+    articlesViewedSettings?: ArticlesViewedSettings,
+    articlesViewedCount?: number,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -142,7 +142,6 @@ declare type InitEpicABTest = {
     geolocation: ?string,
     highPriority: boolean,
     articlesViewedSettings?: ArticlesViewedSettings,
-    articlesViewedCount?: number,
 }
 
 declare type Interaction = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -603,7 +603,9 @@ const buildBannerCopy = (
     return countryName ? replaceCountryName(text, countryName) : text;
 };
 
-export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
+export const buildConfiguredEpicTestFromJson = (
+    test: Object
+): InitEpicABTest => {
     const geolocation = geolocationGetSync();
 
     const countryGroups = test.locations;
@@ -634,7 +636,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
               }
             : undefined;
 
-    return makeEpicABTest({
+    return {
         id: test.name,
         campaignId: test.name,
         geolocation,
@@ -703,7 +705,7 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
             excludedTagIds,
             excludedSections,
         })),
-    });
+    };
 };
 
 export const getConfiguredEpicTests = (): Promise<$ReadOnlyArray<EpicABTest>> =>
@@ -713,7 +715,9 @@ export const getConfiguredEpicTests = (): Promise<$ReadOnlyArray<EpicABTest>> =>
             if (epicTestData.tests) {
                 return epicTestData.tests
                     .filter(test => test.isOn || showDrafts)
-                    .map(buildConfiguredEpicTestFromJson);
+                    .map(json =>
+                        makeEpicABTest(buildConfiguredEpicTestFromJson(json))
+                    );
             }
             return [];
         })

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -54,7 +54,7 @@ import {
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
 import { initTicker } from 'common/modules/commercial/ticker';
-import { getArticleViewCountForWeeks } from "common/modules/onward/history";
+import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -231,14 +231,19 @@ const countryNameIsOk = (
     geolocation: ?string
 ): boolean => (testHasCountryName ? !!getCountryName(geolocation) : true);
 
-const articleViewCountIsOk = (articlesViewedSettings?: ArticlesViewedSettings): boolean => {
+const articleViewCountIsOk = (
+    articlesViewedSettings?: ArticlesViewedSettings
+): boolean => {
     if (articlesViewedSettings) {
-        const upperOk = articlesViewedSettings.maxViews ? articlesViewedSettings.count <= articlesViewedSettings.maxViews : true;
-        const lowerOk = articlesViewedSettings.minViews ? articlesViewedSettings.count >= articlesViewedSettings.minViews : true;
+        const upperOk = articlesViewedSettings.maxViews
+            ? articlesViewedSettings.count <= articlesViewedSettings.maxViews
+            : true;
+        const lowerOk = articlesViewedSettings.minViews
+            ? articlesViewedSettings.count >= articlesViewedSettings.minViews
+            : true;
         return upperOk && lowerOk;
-    } else {
-        return true;
     }
+    return true;
 };
 
 const makeEpicABTestVariant = (
@@ -552,7 +557,7 @@ const buildEpicCopy = (
     row: any,
     testHasCountryName: boolean,
     geolocation: ?string,
-    articlesViewedCount?: number,
+    articlesViewedCount?: number
 ) => {
     const heading = row.heading;
 
@@ -566,16 +571,21 @@ const buildEpicCopy = (
         : undefined;
 
     const replaceCountryNameAndArticlesViewed = (s: ?string): ?string =>
-        s ? replaceArticlesViewed(replaceCountryName(s, countryName), articlesViewedCount) : s;
+        s
+            ? replaceArticlesViewed(
+                  replaceCountryName(s, countryName),
+                  articlesViewedCount
+              )
+            : s;
 
     return {
         heading: replaceCountryNameAndArticlesViewed(heading),
         paragraphs: paragraphs.map<string>(replaceCountryNameAndArticlesViewed),
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(
-                /%%CURRENCY_SYMBOL%%/g,
-                getLocalCurrencySymbol(geolocation)
-            )
+                  /%%CURRENCY_SYMBOL%%/g,
+                  getLocalCurrencySymbol(geolocation)
+              )
             : undefined,
         footer: optionalSplitAndTrim(row.footer, '\n'),
     };
@@ -613,11 +623,16 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
 
     const deploymentRules = test.alwaysAsk ? 'AlwaysAsk' : parseMaxViews();
 
-    const articlesViewedSettings = test.articlesViewedSettings && test.articlesViewedSettings.periodInWeeks ? {
-        minViews: test.articlesViewedSettings.minViews,
-        maxViews: test.articlesViewedSettings.maxViews,
-        count: getArticleViewCountForWeeks(test.articlesViewedSettings.periodInWeeks)
-    } : undefined;
+    const articlesViewedSettings =
+        test.articlesViewedSettings && test.articlesViewedSettings.periodInWeeks
+            ? {
+                  minViews: test.articlesViewedSettings.minViews,
+                  maxViews: test.articlesViewedSettings.maxViews,
+                  count: getArticleViewCountForWeeks(
+                      test.articlesViewedSettings.periodInWeeks
+                  ),
+              }
+            : undefined;
 
     return makeEpicABTest({
         id: test.name,
@@ -666,7 +681,14 @@ export const buildConfiguredEpicTestFromJson = (test: Object): EpicABTest => {
                       supportBaseURL: variant.cta.baseURL,
                   }
                 : {}),
-            copy: buildEpicCopy(variant, test.hasCountryName, geolocation, articlesViewedSettings ? articlesViewedSettings.count : undefined),
+            copy: buildEpicCopy(
+                variant,
+                test.hasCountryName,
+                geolocation,
+                articlesViewedSettings
+                    ? articlesViewedSettings.count
+                    : undefined
+            ),
             classNames: [
                 `contributions__epic--${test.name}`,
                 `contributions__epic--${test.name}-${variant.name}`,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -506,7 +506,7 @@ const makeEpicABTest = ({
     pageCheck = isCompatibleWithArticleEpic,
     template = controlTemplate,
     canRun = () => true,
-    articlesViewedSettings = undefined,
+    articlesViewedSettings,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -570,16 +570,16 @@ const buildEpicCopy = (
         ? getCountryName(geolocation)
         : undefined;
 
-    const replaceCountryNameAndArticlesViewed = (s: ?string): ?string =>
-        s
-            ? replaceArticlesViewed(
-                  replaceCountryName(s, countryName),
-                  articlesViewedCount
-              )
-            : s;
+    const replaceCountryNameAndArticlesViewed = (s: string): string =>
+        replaceArticlesViewed(
+            replaceCountryName(s, countryName),
+            articlesViewedCount
+        );
 
     return {
-        heading: replaceCountryNameAndArticlesViewed(heading),
+        heading: heading
+            ? replaceCountryNameAndArticlesViewed(heading)
+            : heading,
         paragraphs: paragraphs.map<string>(replaceCountryNameAndArticlesViewed),
         highlightedText: row.highlightedText
             ? row.highlightedText.replace(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -43,14 +43,18 @@ const rawTest = {
 
 describe('buildConfiguredEpicTestFromJson', () => {
     it('Parses and constructs an epic test', () => {
-        const test = buildConfiguredEpicTestFromJson(rawTest);
+        const test: InitEpicABTest = buildConfiguredEpicTestFromJson(rawTest);
         expect(test.id).toBe('my_test');
         expect(test.useLocalViewLog).toBe(false);
         expect(test.userCohort).toBe('AllNonSupporters');
 
-        // Have to cast here because type is `Variant`
-        // $FlowFixMe
-        const variant = (test.variants[0]: EpicVariant);
+        expect(test.articlesViewedSettings).toEqual({
+            minViews: 5,
+            maxViews: 10,
+            count: 0,
+        });
+
+        const variant: InitEpicABTestVariant = test.variants[0];
         expect(variant.id).toBe('Control');
         expect(variant.countryGroups).toEqual(['UnitedStates', 'Australia']);
         expect(variant.tagIds).toEqual(['football/football']);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -34,11 +34,11 @@ const rawTest = {
     ],
     highPriority: false,
     useLocalViewLog: false,
-    articlesViewedSettings : {
+    articlesViewedSettings: {
         minViews: 5,
         maxViews: 10,
         periodInWeeks: 4,
-    }
+    },
 };
 
 describe('buildConfiguredEpicTestFromJson', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -34,6 +34,11 @@ const rawTest = {
     ],
     highPriority: false,
     useLocalViewLog: false,
+    articlesViewedSettings : {
+        minViews: 5,
+        maxViews: 10,
+        periodInWeeks: 4,
+    }
 };
 
 describe('buildConfiguredEpicTestFromJson', () => {


### PR DESCRIPTION
## What does this change?
Some of our epic tests include a count of the number of articles a user has read over a period of time. Currently these tests have to be hard-coded in frontend because the tool does not support it. This feature has been doing _very_ well, so this PR updates frontend to support it.

1. If the copy contains the `%%ARTICLE_COUNT%%` template then it is replaced with a count of articles viewed,
2. The test configuration must also include an `articlesViewedSettings` field, which has the period in weeks and optional max/min counts. The max/min counts are for limiting who sees the test based on the count.

If the template is present in the copy but the `articlesViewedSettings` field is not, then this will be caught by [this check](https://github.com/guardian/frontend/blob/d27582f40d18ba6f2913c0d0263297daffd6af04/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L292).
The tool will also guard against this happening.

## Screenshots
Given a test config with:
```
"articlesViewedSettings" : {
    "minViews" : 5,
    "periodInWeeks" : 4
}
```
<img width="629" alt="Screenshot 2019-11-12 at 11 46 34" src="https://user-images.githubusercontent.com/1513454/68669295-1b2aed80-0542-11ea-94a6-e9bd6c1cc140.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
