### PR TITLE
Move all FullMedia75 Dynamo layouts to FullMedia100. Move headlines above image. Add Boosted headline styles.

### DIFF
--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -15,21 +15,21 @@ object DynamicPackage extends DynamicContainer {
   }
 
   override protected def standardSlices(storiesIncludingBackfill: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] = {
+
     storiesIncludingBackfill.length match {
       case 0 => Nil
       case 1 => Seq(FullMedia75)
       case 2 => Seq(ThreeQuarterQuarter)
       case 3 => Seq(ThreeQuarterTallQuarter2)
       case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
-      case 5 => Seq(FullMedia75, QuarterQuarterQuarterQuarter)
-      case 6 => Seq(FullMedia75, QuarterQuarterQuarterQl)
-      case 7 => Seq(FullMedia75, QuarterQuarterQuarterQl)
-      case 8 =>
+      case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)
+      case 6 | 7 => Seq(FullMedia100, QuarterQuarterQuarterQl)
+      case 8 => Seq(FullMedia100, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
         // This case doesn't look _quite_ right. We end up with a row of four
         // and then a row of three, slightly stretched. There isn't a layout
         // which caters for this currently, we'll follow up on this separately.
-        Seq(FullMedia75, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
-      case _ => Seq(FullMedia75, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
+      case _ => Seq(FullMedia100, QuarterQuarterQuarterQuarter, Ql1Ql1Ql1Ql1)
+
     }
   }
 }

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -31,6 +31,7 @@ object GetClasses {
       ("fc-item--has-image", item.hasImage),
       ("fc-item--force-image-upgrade", isFirstContainer),
       (s"fc-item--has-sublinks-${item.sublinks.length}", item.sublinks.nonEmpty),
+      ("fc-item--is-boosted", item.displaySettings.isBoosted),
       ("fc-item--has-boosted-title", item.displaySettings.showBoostedHeadline),
       ("fc-item--live", item.isLive),
       ("fc-item--has-metadata",

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -194,9 +194,6 @@ $story-package-dynamic-card-text: $story-package-card-colour;
         }
     }
 
-
-
-
     .fc-item__container.u-faux-block-link--hover {
         background-color: darken($story-package-card-colour, 5%);
     }
@@ -269,15 +266,21 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             padding-top: $gs-baseline / 2;
         }
 
-        .fc-item--has-boosted-title {
-            .fc-item__content--below .fc-item__header {
-                display: none;
+        &.fc-item--is-boosted {
+            .fc-item__header {
+                @include fs-headline(6);
             }
 
-            .fc-item__content--above {
-                display: block;
-                padding-top: $gs-baseline;
+            @include mq($from: tablet) {
+                .fc-item__content:before {
+                    display: none;
+                }
+
+                .fc-item__header {
+                    @include fs-headline(9);
+                }
             }
+                
         }
 
         &:hover {
@@ -303,14 +306,16 @@ $story-package-dynamic-card-text: $story-package-card-colour;
             color: $story-package-dynamic-card-text;
         }
 
-        // ThreeQuarterTall
-        &.fc-item--three-quarters-tall-tablet {
+        // Flip the headline and image!
+        &.fc-item--three-quarters-tall-tablet,
+        &.fc-item--full-media-100-tablet {
             .fc-item__content--below {
                 display: none;
             }
 
             .fc-item__content--above {
                 display: block;
+                padding-top: $gs-baseline;
 
                 &:before {
                     width: 33%;

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--full-media-100.scss
@@ -22,12 +22,7 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
 */
 
 @mixin fc-item--full-media-100 {
-
-    .responsive-img {
-        top: -25%;
-        height: auto;
-    }
-
+    
     .fc-item__header {
         @include fs-headline(4, true);
         @include fs-headline-quote(4);
@@ -43,7 +38,7 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
     &:not(.fc-item--has-cutout) {
         .fc-item__image-container {
             display: block;
-            padding-bottom: 40%;
+            padding-bottom: 60%;
         }
 
         @include fc-sublinks--below;


### PR DESCRIPTION
## What does this change?

Three related changes:

- Move all FullMedia75 Dynamo layouts to FullMedia100. 
- Move headlines above image. 
- Add Boosted headline styles.

*Note:* Below five stories requires new layouts for the headline to be above, future PR.
**Mobile Non-Boosted**

![Screenshot 2019-12-09 at 13 09 45](https://user-images.githubusercontent.com/638051/70438968-e51c5300-1a86-11ea-9174-c1f4310af027.png)

**Mobile Boosted**

![Screenshot 2019-12-09 at 13 09 36](https://user-images.githubusercontent.com/638051/70438967-e51c5300-1a86-11ea-8b97-9c1e49615cb6.png)

**Desktop Non-Boosted**

![Screenshot 2019-12-09 at 13 11 37](https://user-images.githubusercontent.com/638051/70438969-e51c5300-1a86-11ea-905d-16ac626c4b54.png)

**Desktop Boosted**

![Screenshot 2019-12-09 at 13 11 41](https://user-images.githubusercontent.com/638051/70438970-e5b4e980-1a86-11ea-86a7-a84a7ff095e5.png)

Full page:

![screencapture-localhost-9000-test-2019-12-09-13_12_34-min](https://user-images.githubusercontent.com/638051/70439145-3fb5af00-1a87-11ea-8010-04915ffb76fa.png)
