### PR TITLE
Ds subs banner design tweaks

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -1,6 +1,5 @@
 // @flow
 
-import marque44icon from 'svgs/icon/marque-44.svg';
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -1,6 +1,9 @@
 // @flow
 
 import marque44icon from 'svgs/icon/marque-44.svg';
+import closeCentralIcon from 'svgs/icon/close-central.svg';
+import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
+
 import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
 
 const subscriptionBannerTemplate = (
@@ -11,21 +14,12 @@ const subscriptionBannerTemplate = (
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
             A beautiful way to read it <br>
-            A powerful way <br class="temp-mobile-break" /> to fund it
+            A powerful way to fund it
         </h3>
 
-
-            <div class="site-message--subscription-banner__description">
-                <p>Two innovative apps and ad-free reading on theguardian.com. The complete digital experience from The Guardian</p>
-            </div>
-            <div class="site-message--packshot-container">
-                <img
-                    srcset="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
-                    src="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
-                    alt=""
-                >
-            </div>
-
+        <div class="site-message--subscription-banner__description">
+            <p>Two innovative apps and ad-free reading on theguardian.com. The complete digital experience from The Guardian</p>
+        </div>
 
         <div class="site-message--subscription-banner__cta-container">
             <a
@@ -53,12 +47,28 @@ const subscriptionBannerTemplate = (
                 class="site-message--subscription-banner__subscriber-link"
                 href="${signInUrl}"
             >
-                Sign in to not see this again
+                <span class="site-message--subscription-banner__sign-in-link">Sign in</span> to not see this again
             </a>
         </div>
 
+        <div class="site-message--packshot-container">
+            <img
+                srcset="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
+                src="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
+                alt="the guardian mobile app, the guardian daily"
+            >
+        </div>
+
+        <div id="js-site-message--subscription-banner__close-button"
+            class="site-message--subscription-banner__close-button"
+            aria-label="Close"
+            tabindex="0"
+        >
+            ${closeCentralIcon.markup}
+        </div>
+
         <div class="site-message--subscription-banner__gu-logo">
-            ${marque44icon.markup}
+            ${theGuardianLogo.markup}
         </div>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -82,7 +82,7 @@ const onAgree = (): void => {
 const bindCloseHandler = (button, banner, callback) => {
     const removeBanner = () => {
         callback();
-        if(banner) {
+        if (banner) {
             banner.remove();
         }
     };
@@ -125,16 +125,11 @@ const trackSubscriptionBannerCtaClick = () => {
         },
     });
 };
-const closeActions = (banner, callback) => (buttons) => {
-    buttons.forEach((button) => {
-
-        bindCloseHandler(
-            button,
-            banner,
-            callback
-        );
-    })
-}
+const closeActions = (banner, callback) => buttons => {
+    buttons.forEach(button => {
+        bindCloseHandler(button, banner, callback);
+    });
+};
 
 const bindSubscriptionClickHandlers = () => {
     const subscriptionBannerNotNowButton = document.querySelector(
@@ -159,12 +154,10 @@ const bindSubscriptionClickHandlers = () => {
     );
 
     if (subscriptionBannerHtml) {
-        bindSubscriptionCloseButtons(
-            [
-                subscriptionBannercloseButton,
-                subscriptionBannerNotNowButton
-            ]
-        );
+        bindSubscriptionCloseButtons([
+            subscriptionBannercloseButton,
+            subscriptionBannerNotNowButton,
+        ]);
         bindClickHandler(
             subscriptionBannerCta,
             trackSubscriptionBannerCtaClick

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -82,7 +82,9 @@ const onAgree = (): void => {
 const bindCloseHandler = (button, banner, callback) => {
     const removeBanner = () => {
         callback();
-        banner.remove();
+        if(banner) {
+            banner.remove();
+        }
     };
 
     if (button) {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -123,11 +123,22 @@ const trackSubscriptionBannerCtaClick = () => {
         },
     });
 };
+const closeActions = (banner, callback) => (buttons) => {
+    buttons.forEach((button) => {
+
+        bindCloseHandler(
+            button,
+            banner,
+            callback
+        );
+    })
+}
 
 const bindSubscriptionClickHandlers = () => {
-    const subscriptionBannercloseButton = document.querySelector(
+    const subscriptionBannerNotNowButton = document.querySelector(
         '#js-site-message--subscription-banner__cta-dismiss'
     );
+
     const subscriptionBannerHtml = document.querySelector(
         '#js-subscription-banner-site-message'
     );
@@ -136,11 +147,21 @@ const bindSubscriptionClickHandlers = () => {
         '#js-site-message--subscription-banner__cta'
     );
 
+    const subscriptionBannercloseButton = document.querySelector(
+        '#js-site-message--subscription-banner__close-button'
+    );
+
+    const bindSubscriptionCloseButtons = closeActions(
+        subscriptionBannerHtml,
+        subcriptionBannerCloseActions
+    );
+
     if (subscriptionBannerHtml) {
-        bindCloseHandler(
-            subscriptionBannercloseButton,
-            subscriptionBannerHtml,
-            subcriptionBannerCloseActions
+        bindSubscriptionCloseButtons(
+            [
+                subscriptionBannercloseButton,
+                subscriptionBannerNotNowButton
+            ]
         );
         bindClickHandler(
             subscriptionBannerCta,

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -299,16 +299,16 @@
         border-radius: 50%;
         padding: 2px;
         border: 1px solid $brightness-7;
-        transition: background-color 0.5s ease;
+        transition: background-color .5s ease;
     }
 
     svg:hover {
         cursor: pointer;
-        background-color: rgba(237, 237, 237, 0.5); // $brightness-93
+        background-color: rgba(237, 237, 237, .5); // $brightness-93
     }
 
     svg path {
-        fill: black;
+        fill: $brightness-7;
     }
 }
 

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -23,6 +23,7 @@
     flex-wrap: wrap;
     position: relative;
     margin: 0 auto;
+    width: 100%;
     max-width: 980px;
 
     @include mq($from: leftCol) {
@@ -35,11 +36,16 @@
 }
 
 .site-message--subscription-banner__title {
-    font-size: 24px;
-    line-height: 24px;
+    font-size: 22px;
+    line-height: 22px;
     font-family: $f-serif-headline;
     font-weight: bold;
     width: 100%;
+
+    @media (min-width: 350px) {
+        font-size: 24px;
+        line-height: 24px;
+    }
 
     @media (min-width: 600px) {
         font-size: 28px;
@@ -61,19 +67,22 @@
     }
 }
 
-// text copy
 .site-message--subscription-banner__description {
     display: flex;
     align-items: flex-end;
     align-content: stretch;
-    width: 50%;
+    width: 100%;
 
     @include mq($from: tablet) {
         width: 60%;
     }
 
     @include mq($from: desktop) {
-        width: 45%;
+        width: 43%; // this an uneven number to remove an orphan word at the end of the copy
+    }
+
+    @include mq($from: wide) {
+        width: 47%;
     }
 
     p {
@@ -87,6 +96,7 @@
             line-height: 20px;
         }
 
+        // custom breakpoint
         @media (min-width: 550px) {
             font-size: 20px;
             line-height: 22px;
@@ -126,11 +136,10 @@
     }
 
     @include mq($from: desktop) {
-        width: 45%;
+        width: 100%;
     }
 }
 
-// button
 .site-message--subscription-banner__cta {
     display: inline-block;
     font-size: 16px;
@@ -163,11 +172,16 @@
 }
 
 .site-message--subscription-banner__cta-dismiss {
+    display: none;
     color: $brightness-7;
     font-family: $f-sans-serif-text;
     font-size: 16px;
     width: 100%;
     cursor: pointer;
+
+    @include mq($from: tablet) {
+        display: block;
+    }
 }
 
 .site-message--subscription-banner__sign-in {
@@ -177,6 +191,12 @@
     font-family: $f-sans-serif-text;
     color: $brightness-7;
     margin-top: 10px;
+    text-align: center;
+
+    @include mq($from: tablet) {
+        width: 60%;
+        text-align: left;
+    }
 
     p {
         display: inline-block;
@@ -190,55 +210,67 @@
 
 .site-message--subscription-banner__subscriber-link {
     text-decoration: underline;
-}
-
-// image
-.site-message--packshot-container {
-    position: relative;
-    width: 50%;
-    padding-top: 130px;
+    font-weight: bold;
 
     @include mq($from: tablet) {
-        position: static;
-        padding-top: 0;
-        width: 33%;
+        text-decoration: none;
+        font-weight: normal;
+    }
+}
+
+.site-message--subscription-banner__subscriber-link:hover,
+.site-message--subscription-banner__subscriber-link:focus {
+    text-decoration: none;
+}
+
+.site-message--subscription-banner__sign-in-link {
+    text-decoration: underline;
+    font-weight: bold;
+}
+
+.site-message--packshot-container {
+    width: 100%;
+    margin: 30px 0 -90px;
+
+    @include mq($from: tablet) {
+        position: absolute;
+        width: 45%;
+        right: 0;
+        margin: 0;
+        bottom: -35px;
     }
 
-    @media (min-width: 792px) {
-        padding-top: 13%;
-    }
 
     @include mq($from: desktop) {
-        position: relative;
-        padding-top: 0;
         width: 55%;
     }
 
+    @include mq($from: wide) {
+        bottom: -61px;
+    }
 
     img {
-        position: absolute;
-        bottom: 0;
-        width: 300px;
-        left: 10%;
+        width: 100%;
+        max-width: 380px;
+        margin: 0 auto;
+        display: block;
 
         @include mq($from: tablet) {
-            width: 65%;
-            right: -33%;
-            bottom: -10%;
-            left: auto;
+            margin-right: 0;
         }
 
         @include mq($from: desktop) {
-            width: 480px;
-            right: auto;
-            left: 40px;
-            bottom: -147px;
+            max-width: 420px;
+            margin-right: 90px;
         }
 
         // custom breakpoint
+        @include mq($from: leftCol) {
+            max-width: 500px;
+        }
+
         @media (min-width: 1260px) {
-            width: 460px;
-            bottom: -155px;
+            margin-right: 120px;
         }
     }
 }
@@ -251,19 +283,49 @@
 .temp-mobile-break {
     display: block;
 
-    @include mq($from: mobileLandscape) {
+    @media (min-width: 380px) {
         display: none;
+    }
+}
+
+.site-message--subscription-banner__close-button {
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 1;
+
+    svg {
+        border-radius: 50%;
+        padding: 2px;
+        border: 1px solid $brightness-7;
+        transition: background-color 0.5s ease;
+    }
+
+    svg:hover {
+        cursor: pointer;
+        background-color: rgba(237, 237, 237, 0.5); // $brightness-93
+    }
+
+    svg path {
+        fill: black;
     }
 }
 
 .site-message--subscription-banner__gu-logo {
     display: none;
 
-    @include mq($from: leftCol) {
+    @include mq($from: desktop) {
         display: block;
         position: absolute;
         right: 0;
-        top: 0;
+        bottom: 0;
+        width: 80px;
+    }
+
+    // custom breakpoint
+    @media (min-width: 1260px) {
+        width: 109px;
     }
 }
 


### PR DESCRIPTION
## What does this change?
This PR updates the subscription banner, it adds a new close button and some style updates 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screen Shot 2019-11-20 at 17 21 08](https://user-images.githubusercontent.com/45875444/69262105-c0853780-0bba-11ea-9f4a-91d51cc4c90c.png)

![Screen Shot 2019-11-20 at 17 28 29](https://user-images.githubusercontent.com/45875444/69262341-39848f00-0bbb-11ea-866b-e8b925ed1dd8.png)

## What is the value of this and can you measure success?
N/A
## Checklist
- new close button

### Does this affect other platforms?
- [x] No
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
