### PR TITLE
Fix epic ticker

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -696,7 +696,7 @@ export const buildConfiguredEpicTestFromJson = (
                 `contributions__epic--${test.name}`,
                 `contributions__epic--${test.name}-${variant.name}`,
             ],
-            showTicker: optionalStringToBoolean(variant.showTicker),
+            showTicker: variant.showTicker,
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?
             deploymentRules,


### PR DESCRIPTION
## What does this change?
Enables the ticker on the epic. We haven't used the ticker since we switched to the new epic tool.

The `optionalStringToBoolean` function was left over from when we published test config from google sheets, where boolean values arrived as strings. They're now proper bools
<img width="639" alt="Screenshot 2019-11-18 at 11 18 07" src="https://user-images.githubusercontent.com/1513454/69048422-4fe0ee00-09f5-11ea-81d9-6b14201bd436.png">

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
