### PR TITLE
Include id in DCR model for InteractiveMarkupBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -36,7 +36,7 @@ case class SoundcloudBlockElement(html: String, id: String, isTrack: Boolean, is
 case class ContentAtomBlockElement(atomId: String) extends PageElement
 case class YoutubeBlockElement(id: String, assetId: String, channelId: Option[String], mediaTitle: String) extends PageElement
 case class InteractiveUrlBlockElement(url: String) extends PageElement
-case class InteractiveMarkupBlockElement(html: Option[String], css: Option[String], js: Option[String]) extends PageElement
+case class InteractiveMarkupBlockElement(id: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
 case class TableBlockElement(html: Option[String], role: Role, isMandatory: Option[Boolean]) extends PageElement
 case class WitnessBlockElement(html: Option[String]) extends PageElement
@@ -329,6 +329,7 @@ object PageElement {
 
           case Some(interactive: InteractiveAtom) => {
             Some(InteractiveMarkupBlockElement(
+              id = interactive.id,
               html = Some(interactive.html),
               css = Some(interactive.css),
               js = interactive.mainJS


### PR DESCRIPTION
## What does this change?
The DCR model for `InteractiveMarkupBlockElement` has 

```typescript
{
    html?: string;
    styles?: string;
    js?: string;
}
```

This PR adds `id` to this model as:

```typescript
{
    id?: string;
    html?: string;
    styles?: string;
    js?: string;
}
```

### Why
Because we have a requirement to build a url inside an AMP component and this url is built using this `id` value

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [x] Locally
- [ ] On CODE (optional)
