### PR TITLE
Support west coast container

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,6 +1,6 @@
 package implicits
 
-import com.gu.facia.client.models.{EU27Territory, NZTerritory, TargetedTerritory, USEastCoastTerritory}
+import com.gu.facia.client.models.{EU27Territory, NZTerritory, TargetedTerritory, USEastCoastTerritory, USWestCoastTerritory}
 import conf.Configuration
 import play.api.mvc.RequestHeader
 
@@ -24,7 +24,8 @@ trait Requests {
   val territoryHeaders: List[TerritoryHeader] = List(
     TerritoryHeader(EU27Territory, "EU-27"),
     TerritoryHeader(NZTerritory, "NZ"),
-    TerritoryHeader(USEastCoastTerritory, "US-East"))
+    TerritoryHeader(USEastCoastTerritory, "US-East-Coast"),
+    TerritoryHeader(USWestCoastTerritory, "US-West-Coast"))
 
   implicit class RichRequestHeader(r: RequestHeader) {
 

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -1,6 +1,6 @@
 package utils
 
-import com.gu.facia.client.models.{EU27Territory, NZTerritory, TargetedTerritory, USEastCoastTerritory}
+import com.gu.facia.client.models.{EU27Territory, NZTerritory, TargetedTerritory, USEastCoastTerritory, USWestCoastTerritory}
 import model.PressedPage
 import model.facia.PressedCollection
 import model.pressed.CollectionConfig
@@ -16,7 +16,8 @@ object TargetedCollections {
   val prettyTerritoryLookup: Map[TargetedTerritory, String] = Map(
     NZTerritory -> "New Zealand",
     EU27Territory -> "EU-27 Countries",
-    USEastCoastTerritory -> "US East Coast"
+    USEastCoastTerritory -> "US East Coast",
+    USWestCoastTerritory -> "US West Coast"
   )
 
   def markDisplayName(collection: PressedCollection): PressedCollection = {


### PR DESCRIPTION
## What does this change?
Adds support for a US-West-Coast container, following https://github.com/guardian/fastly-edge-cache/pull/874 and https://github.com/guardian/frontend/pull/22099

This should be a fairly safe change as we've already tested with NZ and EU countries

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
