### PR TITLE
updated countdown banner run conditions to make sense with new countdown logic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-casuals.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-casuals.js
@@ -28,7 +28,7 @@ export const contributionsBannerUsEoyImpeachmentCasuals: AcquisitionsABTest = {
     idealOutcome: 'NA',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => daysLeft >= 0 && isUS,
+    canRun: () => daysLeft > 0 && isUS,
     geolocation,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-regulars.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-us-eoy/contribs-banner-us-eoy-impeachment-regulars.js
@@ -35,7 +35,7 @@ export const contributionsBannerUsEoyImpeachmentRegulars: AcquisitionsABTest = {
     idealOutcome: 'NA',
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    canRun: () => daysLeft >= 0 && isUS && articleViewCount >= minArticleViews,
+    canRun: () => daysLeft > 0 && isUS && articleViewCount >= minArticleViews,
     geolocation,
     variants: [
         {


### PR DESCRIPTION
## What does this change?
We should not run the banner with 0 days left - this fixes it in the canrun condition - thanks @tomrf1 for pointing this out

It should be noted we are not likely not to run this specific banner with the countdown again. But this PR/change are probably good for documentation purposes.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
