### PR TITLE
CMP UI with no opaque overlay

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -145,7 +145,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 7, 30),
     exposeClientSide = true
   )
-  
+
   Switch(
     ABTests,
     "ab-sign-in-gate-first-test",
@@ -153,6 +153,16 @@ trait ABTestSwitches {
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = On,
     sellByDate = new LocalDate(2019, 12, 17),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-commercial-cmp-ui-no-overlay",
+    "Tests whether a CMP UI with no overlay yield higher consent rates",
+    owners = Seq(Owner.withGithub("ripecosta")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 12, 12),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -14,6 +14,7 @@ import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-
 import { permutiveTest } from 'common/modules/experiments/tests/commercial-permutive';
 import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
+import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -25,6 +26,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     permutiveTest,
     commercialCmpUiNonDismissable,
     signInGateFirstTest,
+    commercialCmpUiNoOverlay,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
@@ -1,0 +1,28 @@
+// @flow
+
+export const commercialCmpUiNoOverlay: ABTest = {
+    id: 'CommercialCmpUiNoOverlay',
+    start: '2019-11-21',
+    expiry: '2019-12-12',
+    author: 'Ricardo Costa',
+    description:
+        '0.5% AB test for an IAB compliant consent banner with no overlay',
+    audience: 0.005,
+    audienceOffset: 0.8,
+    successMeasure: 'Consent rates improve',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'Consent rates improve massively',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -2,13 +2,19 @@
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
+import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { cmpConfig, cmpUi } from '@guardian/consent-management-platform';
 import fastdom from 'lib/fastdom-promise';
 import reportError from 'lib/report-error';
 
 const CMP_READY_CLASS = 'cmp-iframe-ready';
 const CMP_ANIMATE_CLASS = 'cmp-animate';
-const OVERLAY_CLASS = 'cmp-overlay';
+const OVERLAY_CLASS = isInVariantSynchronous(
+    commercialCmpUiNoOverlay,
+    'variant'
+)
+    ? 'cmp-no-overlay'
+    : 'cmp-overlay';
 const IFRAME_CLASS = 'cmp-iframe';
 const CONTAINER_CLASS = 'cmp-container';
 let overlay: ?HTMLElement;
@@ -17,7 +23,9 @@ let uiPrepared: boolean = false;
 const isInCmpTest = () =>
     isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
     isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
-    isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant');
+    isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant') ||
+    isInVariantSynchronous(commercialCmpUiNoOverlay, 'control') ||
+    isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant');
 
 const animateCmp = (): Promise<void> =>
     new Promise(resolve => {
@@ -95,6 +103,14 @@ const getUrl = (): string => {
         isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant')
     ) {
         return `${cmpConfig.CMP_URL}?abTestVariant=CmpUiNonDismissable-variant`;
+    } else if (isInVariantSynchronous(commercialCmpUiNoOverlay, 'control')) {
+        return `${
+            cmpConfig.CMP_URL
+        }?abTestVariant=commercialCmpUiNoOverlay-control`;
+    } else if (isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant')) {
+        return `${
+            cmpConfig.CMP_URL
+        }?abTestVariant=commercialCmpUiNoOverlay-variant`;
     }
 
     return cmpConfig.CMP_URL;
@@ -120,7 +136,7 @@ const prepareUi = (): void => {
     container.addEventListener('transitionend', () => {
         fastdom.write(() => {
             if (overlay && overlay.parentNode) {
-                overlay.style.width = '100%';
+                overlay.style.maxWidth = '100%';
             }
         });
     });

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -106,11 +106,11 @@ const getUrl = (): string => {
     } else if (isInVariantSynchronous(commercialCmpUiNoOverlay, 'control')) {
         return `${
             cmpConfig.CMP_URL
-        }?abTestVariant=commercialCmpUiNoOverlay-control`;
+        }?abTestVariant=CommercialCmpUiNoOverlay-control`;
     } else if (isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant')) {
         return `${
             cmpConfig.CMP_URL
-        }?abTestVariant=commercialCmpUiNoOverlay-variant`;
+        }?abTestVariant=CommercialCmpUiNoOverlay-variant`;
     }
 
     return cmpConfig.CMP_URL;
@@ -136,7 +136,13 @@ const prepareUi = (): void => {
     container.addEventListener('transitionend', () => {
         fastdom.write(() => {
             if (overlay && overlay.parentNode) {
-                overlay.style.maxWidth = '100%';
+                if (
+                    isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant')
+                ) {
+                    overlay.style.maxWidth = '100%';
+                } else {
+                    overlay.style.width = '100%';
+                }
             }
         });
     });

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -67,6 +67,9 @@
     z-index: 9999;
     display: none;
 
+    @include mq($until: mobileLandscape) {
+        left: 0;
+    }
     @include mq(mobileLandscape) {
         transition: background-color;
         transition-delay: .6s;

--- a/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
+++ b/static/src/stylesheets/module/site-messages/_cmp-iframe.scss
@@ -55,3 +55,31 @@
     width: 100%;
     border: 0;
 }
+
+// commercialCmpUiNoOverlay A/B test styles
+.cmp-no-overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0;
+    margin: 0;
+    z-index: 9999;
+    display: none;
+
+    @include mq(mobileLandscape) {
+        transition: background-color;
+        transition-delay: .6s;
+        will-change: background-color;
+    }
+
+    &.cmp-iframe-ready {
+        display: block;
+    }
+
+    &.cmp-animate {
+        @include mq(mobileLandscape) {
+            background-color: rgba(#000000, .7);
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
Currently our CMP UI test has an opaque overlay that prevents the users on desktop and tablet from interacting with the website (scrolling is still possible) until they have interacted with the CMP UI. We hypothesise that the added friction is having a negative impact on consent rates so this PR creates a `CommercialCmpUiNoOverlay` A/B test to determine if this is true or not.

`control`: new CMP UI side banner (including the opaque overlay)
`variant`: new CMP UI without opaque overlay

Note: Despite not having an effect on mobile devices this test does not exclude them so we may have comparable results with others tests.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
`control`:
![Screenshot 2019-11-22 at 14 57 43](https://user-images.githubusercontent.com/48949546/69436137-b5f0ac80-0d38-11ea-8ac0-6ffa1b666765.png)

`variant`
![Screenshot 2019-11-22 at 14 57 56](https://user-images.githubusercontent.com/48949546/69436182-c99c1300-0d38-11ea-9f3b-59cd71c2d95c.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)