### PR TITLE
DFP's NonPersonalizedAds flag changes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -117,6 +117,38 @@ const reset = () => {
     fillAdvertSlots.mockReset();
 };
 
+const fakeTrueConsent = {
+    '1': true,
+    '2': true,
+    '3': true,
+    '4': true,
+    '5': true,
+};
+
+const fakeFalseConsent = {
+    '1': false,
+    '2': false,
+    '3': false,
+    '4': false,
+    '5': false,
+};
+
+const fakeNullConsent = {
+    '1': null,
+    '2': null,
+    '3': null,
+    '4': null,
+    '5': null,
+};
+
+const fakeMixedConsent = {
+    '1': true,
+    '2': false,
+    '3': false,
+    '4': false,
+    '5': false,
+};
+
 describe('DFP', () => {
     const domSnippet = `
         <div id="dfp-ad-html-slot" class="js-ad-slot" data-name="html-slot" data-mobile="300,50"></div>
@@ -404,19 +436,53 @@ describe('DFP', () => {
 
     describe('keyword targeting', () => {
         it('should send page level keywords', () => {
-            onIabConsentNotification.mockImplementation(callback =>
-                callback({
-                    '1': true,
-                    '2': true,
-                    '3': true,
-                    '4': true,
-                    '5': true,
-                })
-            );
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setTargeting
                 ).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+            });
+        });
+    });
+
+    describe('NPA flag is set correctly', () => {
+        it('when full IAB consent was given', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(fakeTrueConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(0);
+            });
+        });
+        it('when no IAB consent preferences were specified', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(fakeNullConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(0);
+            });
+        });
+        it('when full IAB consent was denied', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(fakeFalseConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(1);
+            });
+        });
+        it('when only partial IAB consent was given', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(fakeMixedConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(1);
             });
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,8 +103,7 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
-            const consentState =
-                state[1] && state[2] && state[3] && state[4] && state[5];
+            const consentState = !Object.values(state).includes(false);
 
             window.googletag.cmd.push(() => {
                 window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,12 +103,12 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
-            const consentState = !Object.values(state).includes(false);
+            const npaFlag = Object.values(state).includes(false);
 
             window.googletag.cmd.push(() => {
                 window.googletag
                     .pubads()
-                    .setRequestNonPersonalizedAds(consentState ? 0 : 1);
+                    .setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
             });
         });
 


### PR DESCRIPTION
## What does this change?
DFP's `NonPersonalizedAds` (NPA) flag is set whenever we want DFP to not serve personalised ads to the user. Previously we set this flag on every time except when the user has consented to all 5 IAB purposes, which means we would server personalised ads only to users who have said yes to all IAB purposes.

This PR changes that behaviour so that the NPA flag is on only when a user explicitly says no to at least one of the 5 IAB purposes. In other word we now show personalised advertisements to users who have said yes to every IAB purpose as well as users who have not yet configured their privacy/consent preferences.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
