### PR TITLE
Log error states when the healthcheck fails

### DIFF
--- a/facia-press/app/controllers/HealthCheck.scala
+++ b/facia-press/app/controllers/HealthCheck.scala
@@ -15,8 +15,9 @@ class HealthCheck(
   extends HealthCheckController with Results with Logging {
   val ConsecutiveProcessingErrorsThreshold = 5
   override def healthCheck(): Action[AnyContent] = Action.async{
-    if (!toolPressQueueWorker.lastReceipt.exists(_.plusMinutes(1).isAfter(DateTime.now))) {
-      val msg = "Have not been able to retrieve a message from the tool queue for at least a minute"
+    val lastReceiptThresholdInMinutes = 1
+    if (!toolPressQueueWorker.lastReceipt.exists(_.plusMinutes(lastReceiptThresholdInMinutes).isAfter(DateTime.now))) {
+      val msg = s"Have not been able to retrieve a message from the tool queue for at least ${lastReceiptThresholdInMinutes} minute(s)"
       log.error(msg)
       successful(Results.InternalServerError(msg))
     } else if (toolPressQueueWorker.consecutiveErrors >= ConsecutiveProcessingErrorsThreshold) {


### PR DESCRIPTION
## What does this change?

The `facia-press` healthcheck checks for errors which can include timeouts from downstream services, and fails if there are 5 consecutive errors. We think this configuration can result in the arbitrary termination of `facia-press` instances.

This change adds logging at the point at which the healthcheck fails to help us prove that this is occurring.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

If we find that this is happening, we can reconfigure the healthcheck to avoid terminating healthy instances. We think terminating instances is causing latency spikes in the press, as abandoned messages will have to wait another 30 seconds to be re-processed by another instance as per the SQS `visibility timeout` setting.

If we can stop this from happening, we may improve press times for editorial.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
