### PR TITLE
EOY campaign banners for the last three days of the year

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,6 +68,66 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-banner-us-eoy-three-days-regulars",
+    "US End of year banner - three day count with articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-three-days-casuals",
+    "US End of year banner - three day count without articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-two-days-regulars",
+    "US End of year banner - two day count with articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-two-days-casuals",
+    "US End of year banner - two day count without articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-one-day-regulars",
+    "US End of year banner - one day count with articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-banner-us-eoy-one-day-casuals",
+    "US End of year banner - one day count without articles viewed",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 1, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-banner-us-eoy-impeachment-count-down-regulars",
     "US End of year banner - impeachment, with article count",
     owners = Seq(Owner.withGithub("jlieb10")),
@@ -80,46 +140,6 @@ trait ABTestSwitches {
     ABTests,
     "ab-contributions-banner-us-eoy-impeachment-count-down-casuals",
     "US End of year banner - impeachment, no article count",
-    owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-contributions-banner-us-eoy-reader-appreciation-supporters",
-    "US End of year banner - reader appreciation, supporters with article count",
-    owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-contributions-banner-us-eoy-reader-appreciation-nonsupporters",
-    "US End of year banner - reader appreciation, nonsupporters with article count",
-    owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-contributions-banner-us-eoy-reader-appreciation-supporters-casuals",
-    "US End of year banner - reader appreciation, supporters without article count",
-    owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 30),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
-    "ab-contributions-banner-us-eoy-reader-appreciation-nonsupporters-casuals",
-    "US End of year banner - reader appreciation, nonsupporters without article count",
     owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 1, 30),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -14,12 +14,14 @@ import { signInGateSecundus } from 'common/modules/experiments/tests/sign-in-gat
 import { commercialCmpUiNoOverlay } from 'common/modules/experiments/tests/commercial-cmp-ui-no-overlay';
 import { commercialConsentOptionsButton } from 'common/modules/experiments/tests/commercial-consent-options-button';
 import { articlesViewedBannerUkElection } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-uk-election';
