### PR TITLE
Remove playable video from standard card layout

### DIFF
--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -8,7 +8,7 @@ sealed trait CardType {
   def videoPlayer: VideoPlayerMode = this match {
     case FullMedia50 | FullMedia75 | FullMedia100 =>
       VideoPlayerMode(show = true, showEndSlate = true)
-    case ThreeQuarters | ThreeQuartersRight | Half | Third | Standard =>
+    case ThreeQuarters | ThreeQuartersRight | Half | Third =>
       VideoPlayerMode(show = true, showEndSlate = false)
     case _ =>
       VideoPlayerMode(show = false, showEndSlate = false)
@@ -17,7 +17,7 @@ sealed trait CardType {
   def youTubeMediaAtomPlayer: VideoPlayerMode = this match {
     case FullMedia50 | FullMedia75 | FullMedia100 | ThreeQuarters | ThreeQuartersRight =>
       VideoPlayerMode(show = true, showEndSlate = true)
-    case Half | Third | Standard =>
+    case Half | Third =>
       VideoPlayerMode(show = true, showEndSlate = false)
     case _ =>
       VideoPlayerMode(show = false, showEndSlate = false)


### PR DESCRIPTION
## What does this change?

Removes playable video from the standard card layout as it's a little too small to make sense here. It will now click through to the video page.

### Before
![Screenshot 2019-12-11 at 13 14 33](https://user-images.githubusercontent.com/638051/70624461-3a3b9e80-1c18-11ea-851b-b9402a7f1c8d.png)

### After
![Screenshot 2019-12-11 at 13 14 01](https://user-images.githubusercontent.com/638051/70624460-3a3b9e80-1c18-11ea-9901-79335511b8d0.png)

