### PR TITLE
New EOY banner test - article count position

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,7 +68,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-banner-us-eoy-giving-tuesday-regulars",
+    "ab-contributions-banner-us-eoy-giving-tuesday-regulars-round-two",
     "US end of year banner - giving tuesday version for regular readers",
     owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-us-eoy.js
@@ -27,7 +27,11 @@ export const acquisitionsBannerUsEoyTemplate = (
                     }</h2>
                 </div>
                 <div class="engagement-banner__body">
-                    <p>${params.messageText}
+                    <p>
+                    <span class="engagement-banner__body-copy--bold">${
+                        params.leadSentence ? params.leadSentence : ''
+                    }</span>
+                    ${params.messageText}
                     <span class="engagement-banner__body-copy--bold">${
                         params.closingSentence ? params.closingSentence : ''
                     }</span>

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,7 +15,7 @@ import { contributionsBannerUsEoy } from 'common/modules/experiments/tests/contr
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 import { contributionsBannerUsEoyGivingTuesdayCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals';
-import { contributionsBannerUsEoyGivingTuesdayRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
+import { contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -37,7 +37,7 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
-    contributionsBannerUsEoyGivingTuesdayRegulars,
+    contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo,
     contributionsBannerUsEoyGivingTuesdayCasuals,
     contributionsBannerUsEoy,
     articlesViewedBanner,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
@@ -7,8 +7,7 @@ const isUS = geolocation === 'US';
 
 const titles = ['2020 will be a defining year for America'];
 const messageText =
-    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. ';
-const closingSentence = 'Help us reach our year-end goal.';
+    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 
 const tickerHeaderControl = 'Help us reach our year-end goal';
@@ -37,7 +36,6 @@ export const contributionsBannerUsEoyGivingTuesdayCasuals: AcquisitionsABTest = 
             engagementBannerParams: {
                 titles,
                 messageText,
-                closingSentence,
                 ctaText,
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals.js
@@ -1,14 +1,13 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
-
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['Offset fake news this holiday season'];
+const titles = ['2020 will be a defining year for America'];
 const messageText =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
+    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. ';
 const closingSentence = 'Help us reach our year-end goal.';
 const ctaText = 'Support The Guardian';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -26,7 +26,7 @@ const articleCountCopy = `You’ve read ${articleViewCount} articles in the last
 // Copy specific to 'withArticleCountInBody'
 const articleCountInBody = `${articleCountCopy}. `;
 const messageTextBody =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
+    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. Help us reach our goal.'
 const tickerHeaderDefault = `Help us reach our year-end goal`;
 
 export const contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo: AcquisitionsABTest = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -13,16 +13,24 @@ const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 const testRunConditions = isUS && articleViewCount >= minArticleViews;
 
-const titles = ['Offset fake news this holiday season'];
-const messageText =
-    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
-const closingSentence = 'Help us reach our year-end goal.';
+// Copy for both variants:
+const titles = ['2020 will be a defining year for America'];
 const ctaText = 'Support The Guardian';
 
-const tickerHeaderWithArticleCount = `You’ve read ${articleViewCount} articles in the last two months`;
+// Copy specific to 'withArticleCountOnRight'
+const messageText =
+    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. ';
+const closingSentence = 'Help us reach our year-end goal.';
+const articleCountCopy = `You’ve read ${articleViewCount} articles in the last two months`;
 
-export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoyGivingTuesdayRegulars',
+// Copy specific to 'withArticleCountInBody'
+const articleCountInBody = `${articleCountCopy}. `;
+const messageTextBody =
+    'Help the truth triumph in 2020. Amid a tsunami of disinformation and “alternative facts”, the need for truth has never been greater. Support the Guardian’s independent, fact-based journalism this holiday season. As we look to the challenges of the coming year, we’re hoping to raise $1.5m from our US readers by January. ';
+const tickerHeaderDefault = `Help us reach our year-end goal`;
+
+export const contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyGivingTuesdayRegularsRoundTwo',
     campaignId: 'USeoy2019',
     start: '2019-11-15',
     expiry: '2020-1-30',
@@ -40,7 +48,7 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
     geolocation,
     variants: [
         {
-            id: 'withArticleCount',
+            id: 'withArticleCountOnRight',
             test: (): void => {},
             engagementBannerParams: {
                 titles,
@@ -50,7 +58,21 @@ export const contributionsBannerUsEoyGivingTuesdayRegulars: AcquisitionsABTest =
                 template: acquisitionsBannerUsEoyTemplate,
                 hasTicker: true,
                 bannerModifierClass: 'useoy2019',
-                tickerHeader: tickerHeaderWithArticleCount,
+                tickerHeader: articleCountCopy,
+            },
+        },
+        {
+            id: 'withArticleCountInBody',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText: messageTextBody,
+                leadSentence: articleCountInBody,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+                bannerModifierClass: 'useoy2019',
+                tickerHeader: tickerHeaderDefault,
             },
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -26,7 +26,7 @@ const articleCountCopy = `You’ve read ${articleViewCount} articles in the last
 // Copy specific to 'withArticleCountInBody'
 const articleCountInBody = `${articleCountCopy}. `;
 const messageTextBody =
-    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. Help us reach our goal.'
+    'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. Help us reach our goal.';
 const tickerHeaderDefault = `Help us reach our year-end goal`;
 
 export const contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo: AcquisitionsABTest = {


### PR DESCRIPTION
## What does this change?
Copy and variant updates to the end of the year banner test. We'd like to see where article count performs better.

## Screenshots
Test: *ContributionsBannerUsEoyGivingTuesdayRegularsRoundTwo*

Variant: withArticleCountOnRight
![withArticleCountOnRight](https://user-images.githubusercontent.com/3300789/70441866-1566f000-1a8d-11ea-913f-ec663fffa98f.png)

Variant: withArticleCountInBody
![withArticleCountInBody](https://user-images.githubusercontent.com/3300789/70441822-02542000-1a8d-11ea-993d-13d1f6be30f6.png)

Variant: for those not eligible for the test (fewer than 5 articles in the past 60 days)
![withoutArticleCount](https://user-images.githubusercontent.com/3300789/70443741-91af0280-1a90-11ea-9e59-ec5e6b40aa7d.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
