### PR TITLE
removed version of banner without article count from article count test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed.js
@@ -7,26 +7,18 @@ import {
     getSync as geolocationGetSync,
 } from 'lib/geolocation';
 import { getArticleViewCountForDays } from 'common/modules/onward/history';
-import { buildBannerCopy } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 60 days
 const minArticleViews = 5;
 const articleCountDays = 60;
 
 const articleViewCount = getArticleViewCountForDays(articleCountDays);
-
 const geolocation = geolocationGetSync();
-const isUSUKAU = ['GB', 'US', 'AU'].includes(geolocation);
-
 const messageText =
     'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
 const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
     geolocation
 )}1</span>`;
-const USUKAUControlLeadSentence =
-    'We chose a different approach. Will you support it?';
-const ROWControlLeadSentence =
-    'More people in %%COUNTRY_NAME%%, like you, are reading and supporting The Guardian’s independent, investigative journalism.';
 
 export const articlesViewedBanner: AcquisitionsABTest = {
     id: 'ContributionsBannerArticlesViewed',
@@ -46,22 +38,6 @@ export const articlesViewedBanner: AcquisitionsABTest = {
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     geolocation,
     variants: [
-        {
-            id: 'control',
-            test: (): void => {},
-            engagementBannerParams: {
-                leadSentence: buildBannerCopy(
-                    isUSUKAU
-                        ? USUKAUControlLeadSentence
-                        : ROWControlLeadSentence,
-                    !isUSUKAU,
-                    geolocation
-                ),
-                messageText,
-                ctaText,
-                template: acquisitionsBannerControlTemplate,
-            },
-        },
         {
             id: 'variant',
             test: (): void => {},


### PR DESCRIPTION
## What does this change?
I removed the control from the article count banner test. The banner with article count should be shown to 100% of the audience, which is something I missed last week.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
