### PR TITLE
Update Github PR template (to be DCR aware)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
 ## What does this change?
 
+## Does this change need to be reproduced in dotcom-rendering ?
+
+- [ ] No
+- [ ] Yes (please indicate your plans for DCR Implementation)
+
 ## Screenshots
 
 ## What is the value of this and can you measure success?


### PR DESCRIPTION
## What does this change?

Add a new section near the top of the github PR template to raise awareness around the need to keep in mind that frontend-classic and dotcom-rendering need to be kept in sync. 
