### PR TITLE
Fix AB test expiry dates

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-iab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-iab.js
@@ -3,7 +3,7 @@
 export const commercialCmpUiIab: ABTest = {
     id: 'CommercialCmpUiIab',
     start: '2019-10-14',
-    expiry: '2019-01-08',
+    expiry: '2020-01-08',
     author: 'George Haberis',
     description: '1% participation AB test for the new CMP UI',
     audience: 0.01,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-no-overlay.js
@@ -3,7 +3,7 @@
 export const commercialCmpUiNoOverlay: ABTest = {
     id: 'CommercialCmpUiNoOverlay',
     start: '2019-11-21',
-    expiry: '2019-01-08',
+    expiry: '2020-01-08',
     author: 'Ricardo Costa',
     description:
         '0.5% AB test for an IAB compliant consent banner with no overlay',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-consent-options-button.js
@@ -3,7 +3,7 @@
 export const commercialConsentOptionsButton: ABTest = {
     id: 'CommercialConsentOptionsButton',
     start: '2019-11-21',
-    expiry: '2019-01-08',
+    expiry: '2020-01-08',
     author: 'George Haberis',
     description:
         '0.5% AB test for a bottom consent banner with an options button instead of a link',


### PR DESCRIPTION
## What does this change?
Fix test dates that were supposed to be 2020 instead of 2019