### PR TITLE
Update the deduplication logic

### DIFF
--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -43,7 +43,14 @@ object PressedCollectionDeduplication {
 
   def makeNewBackfill(collectionV: PressedCollectionVisibility, preceedingCollectionVsDeduplicated: Seq[PressedCollectionVisibility]): List[PressedContent] = {
     // We want to remove from the current collection' backfilled's PressedCollections those with a header that has already been used
-    val lookUpCuratedDepth = 3
+
+    // 13th December
+    // This refactoring is meant to handle the following case:
+    // If the current collection has no curated elements, then we make sure that there is no duplicate of any previous curated element.
+    // This is actually meant to always be the case, but we are not currently fully doing it due to the Most Popular container.
+    // This is temporary before a later refactoring.
+
+    val lookUpCuratedDepth = if (collectionV.pressedCollection.curated.isEmpty) 99 else 3
     val lookupBackfilledDepth = 3
     val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilled(preceedingCollectionVsDeduplicated, lookUpCuratedDepth, lookupBackfilledDepth)
     collectionV.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )

--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -29,7 +29,7 @@ object PressedCollectionDeduplication {
 
    */
 
-  def getHeaderURLsFromCuratedAndBackfilled(pCVs: Seq[PressedCollectionVisibility], depth: Int): Seq[String] = {
+  def getHeaderURLsFromCuratedAndBackfilled(pCVs: Seq[PressedCollectionVisibility], curatedDepth: Int, backfillDepth: Int): Seq[String] = {
     // Return the header urls of all curated or backfill elements of a sequence of `PressedCollectionVisibility`.
     // Taken within `depth` of the beginning of the sequence.
 
@@ -38,12 +38,14 @@ object PressedCollectionDeduplication {
     // first depth stories of each field. Interestingly the PressedCollectionVisibility has a notion of visibility
     // that is inherited from the old code. The old notion is meant to be decommissioned
 
-    pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(depth) ++ collection.pressedCollection.backfill.take(depth)).map ( pressedContent => pressedContent.header.url ) }
+    pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(curatedDepth) ++ collection.pressedCollection.backfill.take(backfillDepth)).map ( pressedContent => pressedContent.header.url ) }
   }
 
   def makeNewBackfill(collectionV: PressedCollectionVisibility, preceedingCollectionVsDeduplicated: Seq[PressedCollectionVisibility]): List[PressedContent] = {
     // We want to remove from the current collection' backfilled's PressedCollections those with a header that has already been used
-    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilled(preceedingCollectionVsDeduplicated, 3)
+    val lookUpCuratedDepth = 3
+    val lookupBackfilledDepth = 3
+    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilled(preceedingCollectionVsDeduplicated, lookUpCuratedDepth, lookupBackfilledDepth)
     collectionV.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )
   }
 

--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -29,22 +29,21 @@ object PressedCollectionDeduplication {
 
    */
 
-  def getHeaderURLsFromCuratedAndBackfilled(pCVs: Seq[PressedCollectionVisibility]): Seq[String] = {
+  def getHeaderURLsFromCuratedAndBackfilled(pCVs: Seq[PressedCollectionVisibility], depth: Int): Seq[String] = {
     // Return the header urls of all curated or backfill elements of a sequence of `PressedCollectionVisibility`.
+    // Taken within `depth` of the beginning of the sequence.
 
-    val visibility: Int = 3
-
-    // 11th Dec version:
+    // 11th Dec:
     // To prevent a tiny problem with the Most Popular container I am introducing the effect of collecting only the
-    // first 5 stories of each field. Interestingly the PressedCollectionVisibility has a notion of visibility
+    // first depth stories of each field. Interestingly the PressedCollectionVisibility has a notion of visibility
     // that is inherited from the old code. The old notion is meant to be decommissioned
 
-    pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(visibility) ++ collection.pressedCollection.backfill.take(visibility)).map ( pressedContent => pressedContent.header.url ) }
+    pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(depth) ++ collection.pressedCollection.backfill.take(depth)).map ( pressedContent => pressedContent.header.url ) }
   }
 
   def makeNewBackfill(collectionV: PressedCollectionVisibility, preceedingCollectionVsDeduplicated: Seq[PressedCollectionVisibility]): List[PressedContent] = {
     // We want to remove from the current collection' backfilled's PressedCollections those with a header that has already been used
-    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilled(preceedingCollectionVsDeduplicated)
+    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilled(preceedingCollectionVsDeduplicated, 3)
     collectionV.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )
   }
 


### PR DESCRIPTION
## What does this change?

Update the deduplication logic, to handle the case of purposely left empty containers with are only backfilled. This is a temporary refactoring.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No