### PR TITLE
Styling changes for the Sign In Gate AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateFirstTest: ABTest = {
     author: 'Mahesh Makani, Domoinic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates',
-    audience: 0.01,
+    audience: 0.1,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateFirstTest: ABTest = {
     author: 'Mahesh Makani, Domoinic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates',
-    audience: 0.1,
+    audience: 0.01,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/template.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/template.js
@@ -7,11 +7,7 @@ export const make = (signInUrl: string, guUrl: string): string => `
         </div>
         <div class="signin-gate__benefits syndication--bottom">
             <p class="signin-gate__benefits--text">
-                Help keep our independent, progressive
-                <br />
-                journalism alive and thriving by taking a
-                <br />
-                couple of simple steps to sign in
+                Help keep our independent, progressive journalism alive and thriving by taking a couple of simple steps to sign in
             </p>
         </div>
         <div class="signin-gate__buttons">

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -1,15 +1,16 @@
 .signin-gate {
     clear: left;
-    margin-top: $gs-baseline * 3;
     margin-bottom: $gs-baseline * 2;
     padding: ($gs-baseline * 3) ($gs-baseline * 2);
+    @include mq(desktop) {
+        min-height: 600px;
+    }
 }
 
 .signin-gate__header {
     @include fs-header(3);
     border-top: 1px solid $brightness-46;
     margin-bottom: $gs-baseline * 2;
-    padding-top: $gs-baseline / 2;
 }
 
 .signin-gate__buttons {
@@ -17,12 +18,12 @@
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    padding-top: $gs-baseline * 2;
+    padding-top: 4px;
 
     // Horizontal alignment
     align-items: flex-start;
 
-    @include mq($from: mobileLandscape) {
+    @include mq(424px) {
         flex-direction: row;
 
         // Now vertical alignment, because the flex-direction is row
@@ -37,6 +38,11 @@
     font-weight: 700;
     font-size: 17px;
     padding-left: $gs-baseline * 1.5;
+    padding-top: 20px;
+    @include mq(424px) {
+        padding-top: 0px;
+    }
+
 }
 
 .signin-gate__dismiss {
@@ -46,6 +52,10 @@
     font-weight: 700;
     font-size: 17px;
     padding-left: $gs-baseline * 1.5;
+    padding-top: 20px;
+    @include mq(424px) {
+        padding-top: 0px;
+    }
 }
 
 .signin-gate__first-paragraph-container {
@@ -76,7 +86,7 @@
     font-size: 17px;
     height: 42px;
     min-height: 42px;
-    padding: 0 42px;
+    padding: 20px 42px;
     border: 0;
     border-radius: 21px;
     box-sizing: border-box;
@@ -112,20 +122,28 @@
 .signin-gate__header--text {
     font-weight: normal;
     margin-bottom: $gs-baseline;
-    font-size: 34px;
     line-height: initial;
+    font-size: 24px;
+    @include mq(tablet) {
+        font-size: 34px;
+    }
 }
 
 .signin-gate__benefits {
     border-top: 1px solid $brightness-46;
-    padding-top: $gs-baseline;
-    padding-bottom: $gs-baseline * 2;
+    margin-bottom: $gs-baseline * 2;
 }
 
 .signin-gate__benefits--text {
+    @include mq(tablet) {
+        padding-right: $gs-baseline * 12;
+    }
     font-weight: bold;
     color: $sport-main;
-    font-size: 20px;
+    font-size: 17px;
+    @include mq(tablet) {
+        font-size: 20px;
+    }
     &-news {
         color: $news-main;
     }


### PR DESCRIPTION
## What does this change?

- Add a min height to the sign in gate so that content on the sidebar doesn't overlap content above the footer
- Improve media queries by changing font size and spacing for different

## Screenshots
Mobile:
![Screenshot 2019-11-20 at 15 39 13](https://user-images.githubusercontent.com/13315440/69253135-0a1a5600-0bac-11ea-9aff-8e4de83be7b6.png)
Tablet:
![Screenshot 2019-11-20 at 15 39 24](https://user-images.githubusercontent.com/13315440/69253145-0edf0a00-0bac-11ea-863b-4e74ccbdbed7.png)
Desktop:
![m thegulocal com_sport_2016_apr_12_andy-murray-pierre-hugues-herbert-monte-carlo-masters-match-report (1)](https://user-images.githubusercontent.com/13315440/69253150-12729100-0bac-11ea-91e3-cdfdcd0405df.png)

### Tested
- [x] Locally
- [ ] On CODE (optional)