### PR TITLE
Move the dynamo live updates ellipses up a little

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -280,6 +280,7 @@ $fc-item-gutter: $gs-gutter / 4;
             color: mix(#ffffff, $story-package-card-colour, 92%);
             background-color: $story-package-card-colour;
             box-shadow: -5px 0 5px -2px $story-package-card-colour;
+            bottom: 3px;
         }
 
         &:hover {


### PR DESCRIPTION
## What does this change?

Moves the live updates ellipses up a bit when in a dynamo.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:

![Screenshot 2019-12-11 at 13 01 04](https://user-images.githubusercontent.com/379839/70624050-4bd07680-1c17-11ea-820f-cd32d9ea119a.png)

After:

![Screenshot 2019-12-11 at 13 05 53](https://user-images.githubusercontent.com/379839/70624058-51c65780-1c17-11ea-949c-2ddaf0d4be7e.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
