### PR TITLE
Render up to 3 horizontal live blocks if in dynamo

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -23,6 +23,7 @@ const dynamicClass = 'js-liveblog-blocks-dynamic';
 const articleIdAttribute = 'data-article-id';
 const sessionStorageKey = 'gu.liveblog.block-dates';
 const viewportHeightPx = getViewport().height;
+const maxBlockCount = 3;
 
 type Block = {
     id: string,
@@ -162,6 +163,18 @@ const completeUpdate = (
 const isDynamic = (element: Element): boolean =>
     element.classList.contains(dynamicClass);
 
+const calculateBlockCount = (
+    hasNewBlock: boolean,
+    isInDynamicContainer: boolean
+): number => {
+    if (isInDynamicContainer) {
+        return maxBlockCount;
+    } else if (hasNewBlock) {
+        return 2;
+    }
+    return 1;
+};
+
 const showBlocks = (
     articleId: string,
     targets: Array<Element>,
@@ -179,7 +192,7 @@ const showBlocks = (
         ];
 
         const blocksHtml = blocks
-            .slice(0, 2)
+            .slice(0, maxBlockCount)
             .map((block, index) => {
                 if (
                     !hasNewBlock &&
@@ -194,7 +207,7 @@ const showBlocks = (
 
                 return renderBlock(articleId, block, index);
             })
-            .slice(0, hasNewBlock || isDynamic(element) ? 2 : 1);
+            .slice(0, calculateBlockCount(hasNewBlock, isDynamic(element)));
 
         const el = bonzo.create(
             `<div class="${wrapperClasses.join(' ')}">${blocksHtml.join(

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -323,6 +323,12 @@ $block-height: 58px; // Note: duplicated from _item.scss
             transform: none;
         }
 
+        // This is overridden below for the fc-item--full-media-100-tablet and
+        // fc-item--three-quarters-tall-tablet cards (where we show all blocks)
+        .fc-item__liveblog-block:nth-child(n+3) {
+            display: none;
+        }
+
         // Live update circle
         .fc-item__liveblog-block__time:before {
             content: '';
@@ -390,7 +396,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
             .fc-item__liveblog-block {
                 display: flex;
                 flex: 1;
-                max-width: 50%;
+                max-width: 33.3%;
             }
 
             .fc-item__liveblog-block__time {


### PR DESCRIPTION
## What does this change?

When we show live blog updates laid out horizontally across the top of the card, increase the max from 2 to 3 (currently that's the `FullMedia100` and `ThreeQuartersTall` cards). Continue to show a max of 2 in all other cases. In the case that there are fewer than 3 live updates available, each one will have a max width of 33.3% of the container.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2019-12-12 at 14 23 04](https://user-images.githubusercontent.com/379839/70720649-18abe700-1cec-11ea-8c80-38436d0ba485.png)

![Screenshot 2019-12-12 at 14 22 44](https://user-images.githubusercontent.com/379839/70720665-21042200-1cec-11ea-95a2-b27e53b20be9.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)