### PR TITLE
Avoid some redirect loops

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -117,7 +117,7 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
   private object Lowercase {
     def unapply(path: String): Option[String] = path.split("/").toList match {
         case "" :: section :: other if section.exists(_.isUpper) =>
-          Some(s"/${section.toLowerCase}/${other.mkString("/")}")
+          Some(("" :: section.toLowerCase :: other).mkString("/"))
         case _ => None
     }
   }

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -116,7 +116,7 @@ class ArchiveController(redirects: RedirectService, val controllerComponents: Co
 
   private object Lowercase {
     def unapply(path: String): Option[String] = path.split("/").toList match {
-        case "" :: section :: other if section.exists(_.isUpper) =>
+        case "" :: section :: other if URLDecoder.decode(section, "UTF-8").exists(_.isUpper) =>
           Some(("" :: section.toLowerCase :: other).mkString("/"))
         case _ => None
     }


### PR DESCRIPTION
## What does this change?

Changes url rewriting in archive app to avoid a cause of redirect loops.  The extractor that redirects requests with uppercase characters in the section name would in some cases append a `/` to the redirected path, which would then cause another redirect in the [router](https://github.com/guardian/platform/blob/8da399e/router/files/redirects.conf#L51) to strip it off again.

Also changes url rewriting to avoid redirecting because of capital letters created as part of URL encoding.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
