### PR TITLE
Show live blog updates on larger cards

### DIFF
--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -97,6 +97,10 @@ data-test-id="facia-card"
             <div class="fc-item__header">
                 @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
             </div>
+
+            @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
+                <div class="js-liveblog-blocks js-liveblog-blocks-dynamic fc-item__liveblog-blocks" data-article-id="@item.id"></div>
+            }
         </div>
 
         @item.displayElement.filter(const(item.showDisplayElement)) match {

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -7,6 +7,7 @@ $story-package-card-colour: #041f4a;
 $container-title: $story-package-card-colour;
 $story-package-dynamic-card-text: $story-package-card-colour;
 $fc-item-gutter: $gs-gutter / 4;
+$block-height: 58px; // Note: duplicated from _item.scss
 
 @mixin pillar-override($tone, $colour, $dark-colour) {
     .fc-item--pillar-#{$tone} {
@@ -325,7 +326,6 @@ $fc-item-gutter: $gs-gutter / 4;
         // Live update circle
         .fc-item__liveblog-block__time:before {
             content: '';
-            color: #ffffff;
             border: $thin-border solid #ffffff;
             border-radius: 50%;
             height: $circle-diameter;
@@ -340,9 +340,8 @@ $fc-item-gutter: $gs-gutter / 4;
         .fc-item__liveblog-block:first-of-type:not(:only-child) {
             &:before {
                 content: '';
-                color: #ffffff;
                 border: 0;
-                border-left: 1px solid #ffffff;
+                border-left: $thin-border solid #ffffff;
                 border-radius: 0;
                 height: calc(100% - #{$circle-diameter} - #{$thin-border * 2});
                 width: $thin-border;
@@ -373,6 +372,78 @@ $fc-item-gutter: $gs-gutter / 4;
             }
 
             .fc-item__standfirst-wrapper {
+                display: none;
+            }
+        }
+
+        // Invert the live update colours for these cards
+        &.fc-item--full-media-100-tablet, &.fc-item--three-quarters-tall-tablet {
+            .fc-item__liveblog-blocks {
+                height: $block-height;
+            }
+
+            .fc-item__liveblog-blocks__inner {
+                display: flex;
+                flex-direction: row;
+            }
+
+            .fc-item__liveblog-block {
+                display: flex;
+                flex: 1;
+                max-width: 50%;
+            }
+
+            .fc-item__liveblog-block__time {
+                color: $story-package-card-colour;
+                display: inline;
+            }
+
+            .fc-item__liveblog-block__text {
+                color: $story-package-card-colour;
+            }
+
+            .fc-item__liveblog-block__text {
+                border-bottom-color: $story-package-container-colour;
+
+                // Ellipses
+                &:after {
+                    color: $story-package-card-colour;
+                    background-color: $story-package-container-colour;
+                    box-shadow: -5px 0 5px -2px $story-package-container-colour;
+                }
+            }
+
+            &:hover {
+                .fc-item__liveblog-block__text {
+                    border-bottom-color: darken($story-package-container-colour, 5%);
+
+                    // Ellipses
+                    &:after {
+                        background-color: darken($story-package-container-colour, 5%);
+                        box-shadow: -5px 0 5px -2px darken($story-package-container-colour, 5%);
+                    }
+                }
+            }
+
+            .u-faux-block-link--hover {
+                .fc-item__liveblog-block__text {
+                    border-bottom-color: darken($story-package-container-colour, 5%);
+
+                    // Ellipses
+                    &:after {
+                        background-color: darken($story-package-container-colour, 5%);
+                        box-shadow: -5px 0 5px -2px darken($story-package-container-colour, 5%);
+                    }
+                }
+            }
+
+            // Circle
+            .fc-item__liveblog-block__time:before {
+                border: $thin-border solid $story-package-card-colour;
+            }
+
+            // Connector line
+            .fc-item__liveblog-block:first-of-type:not(:only-child):before {
                 display: none;
             }
         }


### PR DESCRIPTION
## What does this change?

Currently for the main card on 2+ card layouts we don't show live blog updates at all - e.q. `ThreeQuarterTall` and `FullMedia100`. This PR lays out the live update horizontally across the top, under the headline.

Note that, similarly to the headline, we're now rendering the live updates container above and below, though only one of these will ever be visible. It does mean that there's more JS work going on than is necessary, since both are kept up to date (we refresh 5 times at 30 second intervals). I don't think that's a large concern perf wise - there aren't usually many live blog cards with updates enabled on a front - but wanted to flag this.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

#### FullMedia100

![Screenshot 2019-12-11 at 17 51 59](https://user-images.githubusercontent.com/379839/70646569-13449300-1c3f-11ea-8665-d4eff9237543.png)

#### ThreeQuarterTall

![Screenshot 2019-12-11 at 17 52 24](https://user-images.githubusercontent.com/379839/70646556-0b84ee80-1c3f-11ea-803a-fd57a409591d.png)

### After

Note that these screenshots do illustrate one thing I didn't notice until quite late on - there's quite a lot of empty space when the live update text is very short (as in the left update). Any thoughts/input on that appreciated!

#### FullMedia100

![Screenshot 2019-12-11 at 17 50 01](https://user-images.githubusercontent.com/379839/70646446-d4164200-1c3e-11ea-87d2-6a9421baaa71.png)

#### ThreeQuarterTall

![Screenshot 2019-12-11 at 17 50 12](https://user-images.githubusercontent.com/379839/70646474-e0020400-1c3e-11ea-8653-5ce52bce1db1.png)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)