### PR TITLE
Fix reader revenue banner redeploys on some browsers

### DIFF
--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -37,9 +37,9 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
   def redeployBanner(region: String, bannerType: BannerType): Action[AnyContent] = Action.async { implicit request =>
     ReaderRevenueRegion.fromString(region).fold(Future.successful(redeployFailed(new Throwable("attempted to redeploy banner in unknown region"), bannerType))){ region: ReaderRevenueRegion =>
       val requester: String = UserIdentity.fromRequest(request) map(_.fullName) getOrElse "unknown user (dev-build?)"
-      val time = DateTime.now
-      val jsonLog: JsValue = Json.toJson(BannerDeploy(time))
-      val message = s"${bannerType.name} banner in ${region.name} redeploy by $requester at ${time.toString}}"
+      val millisSinceEpoch = DateTime.now.getMillis()
+      val jsonLog: JsValue = Json.toJson(BannerDeploy(millisSinceEpoch))
+      val message = s"${bannerType.name} banner in ${region.name} redeploy by $requester at ${millisSinceEpoch.toString}}"
 
       val result = for {
         _ <- updateBannerDeployLog(region, jsonLog.toString, bannerType)

--- a/common/app/model/readerRevenue/BannerDeploy.scala
+++ b/common/app/model/readerRevenue/BannerDeploy.scala
@@ -4,7 +4,7 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import conf.Configuration.readerRevenue._
 
-case class BannerDeploy(millis: Long)
+case class BannerDeploy(time: Long)
 
 object BannerDeploy {
   implicit val deployFormat = Json.format[BannerDeploy]

--- a/common/app/model/readerRevenue/BannerDeploy.scala
+++ b/common/app/model/readerRevenue/BannerDeploy.scala
@@ -4,16 +4,14 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import conf.Configuration.readerRevenue._
 
-case class BannerDeploy(time: DateTime)
+case class BannerDeploy(millis: Long)
 
 object BannerDeploy {
-  private implicit val jodaDateTimeFormats: Format[DateTime] =
-    Format(JodaReads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ssZ"), JodaWrites.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ssZ"))
-  implicit val deployFormat: OFormat[BannerDeploy] = Json.format[BannerDeploy]
+  implicit val deployFormat = Json.format[BannerDeploy]
 }
 
 sealed trait ReaderRevenueRegion {
-  def name: String;
+  def name: String
   override def toString: String = s"ReaderRevenueRegion: $name"
 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -47,7 +47,9 @@ const hasBannerBeenRedeployedSinceClosed = (
 ): Promise<boolean> =>
     getTimestampOfLastBannerDeployForLocation(region)
         .then(timestamp => {
-            const bannerLastDeployedAt = new Date(timestamp);
+            // In order to migrate between ISO string and millisecond format support both temporarily
+            const stringOrNumberTimestamp = Number(timestamp) || timestamp;
+            const bannerLastDeployedAt = new Date(stringOrNumberTimestamp);
             return bannerLastDeployedAt > new Date(userLastClosedBannerAt);
         })
         .catch(err => {

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -60,8 +60,11 @@ const hasAcknowledged = bannerRedeploymentDate => {
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
     
+    // $FlowFixMe
     console.log('hasAcknowledgedBanner->redeploymentDate : ' + redeploymentDate);
+    // $FlowFixMe
     console.log('hasAcknowledgedBanner->lastClosedAt : ' + lastClosedAt);
+    // $FlowFixMe
     console.log('hasAcknowledgedBanner->lastClosedAtTime : ' + lastClosedAtTime);
 
     return lastClosedAt && lastClosedAtTime > redeploymentDate;
@@ -239,6 +242,7 @@ const canShow: () => Promise<boolean> = async () => {
         currentRegion
     );
     
+    // $FlowFixMe
     console.log('hasAcknowledgedSinceLastRedeploy: ' + hasAcknowledgedSinceLastRedeploy);
 
     const can = Promise.resolve(

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -59,13 +59,18 @@ const hasAcknowledged = bannerRedeploymentDate => {
     const redeploymentDate = new Date(bannerRedeploymentDate).getTime();
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
-    
     // $FlowFixMe
-    console.log('hasAcknowledgedBanner->redeploymentDate : ' + redeploymentDate);
+    console.log(
+        `hasAcknowledgedBanner->redeploymentDate : ${redeploymentDate.toString()}`
+    );
     // $FlowFixMe
-    console.log('hasAcknowledgedBanner->lastClosedAt : ' + lastClosedAt);
+    console.log(
+        `hasAcknowledgedBanner->lastClosedAt : ${lastClosedAt.toString()}`
+    );
     // $FlowFixMe
-    console.log('hasAcknowledgedBanner->lastClosedAtTime : ' + lastClosedAtTime);
+    console.log(
+        `hasAcknowledgedBanner->lastClosedAtTime : ${lastClosedAtTime.toString()}`
+    );
 
     return lastClosedAt && lastClosedAtTime > redeploymentDate;
 };
@@ -241,9 +246,11 @@ const canShow: () => Promise<boolean> = async () => {
     const hasAcknowledgedSinceLastRedeploy = await hasAcknowledgedBanner(
         currentRegion
     );
-    
+
     // $FlowFixMe
-    console.log('hasAcknowledgedSinceLastRedeploy: ' + hasAcknowledgedSinceLastRedeploy);
+    console.log(
+        `hasAcknowledgedSinceLastRedeploy: ${hasAcknowledgedSinceLastRedeploy}`
+    );
 
     const can = Promise.resolve(
         fiveOrMorePageViews(pageviews) &&

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -61,7 +61,7 @@ const hasAcknowledged = bannerRedeploymentDate => {
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
     // $FlowFixMe
     console.log(
-        `hasAcknowledgedBanner->redeploymentDate : ${redeploymentDate.toString()}`
+        `hasAcknowledgedBanner->bannerRedeploymentDate : ${bannerRedeploymentDate.toString()}`
     );
     // $FlowFixMe
     console.log(
@@ -79,7 +79,10 @@ const hasAcknowledgedBanner = region =>
     fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
         mode: 'cors',
     })
-        .then(resp => hasAcknowledged(resp.time))
+        .then(resp => {
+            console.log(resp);
+            hasAcknowledged(resp.time);
+        })
         .catch(err => {
             reportError(
                 new Error(

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -59,6 +59,10 @@ const hasAcknowledged = bannerRedeploymentDate => {
     const redeploymentDate = new Date(bannerRedeploymentDate).getTime();
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt).getTime();
+    
+    console.log('hasAcknowledgedBanner->redeploymentDate : ' + redeploymentDate);
+    console.log('hasAcknowledgedBanner->lastClosedAt : ' + lastClosedAt);
+    console.log('hasAcknowledgedBanner->lastClosedAtTime : ' + lastClosedAtTime);
 
     return lastClosedAt && lastClosedAtTime > redeploymentDate;
 };
@@ -234,6 +238,8 @@ const canShow: () => Promise<boolean> = async () => {
     const hasAcknowledgedSinceLastRedeploy = await hasAcknowledgedBanner(
         currentRegion
     );
+    
+    console.log('hasAcknowledgedSinceLastRedeploy: ' + hasAcknowledgedSinceLastRedeploy);
 
     const can = Promise.resolve(
         fiveOrMorePageViews(pageviews) &&

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -249,7 +249,7 @@ const canShow: () => Promise<boolean> = async () => {
 
     // $FlowFixMe
     console.log(
-        `hasAcknowledgedSinceLastRedeploy: ${hasAcknowledgedSinceLastRedeploy}`
+        `hasAcknowledgedSinceLastRedeploy: ${hasAcknowledgedSinceLastRedeploy.toString()}`
     );
 
     const can = Promise.resolve(

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -57,19 +57,20 @@ const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&u
 
 const hasAcknowledged = bannerRedeploymentDate => {
     // In order to migrate between ISO string and millisecond format support both temporarily
-    const stringOrNumberRedeploymentDate = Number(bannerRedeploymentDate) || bannerRedeploymentDate;
+    const stringOrNumberRedeploymentDate =
+        Number(bannerRedeploymentDate) || bannerRedeploymentDate;
     const redeploymentDate = new Date(stringOrNumberRedeploymentDate);
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt);
 
     // Always show to people who have never dismissed
-    if(!lastClosedAt) {
-        return false
+    if (!lastClosedAt) {
+        return false;
     }
 
     // Default to hiding when there is a problem with the redeploy - this is unexpected
-    if(!redeploymentDate) {
-        return true
+    if (!redeploymentDate) {
+        return true;
     }
 
     return lastClosedAtTime > redeploymentDate;


### PR DESCRIPTION
## What does this change?
This changes the default time format saved to S3 during a reader revenue banner redeploy to milliseconds since epoch.  The clientside for both contributions and subscriptions banners has been updated to handle either the old ISO format or milliseconds since epoch.

This is being done to ensure consistent browser behaviour, as there is inconsistency in handling for `new Date(string)`, but not for `new Date(long)`.

In order to migrate from one format to another more easily without downtime, I've let both formats be valid in this PR, with a view to updating all the files in S3 over time (there are quite a few).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?
We correctly serve banners to people depending on redeploy/dismissal status across all browsers.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
