### PR TITLE
Post-goal ticker tweaks

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-ticker.scss
@@ -128,3 +128,11 @@ $progress-bar-height: 10px;
     color: #ffffff;
     opacity: .7;
 }
+
+.epic-ticker__goal-reached .epic-ticker__goal {
+    display: none;
+
+    @include mq($from: tablet) {
+        display: initial;
+    }
+}

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -240,7 +240,7 @@ $blue-accent: #1a5292;
     .epic-ticker__goal-reached .engagement-banner-ticker__goal {
         display: none;
 
-        @include mq($from: desktop) {
+        @include mq($from: tablet) {
             display: initial;
         }
     }

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-us-eoy.scss
@@ -209,6 +209,11 @@ $blue-accent: #1a5292;
         color: $red-accent;
     }
 
+    .engagement-banner-ticker__goal-marker {
+        height: 20px;
+        margin-top: -10px;
+    }
+
     .js-ticker-so-far .engagement-banner-ticker__count {
         font-size: 28px;
         line-height: 1;
@@ -218,9 +223,26 @@ $blue-accent: #1a5292;
         }
     }
 
+    .epic-ticker__goal-reached .js-ticker-so-far .engagement-banner-ticker__count {
+        font-size: 17px;
+        white-space: nowrap;
+
+        @include mq($from: desktop) {
+            font-size: 28px;
+        }
+    }
+
     .js-ticker-goal .engagement-banner-ticker__count {
         font-size: 17px;
         line-height: 1;
+    }
+
+    .epic-ticker__goal-reached .engagement-banner-ticker__goal {
+        display: none;
+
+        @include mq($from: desktop) {
+            display: initial;
+        }
     }
 
     .engagement-banner-ticker__progress {


### PR DESCRIPTION
### What does this change?
Minor tweaks to make sure the ticker works on the banner and epic after the goal is reached

### Screenshots
Desktop:
![test of ticker image](https://user-images.githubusercontent.com/3300789/70258314-e64a3900-1783-11ea-8114-7a17c8ccc5f5.png)

Mobile:
![test of ticker 2](https://user-images.githubusercontent.com/3300789/70258313-e64a3900-1783-11ea-8b8d-f6d44383fd78.png)

### Tested

- [X] Locally
- [ ] On CODE (optional)
