### PR TITLE
Updating US support subtext

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -161,9 +161,16 @@
             <div class="cta-bar__heading">
                 Support The&nbsp;Guardian
             </div>
+            @if(editionId == "us") {
+                <div class="cta-bar__subheading">
+                        Support our journalism with a year-end gift
+                </div>
+            }
+            @if(editionId != "us") {
             <div class="cta-bar__subheading">
-                Available for everyone, funded by readers
+                    Available for everyone, funded by readers
             </div>
+        }
         </div>
 
         <a class="cta-bar__cta js-change-become-member-link js-acquisition-link"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -38,9 +38,16 @@
                             <div class="cta-bar__heading">
                                 Support The Guardian
                             </div>
+                            @if(editionId == "us") {
+                                <div class="cta-bar__subheading">
+                                        Support our journalism with a year-end gift
+                                </div>
+                            }
+                            @if(editionId != "us") {
                             <div class="cta-bar__subheading">
-                                Available for everyone, funded by readers
+                                    Available for everyone, funded by readers
                             </div>
+                        }
                         </div>
                     }
 


### PR DESCRIPTION
## What does this change?
Adds US specific copy in header and footer component

<img width="502" alt="Screen Shot 2019-11-18 at 14 17 41" src="https://user-images.githubusercontent.com/2051501/69060614-8d527500-0a0f-11ea-89f0-4a4a6b441298.png">
<img width="502" alt="Screen Shot 2019-11-18 at 14 19 24" src="https://user-images.githubusercontent.com/2051501/69060615-8deb0b80-0a0f-11ea-94c2-f0bf231849eb.png">
