### PR TITLE
Prevent rich links overlapping numbered lists

### DIFF
--- a/article/app/views/fragments/articleBodyGarnett.scala.html
+++ b/article/app/views/fragments/articleBodyGarnett.scala.html
@@ -79,7 +79,8 @@
                             }
                         }
 
-                        <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
+                        <div class="@RenderClasses(Map("js-article__body--type-numbered-list" -> article.content.isNumberedList), "content__article-body", "from-content-api", "js-article__body")"
+                            itemprop="@bodyType(model)"
                             data-test-id="article-review-body" @langAttributes(article.content)>
 
 

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -127,6 +127,10 @@ const getSpacefinderRules = (): SpacefinderRules => ({
                 : 0,
             minBelow: 0,
         },
+        '.js-article__body--type-numbered-list > h2': {
+            minAbove: 100,
+            minBelow: 200,
+        },
     },
 });
 


### PR DESCRIPTION
## What does this change?

Prevents rich links from overlapping numbers on the numbered list template. Noticed on election content, had to be worked around by inserting rich links in content to force the space finder to not find space for the auto rich links

## Screenshots

### Before

<img width="321" alt="Screenshot 2019-12-13 at 09 40 24" src="https://user-images.githubusercontent.com/638051/70790433-f7e79e00-1d8c-11ea-9734-9513420af613.png">

### After

<img width="321" alt="Screenshot 2019-12-13 at 09 40 46" src="https://user-images.githubusercontent.com/638051/70790449-ff0eac00-1d8c-11ea-9bca-e6c117d11f65.png">

## What is the value of this and can you measure success?

No overlapping content.

## Checklist

