### PR TITLE
More items in dynamic container & new layouts

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -31,7 +31,7 @@ object Container extends Logging {
 
   def storiesCount(collectionConfig: CollectionConfig, items: Seq[PressedContent]): Option[Int] = {
     resolve(collectionConfig.collectionType) match {
-      case Dynamic(dynamicPackage) => dynamicPackage
+      case Dynamic(dynamicContainer) => dynamicContainer
         .slicesFor(items.map(Story.fromFaciaContent))
         .map(Front.itemsVisible)
       case Fixed(fixedContainer) => Some(Front.itemsVisible(fixedContainer.slices))

--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -14,23 +14,22 @@ object DynamicPackage extends DynamicContainer {
     }
   }
 
-  override protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
-    val BigsAndStandards(_, _) = bigsAndStandards(stories)
-
-    if (stories.isEmpty) {
-      Nil
-    } else {
-      if (stories.length == 1) {
-        Seq(FullMedia75)
-      } else if (stories.length == 2) {
-        Seq(ThreeQuarterQuarter)
-      } else if (stories.length == 3) {
-        Seq(ThreeQuarterTallQuarter2)
-      } else if (stories.length == 4) {
-        Seq(ThreeQuarterTallQuarter2Ql2)
-      } else {
-        Seq(FullMedia75, QuarterQuarterQuarterQuarter)
-      }
+  override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
+    storiesIncludingBackfill.length match {
+      case 0 => Nil
+      case 1 => Seq(FullMedia75)
+      case 2 => Seq(ThreeQuarterQuarter)
+      case 3 => Seq(ThreeQuarterTallQuarter2)
+      case 4 => Seq(ThreeQuarterTallQuarter2Ql2)
+      case 5 => Seq(FullMedia75, QuarterQuarterQuarterQuarter)
+      case 6 => Seq(FullMedia75, QuarterQuarterQuarterQl)
+      case 7 => Seq(FullMedia75, QuarterQuarterQuarterQl)
+      case 8 =>
+        // This case doesn't look _quite_ right. We end up with a row of four
+        // and then a row of three, slightly stretched. There isn't a layout
+        // which caters for this currently, we'll follow up on this separately.
+        Seq(FullMedia75, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
+      case _ => Seq(FullMedia75, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Add support for showing additional cards in the dynamic container. The maximum is now 9 + the optional snap (previously 5 + optional snap).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (fronts change)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### 6 cards

![Screenshot 2019-11-29 at 14 20 33](https://user-images.githubusercontent.com/379839/69883582-b2c36680-12cc-11ea-8835-e419761ee88b.png)

### 7 cards

![Screenshot 2019-11-29 at 14 46 36](https://user-images.githubusercontent.com/379839/69883328-8d822880-12cb-11ea-9cb6-366e6cd59ec4.png)

### 8 cards

Note that it's understood that this doesn't look great, and we've got a card in the backlog to follow up (this requires new slice layouts, rather than reusing existing ones).

![Screenshot 2019-11-29 at 14 42 01](https://user-images.githubusercontent.com/379839/69883332-970b9080-12cb-11ea-8fb2-db2cc2c19c3d.png)

### 9 cards

![Screenshot 2019-11-29 at 13 47 53](https://user-images.githubusercontent.com/379839/69883342-a25ebc00-12cb-11ea-8f85-675ea84f8ee0.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
