### PR TITLE
Use Atom ID when pressing interactives

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -218,7 +218,8 @@ object PressedProperties {
       webUrl = FaciaContentUtils.webUrl(content),
       editionBrandings = Some(content.brandingByEdition.flatMap {
         case (editionId, branding) => Edition.byId(editionId) map (EditionBranding(_, branding))
-      }.toSeq)
+      }.toSeq),
+      atomId = FaciaContentUtils.atomId(content),
     )
   }
 
@@ -252,7 +253,8 @@ final case class PressedProperties(
   maybeFrontPublicationDate: Option[Long],
   href: Option[String],
   webUrl: Option[String],
-  editionBrandings: Option[Seq[EditionBranding]]
+  editionBrandings: Option[Seq[EditionBranding]],
+  atomId: Option[String]
 ) {
   lazy val isPaidFor: Boolean = editionBrandings.exists(_.exists(branding => branding.branding.exists(_.isPaid) && branding.edition == Edition.defaultEdition))
 }

--- a/common/test/common/facia/FixtureBuilder.scala
+++ b/common/test/common/facia/FixtureBuilder.scala
@@ -63,7 +63,8 @@ object FixtureBuilder {
       maybeFrontPublicationDate = None,
       href = None,
       webUrl = None,
-      editionBrandings = None
+      editionBrandings = None,
+      atomId = None
     )
 
     def mkHeader(): PressedCardHeader = PressedCardHeader(

--- a/facia-press/test/frontpress/FapiFrontPressTest.scala
+++ b/facia-press/test/frontpress/FapiFrontPressTest.scala
@@ -1,13 +1,167 @@
 package frontpress
 
-import org.scalatest.{FlatSpec, Matchers}
+import com.gu.contentapi.client.model.ItemQuery
+import com.gu.contentapi.client.model.v1.ItemResponse
+import com.gu.contentapi.client.{ContentApiClient => CapiContentApiClient}
+import com.gu.contentatom.thrift.{Atom, AtomData, AtomDataAliases}
+import com.gu.facia.api.models.Collection
+import common.Logging
+import model.pressed.EnrichedContent
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AsyncFlatSpec, Matchers}
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
-class FapiFrontPressTest extends FlatSpec with Matchers {
-  "CapiUrl" should "return the CAPI ID from a CAPI URL" in {
-    val capiUrl = s"https://content.guardianapis.com/atom/interactive/interactives/2019/10/test-snap?api-key=example"
+import scala.concurrent.Future
 
-    val capiId = CapiUrl.extractId(capiUrl)
+class FapiFrontPressTest extends AsyncFlatSpec
+  with Matchers
+  with MockitoSugar
+  with Logging {
+  "EnrichedContent.enrichSnap" should "enrich with snap HTML" in {
+    val embedUri = "http://www.example.com/snap"
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val html = "<strong>Hello</strong>"
+    val mockJson = Json.obj("html" -> html)
+    val wsClient = mockWsResponse(embedUri, mockJson)
 
-    capiId shouldBe "atom/interactive/interactives/2019/10/test-snap"
+    val result = Enrichment.enrichSnap(Some(embedUri), beforeEnrichment, collection, wsClient)
+
+    result map { afterEnrichment =>
+      afterEnrichment.embedHtml shouldBe Some(html)
+    }
+  }
+
+  "EnrichedContent.enrichSnap" should "perform no enriching when embedUri is empty" in {
+    val embedUri = None
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val wsClient = mock[WSClient]
+
+    val result = Enrichment.enrichSnap(embedUri, beforeEnrichment, collection, wsClient)
+
+    result map { afterEnrichment => afterEnrichment shouldBe beforeEnrichment }
+  }
+
+  "EnrichedContent.enrichSnap" should "perform no enriching when the response is invalid" in {
+    val embedUri = "http://www.example.com/snap"
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val invalidJson = Json.obj("foo" -> "bar")
+    val wsClient = mockWsResponse(embedUri, invalidJson)
+
+    val result = Enrichment.enrichSnap(Some(embedUri), beforeEnrichment, collection, wsClient)
+
+    result map { afterEnrichment => afterEnrichment shouldBe beforeEnrichment }
+  }
+
+  "EnrichedContent.enrichInteractive" should "enrich with interactive content" in {
+    val atomId = "capi-id"
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val html = "<strong>Hi</strong>"
+    val css = ".myClass {}"
+    val js = "console.log('hi')"
+    val mockAtom = mockInteractiveAtom(html, css, js)
+    val capiClient = mockCapiResponse(atomId, Some(mockAtom))
+
+    val result = Enrichment.enrichInteractive(Some(atomId), beforeEnrichment, collection, capiClient)
+
+    result map { afterEnrichment =>
+      afterEnrichment.embedHtml shouldBe Some(html)
+      afterEnrichment.embedCss shouldBe Some(css)
+      afterEnrichment.embedJs shouldBe Some(js)
+    }
+  }
+
+  "EnrichedContent.enrichInteractive" should "throw an exception when no interactive data" in {
+    val atomId = "capi-id"
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    when(collection.id).thenReturn("fake-collection-id")
+    val badMockAtom = None
+    val capiClient = mockCapiResponse(atomId, badMockAtom)
+
+    val futureException = recoverToExceptionIf[Throwable] {
+      Enrichment.enrichInteractive(Some(atomId), beforeEnrichment, collection, capiClient)
+    }
+
+    futureException.map { caught =>
+      caught.getMessage should include(s"failed to enrich atom $atomId")
+    }
+  }
+
+  "EnrichedContent.enrichInteractive" should "throw an exception when the atom id is empty" in {
+    val atomId = None
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val capiClient = mock[CapiContentApiClient]
+
+    val futureException = recoverToExceptionIf[Throwable] {
+      Enrichment.enrichInteractive(atomId, beforeEnrichment, collection, capiClient)
+    }
+
+    futureException.map { caught =>
+      caught.getMessage should include("atomId was undefined")
+    }
+  }
+
+  "EnrichedContent.enrichInteractive" should "throw an exception when the call to CAPI fails" in {
+    val atomId = "fake-capi-id"
+    val beforeEnrichment = EnrichedContent.empty
+    val collection = mock[Collection]
+    val capiClient = mockCapiFailure(atomId)
+
+    val futureException = recoverToExceptionIf[Throwable] {
+      Enrichment.enrichInteractive(Some(atomId), beforeEnrichment, collection, capiClient)
+    }
+
+    futureException.map { caught =>
+      caught.getMessage should include("Error message from CAPI")
+    }
+  }
+
+  def mockWsResponse(embedUri: String, json: JsValue): WSClient = {
+    val wsClient = mock[WSClient]
+    val mockResponse = mock[WSResponse]
+    val mockRequest = mock[WSRequest]
+
+    when(mockResponse.json).thenReturn(json)
+    when(mockRequest.get()).thenReturn(Future.successful(mockResponse))
+    when(wsClient.url(embedUri)).thenReturn(mockRequest)
+
+    wsClient
+  }
+
+  def mockInteractiveAtom(html: String, css: String, js: String): Atom = {
+    val mockAtom = mock[Atom]
+    val mockAtomData = mock[AtomData.Interactive]
+    val mockInteractive = mock[AtomDataAliases.InteractiveAlias]
+
+    when(mockInteractive.html).thenReturn(html)
+    when(mockInteractive.css).thenReturn(css)
+    when(mockInteractive.mainJS).thenReturn(Some(js))
+    when(mockAtomData.interactive).thenReturn(mockInteractive)
+    when(mockAtom.data).thenReturn(mockAtomData)
+
+    mockAtom
+  }
+
+  def mockCapiResponse(id: String, interactive: Option[Atom]): CapiContentApiClient = {
+    val capiClient = mock[CapiContentApiClient]
+    val mockResponse = mock[ItemResponse]
+    when(mockResponse.interactive).thenReturn(interactive)
+    when(capiClient.getResponse(ItemQuery(id))).thenReturn(Future.successful(mockResponse))
+
+    capiClient
+  }
+
+  def mockCapiFailure(id: String): CapiContentApiClient = {
+    val capiClient = mock[CapiContentApiClient]
+    when(capiClient.getResponse(ItemQuery(id))).thenReturn(Future.failed(new Exception("Error message from CAPI")))
+
+    capiClient
   }
 }


### PR DESCRIPTION
## What does this change?

Previously when pressing a snap with type `"interactive"` we would extract the atom id from the CAPI URL. A new [atom ID field has been added](https://github.com/guardian/facia-tool/pull/1111) [and made available in the client](https://github.com/guardian/facia-scala-client/pull/231) so we can switch to using that instead.

I've also refactored the enrichment code a little bit to extract the behaviour out to an `Enrichment` object which I've added some tests for, since there are a few different scenarios.

Finally I've extended throwing an exception/bailing from pressing to some other scenarios which became clearer while I was refactoring and adding tests - e.g. if the CAPI request fails, or if no `atomId` is present when the type is `interactive`. I think this is the behaviour we want and that the behaviour added in #22063 didn't quite cover all these scenarios.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)