### PR TITLE
Remove a9publisherid from window.guardian.config.libs

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -64,8 +64,7 @@
             "cmp": { "fullVendorDataUrl": "/commercial/cmp/vendorlist.json",
                      "shortVendorDataUrl": "/commercial/cmp/shortvendorlist.json"
             },
-            "facebookAccountId": "@FBPixel.account",
-            "a9PublisherId": "@{Configuration.javascript.config("a9PublisherId")}"
+            "facebookAccountId": "@FBPixel.account"
         }
     }
 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -34,7 +34,7 @@ const initialise = (): void => {
     initialised = true;
 
     window.apstag.init({
-        pubID: config.get('libs.a9PublisherId'),
+        pubID: config.get('page.a9PublisherId'),
         adServer: 'googletag',
         bidTimeout: bidderTimeout,
     });


### PR DESCRIPTION
## What does this change?
A9 publisher id was added to `window.guardian.config.page` and  `window.guardian.config.libs.` This change removes it from `libs` and keeps it from `page`

