### PR TITLE
Add new headline styles for the dynamo (dynamic/package aka story package) container

### DIFF
--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -24,6 +24,7 @@ case class ItemClasses(mobile: CardType, tablet: CardType, desktop: Option[CardT
   def showYouTubeMediaAtomPlayer: Boolean = allTypes.exists(_.youTubeMediaAtomPlayer.show)
   def showCutOut: Boolean = allTypes.exists(_.showCutOut)
   def canShowSlideshow: Boolean = allTypes.exists(_.canShowSlideshow)
+  def allowsHeadlineAbove: Boolean = allTypes.exists(_.allowsHeadlineAbove)
 }
 case class SliceLayout(cssClassName: String, columns: Seq[Column]) {
   def numItems: Int = columns.map(_.numItems).sum

--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -24,7 +24,7 @@ case class ItemClasses(mobile: CardType, tablet: CardType, desktop: Option[CardT
   def showYouTubeMediaAtomPlayer: Boolean = allTypes.exists(_.youTubeMediaAtomPlayer.show)
   def showCutOut: Boolean = allTypes.exists(_.showCutOut)
   def canShowSlideshow: Boolean = allTypes.exists(_.canShowSlideshow)
-  def allowsHeadlineAbove: Boolean = allTypes.exists(_.allowsHeadlineAbove)
+  def canBeDynamicLayout: Boolean = allTypes.exists(_.canBeDynamicLayout)
 }
 case class SliceLayout(cssClassName: String, columns: Seq[Column]) {
   def numItems: Int = columns.map(_.numItems).sum

--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -48,7 +48,8 @@ sealed trait CardType {
     case _ => false
   }
 
-  def allowsHeadlineAbove: Boolean = this match {
+  /** This is only currently used in the dynamoContentCard.scala.html **/
+  def canBeDynamicLayout: Boolean = this match {
     case FullMedia100 => true
     case _ => false
   }

--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -50,7 +50,7 @@ sealed trait CardType {
 
   /** This is only currently used in the dynamoContentCard.scala.html **/
   def canBeDynamicLayout: Boolean = this match {
-    case FullMedia100 => true
+    case FullMedia100 | FullMedia75 | ThreeQuarters => true
     case _ => false
   }
 }

--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -47,6 +47,11 @@ sealed trait CardType {
     case Half | ThreeQuarters | ThreeQuartersRight | ThreeQuartersTall | FullMedia50 | FullMedia75 | FullMedia100 => true
     case _ => false
   }
+
+  def allowsHeadlineAbove: Boolean = this match {
+    case FullMedia100 => true
+    case _ => false
+  }
 }
 
 /** This is called ListItem because List is already taken */

--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -14,6 +14,7 @@ object DynamicPackage extends DynamicContainer {
     }
   }
 
+
   override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
     storiesIncludingBackfill.length match {
       case 0 => Nil

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -92,14 +92,12 @@ data-test-id="facia-card"
 
 @container(item: layout.ContentCard) = {
     <div class="fc-item__container">
-        @if(item.cardTypes.allowsHeadlineAbove) {
-            <div class="fc-item__content">
-                <div class="fc-item__header">
-                    @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
-                </div>
-            </div>
-        }
 
+        <div class="fc-item__content fc-item__content--above">
+            <div class="fc-item__header">
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+            </div>
+        </div>
 
         @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, fallback)) if item.cardTypes.showVideoPlayer => {
@@ -206,14 +204,13 @@ data-test-id="facia-card"
             case _ => {}
         }
 
-        <div class="fc-item__content @if(item.starRating.isDefined){fc-item__content--has-stars}">
+        <div class="fc-item__content fc-item__content--below @if(item.starRating.isDefined){fc-item__content--has-stars}">
             <div class="@RenderClasses(Map(
                 ("fc-item__header", true),
                 ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
             ))">
-                @if(!item.cardTypes.allowsHeadlineAbove) {
-                    @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
-                }
+
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
 
                 @item.bylineText.map { byline =>
                     <div class="fc-item__byline">@byline</div>

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -92,6 +92,15 @@ data-test-id="facia-card"
 
 @container(item: layout.ContentCard) = {
     <div class="fc-item__container">
+        @if(item.cardTypes.allowsHeadlineAbove) {
+            <div class="fc-item__content">
+                <div class="fc-item__header">
+                    @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                </div>
+            </div>
+        }
+
+
         @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
@@ -202,7 +211,9 @@ data-test-id="facia-card"
                 ("fc-item__header", true),
                 ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
             ))">
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                @if(!item.cardTypes.allowsHeadlineAbove) {
+                    @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+                }
 
                 @item.bylineText.map { byline =>
                     <div class="fc-item__byline">@byline</div>

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -39,7 +39,7 @@ object GetClasses {
       ("fc-item--is-commentable", item.discussionSettings.isCommentable),
       ("fc-item--is-media-link", item.isMediaLink),
       ("fc-item--has-video-main-media", item.hasVideoMainMedia),
-      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined && !item.hasVideoMainMedia)
+      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined && !item.isMediaLink)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
     )

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -38,7 +38,8 @@ object GetClasses {
       ("fc-item--has-timestamp", item.timeStampDisplay.isDefined),
       ("fc-item--is-commentable", item.discussionSettings.isCommentable),
       ("fc-item--is-media-link", item.isMediaLink),
-      ("fc-item--has-video-main-media", item.hasVideoMainMedia)
+      ("fc-item--has-video-main-media", item.hasVideoMainMedia),
+      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined && !item.hasVideoMainMedia)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
     )

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -3,8 +3,8 @@
 
 //specific vars for colours for dynamo
 $story-package-container-colour: #e0e4e8;
