### PR TITLE
Consent banner Options link as button AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -165,4 +165,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2019, 12, 12),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-consent-options-button",
+    "0.5% AB test for a bottom consent banner with an options button instead of a link",
+    owners = Seq(Owner.withGithub("ripecosta")),
+    safeState = Off,
+    sellByDate = new LocalDate(2019, 12, 12),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,6 +15,7 @@ import { permutiveTest } from 'common/modules/experiments/tests/commercial-permu
 import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
+import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -27,6 +28,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialCmpUiNonDismissable,
     signInGateFirstTest,
     commercialCmpUiNoOverlay,
+    commercialConsentOptionsButton,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
@@ -1,0 +1,28 @@
+// @flow
+
+export const commercialConsentOptionsButton: ABTest = {
+    id: 'CommercialConsentOptionsButton',
+    start: '2019-11-21',
+    expiry: '2019-12-12',
+    author: 'George Haberis',
+    description:
+        '0.5% AB test for a bottom consent banner with an options button instead of a link',
+    audience: 0.005,
+    audienceOffset: 0.85,
+    successMeasure: 'Change does not adversely affect consent rates',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'Consent rates stay the same.',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -15,6 +15,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
 import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
+import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 
 type Template = {
     heading: string,
@@ -60,6 +61,8 @@ const bindableClassNames: BindableClassNames = {
     agree: 'js-first-pv-consent-agree',
 };
 
+const OPTIONS_BUTTON_ID = 'cmp-options-button';
+
 const makeHtml = (): string => `
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--head ">${
         template.heading
@@ -75,11 +78,20 @@ const makeHtml = (): string => `
                 bindableClassNames.agree
             }"
         >${checkIcon.markup}<span>${template.agreeButton}</span></button>
-        <a
-            href="${template.linkToPreferences}"
-            data-link-name="first-pv-consent : to-prefs"
-            class="site-message--first-pv-consent__link u-underline"
-        >${template.choicesButton}</a>
+        ${
+            isInVariantSynchronous(commercialConsentOptionsButton, 'variant')
+                ? `
+                    <button class="cmp-options-button" id="${OPTIONS_BUTTON_ID}">
+                        Options
+                    </button>
+                  `
+                : `
+                    <a
+                        href="${template.linkToPreferences}"
+                        data-link-name="first-pv-consent : to-prefs"
+                        class="site-message--first-pv-consent__link u-underline"
+                    >${template.choicesButton}</a>`
+        }
     </div>
 `;
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -140,6 +140,15 @@ const bindClickHandlers = (msg: Message): void => {
     ).forEach(agreeButtonEl => {
         agreeButtonEl.addEventListener('click', () => onAgree(msg));
     });
+
+    if (isInVariantSynchronous(commercialConsentOptionsButton, 'variant')) {
+        const OptButton = document.getElementById(OPTIONS_BUTTON_ID);
+        if (OptButton) {
+            OptButton.addEventListener('click', () => {
+                window.location.href = template.linkToPreferences;
+            });
+        }
+    }
 };
 
 const show = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -61,8 +61,6 @@ const bindableClassNames: BindableClassNames = {
     agree: 'js-first-pv-consent-agree',
 };
 
-const OPTIONS_BUTTON_ID = 'cmp-options-button';
-
 const makeHtml = (): string => `
     <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--head ">${
         template.heading
@@ -78,20 +76,23 @@ const makeHtml = (): string => `
                 bindableClassNames.agree
             }"
         >${checkIcon.markup}<span>${template.agreeButton}</span></button>
-        ${
+        <a
+            href="${template.linkToPreferences}"
+            data-link-name="first-pv-consent : to-prefs"
+            class="site-message--first-pv-consent__link u-underline ${
+                isInVariantSynchronous(
+                    commercialConsentOptionsButton,
+                    'variant'
+                )
+                    ? 'cmp-options-button'
+                    : ''
+            }"
+        >${
             isInVariantSynchronous(commercialConsentOptionsButton, 'variant')
-                ? `
-                    <button class="cmp-options-button" id="${OPTIONS_BUTTON_ID}">
-                        Options
-                    </button>
-                  `
-                : `
-                    <a
-                        href="${template.linkToPreferences}"
-                        data-link-name="first-pv-consent : to-prefs"
-                        class="site-message--first-pv-consent__link u-underline"
-                    >${template.choicesButton}</a>`
-        }
+                ? 'Options'
+                : template.choicesButton
+        }</a>
+
     </div>
 `;
 
@@ -140,15 +141,6 @@ const bindClickHandlers = (msg: Message): void => {
     ).forEach(agreeButtonEl => {
         agreeButtonEl.addEventListener('click', () => onAgree(msg));
     });
-
-    if (isInVariantSynchronous(commercialConsentOptionsButton, 'variant')) {
-        const OptButton = document.getElementById(OPTIONS_BUTTON_ID);
-        if (OptButton) {
-            OptButton.addEventListener('click', () => {
-                window.location.href = template.linkToPreferences;
-            });
-        }
-    }
 };
 
 const show = (): Promise<boolean> => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-plus-engagement-banner.js
