### PR TITLE
Add switch for subscribe link in header/footer, US only

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -452,4 +452,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val UsHeaderAndFooterSubscribeLinkSwitch = Switch(
+    SwitchGroup.Feature,
+    "us-header-and-footer-subscribe-link-switch",
+    "If switched off, the US edition header and footer will not contain a Subscribe link.",
+    owners = Seq(Owner.withName("dotcom.platform")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -9,7 +9,7 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, AmpFooter}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
-@import conf.switches.Switches.{ EmailInlineInFooterSwitch }
+@import conf.switches.Switches.{ EmailInlineInFooterSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
 @import com.gu.identity.model.EmailNewsletters
 @import model.NoCache
 @import views.support.{RenderClasses}
@@ -181,12 +181,16 @@
             @fragments.inlineSvg("arrow-right", "icon")
         </a>
 
-        <a class="cta-bar__cta js-subscribe js-acquisition-link"
+        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
+            <a class="cta-bar__cta js-subscribe js-acquisition-link"
             data-link-name="footer : subscribe-cta"
-            data-edition="@{editionId}"
+            data-edition="@{
+                editionId
+            }"
             href="@getReaderRevenueUrl(SupportSubscribe, Footer)">
-            Subscribe
-            @fragments.inlineSvg("arrow-right", "icon")
-        </a>
+                Subscribe
+                @fragments.inlineSvg("arrow-right", "icon")
+            </a>
+        }
     </div>
 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -72,17 +72,15 @@
                     }
 
                     @if(editionId == "uk") {
-                        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
-                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                            data-link-name="nav2 : support-cta"
-                            data-edition="@{
-                                editionId
-                            }"
-                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                                Subscribe
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
-                        }
+                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                        data-link-name="nav2 : support-cta"
+                        data-edition="@{
+                            editionId
+                        }"
+                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                            Subscribe
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </a>
                     } else {
                         <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                             data-link-name="nav2 : contribute-cta"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -5,7 +5,7 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl, getSoulmatesUrl }
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -59,22 +59,30 @@
                         @fragments.inlineSvg("arrow-right", "icon")
                     </a>
 
-                    <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
+                    @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
+                        <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
                         data-link-name="nav2 : subscribe-cta"
-                        data-edition="@{editionId}"
+                        data-edition="@{
+                            editionId
+                        }"
                         href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                        Subscribe
-                        @fragments.inlineSvg("arrow-right", "icon")
-                    </a>
-
-                    @if(editionId == "uk") {
-                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                            data-link-name="nav2 : support-cta"
-                            data-edition="@{editionId}"
-                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
                             Subscribe
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
+                    }
+
+                    @if(editionId == "uk") {
+                        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : support-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                                Subscribe
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        }
                     } else {
                         <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                             data-link-name="nav2 : contribute-cta"


### PR DESCRIPTION
## What does this change?
Allows us to disable the 'Subscribe' CTA in the header and footer in the US edition only, from the switchboard.
This is for the US end-of-year appeal, which is pushing contributions only.

Footer, not US:
<img width="488" alt="Screenshot 2019-12-20 at 11 53 59" src="https://user-images.githubusercontent.com/1513454/71254516-20d6d880-2323-11ea-85e3-aded5cb0d7e5.png">

Footer, US:
<img width="488" alt="Screenshot 2019-12-20 at 11 54 39" src="https://user-images.githubusercontent.com/1513454/71254517-216f6f00-2323-11ea-88a3-430fbfcf88ac.png">

Header, not US:
<img width="456" alt="Screenshot 2019-12-20 at 11 54 58" src="https://user-images.githubusercontent.com/1513454/71254524-22a09c00-2323-11ea-86d5-76871e5a7b43.png">

Header, US:
<img width="456" alt="Screenshot 2019-12-20 at 11 54 49" src="https://user-images.githubusercontent.com/1513454/71254523-22080580-2323-11ea-9391-8f1f15ce4cc2.png">



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