-$story-package-container-colour: #041f4a;
-$container-title: $story-package-container-colour;
+$story-package-card-colour: #041f4a;
+$container-title: $story-package-card-colour;
 
 @mixin pillar-override($tone, $colour) {
     .fc-item--pillar-#{$tone} {

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -19,8 +19,14 @@ $container-title: $card-colour;
             fill: $colour;
         }
 
+
         .fc-item__container:before {
             background-color: #ffffff;
+        }
+
+        &.fc-item.fc-item--full-media-100-tablet .fc-item__title {
+            background-image: none;
+
         }
     }
 

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -82,6 +82,10 @@ $container-title: $story-package-container-colour;
         padding-left: calc((#{$gs-baseline} / 2) - 2px);
         margin-bottom: $gs-baseline / 2;
 
+        &:after {
+            display: none;
+        }
+
         @include mq($from: desktop) {
             padding-left: 0px;
         }
@@ -137,8 +141,11 @@ $container-title: $story-package-container-colour;
     .fc-item.fc-item--pillar-sport.fc-item--type-comment,
     .fc-item.fc-item--pillar-lifestyle.fc-item--type-comment,
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item.fc-item--type-feature {
-        background-color: $story-package-container-colour;
+    .fc-item.fc-item--type-feature
+    {
+        &:not(.fc-item--dynamic-layout) {
+            background-color: $story-package-card-colour;
+        }
 
         &:hover {
             background-color: darken($story-package-container-colour, 5%);
@@ -203,23 +210,45 @@ $container-title: $story-package-container-colour;
 
     .fc-item--dynamic-layout {
         background-color: $story-package-container-colour;
+        &.fc-item--type-feature {
+            background-color: $story-package-container-colour;
+        }
 
         // The white line above the story
         .fc-item__container:before {
-            width: 25%;
+            display: none; // Remove existing on container
+        }
+
+        .fc-item__content:before {
+            content: '';
+            background-color: #ffffff;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 2;
             height: $gs-baseline / 3;
+            width: calc(100% - 10px);
         }
 
-        .fc-item__content--below .fc-item__header {
-            display: none;
+        .fc-item__content {
+            padding-top: $gs-baseline / 2;
         }
 
-        .fc-item__content--above {
-            display: block;
-            padding-top: $gs-baseline;
+        .fc-item--has-boosted-title {
+            .fc-item__content--below .fc-item__header {
+                display: none;
+            }
+
+            .fc-item__content--above {
+                display: block;
+                padding-top: $gs-baseline;
+            }
         }
 
-        @include mq($until: phablet) {
+
+        @include mq($until: tablet) {
+
             .fc-item__content--below .fc-item__header {
                 display: none;
             }
@@ -227,15 +256,13 @@ $container-title: $story-package-container-colour;
             .fc-item__content--above {
                 display: block;
             }
+
         }
 
         .fc-item__kicker:after {
             display: none;
         }
     }
-
-
-
 
     //These need to exist for all kickers because of tone on tone action
     @include pillar-override(lifestyle, $lifestyle-bright);

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -5,8 +5,9 @@
 $story-package-container-colour: #e0e4e8;
 $story-package-card-colour: #041f4a;
 $container-title: $story-package-card-colour;
+$story-package-dynamic-card-text: $story-package-card-colour;
 
-@mixin pillar-override($tone, $colour) {
+@mixin pillar-override($tone, $colour, $dark-colour) {
     .fc-item--pillar-#{$tone} {
         .fc-item__kicker,
         .rich-link__kicker,
@@ -14,8 +15,17 @@ $container-title: $story-package-card-colour;
             color: $colour;
         }
 
-        .inline-garnett-quote {
-            fill: $colour;
+        &.fc-item--dynamic-layout {
+            .fc-item__kicker,
+            .rich-link__kicker,
+            .fc-item__byline {
+                color: $dark-colour;
+            }
+
+
+            .inline-garnett-quote {
+                fill: $dark-colour;
+            }
         }
 
 
@@ -33,6 +43,14 @@ $container-title: $story-package-card-colour;
         .fc-sublink--pillar-#{$tone} {
             .fc-sublink__kicker {
                 color: $colour;
+            }
+        }
+
+        &.fc-item--dynamic-layout:not(.fc-item--pillar-special-report) {
+            .fc-sublink--pillar-#{$tone} {
+                .fc-sublink__kicker {
+                    color: $dark-colour;
+                }
             }
         }
     }
@@ -111,7 +129,7 @@ $container-title: $story-package-card-colour;
     }
 
     .fc-container__header__description {
-        color: #ffffff;
+        color: $story-package-dynamic-card-text;
     }
 
 
@@ -145,6 +163,10 @@ $container-title: $story-package-card-colour;
     {
         &:not(.fc-item--dynamic-layout) {
             background-color: $story-package-card-colour;
+
+            .fc-item__headline {
+                color: #ffffff;
+            }
         }
 
         &:hover {
@@ -159,9 +181,7 @@ $container-title: $story-package-card-colour;
 
         }
 
-        .fc-item__headline {
-            color: #ffffff;
-        }
+
     }
 
     .fc-item--pillar-news.fc-item--type-comment,
@@ -180,7 +200,7 @@ $container-title: $story-package-card-colour;
     }
 
     .fc-item__container.u-faux-block-link--hover {
-        background-color: darken($special-report-dark, 5%) !important;
+        background-color: darken($story-package-card-colour, 5%);
     }
 
     .fc-item__standfirst {
@@ -191,6 +211,17 @@ $container-title: $story-package-card-colour;
         color: #ffffff;
     }
 
+    &.fc-item--dynamic-layout {
+        .fc-item__standfirst {
+            color: $story-package-dynamic-card-text;
+        }
+
+        .fc-sublink__title {
+            color: $story-package-dynamic-card-text;
+        }
+    }
+
+
     .treats__list-item {
         .treats__treat {
             background-color: $brightness-86;
@@ -200,7 +231,7 @@ $container-title: $story-package-card-colour;
     }
 
     .fc-container__header__title>h2 {
-        color: #ffffff;
+        color: $story-package-dynamic-card-text;
     }
 
     // 'Dynamic Layout'
@@ -219,9 +250,13 @@ $container-title: $story-package-card-colour;
             display: none; // Remove existing on container
         }
 
+        .fc-item__container.u-faux-block-link--hover {
+            background-color: darken($story-package-container-colour, 5%);
+        }
+
         .fc-item__content:before {
             content: '';
-            background-color: #ffffff;
+            background-color: $story-package-dynamic-card-text;
             position: absolute;
             top: 0;
             left: 0;
@@ -262,13 +297,19 @@ $container-title: $story-package-card-colour;
         .fc-item__kicker:after {
             display: none;
         }
+
+        .fc-item__headline,
+        .fc-item__standfirst,
+        .fc-sublink__title {
+            color: $story-package-dynamic-card-text;
+        }
     }
 
     //These need to exist for all kickers because of tone on tone action
-    @include pillar-override(lifestyle, $lifestyle-bright);
-    @include pillar-override(arts, $culture-bright);
-    @include pillar-override(sport, $sport-bright);
-    @include pillar-override(opinion, $opinion-pastel);
-    @include pillar-override(news, $lifestyle-pastel);
-    @include pillar-override(special-report, $highlight-main);
+    @include pillar-override(lifestyle, $lifestyle-bright, $lifestyle-dark);
+    @include pillar-override(arts, $culture-bright, $culture-dark);
+    @include pillar-override(sport, $sport-bright, $sport-dark);
+    @include pillar-override(opinion, $opinion-pastel, $opinion-dark);
+    @include pillar-override(news, $lifestyle-pastel, $news-dark);
+    @include pillar-override(special-report, $highlight-main, $highlight-dark);
 }

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -2,10 +2,9 @@
 @import '../_mixins';
 
 //specific vars for colours for dynamo
-$dynamo-background: #e0e4e8;
-$card-colour: #041f4a;
-$container-title: $card-colour;
-
+$story-package-container-colour: #e0e4e8;
+$story-package-container-colour: #041f4a;
+$container-title: $story-package-container-colour;
 
 @mixin pillar-override($tone, $colour) {
     .fc-item--pillar-#{$tone} {
@@ -40,7 +39,8 @@ $container-title: $card-colour;
 }
 
 .fc-container--story-package {
-    background-color: $dynamo-background;
+
+    background-color: $story-package-container-colour;
 
     .fc-container__body {
         position: relative;
@@ -68,6 +68,7 @@ $container-title: $card-colour;
             border-top: 0;
         }
     }
+
 
     .fc-slice__item + .fc-slice__item:before {
         border-left-color: #929698; // This colour does not exist (in the palette)
@@ -136,19 +137,19 @@ $container-title: $card-colour;
     .fc-item.fc-item--pillar-sport.fc-item--type-comment,
     .fc-item.fc-item--pillar-lifestyle.fc-item--type-comment,
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item.fc-item--type-feature
-    {
-        background-color: $card-colour;
+    .fc-item.fc-item--type-feature {
+        background-color: $story-package-container-colour;
 
         &:hover {
-            background-color: darken($card-colour, 5%);
+            background-color: darken($story-package-container-colour, 5%);
 
             .fc-trail__count--commentcount {
-                background-color: darken($card-colour, 5%);
+                background-color: darken($story-package-container-colour, 5%);
             }
         }
         .fc-trail__count--commentcount {
-            background-color: $card-colour;
+            background-color: $story-package-container-colour;
+
         }
 
         .fc-item__headline {
@@ -191,9 +192,50 @@ $container-title: $card-colour;
         }
     }
 
-    .fc-container--story-package .fc-container__header__title>h2 {
+    .fc-container__header__title>h2 {
         color: #ffffff;
     }
+
+    // 'Dynamic Layout'
+    .fc-item__content--above {
+        display: none;
+    }
+
+    .fc-item--dynamic-layout {
+        background-color: $story-package-container-colour;
+
+        // The white line above the story
+        .fc-item__container:before {
+            width: 25%;
+            height: $gs-baseline / 3;
+        }
+
+        .fc-item__content--below .fc-item__header {
+            display: none;
+        }
+
+        .fc-item__content--above {
+            display: block;
+            padding-top: $gs-baseline;
+        }
+
+        @include mq($until: phablet) {
+            .fc-item__content--below .fc-item__header {
+                display: none;
+            }
+
+            .fc-item__content--above {
+                display: block;
+            }
+        }
+
+        .fc-item__kicker:after {
+            display: none;
+        }
+    }
+
+
+
 
     //These need to exist for all kickers because of tone on tone action
     @include pillar-override(lifestyle, $lifestyle-bright);


### PR DESCRIPTION
## What does this change?

This adds initial 'dynamic layout' styling to allow headlines to be above the image on mobile and different headline styling for some container layouts on desktop.

This PR applies it to layouts `FullMedia100 | FullMedia75 | ThreeQuarters` if not a cut out container and not a media container (work required on video).

See screenshots for changes.

Note, this is the initial PR that then can be applied to layouts as we progress.

- Does this change need to be reproduced in dotcom-rendering? - No

## Screenshots
![Screenshot 2019-12-06 at 11 12 12](https://user-images.githubusercontent.com/638051/70319075-535bde00-1819-11ea-8ed0-9554e746971e.png)
![Screenshot 2019-12-06 at 11 12 15](https://user-images.githubusercontent.com/638051/70319076-53f47480-1819-11ea-9442-a689ac30b4df.png)
![Screenshot 2019-12-06 at 11 12 18](https://user-images.githubusercontent.com/638051/70319078-53f47480-1819-11ea-9dfb-fd7b5552ca8c.png)
![Screenshot 2019-12-06 at 11 12 25](https://user-images.githubusercontent.com/638051/70319079-53f47480-1819-11ea-9034-52dc4365f448.png)


## Checklist

- Does this affect other platforms? - Apps are working on this
- Does this affect GLabs Paid Content Pages? Should it have support for Paid Content? - No
- Does this change break ad-free? - No
- Does this change update the version of CAPI we're using? - No
- Accessibility - No changes that should cause problems with contrast, keyboard focus or screenreaders
- Tested - Locally.