### PR TITLE
Bump @guardian/consent-management-platform to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "2.0.1",
+    "@guardian/consent-management-platform": "2.0.2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.1.tgz#0551e5a3408191f9cc351d6b426ec70e8b69d1f5"
-  integrity sha512-i1vS8s51GNHxxtrKL3UNq1609M6NCuU8iTHKFdzOHzsUiwuBpIBLsLbqX3/p3yYKS3fIw+RslIZCXpoTwOUuKw==
+"@guardian/consent-management-platform@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.2.tgz#affc70ee17d30d69a43f367e9a41af6812bdf435"
+  integrity sha512-Vp4hQYVKJyW3e+yElhspPOJWKzB0AubjerBit9pjzuL2GkCJYKZQmlWs1HJzkfOyVuh17r0f5P/h0X6W0GVfKA==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?

Updates `@guardian/consent-management-platform` to  `2.0.2`. A summary of the changes in version `2.0.2` can be seen here: https://github.com/guardian/consent-management-platform/pull/59