### PR TITLE
US end of year banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,6 +68,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-banner-us-eoy",
+    "US end of year banner",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-always-ask-if-tagged",
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-ticker.js
@@ -5,35 +5,24 @@ import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 export const acquisitionsBannerTickerTemplate = `
     <div id="banner-ticker" class="js-engagement-banner-ticker engagement-banner-ticker is-hidden">
         
-        <div class="js-ticker-under-goal is-hidden">
+        <div class="js-ticker-amounts">
             <div class="js-ticker-so-far engagement-banner-ticker__so-far">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
-                <div class="engagement-banner-ticker__count-label">contributed</div>
+                <div class="js-ticker-count engagement-banner-ticker__count"></div>
+                <div class="js-ticker-label engagement-banner-ticker__count-label is-hidden">contributed</div>
             </div>
             
             <div class="js-ticker-goal engagement-banner-ticker__goal">
                 <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
-                <div class="engagement-banner-ticker__count-label">our goal</div>
-            </div>
-        </div>
-        
-        <div class="js-ticker-over-goal is-hidden">
-            <div class="engagement-banner-ticker__thankyou">
-                <div>Help us beat our goal - thank you</div>
-                <div>Please keep contributing into the new year</div>
-            </div>
-            
-            <div class="js-ticker-exceeded engagement-banner-ticker__exceeded">
-                <div class="js-ticker-count engagement-banner-ticker__count">${getLocalCurrencySymbolSync()}0</div>
-                <div class="engagement-banner-ticker__count-label">contributed</div>
+                <div class="js-ticker-label engagement-banner-ticker__count-label">our goal</div>
             </div>
         </div>
         
         <div class="engagement-banner-ticker__progress-container">
             <div class="engagement-banner-ticker__progress">
-                <div class="js-ticker-filled-progress engagement-banner-ticker__filled-progress ticker__filled-progress-under"></div>
+                <div class="js-ticker-filled-progress engagement-banner-ticker__filled-progress"></div>
             </div>
             <div class="js-ticker-goal-marker engagement-banner-ticker__goal-marker is-hidden"></div>
         </div>
+        
     </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -37,7 +37,7 @@ export const acquisitionsBannerUsEoyTemplate = (
                 </div>
                 
                 <div class="engagement-banner__cta">
-                    <a tabIndex="3" class="component-button component-button--primary" href="${
+                    <a tabIndex="3" class="component-button component-button--secondary" href="${
                         params.linkUrl
                     }">
                         ${params.buttonCaption}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -4,7 +4,7 @@ import marque36icon from 'svgs/icon/marque-36.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
 
-export const acquisitionsBannerUsEoy = (
+export const acquisitionsBannerUsEoyTemplate = (
     params: EngagementBannerTemplateParams
 ): string => `
         <div class="engagement-banner__close">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -28,8 +28,8 @@ export const acquisitionsBannerUsEoyTemplate = (
             </div>
            
             <div class="engagement-banner__cta-container">
-                <div class="engagement-banner__cta-heading">
-                    <h3>Help us reach our year-end goal</h3>
+                <div class="engagement-banner__ticker-header-container">
+                    <h3 class="engagement-banner__ticker-header">Help us reach our year-end goal</h3>
                 </div>
                 
                 <div class="engagement-banner__ticker-container">
@@ -37,18 +37,16 @@ export const acquisitionsBannerUsEoyTemplate = (
                 </div>
                 
                 <div class="engagement-banner__cta">
-                    <a tabIndex="3" class="button engagement-banner__button" href="${
+                    <a tabIndex="3" class="component-button component-button--primary" href="${
                         params.linkUrl
                     }">
                         ${params.buttonCaption}
                     </a>
                 </div>
                 
-                <div class="engagement-banner__cta">
-                    <a tabIndex="3" class="button engagement-banner__button" href="${
-                        params.linkUrl
-                    }">
-                        ${params.buttonCaption}
+                <div class="engagement-banner__cta engagement-banner__cta--editorial">
+                    <a tabIndex="3" class="component-button component-button--greyHollow component-button--greyHollow--eoy" href="${'https://www.theguardian.com/us-news/2019/nov/18/help-raise-15-million-fund-high-impact-journalism-2020'}">
+                        Learn more
                     </a>
                 </div>
             </div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -20,7 +20,11 @@ export const acquisitionsBannerUsEoyTemplate = (
         <div class="engagement-banner__container engagement-banner__container--us-eoy-2019">
             <div class="engagement-banner__text-container">
                 <div class="engagement-banner__header">
-                    </h2>${params.leadSentence ? params.leadSentence : ''}</h2>
+                    </h2>${
+                        params.titles && params.titles[0]
+                            ? params.titles[0]
+                            : ''
+                    }</h2>
                 </div>
                 <div class="engagement-banner__body">
                     <p>${params.messageText}</p>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -20,7 +20,7 @@ export const acquisitionsBannerUsEoyTemplate = (
         <div class="engagement-banner__container engagement-banner__container--us-eoy-2019">
             <div class="engagement-banner__text-container">
                 <div class="engagement-banner__header">
-                    </h2>${params.leadSentence}</h2>
+                    </h2>${params.leadSentence ? params.leadSentence : ''}</h2>
                 </div>
                 <div class="engagement-banner__body">
                     <p>${params.messageText}</p>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -1,0 +1,63 @@
+// @flow
+
+import marque36icon from 'svgs/icon/marque-36.svg';
+import closeCentralIcon from 'svgs/icon/close-central.svg';
+import { acquisitionsBannerTickerTemplate } from 'common/modules/commercial/templates/acquisitions-banner-ticker';
+
+export const acquisitionsBannerUsEoy = (
+    params: EngagementBannerTemplateParams
+): string => `
+        <div class="engagement-banner__close">
+            <div class="engagement-banner__roundel hide-until-phablet">
+                ${marque36icon.markup}
+            </div>
+            <button tabindex="4" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close the support banner</span>
+                ${closeCentralIcon.markup}
+            </button>
+        </div>
+        
+        <div class="engagement-banner__container engagement-banner__container--us-eoy-2019">
+            <div class="engagement-banner__text-container">
+                <div class="engagement-banner__header">
+                    </h2>${params.leadSentence}</h2>
+                </div>
+                <div class="engagement-banner__body">
+                    <p>${params.messageText}</p>
+                </div>
+            </div>
+           
+            <div class="engagement-banner__cta-container">
+                <div class="engagement-banner__cta-heading">
+                    <h3>Help us reach our year-end goal</h3>
+                </div>
+                
+                <div class="engagement-banner__ticker-container">
+                    ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
+                </div>
+                
+                <div class="engagement-banner__cta">
+                    <a tabIndex="3" class="button engagement-banner__button" href="${
+                        params.linkUrl
+                    }">
+                        ${params.buttonCaption}
+                    </a>
+                </div>
+                
+                <div class="engagement-banner__cta">
+                    <a tabIndex="3" class="button engagement-banner__button" href="${
+                        params.linkUrl
+                    }">
+                        ${params.buttonCaption}
+                    </a>
+                </div>
+            </div>
+        </div>
+        
+        <a
+            aria-hidden="true"
+            class="u-faux-block-link__overlay"
+            target="_blank"
+            href="${params.linkUrl}"
+        ></a>
+    `;

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -12,6 +12,7 @@ import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xa
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-gate-first-test';
+import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -32,5 +33,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    contributionsBannerUsEoy,
     articlesViewedBanner,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
@@ -6,7 +6,7 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const leadSentence = 'As we head into another pivotal year...';
+const leadSentence = 'As\xa0we\xa0head\xa0into\nanother\xa0pivotal\xa0year...';
 const messageText =
     'We are asking you to support our independent journalism. Guardian reporting is based in fact, and as a news organisation, we are progressive in how we view the world and respond to it. Whether we are up close or far away, we provide a global perspective on the most critical issues of our lifetimes.';
 const ctaText = 'Support The Guardian';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
@@ -1,7 +1,7 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
-import { acquisitionsBannerUsEoy } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
@@ -35,7 +35,7 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
                 leadSentence,
                 messageText,
                 ctaText,
-                template: acquisitionsBannerUsEoy,
+                template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
@@ -1,0 +1,43 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+import { acquisitionsBannerUsEoy } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+
+const geolocation = geolocationGetSync();
+const isUS = geolocation === 'US';
+
+const leadSentence = 'As we head into another pivotal year...';
+const messageText =
+    'We are asking you to support our independent journalism. Guardian reporting is based in fact, and as a news organisation, we are progressive in how we view the world and respond to it. Whether we are up close or far away, we provide a global perspective on the most critical issues of our lifetimes.';
+const ctaText = 'Support The Guardian';
+
+export const contributionsBannerUsEoy: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoy',
+    campaignId: 'USeoy2019',
+    start: '2019-11-15',
+    expiry: '2020-1-30',
+    author: 'Joshua Lieberman',
+    description: 'show number of articles viewed in contributions banner',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'variant design performs at least as well as control',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => isUS,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerUsEoy,
+                hasTicker: true,
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
@@ -6,11 +6,11 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const leadSentence = '2020 will be a defining year for America';
+const titles = ['2020 will be a defining year for America'];
 const messageTextV1 =
-    'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more.  As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
+    'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
 const messageTextV2 =
-    'Over the last three years, much of what the Guardian holds dear has been threatened - democracy, civility, truth. This US administration is establishing new norms of behaviour. Truth is being chased away. But with your help we can continue put it center stage. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
+    'This year, much of what we hold dear has been threatened - democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million.';
 const ctaText = 'Support The Guardian';
 
 export const contributionsBannerUsEoy: AcquisitionsABTest = {
@@ -34,22 +34,24 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
             id: 'control',
             test: (): void => {},
             engagementBannerParams: {
-                leadSentence,
-                messageTextV1,
+                titles,
+                messageText: messageTextV1,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
+                bannerModifierClass: 'useoy2019',
             },
         },
         {
             id: 'variant',
             test: (): void => {},
             engagementBannerParams: {
-                leadSentence,
-                messageTextV2,
+                titles,
+                messageText: messageTextV2,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
+                bannerModifierClass: 'useoy2019',
             },
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy.js
@@ -6,9 +6,11 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const leadSentence = 'As\xa0we\xa0head\xa0into\nanother\xa0pivotal\xa0year...';
-const messageText =
-    'We are asking you to support our independent journalism. Guardian reporting is based in fact, and as a news organisation, we are progressive in how we view the world and respond to it. Whether we are up close or far away, we provide a global perspective on the most critical issues of our lifetimes.';
+const leadSentence = '2020 will be a defining year for America';
+const messageTextV1 =
+    'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more.  As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
+const messageTextV2 =
+    'Over the last three years, much of what the Guardian holds dear has been threatened - democracy, civility, truth. This US administration is establishing new norms of behaviour. Truth is being chased away. But with your help we can continue put it center stage. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
 const ctaText = 'Support The Guardian';
 
 export const contributionsBannerUsEoy: AcquisitionsABTest = {
@@ -33,7 +35,18 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
             test: (): void => {},
             engagementBannerParams: {
                 leadSentence,
-                messageText,
+                messageTextV1,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence,
+                messageTextV2,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -20,6 +20,7 @@ import marque36icon from 'svgs/icon/marque-36.svg';
 import { getEngagementBannerTestToRun } from 'common/modules/experiments/ab';
 import fastdom from 'lib/fastdom-promise';
 import reportError from 'lib/report-error';
+import { initTicker } from 'common/modules/commercial/ticker';
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 
@@ -153,6 +154,10 @@ const show = (): Promise<boolean> => {
 
                 if (paramsAndEngagementBannerHtml.params.bannerShownCallback) {
                     paramsAndEngagementBannerHtml.params.bannerShownCallback();
+                }
+
+                if (paramsAndEngagementBannerHtml.params.hasTicker) {
+                    initTicker('.js-engagement-banner-ticker');
                 }
 
                 return true;

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -40,3 +40,4 @@
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
 @import 'module/experiments/_update-account';
+@import 'module/site-messages/_engagement-banner-us-eoy';

--- a/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
@@ -1,12 +1,8 @@
 .engagement-banner-ticker {
-    display: none;
-
-    @include mq(desktop) {
         display: block;
         position: relative;
         height: 70px;
         margin-top: 12px;
-    }
 }
 
 .engagement-banner-ticker__count {

--- a/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_banner-ticker.scss
@@ -1,8 +1,8 @@
 .engagement-banner-ticker {
-        display: block;
-        position: relative;
-        height: 70px;
-        margin-top: 12px;
+    display: block;
+    position: relative;
+    height: 70px;
+    margin-top: 12px;
 }
 
 .engagement-banner-ticker__count {

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -138,6 +138,7 @@ $dark-red: #cc5243;
         line-height: 22px;
         font-family: $f-serif-headline;
         font-weight: 300;
+        margin-bottom: 0;
 
         @include mq($from: desktop) {
             font-size: 24px;
@@ -166,7 +167,8 @@ $dark-red: #cc5243;
         border-color: $brightness-97;
         color: $brightness-97 !important;
 
-        &:hover {
+        &:hover,
+        &:focus {
             color: $brightness-7 !important;
         }
     }
@@ -175,7 +177,7 @@ $dark-red: #cc5243;
         padding-top: $gs-baseline;
 
         @include mq($from: desktop) {
-            padding-top: $gs-baseline * 2;
+            padding-top: $gs-baseline * 3;
         }
     }
 

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -8,13 +8,15 @@
 }
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
-$red: #e1594a;
-$dark-red: #cc5243;
+$background: #fef9f5;
+$background-dark: #e6e2de;
+$red-accent: #ea4333;
+$blue-accent: #1a5292;
 
 [data-component*='ContributionsBannerUsEoy'] {
-    border-top: 0;
-    color: $brightness-97;
-    background-color: $red;
+    border-top: 2px solid $brightness-7;
+    color: $brightness-7;
+    background-color: $background;
     position: relative;
     overflow: hidden;
 
@@ -35,14 +37,6 @@ $dark-red: #cc5243;
 
         @include mq($from: desktop) {
             position: static;
-        }
-    }
-
-    .engagement-banner__close-button {
-        border: 1px solid $brightness-97;
-
-        svg {
-            fill: $brightness-97;
         }
     }
 }
@@ -66,7 +60,7 @@ $dark-red: #cc5243;
                 right: 0;
                 width: 1px;
                 height: 200%;
-                background-color: $brightness-97;
+                background-color: $brightness-7;
             }
         }
 
@@ -77,6 +71,7 @@ $dark-red: #cc5243;
 
     .engagement-banner__header {
         font-family: $title;
+        color: $blue-accent;
         display: block;
         line-height: 1.15;
         font-size: 28px;
@@ -119,7 +114,7 @@ $dark-red: #cc5243;
             content: '';
             position: absolute;
             height: 1px;
-            background-color: $brightness-97;
+            background-color: $brightness-7;
             width: 1000%;
             left: -$gs-gutter;
             top: -$gs-baseline;
@@ -163,16 +158,6 @@ $dark-red: #cc5243;
         }
     }
 
-    .component-button--greyHollow--eoy {
-        border-color: $brightness-97;
-        color: $brightness-97 !important;
-
-        &:hover,
-        &:focus {
-            color: $brightness-7 !important;
-        }
-    }
-
     .engagement-banner__ticker-container {
         padding-top: $gs-baseline;
 
@@ -181,15 +166,14 @@ $dark-red: #cc5243;
         }
     }
 
-    .engagement-banner-ticker__goal,
-    .engagement-banner-ticker__count,
     .js-ticker-label {
-        color: $brightness-97;
+        color: $brightness-7;
     }
 
     .engagement-banner-ticker__goal,
     .engagement-banner-ticker__count {
         font-family: $title;
+        color: $red-accent;
     }
 
     .js-ticker-so-far .engagement-banner-ticker__count {
@@ -208,11 +192,11 @@ $dark-red: #cc5243;
 
     .engagement-banner-ticker__progress {
         height: 20px;
-        background-color: $dark-red;
+        background-color: $background-dark;
     }
 
     .js-ticker-filled-progress {
-        background-color: $highlight-main;
+        background-color: $red-accent;
     }
 
     .js-ticker-label {

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -1,15 +1,15 @@
 @font-face {
     font-family: 'Guardian Titlepiece';
     src:
-        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
-        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff') format('woff'),
-        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf') format('truetype');
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff') format('woff'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf') format('truetype');
     font-style: normal;
 }
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
-$red: #E1594A;
-$dark-red: #CC5243;
+$red: #e1594a;
+$dark-red: #cc5243;
 
 [data-component*='ContributionsBannerUsEoy'] {
     border-top: 0;

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -1,0 +1,220 @@
+@font-face {
+    font-family: 'Guardian Titlepiece';
+    src:
+        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff') format('woff'),
+        url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf') format('truetype');
+    font-style: normal;
+}
+
+$title: 'Guardian Titlepiece', Georgia, serif !default;
+$red: #E1594A;
+$dark-red: #CC5243;
+
+[data-component*='ContributionsBannerUsEoy'] {
+    border-top: 0;
+    color: $brightness-97;
+    background-color: $red;
+    position: relative;
+    overflow: hidden;
+
+    .site-message__roundel,
+    .engagement-banner__roundel {
+        display: none;
+    }
+
+    .engagement-banner__close {
+        position: absolute;
+        z-index: 1;
+        right: 0;
+
+        @include mq($from: tablet) {
+            right: $gs-gutter;
+            top: $gs-baseline;
+        }
+
+        @include mq($from: desktop) {
+            position: static;
+        }
+    }
+
+    .engagement-banner__close-button {
+        border: 1px solid $brightness-97;
+
+        svg {
+            fill: $brightness-97;
+        }
+    }
+}
+
+.engagement-banner__container--us-eoy-2019 {
+    @include mq($from: tablet) {
+        display: flex;
+    }
+
+    .engagement-banner__text-container {
+        position: relative;
+        width: 100%;
+
+        @include mq($from: tablet) {
+            width: 50%;
+
+            &:after {
+                content: '';
+                position: absolute;
+                top: -20px;
+                right: 0;
+                width: 1px;
+                height: 200%;
+                background-color: $brightness-97;
+            }
+        }
+
+        @include mq($from: desktop) {
+            width: gs-span(8);
+        }
+    }
+
+    .engagement-banner__header {
+        font-family: $title;
+        display: block;
+        line-height: 1.15;
+        font-size: 28px;
+        border-bottom: 0;
+
+        @include mq($from: desktop) {
+            font-size: 48px;
+            font-weight: bold;
+            padding: $gs-baseline $gs-gutter $gs-baseline 0;
+        }
+    }
+
+    .engagement-banner__body {
+        line-height: 1.35;
+        font-size: 17px;
+
+        @include mq($from: tablet) {
+            padding: $gs-baseline $gs-gutter $gs-baseline 0;
+        }
+    }
+
+    .engagement-banner__cta-container {
+        width: 100%;
+
+        @include mq($from: tablet) {
+            padding-left: $gs-gutter;
+            width: 50%;
+        }
+
+        @include mq($from: desktop) {
+            width: gs-span(6)
+        }
+    }
+
+    .engagement-banner__ticker-header-container {
+        margin-top: $gs-baseline * 2;
+        position: relative;
+
+        &:after {
+            content: '';
+            position: absolute;
+            height: 1px;
+            background-color: $brightness-97;
+            width: 1000%;
+            left: -$gs-gutter;
+            top: -$gs-baseline;
+        }
+
+        @include mq($from: tablet) {
+            &:after {
+                top: initial;
+                bottom: -$gs-baseline;
+            }
+        }
+    }
+
+    .engagement-banner__ticker-header {
+        font-size: 18px;
+        line-height: 22px;
+        font-family: $f-serif-headline;
+        font-weight: 300;
+
+        @include mq($from: desktop) {
+            font-size: 24px;
+            line-height: 30px;
+        }
+    }
+
+    .engagement-banner__cta {
+        padding-top: $gs-baseline / 2;
+
+        @include mq($from: desktop) {
+            padding-top: $gs-baseline
+        }
+    }
+
+    .engagement-banner__cta--editorial {
+        display: block;
+
+        @include mq($from: desktop) {
+            display: inline-block;
+            margin-left: $gs-gutter;
+        }
+    }
+
+    .component-button--greyHollow--eoy {
+        border-color: $brightness-97;
+        color: $brightness-97 !important;
+
+        &:hover {
+            color: $brightness-7 !important;
+        }
+    }
+
+    .engagement-banner__ticker-container {
+        padding-top: $gs-baseline;
+
+        @include mq($from: desktop) {
+            padding-top: $gs-baseline * 2;
+        }
+    }
+
+    .engagement-banner-ticker__goal,
+    .engagement-banner-ticker__count,
+    .js-ticker-label {
+        color: $brightness-97;
+    }
+
+    .engagement-banner-ticker__goal,
+    .engagement-banner-ticker__count {
+        font-family: $title;
+    }
+
+    .js-ticker-so-far .engagement-banner-ticker__count {
+        font-size: 28px;
+        line-height: 1;
+
+        @include mq($from: desktop) {
+            font-size: 42px;
+        }
+    }
+
+    .js-ticker-goal .engagement-banner-ticker__count {
+        font-size: 17px;
+        line-height: 1;
+    }
+
+    .engagement-banner-ticker__progress {
+        height: 20px;
+        background-color: $dark-red;
+    }
+
+    .js-ticker-filled-progress {
+        background-color: $highlight-main;
+    }
+
+    .js-ticker-label {
+        font-style: italic;
+        margin-bottom: $gs-baseline;
+    }
+}

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -13,7 +13,7 @@ $background-dark: #e6e2de;
 $red-accent: #ea4333;
 $blue-accent: #1a5292;
 
-[data-component*='ContributionsBannerUsEoy'] {
+.site-message--useoy2019 {
     border-top: 2px solid $brightness-7;
     color: $brightness-7;
     background-color: $background;
@@ -36,7 +36,7 @@ $blue-accent: #1a5292;
         }
 
         @include mq($from: desktop) {
-            position: static;
+            position: relative;
         }
     }
 }
@@ -74,8 +74,13 @@ $blue-accent: #1a5292;
         color: $blue-accent;
         display: block;
         line-height: 1.15;
-        font-size: 28px;
+        font-size: 23px;
         border-bottom: 0;
+        width: calc(100% - 36px);
+
+        @include mq($from: phablet) {
+            font-size: 28px;
+        }
 
         @include mq($from: desktop) {
             font-size: 48px;
@@ -86,7 +91,11 @@ $blue-accent: #1a5292;
 
     .engagement-banner__body {
         line-height: 1.35;
-        font-size: 17px;
+        font-size: 15px;
+
+        @include mq($from: phablet) {
+            font-size: 17px;
+        }
 
         @include mq($from: tablet) {
             padding: $gs-baseline $gs-gutter $gs-baseline 0;
@@ -107,7 +116,7 @@ $blue-accent: #1a5292;
     }
 
     .engagement-banner__ticker-header-container {
-        margin-top: $gs-baseline * 2;
+        margin-top: $gs-baseline;
         position: relative;
 
         &:after {
@@ -117,9 +126,16 @@ $blue-accent: #1a5292;
             background-color: $brightness-7;
             width: 1000%;
             left: -$gs-gutter;
-            top: -$gs-baseline;
+            top: -$gs-baseline / 2;
         }
 
+        @include mq($from: phablet) {
+            margin-top: $gs-baseline * 2;
+
+            &:after {
+                top: -$gs-baseline;
+            }
+        }
         @include mq($from: tablet) {
             &:after {
                 top: initial;
@@ -129,11 +145,15 @@ $blue-accent: #1a5292;
     }
 
     .engagement-banner__ticker-header {
-        font-size: 18px;
-        line-height: 22px;
         font-family: $f-serif-headline;
         font-weight: 300;
         margin-bottom: 0;
+        font-size: 15px;
+
+        @include mq($from: phablet) {
+            font-size: 18px;
+            line-height: 22px;
+        }
 
         @include mq($from: desktop) {
             font-size: 24px;
@@ -142,6 +162,8 @@ $blue-accent: #1a5292;
     }
 
     .engagement-banner__cta {
+        position: relative;
+        z-index: 1;
         padding-top: $gs-baseline / 2;
 
         @include mq($from: desktop) {
@@ -150,7 +172,11 @@ $blue-accent: #1a5292;
     }
 
     .engagement-banner__cta--editorial {
-        display: block;
+        display: none;
+
+        @include mq($from: phablet) {
+            display: block;
+        }
 
         @include mq($from: desktop) {
             display: inline-block;
@@ -159,7 +185,10 @@ $blue-accent: #1a5292;
     }
 
     .engagement-banner__ticker-container {
-        padding-top: $gs-baseline;
+
+        @include mq($from: phablet) {
+            padding-top: $gs-baseline;
+        }
 
         @include mq($from: desktop) {
             padding-top: $gs-baseline * 3;


### PR DESCRIPTION
## What does this change?
New engagement/contribs banner for the US end of year campaign

## Does this change need to be reproduced in dotcom-rendering ?
- [X] Not sure
- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Variant 1 - Desktop
![variant one - banner - desktop](https://user-images.githubusercontent.com/3300789/69421102-158a9000-0d18-11ea-9b80-5cebb6083c87.png)
Variant 1 - Tablet
![variant one - banner - tablet](https://user-images.githubusercontent.com/3300789/69421104-16232680-0d18-11ea-9de5-95461e0fbd3e.png)
Variant 1 - Mobile
![variant one - banner - mobile](https://user-images.githubusercontent.com/3300789/69421103-16232680-0d18-11ea-8fd4-8c2e13dab770.png)
Variant 2 - Desktop
![variant two - banner - desktop](https://user-images.githubusercontent.com/3300789/69421105-16232680-0d18-11ea-9f0f-49dfe116e0e7.png)
Variant 2 - Tablet
![variant two - banner - tablet](https://user-images.githubusercontent.com/3300789/69421107-16bbbd00-0d18-11ea-899e-9d83e5d655a8.png)
Variant 2 - Mobile
![variant two - banner - mobile](https://user-images.githubusercontent.com/3300789/69421106-16232680-0d18-11ea-9dce-d6623ee6e6e6.png)



## What is the value of this and can you measure success?
We will measure the contributions we get through the banner

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
