### PR TITLE
Bump Identity Lib version to 3.193

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.191"
+  val identityLibVersion = "3.193"
   val awsVersion = "1.11.240"
   val capiVersion = "15.6"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?

Bumps Identity Lib dependency version to 3.193

## Why?

We added a new newsletter to Identity-Model-EmailNewsletters