### PR TITLE
Dynamo fixes to sublinks and mobile images

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -649,13 +649,14 @@ $block-height: 58px; // Note: duplicated from _item.scss
             .fc-sublink {
                 padding: $gs-gutter / 4 $gs-gutter / 4 $gs-gutter / 2;
                 background-color: $story-package-dynamic-card-text;
+                margin-bottom: 0;
 
                 @include mq($from: tablet) {
                     background-color: rgba(4, 31, 74, .8);
                     border-left: 0;
                     border-bottom: 0;
+                    max-width: 33%;
                 }
-                margin-bottom: 0;
             }
 
             .fc-sublink__title,

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -244,11 +244,13 @@ $block-height: 58px; // Note: duplicated from _item.scss
 
     // I'm not sure this is at all reliable, or a good idea, but until I figure
     // out what classes I want to add in Scala this gets things moving:
-    .l-row__item--span-3 + .l-row__item--span-1 {
-        .fc-item--live-updates {
-            &.fc-item--standard-tablet {
-                .fc-item__media-wrapper {
-                    display: block;
+    @include mq($from: desktop) {
+        .l-row__item--span-3 + .l-row__item--span-1 {
+            .fc-item--live-updates {
+                &.fc-item--standard-tablet {
+                    .fc-item__media-wrapper {
+                        display: block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What does this change?

Some fixes to the dynamo.

### Limit width of sublinks to 33%.

#### Before

![Screenshot 2019-12-23 at 11 38 24](https://user-images.githubusercontent.com/638051/71356413-106c6b00-257a-11ea-95c9-96c31d1706a6.png)

#### After

![Screenshot 2019-12-23 at 11 38 33](https://user-images.githubusercontent.com/638051/71356428-182c0f80-257a-11ea-8e86-2f980c23110f.png)

### Prevent mobile double image

#### Before

![Screenshot 2019-12-23 at 11 38 13](https://user-images.githubusercontent.com/638051/71356456-3265ed80-257a-11ea-8ade-3e2a5772b2fd.png)

#### After

![Screenshot 2019-12-23 at 11 37 36](https://user-images.githubusercontent.com/638051/71356461-34c84780-257a-11ea-9d2a-e7be1a978382.png)
