### PR TITLE
Bump elliptic to 6.5.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3717,8 +3717,9 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
+  integrity sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"


### PR DESCRIPTION
Fixes a new vulnerability reported by Snyk.

## What does this change?

Upgrades the version of elliptic we're on to 6.5.1. It looks like that dependency is indirectly pulled in via atom-renderer.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

I don't think we support atoms in DCR yet.

### Tested

- [x] Locally
- [ ] On CODE (optional)

Locally I checked that the atom on this page http://localhost:9000/open-platform/blog/related-content loaded correctly, which it seemed to. Any suggestions on how to test further would be appreciated (I'm still gaining context around all this).

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
