### PR TITLE
Reduce Sentry Sample Size

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -57,7 +57,7 @@ const sentryOptions = {
         const isIgnored =
             typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
         const { enableSentryReporting } = config.get('switches');
-        const isInSample = Math.random() < 0.025; // 2.5%
+        const isInSample = Math.random() < 0.01; // 1%
 
         if (isDev && !isIgnored) {
             // Some environments don't support or don't always expose the console Object


### PR DESCRIPTION
## What does this change?
Reduces Sentry sample size from 2.5% to 1% so we spend less 💰

DCR is currently running at 10% but has substantially less traffic