### PR TITLE
Fixed UK election banner, fixed length of time to represent 'three months'

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election.js
@@ -5,21 +5,21 @@ import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
 } from 'lib/geolocation';
-import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 
-// User must have read at least 5 articles in last 60 days
+// User must have read at least 5 articles in last 3 months (as 13 weeks)
 const minArticleViews = 5;
-const articleCountDays = 60;
+const articleCountWeeks = 13;
 
-const articleViewCount = getArticleViewCountForDays(articleCountDays);
+const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 const geolocation = geolocationGetSync();
 
-const leadSentence = `You’ve read ${articleViewCount} Guardian articles in the last two months – so we hope you will consider supporting us today.`;
+const leadSentence = `You’ve read ${articleViewCount} Guardian articles in the last three months – so we hope you will consider supporting us today.`;
 const messageText =
-    'Unlike many news organisations, we made a choice to keep our journalism free and available for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, big or small, is so valuable – it is essential in protecting our editorial independence.';
+    'Unlike many news organisations, we made a choice to keep our journalism open for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, however big or small, is so valuable – it is essential in protecting our editorial independence.';
 
 const leadSentenceVariant = 'Britain has voted, and the outcome is clear.';
-const messageTextVariant = `Boris Johnson has led the Conservatives to a seismic election win, Labour is left decimated, and a Brexit looks imminent. The Guardian’s independent, measured, authoritative reporting has never been so critical. You’ve read ${articleViewCount} articles in the last two months. Unlike many news organisations, we made a choice to keep all of our independent, investigative reporting free and available for everyone. Support from our readers is essential in safeguarding Guardian journalism. If you value our voice, please consider making a contribution now.`;
+const messageTextVariant = `Boris Johnson has led the Conservatives to a seismic election win, Labour is left decimated, and a Brexit looks imminent. The Guardian’s independent, measured, authoritative reporting has never been so critical. You’ve read ${articleViewCount} articles in the last three months. Unlike many news organisations, we made a choice to keep our journalism open for all. At a time when factual information is a necessity, we believe everyone deserves access to accurate reporting with integrity at its heart. Every contribution, however big or small, is so valuable.`;
 
 const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(
     geolocation
@@ -38,7 +38,7 @@ export const articlesViewedBannerUkElection: AcquisitionsABTest = {
     successMeasure: 'AV per impression',
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
-    canRun: () => articleViewCount >= minArticleViews && geolocation === 'UK',
+    canRun: () => articleViewCount >= minArticleViews && geolocation === 'GB',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     geolocation,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-nonsupporters.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-nonsupporters.js
@@ -3,9 +3,9 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 
-// User must have read at least 5 articles in last 60 days
+// User must have read at least 5 articles in last 3 months (as 13 weeks)
 const minArticleViews = 5;
-const articleCountWeeks = 26; // Requesting a half year in order to get as many as possible for this and next iterations
+const articleCountWeeks = 13;
 const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters.js
@@ -4,9 +4,9 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
-// User must have read at least 5 articles in last 60 days
+// User must have read at least 5 articles in last 3 months (as 13 weeks)
 const minArticleViews = 5;
-const articleCountWeeks = 26; // Requesting a half year in order to get as many as possible for this and next iterations
+const articleCountWeeks = 13;
 const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();


### PR DESCRIPTION
## What does this change?
-UK election banner is now properly targeted to 'GB' 🙈 
-Copy updated, as has been fixed by @ionamckendrick 
-Fixed banners across the site with "three months" in the copy to display 13 weeks of data

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Control:
![uk election banner control](https://user-images.githubusercontent.com/3300789/70925963-24691780-2024-11ea-8c8b-6c152ff23c81.png)

Variant:
![uk election banner variant](https://user-images.githubusercontent.com/3300789/70925979-292dcb80-2024-11ea-9200-9ab005a0aa55.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
