### PR TITLE
Bump Sign In Gate Prius Test to 1.5%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGatePrius: ABTest = {
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic.',
-    audience: 0.01,
+    audience: 0.015,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
Increase the audience of the sign in gate to 1.5% of users which will allow us to reach our targeted number of users per day (approx 25,000).