### PR TITLE
Adding feature switch for interactive full header

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -441,4 +441,15 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+    // Election interactive header switch
+  val InteractiveHeaderSwitch = Switch(
+    SwitchGroup.Feature,
+    "interactive-header-switch",
+    "If switched on, the header on all interctives will display in full.",
+    owners = Seq(Owner.withName("dotcom.platform")),
+    safeState = On,
+    sellByDate = new LocalDate(2019, 12, 16),
+    exposeClientSide = true
+  )
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -23,6 +23,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 import implicits.Booleans._
 import org.joda.time.DateTime
+import conf.switches.Switches.InteractiveHeaderSwitch
 
 sealed trait ContentType {
   def content: Content
@@ -906,7 +907,7 @@ object Interactive {
       contentType = Some(contentType),
       adUnitSuffix = section + "/" + contentType.name.toLowerCase,
       twitterPropertiesOverrides = Map( "twitter:title" -> fields.linkText ),
-      contentWithSlimHeader = true
+      contentWithSlimHeader = InteractiveHeaderSwitch.isSwitchedOff
     )
     val contentOverrides = content.copy(
       metadata = metadata


### PR DESCRIPTION
## What does this change?

Makes the header on the interactive template show in it's full state across all interactives. We're going to have a lot of non-regular and new browsers coming to the site during the election and to our results tracker, so it's an opportunity to showcase the breadth of our offering.

Before: 
![Screen Shot 2019-12-12 at 14 53 38](https://user-images.githubusercontent.com/2051501/70722524-58280280-1cef-11ea-95fd-b21073e355a9.png)
After:
![Screen Shot 2019-12-12 at 14 53 19](https://user-images.githubusercontent.com/2051501/70722521-578f6c00-1cef-11ea-9daf-4ce31452d170.png)


