### PR TITLE
Update subscriptions banner copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -5,6 +5,8 @@ import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 
 import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
 
+//
+
 const isUserLoggedIn = userLoggedIn =>
     userLoggedIn
         ? 'site-message--subscription-banner__sign-in--already-signed-in'
@@ -13,17 +15,21 @@ const isUserLoggedIn = userLoggedIn =>
 const subscriptionBannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
-    userLoggedIn: boolean
+    userLoggedIn: boolean,
+    abTestVariant: any,
 ): string => `
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            A beautiful way to read it <br>
-            A powerful way to fund it
+            ${abTestVariant?
+                `A beautiful way to read it <br /> A powerful way to fund it`:
+                `<span class="variantB-header">We're going to need each other this year</span>`}
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Two innovative apps and ad-free reading on theguardian.com. The complete digital experience from The Guardian.</p>
+            <p>Support The Guardian and enjoy The Guardian Daily,
+            Premium access to The Guardian Live app and ad-free
+            reading on theguardian.com</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">
@@ -97,7 +103,8 @@ const bannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
     showConsent: boolean,
-    userLoggedIn: boolean
+    userLoggedIn: boolean,
+    abTestVariant: any
 ): string =>
     `<div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner subscription-banner--holder"
           tabindex="-1"
@@ -108,7 +115,7 @@ const bannerTemplate = (
           aria-live="polite"
         >
 
-        ${subscriptionBannerTemplate(subscriptionUrl, signInUrl, userLoggedIn)}
+        ${subscriptionBannerTemplate(subscriptionUrl, signInUrl, userLoggedIn, abTestVariant)}
         ${showConsent ? consentSection : ''}
     </div>
     `;

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -16,14 +16,16 @@ const subscriptionBannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
     userLoggedIn: boolean,
-    abTestVariant: any,
+    abTestVariant: any
 ): string => `
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            ${abTestVariant?
-                `A beautiful way to read it <br /> A powerful way to fund it`:
-                `<span class="variantB-header">We're going to need each other this year</span>`}
+            ${
+                abTestVariant
+                    ? `A beautiful way to read it <br /> A powerful way to fund it`
+                    : `<span class="variantB-header">We're going to need each other this year</span>`
+            }
         </h3>
 
         <div class="site-message--subscription-banner__description">
