### PR TITLE
Extended article count banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -2,12 +2,12 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
-import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 
 // User must have read at least 5 articles in last 60 days
 const minArticleViews = 5;
-const articleCountDays = 60;
-const articleViewCount = getArticleViewCountForDays(articleCountDays);
+const articleCountWeeks = 26; // Requesting a half year in order to get as many as possible for this and next iterations
+const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
@@ -21,7 +21,7 @@ const ctaText = 'Support The Guardian';
 const messageText =
     'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. ';
 const closingSentence = 'Help us reach our year-end goal.';
-const articleCountCopy = `You’ve read ${articleViewCount} articles in the last two months`;
+const articleCountCopy = `You’ve read ${articleViewCount} articles in the last three months`;
 
 // Copy specific to 'withArticleCountInBody'
 const articleCountInBody = `${articleCountCopy}. `;


### PR DESCRIPTION
## What does this change?
Getting the maximum amount of articles read & updating copy to say "three months" as we currently have about three months worth. I am grabbing six months worth as Jesse has expressed an interest on continuing to iterate on this over the next month

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![extended article count banner](https://user-images.githubusercontent.com/3300789/70635608-21d57f00-1c2c-11ea-8ccd-1b25f77f6f08.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