-import { contributionsBannerUsEoyReaderAppreciationNonsupportersCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-nonsupporters-casuals';
-import { contributionsBannerUsEoyReaderAppreciationSupportersCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters-casuals';
-import { contributionsBannerUsEoyReaderAppreciationNonsupporters } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-nonsupporters';
-import { contributionsBannerUsEoyReaderAppreciationSupporters } from 'common/modules/experiments/tests/contribs-banner-us-eoy-reader-appreciation-supporters';
 import { contributionsBannerUsEoyImpeachmentCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-casuals';
 import { contributionsBannerUsEoyImpeachmentRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-regulars';
+import { contributionsBannerUsEoyThreeDaysRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars';
+import { contributionsBannerUsEoyThreeDaysCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-three-days-casuals';
+import { contributionsBannerUsEoyTwoDaysRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars';
+import { contributionsBannerUsEoyTwoDaysCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-two-days-casuals';
+import { contributionsBannerUsEoyOneDayCasuals } from 'common/modules/experiments/tests/contribs-banner-us-eoy-one-day-casuals';
+import { contributionsBannerUsEoyOneDayRegulars } from 'common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -41,12 +43,14 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    contributionsBannerUsEoyThreeDaysRegulars,
+    contributionsBannerUsEoyThreeDaysCasuals,
+    contributionsBannerUsEoyTwoDaysRegulars,
+    contributionsBannerUsEoyTwoDaysCasuals,
+    contributionsBannerUsEoyOneDayRegulars,
+    contributionsBannerUsEoyOneDayCasuals,
     contributionsBannerUsEoyImpeachmentRegulars,
     contributionsBannerUsEoyImpeachmentCasuals,
-    contributionsBannerUsEoyReaderAppreciationSupporters,
-    contributionsBannerUsEoyReaderAppreciationNonsupporters,
-    contributionsBannerUsEoyReaderAppreciationSupportersCasuals,
-    contributionsBannerUsEoyReaderAppreciationNonsupportersCasuals,
     articlesViewedBannerUkElection,
     articlesViewedBanner,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-casuals.js
@@ -1,23 +1,24 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['It’s because of you...'];
-const messageText = `... and the readers across all 50 states that supported us in 2019 that our journalism thrived in a challenging climate for publishers. Next year America faces an epic choice and the need for an independent press has never been greater. Support from our readers is vital. Please consider supporting us today with a year-end gift. Contribute from as little as $1 and help us reach our goal.`;
+const titles = ['1 day left to give to the Guardian in 2019'];
+const messageText = `… and one year left in Donald Trump’s first term. Over the last three years, much of what the Guardian holds dear has been threatened – democracy, civility, truth. As 2020 approaches, the need for a robust, independent press has never been greater. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
 const tickerHeader = 'Help us reach our year-end goal';
 
-export const contributionsBannerUsEoyReaderAppreciationNonsupportersCasuals: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoyReaderAppreciationNonsupportersCasuals',
+export const contributionsBannerUsEoyOneDayCasuals: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyOneDayCasuals',
     campaignId: 'USeoy2019',
-    start: '2019-12-16',
+    start: '2019-12-23',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
     description:
-        'reader appreciation banner for the US EOY campaign - potential supporters, no article count',
+        'US End of year banner - three day count without articles viewed',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-casuals.js
@@ -1,7 +1,6 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
@@ -4,27 +4,26 @@ import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templ
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
-// User must have read at least 5 articles in last 3 months (as 13 weeks)
+// User must have read at least 5 articles in last 4 months (as 17 weeks)
 const minArticleViews = 5;
-const articleCountWeeks = 13;
+const articleCountWeeks = 17;
 const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['It’s because of you...'];
-const messageText = `... and your unprecedented support for the Guardian that our journalism thrived in a challenging climate for publishers in 2019. Thank you. You've read ${articleViewCount} articles in the last three months and your support is vital. Next year America faces a momentous choice and the need for an independent press has never been greater. If you can, please consider supporting us again today with a year-end gift. Contribute from as little as $1 and help us reach our goal.`;
+const titles = ['1 day left to give to the Guardian in 2019'];
+const messageText = `… and one year left in Donald Trump’s first term. Over the last three years, much of what the Guardian holds dear has been threatened – democracy, civility, truth. As 2020 approaches, the need for a robust, independent press has never been greater. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = 'Help us reach our year-end goal';
+const tickerHeader = `You've read ${articleViewCount} in the last four months`;
 
-export const contributionsBannerUsEoyReaderAppreciationSupporters: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoyReaderAppreciationSupporters',
+export const contributionsBannerUsEoyOneDayRegulars: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyOneDayRegulars',
     campaignId: 'USeoy2019',
-    start: '2019-12-16',
+    start: '2019-12-23',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description:
-        'reader appreciation banner for the US EOY campaign - known supporters with article count',
+    description: 'US End of year banner - three day count with articles viewed',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -46,9 +45,7 @@ export const contributionsBannerUsEoyReaderAppreciationSupporters: AcquisitionsA
                 hasTicker: true,
                 tickerHeader,
                 bannerModifierClass: 'useoy2019',
-                userCohort: 'AllExistingSupporters',
             },
-            canRun: () => canShowBannerSync(3, 'AllExistingSupporters'),
         },
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
@@ -2,7 +2,6 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 4 months (as 17 weeks)
 const minArticleViews = 5;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-casuals.js
@@ -1,7 +1,6 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-casuals.js
@@ -1,0 +1,46 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
+
+const geolocation = geolocationGetSync();
+const isUS = geolocation === 'US';
+
+const titles = ['3 days left to give to the Guardian in 2019'];
+const messageText = `… and three American billionaires whose family net worth equals the net worth of more than 50% of the US population. The coming year will be an epic one for America and will tell us much about how this country wants to tackle wealth inequality. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
+const ctaText = 'Support The Guardian';
+const tickerHeader = 'Help us reach our year-end goal';
+
+export const contributionsBannerUsEoyThreeDaysCasuals: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyThreeDaysCasuals',
+    campaignId: 'USeoy2019',
+    start: '2019-12-23',
+    expiry: '2020-1-30',
+    author: 'Joshua Lieberman',
+    description:
+        'US End of year banner - three day count without articles viewed',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'NA',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => isUS,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+                tickerHeader,
+                bannerModifierClass: 'useoy2019',
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
@@ -2,7 +2,6 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 4 months (as 17 weeks)
 const minArticleViews = 5;
@@ -31,10 +30,7 @@ export const contributionsBannerUsEoyThreeDaysRegulars: AcquisitionsABTest = {
     idealOutcome: 'NA',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => {
-        debugger;
-        return isUS && articleViewCount >= minArticleViews;
-    },
+    canRun: () => isUS && articleViewCount >= minArticleViews,
     geolocation,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
@@ -2,28 +2,28 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
+import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
-// User must have read at least 5 articles in last 3 months (as 13 weeks)
+// User must have read at least 5 articles in last 4 months (as 17 weeks)
 const minArticleViews = 5;
-const articleCountWeeks = 13;
+const articleCountWeeks = 17;
 const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['It’s because of you...'];
-const messageText = `... and the readers across all 50 states that support us in 2019 that our journalism thrived in a challenging climate for publishers. Next year America faces an epic choice and the need for an independent press has never been greater. In the last three months you’ve read ${articleViewCount} articles. Support from our readers is vital. Please consider supporting us today with a year-end gift. Contribute from as little as $1 and help us reach our goal.`;
+const titles = ['3 days left to give to the Guardian in 2019'];
+const messageText = `… and three American billionaires whose family net worth equals the net worth of more than 50% of the US population. The coming year will be an epic one for America and will tell us much about how this country wants to tackle wealth inequality. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = 'Help us reach our year-end goal';
+const tickerHeader = `You've read ${articleViewCount} in the last four months`;
 
-export const contributionsBannerUsEoyReaderAppreciationNonsupporters: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoyReaderAppreciationNonsupporters',
+export const contributionsBannerUsEoyThreeDaysRegulars: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyThreeDaysRegulars',
     campaignId: 'USeoy2019',
-    start: '2019-12-16',
+    start: '2019-12-23',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description:
-        'reader appreciation banner for the US EOY campaign - potential supporters with article count',
+    description: 'US End of year banner - three day count with articles viewed',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -31,7 +31,10 @@ export const contributionsBannerUsEoyReaderAppreciationNonsupporters: Acquisitio
     idealOutcome: 'NA',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => isUS && articleViewCount >= minArticleViews,
+    canRun: () => {
+        debugger;
+        return isUS && articleViewCount >= minArticleViews;
+    },
     geolocation,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-casuals.js
@@ -1,7 +1,6 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-casuals.js
@@ -1,0 +1,46 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
+
+const geolocation = geolocationGetSync();
+const isUS = geolocation === 'US';
+
+const titles = ['2 days left to give to the Guardian in 2019'];
+const messageText = `… and two supreme court justices Donald Trump has appointed in his first term. The next US president will shape the court for the next half century – and the future of LGBTQ+ rights, immigration, abortion, guns, religion, dark money and more are in play. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
+const ctaText = 'Support The Guardian';
+const tickerHeader = 'Help us reach our year-end goal';
+
+export const contributionsBannerUsEoyTwoDaysCasuals: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyTwoDaysCasuals',
+    campaignId: 'USeoy2019',
+    start: '2019-12-23',
+    expiry: '2020-1-30',
+    author: 'Joshua Lieberman',
+    description:
+        'US End of year banner - three day count without articles viewed',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'NA',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => isUS,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText,
+                ctaText,
+                template: acquisitionsBannerUsEoyTemplate,
+                hasTicker: true,
+                tickerHeader,
+                bannerModifierClass: 'useoy2019',
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
@@ -1,24 +1,29 @@
 // @flow
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
+import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
+
+// User must have read at least 5 articles in last 4 months (as 17 weeks)
+const minArticleViews = 5;
+const articleCountWeeks = 17;
+const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 
 const geolocation = geolocationGetSync();
 const isUS = geolocation === 'US';
 
-const titles = ['It’s because of you...'];
-const messageText = `... and your unprecedented support for the Guardian in 2019 that our journalism thrived in a challenging climate for publishers. Thank you – your support is vital. Next year America faces a momentous choice and the need for an independent press has never been greater. If you can, please consider supporting us again today with a year-end gift. Contribute from as little as $1 and help us reach our goal.`;
+const titles = ['2 days left to give to the Guardian in 2019'];
+const messageText = `… and two supreme court justices Donald Trump has appointed in his first term. The next US president will shape the court for the next half century – and the future of LGBTQ+ rights, immigration, abortion, guns, religion, dark money and more are in play. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = 'Help us reach our year-end goal';
+const tickerHeader = `You've read ${articleViewCount} in the last four months`;
 
-export const contributionsBannerUsEoyReaderAppreciationSupportersCasuals: AcquisitionsABTest = {
-    id: 'ContributionsBannerUsEoyReaderAppreciationSupportersCasuals',
+export const contributionsBannerUsEoyTwoDaysRegulars: AcquisitionsABTest = {
+    id: 'ContributionsBannerUsEoyTwoDaysRegulars',
     campaignId: 'USeoy2019',
-    start: '2019-12-16',
+    start: '2019-12-23',
     expiry: '2020-1-30',
     author: 'Joshua Lieberman',
-    description:
-        'reader appreciation banner for the US EOY campaign - known supporters, no article count',
+    description: 'US End of year banner - three day count with articles viewed',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',
@@ -26,7 +31,7 @@ export const contributionsBannerUsEoyReaderAppreciationSupportersCasuals: Acquis
     idealOutcome: 'NA',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => isUS,
+    canRun: () => isUS && articleViewCount >= minArticleViews,
     geolocation,
     variants: [
         {
@@ -40,9 +45,7 @@ export const contributionsBannerUsEoyReaderAppreciationSupportersCasuals: Acquis
                 hasTicker: true,
                 tickerHeader,
                 bannerModifierClass: 'useoy2019',
-                userCohort: 'AllExistingSupporters',
             },
-            canRun: () => canShowBannerSync(3, 'AllExistingSupporters'),
         },
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
@@ -2,7 +2,6 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { acquisitionsBannerUsEoyTemplate } from 'common/modules/commercial/templates/acquisitions-banner-us-eoy';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
-import { canShowBannerSync } from 'common/modules/commercial/contributions-utilities';
 
 // User must have read at least 5 articles in last 4 months (as 17 weeks)
 const minArticleViews = 5;


### PR DESCRIPTION
## What does this change?
We are running custom copy on the US EOY banner for the last three days of the year. This amounts to two banners for each day, one with article count and one without.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
ab-contributions-banner-us-eoy-three-days-casuals
![3 days left casuals](https://user-images.githubusercontent.com/3300789/71363194-4a486c00-2590-11ea-8f9b-f345ebd106e7.png)

ab-contributions-banner-us-eoy-three-days-regulars
![3 days left regular](https://user-images.githubusercontent.com/3300789/71363199-4caac600-2590-11ea-9a33-37a533cbc947.png)

 ab-contributions-banner-us-eoy-two-days-casuals
![2 days left casual](https://user-images.githubusercontent.com/3300789/71363216-5a604b80-2590-11ea-934d-add18ab9fea2.png)

ab-contributions-banner-us-eoy-two-days-regulars
![2 days left regular](https://user-images.githubusercontent.com/3300789/71363219-5cc2a580-2590-11ea-8b9b-d8f9fa872344.png)

ab-contributions-banner-us-eoy-one-day-casuals
![1 day left casual](https://user-images.githubusercontent.com/3300789/71363223-60562c80-2590-11ea-8e0b-4f23319fcd4b.png)

ab-contributions-banner-us-eoy-one-day-regulars
![1 day left regular](https://user-images.githubusercontent.com/3300789/71363226-62b88680-2590-11ea-931b-9516bececa49.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
