### PR TITLE
Keep interactive header switch in production

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -448,8 +448,8 @@ trait FeatureSwitches {
     "interactive-header-switch",
     "If switched on, the header on all interctives will display in full.",
     owners = Seq(Owner.withName("dotcom.platform")),
-    safeState = On,
-    sellByDate = new LocalDate(2019, 12, 16),
+    safeState = Off,
+    sellByDate = never,
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -445,8 +445,8 @@ trait FeatureSwitches {
     // Election interactive header switch
   val InteractiveHeaderSwitch = Switch(
     SwitchGroup.Feature,
-    "interactive-header-switch",
-    "If switched on, the header on all interctives will display in full.",
+    "interactive-full-header-switch",
+    "If switched on, the header on all interactives will display in full.",
     owners = Seq(Owner.withName("dotcom.platform")),
     safeState = Off,
     sellByDate = never,


### PR DESCRIPTION
## What does this change?
For bigger news agenda items, this will allow us to flick a switch to display the header in full on interactives, rather than creating a PR each time. 

