### PR TITLE
Prevent subs and membership banners from appearing on identity pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -95,6 +95,13 @@ const clearBannerHistory = (): void => {
     userPrefs.remove(lastClosedAtKey);
 };
 
+const pageIsIdentity = (): boolean => {
+    const isIdentityPage =
+        config.get('page.contentType') === 'Identity' ||
+        config.get('page.section') === 'identity';
+    return isIdentityPage;
+};
+
 const bannerParamsToHtml = (params: EngagementBannerParams): string => {
     const messageText = Array.isArray(params.messageText)
         ? selectSequentiallyFrom(params.messageText)
@@ -209,7 +216,11 @@ const show = (): Promise<boolean> =>
         });
 
 const canShow = (): Promise<boolean> => {
-    if (!config.get('switches.membershipEngagementBanner') || isBlocked()) {
+    if (
+        !config.get('switches.membershipEngagementBanner') ||
+        isBlocked() ||
+        pageIsIdentity()
+    ) {
         return Promise.resolve(false);
     }
     return getBannerParams().then(params => {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -75,6 +75,13 @@ const subcriptionBannerCloseActions = (): void => {
     closedAt(SUBSCRIPTION_BANNER_CLOSED_KEY);
 };
 
+const pageIsIdentity = (): boolean => {
+    const isIdentityPage =
+        config.get('page.contentType') === 'Identity' ||
+        config.get('page.section') === 'identity';
+    return isIdentityPage;
+};
+
 const onAgree = (): void => {
     allAdConsents.forEach(_ => {
         setAdConsentState(_, true);
@@ -217,7 +224,8 @@ const canShow: () => Promise<boolean> = () => {
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&
             canShowBannerInRegion(currentRegion) &&
-            subscriptionBannerSwitchIsOn
+            subscriptionBannerSwitchIsOn &&
+            !pageIsIdentity()
     );
     return can;
 };


### PR DESCRIPTION
## What does this change?
This introduces a new condition for the rendering of the membership and subscriptions banners, so they don't appear on identity pages.

I worked on this with @jfsoul and we considered a couple of alternative approaches:
- Categorise each banner as commercial or non-commercial and then by default commercial banners should not show on identity pages
- Adding some code to `bannerPicker.js` or `message.js` that could check for identity pages. 

Given the identity pages are likely to move away from frontend in the short to medium term, and that most banner `canShow` rules are currently in `membership-engagement-banner.js` and `subscriptions-banner.js` it seemed most straightforward to add the rule to both.

## Does this change need to be reproduced in dotcom-rendering ?
- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Banner - showing
![Screen Shot 2019-12-06 at 13 41 57](https://user-images.githubusercontent.com/16781258/70327285-61682980-182e-11ea-8fbb-49a3b9b4e257.png)

## Banner - no longer showing
![Screen Shot 2019-12-06 at 13 42 34](https://user-images.githubusercontent.com/16781258/70327296-67f6a100-182e-11ea-9e10-cbb87abeb83e.png)

## What is the value of this and can you measure success?
N/A (more of a bug fix)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
n/a

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
