### PR TITLE
Changes to Live Updates in Dynamic/Dynamo container

### DIFF
--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -244,7 +244,7 @@ data-test-id="facia-card"
             }
 
             @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
-                <div class="js-liveblog-blocks fc-item__liveblog-blocks" data-article-id="@item.id"></div>
+                <div class="js-liveblog-blocks js-liveblog-blocks-dynamic fc-item__liveblog-blocks" data-article-id="@item.id"></div>
             }
             @if(item.isMediaLink) {
                 <div class="fc-item__footer-meta-wrapper">

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -34,6 +34,7 @@ object GetClasses {
       ("fc-item--is-boosted", item.displaySettings.isBoosted),
       ("fc-item--has-boosted-title", item.displaySettings.showBoostedHeadline),
       ("fc-item--live", item.isLive),
+      ("fc-item--live-updates", item.isLive && item.displaySettings.showLivePlayable),
       ("fc-item--has-metadata",
         item.timeStampDisplay.isDefined || item.discussionSettings.isCommentable),
       ("fc-item--has-timestamp", item.timeStampDisplay.isDefined),

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -10,7 +10,6 @@ $fc-item-gutter: $gs-gutter / 4;
 
 @mixin pillar-override($tone, $colour, $dark-colour) {
     .fc-item--pillar-#{$tone} {
-
         .fc-item__kicker,
         .rich-link__kicker,
         .fc-item__byline {
@@ -42,7 +41,6 @@ $fc-item-gutter: $gs-gutter / 4;
                 color: $dark-colour;
             }
 
-
             .inline-garnett-quote {
                 fill: $dark-colour;
             }
@@ -64,31 +62,26 @@ $fc-item-gutter: $gs-gutter / 4;
             }
         }
 
-
         .fc-item__container:before {
             background-color: #ffffff;
         }
 
         &.fc-item.fc-item--full-media-100-tablet .fc-item__title {
             background-image: none;
-
         }
     }
 
     .fc-sublink--pillar-#{$tone} .fc-sublink__kicker {
         color: $colour;
     }
