### PR TITLE
Fix CommercialConsentOptionsButton bug

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -20,13 +20,6 @@ const CONTAINER_CLASS = 'cmp-container';
 let overlay: ?HTMLElement;
 let uiPrepared: boolean = false;
 
-const isInCmpTest = () =>
-    isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
-    isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
-    isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant') ||
-    isInVariantSynchronous(commercialCmpUiNoOverlay, 'control') ||
-    isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant');
-
 const animateCmp = (): Promise<void> =>
     new Promise(resolve => {
         /**
@@ -186,6 +179,13 @@ const handlePrivacySettingsClick = (evt: Event): void => {
 
     show();
 };
+
+export const isInCmpTest = () =>
+    isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
+    isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
+    isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant') ||
+    isInVariantSynchronous(commercialCmpUiNoOverlay, 'control') ||
+    isInVariantSynchronous(commercialCmpUiNoOverlay, 'variant');
 
 export const addPrivacySettingsLink = (): void => {
     if (!isInCmpTest()) {

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -180,7 +180,7 @@ const handlePrivacySettingsClick = (evt: Event): void => {
     show();
 };
 
-export const isInCmpTest = () =>
+export const isInCmpTest = (): boolean =>
     isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
     isInVariantSynchronous(commercialCmpUiNonDismissable, 'control') ||
     isInVariantSynchronous(commercialCmpUiNonDismissable, 'variant') ||

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -13,9 +13,8 @@ import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { commercialCmpUiIab } from 'common/modules/experiments/tests/commercial-cmp-ui-iab';
-import { commercialCmpUiNonDismissable } from 'common/modules/experiments/tests/commercial-cmp-ui-non-dismissable';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
+import { isInCmpTest } from 'common/modules/ui/cmp-ui';
 
 type Template = {
     heading: string,
@@ -119,15 +118,7 @@ const canShow = (): Promise<boolean> =>
     Promise.resolve(
         hasUnsetAdChoices() &&
             !hasUserAcknowledgedBanner(messageCode) &&
-            (!isInVariantSynchronous(commercialCmpUiIab, 'variant') ||
-                !isInVariantSynchronous(
-                    commercialCmpUiNonDismissable,
-                    'control'
-                ) ||
-                !isInVariantSynchronous(
-                    commercialCmpUiNonDismissable,
-                    'variant'
-                ))
+            !isInCmpTest()
     );
 
 const track = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -29,6 +29,9 @@ beforeEach(() => {
     getCookie.mockImplementation(passingCookies);
 });
 
+jest.mock('common/modules/ui/cmp-ui', () => ({
+    isInCmpTest: jest.fn(() => false),
+}));
 jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(
         (testId, variantId) => variantId === 'notintest'


### PR DESCRIPTION
## What does this change?
This PR prevents users in the `CommercialConsentOptionsButton` from being presented both the new CMP UI as well as the old consent banner.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
