### PR TITLE
Force videos to be click-throughable on Mobile

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -481,12 +481,15 @@ $video-width-desktop: 700px;
 }
 
 .fc-item__video-container {
-    .youtube-media-atom {
-        z-index: 1;
+    // Videos on mobile should just click through to the article
+    @include mq($from: tablet) {
+        .youtube-media-atom {
+            z-index: 1;
 
-        &.no-player,
-        .is-not-modern & {
-            z-index: 0;
+            &.no-player,
+            .is-not-modern & {
+                z-index: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?

It isn't possible to click through videos on mobile (iOS or Android) on Fronts, because we don't load Youtube until click but cannot autoplay - therefore it makes more sense to always force a click through to the video page at the mobile breakpoint.

Before.

![2019-12-12 11 31 25](https://user-images.githubusercontent.com/638051/70708659-f6599f80-1cd2-11ea-854f-a40c9cff8e92.gif)


After.

![2019-12-12 11 30 31](https://user-images.githubusercontent.com/638051/70708672-feb1da80-1cd2-11ea-8948-d7f5c3f9ae88.gif)
