### PR TITLE
Use the dynamoContentCard view when container is set to story package (dynamic/package)

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -1,5 +1,5 @@
 @import model.FrontProperties
-@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None, containerDisplayName: Option[String] = None, frontId: Option[String] = None)(implicit request: RequestHeader)
+@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None, containerDisplayName: Option[String] = None, frontId: Option[String] = None, isStoryPackage: Boolean = false)(implicit request: RequestHeader)
 
 @import layout.{ColumnAndCards, SingleItem, Rows, SplitColumn, MPU}
 @import views.html.fragments.items.facia_cards.item
@@ -10,7 +10,7 @@
         @column match {
             case SingleItem(colSpan, _) => {
                 @cards.headOption.map { card =>
-                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
+                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId, isStoryPackage = isStoryPackage)
                 }
             }
 
@@ -19,7 +19,7 @@
                     <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
                         @if(cards.nonEmpty) {
                             @cards.map{ card =>
-                                @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
+                                @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId, isStoryPackage = isStoryPackage)
                             }
                         }
                     </ul>
@@ -30,7 +30,7 @@
                 <li class="fc-slice__item l-row__item l-row__item--span-@colSpan">
                     <ul class="u-unstyled l-list l-list--columns-1 l-list--rows-@(topItemRows + bottomItemRows)">
                         @cards.map { card =>
-                            @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
+                            @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId, isStoryPackage = isStoryPackage)
                         }
                     </ul>
                 </li>

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -39,7 +39,7 @@
          data-id="@containerDefinition.dataId">
 
         @for(sliceWithCards <- containerLayout.slices) {
-            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName, frontId)
+            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName, frontId, containerDefinition.isStoryPackage)
         }
 
         @if(containerDefinition.hasShowMore && containerDefinition.hasShowMoreEnabled) {

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -1,0 +1,265 @@
+@(item: layout.ContentCard, containerIndex: Int, index: Int, visibilityDataAttribute: String, isFirstContainer: Boolean, isList: Boolean)(implicit request: RequestHeader)
+
+@import layout.{FaciaWidths, FrontendLatestSnap}
+@import model.{CrosswordSvg, InlineImage, InlineSlideshow, InlineVideo, InlineYouTubeMediaAtom, VideoPlayer}
+@import views.html.fragments.items.elements.facia_cards._
+@import views.html.fragments.items.elements.starRating
+@import views.html.fragments.items.facia_cards.meta
+@import views.html.fragments.atoms.youtube
+@import views.html.fragments.media.video
+@import views.html.fragments.inlineSvg
+@import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
+@import model.ContentDesignType.RichContentDesignType
+
+@import Function.const
+
+<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}"
+    @if(item.discussionSettings.isCommentable) {
+        @item.discussionSettings.discussionId.map { id =>
+        data-discussion-id="@id"
+        }
+        data-discussion-closed="@item.discussionSettings.isClosedForComments"
+        data-discussion-url="@item.header.url.get(request)#comments"
+    }
+data-link-name="@item.dataLinkName(index)"
+data-item-visibility="@visibilityDataAttribute"
+data-test-id="facia-card"
+    @item.id.map { id => data-id="@id" }
+    @item.snapStuff.map(_.dataAttributes)
+    @item.shortUrl.map { shortUrl => data-loyalty-short-url="@shortUrl" }>
+
+    @if(item.hasInlineSnapHtml) {
+        @item.snapStuff.map { snap =>
+            @snap.embedCss.map { css => <style>@Html(css)</style> }
+            @snap.embedHtml.map(Html(_))
+            @snap.embedJs.map { js => <script>@Html(js)</script> }
+        }
+    } else {
+        @container(item)
+    }
+
+</div>
+
+@mediaMeta(item: layout.ContentCard) = {
+    <div class="fc-item__meta-wrapper">
+        @if(item.contentType.name.toLowerCase == "video") {
+            @item.displayElement match {
+                case Some(InlineVideo(videoElement, _, _)) => {
+                    <div class="fc-item__media-meta">
+                        @inlineSvg("video-icon", "icon")
+                        @if(videoElement.videos.formattedDuration != "0:00") {
+                            <span class="fc-item__video-duration">@videoElement.videos.formattedDuration</span>
+                        }
+                    </div>
+                }
+
+                case Some(media@InlineYouTubeMediaAtom(youTubeAtom, _)) => {
+                    <div class="fc-item__media-meta">
+                        @inlineSvg("video-icon", "icon")
+                        @if(youTubeAtom.formattedDuration.getOrElse("0:00") != "0:00") {
+                            <span class="fc-item__video-duration">@youTubeAtom.formattedDuration</span>
+                        }
+                    </div>
+                }
+
+                case _ => {}
+            }
+        }
+
+        @if(item.contentType.name.toLowerCase == "audio") {
+            <div class="fc-item__media-meta">
+                @inlineSvg("volume-high", "icon")
+                <span class="u-h">Podcast</span>
+            </div>
+        }
+
+        @if(item.contentType.name.toLowerCase == "gallery") {
+            <div class="fc-item__media-meta">
+                @inlineSvg("camera", "icon")
+                <span class="u-h">Gallery</span>
+            </div>
+        }
+
+        @meta(item)
+    </div>
+}
+
+@standfirst(item: layout.ContentCard) = {
+    @item.trailText.filter(const(item.showStandfirst)).map { text =>
+        <div class="fc-item__standfirst">@Html(text)</div>
+    }
+}
+
+@container(item: layout.ContentCard) = {
+    <div class="fc-item__container">
+        @item.displayElement.filter(const(item.showDisplayElement)) match {
+            case Some(InlineVideo(videoElement, title, fallback)) if item.cardTypes.showVideoPlayer => {
+                @defining(VideoPlayer(
+                    videoElement,
+                    Video640,
+                    title,
+                    autoPlay = false,
+                    showControlsAtStart = false,
+                    overrideIsRatioHd = Some(false),
+                    // We only pass in the ID if this is a video or audio block, as if it's a mainMedia video, the
+                    // ID is actually pointing to the article, which is wrong. It would be nice to have the ID on the
+                    // ContentCard, but we don't for now. Annoyingly this doesn't allow us to check for if we should
+                    // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
+                    embedPath = if (item.isMediaLink) item.id else None,
+                    path = if (item.isMediaLink) item.id else None
+                )) { player =>
+                    <div class="fc-item__media-wrapper fc-item__video u-faux-block-link__promote media__container--hidden js-video-player">
+                        <div class="fc-item__video-container">
+                            @video(player, false, item.cardTypes.showVideoEndSlate, showPoster = false)
+                        </div>
+                    </div>
+                @fallback.map { fallbackImage =>
+                    <div class="fc-item__video fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
+                        <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text">@fragments.inlineSvg("play", "icon")</span></div>
+                        @itemImage(
+                            fallbackImage.imageMedia,
+                            inlineImage = containerIndex == 0 && index < 4,
+                            widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint),
+                        )
+                    </div>
+                }
+                }
+            }
+
+            case Some(svg@CrosswordSvg(_)) => {
+                <div class="fc-item__media-wrapper">
+                    <div class="fc-item__image-container u-responsive-ratio inlined-image">
+                        <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img" alt=""
+                        role="presentation" data-crossword-id="@svg.persistenceId" ></object>
+                    </div>
+                </div>
+            }
+
+            case Some(media@InlineYouTubeMediaAtom(_,_)) => {
+                <div class="fc-item__media-wrapper">
+                    <div class="fc-item__video-container">
+                    @youtube(
+                        media = media.youTubeAtom,
+                        displayCaption = false,
+                        displayDuration = false,
+                        playable = item.cardTypes.showYouTubeMediaAtomPlayer,
+                        posterImageOverride = media.posterImageOverride,
+                        cardStyle = Some(item.cardStyle))
+                    </div>
+                </div>
+            }
+
+            case Some(InlineVideo(_, _, Some(fallbackImage))) => {
+                <div class="fc-item__media-wrapper">
+                    @itemImage(
+                        fallbackImage.imageMedia,
+                        inlineImage = containerIndex == 0 && index < 4,
+                        widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint),
+                    )
+                </div>
+            }
+
+            case Some(InlineImage(images)) => {
+                <div class="fc-item__media-wrapper">
+                    @item.starRating.map { rating =>
+                        @starRating(rating)
+                    }
+                    @itemImage(
+                        images,
+                        inlineImage = containerIndex == 0 && index < 4,
+                        widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint),
+                    )
+                </div>
+            }
+
+            case Some(InlineSlideshow(imageElements)) => {
+                <div class="fc-item__media-wrapper">
+                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
+                    @imageElements.headOption.map { imageElement =>
+                        @image(
+                            classes = Seq("responsive-img"),
+                            widths = item.mediaWidthsByBreakpoint,
+                            maybePath = Some(imageElement.url),
+                            maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
+                        )
+                        @imageElements.tail.map { imageElement =>
+                            @image(
+                                classes = Seq("responsive-img "),
+                                widths = item.mediaWidthsByBreakpoint,
+                                maybePath = Some(imageElement.url)
+                            )
+                        }
+                    }
+                    </div>
+                </div>
+            }
+
+            case _ => {}
+        }
+
+        <div class="fc-item__content @if(item.starRating.isDefined){fc-item__content--has-stars}">
+            <div class="@RenderClasses(Map(
+                ("fc-item__header", true),
+                ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
+            ))">
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+
+                @item.bylineText.map { byline =>
+                    <div class="fc-item__byline">@byline</div>
+                }
+                @item.starRating.map { rating =>
+                    @starRating(rating)
+                }
+            </div>
+
+            @if(item.isMediaLink) {
+                @standfirst(item)
+            } else {
+                <div class="@RenderClasses(Map(
+                    ("fc-item__standfirst-wrapper", true),
+                    ("fc-item__standfirst-wrapper--timestamp", !item.timeStampDisplay.isEmpty)
+                ))">
+                    @standfirst(item)
+                    @meta(item)
+                </div>
+                @if(item.cardTypes.showCutOut) {
+                    @item.cutOut.map { case cutOut@CutOut(imageUrl, _) =>
+                    <div class="fc-item__avatar">
+                        @image(
+                            classes = Seq("fc-item__avatar__media", cutOut.cssClass),
+                            widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
+                            maybePath = Some(imageUrl)
+                        )
+                    </div>
+                    }
+                }
+            }
+
+            @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
+                <div class="js-liveblog-blocks fc-item__liveblog-blocks" data-article-id="@item.id"></div>
+            }
+            @if(item.isMediaLink) {
+                <div class="fc-item__footer-meta-wrapper">
+                    @mediaMeta(item)
+                    @if(item.sublinks.nonEmpty) {
+                        <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
+                    }
+                </div>
+            } else {
+                @if(item.sublinks.nonEmpty) {
+                    <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
+                }
+            }
+        </div>
+
+        @if(item.sublinks.nonEmpty) {
+            <footer class="fc-item__footer--horizontal">@sublinks(item.sublinks)</footer>
+        }
+
+        @if(item.designType.nameOrDefault == "comment") {
+            @meta(item)
+        }
+
+        <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1" aria-hidden="true">@RemoveOuterParaHtml(item.header.headline)</a>
+    </div>
+}

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -6,12 +6,15 @@
     colSpan: Int = 1,
     frontProperties: Option[FrontProperties] = None,
     containerDisplayName: Option[String] = None,
