### PR TITLE
Change rememberMe to true in AuthenticationController

### DIFF
--- a/identity/app/controllers/AuthenticationController.scala
+++ b/identity/app/controllers/AuthenticationController.scala
@@ -54,7 +54,7 @@ class AuthenticationController(
          Future.successful(NoCache(InternalServerError(Json.toJson(formWithErrors.errors.map(_.toString)))))
        },
        emailPassword => {
-         val authResponse = signInService.getCookies(api.authBrowser(emailPassword, idRequest.trackingData), rememberMe = false)
+         val authResponse = signInService.getCookies(api.authBrowser(emailPassword, idRequest.trackingData), rememberMe = true)
          authResponse.map {
            case Right(cookies) =>
              Cors(NoCache(Ok("{}")), fallbackAllowOrigin = Some(fallbackAccessControlOrigin)).withCookies(cookies: _*)


### PR DESCRIPTION
## What does this change?

Ensures users who sign in to the Guardian on Chrome via their saved passwords in Chrome will receive a normal cookie to keep them logged in rather than a Session cookie that logs them out when they close the browser.


## Why? 

PR #20254 gave users who saved their passwords in Chrome a super quick and easy way to sign in thanks to the Credentials Management API. When a user clicks the 'Sign In' button on the Header, rather than navigate away to Profile two-step sign in page, a Chrome pop up asks them if they would like to 'Sign in as...' and they are signed in in one click and without being navigated away from the page. 

The SG_GU_U cookie they received however, was set as a Session cookie via the PlaySignInService in Frontend/Identity. This meant if they closed Chrome and reopened it, they would have to log in again. This change means they will stay signed in if the close/open Chrome, unless they actively sign out of the Guardian. 

This [feature depends on](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/identity/identity-features.js#L9) two web APIs being available [(Navigator.credentials](https://caniuse.com/#feat=mdn-api_navigator_credentials) &[ window.PasswordCredential](https://caniuse.com/#search=passwordCredential)) which are currently only available fully in Chrome, Opera, Android Browser, and Chrome for Android. 

### Tested in Code (with Gu signin credentials saved in the browser password manager)

#### TODO

- [x] Chrome

Flow 1
1/ user is signed into Chrome/GoogleAccount and the Guardian
2/ user removes their account from Chrome via 'Manage People' Chrome option
3/ All cookies are removed from Chrome and completely blank session is started

Flow 2
1/ user is signed into Chrome/GoogleAccount and the Guardian
2/ user signs out of their Google Account in Chrome (which 'pauses' syncing but does not remove them from Chrome itself)
3/ All cookies remain and they are logged back into Guardian after closing/reopening Chrome. 

- [x] Opera

Flow 1
1/ user is signed the Guardian (There is no option to sign into Opera the same as Chrome as far as I can see)
2/ user closes/reopens Opera
3/ All cookies remain and they are signed into Gu again. 




  


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
