### PR TITLE
Add new Slice layout and add headline adjustments for three and four count stories

### DIFF
--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -50,7 +50,7 @@ sealed trait CardType {
 
   /** This is only currently used in the dynamoContentCard.scala.html **/
   def canBeDynamicLayout: Boolean = this match {
-    case FullMedia100 | FullMedia75 | ThreeQuarters => true
+    case FullMedia100 | FullMedia75 | ThreeQuarters | ThreeQuartersTall => true
     case _ => false
   }
 }

--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -20,7 +20,7 @@ object DynamicPackage extends DynamicContainer {
       case 1 => Seq(FullMedia75)
       case 2 => Seq(ThreeQuarterQuarter)
       case 3 => Seq(ThreeQuarterTallQuarter2)
-      case 4 => Seq(ThreeQuarterTallQuarter2Ql2)
+      case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
       case 5 => Seq(FullMedia75, QuarterQuarterQuarterQuarter)
       case 6 => Seq(FullMedia75, QuarterQuarterQuarterQl)
       case 7 => Seq(FullMedia75, QuarterQuarterQuarterQl)

--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -14,7 +14,6 @@ object DynamicPackage extends DynamicContainer {
     }
   }
 
-
   override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
     storiesIncludingBackfill.length match {
       case 0 => Nil

--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -608,6 +608,44 @@ case object ThreeQuarterTallQuarter2 extends Slice {
  * |##########################|        |
  * |##########################|        |
  * |##########################|--------|
+ * |                          |        |
+ * |                          |--------|
+ * |                          |        |
+ * `--------------------------'--------'
+ */
+case object ThreeQuarterTallQuarter1Ql2 extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "qqqtall-q1-ql2",
+    columns = Seq(
+      SingleItem(
+        colSpan = 3,
+        ItemClasses(
+          mobile = Standard,
+          tablet = ThreeQuartersTall
+        )
+      ),
+      SplitColumn(
+        colSpan = 1,
+        topItemRows = 1,
+        topItemClasses = ItemClasses(
+          mobile = ListItem,
+          tablet = Standard
+        ),
+        bottomItemRows = 2,
+        bottomItemsClasses = ItemClasses(
+          mobile = ListItem,
+          tablet = ListItem
+        )
+      )
+    )
+  )
+}
+
+/* .__________________________.________.
+ * |##########################|########|
+ * |##########################|        |
+ * |##########################|        |
+ * |##########################|--------|
  * |##########################|########|
  * |##########################|        |
  * |##########################|        |

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -1,7 +1,6 @@
 @import '../_vars';
 @import '../_mixins';
 
-<<<<<<< HEAD
 //specific vars for colours for dynamo
 $story-package-container-colour: #e0e4e8;
 $story-package-card-colour: #041f4a;
@@ -16,6 +15,20 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             color: $colour;
         }
 
+        &.fc-item--type-comment {
+            .fc-item__meta {
+                background-image: none;
+            }
+
+            .fc-item__standfirst-wrapper .fc-item__meta {
+                background-image: none;
+            }
+
+            .fc-item__container.u-faux-block-link--hover {
+                background-color: darken($story-package-card-colour, 5%);
+            }
+        }
+
         &.fc-item--dynamic-layout {
             .fc-item__kicker,
             .rich-link__kicker,
@@ -26,6 +39,10 @@ $story-package-dynamic-card-text: $story-package-card-colour;
 
             .inline-garnett-quote {
                 fill: $dark-colour;
+            }
+
+            .fc-item__container.u-faux-block-link--hover {
+                background-color: darken($story-package-container-colour, 5%);
             }
         }
 
@@ -158,6 +175,11 @@ $story-package-dynamic-card-text: $story-package-card-colour;
     .fc-item.fc-item--type-feature {
         &:not(.fc-item--dynamic-layout) {
             background-color: $story-package-card-colour;
+
+
+            .fc-item__headline {
+                color: #ffffff;
+            }
         }
         
         &:hover {
@@ -173,24 +195,7 @@ $story-package-dynamic-card-text: $story-package-card-colour;
     }
 
 
-    // Comment style overrides
-    .fc-item--pillar-news.fc-item--type-comment,
-    .fc-item--pillar-opinion.fc-item--type-comment,
-    .fc-item--pillar-sport.fc-item--type-comment,
-    .fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item--pillar-lifestyle.fc-item--type-comment {
-        .fc-item__meta {
-            background-image: none;
-        }
 
-        .fc-item__standfirst-wrapper .fc-item__meta {
-            background-image: none;
-        }
-
-        .fc-item__container.u-faux-block-link--hover {
-            background-color: darken($story-package-card-colour, 5%);
-        }
-    }
 
     .fc-item__container.u-faux-block-link--hover {
         background-color: darken($story-package-card-colour, 5%);
@@ -288,19 +293,6 @@ $story-package-dynamic-card-text: $story-package-card-colour;
 
         }
 
-
-        @include mq($until: tablet) {
-
-            .fc-item__content--below .fc-item__header {
-                display: none;
-            }
-
-            .fc-item__content--above {
-                display: block;
-            }
-
-        }
-
         .fc-item__kicker:after {
             display: none;
         }
@@ -309,54 +301,6 @@ $story-package-dynamic-card-text: $story-package-card-colour;
         .fc-item__standfirst,
         .fc-sublink__title {
             color: $story-package-dynamic-card-text;
-        }
-
-        &.fc-item--type-live.fc-item--pillar-news .fc-sublink__link {
-            color: $story-package-dynamic-card-text;
-        }
-    }
-
-    // 'Dynamic Layout'
-    .fc-item__content--above {
-        display: none;
-    }
-
-    .fc-item--dynamic-layout {
-        background-color: $story-package-container-colour;
-        &.fc-item--type-feature {
-            background-color: $story-package-container-colour;
-        }
-
-        // The white line above the story
-        .fc-item__container:before {
-            display: none; // Remove existing on container
-        }
-
-        .fc-item__content:before {
-            content: '';
-            background-color: #ffffff;
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            z-index: 2;
-            height: $gs-baseline / 3;
-            width: calc(100% - 10px);
-        }
-
-        .fc-item__content {
-            padding-top: $gs-baseline / 2;
-        }
-
-        .fc-item--has-boosted-title {
-            .fc-item__content--below .fc-item__header {
-                display: none;
-            }
-
-            .fc-item__content--above {
-                display: block;
-                padding-top: $gs-baseline;
-            }
         }
 
         // ThreeQuarterTall
@@ -369,11 +313,10 @@ $story-package-dynamic-card-text: $story-package-card-colour;
                 display: block;
 
                 &:before {
-                    width: $gs-column-width;
+                    width: 33%;
                 }
             }
         }
-
 
         @include mq($until: tablet) {
 
@@ -385,11 +328,16 @@ $story-package-dynamic-card-text: $story-package-card-colour;
                 display: block;
             }
 
+            &.fc-item--three-quarters-tall-tablet .fc-item__content--above:before {
+                width: 100%;
+            }
+
         }
 
-        .fc-item__kicker:after {
-            display: none;
+        &.fc-item--type-live.fc-item--pillar-news .fc-sublink__link {
+            color: $story-package-dynamic-card-text;
         }
+
     }
     
     //These need to exist for all kickers because of tone on tone action

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -158,12 +158,8 @@ $story-package-dynamic-card-text: $story-package-card-colour;
     .fc-item.fc-item--type-feature {
         &:not(.fc-item--dynamic-layout) {
             background-color: $story-package-card-colour;
-
-            .fc-item__headline {
-                color: #ffffff;
-            }
         }
-
+        
         &:hover {
             background-color: darken($story-package-card-colour, 5%);
 
@@ -327,23 +323,45 @@ $story-package-dynamic-card-text: $story-package-card-colour;
 
     .fc-item--dynamic-layout {
         background-color: $story-package-container-colour;
+        &.fc-item--type-feature {
+            background-color: $story-package-container-colour;
+        }
 
         // The white line above the story
         .fc-item__container:before {
-            width: 25%;
+            display: none; // Remove existing on container
+        }
+
+        .fc-item__content:before {
+            content: '';
+            background-color: #ffffff;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 2;
             height: $gs-baseline / 3;
+            width: calc(100% - 10px);
         }
 
-        .fc-item__content--below .fc-item__header {
-            display: none;
+        .fc-item__content {
+            padding-top: $gs-baseline / 2;
         }
 
-        .fc-item__content--above {
-            display: block;
-            padding-top: $gs-baseline;
+        .fc-item--has-boosted-title {
+            .fc-item__content--below .fc-item__header {
+                display: none;
+            }
+
+            .fc-item__content--above {
+                display: block;
+                padding-top: $gs-baseline;
+            }
         }
 
-        @include mq($until: phablet) {
+
+        @include mq($until: tablet) {
+
             .fc-item__content--below .fc-item__header {
                 display: none;
             }
@@ -351,6 +369,7 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             .fc-item__content--above {
                 display: block;
             }
+
         }
 
         .fc-item__kicker:after {

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -1,6 +1,7 @@
 @import '../_vars';
 @import '../_mixins';
 
+<<<<<<< HEAD
 //specific vars for colours for dynamo
 $story-package-container-colour: #e0e4e8;
 $story-package-card-colour: #041f4a;
@@ -56,7 +57,6 @@ $story-package-dynamic-card-text: $story-package-card-colour;
 }
 
 .fc-container--story-package {
-
     background-color: $story-package-container-colour;
 
     .fc-container__body {
@@ -85,7 +85,6 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             border-top: 0;
         }
     }
-
 
     .fc-slice__item + .fc-slice__item:before {
         border-left-color: #929698; // This colour does not exist (in the palette)
@@ -156,8 +155,7 @@ $story-package-dynamic-card-text: $story-package-card-colour;
     .fc-item.fc-item--pillar-sport.fc-item--type-comment,
     .fc-item.fc-item--pillar-lifestyle.fc-item--type-comment,
     .fc-item.fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item.fc-item--type-feature
-    {
+    .fc-item.fc-item--type-feature {
         &:not(.fc-item--dynamic-layout) {
             background-color: $story-package-card-colour;
 
@@ -175,10 +173,7 @@ $story-package-dynamic-card-text: $story-package-card-colour;
         }
         .fc-trail__count--commentcount {
             background-color: $story-package-card-colour;
-
         }
-
-
     }
 
 
@@ -325,6 +320,44 @@ $story-package-dynamic-card-text: $story-package-card-colour;
         }
     }
 
+    // 'Dynamic Layout'
+    .fc-item__content--above {
+        display: none;
+    }
+
+    .fc-item--dynamic-layout {
+        background-color: $story-package-container-colour;
+
+        // The white line above the story
+        .fc-item__container:before {
+            width: 25%;
+            height: $gs-baseline / 3;
+        }
+
+        .fc-item__content--below .fc-item__header {
+            display: none;
+        }
+
+        .fc-item__content--above {
+            display: block;
+            padding-top: $gs-baseline;
+        }
+
+        @include mq($until: phablet) {
+            .fc-item__content--below .fc-item__header {
+                display: none;
+            }
+
+            .fc-item__content--above {
+                display: block;
+            }
+        }
+
+        .fc-item__kicker:after {
+            display: none;
+        }
+    }
+    
     //These need to exist for all kickers because of tone on tone action
     @include pillar-override(lifestyle, $lifestyle-bright, $lifestyle-dark);
     @include pillar-override(arts, $culture-bright, $culture-dark);

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -359,6 +359,21 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             }
         }
 
+        // ThreeQuarterTall
+        &.fc-item--three-quarters-tall-tablet {
+            .fc-item__content--below {
+                display: none;
+            }
+
+            .fc-item__content--above {
+                display: block;
+
+                &:before {
+                    width: $gs-column-width;
+                }
+            }
+        }
+
 
         @include mq($until: tablet) {
 


### PR DESCRIPTION
## What does this change?

Applies the headline styling to `threeQuarterTall` layout, placing the headline above the image in this context.

Also adds a new slice type `ThreeQuarterTallQuarter1Ql2` to handle 4 count in dynamic container.


## Screenshots

![image](https://user-images.githubusercontent.com/638051/70427731-2ef83f80-1a6d-11ea-8e83-7a76000e055c.png)
![image](https://user-images.githubusercontent.com/638051/70427745-34558a00-1a6d-11ea-9e2d-6e6d17c8a112.png)
![image](https://user-images.githubusercontent.com/638051/70427770-433c3c80-1a6d-11ea-9fff-0745b4a74de8.png)
![image](https://user-images.githubusercontent.com/638051/70427794-4afbe100-1a6d-11ea-9a6f-71ab0fcf0b2e.png)

## Checklist

Does this affect other platforms? - Apps are working on this
Does this affect GLabs Paid Content Pages? Should it have support for Paid Content? - No
Does this change break ad-free? - No
Does this change update the version of CAPI we're using? - No
Accessibility - No changes that should cause problems with contrast, keyboard focus or screenreaders
Tested - Locally.