### PR TITLE
Use ThreeQuarterQuarter in 2 story variation

### DIFF
--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -19,7 +19,7 @@ object DynamicPackage extends DynamicContainer {
     storiesIncludingBackfill.length match {
       case 0 => Nil
       case 1 => Seq(FullMedia75)
-      case 2 => Seq(ThreeQuarterTallQuarter)
+      case 2 => Seq(ThreeQuarterQuarter)
       case 3 => Seq(ThreeQuarterTallQuarter2)
       case 4 => Seq(ThreeQuarterTallQuarter1Ql2)
       case 5 => Seq(FullMedia100, QuarterQuarterQuarterQuarter)

--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -643,7 +643,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
         &.fc-item--full-media-75-tablet.fc-item--has-sublinks-3,
         &.fc-item--full-media-100-tablet,
         &.fc-item--full-media-100-tablet,
-        &.fc-item--three-quarters-tablet,
+        &.fc-item--three-quarters-tablet.fc-item--has-sublinks-2,
         &.fc-item--three-quarters-tall-tablet {
 
             .fc-sublink {
@@ -685,7 +685,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
             &.fc-item--full-media-75-tablet.fc-item--has-sublinks-3,
             &.fc-item--full-media-100-tablet,
             &.fc-item--full-media-100-tablet,
-            &.fc-item--three-quarters-tablet,
+            &.fc-item--three-quarters-tablet.fc-item--has-sublinks-2,
             &.fc-item--three-quarters-tall-tablet {
                 .fc-sublink {
                     margin-bottom: $gs-baseline;
@@ -709,6 +709,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
             }
 
             // FullMedia75
+            &.fc-item--three-quarters-tablet.fc-item--has-sublinks-2,
             &.fc-item--full-media-75-tablet.fc-item--has-sublinks-3,
             &.fc-item--full-media-75-tablet.fc-item--has-sublinks-4 {
                 .fc-item__footer--horizontal {
@@ -736,9 +737,13 @@ $block-height: 58px; // Note: duplicated from _item.scss
             }
 
             // ThreeQuarters
-            &.fc-item--three-quarters-tablet {
+            &.fc-item--three-quarters-tablet.fc-item--has-sublinks-2 {
                 .fc-item__footer--horizontal {
                     width: 66%;
+                }
+
+                .fc-sublink {
+                    max-width: 50%;
                 }
             }
         }


### PR DESCRIPTION
## What does this change?

Changes the layout of the two story dynamo container back to previous design.

Some adjustment to the handling of sublinks in the smaller image size.

### Before

<img width="1262" alt="Screenshot 2019-12-23 at 15 13 23" src="https://user-images.githubusercontent.com/638051/71366475-f478c180-2599-11ea-9262-87ec20e1a868.png">

### After

<img width="1262" alt="Screenshot 2019-12-23 at 15 26 06" src="https://user-images.githubusercontent.com/638051/71366485-fe022980-2599-11ea-9dd2-5f6512f8a0e6.png">

<img width="1262" alt="Screenshot 2019-12-23 at 15 13 05" src="https://user-images.githubusercontent.com/638051/71366499-078b9180-259a-11ea-92a0-a2feddf56074.png">


<img width="1262" alt="Screenshot 2019-12-23 at 15 26 00" src="https://user-images.githubusercontent.com/638051/71366489-02c6dd80-259a-11ea-90b1-efd314109e8c.png">
