### PR TITLE
Reduce audience percentage of the sign in test to 6%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateSecundus: ABTest = {
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
-    audience: 0.28,
+    audience: 0.06,
     audienceOffset: 0.1,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?

There is a sign in test running 
https://github.com/guardian/frontend/pull/22154

But a bug was flagged where inline tests are not appearing
https://trello.com/c/YZTuXIeV/1757-bug-inline-ads-should-continue-to-appear-after-dismissing-the-sign-in-gate

Eventually we need to merge this PR to resolve the issue https://github.com/guardian/frontend/pull/22166 

But in the meantime, we wish to reduce the audience percentage, and just run the test for longer once after we get the fix out. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No 
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
The behaviour of the test should remain as is https://github.com/guardian/frontend/pull/22154 but just fewer people should see it 

## What is the value of this and can you measure success?
Until we get a fix out, this mitigates the impact of inline ads not appearing for people in the test who dismiss the gate. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
There are no changes to the actual test, just the percentage
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
- [x] to be verified by querying on Friday how many people have seen the gate and seeing it decreasing from the numbers until this PR is merged.
<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
