### PR TITLE
Adding JVM opts to prevent build from blowing up

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-Xmx2G
+-Djava.net.preferIPv4Stack=true
+-XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=1G

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,9 @@ import com.gu.Dependencies._
 import com.gu.ProjectSettings._
 
 val common = library("common").settings(
-  javaOptions in Test += "-Dconfig.file=common/conf/test.conf",
+  javaOptions in Test ++= Seq(
+    "-Dconfig.file=common/conf/test.conf"
+  ),
   libraryDependencies ++= Seq(
     guBox,
     apacheCommonsMath3,
@@ -59,7 +61,7 @@ val common = library("common").settings(
     jsonSchema
   )
 ).settings(
-    mappings in TestAssets ~= filterAssets
+  mappings in TestAssets ~= filterAssets
 )
 
 val commonWithTests = withTests(common)
@@ -185,9 +187,9 @@ val main = root().aggregate(
   preview,
   rss
 ).settings(
-  riffRaffBuildIdentifier := System.getenv().getOrDefault("BUILD_NUMBER", "0").replaceAll("\"",""),
-  riffRaffUploadArtifactBucket := Some(System.getenv().getOrDefault("RIFF_RAFF_ARTIFACT_BUCKET", "aws-frontend-teamcity")),
-  riffRaffUploadManifestBucket := Some(System.getenv().getOrDefault("RIFF_RAFF_BUILD_BUCKET", "aws-frontend-teamcity")),
+  riffRaffBuildIdentifier := sys.env.getOrElse("BUILD_NUMBER", "0").replaceAll("\"",""),
+  riffRaffUploadArtifactBucket := Some(sys.env.getOrElse("RIFF_RAFF_ARTIFACT_BUCKET", "aws-frontend-teamcity")),
+  riffRaffUploadManifestBucket := Some(sys.env.getOrElse("RIFF_RAFF_BUILD_BUCKET", "aws-frontend-teamcity")),
   riffRaffManifestProjectName := s"dotcom:all",
   riffRaffArtifactResources := Seq(
     (packageBin in Universal in admin).value -> s"${(name in admin).value}/${(packageBin in Universal in admin).value.getName}",
@@ -227,4 +229,3 @@ badgeHash := {
 
   println(result)
 }
-


### PR DESCRIPTION
## What does this change?

Adds a `.jvmopts` file to allow overriding standard VM memory settings when loading up SBT. Right now running SBT from root makes the compiler blow up with OOMs, and custom settings are required to prevent this.

Uses native Scala instead of Java API to read system properties.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

Build no longer blows up when running simple SBT, because the `.jvmopts` file gets automatically picked up.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
