### PR TITLE
Introduce BodyBlock's referenceDateForDisplay()

### DIFF
--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -22,7 +22,7 @@ object KeyEventData {
     val bodyBlocks = (latestSummary.toSeq ++ keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
 
     bodyBlocks.map { bodyBlock =>
-      KeyEventData(bodyBlock.id, bodyBlock.firstPublishedDate.map(LiveBlogDate(_, timezone)), bodyBlock.title)
+      KeyEventData(bodyBlock.id, bodyBlock.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), bodyBlock.title)
     }
   }
 

--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -2,8 +2,8 @@
 
 @(date: Option[LiveBlogDate])
 
-@date.map { case LiveBlogDate(firstPublishedDate, hhmm, ampm, gmt) =>
-    <time datetime="@firstPublishedDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
+@date.map { case LiveBlogDate(referenceDate, hhmm, ampm, gmt) =>
+    <time datetime="@referenceDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
     <span class="block-time__absolute">@hhmm</span>
 }
 

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -34,7 +34,7 @@
 
         <p class="block-time published-time">
                 <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-                    @views.html.liveblog.dateBlock(block.firstPublishedDate.map(LiveBlogDate(_, timezone)))
+                    @views.html.liveblog.dateBlock(block.referenceDateForDisplay().map(LiveBlogDate(_, timezone)))
                 </a>
         </p>
 

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -117,7 +117,7 @@ case class BodyBlock(
 
   def publishedCreatedTimestamp(): Option[Long] = firstPublishedDate.orElse(createdDate).map(_.getMillis())
 
-  def referenceDateForDisplay(): Option[DateTime] = Option(firstPublishedDate.getOrElse(publishedDate.getOrElse(createdDate.getOrElse(null))))
+  def referenceDateForDisplay(): Option[DateTime] = firstPublishedDate.orElse(publishedDate).orElse(createdDate)
 
 }
 

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -116,6 +116,10 @@ case class BodyBlock(
   def publishedCreatedDate(timezone: DateTimeZone): Option[LiveBlogDate] = firstPublishedDate.orElse(createdDate).map(LiveBlogDate.apply(_, timezone))
 
   def publishedCreatedTimestamp(): Option[Long] = firstPublishedDate.orElse(createdDate).map(_.getMillis())
+
+  def referenceDateForDisplay(): Option[DateTime] = {
+    firstPublishedDate
+  }
 }
 
 object LiveBlogDate {

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -117,9 +117,8 @@ case class BodyBlock(
 
   def publishedCreatedTimestamp(): Option[Long] = firstPublishedDate.orElse(createdDate).map(_.getMillis())
 
-  def referenceDateForDisplay(): Option[DateTime] = {
-    firstPublishedDate
-  }
+  def referenceDateForDisplay(): Option[DateTime] = Option(firstPublishedDate.getOrElse(publishedDate.getOrElse(createdDate.getOrElse(null))))
+
 }
 
 object LiveBlogDate {


### PR DESCRIPTION
## What does this change?

Introduce `BodyBlock`'s `referenceDateForDisplay()`, which is used to decide a correct liveblog block DateTime before and after publishing.

## Does this change need to be reproduced in dotcom-rendering ?

No