### PR TITLE
Reduce cricket polling frequency to every 5 minutes

### DIFF
--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -21,7 +21,7 @@ class CricketLifecycle(
   }}
 
   private def scheduleJobs() {
-    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 120.seconds) {
+    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 5.minutes) {
       Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
     }
     jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", 10.minutes) {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -21,7 +21,7 @@ class CricketLifecycle(
   }}
 
   private def scheduleJobs() {
-    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 15.seconds) {
+    jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 120.seconds) {
       Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
     }
     jobs.scheduleEvery("CricketAgentRefreshHistoricalMatches", 10.minutes) {


### PR DESCRIPTION
## What does this change?
We've had a request from PA to stop hitting their API so much. The only tournaments we show live cricket scores for are the world cup and the ashes. The next ashes isn't till 2021, so we might as well slow down the frequency at which we update results.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
