### PR TITLE
changes to the table dividers to show the teams which progress to the…

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -100,7 +100,7 @@ object CompetitionsProvider {
 
     Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(4, 5, 17)),
     Competition("625", "/football/bundesligafootball", "Bundesliga", "Bundesliga", "European", showInTeamsList = true, tableDividers = List(3, 4, 6, 15, 16)),
-    Competition("635", "/football/serieafootball", "Serie A", "Serie A", "European", showInTeamsList = true, tableDividers = List(3, 5, 17)),
+    Competition("635", "/football/serieafootball", "Serie A", "Serie A", "European", showInTeamsList = true, tableDividers = List(4, 6, 17)),
     Competition("650", "/football/laligafootball", "La Liga", "La Liga", "European", showInTeamsList = true, tableDividers = List(4, 6, 17)),
     Competition("620", "/football/ligue1football", "Ligue 1", "Ligue 1", "European", showInTeamsList = true, tableDividers = List(3, 4, 17)),
     Competition("961", "/football/womens-super-league", "Women's Super League",  "Women's Super League", "English"),


### PR DESCRIPTION
Before:
![Screen Shot 2019-12-03 at 14 52 27](https://user-images.githubusercontent.com/2051501/70062041-3f2b9d00-15dd-11ea-9812-63b98df82eb0.png)

After:
![Screen Shot 2019-12-03 at 14 52 11](https://user-images.githubusercontent.com/2051501/70062040-3e930680-15dd-11ea-8e26-f6c6aebd01c3.png)

## What does this change?

Moving the table dividers down to show that four Italian teams qualify for the Champions League, instead of three.
