### PR TITLE
Add 'membership' section to be excluded from sign in gate

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -114,7 +114,7 @@ const isInvalidArticleType = (): boolean => {
 
 // hide the sign in gate on certain sections of the site, e.g info, about, help etc.
 const isInvalidSection = (): boolean => {
-    const invalidSections = ['about', 'info'];
+    const invalidSections = ['about', 'info', 'membership'];
 
     return invalidSections.reduce((isSectionInvalid, section) => {
         if (isSectionInvalid) return true;


### PR DESCRIPTION
## What does this change?

The help article on about the sign in gate (https://www.theguardian.com/membership/2019/dec/20/signing-in-to-the-guardian) sits on a section which wasn't previously excluded from the sign in gate, meaning that some users might have had to sign in to view the article about signing in!

This PR adds the `membership` section to the excluded list, so the gate doesn't show up.
