### PR TITLE
UK Election Articles Viewed Banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,6 +48,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-banner-articles-viewed-uk-election",
+    "uk election test that shows number of articles viewed in contributions banner",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-banner-articles-viewed",
     "show number of articles viewed in contributions banner",
     owners = Seq(Owner.withGithub("tomrf1")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -16,6 +16,7 @@ import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/comme
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 import { contributionsBannerUsEoyGivingTuesdayCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-casuals';
 import { contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo } from 'common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars';
+import { articlesViewedBannerUkElection } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -40,5 +41,6 @@ export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
     contributionsBannerUsEoyGivingTuesdayRegularsRoundTwo,
     contributionsBannerUsEoyGivingTuesdayCasuals,
     contributionsBannerUsEoy,
+    articlesViewedBannerUkElection,
     articlesViewedBanner,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
@@ -1,0 +1,67 @@
+// @flow
+
+import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
+import {
+    getLocalCurrencySymbol,
+    getSync as geolocationGetSync,
+} from 'lib/geolocation';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
+
+// User must have read at least 5 articles in last 60 days
+const minArticleViews = 5;
+const articleCountDays = 60;
+
+const articleViewCount = getArticleViewCountForDays(articleCountDays);
+const geolocation = geolocationGetSync();
+
+const leadSentence = `You’ve read ${articleViewCount} Guardian articles in the last two months – so we hope you will consider supporting us today.`;
+const messageText =
+    'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
+
+const leadSentenceVariant = 'Britain has voted, and the outcome is clear.';
+const messageTextVariant = `Boris Johnson has led the Conservatives to a seismic election win, Labour is left decimated, and a Brexit looks imminent. The Guardian’s independent, measured, authoritative reporting has never been so critical. You’ve read ${articleViewCount} articles in the last two months. Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. Support from our readers is essential in safeguarding Guardian journalism. If you value our voice, please consider making a contribution now.`;
+
+const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
+    geolocation
+)}1</span>`;
+
+export const articlesViewedBannerUkElection: AcquisitionsABTest = {
+    id: 'ContributionsBannerArticlesViewedUkElection',
+    campaignId: 'contributions_banner_articles_viewed_uk_election',
+    start: '2019-12-13',
+    expiry: '2020-10-30',
+    author: 'Joshua Lieberman',
+    description:
+        'UK post-election test that shows number of articles viewed in contributions banner',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'variant design performs at least as well as control',
+    canRun: () => articleViewCount >= minArticleViews && geolocation === 'UK';
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerControlTemplate,
+            },
+        },
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                leadSentence: leadSentenceVariant,
+                messageText: messageTextVariant,
+                ctaText,
+                template: acquisitionsBannerControlTemplate,
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
@@ -38,7 +38,7 @@ export const articlesViewedBannerUkElection: AcquisitionsABTest = {
     successMeasure: 'AV per impression',
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
-    canRun: () => articleViewCount >= minArticleViews && geolocation === 'UK';
+    canRun: () => articleViewCount >= minArticleViews && geolocation === 'UK',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     geolocation,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
@@ -54,7 +54,7 @@ export const articlesViewedBannerUkElection: AcquisitionsABTest = {
             },
         },
         {
-            id: 'control',
+            id: 'variant',
             test: (): void => {},
             engagementBannerParams: {
                 leadSentence: leadSentenceVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-giving-tuesday-regulars.js
@@ -21,6 +21,8 @@ const ctaText = 'Support The Guardian';
 const messageText =
     'This year, much of what we hold dear has been threatened – democracy, civility, truth. This administration is establishing new norms of behaviour. Truth is being chased away. With your help we can continue put it center stage. As we prepare for 2020, we’re asking our readers to help us raise $1.5 million. ';
 const closingSentence = 'Help us reach our year-end goal.';
+
+// NB This copy expires and must be changed week of the 16th - Please see Joshua for more details
 const articleCountCopy = `You’ve read ${articleViewCount} articles in the last three months`;
 
 // Copy specific to 'withArticleCountInBody'


### PR DESCRIPTION
## What does this change?
New election-focused, uk-only article count banner test

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Control:
<img width="1301" alt="uk election banner control" src="https://user-images.githubusercontent.com/3300789/70817196-fcca4300-1dc8-11ea-90ea-6041ad332104.png">

Variant:
<img width="1338" alt="uk election banner variant" src="https://user-images.githubusercontent.com/3300789/70817202-ffc53380-1dc8-11ea-9924-a8044c0f57d0.png">

## What is the value of this and can you measure success?
Will be measured as an AB Test

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
