### PR TITLE
Updating sign in gate secundus test audience

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-first-test.js
@@ -6,7 +6,7 @@ export const signInGateSecundus: ABTest = {
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
-    audience: 0.06,
+    audience: 0.28,
     audienceOffset: 0.1,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?

After fixing the in line ads not loading after a gate was dismissed (#22166), we're upping the test numbers to what they we're before we reduced the audience size to reach our targeted number of browsers who view the test.