### PR TITLE
Remove leading zeros

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Test whether our new CMP UI obtains target consent rates",
     owners = Seq(Owner.withGithub("ghaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 01, 08),
+    sellByDate = new LocalDate(2020, 1, 8),
     exposeClientSide = true
   )
 
@@ -162,7 +162,7 @@ trait ABTestSwitches {
     "Tests whether a CMP UI with no overlay yield higher consent rates",
     owners = Seq(Owner.withGithub("ripecosta")),
     safeState = Off,
-    sellByDate = new LocalDate(2019, 01, 08),
+    sellByDate = new LocalDate(2020, 1, 8),
     exposeClientSide = true
   )
 
@@ -172,7 +172,7 @@ trait ABTestSwitches {
     "0.5% AB test for a bottom consent banner with an options button instead of a link",
     owners = Seq(Owner.withGithub("ripecosta")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 01, 08),
+    sellByDate = new LocalDate(2020, 1, 8),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
Remove leading zeroes from AB test expiry dates that are preventing master from building.

Apologies for the disruption!