### PR TITLE
Reduce CAPI client max retry attempt count

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -105,8 +105,8 @@ trait MonitoredContentApiClientLogic extends CapiContentApiClient with ApiQueryD
   val httpClient: HttpClient
 
   override implicit val executor = ScheduledExecutor()
-  val retryDuration = Duration(250L, TimeUnit.MILLISECONDS)
-  val retryAttempts = 3
+  val retryDuration = Duration(350L, TimeUnit.MILLISECONDS)
+  val retryAttempts = 1
   override val backoffStrategy: ContentApiBackoff = ContentApiBackoff.constantStrategy(retryDuration, retryAttempts)
 
   def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext): Future[HttpResponse] = {


### PR DESCRIPTION
## What does this change?

We’ve seen a few scenarios lately where CAPI is under strain and starts returning errors. In these cases frontend will retry the request up to 3 times which seems to largely have the effect of kicking CAPI while it’s down.

In the context of an HTTP request we think that retrying multiple times probably isn’t what we want. There is a 2 second limit on requests to frontend. If this limit is reached the request is terminated. Combined with CAPI’s circuit breaker logic this means that retrying with a delay is unlikely to yield a successful result within the 2 second window.

It isn’t possible to return to the previous behaviour of not-retrying at all because the client enforces that we provide a retry strategy. The closest we can get right now is to reduce the retry count limit to 1 (i.e. an initial request and a single retry if the first request fails). (My understanding is that until #22013 there was no retry behaviour in place.) I've also increased the delay, which I think we can afford to do since we've reduced the number of retries and thereby have increased the maximum total amount of time we might spend waiting for a response from CAPI.

Going forward we think we probably _do_ want an exponential backoff with retries and a limit on the total number of in-flight requests to CAPI for offline jobs, where response time to an end user isn’t a concern. This will require splitting the ContentApiClient implementation to handle both scenarios.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We expect that it will reduce the load on CAPI when it is throwing errors, allowing CAPI to recover more quickly and reduce downtime.

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)
