### PR TITLE
Add dcre to DFP page targetting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -229,6 +229,18 @@ const buildPageTargetting = (
             rp: config.get('isDotcomRendering', false)
                 ? 'dotcom-rendering'
                 : 'dotcom-platform', // rendering platform
+            dcre:
+                config.get('isDotcomRendering', false) ||
+                config.get('page.dcrCouldRender', false)
+                    ? 't'
+                    : 'f', // Indicates whether the page is DCR eligible. This happens when the page
+            // was DCR eligible and was actually rendered by DCR or
+            // was DCR eligible but rendered by frontend for a user not in the
+            // DotcomRenderingAdvertisements experiment
+            //
+            // This is introduced (Nov 2019) to be used as part of correctly
+            // validating ad performance on DCR (against DCR eligible pages)
+            // and can be decomissioned after Pascal and D&I no longer need the flag.
             inskin: inskinTargetting(),
         },
         page.sharedAdTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -236,6 +236,7 @@ describe('Build Page Targeting', () => {
             pa: 'f',
             cc: 'US',
             rp: 'dotcom-platform',
+            dcre: 'f',
         });
     });
 


### PR DESCRIPTION
## What does this change?

Adds the `dcre` key value to Page Targeting sent to DFP. Value is true when the page was DCR eligible and was actually rendered by DCR or was DCR eligible but rendered by frontend for a user not in the DotcomRenderingAdvertisements experiment

## Does this change need to be reproduced in dotcom-rendering ?

No. The code is shared between the two platforms
