### PR TITLE
New CMP UI A/B test without cancel button

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,6 +18,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-commercial-cmp-ui-non-dismissable",
+    "Test whether our new CMP UI obtains target consent rates using non-dismissable variant",
+    owners = Seq(Owner.withGithub("ghaberis")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 12, 3),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-ask-four-earning",
     "This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "1.1.0-beta.5",
+    "@guardian/consent-management-platform": "1.1.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "1.0.2",
+    "@guardian/consent-management-platform": "1.1.0-beta.5",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,6 +1,7 @@
 // @flow
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
+import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { articlesViewed } from 'common/modules/experiments/tests/contributions-epic-articles-viewed';
 import { articlesViewedMonthMomentFinal } from 'common/modules/experiments/tests/contributions-epic-articles-viewed-month-moment';
@@ -22,6 +23,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     xaxisAdapterTest,
     appnexusUSAdapter,
     pangaeaAdapterTest,
+    commercialCmpUiNonDismissable,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-non-dismissable.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-non-dismissable.js
@@ -1,0 +1,30 @@
+// @flow
+
+export const commercialCmpUiNonDismissable: ABTest = {
+    id: 'CommercialCmpUiNonDismissable',
+    start: '2019-11-13',
+    expiry: '2019-12-03',
+    author: 'George Haberis',
+    description:
+        '1% participation AB test for the new CMP UI testing non-dismissable variant',
+    audience: 0.01,
+    audienceOffset: 0.6,
+    successMeasure:
+        'Our new CMP UI obtains target consent rates using non-dismissable variant',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Our new CMP UI obtains target consent rates using non-dismissable variant',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -14,6 +14,7 @@ import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
+import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
 
 type Template = {
     heading: string,
@@ -105,7 +106,15 @@ const canShow = (): Promise<boolean> =>
     Promise.resolve(
         hasUnsetAdChoices() &&
             !hasUserAcknowledgedBanner(messageCode) &&
-            !isInVariantSynchronous(commercialCmpUiIab, 'variant')
+            (!isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
+                !isInVariantSynchronous(
+                    commercialCmpUiNonDismissable,
+                    'control'
+                ) ||
+                !isInVariantSynchronous(
+                    commercialCmpUiNonDismissable,
+                    'variant'
+                ))
     );
 
 const track = (): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.0.2.tgz#f757c92a268a1c5ed198f3bb053d272d35d92e8f"
-  integrity sha512-YM75Fgf0T55lyIFraYWTMgO8xonDyf2X5wVF+/I5zdO5YD8KgQxiUK1C7oBMMLd+ez62T/6W/9xfRemWS7Tfig==
+"@guardian/consent-management-platform@1.1.0-beta.5":
+  version "1.1.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta.5.tgz#9f1c3f8de7060fb6e1a846bc50e258abe325048a"
+  integrity sha512-8ahDEmmvepaWg5CGqY2cDfLnRlhJBPiNuiVOUJ9kK82PRDOc+dG0WpAjjPbq9SxApQNl3iOeO3XuWxAPLmzIQA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@1.1.0-beta.5":
-  version "1.1.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0-beta.5.tgz#9f1c3f8de7060fb6e1a846bc50e258abe325048a"
-  integrity sha512-8ahDEmmvepaWg5CGqY2cDfLnRlhJBPiNuiVOUJ9kK82PRDOc+dG0WpAjjPbq9SxApQNl3iOeO3XuWxAPLmzIQA==
+"@guardian/consent-management-platform@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-1.1.0.tgz#ca93b41c9649f3f90c8075fa1b64065406ea682c"
+  integrity sha512-+C1IzMb+PDCatnmA9B2oNx4KVbaQw/U0fwpIAUC7l/ebDhU2a6b94ha4xTu+iE2gAt/heOMKLs+o3avCNdSGqA==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
## What does this change?

- Sets up a new A/B test `CommercialCmpUiNonDismissable`. This A/B test will run on 1% of the audience, with a 50/50 split between the "variant" and the "control". The control will see the new CMP UI with a cancel button (dismissable) and the variant will see the new CMP UI withou a cancel button (non-dismissable)
- We now notify the CMP UI of the AB test variant by adding it as query string parameter the the URL of the CMP UI when we iframe it in: `?abTestVariant=CmpUiNonDismissable-variant`

The supporting PR on `manage-frontend` that handles the query string parameter is here: https://github.com/guardian/manage-frontend/pull/318

### Tested

- [x] On CODE (optional)
