### PR TITLE
Article count banner update: one month to two months

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -66,7 +66,7 @@ export const articlesViewedBanner: AcquisitionsABTest = {
             id: 'variant',
             test: (): void => {},
             engagementBannerParams: {
-                leadSentence: `You’ve read ${articleViewCount} Guardian articles in the last two months – if you’ve enjoyed reading, we hope you will consider supporting us today.`,
+                leadSentence: `You’ve read ${articleViewCount} Guardian articles in the last two months – so we hope you will consider supporting us today.`,
                 messageText,
                 ctaText,
                 template: acquisitionsBannerControlTemplate,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -9,9 +9,9 @@ import {
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
 
-// User must have read at least 5 articles in last 30 days
+// User must have read at least 5 articles in last 60 days
 const minArticleViews = 5;
-const articleCountDays = 30;
+const articleCountDays = 60;
 
 const articleViewCount = getArticleViewCountForDays(articleCountDays);
 
@@ -66,7 +66,7 @@ export const articlesViewedBanner: AcquisitionsABTest = {
             id: 'variant',
             test: (): void => {},
             engagementBannerParams: {
-                leadSentence: `You’ve read ${articleViewCount} Guardian articles in the last month – if you’ve enjoyed reading, we hope you will consider supporting us today.`,
+                leadSentence: `You’ve read ${articleViewCount} Guardian articles in the last two months – if you’ve enjoyed reading, we hope you will consider supporting us today.`,
                 messageText,
                 ctaText,
                 template: acquisitionsBannerControlTemplate,


### PR DESCRIPTION
## What does this change?
Updated the article count banner from to display one month to two months worth of articles.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="1292" alt="article count banner" src="https://user-images.githubusercontent.com/3300789/70251186-f60f5080-1776-11ea-86d8-5f6689c6ef60.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
