### PR TITLE
Prepare for CommercialCmpUiBannerModal a/b test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -2,12 +2,12 @@
 
 export const commercialCmpUiBannerModal: ABTest = {
     id: 'CommercialCmpUiBannerModal',
-    start: '2020-01-08',
+    start: '2020-01-13',
     expiry: '2020-01-28',
     author: 'George Haberis',
     description: '0% participation AB test for the new banner/modal CMP UI',
-    audience: 0,
-    audienceOffset: 0.6,
+    audience: 0.01,
+    audienceOffset: 0.8,
     successMeasure: 'Our new banner/modal CMP UI obtains target consent rates',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -5,7 +5,7 @@ export const commercialCmpUiBannerModal: ABTest = {
     start: '2020-01-13',
     expiry: '2020-01-28',
     author: 'George Haberis',
-    description: '0% participation AB test for the new banner/modal CMP UI',
+    description: '1% participation AB test for the new banner/modal CMP UI',
     audience: 0.01,
     audienceOffset: 0.8,
     successMeasure: 'Our new banner/modal CMP UI obtains target consent rates',


### PR DESCRIPTION
## What does this change?

Prepare for `CommercialCmpUiBannerModal` a/b test by bumping audience to 1% and setting audience offset to 0.8.