### PR TITLE
Ds hide sign in link

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -40,7 +40,11 @@ const subscriptionBannerTemplate = (
             </div>
         </div>
 
-        <div class="site-message--subscription-banner__sign-in ${userLoggedIn ? 'site-message--subscription-banner__sign-in--visibility--hidden' : ''}">
+        <div class="site-message--subscription-banner__sign-in ${
+            userLoggedIn
+                ? 'site-message--subscription-banner__sign-in--visibility-hidden'
+                : ''
+        }">
             <p>Already a subscriber?</p>
             <br class="temp-mobile-break" />
             <a

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -7,7 +7,8 @@ import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-c
 
 const subscriptionBannerTemplate = (
     subscriptionUrl: string,
-    signInUrl: string
+    signInUrl: string,
+    userLoggedIn: boolean
 ): string => `
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
@@ -39,7 +40,7 @@ const subscriptionBannerTemplate = (
             </div>
         </div>
 
-        <div class="site-message--subscription-banner__sign-in">
+        <div class="site-message--subscription-banner__sign-in ${userLoggedIn ? 'site-message--subscription-banner__sign-in--visibility--hidden' : ''}">
             <p>Already a subscriber?</p>
             <br class="temp-mobile-break" />
             <a
@@ -86,7 +87,8 @@ const consentSection = `<div id="js-first-pv-consent-site-message" class="site-m
 const bannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
-    showConsent: boolean
+    showConsent: boolean,
+    userLoggedIn: boolean
 ): string =>
     `<div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner subscription-banner--holder"
           tabindex="-1"
@@ -97,7 +99,7 @@ const bannerTemplate = (
           aria-live="polite"
         >
 
-        ${subscriptionBannerTemplate(subscriptionUrl, signInUrl)}
+        ${subscriptionBannerTemplate(subscriptionUrl, signInUrl, userLoggedIn)}
         ${showConsent ? consentSection : ''}
     </div>
     `;

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -25,6 +25,7 @@ import { bannerTemplate } from 'common/modules/ui/subscription-banner-template';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 
 // types
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
@@ -189,7 +190,7 @@ const show: () => Promise<boolean> = async () => {
     if (document.body) {
         document.body.insertAdjacentHTML(
             'beforeend',
-            bannerTemplate(subscriptionUrl, signInUrl, showConsent)
+            bannerTemplate(subscriptionUrl, signInUrl, showConsent,  isUserLoggedIn())
         );
     }
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -190,7 +190,12 @@ const show: () => Promise<boolean> = async () => {
     if (document.body) {
         document.body.insertAdjacentHTML(
             'beforeend',
-            bannerTemplate(subscriptionUrl, signInUrl, showConsent,  isUserLoggedIn())
+            bannerTemplate(
+                subscriptionUrl,
+                signInUrl,
+                showConsent,
+                isUserLoggedIn()
+            )
         );
     }
 

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -329,6 +329,10 @@
     }
 }
 
+.site-message--subscription-banner__sign-in--visibility--hidden {
+    visibility: hidden;
+}
+
 /*********************** footer hacks *********************/
 
 .subscription-banner--holder


### PR DESCRIPTION
## What does this change?
This removes the sign in link from the subs banner when a reader is signed

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
- Before
![Screen Shot 2019-12-03 at 10 51 04](https://user-images.githubusercontent.com/45875444/70045330-d5e76200-15bb-11ea-9de2-e7a62c36b0b9.png)

- After
![Screen Shot 2019-12-03 at 10 57 50](https://user-images.githubusercontent.com/45875444/70045374-e7306e80-15bb-11ea-8f14-a9cdc3c38d6f.png)

## What is the value of this and can you measure success?
N/A

## Checklist
- sign-in link is hidden when readers sign in 

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
