### PR TITLE
Aligns showcase image with its caption

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-immersive.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-immersive.scss
@@ -491,6 +491,10 @@
                 margin-left: 0;
                 margin-right: 0;
             }
+
+            @include mq($from: desktop) {
+                padding-left: $gs-gutter;
+            }
         }
 
         .block-share {
@@ -510,11 +514,17 @@
         }
 
         @include mq(leftCol) {
-            margin-left: -(gs-span(2) + $gs-gutter * 2);
+            margin-left: -(gs-span(2) + $gs-gutter);
         }
 
         @include mq(wide) {
-            margin-left: -(gs-span(3) + $gs-gutter * 2);
+            margin-left: -(gs-span(3) + $gs-gutter);
+        }
+
+        .caption {
+            @include mq($from: desktop, $until: leftCol) {
+                padding-left: $gs-gutter;
+            }
         }
 
         //important overrides the hide on mobile class
@@ -534,10 +544,6 @@
         }
 
         .caption {
-            @include mq(desktop) {
-                padding-left: $gs-gutter;
-            }
-
             @include mq(leftCol) {
                 position: absolute;
                 width: gs-span(2);


### PR DESCRIPTION
## What does this change?

Reduces showcase image size slightly on `leftCol` and `wide` so they're aligned with the caption.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

**Note:** showcase image captions on dotcom-rendering look different from frontend already (and need a separate fix), but this particular change does not need to be applied to DCR.

## Screenshots

**Before:**
![Before](https://user-images.githubusercontent.com/4561/68773368-b9df4900-062b-11ea-9921-9c460667bc90.jpg)


**After:**
![After](https://user-images.githubusercontent.com/4561/68773358-b51a9500-062b-11ea-958f-1abe1713bdf9.jpg)


### Tested

- [X] Locally
- [ ] On CODE (optional)
