### PR TITLE
Call initPermutive on DCR

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -42,7 +42,7 @@ if (!commercialFeatures.adFree) {
         ['cm-prepare-prebid', preparePrebid],
         ['cm-thirdPartyTags', initThirdPartyTags],
         // Permutive init code must run before google tag enableServices()
-        // The permutive lib however is loaded async in `initPermutiveLib`
+        // The permutive lib however is loaded async with the third party tags
         ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -18,6 +18,7 @@ import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-
 import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
+import { initPermutive } from 'commercial/modules/dfp/prepare-permutive';
 import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts';
 import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
@@ -42,8 +43,8 @@ const commercialModules: Array<Array<any>> = [
 if (!commercialFeatures.adFree) {
     commercialModules.push(
         ['cm-prepare-prebid', preparePrebid],
-        ['cm-prepare-googletag', prepareGoogletag],
         ['cm-thirdPartyTags', initThirdPartyTags],
+        ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],
         ['cm-highMerch', initHighMerch],

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -44,6 +44,8 @@ if (!commercialFeatures.adFree) {
     commercialModules.push(
         ['cm-prepare-prebid', preparePrebid],
         ['cm-thirdPartyTags', initThirdPartyTags],
+        // Permutive init code must run before google tag enableServices()
+        // The permutive lib however is loaded async with the third party tags
         ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],


### PR DESCRIPTION
Co-authored-by: Fares Basmadji <removed email - GT>

## What does this change?

Update the DCR commercial init script to align with the more up to date frontend-platform commercial init script.

Regarding the Permutive schema, the `content` sub schema is available, however since DCR doesn't support identity yet, the `user` sub schema will always have the identity set to false.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No

.... but obviously directly affects DCR.