### PR TITLE
Add headline to onwards DCR model

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -21,6 +21,7 @@ case class OnwardItem(
   pillar: String,
   designType: String,
   webPublicationDate: String,
+  headline: String,
 )
 
 case class MostPopularGeoResponse(
@@ -61,7 +62,8 @@ object OnwardCollection {
         isLiveBlog = content.properties.isLiveBlog,
         pillar = findPillar(content.maybePillar, content.frontendTags.toList),
         designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,
-        webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString
+        webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString,
+        headline = content.header.headline,
       )
     )
   }


### PR DESCRIPTION
## What does this change?

Adds `headline` property to the DCR onwards model.

The difference between headline and webTitle/linkText is that the latter can include bylines and other descriptives at the end - things like `| Editorial` and so on. We usually don't want to show these on the site itself as we have existing visual clues/text for this information.
