### PR TITLE
Sign In Gate: Increase audience to 4%, header line height change

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateFirstTest: ABTest = {
     author: 'Mahesh Makani, Domoinic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates',
-    audience: 0.01,
+    audience: 0.04,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -122,7 +122,7 @@
 .signin-gate__header--text {
     font-weight: normal;
     margin-bottom: $gs-baseline;
-    line-height: initial;
+    line-height: 1.25em;
     font-size: 24px;
     @include mq(tablet) {
         font-size: 34px;


### PR DESCRIPTION
## What does this change?
Increase the audience of the sign in gate to 4% of users which will allow us to reach our targeted number of users who viewed the component in under 7 days.

Change the line height on the header text of the sign in gate for IE compatibility.