### PR TITLE
Impeachment Banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,6 +68,26 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-banner-us-eoy-impeachment-regulars",
+    "US End of year banner - impeachment, with article count",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-impeachment-casuals",
+    "US End of year banner - impeachment, no article count",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-banner-us-eoy-reader-appreciation-supporters",
     "US End of year banner - reader appreciation, supporters with article count",
     owners = Seq(Owner.withGithub("jlieb10")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -18,6 +18,8 @@ import { contributionsBannerUsEoyReaderAppreciationNonsupportersCasuals } from '
 import { contributionsBannerUsEoyReaderAppreciationSupportersCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters-casuals';
 import { contributionsBannerUsEoyReaderAppreciationNonsupporters } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-nonsupporters';
 import { contributionsBannerUsEoyReaderAppreciationSupporters } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters';
+import { contributionsBannerUsEoyImpeachmentCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-casuals';
+import { contributionsBannerUsEoyImpeachmentRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-regulars';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -39,6 +41,8 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    contributionsBannerUsEoyImpeachmentRegulars,
+    contributionsBannerUsEoyImpeachmentCasuals,
     contributionsBannerUsEoyReaderAppreciationSupporters,
     contributionsBannerUsEoyReaderAppreciationNonsupporters,
     contributionsBannerUsEoyReaderAppreciationSupportersCasuals,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-casuals.js
@@ -1,0 +1,45 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+
+const geolocation = geolocationGetSync();
+const isUS = geolocation === 'US';
+
+const titles = ['At\xa0this\xa0historic\nmoment\xa0for\xa0America'];
+const messageText = `Donald Trump has been impeached – only the third president in history to face this sanction. But the challenges to American democracy do not end today. 2020 will be an epic year – and the need for robust, independent reporting has never been greater. The Guardian relies on your support. Make a year-end gift today from as little as $1. Thank you.`;
+const ctaText = 'Support The Guardian';
+const tickerHeader = 'Help us reach our year-end goal';
+
+export const contributionsBannerUsEoyImpeachmentCasuals: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyImpeachmentCasuals',
+    campaignId: 'USeoy2019',
+    start: '2019-12-16',
+    expiry: '2020-1-30',
+    author: 'Joshua Lieberman',
+    description:
+        'reader appreciation banner for the US EOY campaign - potential supporters with article count',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'NA',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => isUS,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+                tickerHeader,
+                bannerModifierClass: 'useoy2019',
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-impeachment-regulars.js
@@ -1,0 +1,52 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
+
+// User must have read at least 6 articles this year to qualify
+const minArticleViews = 6;
+const articleCountWeeks = 26;
+// Ensure accuracy of the "more than" copy
+const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks) - 1;
+
+const geolocation = geolocationGetSync();
+const isUS = geolocation === 'US';
+
+const titles = ['At\xa0this\xa0historic\nmoment\xa0for\xa0America'];
+const messageText = `Donald Trump has been impeached – only the third president in history to face this sanction. But the challenges to American democracy do not end today. 2020 will be an epic year – and the need for robust, independent reporting has never been greater. You’ve read more than ${articleViewCount} articles in 2019, and the Guardian relies on your support. Make a year-end gift today from as little as $1. Thank you.`;
+const ctaText = 'Support The Guardian';
+const tickerHeader = 'Help us reach our year-end goal';
+
+export const contributionsBannerUsEoyImpeachmentRegulars: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyImpeachmentRegulars',
+    campaignId: 'USeoy2019',
+    start: '2019-12-16',
+    expiry: '2020-1-30',
+    author: 'Joshua Lieberman',
+    description:
+        'reader appreciation banner for the US EOY campaign - potential supporters with article count',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'NA',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => isUS && articleViewCount >= minArticleViews,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+                tickerHeader,
+                bannerModifierClass: 'useoy2019',
+            },
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?
Banner for impeachment is ready to go..

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
With article count:
<img width="1325" alt="impeachment banner with article count" src="https://user-images.githubusercontent.com/3300789/70999771-f2ae8a00-20d1-11ea-954c-fe957c9a83a1.png">

Without article count:
<img width="1334" alt="impeachment banner without article count" src="https://user-images.githubusercontent.com/3300789/70999773-f2ae8a00-20d1-11ea-99d4-2455554a2054.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
