### PR TITLE
Extend Identity switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -192,7 +192,7 @@ trait ABTestSwitches {
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = On,
-    sellByDate = new LocalDate(2019, 12, 17),
+    sellByDate = new LocalDate(2019, 12, 20),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the Identity team's `sign in gate prius` switch to till the 20th of December when they will update it.