### PR TITLE
Extend CMP switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Test whether our new CMP UI obtains target consent rates",
     owners = Seq(Owner.withGithub("ghaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 12, 17),
+    sellByDate = new LocalDate(2019, 01, 08),
     exposeClientSide = true
   )
 
@@ -162,7 +162,7 @@ trait ABTestSwitches {
     "Tests whether a CMP UI with no overlay yield higher consent rates",
     owners = Seq(Owner.withGithub("ripecosta")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 12, 19),
+    sellByDate = new LocalDate(2019, 01, 08),
     exposeClientSide = true
   )
 
@@ -172,7 +172,7 @@ trait ABTestSwitches {
     "0.5% AB test for a bottom consent banner with an options button instead of a link",
     owners = Seq(Owner.withGithub("ripecosta")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 12, 19),
+    sellByDate = new LocalDate(2020, 01, 08),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-iab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-iab.js
@@ -3,7 +3,7 @@
 export const commercialCmpUiIab: ABTest = {
     id: 'CommercialCmpUiIab',
     start: '2019-10-14',
-    expiry: '2019-12-17',
+    expiry: '2019-01-08',
     author: 'George Haberis',
     description: '1% participation AB test for the new CMP UI',
     audience: 0.01,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
@@ -3,7 +3,7 @@
 export const commercialCmpUiNoOverlay: ABTest = {
     id: 'CommercialCmpUiNoOverlay',
     start: '2019-11-21',
-    expiry: '2019-12-12',
+    expiry: '2019-01-08',
     author: 'Ricardo Costa',
     description:
         '0.5% AB test for an IAB compliant consent banner with no overlay',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
@@ -3,7 +3,7 @@
 export const commercialConsentOptionsButton: ABTest = {
     id: 'CommercialConsentOptionsButton',
     start: '2019-11-21',
-    expiry: '2019-12-12',
+    expiry: '2019-01-08',
     author: 'George Haberis',
     description:
         '0.5% AB test for a bottom consent banner with an options button instead of a link',


### PR DESCRIPTION
## What does this change?
This PR extends 3 switches (`commercialCmpUiIab`, `commercialCmpUiNoOverlay` and `commercialConsentOptionsButton`) until the end of the month because as we're not yet ready to remove them.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)