### PR TITLE
Giving Tuesday banner tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,6 +68,26 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-banner-us-eoy-giving-tuesday-regulars",
+    "US end of year banner - giving tuesday version for regular readers",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-giving-tuesday-casuals",
+    "US end of year banner - giving tuesday version for casual readers",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-always-ask-if-tagged",
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -61,6 +61,7 @@ declare type EngagementBannerTestParams = {
     buttonCaption?: string,
     linkUrl?: string,
     hasTicker?: boolean,
+    tickerHeader?: string,
     products?: OphanProduct[],
     template?: (templateParams: EngagementBannerTemplateParams) => string,
     bannerModifierClass?: string,

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -21,6 +21,7 @@ declare type EngagementBannerTemplateParams = {
     buttonCaption: string,
     linkUrl: string,
     hasTicker: boolean,
+    tickerHeader?: string,
     signInUrl?: string,
     secondaryLinkUrl?: string,
     secondaryLinkLabel?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -101,6 +101,7 @@ const bannerParamsToHtml = (params: EngagementBannerParams): string => {
         : params.messageText;
     const ctaText = params.ctaText;
     const leadSentence = params.leadSentence;
+    const tickerHeader = params.tickerHeader;
 
     const linkUrl = addTrackingCodesToUrl({
         base: params.linkUrl,
@@ -120,6 +121,7 @@ const bannerParamsToHtml = (params: EngagementBannerParams): string => {
         linkUrl,
         buttonCaption,
         hasTicker: params.hasTicker,
+        tickerHeader,
         signInUrl: params.signInUrl,
         secondaryLinkUrl: params.secondaryLinkUrl,
         secondaryLinkLabel: params.secondaryLinkLabel,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -57,5 +57,4 @@ export const acquisitionsBannerUsEoyTemplate = (
                 </div>
             </div>
         </div>
-
     `;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -33,7 +33,9 @@ export const acquisitionsBannerUsEoyTemplate = (
 
             <div class="engagement-banner__cta-container">
                 <div class="engagement-banner__ticker-header-container">
-                    <h3 class="engagement-banner__ticker-header">${params.tickerHeader ? params.tickerHeader : ''}</h3>
+                    <h3 class="engagement-banner__ticker-header">${
+                        params.tickerHeader ? params.tickerHeader : ''
+                    }</h3>
                 </div>
 
                 <div class="engagement-banner__ticker-container">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -33,7 +33,7 @@ export const acquisitionsBannerUsEoyTemplate = (
 
             <div class="engagement-banner__cta-container">
                 <div class="engagement-banner__ticker-header-container">
-                    <h3 class="engagement-banner__ticker-header">Help us reach our year-end goal</h3>
+                    <h3 class="engagement-banner__ticker-header">${params.tickerHeader ? params.tickerHeader : ''}</h3>
                 </div>
 
                 <div class="engagement-banner__ticker-container">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -27,7 +27,11 @@ export const acquisitionsBannerUsEoyTemplate = (
                     }</h2>
                 </div>
                 <div class="engagement-banner__body">
-                    <p>${params.messageText}</p>
+                    <p>${params.messageText}
+                    <span class="engagement-banner__body-copy--bold">${
+                        params.closingSentence ? params.closingSentence : ''
+                    }</span>
+                    </p>
                 </div>
             </div>
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,8 +15,8 @@ import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-ga
 import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
-import { contributionsBannerUsEoyGivingTuesdayRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
 import { contributionsBannerUsEoyGivingTuesdayCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals';
+import { contributionsBannerUsEoyGivingTuesdayRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,6 +15,8 @@ import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-ga
 import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
+import { contributionsBannerUsEoyGivingTuesdayRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
+import { contributionsBannerUsEoyGivingTuesdayCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -37,6 +39,8 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    contributionsBannerUsEoyGivingTuesdayRegulars,
+    contributionsBannerUsEoyGivingTuesdayCasuals,
     contributionsBannerUsEoy,
     articlesViewedBanner,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
@@ -8,7 +8,7 @@ const isUS = geolocation === 'US';
 
 const titles = ['Offset fake news this Giving Tuesday'];
 const messageText =
-    'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
@@ -19,7 +19,8 @@ export const contributionsBannerUsEoyGivingTuesdayCasuals: AcquisitionsABTest = 
     start: '2019-11-15',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description: 'banner for the US EOY campaign for readers who have seen fewer than 5 articles',
+    description:
+        'banner for the US EOY campaign for readers who have seen fewer than 5 articles',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -43,6 +44,5 @@ export const contributionsBannerUsEoyGivingTuesdayCasuals: AcquisitionsABTest = 
                 bannerModifierClass: 'useoy2019',
             },
         },
-        ,
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
@@ -6,22 +6,20 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['2020 will be a defining year for America'];
-const messageTextV1 =
+const titles = ['Offset fake news this Giving Tuesday'];
+const messageText =
     'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
-const messageTextV2 =
-    'This year, much of what we hold dear has been threatened - democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue to put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
 
-export const contributionsBannerUsEoy: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoy',
+export const contributionsBannerUsEoyGivingTuesdayCasuals: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyGivingTuesdayCasuals',
     campaignId: 'USeoy2019',
     start: '2019-11-15',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description: 'general banner for the US EOY campaign',
+    description: 'banner for the US EOY campaign for readers who have seen fewer than 5 articles',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -37,7 +35,7 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
             test: (): void => {},
             engagementBannerParams: {
                 titles,
-                messageText: messageTextV1,
+                messageText,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
@@ -45,18 +43,6 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
                 bannerModifierClass: 'useoy2019',
             },
         },
-        {
-            id: 'variant',
-            test: (): void => {},
-            engagementBannerParams: {
-                titles,
-                messageText: messageTextV2,
-                ctaText,
-                template: acquisitionsBannerUsEoyTemplate,
-                hasTicker: true,
-                tickerHeader: tickerHeaderControl,
-                bannerModifierClass: 'useoy2019',
-            },
-        },
+        ,
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
@@ -8,7 +8,8 @@ const isUS = geolocation === 'US';
 
 const titles = ['Offset fake news this Giving Tuesday'];
 const messageText =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
+const closingSentence = 'Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
@@ -37,6 +38,7 @@ export const contributionsBannerUsEoyGivingTuesdayCasuals: AcquisitionsABTest = 
             engagementBannerParams: {
                 titles,
                 messageText,
+                closingSentence,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -11,17 +11,18 @@ const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
+const testRunConditions = isUS && articleViewCount >= minArticleViews;
 
 const titles = ['Offset fake news this Giving Tuesday'];
 const messageText =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts,” the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
 const tickerHeaderWithArticleCount = `You’ve read ${articleViewCount} articles in the last two months`;
 
 export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest = {
-    id: 'contributionsBannerUsEoyGivingTuesdayRegulars',
+    id: 'ContributionsBannerUsEoyGivingTuesdayRegulars',
     campaignId: 'USeoy2019',
     start: '2019-11-15',
     expiry: '2020-1-30',
@@ -35,7 +36,7 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
     idealOutcome: 'variant design performs at least as well as control',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => isUS && articleViewCount >= minArticleViews,
+    canRun: () => testRunConditions,
     geolocation,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -13,15 +13,13 @@ const messageTextV2 =
     'This year, much of what we hold dear has been threatened - democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue to put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million.';
 const ctaText = 'Support The Guardian';
 
-const tickerHeaderControl = 'Help us reach our year-end goal';
-
-export const contributionsBannerUsEoy: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoy',
+export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest = {
+    id: 'contributionsBannerUsEoyGivingTuesdayRegulars',
     campaignId: 'USeoy2019',
     start: '2019-11-15',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description: 'general banner for the US EOY campaign',
+    description: 'banner test for the US EOY campaign for readers who have seen more than 5 articles',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -41,7 +39,6 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
-                tickerHeader: tickerHeaderControl,
                 bannerModifierClass: 'useoy2019',
             },
         },
@@ -54,7 +51,6 @@ export const contributionsBannerUsEoy: AcquisitionsABTest = {
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
-                tickerHeader: tickerHeaderControl,
                 bannerModifierClass: 'useoy2019',
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -2,16 +2,23 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
+
+// User must have read at least 5 articles in last 60 days
+const minArticleViews = 5;
+const articleCountDays = 60;
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['2020 will be a defining year for America'];
-const messageTextV1 =
-    'And the result could define the country for a generation. Many vital aspects of American public life are in play - the supreme court, abortion rights, climate policy, wealth inequality, Big Tech and more. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million.';
-const messageTextV2 =
-    'This year, much of what we hold dear has been threatened - democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue to put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million.';
+const titles = ['Offset fake news this Giving Tuesday'];
+const messageText =
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
+
+const tickerHeaderControl = 'Help us reach our year-end goal';
+const tickerHeaderWithArticleCount = `You’ve read ${articleViewCount} articles in the last two months`;
 
 export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest = {
     id: 'contributionsBannerUsEoyGivingTuesdayRegulars',
@@ -19,7 +26,8 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
     start: '2019-11-15',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description: 'banner test for the US EOY campaign for readers who have seen more than 5 articles',
+    description:
+        'banner test for the US EOY campaign for readers who have seen more than 5 articles',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -27,7 +35,7 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
     idealOutcome: 'variant design performs at least as well as control',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => isUS,
+    canRun: () => isUS && articleViewCount >= minArticleViews,
     geolocation,
     variants: [
         {
@@ -35,23 +43,25 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
             test: (): void => {},
             engagementBannerParams: {
                 titles,
-                messageText: messageTextV1,
+                messageText,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
                 bannerModifierClass: 'useoy2019',
+                tickerHeader: tickerHeaderControl,
             },
         },
         {
-            id: 'variant',
+            id: 'withArticleCount',
             test: (): void => {},
             engagementBannerParams: {
                 titles,
-                messageText: messageTextV2,
+                messageText,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
                 bannerModifierClass: 'useoy2019',
+                tickerHeader: tickerHeaderWithArticleCount,
             },
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -15,7 +15,8 @@ const testRunConditions = isUS && articleViewCount >= minArticleViews;
 
 const titles = ['Offset fake news this Giving Tuesday'];
 const messageText =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts,” the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. Help us reach our year-end goal.';
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
+const closingSentence = 'Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
@@ -45,6 +46,7 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
             engagementBannerParams: {
                 titles,
                 messageText,
+                closingSentence,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
@@ -58,6 +60,7 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
             engagementBannerParams: {
                 titles,
                 messageText,
+                closingSentence,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -111,7 +111,7 @@ $blue-accent: #1a5292;
         }
 
         @include mq($from: desktop) {
-            width: gs-span(6)
+            width: gs-span(7)
         }
     }
 

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -102,6 +102,10 @@ $blue-accent: #1a5292;
         }
     }
 
+    .engagement-banner__body-copy--bold {
+        font-weight: bold;
+    }
+
     .engagement-banner__cta-container {
         width: 100%;
 


### PR DESCRIPTION
## What does this change?
We are running a new banner for Giving Tuesday:
50% of the US audience who have read more than 5 articles in the past two months see Giving Tuesday copy without article count ("control")
50% of the US audience who have read more than 5 articles in the past 2 months see Giving Tuesday copy with article count ("article count variant")
100% of the US audience who have read fewer than 5 articles in the past 2 months see Giving Tuesday copy without article count ("casuals")

## Screenshots
Regular readers - control
<img width="1302" alt="giving tuesday control" src="https://user-images.githubusercontent.com/3300789/69878822-d9c66c00-12bd-11ea-8597-3288a04e59d0.png">

Regular readers - article count variant
<img width="1331" alt="giving tuesday - articles read" src="https://user-images.githubusercontent.com/3300789/69878821-d9c66c00-12bd-11ea-8783-1800cdf4afdb.png">

Casual readers
<img width="1302" alt="giving tuesday control" src="https://user-images.githubusercontent.com/3300789/69878822-d9c66c00-12bd-11ea-8597-3288a04e59d0.png">

## What is the value of this and can you measure success?

## Checklist
### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
