### PR TITLE
Support Interactive Atoms on Fronts

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -135,9 +135,23 @@ object SnapStuff {
       case link: LinkSnap => link.enriched.flatMap(_.embedHtml)
       case _ => None
     }
+
+    val embedCss = faciaContent match {
+      case curated: CuratedContent => curated.enriched.flatMap(_.embedCss)
+      case link: LinkSnap => link.enriched.flatMap(_.embedCss)
+      case _ => None
+    }
+
+    val embedJs = faciaContent match {
+      case curated: CuratedContent => curated.enriched.flatMap(_.embedJs)
+      case link: LinkSnap => link.enriched.flatMap(_.embedJs)
+      case _ => None
+    }
+
     faciaContent.properties.embedType match {
       case Some("latest") => Some(SnapStuff(snapData, faciaContent.properties.embedCss, FrontendLatestSnap, embedHtml))
       case Some("link") => Some(SnapStuff(snapData, faciaContent.properties.embedCss, FrontendLinkSnap, embedHtml))
+      case Some("interactive") => Some(SnapStuff(snapData, faciaContent.properties.embedCss, FrontendLinkSnap, embedHtml, embedCss, embedJs))
       case Some(_) => Some(SnapStuff(snapData, faciaContent.properties.embedCss, FrontendOtherSnap, embedHtml))
       case None => None}}
 }
@@ -146,7 +160,9 @@ case class SnapStuff(
   dataAttributes: String,
   snapCss: Option[String],
   snapType: SnapType,
-  embedHtml: Option[String]
+  embedHtml: Option[String],
+  embedCss: Option[String] = None,
+  embedJs: Option[String] = None,
 ) {
   def cssClasses: Seq[String] = Seq(
     Some("js-snap"),

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -356,11 +356,13 @@ final case class PressedCard(
 // It contains additional content that has been pre-fetched by facia-press, to
 // enable facia-server-side rendering of FAPI content, such as embeds.
 final case class EnrichedContent(
-  embedHtml: Option[String]
+  embedHtml: Option[String],
+  embedCss: Option[String],
+  embedJs: Option[String]
 )
 
 object EnrichedContent {
-  val empty = EnrichedContent(None)
+  val empty = EnrichedContent(None, None, None)
 }
 
 sealed trait PressedContent {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -28,11 +28,14 @@ data-test-id="facia-card"
     @item.snapStuff.map(_.dataAttributes)
     @item.shortUrl.map { shortUrl => data-loyalty-short-url="@shortUrl" }>
 
-    @if(!item.hasInlineSnapHtml) {
-        @container(item)
-    }
     @if(item.hasInlineSnapHtml) {
-        @item.snapStuff.map { snap => @snap.embedHtml.map(Html(_)) }
+        @item.snapStuff.map { snap =>
+            @snap.embedCss.map { css => <style>@Html(css)</style> }
+            @snap.embedHtml.map(Html(_))
+            @snap.embedJs.map { js => <script>@Html(js)</script> }
+        }
+    } else {
+        @container(item)
     }
 
 </div>

--- a/facia-press/test/frontpress/FapiFrontPressTest.scala
+++ b/facia-press/test/frontpress/FapiFrontPressTest.scala
@@ -1,0 +1,13 @@
+package frontpress
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class FapiFrontPressTest extends FlatSpec with Matchers {
+  "CapiUrl" should "return the CAPI ID from a CAPI URL" in {
+    val capiUrl = s"https://content.guardianapis.com/atom/interactive/interactives/2019/10/test-snap?api-key=example"
+
+    val capiId = CapiUrl.extractId(capiUrl)
+
+    capiId shouldBe "atom/interactive/interactives/2019/10/test-snap"
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds support for interactive atoms on fronts. The fronts tool already support interactive atoms which have HTML, JS and CSS. Facia press needs to press these into the json and facia needs to render them into the page.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (fronts aren't handled by dotcom-rendering)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1552" alt="Screenshot 2019-11-13 at 15 16 36" src="https://user-images.githubusercontent.com/379839/68784802-0d09c980-0635-11ea-97b7-1e7a39ef71db.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
