### PR TITLE
Fix live sublink colours

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -319,6 +319,10 @@ $story-package-dynamic-card-text: $story-package-card-colour;
         .fc-sublink__title {
             color: $story-package-dynamic-card-text;
         }
+
+        &.fc-item--type-live.fc-item--pillar-news .fc-sublink__link {
+            color: $story-package-dynamic-card-text;
+        }
     }
 
     //These need to exist for all kickers because of tone on tone action


### PR DESCRIPTION
Adds yet another override to make this

![Screenshot 2019-12-06 at 17 37 58](https://user-images.githubusercontent.com/638051/70343447-380bc580-184f-11ea-9bde-0b4881be4314.png)


this

![Screenshot 2019-12-06 at 17 37 11](https://user-images.githubusercontent.com/638051/70343409-22969b80-184f-11ea-8872-4c6df3ff94d3.png)
