### PR TITLE
Prebid on interactive adslots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -4,7 +4,7 @@ import config from 'lib/config';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { bids } from 'commercial/modules/prebid/bid-config';
-import { slots } from 'commercial/modules/prebid/slot-config';
+import { getPrebidAdSlots } from 'commercial/modules/prebid/slot-config';
 import { priceGranularity } from 'commercial/modules/prebid/price-config';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import type {
@@ -237,8 +237,9 @@ const requestBids = (
         return requestQueue;
     }
 
-    const adUnits: Array<PrebidAdUnit> = slots(
-        advert.id,
+    console.log('Looking for prebid slot for advert = ', advert);
+    const adUnits: Array<PrebidAdUnit> = getPrebidAdSlots(
+        advert,
         config.get('page.contentType', '')
     )
         .map(effectiveSlotFlatMap)

--- a/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/prebid.js
@@ -237,7 +237,6 @@ const requestBids = (
         return requestQueue;
     }
 
-    console.log('Looking for prebid slot for advert = ', advert);
     const adUnits: Array<PrebidAdUnit> = getPrebidAdSlots(
         advert,
         config.get('page.contentType', '')

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -16,9 +16,14 @@ const filterByAdvert = (
     ad: Advert,
     slots: Array<PrebidSlot>
 ): Array<PrebidSlot> => {
-    console.log('Filtering by ', ad, slots);
     const adUnits = slots.filter(slot =>
-        stripTrailingNumbersAbove1(stripMobileSuffix(ad.id)).endsWith(slot.key)
+        slot.key === 'banner' // Special case for interactive banner slots
+            ? // as they are currently incorrectly identified.
+              !!ad.id.match(/^dfp-ad--\d+/) &&
+              ad.node.classList.contains('ad-slot--banner-ad-desktop')
+            : stripTrailingNumbersAbove1(stripMobileSuffix(ad.id)).endsWith(
+                  slot.key
+              )
     );
     return adUnits;
 };
@@ -60,6 +65,8 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
             key: 'comments',
             sizes: [[160, 600], [300, 250], [300, 600]],
         },
+        // Banner slots appear on interactives, like on
+        // https://www.theguardian.com/us-news/ng-interactive/2018/nov/06/midterm-elections-2018-live-results-latest-winners-and-seats
         {
             key: 'banner',
             sizes: [[88, 70], [728, 90], [940, 230], [900, 250], [970, 250]],

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.js
@@ -1,4 +1,6 @@
 // @flow strict
+import { Advert } from 'commercial/modules/dfp/Advert';
+
 import {
     getBreakpointKey,
     stripMobileSuffix,
@@ -10,14 +12,13 @@ import config from 'lib/config';
 
 import type { PrebidSlot } from 'commercial/modules/prebid/types';
 
-const filterByAdvertId = (
-    advertId: string,
+const filterByAdvert = (
+    ad: Advert,
     slots: Array<PrebidSlot>
 ): Array<PrebidSlot> => {
+    console.log('Filtering by ', ad, slots);
     const adUnits = slots.filter(slot =>
-        stripTrailingNumbersAbove1(stripMobileSuffix(advertId)).endsWith(
-            slot.key
-        )
+        stripTrailingNumbersAbove1(stripMobileSuffix(ad.id)).endsWith(slot.key)
     );
     return adUnits;
 };
@@ -58,6 +59,10 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
         {
             key: 'comments',
             sizes: [[160, 600], [300, 250], [300, 600]],
+        },
+        {
+            key: 'banner',
+            sizes: [[88, 70], [728, 90], [940, 230], [900, 250], [970, 250]],
         },
     ];
 
@@ -111,7 +116,9 @@ const getSlots = (contentType: string): Array<PrebidSlot> => {
     }
 };
 
-export const slots = (advertId: string, contentType: string) =>
-    filterByAdvertId(advertId, getSlots(contentType));
+export const getPrebidAdSlots = (
+    ad: Advert,
+    contentType: string
+): Array<PrebidSlot> => filterByAdvert(ad, getSlots(contentType));
 
 export const _ = { getSlots };

--- a/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/slot-config.spec.js
@@ -69,7 +69,6 @@ window.googletag = {
 const buildAdvert = id => {
     const elt = document.createElement('div');
     elt.setAttribute('id', id);
-    // slot.setAttribute('data-name', 'top-above-nav');
     return new Advert(elt);
 };
 
@@ -219,6 +218,21 @@ describe('getPrebidAdSlots', () => {
         ]);
     });
 
+    test('should return the correct interactive banner slot at breakpoint D', () => {
+        getBreakpointKey.mockReturnValue('D');
+        const dfpAdvert = buildAdvert('dfp-ad--1');
+        dfpAdvert.node.setAttribute(
+            'class',
+            'js-ad-slot ad-slot ad-slot--banner-ad ad-slot--banner-ad-desktop ad-slot--rendered'
+        );
+
+        const slotReturned = getPrebidAdSlots(dfpAdvert, '')[0];
+        expect(slotReturned).toBeDefined();
+        expect(slotReturned).toMatchObject({
+            key: 'banner',
+        });
+    });
+
     test('should return the correct top-above-nav slot at breakpoint T', () => {
         getBreakpointKey.mockReturnValue('T');
         expect(getPrebidAdSlots(buildAdvert('top-above-nav'), '')).toEqual([
@@ -243,7 +257,9 @@ describe('getPrebidAdSlots', () => {
         getBreakpointKey.mockReturnValue('M');
         config.set('switches.mobileStickyPrebid', true);
         shouldIncludeMobileSticky.mockReturnValue(true);
-        expect(getPrebidAdSlots(buildAdvert('mobile-sticky'), '')).toEqual([
+        expect(
+            getPrebidAdSlots(buildAdvert('dfp-ad-mobile-sticky'), '')
+        ).toEqual([
             {
                 key: 'mobile-sticky',
                 sizes: [[320, 50]],

--- a/static/src/javascripts/projects/commercial/modules/prebid/types.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/types.js
@@ -75,7 +75,8 @@ export type PrebidSlot = {
         | 'inline'
         | 'mostpop'
         | 'comments'
-        | 'mobile-sticky',
+        | 'mobile-sticky'
+        | 'banner',
     sizes: PrebidSize[],
 };
 

--- a/static/src/javascripts/projects/commercial/modules/prebid/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/prebid/utils.js
@@ -12,8 +12,19 @@ import type { PrebidSize } from './types';
 const isInAppnexusUSAdapterTestVariant = (): boolean =>
     isInVariantSynchronous(appnexusUSAdapter, 'variant');
 
+const SUFFIX_REGEXPS = {};
 const stripSuffix = (s: string, suffix: string): string => {
-    const re = new RegExp(`${suffix}$`);
+    const re =
+        SUFFIX_REGEXPS[suffix] ||
+        (SUFFIX_REGEXPS[suffix] = new RegExp(`${suffix}$`));
+    return s.replace(re, '');
+};
+
+const PREFIX_REGEXPS = {};
+const stripPrefix = (s: string, prefix: string): string => {
+    const re =
+        PREFIX_REGEXPS[prefix] ||
+        (PREFIX_REGEXPS[prefix] = new RegExp(`^${prefix}`));
     return s.replace(re, '');
 };
 
@@ -21,11 +32,6 @@ const currentGeoLocation = once((): string => geolocationGetSync());
 
 const contains = (sizes: PrebidSize[], size: PrebidSize): boolean =>
     Boolean(sizes.find(s => s[0] === size[0] && s[1] === size[1]));
-
-const stripPrefix = (s: string, prefix: string): string => {
-    const re = new RegExp(`^${prefix}`);
-    return s.replace(re, '');
-};
 
 export const removeFalseyValues = (o: {
     [string]: string,
@@ -151,7 +157,7 @@ export const shouldIncludeMobileSticky = once(
 );
 
 export const stripMobileSuffix = (s: string): string =>
-    stripSuffix(s, '--mobile');
+    stripSuffix(stripSuffix(s, '--mobile'), 'Mobile');
 
 export const stripTrailingNumbersAbove1 = (s: string): string =>
     stripSuffix(s, '([2-9]|\\d{2,})');


### PR DESCRIPTION
## What does this change?

1) Makes sure prebid will work on the current interactive adslots, like in this page:

https://www.theguardian.com/us-news/ng-interactive/2018/nov/06/midterm-elections-2018-live-results-latest-winners-and-seats?pbjs_debug=true

2) Makes sure prebid will also work on new interactive adslots with the correct ID scheme. Live example to be provided by interactive team at some point.

See https://trello.com/c/LGEX3wOM/604-add-prebid-to-banners-on-interactive-pages

It does 1) that by:

- Introducing a mechanism to make matching prebid slots to their GoogleTag equivalent more flexible

- Using this mechanism to match the current interactive banner slots.

- Adapting the suffix cleaning to the interactive adslot ID scheme.

It does 2) by:

- Adding to the standard prebid data structure.