### PR TITLE
Add click events tracking for subs banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -36,7 +36,9 @@ const subscriptionBannerTemplate = (
             <a
                 id="js-site-message--subscription-banner__cta"
                 class="site-message--subscription-banner__cta"
+                data-link-name="subscription-banner : cta"
                 href="${subscriptionUrl}"
+
             >
                 Become a digital subscriber
             </a>
@@ -46,6 +48,7 @@ const subscriptionBannerTemplate = (
                 <a
                     id="js-site-message--subscription-banner__cta-dismiss"
                     class="site-message--subscription-banner__cta-dismiss"
+                    data-link-name="subscription-banner : not now"
                     tabindex="0"
                 >
                     Not now
@@ -55,12 +58,16 @@ const subscriptionBannerTemplate = (
 
         <div class="site-message--subscription-banner__sign-in ${isUserLoggedIn(
             userLoggedIn
-        )}">
+        )}"
+        >
             <p>Already a subscriber?</p>
             <br class="temp-mobile-break" />
             <a
+                id="site-message--subscription-banner__sign-in"
                 class="site-message--subscription-banner__subscriber-link"
+                data-link-name="subscription-banner : sign in"
                 href="${signInUrl}"
+
             >
                 <span class="site-message--subscription-banner__sign-in-link">Sign in</span> to not see this again
             </a>
@@ -74,8 +81,10 @@ const subscriptionBannerTemplate = (
             >
         </div>
 
-        <div id="js-site-message--subscription-banner__close-button"
+        <div
+            id="js-site-message--subscription-banner__close-button"
             class="site-message--subscription-banner__close-button"
+            data-link-name="subscription-banner : close"
             aria-label="Close"
             tabindex="0"
         >

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -36,7 +36,10 @@ const DISPLAY_EVENT_KEY = 'subscription-banner : display';
 const MESSAGE_CODE = 'subscription-banner';
 const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 const COMPONENT_TYPE = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
-const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
+const CLICK_EVENT_CTA = 'subscription-banner : cta';
+const CLICK_EVENT_CLOSE_NOT_NOW = 'subscription-banner : not now';
+const CLICK_EVENT_CLOSE_BUTTON = 'subscription-banner : close';
+const CLICK_EVENT_SIGN_IN = 'subscription-banner : sign in';
 
 const subscriptionHostname: string = config.get('page.supportUrl');
 const signinHostname: string = config.get('page.idUrl');
@@ -52,7 +55,7 @@ const hideBannerInTheseRegions: ReaderRevenueRegion[] = [
     'united-states',
     'australia',
 ];
-const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${OPHAN_EVENT_ID}%22%7D`;
+const subscriptionUrl = `${subscriptionHostname}/subscribe/digital?INTCMP=gdnwb_copts_banner_subscribe_SubscriptionBanner&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22subscriptions_banner%22%2C%22componentType%22%3A%22${COMPONENT_TYPE}%22%2C%22componentId%22%3A%22${CLICK_EVENT_CTA}%22%7D`;
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
 const hasAcknowledged = bannerRedeploymentDate => {
@@ -73,7 +76,7 @@ const hasAcknowledged = bannerRedeploymentDate => {
         return true;
     }
 
-    return lastClosedAtTime > redeploymentDate;
+    return lastClosedAtTime < redeploymentDate;
 };
 
 const hasAcknowledgedBanner = region =>
@@ -121,6 +124,17 @@ const bindCloseHandler = (button, banner, callback) => {
     const removeBanner = () => {
         callback();
         if (banner) {
+            submitClickEvent({
+                component: {
+                    componentType: COMPONENT_TYPE,
+                    id:
+                        button &&
+                        button.id ===
+                            'js-site-message--subscription-banner__close-button'
+                            ? CLICK_EVENT_CLOSE_BUTTON
+                            : CLICK_EVENT_CLOSE_NOT_NOW,
+                },
+            });
             banner.remove();
         }
     };
@@ -141,7 +155,7 @@ const bindCloseHandler = (button, banner, callback) => {
 const bindClickHandler = (button, callback) => {
     if (button) {
         button.addEventListener('click', () => {
-            callback();
+            callback(button);
         });
     }
 };
@@ -150,16 +164,19 @@ const trackSubscriptionBannerView = () => {
     submitViewEvent({
         component: {
             componentType: COMPONENT_TYPE,
-            id: OPHAN_EVENT_ID,
+            id: CLICK_EVENT_CTA,
         },
     });
 };
 
-const trackSubscriptionBannerCtaClick = () => {
+const trackSubscriptionBannerClick = button => {
     submitClickEvent({
         component: {
             componentType: COMPONENT_TYPE,
-            id: OPHAN_EVENT_ID,
+            id:
+                button.id === 'js-site-message--subscription-banner__cta'
+                    ? CLICK_EVENT_CTA
+                    : CLICK_EVENT_SIGN_IN,
         },
     });
 };
@@ -187,6 +204,10 @@ const bindSubscriptionClickHandlers = () => {
         '#js-site-message--subscription-banner__close-button'
     );
 
+    const subscriptionBannerSignIn = document.querySelector(
+        '#site-message--subscription-banner__sign-in'
+    );
+
     const bindSubscriptionCloseButtons = closeActions(
         subscriptionBannerHtml,
         subcriptionBannerCloseActions
@@ -197,9 +218,10 @@ const bindSubscriptionClickHandlers = () => {
             subscriptionBannercloseButton,
             subscriptionBannerNotNowButton,
         ]);
+        bindClickHandler(subscriptionBannerCta, trackSubscriptionBannerClick);
         bindClickHandler(
-            subscriptionBannerCta,
-            trackSubscriptionBannerCtaClick
+            subscriptionBannerSignIn,
+            trackSubscriptionBannerClick
         );
     }
 };

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -76,7 +76,7 @@ const hasAcknowledged = bannerRedeploymentDate => {
         return true;
     }
 
-    return lastClosedAtTime < redeploymentDate;
+    return lastClosedAtTime > redeploymentDate;
 };
 
 const hasAcknowledgedBanner = region =>


### PR DESCRIPTION
## What does this change?
This adds tracking for click events on the subscriptions banner (for Ophan and GA).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A

## What is the value of this and can you measure success?
This will give us better information about what people do when they see the banner.

## Checklist
- [x] Add CTA tracking
- [x] Add not now tracking
- [x] Add close button tracking
- [x] Add sign in tracking

### Does this affect other platforms?
N/A
- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