@@ -17,10 +17,14 @@ import {
     makeHtml as makeFirstPvConsentHtml,
 } from 'common/modules/ui/first-pv-consent-banner';
 import marque36icon from 'svgs/icon/marque-36.svg';
-import { getEngagementBannerTestToRun } from 'common/modules/experiments/ab';
+import {
+    isInVariantSynchronous,
+    getEngagementBannerTestToRun,
+} from 'common/modules/experiments/ab';
 import fastdom from 'lib/fastdom-promise';
 import reportError from 'lib/report-error';
 import { initTicker } from 'common/modules/commercial/ticker';
+import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 
 const messageCode: string = 'first-pv-consent-plus-engagement-banner';
 
@@ -182,6 +186,14 @@ const firstPvConsentPlusEngagementBanner: Banner = {
     canShow: (): Promise<boolean> =>
         Promise.all([canShowFirstPvConsent(), canShowEngagementBanner()]).then(
             (canShowBanners: Array<boolean>) =>
+                !isInVariantSynchronous(
+                    commercialConsentOptionsButton,
+                    'control'
+                ) &&
+                !isInVariantSynchronous(
+                    commercialConsentOptionsButton,
+                    'variant'
+                ) &&
                 canShowBanners.every(canShowBanner => canShowBanner === true)
         ),
     show,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -25,6 +25,8 @@ import {
 } from 'common/modules/commercial/ad-prefs.lib';
 import { bannerTemplate } from 'common/modules/ui/subscription-banner-template';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 
 // types
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
@@ -200,7 +202,13 @@ const show: () => Promise<boolean> = async () => {
 
 const canShow: () => Promise<boolean> = () => {
     const can = Promise.resolve(
-        fiveOrMorePageViews(pageviews) &&
+        !isInVariantSynchronous(commercialConsentOptionsButton, 'control') &&
+            !isInVariantSynchronous(
+                commercialConsentOptionsButton,
+                'variant'
+            ) &&
+            fiveOrMorePageViews(pageviews) &&
+            fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -208,7 +208,6 @@ const canShow: () => Promise<boolean> = () => {
                 'variant'
             ) &&
             fiveOrMorePageViews(pageviews) &&
-            fiveOrMorePageViews(pageviews) &&
             !hasUserAcknowledgedBanner(MESSAGE_CODE) &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -198,11 +198,12 @@ $btn-height: ($gs-baseline*3.5);
 // commercialIabBottomConsentBanner A/B test styles
 
 .cmp-options-button {
-    height: 42px;
+    height: 22px;
     border: 0;
     border-radius: 1000px;
-    padding: 0 20px;
+    padding: 10px 20px;
     margin-left: 8px;
+    vertical-align: bottom;
     background: #767676;
     color: #ffffff;
 }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -205,8 +205,4 @@ $btn-height: ($gs-baseline*3.5);
     margin-left: 8px;
     background: #767676;
     color: #ffffff;
-
-    :focus {
-        outline: none;
-    }
 }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -204,6 +204,6 @@ $btn-height: ($gs-baseline*3.5);
     padding: 10px 20px;
     margin-left: 8px;
     vertical-align: bottom;
-    background: #767676;
-    color: #ffffff;
+    background: $brightness-46;
+    color: $brightness-100;
 }

--- a/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
+++ b/static/src/stylesheets/module/site-messages/_first-pv-consent.scss
@@ -194,3 +194,19 @@ $btn-height: ($gs-baseline*3.5);
         }
     }
 }
+
+// commercialIabBottomConsentBanner A/B test styles
+
+.cmp-options-button {
+    height: 42px;
+    border: 0;
+    border-radius: 1000px;
+    padding: 0 20px;
+    margin-left: 8px;
+    background: #767676;
+    color: #ffffff;
+
+    :focus {
+        outline: none;
+    }
+}


### PR DESCRIPTION
## What does this change?
This PR adds an AB test called `commercialConsentOptionsButton` so we can confirm the hypothesis changing the 'My Options' link on the consent banner to a button has no impact on consent rates.

`control`: regular bottom consent banner 
`variant`: bottom consent banner with an 'Options' button instead of link

Note: Users in this test will not be served double banners, such as the consent + engagement or the consent + subscriptions double banners to avoid skewing results.

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
`control` on desktop:
![Screenshot 2019-11-22 at 16 15 01](https://user-images.githubusercontent.com/48949546/69442323-497baa80-0d44-11ea-8c1e-83c5675d0207.png)

`variant` on desktop:
![Screenshot 2019-11-22 at 16 15 28](https://user-images.githubusercontent.com/48949546/69442338-50a2b880-0d44-11ea-97af-842ae45f90fa.png)

`control` on mobile:
![Screenshot 2019-11-22 at 16 24 47](https://user-images.githubusercontent.com/48949546/69442525-a5deca00-0d44-11ea-9deb-7cfa8e036184.png)

`variant` on mobile:
![Screenshot 2019-11-22 at 16 24 31](https://user-images.githubusercontent.com/48949546/69442533-a8d9ba80-0d44-11ea-8efb-730b44d60d94.png)

## Checklist

### Tested

- [X] Locally
- [x] On CODE (optional)

