### PR TITLE
Hide subscriptions banner in US

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -48,7 +48,6 @@ const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()
 );
 const hideBannerInTheseRegions: ReaderRevenueRegion[] = [
-    'united-states',
     'australia',
 ];
 const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -39,18 +39,23 @@ const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
-const edition: string = config.get('page.edition');
 const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
 );
 const pageviews: number = local.get('gu.alreadyVisited');
 
-const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(geolocationGetSync());
-const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['united-states', 'australia'];
+const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
+    geolocationGetSync()
+);
+const hideBannerInTheseRegions: ReaderRevenueRegion[] = [
+    'united-states',
+    'australia',
+];
 const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
-const canShowBannerInRegion = (region: ReaderRevenueRegion): boolean => !(hideBannerInTheseRegions.includes(region));
+const canShowBannerInRegion = (region: ReaderRevenueRegion): boolean =>
+    !hideBannerInTheseRegions.includes(region);
 
 const fiveOrMorePageViews = (currentPageViews: number) => currentPageViews >= 5;
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -47,9 +47,7 @@ const pageviews: number = local.get('gu.alreadyVisited');
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()
 );
-const hideBannerInTheseRegions: ReaderRevenueRegion[] = [
-    'australia',
-];
+const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['australia'];
 const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -47,7 +47,10 @@ const pageviews: number = local.get('gu.alreadyVisited');
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()
 );
-const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['australia'];
+const hideBannerInTheseRegions: ReaderRevenueRegion[] = [
+    'united-states',
+    'australia',
+];
 const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 


### PR DESCRIPTION
## What does this change?
On the 18/11/19 we will be starting the US end-of-year appeal with a banner campaign to support this, this PR will hide the subscription banner in the US to avoid any clashing with that.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A

## What is the value of this and can you measure success?
N/A

## Checklist
N/A

### Does this affect other platforms?

- [x] No
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
