### PR TITLE
Deduplication updated logic

### DIFF
--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -29,25 +29,11 @@ object PressedCollectionDeduplication {
    */
 
   /*
-      Pascal - 13th Dec 2019
-
-      Today I am introducing a logic that is as close to the target logic as possible, while handling two interesting cases:
-        1. Maintaining the integrity of the Most Popular container.
-        2. Allowing for backfill'ed only containers to work fine.
-
-      Considering the situation:
-        - The `PressedCollection`s are given in order `[pc_{1}, pc_{2}, ...., pc_{n-1}, pc_{n}, pc_{n+1}, ... ]`.
-        - During the fold we have computed `[pc_{1}, pc_{2}, ...., pc_{n-1}]` and we are given `pc_{n}`.
-
-      Define: `pc_{n}'i` = Deduplication at depth `i` of the backfilled elements of `pc_{n}` using the first `i` curated or backfilled elements of `[pc_{1}, pc_{2}, ...., pc_{n-1}]`
-
-      We compute `pc_{n}'i` for i \in { 1, ...., i_{max} } # Where `i_{max}` the maximum length of the curated or backfilled arrays of the entire collection `[pc_{1}, pc_{2}, ...., pc_{n-1}]`.
-
-      The intuitive meaning of `pc_{n}'i` is that the bigger the `i` the closer we are from the ideal situation of complete deduplication.
-
-      The having been said `pc_{n}'i` with large `i` can lead to Most Popular containers being only partially filled.
-
-      Therefore, once [pc_{n}'1, pc_{n}'2, ..., pc_{n}'i_{max}] has been computed, we take either the first one or the last possible one with at least 10 elements (curated and backfilled counted together).
+      Pascal - 18th Dec 2019
+        The implementation is a variation of the general rules (exposed on 05th Dec 2019) to allow for:
+          1. Maintaining the integrity of the Most Popular container.
+          2. Allowing for backfill'ed only containers to work fine.
+          3. Forcing backfilled deduplication in consecutive containers
    */
 
   def getHeaderURLsFromCuratedAndBackfilledAtDepth(pCVs: Seq[PressedCollectionVisibility], depth: Int): Seq[String] = {
@@ -88,13 +74,31 @@ object PressedCollectionDeduplication {
     }
   }
 
+  def completelyDeduplicateSecondBackfilledAgainstFirstCurated(collectionV1: PressedCollectionVisibility, collectionV2: PressedCollectionVisibility): PressedCollectionVisibility = {
+    val accumulatedHeaderURLsForDeduplication = collectionV1.pressedCollection.curated.map ( pressedContent => pressedContent.header.url )
+    val newBackfill = collectionV2.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )
+    collectionV2.copy(
+      pressedCollection = collectionV2.pressedCollection.copy (
+        backfill = newBackfill
+      )
+    )
+  }
+
+  def completelyDeduplicateCollectionAgainstAccumulatorEnding(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility): PressedCollectionVisibility = {
+    val last = accum.reverse.headOption
+    last match {
+      case None => collectionV
+      case Some(lastCollectionV) => completelyDeduplicateSecondBackfilledAgainstFirstCurated(lastCollectionV: PressedCollectionVisibility, collectionV: PressedCollectionVisibility)
+    }
+  }
+
   def deduplication(pressedCollections: Seq[PressedCollectionVisibility]): Seq[PressedCollectionVisibility] = {
     pressedCollections.foldLeft[Seq[PressedCollectionVisibility]](Nil) { (accum, collectionV) =>
       // Given collectionV we compute the candidates for its replacement, then add the best of those candidates (according to reduceDeduplicatedCollectionCandidates) to accum
       val candidates: Seq[PressedCollectionVisibility] = makeDeduplicatedCollectionCandidates(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility)
       reduceDeduplicatedCollectionCandidates(candidates) match {
         case None => accum
-        case Some(collectionV) => accum :+ collectionV
+        case Some(collectionV) => accum :+ completelyDeduplicateCollectionAgainstAccumulatorEnding(accum, collectionV)
       }
     }
   }

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -52,18 +52,23 @@ trait FaciaPressDeduplicationTestData {
 
   val collection0 = collectionFromCuratedAndBackfilled(
     List(
-      "link10",
       "link11",
     ).map(id => pressedContentFromId(id)),
     List(
+      "link10",
       "link22",
       "link23"
     ).map(id => pressedContentFromId(id))
   )
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // Test that we do not deduplicate below 10 elements [1]
+  // We expect backfill to stay even if a duplicate of collection0 backfill
+  // -----------------------------------------------------
   val collection1 = collectionFromCuratedAndBackfilled(
     List(
-      "link11",
+      "link10",
       "link12",
       "link13",
       "link43",
@@ -78,6 +83,12 @@ trait FaciaPressDeduplicationTestData {
     ).map(id => pressedContentFromId(id))
   )
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // Test that we deduplicate against curated and backfilled elements
+  // We expect 11 to go because of collection0's curated
+  // We expect 22 to go because of collection0's backfilled
+  // -----------------------------------------------------
   val collection2 = collectionFromCuratedAndBackfilled(
     List(
       "link11",
@@ -92,59 +103,35 @@ trait FaciaPressDeduplicationTestData {
       "link51"
     ).map(id => pressedContentFromId(id)),
     List(
-      "link10",
+      "link11",
       "link22"
     ).map(id => pressedContentFromId(id))
   )
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // Test remove backfilled contents when appearing in the previous container as curated
+  // .... thereby overidding [1]
+  // We expect "link10" in collection4 to go, but "link10" in collection5 to stay
+  // -----------------------------------------------------
   val collection3 = collectionFromCuratedAndBackfilled(
     List(
       "link10",
-      "link30",
-      "link31",
-      "link32",
-      "link33",
-      "link34",
-      "link35",
-      "link36",
-      "link37",
-      "link38",
-      "link39",
-      "link40",
-      "link41",
-      "link42",
-      "link43",
-      "link44",
-      "link45",
     ).map(id => pressedContentFromId(id)),
     Nil
   )
 
   val collection4 = collectionFromCuratedAndBackfilled(
+    Nil,
     List(
-      "link30",
-      "link31",
-      "link32",
-      "link33",
-      "link34",
-      "link35",
-      "link36",
-      "link37",
-      "link38",
-      "link39",
-      "link40"
-    ).map(id => pressedContentFromId(id)),
+      "link10",
+    ).map(id => pressedContentFromId(id))
+  )
+
+  val collection5 = collectionFromCuratedAndBackfilled(
+    Nil,
     List(
-      "link41",
-      "link42",
-      "link43",
-      "link44",
-      "link45",
-      "link46",
-      "link47",
-      "link48",
-      "link49",
-      "link50"
+      "link10",
     ).map(id => pressedContentFromId(id))
   )
 }

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -65,19 +65,20 @@ trait FaciaPressDeduplicationTestData {
 
   val collection1 = collectionFromCuratedAndBackfilled(
     List(
-      "link10",
       "link11",
       "link12",
       "link13",
       "link43",
+      "link46",
+      "link47",
       "link48",
       "link49",
-      "link50",
+      "link50"
     ).map(id => pressedContentFromId(id)),
     List(
-      "link21",
-      "link22",
-      "link23"
+      "link10",
+      "link12",
+      "link22"
     ).map(id => pressedContentFromId(id))
   )
 
@@ -100,11 +101,7 @@ trait FaciaPressDeduplicationTestData {
       "link43",
       "link44",
       "link45",
-      "link46",
-      "link47",
-      "link48",
-      "link49",
-      "link50"
+
     ).map(id => pressedContentFromId(id)),
     Nil
   )

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -54,8 +54,6 @@ trait FaciaPressDeduplicationTestData {
     List(
       "link10",
       "link11",
-      "link12",
-      "link13",
     ).map(id => pressedContentFromId(id)),
     List(
       "link22",
@@ -73,16 +71,33 @@ trait FaciaPressDeduplicationTestData {
       "link47",
       "link48",
       "link49",
-      "link50"
+      "link50",
     ).map(id => pressedContentFromId(id)),
     List(
       "link10",
-      "link12",
-      "link22"
     ).map(id => pressedContentFromId(id))
   )
 
   val collection2 = collectionFromCuratedAndBackfilled(
+    List(
+      "link11",
+      "link12",
+      "link13",
+      "link43",
+      "link46",
+      "link47",
+      "link48",
+      "link49",
+      "link50",
+      "link51"
+    ).map(id => pressedContentFromId(id)),
+    List(
+      "link10",
+      "link22"
+    ).map(id => pressedContentFromId(id))
+  )
+
+  val collection3 = collectionFromCuratedAndBackfilled(
     List(
       "link10",
       "link30",
@@ -101,12 +116,11 @@ trait FaciaPressDeduplicationTestData {
       "link43",
       "link44",
       "link45",
-
     ).map(id => pressedContentFromId(id)),
     Nil
   )
 
-  val collection3 = collectionFromCuratedAndBackfilled(
+  val collection4 = collectionFromCuratedAndBackfilled(
     List(
       "link30",
       "link31",

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -65,11 +65,11 @@ trait FaciaPressDeduplicationTestData {
 
   val collection1 = collectionFromCuratedAndBackfilled(
     List(
+      "link10",
+      "link11",
+      "link12",
+      "link13",
       "link43",
-      "link44",
-      "link45",
-      "link46",
-      "link47",
       "link48",
       "link49",
       "link50",
@@ -83,6 +83,7 @@ trait FaciaPressDeduplicationTestData {
 
   val collection2 = collectionFromCuratedAndBackfilled(
     List(
+      "link10",
       "link30",
       "link31",
       "link32",
@@ -135,13 +136,4 @@ trait FaciaPressDeduplicationTestData {
       "link50"
     ).map(id => pressedContentFromId(id))
   )
-
-  // What we want to see.
-
-  // 1. The curated elements are never removed
-
-  // 2. Just one element backfilled elements of collection1 is going to be removed (this is because after "link21" is
-  // removed, we will be with a collection which has exactly 10 elements)
-
-  // 3. All the backfilled elements of collection3 are going to be removed.
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -5,7 +5,13 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPressDeduplicationTestData {
 
-  var sequence = List(PressedCollectionVisibility(collection0, 0), PressedCollectionVisibility(collection1, 0), PressedCollectionVisibility(collection2, 0), PressedCollectionVisibility(collection3, 0))
+  var sequence = List(
+    PressedCollectionVisibility(collection0, 0),
+    PressedCollectionVisibility(collection1, 0),
+    PressedCollectionVisibility(collection2, 0),
+    PressedCollectionVisibility(collection3, 0),
+    PressedCollectionVisibility(collection4, 0)
+  )
   // Note that the integer (0) passed as second argument of PressedCollectionVisibility.apply is irrelevant. We use
   // it because the current version of PressedCollectionDeduplication.deduplication still takes PressedCollectionVisibility
 
@@ -20,18 +26,20 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
 
   // 3. All the backfilled elements of collection3 are going to be removed.
 
-  it should "curated elements are never removed" in {
+  it should "never remove curated elements" in {
     newSequence(0).pressedCollection.curated.size shouldBe sequence(0).pressedCollection.curated.size
     newSequence(1).pressedCollection.curated.size shouldBe sequence(1).pressedCollection.curated.size
     newSequence(2).pressedCollection.curated.size shouldBe sequence(2).pressedCollection.curated.size
+    newSequence(3).pressedCollection.curated.size shouldBe sequence(3).pressedCollection.curated.size
+    newSequence(4).pressedCollection.curated.size shouldBe sequence(4).pressedCollection.curated.size
   }
 
-  it should "remove duplicated backfill'ed content" in {
-    newSequence(1).pressedCollection.backfill.size shouldBe 1
-    // It is not 1, because we do not deduplicate if resulting in less than 10 elements.
+  it should "deduplicate backfill'ed content" in {
+    newSequence(1).pressedCollection.backfill.size shouldBe 1 // Test that we do not deduplicate below 10 elements
+    newSequence(2).pressedCollection.backfill.size shouldBe 0 // Test that we deduplicated against curated and backfilled elements
   }
 
   it should "remove all backfilled contents when possible" in {
-    newSequence(3).pressedCollection.backfill shouldBe empty
+    // newSequence(3).pressedCollection.backfill shouldBe empty
   }
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -11,15 +11,25 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
 
   val newSequence = PressedCollectionDeduplication.deduplication(sequence)
 
+  // What we want to see.
+
+  // 1. The curated elements are never removed
+
+  // 2. Just one element backfilled elements of collection1 is going to be removed (this is because after "link21" is
+  // removed, we will be with a collection which has exactly 10 elements)
+
+  // 3. All the backfilled elements of collection3 are going to be removed.
+
   it should "curated elements are never removed" in {
     newSequence(0).pressedCollection.curated.size shouldBe 4
     newSequence(1).pressedCollection.curated.size shouldBe 8
-    newSequence(2).pressedCollection.curated.size shouldBe 21
+    newSequence(2).pressedCollection.curated.size shouldBe 22
     newSequence(3).pressedCollection.curated.size shouldBe 11
   }
 
   it should "remove duplicated backfill'ed content" in {
     newSequence(1).pressedCollection.backfill.size shouldBe 2
+    // It is not 1, because we do not deduplicate if resulting in less than 10 elements.
   }
 
   it should "remove all backfilled contents when possible" in {

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -10,21 +10,13 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
     PressedCollectionVisibility(collection1, 0),
     PressedCollectionVisibility(collection2, 0),
     PressedCollectionVisibility(collection3, 0),
-    PressedCollectionVisibility(collection4, 0)
+    PressedCollectionVisibility(collection4, 0),
+    PressedCollectionVisibility(collection5, 0)
   )
   // Note that the integer (0) passed as second argument of PressedCollectionVisibility.apply is irrelevant. We use
   // it because the current version of PressedCollectionDeduplication.deduplication still takes PressedCollectionVisibility
 
   val newSequence = PressedCollectionDeduplication.deduplication(sequence)
-
-  // What we want to see.
-
-  // 1. The curated elements are never removed
-
-  // 2. Just one element backfilled elements of collection1 is going to be removed (this is because after "link21" is
-  // removed, we will be with a collection which has exactly 10 elements)
-
-  // 3. All the backfilled elements of collection3 are going to be removed.
 
   it should "never remove curated elements" in {
     newSequence(0).pressedCollection.curated.size shouldBe sequence(0).pressedCollection.curated.size
@@ -34,12 +26,17 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
     newSequence(4).pressedCollection.curated.size shouldBe sequence(4).pressedCollection.curated.size
   }
 
-  it should "deduplicate backfill'ed content" in {
-    newSequence(1).pressedCollection.backfill.size shouldBe 1 // Test that we do not deduplicate below 10 elements
-    newSequence(2).pressedCollection.backfill.size shouldBe 0 // Test that we deduplicated against curated and backfilled elements
+  it should "not deduplicate backfill'ed content if resulting in less than 10 elements" in {
+    newSequence(1).pressedCollection.backfill.size shouldBe 1 // Test that we do not deduplicate below 10 elements [1]
   }
 
-  it should "remove all backfilled contents when possible" in {
-    // newSequence(3).pressedCollection.backfill shouldBe empty
+  it should "deduplicate backfill'ed content against curated and backfilled elements" in {
+    newSequence(2).pressedCollection.backfill.size shouldBe 0 // Test that we deduplicate against curated and backfilled elements
+  }
+
+  it should "force remove backfilled contents when appearing in the previous container as curated (even if less than 10 elements)" in {
+    // .... thereby overidding [1]
+    newSequence(4).pressedCollection.backfill.size shouldBe 0
+    newSequence(5).pressedCollection.backfill.size shouldBe 1
   }
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -21,14 +21,13 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
   // 3. All the backfilled elements of collection3 are going to be removed.
 
   it should "curated elements are never removed" in {
-    newSequence(0).pressedCollection.curated.size shouldBe 4
-    newSequence(1).pressedCollection.curated.size shouldBe 8
-    newSequence(2).pressedCollection.curated.size shouldBe 22
-    newSequence(3).pressedCollection.curated.size shouldBe 11
+    newSequence(0).pressedCollection.curated.size shouldBe sequence(0).pressedCollection.curated.size
+    newSequence(1).pressedCollection.curated.size shouldBe sequence(1).pressedCollection.curated.size
+    newSequence(2).pressedCollection.curated.size shouldBe sequence(2).pressedCollection.curated.size
   }
 
   it should "remove duplicated backfill'ed content" in {
-    newSequence(1).pressedCollection.backfill.size shouldBe 2
+    newSequence(1).pressedCollection.backfill.size shouldBe 1
     // It is not 1, because we do not deduplicate if resulting in less than 10 elements.
   }
 


### PR DESCRIPTION
## What does this change?

Introduces a tiny change in the deduplication logic (one more step towards complete compliance with the ideal, while preserving Most Popular): completely deduplicate a collection (card) against accumulator ending during deduplication fold.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
