### PR TITLE
Move the dynamo two story, FullMedia75, to have liveblog updates on plain bg

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -353,31 +353,13 @@ $block-height: 58px; // Note: duplicated from _item.scss
             }
         }
 
-        &.fc-item--full-media-75-tablet {
-            .fc-item__container.u-faux-block-link--hover .fc-item__liveblog-blocks__inner {
-                background-color: darken($story-package-card-colour, 5%);
-            }
-
-            .fc-item__liveblog-blocks__inner {
-                background-color: $story-package-card-colour;
-                margin-left: -5px;
-                margin-right: 5px;
-                padding-left: 5px;
-                position: absolute;
-                bottom: 0;
-
-                &:hover {
-                    background-color: darken($story-package-card-colour, 5%);
-                }
-            }
-
-            .fc-item__standfirst-wrapper {
-                display: none;
-            }
+        &.fc-item--full-media-75-tablet .fc-item__standfirst-wrapper {
+            display: none;
         }
 
-        // Invert the live update colours for these cards
-        &.fc-item--full-media-100-tablet, &.fc-item--three-quarters-tall-tablet {
+        // Live updates in horizontal mode
+        &.fc-item--full-media-100-tablet,
+        &.fc-item--three-quarters-tall-tablet {
             .fc-item__liveblog-blocks {
                 height: $block-height;
             }
@@ -393,6 +375,20 @@ $block-height: 58px; // Note: duplicated from _item.scss
                 max-width: 50%;
             }
 
+        }
+
+        // Stick the liveblog blocks to the bottom
+        &.fc-item--full-media-75-tablet {
+            .fc-item__liveblog-blocks__inner {
+                position: absolute;
+                bottom: -#{$border-bottom-width};
+            }
+        }
+
+        // Invert the live update colours for these cards
+        &.fc-item--full-media-100-tablet,
+        &.fc-item--three-quarters-tall-tablet,
+        &.fc-item--full-media-75-tablet {
             .fc-item__liveblog-block__time {
                 color: $story-package-card-colour;
                 display: inline;


### PR DESCRIPTION
DNM until after election.

## What does this change?

Makes the colours for the liveblog blocks blue on grey rather than grey on blue on the FullMedia75 layout. Splits the layout from the colour styling.


### Before

![image](https://user-images.githubusercontent.com/638051/70721186-0e3e1d00-1ced-11ea-8efc-92e65dcec575.png)

### After

![Screenshot 2019-12-12 at 14 32 20](https://user-images.githubusercontent.com/638051/70721205-139b6780-1ced-11ea-9e48-3a22967365d4.png)


### See all

![screencapture-localhost-9000-test-2019-12-12-14_32_29-min](https://user-images.githubusercontent.com/638051/70721157-041c1e80-1ced-11ea-8ed3-dc1959ce5411.png)
