### PR TITLE
Bump CAPI for recent design type changes

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -2,28 +2,26 @@ package model.dotcomponents
 
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.DesignType
+import com.gu.contentapi.client.utils.Article
 import common.Edition
 import common.Maps.RichMap
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
 import conf.Configuration.affiliateLinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
+import controllers.ArticlePage
+import experiments.ActiveExperiments
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
-import model.{Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, SubMetaLinks}
+import model.{Canonical, LiveBlogPage, PageWithStoryPackage, Pillar}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
-import navigation.{FlatSubnav, NavLink, NavMenu, ParentSubnav, Subnav}
-import navigation.{FooterLink, FooterLinks}
+import navigation._
+import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, GUDateTimeFormat, ImgSrc, Item300}
-import controllers.ArticlePage
-import experiments.ActiveExperiments
-import org.joda.time.DateTime
-import views.support.JavaScriptPage
+import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, GUDateTimeFormat, ImgSrc, Item300, JavaScriptPage}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -397,12 +395,6 @@ object DotcomponentsDataModel {
       }.getOrElse("news")
     }
 
-    def findDesignType(designType: Option[DesignType], tags: List[Tag]): String = {
-      // TODO Remove this when changes can be moved to https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
-      if (isPaidContent(tags)) "AdvertisementFeature"
-      else designType.map(_.toString).getOrElse("Article")
-    }
-
     val bodyBlocksRaw = articlePage match {
       case lb: LiveBlogPage => blocksForLiveblogPage(lb, blocks)
       case article => blocks.body.getOrElse(Nil)
@@ -611,7 +603,7 @@ object DotcomponentsDataModel {
       trailText = article.trail.fields.trailText.getOrElse(""),
       nav = nav,
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(article),
-      designType = findDesignType(article.metadata.designType, allTags),
+      designType = article.metadata.designType.getOrElse(Article).toString,
       pageFooter = pageFooter,
       publication = article.content.publication,
     )

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
-import com.gu.contentapi.client.{ContentApiClient => CapiContentApiClient}
+import com.gu.contentapi.client.{ContentApiBackoff, ScheduledExecutor, ContentApiClient => CapiContentApiClient}
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1.{Edition => _, _}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
@@ -121,6 +121,9 @@ final case class CircuitBreakingContentApiClient(
   apiKey: String
 )(implicit executionContext: ExecutionContext)
   extends MonitoredContentApiClientLogic {
+
+  override implicit val executor = ScheduledExecutor()
+  override val backoffStrategy = ContentApiBackoff.constantStrategy(Duration.Zero, 1)
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
     name = "content-api-client",

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -159,6 +159,7 @@ object PressedContentFormat {
       case JsString("GuardianView") => JsSuccess(com.gu.contentapi.client.utils.GuardianView)
       case JsString("Quiz") => JsSuccess(com.gu.contentapi.client.utils.Quiz)
       case JsString("GuardianLabs") => JsSuccess(com.gu.contentapi.client.utils.GuardianLabs)
+      case JsString("AdvertisementFeature") => JsSuccess(com.gu.contentapi.client.utils.AdvertisementFeature)
       case _ => JsError(s"Unknown design type: '$json'")
     }
     override def writes(dt: DesignType): JsValue = dt match {
@@ -177,6 +178,7 @@ object PressedContentFormat {
       case com.gu.contentapi.client.utils.GuardianView => JsString("GuardianView")
       case com.gu.contentapi.client.utils.Quiz => JsString("Quiz")
       case com.gu.contentapi.client.utils.GuardianLabs => JsString("GuardianLabs")
+      case com.gu.contentapi.client.utils.AdvertisementFeature => JsString("AdvertisementFeature")
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.191"
   val awsVersion = "1.11.240"
-  val capiVersion = "15.4"
+  val capiVersion = "15.7"
   val faciaVersion = "3.0.11"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
See https://github.com/guardian/content-api-scala-client/pull/294 for context.
