### PR TITLE
fixed copy on end of year countdown banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-one-day-regulars.js
@@ -14,7 +14,7 @@ const isUS = geolocation === 'US';
 const titles = ['1 day left to give to the Guardian in 2019'];
 const messageText = `… and one year left in Donald Trump’s first term. Over the last three years, much of what the Guardian holds dear has been threatened – democracy, civility, truth. As 2020 approaches, the need for a robust, independent press has never been greater. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = `You've read ${articleViewCount} in the last four months`;
+const tickerHeader = `You've read ${articleViewCount} articles in the last four months`;
 
 export const contributionsBannerUsEoyOneDayRegulars: AcquisitionsABTest = {
     id: 'ContributionsBannerUsEoyOneDayRegulars',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-three-days-regulars.js
@@ -14,7 +14,7 @@ const isUS = geolocation === 'US';
 const titles = ['3 days left to give to the Guardian in 2019'];
 const messageText = `… and three American billionaires whose family net worth equals the net worth of more than 50% of the US population. The coming year will be an epic one for America and will tell us much about how this country wants to tackle wealth inequality. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = `You've read ${articleViewCount} in the last four months`;
+const tickerHeader = `You've read ${articleViewCount} articles in the last four months`;
 
 export const contributionsBannerUsEoyThreeDaysRegulars: AcquisitionsABTest = {
     id: 'ContributionsBannerUsEoyThreeDaysRegulars',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy-two-days-regulars.js
@@ -14,7 +14,7 @@ const isUS = geolocation === 'US';
 const titles = ['2 days left to give to the Guardian in 2019'];
 const messageText = `… and two supreme court justices Donald Trump has appointed in his first term. The next US president will shape the court for the next half century – and the future of LGBTQ+ rights, immigration, abortion, guns, religion, dark money and more are in play. As we prepare for 2020, we’re asking our US readers to help us raise $1.5 million to cover the issues that matter.`;
 const ctaText = 'Support The Guardian';
-const tickerHeader = `You've read ${articleViewCount} in the last four months`;
+const tickerHeader = `You've read ${articleViewCount} articles in the last four months`;
 
 export const contributionsBannerUsEoyTwoDaysRegulars: AcquisitionsABTest = {
     id: 'ContributionsBannerUsEoyTwoDaysRegulars',


### PR DESCRIPTION
## What does this change?
Added the word "articles" to banner copy - amending https://github.com/guardian/frontend/pull/22164