### PR TITLE
Redeploying the subscriptions banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -82,7 +82,10 @@ const hasAcknowledgedSinceRedeploy = () => {
         return !hasUserAcknowledgedBanner(MESSAGE_CODE);
     }
 
-    return !lastClosedAt || wasBannerClosedBeforeRedeployDate(bannerRedeploymentDate, lastClosedAt);
+    return (
+        !lastClosedAt ||
+        wasBannerClosedBeforeRedeployDate(bannerRedeploymentDate, lastClosedAt)
+    );
 };
 
 const bannerHasBeenAcknowledged = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -1,6 +1,5 @@
 // @flow
 
-import uniq from 'lodash/uniq';
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import config from 'lib/config';
 import userPrefs from 'common/modules/user-prefs';
@@ -68,8 +67,7 @@ const hasAcknowledged = () => {
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
 
-    return lastClosedAt &&
-        lastClosedAtTime > bannerRedeploymentDate;
+    return lastClosedAt && lastClosedAtTime > bannerRedeploymentDate;
 };
 
 const subcriptionBannerCloseActions = (): void => {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -69,24 +69,20 @@ const wasBannerClosedBeforeRedeployDate = (
     lastClosedAt: string
 ) => {
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
-    return bannerRedeploymentDate - lastClosedAtTime > 0;
+    return bannerRedeploymentDate < lastClosedAtTime;
 };
 
-const shouldRedeploy = () => {
+const hasAcknowledgedSinceRedeploy = () => {
     const bannerRedeploymentDate = new Date(2019, 11, 2, 5, 0).getTime(); // 2 Dec 2019 @ 5:00
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const now = new Date().getTime();
+    const redeployActive = now > bannerRedeploymentDate;
 
-    if (now < bannerRedeploymentDate) {
+    if (!redeployActive) {
         return !hasUserAcknowledgedBanner(MESSAGE_CODE);
     }
 
-    return !lastClosedAt
-        ? true
-        : wasBannerClosedBeforeRedeployDate(
-              bannerRedeploymentDate,
-              lastClosedAt
-          );
+    return !lastClosedAt || wasBannerClosedBeforeRedeployDate(bannerRedeploymentDate, lastClosedAt);
 };
 
 const bannerHasBeenAcknowledged = (): void => {
@@ -233,7 +229,7 @@ const canShow: () => Promise<boolean> = () => {
                 'variant'
             ) &&
             fiveOrMorePageViews(pageviews) &&
-            shouldRedeploy() &&
+            hasAcknowledgedSinceRedeploy() &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&
             canShowBannerInRegion(currentRegion) &&


### PR DESCRIPTION
## What does this change?
This PR is to redeploy the current subs banner on 2nd Dec 2019

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A

## What is the value of this and can you measure success?
N/A

## Checklist
- new redeployment logic

### Does this affect other platforms?
- [x] No
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
