### PR TITLE
Dark colours for kicker on story package container

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -742,10 +742,10 @@ $block-height: 58px; // Note: duplicated from _item.scss
     }
 
     //These need to exist for all kickers because of tone on tone action
-    @include pillar-override(lifestyle, $lifestyle-bright, $lifestyle-bright);
-    @include pillar-override(arts, $culture-bright, $culture-bright);
+    @include pillar-override(lifestyle, $lifestyle-bright, $lifestyle-dark);
+    @include pillar-override(arts, $culture-bright, $culture-dark);
     @include pillar-override(sport, $sport-bright, $sport-bright);
     @include pillar-override(opinion, $opinion-bright, $opinion-bright);
     @include pillar-override(news, $news-bright, $news-bright);
-    @include pillar-override(special-report, $highlight-main, $highlight-main);
+    @include pillar-override(special-report, $highlight-main, $highlight-dark);
 }


### PR DESCRIPTION
## What does this change?

Fixes the dark colours on light background on Dynamo/Story package container. Note: I need @blongden73 to look at this as the colour is still not accessible, but just less bad.

### Before

![image](https://user-images.githubusercontent.com/638051/71168673-2e229300-224f-11ea-89d8-83f184b32331.png)


### After

![image](https://user-images.githubusercontent.com/638051/71168728-4397bd00-224f-11ea-93b7-35e8d7079827.png)


### Also changed lifestyle and culture as these had the same issue

![image](https://user-images.githubusercontent.com/638051/71168756-55796000-224f-11ea-842c-dbad5167821d.png)
![image](https://user-images.githubusercontent.com/638051/71168773-5c07d780-224f-11ea-92dd-8abeece57923.png)
