### PR TITLE
bump @guardian/consent-management-platform to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "2.0.2",
+    "@guardian/consent-management-platform": "2.0.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.2.tgz#affc70ee17d30d69a43f367e9a41af6812bdf435"
-  integrity sha512-Vp4hQYVKJyW3e+yElhspPOJWKzB0AubjerBit9pjzuL2GkCJYKZQmlWs1HJzkfOyVuh17r0f5P/h0X6W0GVfKA==
+"@guardian/consent-management-platform@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.3.tgz#cf13262a631567bf2edab013df08757ff5d1e5ed"
+  integrity sha512-JanOjVlHEw2vAbpqrSr6t7Dg/WuMPtLFkXyuNHOks3CH6sDKQpzT7/XgfNIFLQ3RWJKPtmDuT4Khgze6samnsQ==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?

Updates `@guardian/consent-management-platform` to `2.0.3`. A summary of the changes in version 2.0.2 can be seen here: guardian/consent-management-platform#60