### PR TITLE
Fix submeta badge positioning

### DIFF
--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -3,7 +3,7 @@
     margin-top: $gs-baseline;
     padding-top: $gs-baseline * 1.5;
 
-    .content--media:not(.paid-content):not(.content--gallery)  & {
+    .content--media:not(.paid-content):not(.content--gallery) & {
         @include multiline(4, $brightness-20, top);
 
         .submeta__keywords {
@@ -37,7 +37,6 @@
     padding-bottom: $gs-baseline;
 }
 
-
 // Nesting 'article' overrides from-content-api ul rules
 article .submeta__links,
 .submeta__links {
@@ -68,7 +67,7 @@ article .submeta__links,
 }
 
 .submeta__badge {
-    width: 33px;
+    // width: 33px;
     float: right;
     margin-top: -$gs-baseline;
     margin-left: $gs-gutter / 2;

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -67,7 +67,6 @@ article .submeta__links,
 }
 
 .submeta__badge {
-    // width: 33px;
     float: right;
     margin-top: -$gs-baseline;
     margin-left: $gs-gutter / 2;


### PR DESCRIPTION
## What does this change?
Fixes the issue whereby badges were incorrectly positioned in the submeta area.
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before 
<img width="673" alt="Screen Shot 2019-11-12 at 17 27 04" src="https://user-images.githubusercontent.com/2051501/68695132-665cf480-0572-11ea-9c75-d79d4f96695d.png">

After
<img width="673" alt="Screen Shot 2019-11-12 at 17 26 15" src="https://user-images.githubusercontent.com/2051501/68695127-65c45e00-0572-11ea-88df-d87475f4b5c6.png">

