### PR TITLE
Fix ad overlapping article content when placed next to supporting figure

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -101,6 +101,10 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
                 minAbove: 0,
                 minBelow: 600,
             },
+            ' figure.element--supporting': {
+                minAbove: 500,
+                minBelow: 0,
+            },
         },
         filter: filterNearbyCandidates(adSizes.mpu.height),
     };


### PR DESCRIPTION
## What does this change?

Fixes issue with a large ad slot hiding article text (happening next to supporting figure elements). Adjust spacefinder rules to consider placing inline1 desktop ad slot below supporting figure elements.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Normally no change would be needed as spacefinder is shared between the stacks, although there is an issue in dcr not showing supporting figures so couldn't test (notified @guardian/dotcom-platform about it)

## Screenshots

### Before
![Screenshot 2020-01-07 at 11 33 16](https://user-images.githubusercontent.com/51630004/71892898-1baac380-3142-11ea-9e4d-ba77e0b1178a.png)

### After
![Screenshot 2020-01-07 at 11 32 14](https://user-images.githubusercontent.com/51630004/71892905-1fd6e100-3142-11ea-88c8-de72d119d968.png)

## What is the value of this and can you measure success?
Will not block article content

### Tested

- [x] Locally
- [ ] On CODE (optional)
