### PR TITLE
Add mediaType to onward collection response

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -2,7 +2,7 @@ package models
 
 import com.gu.contentapi.client.utils.{Article, DesignType}
 import common.LinkTo
-import model.pressed.PressedContent
+import model.pressed.{MediaType, PressedContent}
 import play.api.mvc.RequestHeader
 import views.support.{ContentOldAgeDescriber, GUDateTimeFormat, ImgSrc, RemoveOuterParaHtml}
 import play.api.libs.json._
@@ -22,6 +22,7 @@ case class OnwardItem(
   designType: String,
   webPublicationDate: String,
   headline: String,
+  mediaType: Option[String],
 )
 
 case class MostPopularGeoResponse(
@@ -64,6 +65,7 @@ object OnwardCollection {
         designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,
         webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString,
         headline = content.header.headline,
+        mediaType = content.card.mediaType.map(_.toString())
       )
     )
   }


### PR DESCRIPTION
## What does this change?

Adds mediaType (if applicable) to trail items in onward collection responses, which will be consumed by DCR. Part of https://trello.com/c/jvwweqTl/1011-mediaduration-mediatype.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1395" alt="Screenshot 2020-01-03 at 15 19 12" src="https://user-images.githubusercontent.com/379839/71731403-8b683800-2e3c-11ea-918e-17b7e53df531.png">

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
