### PR TITLE
Add ability to force DCR to render an article

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -115,6 +115,11 @@ object ArticlePicker {
     )
   }
 
+  def isInWhitelist(path: String): Boolean = {
+    // our whitelist is only one article at the moment
+    path == "/info/2019/dec/08/migrating-to-react";
+  }
+
   def dcrCouldRender(page: PageWithStoryPackage, request: RequestHeader): Boolean = {
     val whitelistFeatures = featureWhitelist(page, request)
     val isSupported = whitelistFeatures.forall({ case (test, isMet) => isMet})
@@ -126,10 +131,8 @@ object ArticlePicker {
     // dcrShouldRender provides an override to let us force rendering by DCR even
     // when an article is not supportted
     val forceDCR = request.forceDCR
-    // our whitelist is only one article at the moment
-    val isInWhitelist = request.path == "/info/2019/dec/08/migrating-to-react"
 
-    forceDCR || isInWhitelist
+    forceDCR || isInWhitelist(request.path)
   }
 
   def dcrShouldNotRender(request: RequestHeader): Boolean = {

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -144,18 +144,13 @@ object ArticlePicker {
     val userIsInCohort = ActiveExperiments.isParticipating(DotcomRenderingAdvertisements)
 
     // Decide if we should render this request with the DCR platform or not
-    // RemoteRender means DCR
     val tier = if (dcrShouldNotRender(request)) {
-      // DCR is not turned on or dcr=false was passed
       LocalRenderArticle
     } else if (dcrShouldRender(request)) {
-      // DCR is on and either dcr=true was passed or this article is in the whitelist
       RemoteRender
     } else if (dcrCouldRender(page, request) && userIsInCohort) {
-      // The page is supported by DCR AND the user is part of the DCR test group
       RemoteRender
     } else {
-      // The page was not supported by DCR or the user was not part of the test
       LocalRenderArticle
     }
 


### PR DESCRIPTION
## What does this change?
Added `dcrShouldRender` function to let us force DCR when desired

This is an override to the normal logic that decides when DCR could render and then if it should. 

## Why?
Specifically, it is being used here to force DCR on the pending digital blog post https://www.theguardian.com/info/2019/dec/08/migrating-to-react (not yet published), but has benefit in general by giving us more flexibility and control. For example, ee could extend this function to implement a whitelist.
