### PR TITLE
Temporarily add running tests (epics/banners) to window.guardian.tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -152,6 +152,9 @@ export const runAndTrackAbTests = (): Promise<void> => {
     return getAsyncTestsToRun().then(tests => {
         tests.forEach(test => test.variantToRun.test(test));
 
+        // temp adding tests to the window.guardian object
+        window.guardian.tests = tests.map(test => test.id);
+
         registerImpressionEvents(tests);
         registerCompleteEvents(tests);
         trackABTests(tests);


### PR DESCRIPTION
## What does this change?
Identity are running a sign in gate AB test. However over the last couple of days the number of unique browser ids viewing the sign in page has dropped significantly. Due to our strict requirements for showing this banner, such as being lowest priority on the banner list and not showing on any pages with an epic, we suspect that this is due to an Epic or Banner that is running.

However there is no functionality to be able to see on a page/article which ones are currently running.

This PR adds the currently running epic and banner ids to `window.guardian` so that we are able to see which ones are currently running by using the `tests` from the `runAndTrackAbTests` method.

Once we've determined what was causing the issues with the sign in gate, we will revert this PR.

### Tested

- [X] Locally
- [X] On CODE (optional)
