### PR TITLE
Fix privacy settings link not showing when a CMP UI test is on

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -14,6 +14,11 @@ const CONTAINER_CLASS = 'cmp-container';
 let overlay: ?HTMLElement;
 let uiPrepared: boolean = false;
 
+const isInCmpTest = () =>
+    isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
+    isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
+    isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant');
+
 const animateCmp = (): Promise<void> =>
     new Promise(resolve => {
         /**
@@ -161,11 +166,7 @@ const handlePrivacySettingsClick = (evt: Event): void => {
 };
 
 export const addPrivacySettingsLink = (): void => {
-    if (
-        !isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
-        !isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
-        !isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant')
-    ) {
+    if (!isInCmpTest()) {
         return;
     }
 
@@ -190,7 +191,7 @@ export const addPrivacySettingsLink = (): void => {
             newPrivacyLinkListItem.appendChild(newPrivacyLink);
 
             privacyLinkListItem.insertAdjacentElement(
-                'afterend',
+                'beforebegin',
                 newPrivacyLinkListItem
             );
 
@@ -205,11 +206,7 @@ export const addPrivacySettingsLink = (): void => {
 export const consentManagementPlatformUi = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
-        if (
-            isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
-            isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
-            isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant')
-        ) {
+        if (isInCmpTest()) {
             return Promise.resolve(cmpUi.canShow());
         }
 


### PR DESCRIPTION
## What does this change?
The privacy settings link at the bottom of the page that resurfaces the new CMP UI was not showing up for users in a CMP UI test, which is it's expected behaviour, do to a faulty if statement. This PR fixes that bug and refactors that logic so it's easier to refactor or add/remove tests to it in the future.

It also moves the privacy settings link to be above the two policy links (privacy and cookie) instead of in the middle of them.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screenshot 2019-11-20 at 18 21 20](https://user-images.githubusercontent.com/48949546/69266186-99caff00-0bc2-11ea-9a61-2d6efd8f7a48.png)

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)