### PR TITLE
Ds subs banner design tweaks

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -5,6 +5,10 @@ import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 
 import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
 
+const isUserLoggedIn = (userLoggedIn) => userLoggedIn
+    ? 'site-message--subscription-banner__sign-in--already-signed-in'
+    : '';
+
 const subscriptionBannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
@@ -18,7 +22,7 @@ const subscriptionBannerTemplate = (
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Two innovative apps and ad-free reading on theguardian.com. The complete digital experience from The Guardian</p>
+            <p>Two innovative apps and ad-free reading on theguardian.com. The complete digital experience from The Guardian.</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">
@@ -29,7 +33,7 @@ const subscriptionBannerTemplate = (
             >
                 Become a digital subscriber
             </a>
-            <div class="site-message--subscription-banner__cta-dismiss-container">
+            <div class="site-message--subscription-banner__cta-dismiss-container ${isUserLoggedIn(userLoggedIn)}">
                 <a
                     id="js-site-message--subscription-banner__cta-dismiss"
                     class="site-message--subscription-banner__cta-dismiss"
@@ -40,11 +44,7 @@ const subscriptionBannerTemplate = (
             </div>
         </div>
 
-        <div class="site-message--subscription-banner__sign-in ${
-            userLoggedIn
-                ? 'site-message--subscription-banner__sign-in--visibility-hidden'
-                : ''
-        }">
+        <div class="site-message--subscription-banner__sign-in ${isUserLoggedIn(userLoggedIn)}">
             <p>Already a subscriber?</p>
             <br class="temp-mobile-break" />
             <a

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -5,9 +5,10 @@ import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 
 import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
 
-const isUserLoggedIn = (userLoggedIn) => userLoggedIn
-    ? 'site-message--subscription-banner__sign-in--already-signed-in'
-    : '';
+const isUserLoggedIn = userLoggedIn =>
+    userLoggedIn
+        ? 'site-message--subscription-banner__sign-in--already-signed-in'
+        : '';
 
 const subscriptionBannerTemplate = (
     subscriptionUrl: string,
@@ -33,7 +34,9 @@ const subscriptionBannerTemplate = (
             >
                 Become a digital subscriber
             </a>
-            <div class="site-message--subscription-banner__cta-dismiss-container ${isUserLoggedIn(userLoggedIn)}">
+            <div class="site-message--subscription-banner__cta-dismiss-container ${isUserLoggedIn(
+                userLoggedIn
+            )}">
                 <a
                     id="js-site-message--subscription-banner__cta-dismiss"
                     class="site-message--subscription-banner__cta-dismiss"
@@ -44,7 +47,9 @@ const subscriptionBannerTemplate = (
             </div>
         </div>
 
-        <div class="site-message--subscription-banner__sign-in ${isUserLoggedIn(userLoggedIn)}">
+        <div class="site-message--subscription-banner__sign-in ${isUserLoggedIn(
+            userLoggedIn
+        )}">
             <p>Already a subscriber?</p>
             <br class="temp-mobile-break" />
             <a

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -169,6 +169,14 @@
     @include mq($from: tablet) {
         margin: 12px 0 0 10px;
     }
+
+    &.site-message--subscription-banner__sign-in--already-signed-in {
+        display: none;
+
+        @include mq($from: tablet) {
+            display: block;
+        }
+    }
 }
 
 .site-message--subscription-banner__cta-dismiss {
@@ -206,6 +214,14 @@
     a {
         color: $brightness-7;
     }
+
+    &.site-message--subscription-banner__sign-in--already-signed-in {
+        display: none;
+
+        @include mq($from: tablet) {
+            visibility: hidden;
+        }
+    }
 }
 
 .site-message--subscription-banner__subscriber-link {
@@ -230,7 +246,12 @@
 
 .site-message--packshot-container {
     width: 100%;
-    margin: 30px 0 -90px;
+    margin: 30px 0 -75px;
+
+    @include mq($from: tablet) {
+        margin-bottom: -105px;
+    }
+
 
     @include mq($from: tablet) {
         position: absolute;
@@ -251,9 +272,13 @@
 
     img {
         width: 100%;
-        max-width: 380px;
+        max-width: 280px;
         margin: 0 auto;
         display: block;
+
+        @include mq($from: mobileLandscape) {
+            max-width: 380px;
+        }
 
         @include mq($from: tablet) {
             margin-right: 0;
@@ -329,9 +354,6 @@
     }
 }
 
-.site-message--subscription-banner__sign-in--visibility-hidden {
-    visibility: hidden;
-}
 
 /*********************** footer hacks *********************/
 
@@ -344,7 +366,11 @@
 .site-message__copy.js-site-message-copy.u-cf {
     margin: 0;
 }
-
+.subscription-banner--holder .site-message--first-pv-consent {
+    @include mq($from: desktop) {
+        padding: 12px 20px;
+    }
+}
 
 .subscription-banner--holder
 .gs-container {


### PR DESCRIPTION
## What does this change?
this PR has some design tweaks for the subs banner (the changes are listed in the checklist)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist
- add full stop to text
- remove gap between cta button and image on mobile
- fix margin on consent banner
- update images sizes on mobile to match design



### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
