### PR TITLE
Remove block.title from email template

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -117,11 +117,6 @@
 
     @page.article.fields.blocks.toSeq.map { blocks =>
         @blocks.body.map { block =>
-            @block.title.map { title =>
-                @row(Seq("padded")) {
-                    <h2 class="block__title">@title</h2>
-                }
-            }
 
             @block.elements.map { element =>
                 @element match {


### PR DESCRIPTION
## What does this change?

Remote the block title from the article email. This causes problems when the article was created from a blog post. 

**Before**

![Screenshot 2019-11-18 at 12 49 55](https://user-images.githubusercontent.com/6035518/69054001-94bf5180-0a02-11ea-8ae9-01e8926814ff.png)


**Article**

![Screenshot 2019-11-18 at 12 50 14](https://user-images.githubusercontent.com/6035518/69053972-8113eb00-0a02-11ea-8b70-af808dd9549b.png)


## Does this change need to be reproduced in dotcom-rendering ?

No, DCR doesn't do email rendering.