@@ -115,7 +117,12 @@ const bannerTemplate = (
           aria-live="polite"
         >
 
-        ${subscriptionBannerTemplate(subscriptionUrl, signInUrl, userLoggedIn, abTestVariant)}
+        ${subscriptionBannerTemplate(
+            subscriptionUrl,
+            signInUrl,
+            userLoggedIn,
+            abTestVariant
+        )}
         ${showConsent ? consentSection : ''}
     </div>
     `;

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -16,15 +16,15 @@ const subscriptionBannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
     userLoggedIn: boolean,
-    abTestVariant: any
+    abTestVariant: boolean
 ): string => `
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
             ${
                 abTestVariant
-                    ? `A beautiful way to read it <br /> A powerful way to fund it`
-                    : `<span class="variantB-header">We're going to need each other this year</span>`
+                    ? `<span class="variantB-header">We're going to need each other this year</span>`
+                    : `A beautiful way to read it <br /> A powerful way to fund it`
             }
         </h3>
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -23,7 +23,7 @@ const subscriptionBannerTemplate = (
         <h3 class="site-message--subscription-banner__title">
             ${
                 abTestVariant
-                    ? `<span class="variantB-header">We're going to need each other this year</span>`
+                    ? `<span class="variantB-header">We're going to need <br /> each other this year</span>`
                     : `A beautiful way to read it <br /> A powerful way to fund it`
             }
         </h3>

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -5,8 +5,6 @@ import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 
 import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
 
-//
-
 const isUserLoggedIn = userLoggedIn =>
     userLoggedIn
         ? 'site-message--subscription-banner__sign-in--already-signed-in'
@@ -106,7 +104,7 @@ const bannerTemplate = (
     signInUrl: string,
     showConsent: boolean,
     userLoggedIn: boolean,
-    abTestVariant: any
+    abTestVariant: boolean
 ): string =>
     `<div class="site-message js-site-message js-double-site-message site-message--banner site-message--double-banner subscription-banner--holder"
           tabindex="-1"

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -38,12 +38,6 @@ const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 const COMPONENT_TYPE = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
 const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 
-const getVariant = () =>
-    // pass variant to ga
-    // pass variant to ophan
-    Math.round(Math.random());
-
-console.log(getVariant());
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
 const subscriptionBannerSwitchIsOn: boolean = config.get(
@@ -70,7 +64,7 @@ const closedAt = (lastClosedAtKey: string) =>
     userPrefs.set(lastClosedAtKey, new Date().toISOString());
 
 const hasAcknowledged = () => {
-    const bannerRedeploymentDate = new Date(2019, 11, 12, 5, 0).getTime(); // 2 Dec 2019 @ 5:00
+    const bannerRedeploymentDate = new Date(2020, 0, 6, 5, 0).getTime(); // 6 Jan 2019 @ 5:00
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
 
@@ -208,7 +202,7 @@ const show: () => Promise<boolean> = async () => {
                 signInUrl,
                 showConsent,
                 isUserLoggedIn(),
-                getVariant()
+                true // This should be taken from A/B test participation if we want to run this as a test eventually
             )
         );
     }

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -38,6 +38,13 @@ const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 const COMPONENT_TYPE = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
 const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 
+
+const getVariant = () => {
+    // pass variant to ga
+    // pass variant to ophan
+    return Math.round(Math.random());
+}
+console.log(getVariant());
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
 const subscriptionBannerSwitchIsOn: boolean = config.get(
@@ -201,7 +208,8 @@ const show: () => Promise<boolean> = async () => {
                 subscriptionUrl,
                 signInUrl,
                 showConsent,
-                isUserLoggedIn()
+                isUserLoggedIn(),
+                getVariant()
             )
         );
     }

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -38,12 +38,11 @@ const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 const COMPONENT_TYPE = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
 const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 
-
-const getVariant = () => {
+const getVariant = () =>
     // pass variant to ga
     // pass variant to ophan
-    return Math.round(Math.random());
-}
+    Math.round(Math.random());
+
 console.log(getVariant());
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -55,8 +55,8 @@
     @include mq($from: tablet) {
         margin-bottom: 10px;
         width: 60%;
-        font-size: 4.7vw;
-        line-height: 4.9vw;
+        font-size: 30px;
+        line-height: 32px;
     }
 
     @include mq($from: desktop) {
@@ -355,6 +355,24 @@
     }
 }
 
+.variantB-header {
+    display: block;
+    background-color: pink;
+    max-width: 350px;
+    padding-right: 36px;
+
+    @include mq($from: phablet) {
+        max-width: 450px;
+    }
+
+    @include mq($from: tablet) {
+        max-width: 480px;
+    }
+
+    @include mq($from: desktop) {
+        max-width: 500px;
+    }
+}
 
 /*********************** footer hacks *********************/
 

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -74,7 +74,7 @@
     width: 100%;
 
     @include mq($from: tablet) {
-        width: 60%;
+        width: 55%;
     }
 
     @include mq($from: desktop) {
@@ -98,18 +98,18 @@
 
         // custom breakpoint
         @media (min-width: 550px) {
-            font-size: 20px;
-            line-height: 22px;
+            font-size: 17px;
+            line-height: 19px;
         }
 
         @include mq($from: phablet) {
-            font-size: 22px;
-            line-height: 24px;
+            font-size: 17px;
+            line-height: 19px;
         }
 
         @include mq($from: tablet) {
-            font-size: 2.5vw;
-            line-height: 3vw;
+            font-size: 17px;
+            line-height: 19px;
         }
 
         @include mq($from: desktop) {
@@ -357,7 +357,7 @@
 
 .variantB-header {
     display: block;
-    max-width: 350px;
+    max-width: 340px;
     padding-right: 36px;
 
     @include mq($from: phablet) {

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -71,7 +71,7 @@
     display: flex;
     align-items: flex-end;
     align-content: stretch;
-    width: 100%;
+    width: 95%;
 
     @include mq($from: tablet) {
         width: 55%;

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -357,7 +357,6 @@
 
 .variantB-header {
     display: block;
-    background-color: pink;
     max-width: 350px;
     padding-right: 36px;
 


### PR DESCRIPTION
## What does this change?
This updates the subscriptions banner title and standfirst copy for the new year. Originally this was going to be run as a test but there wasn't enough time to hook that up with Optimize on support-frontend, so now it is just an update (but with some consideration for being turned into a test in the near future).

The eventual test would only alter the title - the standfirst will be changed for everyone.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/71734753-860eeb80-2e44-11ea-9cbe-bd668296966d.png)
![image](https://user-images.githubusercontent.com/8754692/71734778-92934400-2e44-11ea-9bd7-52fafe5f944d.png)
![image](https://user-images.githubusercontent.com/8754692/71734797-9de66f80-2e44-11ea-956e-6185887cd18b.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
