### PR TITLE
Iab Bottom Consent Banner AB Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -158,11 +158,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-commercial-iab-consent-banner",
-    "1% participation AB test for an IAB compliant consent banner",
+    "ab-commercial-iab-bottom-consent-banner",
+    "1% AB test for an IAB compliant consent banner",
     owners = Seq(Owner.withGithub("ghaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 11, 27),
+    sellByDate = new LocalDate(2019, 12, 12),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -159,7 +159,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-commercial-iab-bottom-consent-banner",
-    "1% AB test for an IAB compliant consent banner",
+    "0.5% AB test for an IAB compliant consent banner",
     owners = Seq(Owner.withGithub("ghaberis")),
     safeState = Off,
     sellByDate = new LocalDate(2019, 12, 12),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -155,4 +155,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 12, 17),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-iab-consent-banner",
+    "1% participation AB test for an IAB compliant consent banner",
+    owners = Seq(Owner.withGithub("ghaberis")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 11, 27),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,5 +1,6 @@
 // @flow
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
+import { commercialIabConsentBanner } from 'common/modules/experiments/tests/commercial-iab-consent-banner';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
@@ -25,6 +26,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     permutiveTest,
     commercialCmpUiNonDismissable,
     signInGateFirstTest,
+    commercialIabConsentBanner,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,6 +1,6 @@
 // @flow
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
-import { commercialIabConsentBanner } from 'common/modules/experiments/tests/commercial-iab-consent-banner';
+import { commercialIabBottomConsentBanner } from 'common/modules/experiments/tests/commercial-iab-bottom-consent-banner';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
@@ -26,7 +26,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     permutiveTest,
     commercialCmpUiNonDismissable,
     signInGateFirstTest,
-    commercialIabConsentBanner,
+    commercialIabBottomConsentBanner,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
@@ -1,9 +1,9 @@
 // @flow
 
-export const commercialIabConsentBanner: ABTest = {
-    id: 'CommercialIabConsentBanner',
-    start: '2019-11-17',
-    expiry: '2019-11-27',
+export const commercialIabBottomConsentBanner: ABTest = {
+    id: 'CommercialIabBottomConsentBanner',
+    start: '2019-11-21',
+    expiry: '2019-12-12',
     author: 'George Haberis',
     description: '1% participation AB test for an IAB compliant consent banner',
     audience: 0.01,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
@@ -6,7 +6,7 @@ export const commercialIabBottomConsentBanner: ABTest = {
     expiry: '2019-12-12',
     author: 'George Haberis',
     description: '1% participation AB test for an IAB compliant consent banner',
-    audience: 0.01,
+    audience: 0.005,
     audienceOffset: 0.7,
     successMeasure:
         'IAB compliant consent banner does not adversely affect consent rates',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
@@ -17,6 +17,10 @@ export const commercialIabBottomConsentBanner: ABTest = {
     canRun: () => true,
     variants: [
         {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
             id: 'variant',
             test: (): void => {},
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-bottom-consent-banner.js
@@ -5,7 +5,7 @@ export const commercialIabBottomConsentBanner: ABTest = {
     start: '2019-11-21',
     expiry: '2019-12-12',
     author: 'George Haberis',
-    description: '1% participation AB test for an IAB compliant consent banner',
+    description: '0.5% AB test for an IAB compliant bottom consent banner',
     audience: 0.005,
     audienceOffset: 0.7,
     successMeasure:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-iab-consent-banner.js
@@ -1,0 +1,24 @@
+// @flow
+
+export const commercialIabConsentBanner: ABTest = {
+    id: 'CommercialIabConsentBanner',
+    start: '2019-11-17',
+    expiry: '2019-11-27',
+    author: 'George Haberis',
+    description: '1% participation AB test for an IAB compliant consent banner',
+    audience: 0.01,
+    audienceOffset: 0.7,
+    successMeasure:
+        'IAB compliant consent banner does not adversely affect consent rates',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'consent rates do not go down at all',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -15,7 +15,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
-import { commercialIabConsentBanner } from 'common/modules/experiments/tests/commercial-iab-consent-banner';
+import { commercialIabBottomConsentBanner } from 'common/modules/experiments/tests/commercial-iab-bottom-consent-banner';
 
 type Template = {
     heading: string,
@@ -103,7 +103,7 @@ const makeHtml = (): string => `
         .join('')}
     </div>
     ${
-        isInVariantSynchronous(commercialIabConsentBanner, 'variant')
+        isInVariantSynchronous(commercialIabBottomConsentBanner, 'variant')
             ? `
                 <div class="site-message--first-pv-consent--commercialIabConsentBanner site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">
                     <div class="cmp-list-container" id="${INFO_LIST_ID}">
@@ -197,7 +197,7 @@ const bindClickHandlers = (msg: Message): void => {
         agreeButtonEl.addEventListener('click', () => onAgree(msg));
     });
 
-    if (isInVariantSynchronous(commercialIabConsentBanner, 'variant')) {
+    if (isInVariantSynchronous(commercialIabBottomConsentBanner, 'variant')) {
         const infoListButton = document.getElementById(INFO_LIST_BUTTON_ID);
 
         if (infoListButton) {
@@ -223,7 +223,7 @@ const show = (): Promise<boolean> => {
 
     const opts = {};
 
-    if (isInVariantSynchronous(commercialIabConsentBanner, 'variant')) {
+    if (isInVariantSynchronous(commercialIabBottomConsentBanner, 'variant')) {
         opts.cssModifierClass = 'first-pv-consent--commercialIabConsentBanner';
     }
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -63,6 +63,7 @@ const bindableClassNames: BindableClassNames = {
 
 const INFO_LIST_BUTTON_ID = 'cmp-info-list-button';
 const PURPOSE_LIST_BUTTON_ID = 'cmp-purpose-list-button';
+const OPTIONS_BUTTON_ID = 'cmp-options-button';
 const INFO_LIST_ID = 'cmp-info-list';
 const PURPOSE_LIST_ID = 'cmp-purpose-button';
 
@@ -129,11 +130,21 @@ const makeHtml = (): string => `
                 bindableClassNames.agree
             }"
         >${checkIcon.markup}<span>${template.agreeButton}</span></button>
-        <a
-            href="${template.linkToPreferences}"
-            data-link-name="first-pv-consent : to-prefs"
-            class="site-message--first-pv-consent__link u-underline"
-        >${template.choicesButton}</a>
+        ${
+            isInVariantSynchronous(commercialIabBottomConsentBanner, 'variant')
+                ? `
+                    <button class="cmp-options-button" id="${OPTIONS_BUTTON_ID}">
+                        Options
+                    </button>
+                  `
+                : `
+                    <a
+                        href="${template.linkToPreferences}"
+                        data-link-name="first-pv-consent : to-prefs"
+                        class="site-message--first-pv-consent__link u-underline"
+                    >${template.choicesButton}</a>`
+        }
+
     </div>
 `;
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -105,17 +105,19 @@ const makeHtml = (): string => `
     ${
         isInVariantSynchronous(commercialIabConsentBanner, 'variant')
             ? `
-                <div class="site-message--first-pv-consent__block cmp-list-container" id="${INFO_LIST_ID}">
-                    <button class="cmp-button" id="${INFO_LIST_BUTTON_ID}" >
-                        Information that may be used
-                    </button>
-                    ${buildInfoList()}
-                </div>
-                <div class="site-message--first-pv-consent__block cmp-list-container" id="${PURPOSE_LIST_ID}">
-                    <button class="cmp-button" id="${PURPOSE_LIST_BUTTON_ID}">
-                        Purposes for storing information
-                    </button>
-                    ${buildPurposeList()}
+                <div class="site-message--first-pv-consent--commercialIabConsentBanner site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">
+                    <div class="cmp-list-container" id="${INFO_LIST_ID}">
+                        <button class="cmp-button" id="${INFO_LIST_BUTTON_ID}" >
+                            Information that may be used
+                        </button>
+                        ${buildInfoList()}
+                    </div>
+                    <div class="cmp-list-container" id="${PURPOSE_LIST_ID}">
+                        <button class="cmp-button" id="${PURPOSE_LIST_BUTTON_ID}">
+                            Purposes for storing information
+                        </button>
+                        ${buildPurposeList()}
+                    </div>
                 </div>
             `
             : ''

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -17,10 +17,14 @@ import {
     makeHtml as makeFirstPvConsentHtml,
 } from 'common/modules/ui/first-pv-consent-banner';
 import marque36icon from 'svgs/icon/marque-36.svg';
-import { getEngagementBannerTestToRun } from 'common/modules/experiments/ab';
+import {
+    isInVariantSynchronous,
+    getEngagementBannerTestToRun,
+} from 'common/modules/experiments/ab';
 import fastdom from 'lib/fastdom-promise';
 import reportError from 'lib/report-error';
 import { initTicker } from 'common/modules/commercial/ticker';
+import { commercialIabBottomConsentBanner } from 'common/modules/experiments/tests/commercial-iab-bottom-consent-banner';
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 
@@ -182,6 +186,10 @@ const firstPvConsentPlusEngagementBanner: Banner = {
     canShow: (): Promise<boolean> =>
         Promise.all([canShowFirstPvConsent(), canShowEngagementBanner()]).then(
             (canShowBanners: Array<boolean>) =>
+                !isInVariantSynchronous(
+                    commercialIabBottomConsentBanner,
+                    'variant'
+                ) &&
                 canShowBanners.every(canShowBanner => canShowBanner === true)
         ),
     show,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -29,6 +29,8 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 // types
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialIabBottomConsentBanner } from 'common/modules/experiments/tests/commercial-iab-bottom-consent-banner';
 
 const ENTER_KEY_CODE = 'Enter';
 const DISPLAY_EVENT_KEY = 'subscription-banner : display';
@@ -200,7 +202,8 @@ const show: () => Promise<boolean> = async () => {
 
 const canShow: () => Promise<boolean> = () => {
     const can = Promise.resolve(
-        fiveOrMorePageViews(pageviews) &&
+        !isInVariantSynchronous(commercialIabBottomConsentBanner, 'variant') &&
+            fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -194,3 +194,63 @@ $btn-height: ($gs-baseline*3.5);
         }
     }
 }
+
+// commercialIabConsentBanner a/b test styles
+.site-message--first-pv-consent--commercialIabConsentBanner {
+
+    .cmp-list-container {
+        .cmp-button {
+            border: 0;
+            color: currentColor;
+            background-color: transparent;
+            margin: 0;
+            padding: 0;
+            position: relative;
+            padding-left: 24px;
+            margin-bottom: 4px;
+            margin-left: -4px;
+
+            &::before {
+                content: '';
+                position: absolute;
+                top: 5px;
+                left: 6px;
+                border: 2px solid $highlight-main;
+                border-top: 0;
+                border-left: 0;
+                display: inline-block;
+                transform: rotate(45deg);
+                height: 6px;
+                width: 6px;
+            }
+        }
+
+        .cmp-list {
+            margin: 0;
+            max-height: 0;
+            transition: max-height 0.15s ease-out;
+            overflow-y: hidden;
+            padding-left: 24px;
+            list-style-position: outside;
+
+            li {
+                padding-top: 2px;
+            }
+        }
+    }
+
+    .cmp-list-container--visible {
+        .cmp-button {
+            &::before {
+                top: 7px;
+                transform: rotate(-135deg);
+            }
+        }
+
+        .cmp-list {
+            display: block;
+            max-height: 500px;
+            transition: max-height 0.25s ease-in;
+        }
+    }
+}

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -197,7 +197,6 @@ $btn-height: ($gs-baseline*3.5);
 
 // commercialIabConsentBanner a/b test styles
 .site-message--first-pv-consent--commercialIabConsentBanner {
-
     .cmp-list-container {
         .cmp-button {
             border: 0;
@@ -228,7 +227,7 @@ $btn-height: ($gs-baseline*3.5);
         .cmp-list {
             margin: 0;
             max-height: 0;
-            transition: max-height 0.15s ease-out;
+            transition: max-height .15s ease-out;
             overflow-y: hidden;
             padding-left: 24px;
             list-style-position: outside;
@@ -250,7 +249,7 @@ $btn-height: ($gs-baseline*3.5);
         .cmp-list {
             display: block;
             max-height: 500px;
-            transition: max-height 0.25s ease-in;
+            transition: max-height .25s ease-in;
         }
     }
 }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -197,7 +197,7 @@ $btn-height: ($gs-baseline*3.5);
 
 // commercialIabConsentBanner a/b test styles
 .site-message--first-pv-consent--commercialIabConsentBanner {
-    font-family: "Guardian Text Egyptian Web",Georgia,serif;
+    font-family: 'Guardian Text Egyptian Web', Georgia, serif;
     .cmp-list-container {
         .cmp-button {
             border: 0;

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -197,16 +197,15 @@ $btn-height: ($gs-baseline*3.5);
 
 // commercialIabConsentBanner a/b test styles
 .site-message--first-pv-consent--commercialIabConsentBanner {
+    font-family: "Guardian Text Egyptian Web",Georgia,serif;
     .cmp-list-container {
         .cmp-button {
             border: 0;
             color: currentColor;
             background-color: transparent;
-            margin: 0;
             padding: 0;
             position: relative;
             padding-left: 24px;
-            margin-bottom: 4px;
             margin-left: -4px;
 
             &::before {
@@ -229,11 +228,17 @@ $btn-height: ($gs-baseline*3.5);
             max-height: 0;
             transition: max-height .15s ease-out;
             overflow-y: hidden;
-            padding-left: 24px;
+            padding-left: 36px;
             list-style-position: outside;
 
+            &::after {
+                content: '';
+                height: 8px;
+                display: block;
+            }
+
             li {
-                padding-top: 2px;
+                padding-top: 4px;
             }
         }
     }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -195,7 +195,7 @@ $btn-height: ($gs-baseline*3.5);
     }
 }
 
-// commercialIabConsentBanner a/b test styles
+// commercialIabBottomConsentBanner a/b test styles
 .site-message--first-pv-consent--commercialIabConsentBanner {
     font-family: 'Guardian Text Egyptian Web', Georgia, serif;
     .cmp-list-container {

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -208,6 +208,10 @@ $btn-height: ($gs-baseline*3.5);
             padding-left: 24px;
             margin-left: -4px;
 
+            &:focus {
+                outline: none;
+            }
+
             &::before {
                 content: '';
                 position: absolute;
@@ -268,4 +272,7 @@ $btn-height: ($gs-baseline*3.5);
     background: #767676;
     color: #FFFFFF;
 
+    :focus {
+        outline: none;
+    }
 }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -258,3 +258,14 @@ $btn-height: ($gs-baseline*3.5);
         }
     }
 }
+
+.cmp-options-button {
+    height: 42px;
+    border: 0;
+    border-radius: 1000px;
+    padding: 0 20px;
+    margin-left: 8px;
+    background: #767676;
+    color: #FFFFFF;
+
+}

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -270,7 +270,7 @@ $btn-height: ($gs-baseline*3.5);
     padding: 0 20px;
     margin-left: 8px;
     background: #767676;
-    color: #FFFFFF;
+    color: #ffffff;
 
     :focus {
         outline: none;


### PR DESCRIPTION
## What does this change?
This PR adds an AB test called `ab-CommercialIabBottomConsentBanner` so we can confirm the hypothesis that a more discrete CMP (similar to our current one) would yield better consent rates when compared to the new CMP UI we've been testing (which our current consent banner does). (https://github.com/guardian/frontend/pull/21910 and https://github.com/guardian/frontend/pull/21993)

`control`: regular bottom consent banner 
`variant`: bottom consent banner with IAB elements

Note: Users in the variant will not be served double banners, such as the consent + engagement or the consent + subscriptions double banners.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
`control` on desktop:
![Screenshot 2019-11-21 at 15 55 47](https://user-images.githubusercontent.com/48949546/69361484-7c5e6980-0c84-11ea-9110-a24719586083.png)

`variant` on desktop:
![Screenshot 2019-11-21 at 15 54 49](https://user-images.githubusercontent.com/48949546/69361394-4d47f800-0c84-11ea-815f-b122739c46df.png)

`variant` on desktop (expanded): 
![Screenshot 2019-11-21 at 15 56 18](https://user-images.githubusercontent.com/48949546/69361407-52a54280-0c84-11ea-9c14-5f1324cf5612.png)

`control` on mobile:
![Screenshot 2019-11-21 at 15 57 23](https://user-images.githubusercontent.com/48949546/69361548-a0ba4600-0c84-11ea-8ddc-34e4e222d96b.png)

`variant` on mobile:
![Screenshot 2019-11-21 at 16 00 22](https://user-images.githubusercontent.com/48949546/69361460-710b3e00-0c84-11ea-9273-bb875ea8285b.png)


## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)