-
 }
 
 .fc-container--story-package {
-
     background-color: $story-package-container-colour;
 
     .fc-container__body {
         position: relative;
         @include mq($from: leftCol) {
-
             &:before {
                 position: absolute;
                 content: '';
@@ -176,7 +169,6 @@ $fc-item-gutter: $gs-gutter / 4;
         color: $story-package-dynamic-card-text;
     }
 
-
     .fc-container__inner {
         border-top: 1px solid #929698;
 
@@ -219,6 +211,7 @@ $fc-item-gutter: $gs-gutter / 4;
                 background-color: darken($story-package-card-colour, 5%);
             }
         }
+
         .fc-trail__count--commentcount {
             background-color: $story-package-card-colour;
         }
@@ -235,6 +228,138 @@ $fc-item-gutter: $gs-gutter / 4;
 
         .fc-item__standfirst-wrapper .fc-item__meta {
             background-image: none;
+        }
+    }
+
+    // I'm not sure this is at all reliable, or a good idea, but until I figure
+    // out what classes I want to add in Scala this gets things moving:
+    .l-row__item--span-3 + .l-row__item--span-1 {
+        .fc-item--live-updates {
+            &.fc-item--standard-tablet {
+                .fc-item__media-wrapper {
+                    display: block;
+                }
+            }
+        }
+    }
+
+    .fc-item--live-updates {
+        $border-bottom-width: 5px;
+        $circle-diameter: 13px;
+        $circle-top-position: 5px;
+        $thin-border: 1px;
+
+        @include mq($from: desktop) {
+            &.fc-item--standard-tablet {
+                .fc-item__media-wrapper {
+                    display: none;
+                }
+            }
+
+            .fc-item__liveblog-blocks {
+                height: 100%;
+            }
+        }
+
+        .fc-item__liveblog-block__text {
+            @include f-textSans;
+            background-color: transparent;
+            border-top: 0;
+            border-bottom: $border-bottom-width solid $story-package-card-colour;
+            padding-left: 20px;
+            position: relative;
+        }
+
+        .fc-item__liveblog-block__time {
+            .block-time-prefix {
+                display: none;
+            }
+        }
+
+        .fc-item__liveblog-block__text:after {
+            color: mix(#ffffff, $story-package-card-colour, 92%);
+            background-color: $story-package-card-colour;
+            box-shadow: -5px 0 5px -2px $story-package-card-colour;
+        }
+
+        &:hover {
+            .fc-item__liveblog-block__text:after {
+                color: mix(#ffffff, $story-package-card-colour, 92%);
+                background-color: darken($story-package-card-colour, 5%);
+                box-shadow: -5px 0 5px -2px darken($story-package-card-colour, 5%);
+            }
+
+            .fc-item__liveblog-block__text {
+                border-bottom: $border-bottom-width solid darken($story-package-card-colour, 5%);
+            }
+        }
+
+        .fc-item__liveblog-blocks--visible {
+            visibility: visible;
+            opacity: 1;
+            transition: opacity .1s linear;
+        }
+
+        .fc-item__liveblog-blocks--hidden {
+            visibility: hidden;
+            opacity: 0;
+            transition: visibility 0s .1s, opacity .1s linear;
+        }
+
+        .fc-item__liveblog-blocks__inner {
+            transition: none;
+            transform: none;
+        }
+
+        // Live update circle
+        .fc-item__liveblog-block__time:before {
+            content: '';
+            color: #ffffff;
+            border: $thin-border solid #ffffff;
+            border-radius: 50%;
+            height: $circle-diameter;
+            width: $circle-diameter;
+            display: block;
+            position: absolute;
+            left: 0;
+            top: $circle-top-position;
+        }
+
+        // Live update circle connector/line
+        .fc-item__liveblog-block:first-of-type:not(:only-child) {
+            &:before {
+                content: '';
+                color: #ffffff;
+                border: 0;
+                border-left: 1px solid #ffffff;
+                border-radius: 0;
+                height: calc(100% - #{$circle-diameter} - #{$thin-border * 2});
+                width: $thin-border;
+                display: block;
+                position: absolute;
+                left: calc((#{$circle-diameter} / 2) + #{$thin-border});
+                top: calc(#{$circle-top-position} + #{$circle-diameter} + #{$thin-border * 2});
+                z-index: 2;
+            }
+        }
+
+        &.fc-item--full-media-75-tablet {
+            .fc-item__liveblog-blocks {
+                margin-bottom: 5px;
+            }
+
+            .fc-item__container.u-faux-block-link--hover .fc-item__liveblog-blocks__inner {
+                background-color: darken($story-package-card-colour, 5%);
+            }
+
+            .fc-item__liveblog-blocks__inner {
+                background-color: $story-package-card-colour;
+                padding-left: 5px;
+
+                &:hover {
+                    background-color: darken($story-package-card-colour, 5%);
+                }
+            }
         }
     }
 
@@ -259,7 +384,6 @@ $fc-item-gutter: $gs-gutter / 4;
             color: $story-package-dynamic-card-text;
         }
     }
-
 
     .treats__list-item {
         .treats__treat {
@@ -323,8 +447,6 @@ $fc-item-gutter: $gs-gutter / 4;
                     @include fs-headline(9);
                 }
             }
-
-
         }
 
         &:hover {
@@ -337,7 +459,6 @@ $fc-item-gutter: $gs-gutter / 4;
 
         .fc-trail__count--commentcount {
             background-color: $story-package-container-colour;
-
         }
 
         .fc-item__kicker:after {
@@ -367,9 +488,7 @@ $fc-item-gutter: $gs-gutter / 4;
             }
         }
 
-
         @include mq($until: tablet) {
-
             &.fc-item--three-quarters-tall-tablet,
             &.fc-item--full-media-100-tablet {
                 // Show the sublinks
@@ -411,7 +530,6 @@ $fc-item-gutter: $gs-gutter / 4;
             .fc-sublink {
                 flex: 1 1 100%;
 
-
                 &+* {
                     margin-left: $gs-gutter / 2;
                 }
@@ -423,7 +541,6 @@ $fc-item-gutter: $gs-gutter / 4;
         &.fc-item--full-media-100-tablet,
         &.fc-item--three-quarters-tablet,
         &.fc-item--three-quarters-tall-tablet {
-
             .fc-item__footer--vertical {
                 margin-top: -35px;
             }
@@ -444,16 +561,13 @@ $fc-item-gutter: $gs-gutter / 4;
             }
         }
 
-
         // Sublink desktop widths
         @include mq($from: tablet) {
-
             &.fc-item--full-media-75-tablet.fc-item--has-sublinks-3,
             &.fc-item--full-media-100-tablet,
             &.fc-item--full-media-100-tablet,
             &.fc-item--three-quarters-tablet,
             &.fc-item--three-quarters-tall-tablet {
-
                 .fc-sublink {
                     margin-bottom: $gs-baseline;
                 }
@@ -473,7 +587,6 @@ $fc-item-gutter: $gs-gutter / 4;
                     bottom: 0;
                     right: 0;
                 }
-
             }
 
             // FullMedia75
@@ -483,8 +596,6 @@ $fc-item-gutter: $gs-gutter / 4;
                     @include fc-sublinks--horizontal;
                     width: calc(75% - 2px);
                 }
-
-
             }
 
             // FullMedia100 & ThreeQuarterTall
@@ -505,7 +616,6 @@ $fc-item-gutter: $gs-gutter / 4;
         }
     }
 
-
     //These need to exist for all kickers because of tone on tone action
     @include pillar-override(lifestyle, $lifestyle-bright, $lifestyle-bright);
     @include pillar-override(arts, $culture-bright, $culture-bright);
@@ -513,5 +623,4 @@ $fc-item-gutter: $gs-gutter / 4;
     @include pillar-override(opinion, $opinion-bright, $opinion-bright);
     @include pillar-override(news, $news-bright, $news-bright);
     @include pillar-override(special-report, $highlight-main, $highlight-main);
-
 }


### PR DESCRIPTION
## What does this change?

This introduces some changes to the look and feel of live blog updates in a dynamo container. It is incomplete in its current state and shouldn't be merged yet. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![2019-12-06 17 46 18](https://user-images.githubusercontent.com/379839/70343944-68a02f00-1850-11ea-9865-7a2e0e3fbaaa.gif)

## Known Issues

### ~~Does not currently work when used as a full media 75 card~~

~~From the test front in CODE:~~

![Screenshot 2019-12-06 at 17 51 55](https://user-images.githubusercontent.com/379839/70344302-43f88700-1851-11ea-85d3-0b4190f35add.png)

This is now looking better:

<img width="1211" alt="Screenshot 2019-12-10 at 21 56 50" src="https://user-images.githubusercontent.com/379839/70572609-04ef6c00-1b98-11ea-8d86-bf23072194db.png">

### Fade in/out behaviour

I'd be keen to get some feedback on the timeouts and css transitions here. On the non-dynamo version when update slides in, we don't do the slide in until the container is in the viewport. I've not kept this behaviour when a new update fades in in a dynamo because I didn't think it looked _quite_ right. I'd like to do a bit more testing of the non-dynamo version after making changes in this PR.

### Contextual image showing and hiding

We hide the image for `.fc-item--standard-tablet` items on desktop in a dynamo. But when the card is a tall one (i.e. 2-card layout) we _want_ the image. There's a gross CSS hack to make this work which uses the following selector: `.l-row__item--span-3 + .l-row__item--span-1`. Not sure how robust or workable that is. It's probably a better approach to add a more specific class in the Scala code for us to target in this case.

### Long update time text in Safari issue

![Screenshot 2019-12-06 at 17 29 01](https://user-images.githubusercontent.com/379839/70395822-b0fb5080-19fa-11ea-8cde-a2760edf36eb.png)

I noticed an issue in Safari where long update time text breaks out of the card container (in the screenshot above, it's the second update doing this - "Latest update Wednesday..."). It seems this is also an issue with the existing implementation in `master` too. This PR possibly makes it more likely since we've added the circle to the update time line. One thing to note is that the update time text in the screenshot is weird I think because I'm faking things. So this may not be likely to happen with real live updates.

## Notes

There's a commit [here](https://github.com/guardian/frontend/commit/b728bcd7c97f059d00e113ecca269dea8048034e) which can be cherry-picked to help with local testing (it increases the refresh frequency, fakes out the blog updates hardcoding some blocks to return, setting the timestamp of the first one to now, and appending a random string to the start so you can see things changing). We don't want to keep this commit/merge it to master! It's just for testing.

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
