### PR TITLE
Check for incorrect geolocation 'UK' in reader-revenue-dev-utils.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -119,7 +119,9 @@ const changeGeolocation = (asExistingSupporter: boolean = false): void => {
     const geo = window.prompt(
         `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${geolocationGetSync()}.`
     );
-    if (geo) {
+    if (geo === 'UK') {
+        alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
+    } else if (geo) {
         setGeolocation(geo);
         clearCommonReaderRevenueStateAndReload(asExistingSupporter);
     }


### PR DESCRIPTION
we use this helper for testing epic + banner in different regions.
The use of GB instead of UK causes a _lot_ of confusion, so I've added an alert