### PR TITLE
Reduce clickable area to buttons only on engagement banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -42,10 +42,5 @@ export const acquisitionsBannerControlTemplate = (
                 )}
             </div>
         </div>
-        <a
-            aria-hidden="true"
-            class="u-faux-block-link__overlay"
-            target="_blank"
-            href="${params.linkUrl}"
-        ></a>
+
     `;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -16,7 +16,7 @@ export const acquisitionsBannerUsEoyTemplate = (
                 ${closeCentralIcon.markup}
             </button>
         </div>
-        
+
         <div class="engagement-banner__container engagement-banner__container--us-eoy-2019">
             <div class="engagement-banner__text-container">
                 <div class="engagement-banner__header">
@@ -30,16 +30,16 @@ export const acquisitionsBannerUsEoyTemplate = (
                     <p>${params.messageText}</p>
                 </div>
             </div>
-           
+
             <div class="engagement-banner__cta-container">
                 <div class="engagement-banner__ticker-header-container">
                     <h3 class="engagement-banner__ticker-header">Help us reach our year-end goal</h3>
                 </div>
-                
+
                 <div class="engagement-banner__ticker-container">
                     ${params.hasTicker ? acquisitionsBannerTickerTemplate : ''}
                 </div>
-                
+
                 <div class="engagement-banner__cta">
                     <a tabIndex="3" class="component-button component-button--secondary" href="${
                         params.linkUrl
@@ -47,7 +47,7 @@ export const acquisitionsBannerUsEoyTemplate = (
                         ${params.buttonCaption}
                     </a>
                 </div>
-                
+
                 <div class="engagement-banner__cta engagement-banner__cta--editorial">
                     <a tabIndex="3" class="component-button component-button--greyHollow component-button--greyHollow--eoy" href="${'https://www.theguardian.com/us-news/2019/nov/18/help-raise-15-million-fund-high-impact-journalism-2020'}">
                         Learn more
@@ -55,11 +55,5 @@ export const acquisitionsBannerUsEoyTemplate = (
                 </div>
             </div>
         </div>
-        
-        <a
-            aria-hidden="true"
-            class="u-faux-block-link__overlay"
-            target="_blank"
-            href="${params.linkUrl}"
-        ></a>
+
     `;


### PR DESCRIPTION
## What does this change?
The whole region of the banner is clickable which is a usability issue for people with motor impairments. This changes makes buttons on the banner the only clickable regions.

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
