### PR TITLE
Epic article count test round 3

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,7 +38,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-articles-viewed-month",
+    "ab-contributions-epic-articles-viewed-round-3",
     "States how many articles a user has viewed in the epic in a month",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -39,7 +39,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-contributions-epic-articles-viewed-round-3",
-    "States how many articles a user has viewed in the epic in a month",
+    "Tests adding a count of articles viewed in the epic",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 1, 27),

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -102,6 +102,7 @@ declare type InitEpicABTestVariant = {
     showTicker?: boolean,
     supportBaseURL?: string,
     backgroundImageUrl?: string,
+    canRun?: () => boolean,
 };
 
 declare type InitBannerABTestVariant = {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -336,6 +336,7 @@ const makeEpicABTestVariant = (
             );
 
             return (
+                (!initVariant.canRun || initVariant.canRun()) &&
                 meetsMaxViewsConditions &&
                 matchesCountryGroups &&
                 matchesTagsOrSections &&

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -68,7 +68,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     expiry: '2020-01-27',
 
     author: 'Tom Forbes',
-    description: 'States how many articles a user has viewed in the epic',
+    description: 'Tests adding a count of articles viewed in the epic',
     successMeasure: 'Conversion rate',
     idealOutcome: 'Acquires many Supporters',
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -5,29 +5,17 @@ import {
     buildEpicCopy,
 } from 'common/modules/commercial/contributions-utilities';
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
-import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const geolocation = geolocationGetSync();
-const isUSUK = ['GB', 'US'].includes(geolocation);
 
 const highlightedText =
     'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
 
-const USUKControlCopy = {
+const controlCopy = {
     heading: 'Since you’re here...',
     paragraphs: [
         '... we have a small favour to ask. More people are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
-        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
-        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
-    ],
-    highlightedText,
-};
-
-const ROWControlCopy = {
-    heading: 'More people in %%COUNTRY_NAME%%...',
-    paragraphs: [
-        '... like you, are reading and supporting The Guardian’s independent, investigative journalism than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
         'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
@@ -91,18 +79,12 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     geolocation,
     highPriority: true,
 
-    canRun: () => !!getCountryName(geolocation),
-
     variants: [
         {
             id: 'control',
             buttonTemplate: defaultButtonTemplate,
             products: [],
-            copy: buildEpicCopy(
-                isUSUK ? USUKControlCopy : ROWControlCopy,
-                !isUSUK,
-                geolocation
-            ),
+            copy: buildEpicCopy(controlCopy, false, geolocation),
         },
         buildArticleCountVariant({
             name: '5_articles_in_1_month',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-articles-viewed.js
@@ -7,11 +7,8 @@ import {
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { getCountryName, getSync as geolocationGetSync } from 'lib/geolocation';
 
-// User must have read at least 5 articles in last 14 days
-const minArticleViews = 5;
-const articleCountDays = 30;
-
-const articleViewCount = getArticleViewCountForDays(articleCountDays);
+const geolocation = geolocationGetSync();
+const isUSUK = ['GB', 'US'].includes(geolocation);
 
 const highlightedText =
     'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
@@ -38,12 +35,46 @@ const ROWControlCopy = {
     highlightedText,
 };
 
-const geolocation = geolocationGetSync();
-const isUSUK = ['GB', 'US'].includes(geolocation);
+declare type ArticleCountVariantConfig = {
+    name: string,
+    minArticleViews: number,
+    articleCountDays: number,
+    periodText: string,
+};
+
+const buildArticleCountVariant = ({
+    name,
+    minArticleViews,
+    articleCountDays,
+    periodText,
+}: ArticleCountVariantConfig): InitEpicABTestVariant => {
+    const articleViewCount = getArticleViewCountForDays(articleCountDays);
+
+    return {
+        id: name,
+        buttonTemplate: defaultButtonTemplate,
+        products: [],
+        copy: buildEpicCopy(
+            {
+                heading: `You’ve read ${articleViewCount} articles...`,
+                paragraphs: [
+                    `... in the last ${periodText}. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.`,
+                    'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+                    'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+                    'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
+                ],
+                highlightedText,
+            },
+            false,
+            geolocation
+        ),
+        canRun: () => articleViewCount >= minArticleViews,
+    };
+};
 
 export const articlesViewed: EpicABTest = makeEpicABTest({
-    id: 'ContributionsEpicArticlesViewedMonth',
-    campaignId: 'epic_articles_viewed_month',
+    id: 'ContributionsEpicArticlesViewedRound3',
+    campaignId: 'epic_articles_viewed_round_3',
 
     start: '2019-06-24',
     expiry: '2020-01-27',
@@ -60,8 +91,7 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
     geolocation,
     highPriority: true,
 
-    canRun: () =>
-        articleViewCount >= minArticleViews && !!getCountryName(geolocation),
+    canRun: () => !!getCountryName(geolocation),
 
     variants: [
         {
@@ -74,24 +104,23 @@ export const articlesViewed: EpicABTest = makeEpicABTest({
                 geolocation
             ),
         },
-        {
-            id: 'variant',
-            buttonTemplate: defaultButtonTemplate,
-            products: [],
-            copy: buildEpicCopy(
-                {
-                    heading: `You’ve read ${articleViewCount} articles...`,
-                    paragraphs: [
-                        '... in the last month. If you’ve enjoyed reading, we hope you will consider supporting our independent, investigative journalism today. More people around the world are reading and supporting The Guardian than ever before. And unlike many new organisations, we have chosen an approach that allows us to keep our journalism accessible to all, regardless of where they live or what they can afford. But we need your ongoing support to keep working as we do.',
-                        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
-                        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
-                        'We need your support to keep delivering quality journalism, to maintain our openness and to protect our precious independence. Every reader contribution, big or small, is so valuable.',
-                    ],
-                    highlightedText,
-                },
-                false,
-                geolocation
-            ),
-        },
+        buildArticleCountVariant({
+            name: '5_articles_in_1_month',
+            minArticleViews: 5,
+            articleCountDays: 30,
+            periodText: 'month',
+        }),
+        buildArticleCountVariant({
+            name: '5_articles_in_2_months',
+            minArticleViews: 5,
+            articleCountDays: 60,
+            periodText: 'two months',
+        }),
+        buildArticleCountVariant({
+            name: '3_articles_in_1_month',
+            minArticleViews: 3,
+            articleCountDays: 30,
+            periodText: 'month',
+        }),
     ],
 });


### PR DESCRIPTION
## What does this change?
This is an unusual test because the variants mix what users should see with who should see it. The stated aim of the test is:
"Explore how much we can grow the pool of eligible users for the article count message and if this can increase the net £AV."

All users are entered into the test. As usual, a user is (effectively) randomly assigned to a variant. The variants have a `canRun` condition, which checks a minimum article count threshold. This means that if a user is assigned to a variant and they have not viewed enough articles to see the variant then they are excluded from the whole test, and will instead be put into a different test.
This means that the impression count will be very different across the variants, because we are not just measuring the uplift in the conversion rate.

### Control
<img width="627" alt="Screenshot 2019-11-13 at 13 28 39" src="https://user-images.githubusercontent.com/1513454/68768032-a7f4aa80-0619-11ea-8184-83cd3b19aa7e.png">

### 5/30
<img width="627" alt="Screenshot 2019-11-13 at 13 23 07" src="https://user-images.githubusercontent.com/1513454/68768042-afb44f00-0619-11ea-8daa-17a36a6d296e.png">

### 5/60
<img width="627" alt="Screenshot 2019-11-13 at 13 27 43" src="https://user-images.githubusercontent.com/1513454/68768052-b4790300-0619-11ea-8dca-8b9ec1455ac3.png">

### 3/30
<img width="627" alt="Screenshot 2019-11-13 at 13 28 20" src="https://user-images.githubusercontent.com/1513454/68768059-b8a52080-0619-11ea-8b26-1b6cdaa1e7f6.png">


### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
