### PR TITLE
Update CAPI client to 15.6

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
-import com.gu.contentapi.client.{ContentApiClient => CapiContentApiClient}
+import com.gu.contentapi.client.{ContentApiBackoff, ScheduledExecutor, ContentApiClient => CapiContentApiClient}
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Edition => _, _}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
@@ -103,6 +103,11 @@ trait ApiQueryDefaults extends Logging {
 trait MonitoredContentApiClientLogic extends CapiContentApiClient with ApiQueryDefaults with Logging {
 
   val httpClient: HttpClient
+
+  override implicit val executor = ScheduledExecutor()
+  val retryDuration = Duration(250L, TimeUnit.MILLISECONDS)
+  val retryAttempts = 5
+  override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.doublingStrategy(retryDuration, retryAttempts)
 
   def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext): Future[HttpResponse] = {
     val futureContent = httpClient.GET(url, headers) map { response: Response =>

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -106,8 +106,8 @@ trait MonitoredContentApiClientLogic extends CapiContentApiClient with ApiQueryD
 
   override implicit val executor = ScheduledExecutor()
   val retryDuration = Duration(250L, TimeUnit.MILLISECONDS)
-  val retryAttempts = 5
-  override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.doublingStrategy(retryDuration, retryAttempts)
+  val retryAttempts = 3
+  override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.constantStrategy(retryDuration, retryAttempts)
 
   def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext): Future[HttpResponse] = {
     val futureContent = httpClient.GET(url, headers) map { response: Response =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.191"
   val awsVersion = "1.11.240"
-  val capiVersion = "15.4"
+  val capiVersion = "15.6"
   val faciaVersion = "3.0.11"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
We (the CAPI team) released a new version of the scala client yesterday. This PR brings that update into dotcom.

What does it do? Well, it adds an automatic backoff and retry mechanism so that if CAPI is under strain, clients don't have to think too hard about how to deal with that, and CAPI may not get bombarded with so many requests that it gets clogged up and becomes completely unresponsive.

We have a specific set of error codes that will invoke the new backoff code if they are encountered while handling a request. These are;
```
408 - Request Timeout
429 - Too Many Requests
503 - Service Unavailable
504 - Gateway Timeout
509 - Bandwidth Limit Exceeded
```
There's more information about the different strategies and their expected behaviour in the [client's README file](https://github.com/guardian/content-api-scala-client/blob/master/README.md).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (or at least I don't _think_ so)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A (everything looks the same)

## What is the value of this and can you measure success?
If the new code is invoked, we should expect to see the circuitbreakers opening less frequently. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [x] None

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)
- [x] Yes, but the data models are unchanged from the previous version

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
