### PR TITLE
Fix hover state ovverride for comment type

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -184,18 +184,23 @@ $story-package-dynamic-card-text: $story-package-card-colour;
 
     }
 
+
+    // Comment style overrides
     .fc-item--pillar-news.fc-item--type-comment,
     .fc-item--pillar-opinion.fc-item--type-comment,
     .fc-item--pillar-sport.fc-item--type-comment,
     .fc-item--pillar-arts.fc-item--type-comment,
-    .fc-item--pillar-lifestyle.fc-item--type-comment
-    {
+    .fc-item--pillar-lifestyle.fc-item--type-comment {
         .fc-item__meta {
             background-image: none;
         }
 
         .fc-item__standfirst-wrapper .fc-item__meta {
             background-image: none;
+        }
+
+        .fc-item__container.u-faux-block-link--hover {
+            background-color: darken($story-package-card-colour, 5%);
         }
     }
 


### PR DESCRIPTION
## What does this change?

Fixes a bug previous to this work with the comment type hover style.

### Hover state before
![Screenshot 2019-12-06 at 13 09 09](https://user-images.githubusercontent.com/638051/70325850-e18c9000-182a-11ea-93c4-b038f4d96a65.png)

### Hover state after

![Screenshot 2019-12-06 at 13 09 46](https://user-images.githubusercontent.com/638051/70325852-e3eeea00-182a-11ea-88e5-6ca31423be8f.png)

