### PR TITLE
Bring deduplication much closer to fundamental rules

### DIFF
--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -45,7 +45,7 @@ object PressedCollectionDeduplication {
   }
 
   def getHeaderURLsFromCuratedAndBackfilledAtDepth(pCVs: Seq[PressedCollectionVisibility], depth: Int): Seq[String] = {
-    pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(depth) ++ collection.pressedCollection.backfill.take(depth)).map ( pressedContent => pressedContent.header.url ) }
+    pCVs.flatMap{ collection => (collection.pressedCollection.curated ++ collection.pressedCollection.backfill).take(depth).map ( pressedContent => pressedContent.header.url ) }
   }
 
   def deduplicateCollectionAgainstAccumulator(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility): PressedCollectionVisibility = {

--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -30,10 +30,9 @@ object PressedCollectionDeduplication {
 
   /*
       Pascal - 20th Dec 2019
-        The implementation is a variation of the general rules (exposed on 05th Dec 2019) to allow for:
-          1. Maintaining the integrity of the Most Popular container.
-          2. Allowing for backfill'ed only containers to work fine.
-          3. Forcing backfilled deduplication in consecutive containers
+
+      This section presents all exceptions to the above general principle:
+          - The Most Popular container is not deduplicated
    */
 
   def collectionIsMostPopular(collectionV: PressedCollectionVisibility): Boolean = {
@@ -49,11 +48,9 @@ object PressedCollectionDeduplication {
     pCVs.flatMap{ collection => (collection.pressedCollection.curated.take(depth) ++ collection.pressedCollection.backfill.take(depth)).map ( pressedContent => pressedContent.header.url ) }
   }
 
-  def pressedCollectionCommonLength(pC: PressedCollection): Int = pC.curated.size + pC.backfill.size
-
-  def deduplicatedThisCollectionV(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility, depth: Int): PressedCollectionVisibility = {
+  def deduplicateCollectionAgainstAccumulator(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility): PressedCollectionVisibility = {
     // Essentially deduplicate the backfill of collectionV using header values values from accum's elements curated and backfill
-    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilledAtDepth(accum, depth)
+    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilledAtDepth(accum, 10)
     val newBackfill = collectionV.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )
     collectionV.copy(
       pressedCollection = collectionV.pressedCollection.copy (
@@ -62,54 +59,10 @@ object PressedCollectionDeduplication {
     )
   }
 
-  def makeDeduplicatedCollectionCandidates(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility): Seq[PressedCollectionVisibility] = {
-    // Given accum prepare a sequence of more and more aggressively deduplicated versions of collectionV
-    val depths: List[Int] = accum.map( c => pressedCollectionCommonLength(c.pressedCollection) ).toList
-    val maxDepth = if (depths.isEmpty) 1 else depths.max + 1 // We meed to ensure that maxDepth is at least one for the return Seq to have at least one element
-    Seq.range(0, maxDepth).map{ depth => deduplicatedThisCollectionV(accum, collectionV, depth) }
-  }
-
-  def secondCollectionShouldBeChosenOverTheFirst(c1: PressedCollectionVisibility, c2: PressedCollectionVisibility): Boolean = {
-    pressedCollectionCommonLength(c2.pressedCollection) >= 10
-  }
-
-  def reduceDeduplicatedCollectionCandidates(candidates: Seq[PressedCollectionVisibility]): Option[PressedCollectionVisibility] = {
-    // Reduces the sequence prepared by makeDeduplicatedCollectionCandidates using the boolean computed by secondCollectionShouldBeChosenOverTheFirst
-    candidates.foldLeft[Option[PressedCollectionVisibility]](None){ (accum, collectionV_) =>
-      accum match {
-        case None => Some(collectionV_)
-        case Some(collectionV) => Some( if(secondCollectionShouldBeChosenOverTheFirst(collectionV, collectionV_)) collectionV_ else collectionV )
-      }
-    }
-  }
-
-  def completelyDeduplicateSecondBackfilledAgainstFirstCurated(collectionV1: PressedCollectionVisibility, collectionV2: PressedCollectionVisibility): PressedCollectionVisibility = {
-    val accumulatedHeaderURLsForDeduplication = collectionV1.pressedCollection.curated.map ( pressedContent => pressedContent.header.url )
-    val newBackfill = collectionV2.pressedCollection.backfill.filter( pressedContent => !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url) )
-    collectionV2.copy(
-      pressedCollection = collectionV2.pressedCollection.copy (
-        backfill = newBackfill
-      )
-    )
-  }
-
-  def completelyDeduplicateCollectionAgainstAccumulatorEnding(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility): PressedCollectionVisibility = {
-    val last = accum.reverse.headOption
-    last match {
-      case None => collectionV
-      case Some(lastCollectionV) => completelyDeduplicateSecondBackfilledAgainstFirstCurated(lastCollectionV: PressedCollectionVisibility, collectionV: PressedCollectionVisibility)
-    }
-  }
-
   def deduplication(pressedCollections: Seq[PressedCollectionVisibility]): Seq[PressedCollectionVisibility] = {
     pressedCollections.foldLeft[Seq[PressedCollectionVisibility]](Nil) { (accum, collectionV) =>
       if (collectionShouldBeDeduplicated(collectionV: PressedCollectionVisibility)) {
-        // Given collectionV we compute the candidates for its replacement, then add the best of those candidates (according to reduceDeduplicatedCollectionCandidates) to accum
-        val candidates: Seq[PressedCollectionVisibility] = makeDeduplicatedCollectionCandidates(accum: Seq[PressedCollectionVisibility], collectionV: PressedCollectionVisibility)
-        reduceDeduplicatedCollectionCandidates(candidates) match {
-          case None => accum
-          case Some(collectionV) => accum :+ completelyDeduplicateCollectionAgainstAccumulatorEnding(accum, collectionV)
-        }
+        accum :+ deduplicateCollectionAgainstAccumulator(accum, collectionV)
       } else {
         accum :+ collectionV
       }

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -50,12 +50,18 @@ trait FaciaPressDeduplicationTestData {
     )
   }
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // collection1 is used to test that we do not touch curated elements and that we deduplicate backfilled elements
+  // We expect: curated of size 2, backfill of size 3
+  // -----------------------------------------------------
   val collection0 = collectionFromCuratedAndBackfilled(
     List(
+      "link10",
       "link11",
     ).map(id => pressedContentFromId(id)),
     List(
-      "link10",
+      "link20",
       "link22",
       "link23"
     ).map(id => pressedContentFromId(id))
@@ -63,75 +69,39 @@ trait FaciaPressDeduplicationTestData {
 
   // -----------------------------------------------------
   // Comment for FaciaPressDeduplicationTest:
-  // Test that we do not deduplicate below 10 elements [1]
-  // We expect backfill to stay even if a duplicate of collection0 backfill
+  // collection1 is used to test that we do not touch curated elements and that we deduplicate backfilled elements
+  // We expect: curated of size 3, backfill of size 1 ("link24")
   // -----------------------------------------------------
   val collection1 = collectionFromCuratedAndBackfilled(
     List(
       "link10",
+      "link11",
       "link12",
-      "link13",
-      "link43",
-      "link46",
-      "link47",
-      "link48",
-      "link49",
-      "link50",
     ).map(id => pressedContentFromId(id)),
     List(
-      "link10",
+      "link20",
+      "link22",
+      "link23",
+      "link24"
     ).map(id => pressedContentFromId(id))
   )
 
   // -----------------------------------------------------
   // Comment for FaciaPressDeduplicationTest:
-  // Test that we deduplicate against curated and backfilled elements
-  // We expect 11 to go because of collection0's curated
-  // We expect 22 to go because of collection0's backfilled
+  // collection2 is used to test that we do not touch curated elements and that we deduplicate backfilled elements
+  // We expect: curated of size 3, backfill of size 2 ("link25", "link26")
   // -----------------------------------------------------
   val collection2 = collectionFromCuratedAndBackfilled(
     List(
       "link11",
       "link12",
-      "link13",
-      "link43",
-      "link46",
-      "link47",
-      "link48",
-      "link49",
-      "link50",
-      "link51"
+      "link20",
     ).map(id => pressedContentFromId(id)),
     List(
-      "link11",
-      "link22"
+      "link23",
+      "link25",
+      "link26",
     ).map(id => pressedContentFromId(id))
   )
 
-  // -----------------------------------------------------
-  // Comment for FaciaPressDeduplicationTest:
-  // Test remove backfilled contents when appearing in the previous container as curated
-  // .... thereby overidding [1]
-  // We expect "link10" in collection4 to go, but "link10" in collection5 to stay
-  // -----------------------------------------------------
-  val collection3 = collectionFromCuratedAndBackfilled(
-    List(
-      "link10",
-    ).map(id => pressedContentFromId(id)),
-    Nil
-  )
-
-  val collection4 = collectionFromCuratedAndBackfilled(
-    Nil,
-    List(
-      "link10",
-    ).map(id => pressedContentFromId(id))
-  )
-
-  val collection5 = collectionFromCuratedAndBackfilled(
-    Nil,
-    List(
-      "link10",
-    ).map(id => pressedContentFromId(id))
-  )
 }

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -104,4 +104,15 @@ trait FaciaPressDeduplicationTestData {
     ).map(id => pressedContentFromId(id))
   )
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // collection3 is a variation of collection 1
+  // collection3 is used to demonstrate that the Most Popular container is not deduplicated
+  // -----------------------------------------------------
+  val collection3 = collection1.copy(
+    config = collection1.config.copy(
+      collectionType = "news/most-popular"
+    )
+  )
+
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -8,10 +8,7 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
   var sequence = List(
     PressedCollectionVisibility(collection0, 0),
     PressedCollectionVisibility(collection1, 0),
-    PressedCollectionVisibility(collection2, 0),
-    PressedCollectionVisibility(collection3, 0),
-    PressedCollectionVisibility(collection4, 0),
-    PressedCollectionVisibility(collection5, 0)
+    PressedCollectionVisibility(collection2, 0)
   )
   // Note that the integer (0) passed as second argument of PressedCollectionVisibility.apply is irrelevant. We use
   // it because the current version of PressedCollectionDeduplication.deduplication still takes PressedCollectionVisibility
@@ -22,21 +19,14 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
     newSequence(0).pressedCollection.curated.size shouldBe sequence(0).pressedCollection.curated.size
     newSequence(1).pressedCollection.curated.size shouldBe sequence(1).pressedCollection.curated.size
     newSequence(2).pressedCollection.curated.size shouldBe sequence(2).pressedCollection.curated.size
-    newSequence(3).pressedCollection.curated.size shouldBe sequence(3).pressedCollection.curated.size
-    newSequence(4).pressedCollection.curated.size shouldBe sequence(4).pressedCollection.curated.size
   }
 
-  it should "not deduplicate backfill'ed content if resulting in less than 10 elements" in {
-    newSequence(1).pressedCollection.backfill.size shouldBe 1 // Test that we do not deduplicate below 10 elements [1]
-  }
-
-  it should "deduplicate backfill'ed content against curated and backfilled elements" in {
-    newSequence(2).pressedCollection.backfill.size shouldBe 0 // Test that we deduplicate against curated and backfilled elements
-  }
-
-  it should "force remove backfilled contents when appearing in the previous container as curated (even if less than 10 elements)" in {
-    // .... thereby overidding [1]
-    newSequence(4).pressedCollection.backfill.size shouldBe 0
-    newSequence(5).pressedCollection.backfill.size shouldBe 1
+  it should "deterministically deduplicate backfill'ed content against curated and backfilled elements" in {
+    newSequence(0).pressedCollection.backfill.size shouldBe 3
+    newSequence(1).pressedCollection.backfill.size shouldBe 1
+    newSequence(1).pressedCollection.backfill(0).header.url shouldEqual "/link24"
+    newSequence(2).pressedCollection.backfill.size shouldBe 2
+    newSequence(2).pressedCollection.backfill(0).header.url shouldEqual "/link25"
+    newSequence(2).pressedCollection.backfill(1).header.url shouldEqual "/link26"
   }
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -8,7 +8,8 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
   var sequence = List(
     PressedCollectionVisibility(collection0, 0),
     PressedCollectionVisibility(collection1, 0),
-    PressedCollectionVisibility(collection2, 0)
+    PressedCollectionVisibility(collection2, 0),
+    PressedCollectionVisibility(collection3, 0)
   )
   // Note that the integer (0) passed as second argument of PressedCollectionVisibility.apply is irrelevant. We use
   // it because the current version of PressedCollectionDeduplication.deduplication still takes PressedCollectionVisibility
@@ -19,6 +20,7 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
     newSequence(0).pressedCollection.curated.size shouldBe sequence(0).pressedCollection.curated.size
     newSequence(1).pressedCollection.curated.size shouldBe sequence(1).pressedCollection.curated.size
     newSequence(2).pressedCollection.curated.size shouldBe sequence(2).pressedCollection.curated.size
+    newSequence(3).pressedCollection.curated.size shouldBe sequence(3).pressedCollection.curated.size
   }
 
   it should "deterministically deduplicate backfill'ed content against curated and backfilled elements" in {
@@ -28,5 +30,9 @@ class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPress
     newSequence(2).pressedCollection.backfill.size shouldBe 2
     newSequence(2).pressedCollection.backfill(0).header.url shouldEqual "/link25"
     newSequence(2).pressedCollection.backfill(1).header.url shouldEqual "/link26"
+  }
+
+  it should "not deduplicate Most Popular containers" in {
+    newSequence(3).pressedCollection.backfill.size shouldBe sequence(3).pressedCollection.backfill.size
   }
 }


### PR DESCRIPTION
## What does this change?

This brings the actual logic of the deduplication much closer to the ideal situation (rules: 05th Dec 2019) we want to be in. This was made possible by finding a way to gracefully handle the case of the Most Popular container. We no longer need to perform partial deduplications of the other containers. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No