### PR TITLE
Add initial CSS Styles for Dynamo (Story Package) Container

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -1,7 +1,7 @@
 @import '../_vars';
 @import '../_mixins';
 
-@mixin kicker-override($tone, $colour) {
+@mixin pillar-override($tone, $colour) {
     .fc-item--pillar-#{$tone} {
         .fc-item__kicker,
         .rich-link__kicker,
@@ -11,6 +11,10 @@
 
         .inline-garnett-quote {
             fill: $colour;
+        }
+
+        .fc-item__container:before {
+            background-color: #ffffff;
         }
     }
 
@@ -24,7 +28,11 @@
 }
 
 .fc-container--story-package {
-    background-color: $brightness-86;
+    background-color: #888f92; // This colour does not exist (in the palette)
+
+    .fc-slice__item + .fc-slice__item:before {
+        border-left-color: #929698; // This colour does not exist (in the palette)
+    }
 
     .fc-container__toggle {
         display: none;
@@ -40,12 +48,8 @@
 
         & > span,
         h2.fc-container__title__text {
-            background: #fff132;
-            background: -moz-linear-gradient(top, #ffe500 0%,  #ffe500 50%, #ffe500 100%);
-            background: -webkit-linear-gradient(top, #ffe500 0%, #ffe500 50%, #ffe500 100%);
-            background: linear-gradient(to bottom,  #ffe500 0%, #ffe500 50%, #ffe500 100%);
+            color: #ffffff;
             display: inline;
-            box-shadow: -4px 0 0 0 #ffe500;
             line-height: 32px;
             top: 6px;
             position: relative;
@@ -61,10 +65,23 @@
                 line-height: 30px;
             }
         }
+
+        a:hover {
+            text-decoration: none;
+            border-bottom: #ffffff;
+        }
+    }
+
+    .fc-container__header__description {
+        color: #ffffff;
     }
 
     .fc-container__inner {
         border-top: 0;
+    }
+
+    .fc-item--pillar-news.fc-item--type-analysis.fc-item--full-media-75-tablet .fc-item__title {
+        background-image: none;
     }
 
     //These need to be this specific as elsewhere in pillars.scss these are targeted using 3 selectors
@@ -77,17 +94,17 @@
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
     .fc-item.fc-item--type-feature
     {
-        background-color: $special-report-dark;
+        background-color: #383a3c; // This colour does not exist (in the palette)
 
         &:hover {
-            background-color: darken($special-report-dark, 5%);
+            background-color: darken(#383a3c, 5%);
 
             .fc-trail__count--commentcount {
-                background-color: darken($special-report-dark, 5%);
+                background-color: darken(#383a3c, 5%);
             }
         }
         .fc-trail__count--commentcount {
-            background-color: $special-report-dark;
+            background-color: #383a3c;
         }
 
         .fc-item__headline {
@@ -102,7 +119,7 @@
     .fc-item--pillar-lifestyle.fc-item--type-comment
     {
         .fc-item__meta {
-            @include multiline(4, $brightness-46, $position: bottom);
+            background-image: none;
         }
 
         .fc-item__standfirst-wrapper .fc-item__meta {
@@ -130,11 +147,15 @@
         }
     }
 
+    .fc-container--story-package .fc-container__header__title>h2 {
+        color: #ffffff;
+    }
+
     //These need to exist for all kickers because of tone on tone action
-    @include kicker-override(lifestyle, $lifestyle-bright);
-    @include kicker-override(arts, $culture-bright);
-    @include kicker-override(sport, $sport-bright);
-    @include kicker-override(opinion, $opinion-bright);
-    @include kicker-override(news, $news-bright);
-    @include kicker-override(special-report, $highlight-main);
+    @include pillar-override(lifestyle, $lifestyle-bright);
+    @include pillar-override(arts, $culture-bright);
+    @include pillar-override(sport, $sport-bright);
+    @include pillar-override(opinion, $opinion-pastel);
+    @include pillar-override(news, $lifestyle-pastel);
+    @include pillar-override(special-report, $highlight-main);
 }

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -28,7 +28,7 @@
 }
 
 .fc-container--story-package {
-    background-color: #888f92; // This colour does not exist (in the palette)
+    background-color: #6b6e71; // This colour does not exist (in the palette)
 
     .fc-slice__item + .fc-slice__item:before {
         border-left-color: #929698; // This colour does not exist (in the palette)


### PR DESCRIPTION
Depends on https://github.com/guardian/frontend/pull/22045

## What does this change?

This adds the initial styles for the story package container. There are no major changes to layout, only colours in this PR and as such it should be safe to go out as is.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No

## Screenshots

### Design

<img width="887" alt="Screenshot 2019-11-27 at 16 43 21" src="https://user-images.githubusercontent.com/638051/69742824-4eba6a00-1135-11ea-92f8-1ed52aab05ea.png">

### Before

<img width="972" alt="Screenshot 2019-11-27 at 16 43 41" src="https://user-images.githubusercontent.com/638051/69742848-5974ff00-1135-11ea-81e1-de1645dfa0f3.png">

### After

<img width="1030" alt="Screenshot 2019-11-27 at 16 55 02" src="https://user-images.githubusercontent.com/638051/69743653-b1603580-1136-11ea-8c40-ad93716c9531.png">


## Checklist

### Does this affect other platforms?
Not directly.

### Accessibility test checklist

Colours have been tested with https://whocanuse.com/ meeting AA.

### Tested

- [X] Locally


See alternative card styles:

![Screenshot 2019-11-27 at 16 48 15](https://user-images.githubusercontent.com/638051/69743078-bb356900-1135-11ea-82de-7500a7f5167b.png)


Mobile: 


![ezgif com-optimize](https://user-images.githubusercontent.com/638051/69744588-5deee700-1138-11ea-9a8c-4b42fbd06684.gif)

