### PR TITLE
Dynamo Live Updates: Hide Standfirst

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -373,6 +373,10 @@ $fc-item-gutter: $gs-gutter / 4;
                     background-color: darken($story-package-card-colour, 5%);
                 }
             }
+
+            .fc-item__standfirst-wrapper {
+                display: none;
+            }
         }
     }
 

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -357,17 +357,17 @@ $fc-item-gutter: $gs-gutter / 4;
         }
 
         &.fc-item--full-media-75-tablet {
-            .fc-item__liveblog-blocks {
-                margin-bottom: 5px;
-            }
-
             .fc-item__container.u-faux-block-link--hover .fc-item__liveblog-blocks__inner {
                 background-color: darken($story-package-card-colour, 5%);
             }
 
             .fc-item__liveblog-blocks__inner {
                 background-color: $story-package-card-colour;
+                margin-left: -5px;
+                margin-right: 5px;
                 padding-left: 5px;
+                position: absolute;
+                bottom: 0;
 
                 &:hover {
                     background-color: darken($story-package-card-colour, 5%);


### PR DESCRIPTION
## What does this change?

For the FullMedia75 card if live updates are enabled then don't show the standfirst. Also pull the live updates container down so it's flush with the image.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:

![Screenshot 2019-12-11 at 13 41 58](https://user-images.githubusercontent.com/379839/70628874-dd90b180-1c20-11ea-979e-dd6de50757f5.png)

After:

![Screenshot 2019-12-11 at 14 10 36](https://user-images.githubusercontent.com/379839/70628890-e41f2900-1c20-11ea-8bd0-62cf460e765b.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
