### PR TITLE
Keep original article in document behind the signin gate

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -2,12 +2,14 @@
 import config from 'lib/config';
 import { isBreakpoint } from 'lib/detect';
 import fastdom from 'lib/fastdom-promise';
+import mediator from 'lib/mediator';
 import type { SpacefinderItem } from 'common/modules/spacefinder';
 import { spaceFiller } from 'common/modules/article/space-filler';
 import { adSizes } from 'commercial/modules/ad-sizes';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
 import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { createSlots } from 'commercial/modules/dfp/create-slots';
+
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCarrot } from 'commercial/modules/carrot-traffic-driver';
 
@@ -246,7 +248,7 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
     );
 };
 
-export const init = (): Promise<boolean> => {
+const doInit = (): Promise<boolean> => {
     if (!commercialFeatures.articleBodyAdverts) {
         return Promise.resolve(false);
     }
@@ -261,4 +263,13 @@ export const init = (): Promise<boolean> => {
         .then(initCarrot);
 
     return im;
+};
+
+export const init = (): Promise<boolean> => {
+    // Also init when the main article is redisplayed
+    // For instance by the signin gate.
+    mediator.on('page:article:redisplayed', () => {
+        doInit();
+    });
+    return doInit();
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -4,6 +4,7 @@ import userPrefs from 'common/modules/user-prefs';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import ophan from 'ophan/ng';
 import config from 'lib/config';
+import mediator from 'lib/mediator';
 import { local } from 'lib/storage';
 import { getCookie } from 'lib/cookies';
 import {
@@ -219,8 +220,6 @@ const show: () => Promise<boolean> = () => {
             // get the whole article body
             const articleBody = document.querySelector('.js-article__body');
             if (articleBody) {
-                // clone article body html string representation into memory
-                const currentContent = articleBody.cloneNode(true);
                 // get the first paragraph of the article
                 const articleBodyFirstChild = articleBody.firstElementChild;
                 if (articleBodyFirstChild) {
@@ -299,8 +298,12 @@ const show: () => Promise<boolean> = () => {
                                 value: 'dismiss',
                             });
 
-                            // replace the shadow article with the original content
-                            shadowArticleBody.replaceWith(currentContent);
+                            // show the current body. Remove the shadow one
+                            articleBody.style.display = 'block';
+                            shadowArticleBody.remove();
+
+                            // Tell other things the article has been redisplayed
+                            mediator.emit('page:article:redisplayed');
 
                             // user pref dismissed gate
                             setUserDismissedGate(
@@ -340,8 +343,11 @@ const show: () => Promise<boolean> = () => {
                         }
                     );
 
-                    // replace the real article with the shadow article
-                    articleBody.replaceWith(shadowArticleBody);
+                    // Hide the article Body. Append the shadow one.
+                    articleBody.style.display = 'none';
+                    if (articleBody.parentNode) {
+                        articleBody.parentNode.appendChild(shadowArticleBody);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What does this change?

This changes the implementation of the sigin gate so it doesn't detach the original article content from the document anymore (but just hides it). This allow elements like advertisement and other embeds to display correctly when the gate is dismissed.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Check the page https://www.theguardian.com/lifeandstyle/2019/dec/23/worst-trends-decade-ranked-2010s under the sign in gate.

Dismiss and see that ads and and the giffy embeded elements are fine.

### Tested

- [X] Locally
- [ ] On CODE (optional)
