### PR TITLE
The number of 'days left' in the US banner should be inclusive of the current day

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/common.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/common.js
@@ -4,7 +4,7 @@ const getDaysLeftInCampaign = (endDate: number): number => {
     const currentDate: number = new Date().getTime();
     const timeLeft: number = endDate - currentDate;
 
-    return Math.floor(timeLeft / (1000 * 60 * 60 * 24));
+    return Math.floor(timeLeft / (1000 * 60 * 60 * 24)) + 1; // days are inclusive
 };
 
 export const getDaysLeftBeforeEOY2019 = (): number =>
@@ -12,10 +12,8 @@ export const getDaysLeftBeforeEOY2019 = (): number =>
 
 export const daysLeftCopy = (daysLeft: number): string => {
     switch (daysLeft) {
-        case 0:
-            return `It's the last day to contribute in 2019`;
         case 1:
-            return '1 day left to contribute in 2019';
+            return `It's the last day to contribute in 2019`;
         default:
             return `${daysLeft} days left to contribute in 2019`;
     }


### PR DESCRIPTION
## What does this change?

The number of 'days left' in the US banner should be inclusive of the current day, however far through it the reader is

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Before
The banner should say '5 days left':
![Screen Shot 2019-12-27 at 10 03 53](https://user-images.githubusercontent.com/1515970/71512964-541fe700-2890-11ea-9ea8-24e1f9789398.png)

### After
![Screen Shot 2019-12-27 at 10 03 44](https://user-images.githubusercontent.com/1515970/71512967-5aae5e80-2890-11ea-87c8-1eac3572bfa3.png)

## What is the value of this and can you measure success?
The test variant of the banner which uses this function has its number of impressions and conversion rate measured.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
