### PR TITLE
Use headline as webTitle is defunct

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -53,7 +53,7 @@ object OnwardCollection {
     trails.take(10).map(content =>
       OnwardItem(
         url = LinkTo(content.header.url),
-        linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.properties.webTitle)).body,
+        linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.header.headline)).body,
         showByline = content.properties.showByline,
         byline = content.properties.byline,
         image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),


### PR DESCRIPTION
Minor change to use headline for onwards DCR model rather than the incorrect webtitle field.