### PR TITLE
Show Adtest Page skins in Production

### DIFF
--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -58,8 +58,7 @@ trait PageskinAdAgent {
   // If the sponsorship is an adTest, it is only considered outside of production.
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition): Boolean = {
     if (metaData.isFront) {
-      findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
-        sponsorship.targetsAdTest)
+      findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
     } else false
   }
 

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -58,8 +58,7 @@ trait PageskinAdAgent {
   // If the sponsorship is an adTest, it is only considered outside of production.
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition): Boolean = {
     if (metaData.isFront) {
-      findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
-        !(environmentIsProd && sponsorship.targetsAdTest))
+      findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
     } else false
   }
 

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -58,7 +58,8 @@ trait PageskinAdAgent {
   // If the sponsorship is an adTest, it is only considered outside of production.
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition): Boolean = {
     if (metaData.isFront) {
-      findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
+      findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
+        sponsorship.targetsAdTest)
     } else false
   }
 

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -164,6 +164,10 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       true)
   }
 
+  "production DfpAgent" should "should recognise adtest targetted line items" in {
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition) should be(true)
+  }
+
   "findSponsorships" should "find keyword-targeted sponsorship when keyword page has been overwritten by a pressed front" in {
     TestPageskinAdAgent.findSponsorships(
       adUnitPath = "/123456/root/technology/subsection/ng",

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -158,10 +158,6 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition) should be(true)
   }
 
-  "production DfpAgent" should "not recognise adtest targetted line items" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition) should be(false)
-  }
-
   "non production DfpAgent" should "should recognise adtest targetted line items" in {
     NotProductionTestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta,
       defaultEdition) should be(


### PR DESCRIPTION
## What does this change?
Currently there is a restriction on not showing page skins in production when `adtest` param is present. 
This PR removes that logic. The modified method `hasPageSkin` becomes exact duplicate as `hasPageSkinOrAdTestPageSkin` but I kept both of them for now as they seem to have lots of usages both server side & client side which makes me unsure of the exact impact across all platforms, so better to separate on another card under Maintenance to analyse impact to implement appropriate refactoring

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [ ] Locally
- [x] On CODE (optional)

