### PR TITLE
Sign In Gate New AB Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -138,7 +138,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-first-test",
+    "ab-sign-in-gate-prius-test",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = On,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -138,7 +138,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-prius-test",
+    "ab-sign-in-gate-prius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = On,

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -311,12 +311,12 @@ const initialiseBanner = (): void => {
         firstPvConsentPlusEngagementBanner,
         firstPvConsentBanner,
         breakingNews,
+        signInGate,
         membershipBanner,
         membershipEngagementBanner,
         smartAppBanner,
         adFreeBanner,
         emailSignInBanner,
-        signInGate,
     ];
 
     initBannerPicker(bannerList);

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -11,7 +11,7 @@ import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xa
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 import { permutiveTest } from 'common/modules/experiments/tests/commercial-permutive';
-import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-gate-first-test';
+import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contribs-banner-us-eoy';
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
@@ -24,7 +24,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     appnexusUSAdapter,
     pangaeaAdapterTest,
     permutiveTest,
-    signInGateFirstTest,
+    signInGatePrius,
     commercialCmpUiNoOverlay,
     commercialConsentOptionsButton,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -1,12 +1,12 @@
 // @flow
-export const signInGateFirstTest: ABTest = {
-    id: 'SignInGateFirstTest',
-    start: '2019-10-18',
+export const signInGatePrius: ABTest = {
+    id: 'SignInGatePrius',
+    start: '2019-12-02',
     expiry: '2019-12-17',
-    author: 'Mahesh Makani, Domoinic Kendrick',
+    author: 'Mahesh Makani, Dominic Kendrick',
     description:
-        'Test adding a sign in component on the 2nd pageview of simple article templates',
-    audience: 0.04,
+        'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic.',
+    audience: 0.01,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -11,7 +11,7 @@ import {
     isInABTestSynchronous,
     getAsyncTestsToRun,
 } from 'common/modules/experiments/ab';
-import { signInGateFirstTest } from 'common/modules/experiments/tests/sign-in-gate-first-test';
+import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { constructQuery } from 'lib/url';
 
@@ -128,7 +128,7 @@ const isInvalidSection = (): boolean => {
 const getVariant: () => string = () => {
     //  get the current test
     const currentTest = getSynchronousTestsToRun().find(
-        t => t.id === signInGateFirstTest.id
+        t => t.id === signInGatePrius.id
     );
 
     // get variant user is in for the test
@@ -141,13 +141,13 @@ const canShow: () => Promise<boolean> = async () => {
 
     return Promise.resolve(
         // is in sign in gate ab test
-        isInABTestSynchronous(signInGateFirstTest) &&
+        isInABTestSynchronous(signInGatePrius) &&
             // check if user already dismissed gate
-            !hasUserDismissedGate(signInGateFirstTest.id, variant) &&
+            !hasUserDismissedGate(signInGatePrius.id, variant) &&
             // check number of page views
             isSecondPageOrHigherPageView() &&
             // check for epics and banners, returns empty array if none shown
-            !(await getAsyncTestsToRun()).length &&
+            // !(await getAsyncTestsToRun()).length &&
             // check if user is not logged by checking for cookie
             !isUserLoggedIn() &&
             // check if article type is valid
@@ -166,7 +166,7 @@ const show: () => Promise<boolean> = () => {
     if (variant) {
         // object helper to determine the ab test
         const abTest = {
-            name: signInGateFirstTest.id,
+            name: signInGatePrius.id,
             variant,
         };
 
@@ -179,7 +179,7 @@ const show: () => Promise<boolean> = () => {
         const queryParams: ComponentEventParams = {
             componentType: 'signingate',
             componentId: component.id,
-            abTestName: signInGateFirstTest.id,
+            abTestName: signInGatePrius.id,
             abTestVariant: variant,
         };
 
@@ -306,10 +306,7 @@ const show: () => Promise<boolean> = () => {
                             shadowArticleBody.replaceWith(currentContent);
 
                             // user pref dismissed gate
-                            setUserDismissedGate(
-                                signInGateFirstTest.id,
-                                variant
-                            );
+                            setUserDismissedGate(signInGatePrius.id, variant);
                         }
                     );
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -42,7 +42,7 @@ const componentName = 'sign-in-gate';
 
 const component = {
     componentType: 'SIGN_IN_GATE',
-    id: 'initial_test',
+    id: 'prius_test',
 };
 
 // ophan helper methods

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -9,7 +9,7 @@ import { getCookie } from 'lib/cookies';
 import {
     getSynchronousTestsToRun,
     isInABTestSynchronous,
-    getAsyncTestsToRun,
+    // getAsyncTestsToRun,
 } from 'common/modules/experiments/ab';
 import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { isUserLoggedIn } from 'common/modules/identity/api';

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -9,7 +9,6 @@ import { getCookie } from 'lib/cookies';
 import {
     getSynchronousTestsToRun,
     isInABTestSynchronous,
-    // getAsyncTestsToRun,
 } from 'common/modules/experiments/ab';
 import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { isUserLoggedIn } from 'common/modules/identity/api';
@@ -146,8 +145,6 @@ const canShow: () => Promise<boolean> = async () => {
             !hasUserDismissedGate(signInGatePrius.id, variant) &&
             // check number of page views
             isSecondPageOrHigherPageView() &&
-            // check for epics and banners, returns empty array if none shown
-            // !(await getAsyncTestsToRun()).length &&
             // check if user is not logged by checking for cookie
             !isUserLoggedIn() &&
             // check if article type is valid

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -91,7 +91,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGatePriusTest-variant': Date.now(),
+                'SignInGatePrius-variant': Date.now(),
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -45,8 +45,8 @@ const fakeIsInABTestSynchronous: any = require('common/modules/experiments/ab')
 
 const fakeLocal: any = require('lib/storage').local;
 
-const fakeGetAsyncTestsToRun: any = require('common/modules/experiments/ab')
-    .getAsyncTestsToRun;
+// const fakeGetAsyncTestsToRun: any = require('common/modules/experiments/ab')
+//     .getAsyncTestsToRun;
 
 const fakeIsUserLoggedIn: any = require('common/modules/identity/api')
     .isUserLoggedIn;
@@ -98,14 +98,14 @@ describe('Sign in gate test', () => {
             });
         });
 
-        it('should return false if there are any epics or banners (through getAsyncTestsToRun length', () => {
-            fakeGetAsyncTestsToRun.mockReturnValueOnce(
-                Promise.resolve(['test'])
-            );
-            return signInGate.canShow().then(show => {
-                expect(show).toBe(false);
-            });
-        });
+        // it('should return false if there are any epics or banners (through getAsyncTestsToRun length', () => {
+        //     fakeGetAsyncTestsToRun.mockReturnValueOnce(
+        //         Promise.resolve(['test'])
+        //     );
+        //     return signInGate.canShow().then(show => {
+        //         expect(show).toBe(false);
+        //     });
+        // });
 
         it('should return false if the user is logged in', () => {
             fakeIsUserLoggedIn.mockReturnValueOnce(true);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -45,9 +45,6 @@ const fakeIsInABTestSynchronous: any = require('common/modules/experiments/ab')
 
 const fakeLocal: any = require('lib/storage').local;
 
-// const fakeGetAsyncTestsToRun: any = require('common/modules/experiments/ab')
-//     .getAsyncTestsToRun;
-
 const fakeIsUserLoggedIn: any = require('common/modules/identity/api')
     .isUserLoggedIn;
 
@@ -97,15 +94,6 @@ describe('Sign in gate test', () => {
                 'SignInGatePriusTest-variant': Date.now(),
             });
         });
-
-        // it('should return false if there are any epics or banners (through getAsyncTestsToRun length', () => {
-        //     fakeGetAsyncTestsToRun.mockReturnValueOnce(
-        //         Promise.resolve(['test'])
-        //     );
-        //     return signInGate.canShow().then(show => {
-        //         expect(show).toBe(false);
-        //     });
-        // });
 
         it('should return false if the user is logged in', () => {
             fakeIsUserLoggedIn.mockReturnValueOnce(true);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -94,7 +94,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGateFirstTest-variant': Date.now(),
+                'SignInGatePriusTest-variant': Date.now(),
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -10,7 +10,7 @@ jest.mock('common/modules/experiments/ab', () => ({
     getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
     getSynchronousTestsToRun: jest.fn(() => [
         {
-            id: 'SignInGateFirstTest',
+            id: 'SignInGatePrius',
             variantToRun: {
                 id: 'variant',
             },


### PR DESCRIPTION
## What does this change?

This PR removes the old sign in gate test, and replaces it with a new one with some changes, to help us get more deterministic results.

1. We've increased the priority of the sign in gate in banner list, to be just below consents and breaking news.
2. Removed the check for epics and banners (`getAsyncTestsToRun`) from the sign in gate `canShow` method, which will help show the component on an increased number of pageviews.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

This is the component in context of an article
![Group 27](https://user-images.githubusercontent.com/1289259/69141047-c21c0600-0abb-11ea-9b30-df992b070b53.png)
This is a different tone
![Group 28](https://user-images.githubusercontent.com/1289259/69142326-774fbd80-0abe-11ea-85bf-0c714913025f.png)
This is also a different tone !
![Group 24](https://user-images.githubusercontent.com/1289259/69142327-774fbd80-0abe-11ea-9b91-00841f013f57.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
