### PR TITLE
Add 'help' section to sign in gate exclusion list

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -114,7 +114,7 @@ const isInvalidArticleType = (): boolean => {
 
 // hide the sign in gate on certain sections of the site, e.g info, about, help etc.
 const isInvalidSection = (): boolean => {
-    const invalidSections = ['about', 'info', 'membership'];
+    const invalidSections = ['about', 'info', 'membership', 'help'];
 
     return invalidSections.reduce((isSectionInvalid, section) => {
         if (isSectionInvalid) return true;


### PR DESCRIPTION
The help pages e.g. https://www.theguardian.com/help/2017/dec/11/help-with-delivery sits on a section which wasn't previously excluded from the sign in gate, meaning that some users might have had to sign in to view the article about help!

This PR adds the `help` section to the excluded list, so the gate doesn't show up.