### PR TITLE
Add an AB test for subs banner copy

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -111,8 +111,8 @@ trait ABTestSwitches {
     "ab-subs-banner-new-year-copy-test",
     "Test subscription banner copy variants",
     owners = Seq(Owner.withGithub("jfsoul")),
-    safeState = On,
-    sellByDate = new LocalDate(2020, 2, 25),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 3, 10),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -105,4 +105,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 9, 4),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-subs-banner-new-year-copy-test",
+    "Test subscription banner copy variants",
+    owners = Seq(Owner.withGithub("jfsoul")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 2, 25),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -11,7 +11,6 @@ import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-
 import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 import { subscriptionsBannerNewYearCopyTest } from 'common/modules/experiments/tests/subscriptions-banner-new-year-copy';
 
-
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     commercialCmpUiBannerModal,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -9,6 +9,8 @@ import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xa
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
 import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
+import { subscriptionsBannerNewYearCopyTest } from 'common/modules/experiments/tests/subscriptions-banner-new-year-copy';
+
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -18,6 +20,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     xaxisAdapterTest,
     appnexusUSAdapter,
     pangaeaAdapterTest,
+    subscriptionsBannerNewYearCopyTest,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
@@ -2,10 +2,10 @@
 
 export const subscriptionsBannerNewYearCopyTest: ABTest = {
     id: 'SubsBannerNewYearCopyTest',
-    start: '2019-11-12', //TODO: update for 6th Jan
+    start: '2019-11-12', // TODO: update for 6th Jan
     expiry: '2020-02-25',
     author: 'Jon Soul',
-    description: 'Test new copy on the subscriptions banner', //TODO: is this accurate based on final design implemented?
+    description: 'Test new copy on the subscriptions banner', // TODO: is this accurate based on final design implemented?
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'Conversion rate',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
@@ -1,0 +1,25 @@
+// @flow strict
+
+export const subscriptionsBannerNewYearCopyTest: ABTest = {
+    id: 'SubsBannerNewYearCopyTest',
+    start: '2019-11-12', //TODO: update for 6th Jan
+    expiry: '2020-02-25',
+    author: 'Jon Soul',
+    description: 'Test new copy on the subscriptions banner', //TODO: is this accurate based on final design implemented?
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'Conversion rate',
+    audienceCriteria: 'n/a',
+    idealOutcome: 'Higher conversions based on new copy',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
@@ -6,7 +6,7 @@ const geolocation = geolocationGetSync();
 export const subscriptionsBannerNewYearCopyTest: ABTest = {
     id: 'SubsBannerNewYearCopyTest',
     start: '2020-02-03',
-    expiry: '2020-02-25',
+    expiry: '2020-03-10',
     author: 'Jon Soul',
     description: 'Test headline copy variant on the subscriptions banner',
     audience: 1,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/subscriptions-banner-new-year-copy.js
@@ -1,17 +1,20 @@
 // @flow strict
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+const geolocation = geolocationGetSync();
 
 export const subscriptionsBannerNewYearCopyTest: ABTest = {
     id: 'SubsBannerNewYearCopyTest',
-    start: '2019-11-12', // TODO: update for 6th Jan
+    start: '2020-02-03',
     expiry: '2020-02-25',
     author: 'Jon Soul',
-    description: 'Test new copy on the subscriptions banner', // TODO: is this accurate based on final design implemented?
+    description: 'Test headline copy variant on the subscriptions banner',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'Conversion rate',
     audienceCriteria: 'n/a',
-    idealOutcome: 'Higher conversions based on new copy',
-    canRun: () => true,
+    idealOutcome: 'Higher conversions based on new year copy',
+    canRun: () => geolocation !== 'US', // Banner is live in the US but we are not testing there
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -21,7 +21,7 @@ const subscriptionBannerTemplate = (
         <h3 class="site-message--subscription-banner__title">
             ${
                 abTestVariant
-                    ? `<span class="variantB-header">We're going to need <br /> each other this year</span>`
+                    ? `We're going to need <br /> each other this year`
                     : `A beautiful way to read it <br /> A powerful way to fund it`
             }
         </h3>

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -7,6 +7,7 @@ import { local } from 'lib/storage';
 import {
     submitViewEvent,
     submitClickEvent,
+    addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import {
@@ -26,6 +27,12 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import fetchJson from 'lib/fetch-json';
 import reportError from 'lib/report-error';
+import {
+    isInVariantSynchronous,
+    isInABTestSynchronous,
+} from 'common/modules/experiments/ab';
+import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
+import { subscriptionsBannerNewYearCopyTest } from 'common/modules/experiments/tests/subscriptions-banner-new-year-copy';
 
 // types
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
@@ -40,6 +47,8 @@ const CLICK_EVENT_CTA = 'subscription-banner : cta';
 const CLICK_EVENT_CLOSE_NOT_NOW = 'subscription-banner : not now';
 const CLICK_EVENT_CLOSE_BUTTON = 'subscription-banner : close';
 const CLICK_EVENT_SIGN_IN = 'subscription-banner : sign in';
+const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
+const CAMPAIGN_CODE = 'gdnwb_copts_banner_subscribe_SubscriptionBanner';
 
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
@@ -52,7 +61,23 @@ const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()
 );
 const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['australia'];
-const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${CLICK_EVENT_CTA}%22%7D`;
+
+const abTest =
+    isInABTestSynchronous(subscriptionsBannerNewYearCopyTest) ? {
+        abTest: {
+            name: subscriptionsBannerNewYearCopyTest.id,
+            variant: isInVariantSynchronous(subscriptionsBannerNewYearCopyTest, 'control') ? 'control' : 'variant',
+        }
+    } : {};
+
+const subscriptionUrl = addTrackingCodesToUrl({
+    base: `${subscriptionHostname}/subscribe/digital`,
+    componentType: COMPONENT_TYPE,
+    componentId: OPHAN_EVENT_ID,
+    campaignCode: CAMPAIGN_CODE,
+    ...abTest,
+});
+
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
 const hasAcknowledged = bannerRedeploymentDate => {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -281,7 +281,10 @@ const show: () => Promise<boolean> = async () => {
                 signInUrl,
                 showConsent,
                 isUserLoggedIn(),
-                true // This should be taken from A/B test participation if we want to run this as a test eventually
+                isInVariantSynchronous(
+                    subscriptionsBannerNewYearCopyTest,
+                    'variant'
+                ) || !isInABTestSynchronous(subscriptionsBannerNewYearCopyTest)
             )
         );
     }

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -31,7 +31,6 @@ import {
     isInVariantSynchronous,
     isInABTestSynchronous,
 } from 'common/modules/experiments/ab';
-import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 import { subscriptionsBannerNewYearCopyTest } from 'common/modules/experiments/tests/subscriptions-banner-new-year-copy';
 
 // types
@@ -64,16 +63,16 @@ const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['australia'];
 
 const abTest = isInABTestSynchronous(subscriptionsBannerNewYearCopyTest)
     ? {
-        abTest: {
-            name: subscriptionsBannerNewYearCopyTest.id,
-            variant: isInVariantSynchronous(
-                subscriptionsBannerNewYearCopyTest,
-                'control'
-            )
-                ? 'control'
-                : 'variant',
-        },
-    }
+          abTest: {
+              name: subscriptionsBannerNewYearCopyTest.id,
+              variant: isInVariantSynchronous(
+                  subscriptionsBannerNewYearCopyTest,
+                  'control'
+              )
+                  ? 'control'
+                  : 'variant',
+          },
+      }
     : {};
 
 const subscriptionUrl = addTrackingCodesToUrl({

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -62,13 +62,19 @@ const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
 );
 const hideBannerInTheseRegions: ReaderRevenueRegion[] = ['australia'];
 
-const abTest =
-    isInABTestSynchronous(subscriptionsBannerNewYearCopyTest) ? {
+const abTest = isInABTestSynchronous(subscriptionsBannerNewYearCopyTest)
+    ? {
         abTest: {
             name: subscriptionsBannerNewYearCopyTest.id,
-            variant: isInVariantSynchronous(subscriptionsBannerNewYearCopyTest, 'control') ? 'control' : 'variant',
-        }
-    } : {};
+            variant: isInVariantSynchronous(
+                subscriptionsBannerNewYearCopyTest,
+                'control'
+            )
+                ? 'control'
+                : 'variant',
+        },
+    }
+    : {};
 
 const subscriptionUrl = addTrackingCodesToUrl({
     base: `${subscriptionHostname}/subscribe/digital`,

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -60,8 +60,8 @@
     }
 
     @include mq($from: desktop) {
-        width: 45%;
-        margin-right: 55%;
+        width: 48%;
+        margin-right: 52%;
         font-size: 34px;
         line-height: 36px;
     }
@@ -264,7 +264,7 @@
 
 
     @include mq($from: desktop) {
-        width: 55%;
+        width: 52%;
     }
 
     @include mq($from: wide) {
@@ -346,32 +346,15 @@
         position: absolute;
         right: 0;
         bottom: 0;
-        width: 80px;
+        width: 70px;
     }
 
     // custom breakpoint
     @media (min-width: 1260px) {
-        width: 109px;
+        width: 90px;
     }
 }
 
-.variantB-header {
-    display: block;
-    max-width: 340px;
-    padding-right: 36px;
-
-    @include mq($from: phablet) {
-        max-width: 450px;
-    }
-
-    @include mq($from: tablet) {
-        max-width: 480px;
-    }
-
-    @include mq($from: desktop) {
-        max-width: 500px;
-    }
-}
 
 /*********************** footer hacks *********************/
 


### PR DESCRIPTION
## What does this change?
This adds (belatedly) a test for different copy on the subscriptions banner. This will show two variations of the banner header copy - one specifically referencing the new year - one "BAU" product related copy.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Desktop
![image](https://user-images.githubusercontent.com/8754692/73379142-a69e5a00-42b9-11ea-9421-6530e88255ae.png)
Tablet
![image](https://user-images.githubusercontent.com/8754692/73379190-c0d83800-42b9-11ea-87dc-76b96d404ccb.png)
Mobile
![image](https://user-images.githubusercontent.com/8754692/73379259-d8afbc00-42b9-11ea-8fe9-4b6e6de41fe2.png)



## What is the value of this and can you measure success?
We can assess the success of a topical copy variation.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
