### PR TITLE
Add series to our permutive schema implementation

### DIFF
--- a/common/app/templates/inlineJS/blocking/permutive.scala.js
+++ b/common/app/templates/inlineJS/blocking/permutive.scala.js
@@ -63,6 +63,7 @@
             author,
             keywords,
             webPublicationDate,
+            series,
         } = window.guardian.config.page;
 
         const safeAuthors =
@@ -84,6 +85,7 @@
             authors: safeAuthors,
             keywords: safeKeywords,
             publishedAt: safePublishedAt,
+            series: series,
         };
 
         const isEmpty = value =>


### PR DESCRIPTION
## What does this change?
Appends the data sent to permutive with the series field if it exists, as requested by our Australian team.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (implementing permutive for DCR is in our backlog)

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
