### PR TITLE
Put permutive back behind 0% ab test

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -16,10 +16,7 @@ import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-
 import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
-import {
-    initPermutive,
-    initPermutiveLib,
-} from 'commercial/modules/dfp/prepare-permutive';
+import { initPermutive } from 'commercial/modules/dfp/prepare-permutive';
 import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
 import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
@@ -47,7 +44,6 @@ if (!commercialFeatures.adFree) {
         // Permutive init code must run before google tag enableServices()
         // The permutive lib however is loaded async in `initPermutiveLib`
         ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
-        ['cm-prepare-permutiveLib', initPermutiveLib],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],
         ['cm-highMerch', initHighMerch],

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -1,5 +1,4 @@
 // @flow
-import { loadScript } from 'lib/load-script';
 import config from 'lib/config';
 import reportError from 'lib/report-error';
 
@@ -124,14 +123,4 @@ export const initPermutive = (): Promise<void> => {
 
         return resolve();
     });
-};
-
-export const initPermutiveLib = (): Promise<void> => {
-    const setupPermutive = (): Promise<void> =>
-        loadScript(
-            '//cdn.permutive.com/d6691a17-6fdb-4d26-85d6-b3dd27f55f08-web.js',
-            { async: true }
-        );
-
-    return setupPermutive();
 };


### PR DESCRIPTION
## What does this change?
Remove duplicate permutive library loading code. The duplicate was unconditionally loading the library so this change restores the expected AB test behaviour.  

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Permutive is only loaded on consented pageviews where the user is in the permutive AB test.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
