### PR TITLE
Revert "update @guardian/consent-management-platform 2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "2.0.0",
+    "@guardian/consent-management-platform": "2.0.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.0.tgz#ff803d7ec9c9e20b3a7afb5a6e7030a00f6c30bf"
-  integrity sha512-VacoXxQD0Wj1m5TxOS66a4+HSFqN1usKw6HBtn3Hx+b9GrHmUJqUet69rpaVGXJEfFyQ3V1gFgXr9DXdmegGLA==
+"@guardian/consent-management-platform@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.1.tgz#0551e5a3408191f9cc351d6b426ec70e8b69d1f5"
+  integrity sha512-i1vS8s51GNHxxtrKL3UNq1609M6NCuU8iTHKFdzOHzsUiwuBpIBLsLbqX3/p3yYKS3fIw+RslIZCXpoTwOUuKw==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
Reverts guardian/frontend#22200

I want to use `@guardian/consent-management-platform@2.0.1` as the `vendorlist.json` URL in this build appears more stable than `@guardian/consent-management-platform@2.0.0`