### PR TITLE
Deduplication, update visibility index

### DIFF
--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -32,7 +32,7 @@ object PressedCollectionDeduplication {
   def getHeaderURLsFromCuratedAndBackfilled(pCVs: Seq[PressedCollectionVisibility]): Seq[String] = {
     // Return the header urls of all curated or backfill elements of a sequence of `PressedCollectionVisibility`.
 
-    val visibility: Int = 5
+    val visibility: Int = 3
 
     // 11th Dec version:
     // To prevent a tiny problem with the Most Popular container I am introducing the effect of collecting only the


### PR DESCRIPTION
## What does this change?

I have just noticed that the Most Popular container can be missing one element. Moving the deduplication visibility index from 5 to 3. This will result in a less aggressive deduplication.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No