### PR TITLE
Permutive ophan integration

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -200,6 +200,7 @@ export const initPermutive = (): Promise<void> =>
         const permutiveConfig = {
             user: config.get('user', {}),
             page: config.get('page', {}),
+            ophan: config.get('ophan', {}),
         };
         runPermutive(permutiveConfig, permutive, reportError);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -21,6 +21,11 @@ type PermutiveSchema = {
     },
 };
 
+type PermutiveIdentity = {
+    id: string,
+    tag: string,
+};
+
 const isEmpty = (value: any) =>
     value === '' ||
     value === null ||
@@ -90,6 +95,18 @@ const generatePayload = (
     return cleanPayload;
 };
 
+const generatePermutiveIdentities = (
+    pageConfig: Config = {}
+): Array<PermutiveIdentity> => {
+    if (
+        typeof pageConfig.ophan === 'object' &&
+        typeof pageConfig.ophan.browserId === 'string'
+    ) {
+        return [{ tag: 'ophan', id: pageConfig.ophan.browserId }];
+    }
+    return [];
+};
+
 const runPermutive = (
     pageConfig: Config = {},
     permutiveGlobal: any,
@@ -100,8 +117,12 @@ const runPermutive = (
             throw new Error('Global Permutive setup error');
         }
 
-        const payload = generatePayload(pageConfig);
+        const permutiveIdentities = generatePermutiveIdentities(pageConfig);
+        if (permutiveIdentities.length > 0) {
+            permutiveGlobal.identify(permutiveIdentities);
+        }
 
+        const payload = generatePayload(pageConfig);
         permutiveGlobal.addon('web', {
             page: payload,
         });
@@ -189,5 +210,6 @@ export const _ = {
     isEmpty,
     removeEmpty,
     generatePayload,
+    generatePermutiveIdentities,
     runPermutive,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -100,7 +100,8 @@ const generatePermutiveIdentities = (
 ): Array<PermutiveIdentity> => {
     if (
         typeof pageConfig.ophan === 'object' &&
-        typeof pageConfig.ophan.browserId === 'string'
+        typeof pageConfig.ophan.browserId === 'string' &&
+        pageConfig.ophan.browserId.length > 0
     ) {
         return [{ tag: 'ophan', id: pageConfig.ophan.browserId }];
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -212,7 +212,26 @@ describe('Generating Permutive payload utils', () => {
             expect(_.generatePayload(config3)).toEqual(expected3);
         });
     });
+    describe('generatePermutiveIdentities', () => {
+        it('returns array containing ophan-tagged id if browser ID is present', () => {
+            expect(
+                _.generatePermutiveIdentities({
+                    ophan: { browserId: 'abc123' },
+                })
+            ).toEqual([{ tag: 'ophan', id: 'abc123' }]);
+        });
+        it('returns an empty array if there is no browser ID present', () => {
+            expect(
+                _.generatePermutiveIdentities({ ophan: { pageViewId: 'pvid' } })
+            ).toEqual([]);
+        });
+        it('returns an empty array if ophan config object is completely missing', () => {
+            expect(_.generatePermutiveIdentities({})).toEqual([]);
+        });
+    });
     describe('runPermutive', () => {
+        const validConfigForPayload = { page: { section: 'uk' } };
+
         it('catches errors and calls the logger correctly when no global permutive', () => {
             const logger = jest.fn();
             _.runPermutive({}, undefined, logger);
@@ -220,15 +239,51 @@ describe('Generating Permutive payload utils', () => {
             expect(err).toBeInstanceOf(Error);
             expect(err.message).toBe('Global Permutive setup error');
         });
-        it('calles the permutive addon method with the correct payload', () => {
+        it('calls the permutive addon method with the correct payload', () => {
+            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
             const logger = jest.fn();
-            const mockPermutive = { addon: jest.fn() };
-            const config = { page: { section: 'uk' } };
 
-            _.runPermutive(config, mockPermutive, logger);
+            _.runPermutive(validConfigForPayload, mockPermutive, logger);
             expect(mockPermutive.addon).toHaveBeenCalledWith('web', {
                 page: { content: { section: 'uk' }, user: { identity: false } },
             });
+            expect(logger).not.toHaveBeenCalled();
+        });
+        it("calls permutive's identify method, passing the ophan browser ID", () => {
+            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+            const logger = jest.fn();
+            const bwid = '1234567890abcdef';
+            const config = {
+                ophan: { browserId: bwid },
+                ...validConfigForPayload,
+            };
+
+            _.runPermutive(config, mockPermutive, logger);
+            expect(mockPermutive.identify).toHaveBeenCalledWith([
+                { tag: 'ophan', id: bwid },
+            ]);
+            expect(logger).not.toHaveBeenCalled();
+        });
+        it("calls permutive's identify before it calls addon, if the browser ID is present", () => {
+            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+            const logger = jest.fn();
+            const bwid = '1234567890abcdef';
+            const config = {
+                ophan: { browserId: bwid },
+                ...validConfigForPayload,
+            };
+
+            _.runPermutive(config, mockPermutive, logger);
+            const [ identifyCallOrder ] = mockPermutive.identify.mock.invocationCallOrder
+            const [ addonCallOrder ] = mockPermutive.addon.mock.invocationCallOrder
+            expect(identifyCallOrder).toBeLessThan(addonCallOrder);
+        });
+        it('does not call the identify method if no browser ID is present', () => {
+            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+            const logger = jest.fn();
+
+            _.runPermutive(validConfigForPayload, mockPermutive, logger);
+            expect(mockPermutive.identify).not.toHaveBeenCalled();
             expect(logger).not.toHaveBeenCalled();
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -276,9 +276,11 @@ describe('Generating Permutive payload utils', () => {
             _.runPermutive(config, mockPermutive, logger);
             const [
                 identifyCallOrder,
+                // $FlowFixMe Flow types for jest are missing invocationCallOrder
             ] = mockPermutive.identify.mock.invocationCallOrder;
             const [
                 addonCallOrder,
+                // $FlowFixMe Flow types for jest are missing invocationCallOrder
             ] = mockPermutive.addon.mock.invocationCallOrder;
             expect(identifyCallOrder).toBeLessThan(addonCallOrder);
         });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -274,8 +274,12 @@ describe('Generating Permutive payload utils', () => {
             };
 
             _.runPermutive(config, mockPermutive, logger);
-            const [ identifyCallOrder ] = mockPermutive.identify.mock.invocationCallOrder
-            const [ addonCallOrder ] = mockPermutive.addon.mock.invocationCallOrder
+            const [
+                identifyCallOrder,
+            ] = mockPermutive.identify.mock.invocationCallOrder;
+            const [
+                addonCallOrder,
+            ] = mockPermutive.addon.mock.invocationCallOrder;
             expect(identifyCallOrder).toBeLessThan(addonCallOrder);
         });
         it('does not call the identify method if no browser ID is present', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -225,6 +225,11 @@ describe('Generating Permutive payload utils', () => {
                 _.generatePermutiveIdentities({ ophan: { pageViewId: 'pvid' } })
             ).toEqual([]);
         });
+        it('returns an empty array if an empty browser ID is present', () => {
+            expect(
+                _.generatePermutiveIdentities({ ophan: { browserId: '' } })
+            ).toEqual([]);
+        });
         it('returns an empty array if ophan config object is completely missing', () => {
             expect(_.generatePermutiveIdentities({})).toEqual([]);
         });


### PR DESCRIPTION
## What does this change?

Integrates the Ophan browser ID with Permutive. The permutive object includes an `identify` call that lets clients connect Permutive's internal ID up with their own IDs. This lets us identify users based on their Ophan browser ID.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Permutive is not yet set up on DCR, this change will be required when that is done.

## What is the value of this and can you measure success?

Permutive will be connected with our Browser ID, which is useful for reporting among other things.

## Checklist

### Does this affect other platforms?

No

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

This won't be in effect for ad-free (nor for users without advertising consent).
<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

N/A, not user-facing.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
