### PR TITLE
Fix live blog linking

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -56,7 +56,7 @@ const renderBlock = (
 
     return template(blockTemplate)({
         ariaHidden: !block.isNew,
-        href: `/${articleId}#${block.id}`,
+        href: `/${articleId}#block-${block.id}`,
         relativeTime: relTime,
         text: [block.title, block.body.slice(0, 500)]
             .filter(x => x != null)


### PR DESCRIPTION
## What does this change?

Fixing the anchor on live blog links. At some point the format used here and the format on the article page diverged and we were missing the `block-` prefix.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![2019-12-12 13 43 03](https://user-images.githubusercontent.com/379839/70717067-81dc2c00-1ce5-11ea-9c6b-9149a7bf6248.gif)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)