### PR TITLE
Sign In Gate Secundus Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -142,7 +142,7 @@ trait ABTestSwitches {
     "Test the impact of serving prebid ads in safeframes",
     owners = Seq(Owner.withGithub("jeteve")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 18),
+    sellByDate = new LocalDate(2020, 1, 20),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -188,11 +188,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-prius",
+    "ab-sign-in-gate-secundus",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
-    sellByDate = new LocalDate(2020, 1, 20),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 31),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,7 +10,7 @@ import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
-import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
+import { signInGateSecundus } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 import { articlesViewedBannerUkElection } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election';
@@ -28,7 +28,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     xaxisAdapterTest,
     appnexusUSAdapter,
     pangaeaAdapterTest,
-    signInGatePrius,
+    signInGateSecundus,
     commercialCmpUiNoOverlay,
     commercialConsentOptionsButton,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateSecundus: ABTest = {
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
-    audience: 0.1,
+    audience: 0.285,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -1,18 +1,18 @@
 // @flow
-export const signInGatePrius: ABTest = {
-    id: 'SignInGatePrius',
-    start: '2019-12-02',
-    expiry: '2019-12-17',
+export const signInGateSecundus: ABTest = {
+    id: 'SignInGateSecundus',
+    start: '2019-12-20',
+    expiry: '2020-01-31',
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
-        'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic.',
-    audience: 0.015,
+        'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
+    audience: 0.1,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',
     dataLinkNames: 'n/a',
-    idealOutcome: '60% of users sign in, and bounce rate is below 40%',
+    idealOutcome: '60% of users sign in, and dismiss rate is below 40%',
     showForSensitive: false,
     canRun: () => true,
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -7,7 +7,7 @@ export const signInGateSecundus: ABTest = {
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
     audience: 0.285,
-    audienceOffset: 0.9,
+    audienceOffset: 0.7,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -10,7 +10,7 @@ import {
     getSynchronousTestsToRun,
     isInABTestSynchronous,
 } from 'common/modules/experiments/ab';
-import { signInGatePrius } from 'common/modules/experiments/tests/sign-in-gate-first-test';
+import { signInGateSecundus } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { constructQuery } from 'lib/url';
 
@@ -41,7 +41,7 @@ const componentName = 'sign-in-gate';
 
 const component = {
     componentType: 'SIGN_IN_GATE',
-    id: 'prius_test',
+    id: 'secundus_test',
 };
 
 // ophan helper methods
@@ -127,7 +127,7 @@ const isInvalidSection = (): boolean => {
 const getVariant: () => string = () => {
     //  get the current test
     const currentTest = getSynchronousTestsToRun().find(
-        t => t.id === signInGatePrius.id
+        t => t.id === signInGateSecundus.id
     );
 
     // get variant user is in for the test
@@ -140,9 +140,9 @@ const canShow: () => Promise<boolean> = async () => {
 
     return Promise.resolve(
         // is in sign in gate ab test
-        isInABTestSynchronous(signInGatePrius) &&
+        isInABTestSynchronous(signInGateSecundus) &&
             // check if user already dismissed gate
-            !hasUserDismissedGate(signInGatePrius.id, variant) &&
+            !hasUserDismissedGate(signInGateSecundus.id, variant) &&
             // check number of page views
             isSecondPageOrHigherPageView() &&
             // check if user is not logged by checking for cookie
@@ -163,7 +163,7 @@ const show: () => Promise<boolean> = () => {
     if (variant) {
         // object helper to determine the ab test
         const abTest = {
-            name: signInGatePrius.id,
+            name: signInGateSecundus.id,
             variant,
         };
 
@@ -176,7 +176,7 @@ const show: () => Promise<boolean> = () => {
         const queryParams: ComponentEventParams = {
             componentType: 'signingate',
             componentId: component.id,
-            abTestName: signInGatePrius.id,
+            abTestName: signInGateSecundus.id,
             abTestVariant: variant,
         };
 
@@ -303,7 +303,10 @@ const show: () => Promise<boolean> = () => {
                             shadowArticleBody.replaceWith(currentContent);
 
                             // user pref dismissed gate
-                            setUserDismissedGate(signInGatePrius.id, variant);
+                            setUserDismissedGate(
+                                signInGateSecundus.id,
+                                variant
+                            );
                         }
                     );
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -10,7 +10,7 @@ jest.mock('common/modules/experiments/ab', () => ({
     getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
     getSynchronousTestsToRun: jest.fn(() => [
         {
-            id: 'SignInGatePrius',
+            id: 'SignInGateSecundus',
             variantToRun: {
                 id: 'variant',
             },
@@ -91,7 +91,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGatePrius-variant': Date.now(),
+                'SignInGateSecundus-variant': Date.now(),
             });
         });
 


### PR DESCRIPTION
## What does this change?

This PR removes the old sign in gate test, and replaces it with a new one with a different name, and an increased audience size to target approx 563K browsers each day (282K in each variation) who see the test.

This will allow us to see how different segments (region, device, engagement) respond to it in order to identify if there's any segment that we could roll it out to permanently and set a benchmark against which we can test more radical variations to increase sign in.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

This is the component in context of an article
![Group 27](https://user-images.githubusercontent.com/1289259/69141047-c21c0600-0abb-11ea-9b30-df992b070b53.png)
This is a different tone
![Group 28](https://user-images.githubusercontent.com/1289259/69142326-774fbd80-0abe-11ea-85bf-0c714913025f.png)
This is also a different tone !
![Group 24](https://user-images.githubusercontent.com/1289259/69142327-774fbd80-0abe-11ea-9b91-00841f013f57.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
