### PR TITLE
Appnexus Permutive segments

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -175,8 +175,8 @@ const formatAppNexusTargeting = (obj: { [string]: string }): string =>
     ).join(',');
 
 const buildAppNexusTargetingObject = once(
-    (pageTargeting: PageTargeting): {} => ({
-        ...removeFalseyValues({
+    (pageTargeting: PageTargeting): {} =>
+        removeFalseyValues({
             sens: pageTargeting.sens,
             pt1: pageTargeting.url,
             pt2: pageTargeting.edition,
@@ -193,9 +193,8 @@ const buildAppNexusTargetingObject = once(
                 pageTargeting.tn,
                 pageTargeting.slot,
             ].join('|'),
-        }),
-        permutive: pageTargeting.permutive,
-    })
+            permutive: pageTargeting.permutive,
+        })
 );
 
 const buildAppNexusTargeting = once(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -10,6 +10,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { local } from 'lib/storage';
 import { getUrlVars } from 'lib/url';
 import { getKruxSegments } from 'common/modules/commercial/krux';
+import { getPermutiveSegments } from 'common/modules/commercial/permutive';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
@@ -36,6 +37,7 @@ type PageTargeting = {
     co: string,
     tn: string,
     slot: string,
+    permutive: string,
 };
 
 let myPageTargetting: {} = {};
@@ -173,8 +175,8 @@ const formatAppNexusTargeting = (obj: { [string]: string }): string =>
     ).join(',');
 
 const buildAppNexusTargetingObject = once(
-    (pageTargeting: PageTargeting): {} =>
-        removeFalseyValues({
+    (pageTargeting: PageTargeting): {} => ({
+        ...removeFalseyValues({
             sens: pageTargeting.sens,
             pt1: pageTargeting.url,
             pt2: pageTargeting.edition,
@@ -191,7 +193,9 @@ const buildAppNexusTargetingObject = once(
                 pageTargeting.tn,
                 pageTargeting.slot,
             ].join('|'),
-        })
+        }),
+        permutive: pageTargeting.permutive,
+    })
 );
 
 const buildAppNexusTargeting = once(
@@ -211,6 +215,7 @@ const buildPageTargetting = (
         {
             sens: page.isSensitive ? 't' : 'f',
             x: getKruxSegments(adConsentState),
+            permutive: getPermutiveSegments(),
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -1,0 +1,15 @@
+// @flow
+import { local } from 'lib/storage';
+
+const PERMUTIVE_KEY = `_papns`;
+
+export const getPermutiveSegments = (): Array<string> => {
+    try {
+        return JSON.parse(local.getRaw(PERMUTIVE_KEY) || '[]')
+            .slice(0, 250)
+            .filter(s => typeof s === 'number')
+            .map(String);
+    } catch (e) {
+        return [];
+    }
+};

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
@@ -1,0 +1,28 @@
+// @flow
+import { local } from 'lib/storage';
+import { getPermutiveSegments } from './permutive';
+
+jest.mock('lib/storage', () => ({
+    local: {
+        getRaw: jest.fn(),
+    },
+}));
+
+describe('getPermutiveSegments', () => {
+    test('parses Permutive segments correctly', () => {
+        local.getRaw.mockReturnValue(['[42,84,63]']);
+        expect(getPermutiveSegments()).toEqual(['42', '84', '63']);
+        local.getRaw.mockReturnValue([]);
+        expect(getPermutiveSegments()).toEqual([]);
+    });
+    test('returns an empty array for bad inputs', () => {
+        local.getRaw.mockReturnValue('-1');
+        expect(getPermutiveSegments()).toEqual([]);
+        local.getRaw.mockReturnValue('bad-string');
+        expect(getPermutiveSegments()).toEqual([]);
+        local.getRaw.mockReturnValue('{}');
+        expect(getPermutiveSegments()).toEqual([]);
+        local.getRaw.mockReturnValue('["not-a-number-segment"]');
+        expect(getPermutiveSegments()).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What does this change?
Passes the Permutive segments into the page targeting object that Appnexus adapter uses for bidding.
[Trello card](https://trello.com/c/1XfNs4Ek/595-permutive-passing-permutive-key-values-to-appnexus)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
