### PR TITLE
Onward endpoints for dotcom-rendering

### DIFF
--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -7,8 +7,11 @@ import containers.Containers
 import contentapi.ContentApiClient
 import feed.MostReadAgent
 import model._
+import models.OnwardCollectionResponse
 import play.api.mvc._
 import services._
+import models.OnwardCollection._
+
 
 class PopularInTag(
   val contentApiClient: ContentApiClient,
@@ -32,11 +35,24 @@ class PopularInTag(
     // Initially a fix for PaidFor related content (where this problem is more common), the decision to truncate is due
     // to aesthetic issues with the second slice when there are only 5 or 6 results in related content (7 looks fine).
     val numberOfCards = if (trails.faciaItems.length == 5 || trails.faciaItems.length == 6) 4 else 8
-    val html = views.html.fragments.containers.facia_cards.container(
-      containerDefinition = onwardContainer("Related content", trails.faciaItems take numberOfCards),
-      frontId = request.referrer.map(new URI(_).getPath.stripPrefix("/"))
-    )
 
-    JsonComponent(html)
+    if (request.forceDCR) {
+      JsonComponent(
+        OnwardCollectionResponse(
+          heading = "Related content",
+          trails = trailsToItems(trails.items.map(_.faciaContent))
+        )
+      )
+    } else {
+      val html = views.html.fragments.containers.facia_cards.container(
+        containerDefinition = onwardContainer("Related content", trails.faciaItems take numberOfCards),
+        frontId = request.referrer.map(new URI(_).getPath.stripPrefix("/"))
+      )
+
+      JsonComponent(html)
+    }
+
+
+
   }
 }

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -6,12 +6,12 @@ import contentapi.ContentApiClient
 import feed.MostReadAgent
 import model.Cached.RevalidatableResult
 import model._
-import models.{OnwardCollection, OnwardCollectionResponse}
+import models.OnwardCollection._
+import models.OnwardCollectionResponse
 import play.api.libs.json._
 import play.api.mvc._
 import services._
 import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
-import models.OnwardCollection._
 
 import scala.concurrent.duration._
 

--- a/onward/app/controllers/StoryPackageController.scala
+++ b/onward/app/controllers/StoryPackageController.scala
@@ -4,10 +4,13 @@ import common._
 import containers.Containers
 import contentapi.ContentApiClient
 import model._
+import models.OnwardCollectionResponse
 import play.api.libs.json._
 import play.api.mvc._
 import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
+import models.OnwardCollection._
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class StoryPackageController(val contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
@@ -16,25 +19,39 @@ class StoryPackageController(val contentApiClient: ContentApiClient, val control
     with Logging
     with ImplicitControllerExecutionContext {
 
-  def render(path: String): Action[AnyContent] = Action.async { implicit request =>
+  private[this] def getRelatedContent(path: String): Future[Seq[RelatedContentItem]] = {
     val fields = "headline,standfirst,shortUrl,webUrl,byline,trailText,liveBloggingNow,commentCloseDate,commentable,thumbnail"
     val query = contentApiClient.item(path).showPackages(true).showFields(fields).showElements("image")
     val resp = contentApiClient.getResponse(query)
+    resp.map(item => StoryPackages(path, item).items)
+  }
 
-    for {
-      items <- resp.map(item => StoryPackages(path, item).items)
-    } yield {
-      Cached(5.minutes) {
-        JsonComponent(
-          "items" -> JsArray(Seq(
-            Json.obj(
-              "displayName" -> "More on this story",
-              "showContent" -> items.nonEmpty,
-              "content" -> items.take(6).map( collection => isCuratedContent(collection.faciaContent))
-            )
-          ))
+  def render(path: String): Action[AnyContent] = Action.async { implicit request =>
+    getRelatedContent(path).map(items => {
+      val json = JsonComponent(
+        OnwardCollectionResponse(
+          heading = "More on this story",
+          trails = trailsToItems(items.map(_.faciaContent))
         )
-      }
-    }
+      )
+
+      Cached(5.minutes)(json)
+    })
+  }
+
+  def renderMF2(path: String): Action[AnyContent] = Action.async { implicit request =>
+    getRelatedContent(path).map(items => {
+      val json = JsonComponent(
+        "items" -> JsArray(Seq(
+          Json.obj(
+            "displayName" -> "More on this story",
+            "showContent" -> items.nonEmpty,
+            "content" -> items.take(6).map( collection => isCuratedContent(collection.faciaContent))
+          )
+        ))
+      )
+
+      Cached(5.minutes)(json)
+    })
   }
 }

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -1,5 +1,6 @@
 package models
 
+import com.gu.contentapi.client.utils.{DesignType, Article}
 import common.LinkTo
 import model.pressed.PressedContent
 import play.api.mvc.RequestHeader
@@ -16,7 +17,8 @@ case class OnwardItem(
   image: Option[String],
   ageWarning: Option[String],
   isLiveBlog: Boolean,
-  pillar: String
+  pillar: String,
+  designType: String
 )
 
 case class MostPopularGeoResponse(
@@ -53,7 +55,8 @@ object OnwardCollection {
         image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
         ageWarning = ageWarning(content),
         isLiveBlog = content.properties.isLiveBlog,
-        pillar = findPillar(content.maybePillar, content.frontendTags.toList)
+        pillar = findPillar(content.maybePillar, content.frontendTags.toList),
+        designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString
       )
     )
   }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -69,12 +69,15 @@ GET        /business-data/stocks.json                 controllers.StocksControll
 POST       /info/tech-feedback/send                   controllers.TechFeedbackController.submitFeedback(path = "")
 GET        /info/tech-feedback                        controllers.TechFeedbackController.techFeedback(path = "")
 
+# DCR
+GET        /story-package/*path.json                  controllers.StoryPackageController.render(path)
+
 # AMP
 GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()
 GET        /related-mf2/*path.json                    controllers.RelatedController.renderMf2(path)
 GET        /series-mf2/*path.json                     controllers.SeriesController.renderMf2SeriesStories(path)
 GET        /editionalised-nav.json                    controllers.NavigationController.renderAmpNav()
-GET        /story-package-mf2/*path.json              controllers.StoryPackageController.render(path)
+GET        /story-package-mf2/*path.json              controllers.StoryPackageController.renderMF2(path)
 
 ## Breaking-news
 GET     /news-alert/alerts                            controllers.NewsAlertController.alerts()


### PR DESCRIPTION
## What does this change?

Adds simple onward endpoints for DCR.

For the most part, existing endpoints are re-used, and passing a `dcr` parameter will force the DCR version.

In the case of story packages, no suitable endpoint existed, so I've added that. Note the story-package-mf2 endpoint relates to a format that is not required by web but currently in use by AMP (although it's unclear if AMP needs the different model and potentially we should consolidate).

Further TODOs:

* update nginx routes to support new endpoints in api nextgen
* CAPI change to add AdvertisingFeature as a design type

## Does this change need to be reproduced in dotcom-rendering ?

(Relates to work to support these in DCR.)