### PR TITLE
Remove the opinion styling overrides from dynamic layout and reduce the general specificity

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -35,7 +35,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
                 background-image: none;
             }
 
-            &.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+            &.fc-item--type-comment:not(.fc-item--pillar-special-report):not(.fc-item--dynamic-layout) .fc-item__container.u-faux-block-link--hover {
                 background-color: darken($story-package-card-colour, 5%);
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -275,15 +275,9 @@ $pillars: (
         background-color: map-get($palette, kicker);
     }
 
-    &.fc-item--type-comment:not(.fc-item--pillar-special-report) {
-        &.fc-item--pillar-news,
-        &.fc-item--pillar-opinion,
-        &.fc-item--pillar-sport,
-        &.fc-item--pillar-arts,
-        &.fc-item--pillar-lifestyle {
-            background-color: $opinion-faded;
-        }
+    &.fc-item--type-comment:not(.fc-item--pillar-special-report):not(.fc-item--dynamic-layout) {
 
+        background-color: $opinion-faded;
 
         .fc-item__container.u-faux-block-link--hover {
             background-color: darken($opinion-faded, 2%);


### PR DESCRIPTION
## What does this change?

This PR, removes opinion styling from the `dynamic content` card style to prevent clashing. It also removes the overly specific pillar styling as the mixin is already included inside the pillars so a pillar class is added twice to the selector.

### Before

![image](https://user-images.githubusercontent.com/638051/71079944-1af6c100-2184-11ea-8623-be2ac7953c24.png)
![image](https://user-images.githubusercontent.com/638051/71079956-20540b80-2184-11ea-8871-a102125d98a9.png)

### After

![image](https://user-images.githubusercontent.com/638051/71080038-49749c00-2184-11ea-8557-6e685219aacb.png)
![image](https://user-images.githubusercontent.com/638051/71080087-5ee9c600-2184-11ea-84b5-0bb7c1913769.png)