-    frontId: Option[String] = None)(implicit request: RequestHeader)
+    frontId: Option[String] = None,
+    isStoryPackage: Boolean = false)(implicit request: RequestHeader)
 
 @import layout.{ContentCard, HtmlBlob, PaidCard}
 @import views.html.fragments.items.facia_cards.contentCard
 @import views.html.fragments.items.facia_cards.paidContentCard
-@import views.support.Commercial.TrackingCodeBuilder.mkInteractionTrackingCode
+    @import views.html.fragments.items.facia_cards.dynamoContentCard
+
+    @import views.support.Commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 @import views.support.{GetClasses, RenderClasses}
 
 @defining((card.item, card.index)) { case (item, index) =>
@@ -37,6 +40,10 @@
             )
         }
 
+        case content: ContentCard if isStoryPackage => {
+            @dynamoContentCard(content, containerIndex, index, card.visibilityDataAttribute, isFirstContainer, isList)
+        }
+            
         case content: ContentCard => {
             @contentCard(content, containerIndex, index, card.visibilityDataAttribute, isFirstContainer, isList)
 


### PR DESCRIPTION
## What does this change?

This PR adds a new 'Content Card' type for when a container is a 'story package' container i.e `dynamic/package`

```scala
  def isStoryPackage: Boolean = container match {
    case Dynamic(DynamicPackage) => true
    case _ => false
  }
}
```

In this PR, contentCard.scala.html and dynamoContentCard.html are identical:

![Screenshot 2019-11-27 at 13 59 08](https://user-images.githubusercontent.com/638051/69729860-f5474080-111e-11ea-8acf-faac00c7190b.png)

This is essentially, hopefully, a noop PR, in that there should be no changes to any Frontend view.

I know what you might says, "Why the duplication, Gareth!?". Well, yes, it's likely that we want to share or reduce the duplication between these two files but in order to A) break as few things as possible and b) move quickly, in this instance we will work against a duplicate content card view.

Once complete, we can decide what makes sense to split out and share and whether we merge the two types back in and fill the actual view with if statements. (Note to @rcrphillips that we'll need time in for this tidy up, to discuss...)

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No, Fronts only.

## Screenshots

NOOP.

## What is the value of this and can you measure success?

We'll be able to move quicker against a clean, non-scary template, moving markup positioning, adding classes etc.

## Checklist

### Does this affect other platforms?
- [X] Apps are working on this

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine

### Accessibility test checklist

No changes.

### Tested

- [X] Locally
