### PR TITLE
Liveblogs poll frequency does not slow when window is hidden

### DIFF
--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -267,6 +267,7 @@ const initPageVisibility = (): void => {
         } else {
             pageVisibility = document && document.hidden ? 'hidden' : 'visible';
         }
+        mediator.emit(`modules:detect:pagevisibility:${pageVisibility}`);
     };
 
     // Standards:

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -265,7 +265,7 @@ const initPageVisibility = (): void => {
         if (evt.type in evtMap) {
             pageVisibility = evtMap[evt.type];
         } else {
-            pageVisibility = window && window.hidden ? 'hidden' : 'visible';
+            pageVisibility = document && document.hidden ? 'hidden' : 'visible';
         }
     };
 


### PR DESCRIPTION
## What does this change?

This fixes a bug with the live blog polling that caused the poll interval to be fixed at 10s (on desktop), rather than gradually slowing down if the window is not visible.

## Does this change need to be reproduced in dotcom-rendering ?

Maybe?

## Screenshots

## What is the value of this and can you measure success?

Reduced number of calls to Fastly, reducing our bill.  Should be measurable in the Fastly console.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
