### PR TITLE
Gtrufitt/click through video on mobile

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -41,7 +41,7 @@ object GetClasses {
       ("fc-item--is-commentable", item.discussionSettings.isCommentable),
       ("fc-item--is-media-link", item.isMediaLink),
       ("fc-item--has-video-main-media", item.hasVideoMainMedia),
-      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined && !item.isMediaLink)
+      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
     )

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -64,8 +64,10 @@ const onPlayerStateChangeEvent = (
                 );
                 const fcItem = $.ancestor(el, 'fc-item');
                 if (fcItem) {
-                    fcItem.classList.toggle(`fc-item--has-video-main-media__${status.toLocaleLowerCase()}`,
-                        event.data === window.YT.PlayerState[status])
+                    $(fcItem)[0].classList.toggle(
+                        `fc-item--has-video-main-media__${status.toLocaleLowerCase()}`,
+                        event.data === window.YT.PlayerState[status]
+                    );
                 }
                 addVideoStartedClass(el);
             }

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -7,6 +7,7 @@ import { constructQuery } from 'lib/url';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
+import $ from 'lib/$';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {
@@ -61,6 +62,11 @@ const onPlayerStateChangeEvent = (
                     `youtube__video-${status.toLocaleLowerCase()}`,
                     event.data === window.YT.PlayerState[status]
                 );
+                const fcItem = $.ancestor(el, 'fc-item');
+                if (fcItem) {
+                    fcItem.classList.toggle(`fc-item--has-video-main-media__${status.toLocaleLowerCase()}`,
+                        event.data === window.YT.PlayerState[status])
+                }
                 addVideoStartedClass(el);
             }
         });

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -445,9 +445,10 @@ $fc-item-gutter: $gs-gutter / 4;
             padding-top: $gs-baseline / 2;
         }
 
-
-        .youtube-media-atom__play-button {
-            bottom: 43%;
+        @include mq($from: tablet) {
+            .youtube-media-atom__play-button {
+                bottom: 43%;
+            }
         }
         
         .fc-item__header {

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -85,6 +85,7 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-container--story-package {
+    
     background-color: $story-package-container-colour;
 
     .facia-snap {
@@ -630,6 +631,15 @@ $fc-item-gutter: $gs-gutter / 4;
                 .fc-item__footer--horizontal {
                     @include fc-sublinks--horizontal;
                     width: calc(75% - 2px);
+                }
+
+                @include mq($from: tablet) {
+                    &.fc-item--has-video-main-media__playing,
+                    &.fc-item--has-video-main-media__paused {
+                        .fc-sublinks {
+                            display: none;
+                        }
+                    }
                 }
             }
 

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -569,7 +569,10 @@ $fc-item-gutter: $gs-gutter / 4;
 
             .fc-sublink {
                 padding: $gs-gutter / 4 $gs-gutter / 4 $gs-gutter / 2;
-                background-color: rgba(4, 31, 74, .8);
+                background-color: $story-package-card-colour;
+                @include mq($from: tablet) {
+                    background-color: rgba(4, 31, 74, .8);
+                }
                 margin-bottom: 0;
             }
 

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -563,7 +563,7 @@ $fc-item-gutter: $gs-gutter / 4;
         &.fc-item--full-media-100-tablet,
         &.fc-item--three-quarters-tablet,
         &.fc-item--three-quarters-tall-tablet {
-            .fc-item__footer--vertical {
+            &:not(.fc-item--has-video-main-media) .fc-item__footer--vertical {
                 margin-top: -35px;
             }
 
@@ -579,6 +579,16 @@ $fc-item-gutter: $gs-gutter / 4;
 
                 &:before {
                     width: 100%;
+                }
+            }
+        }
+
+        @include mq($from: tablet) {
+
+            &.fc-item--has-video-main-media__playing,
+            &.fc-item--has-video-main-media__paused {
+                .fc-sublinks {
+                    display: none;
                 }
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -481,12 +481,15 @@ $video-width-desktop: 700px;
 }
 
 .fc-item__video-container {
-    .youtube-media-atom {
-        z-index: 1;
+    // Videos on mobile should just click through to the article
+    @include mq($from: tablet) {
+        .youtube-media-atom {
+            z-index: 1;
 
-        &.no-player,
-        .is-not-modern & {
-            z-index: 0;
+            &.no-player,
+            .is-not-modern & {
+                z-index: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?

It isn't possible to click through videos on mobile (iOS or Android) on Fronts, because we don't load Youtube until click but cannot autoplay - therefore it makes more sense to always force a click through to the video page at the mobile breakpoint.

Before.

![2019-12-12 11 31 25](https://user-images.githubusercontent.com/638051/70708659-f6599f80-1cd2-11ea-854f-a40c9cff8e92.gif)


After.

![2019-12-12 11 30 31](https://user-images.githubusercontent.com/638051/70708672-feb1da80-1cd2-11ea-8948-d7f5c3f9ae88.gif)
