### PR TITLE
Revert "Temporarily add running tests (epics/banners) to window.guardian.tests"

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -152,9 +152,6 @@ export const runAndTrackAbTests = (): Promise<void> => {
     return getAsyncTestsToRun().then(tests => {
         tests.forEach(test => test.variantToRun.test(test));
 
-        // temp adding tests to the window.guardian object
-        window.guardian.tests = tests.map(test => test.id);
-
         registerImpressionEvents(tests);
         registerCompleteEvents(tests);
         trackABTests(tests);


### PR DESCRIPTION
Reverts guardian/frontend#22052 as no longer required since we can use breakpoints in production.