### PR TITLE
Fix Teads ad bug 

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -309,17 +309,16 @@
 .ad-slot--outstream {
 
     background: transparent;
+    height: auto;
 
     @include mq(mobile) {
         width: 300px;
-        height: auto;
         min-height: auto;
     }
 
     @include mq($from: phablet) {
         float: none;
         width: 620px;
-        height: $mpu-ad-label-height + 350px;
         margin: 4px 0 0;
 
         & > div.ad-slot__label {


### PR DESCRIPTION
## What does this change?
Fixes teads ad overlapping with text.
Allows teads ad to have auto heigh

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

![Screenshot 2020-01-16 at 12 13 57](https://user-images.githubusercontent.com/51630004/72524487-f44aa980-3859-11ea-8229-5abb35e24d9e.png)

### After 

![Screenshot 2020-01-16 at 12 07 56](https://user-images.githubusercontent.com/51630004/72524499-f876c700-3859-11ea-8112-b28ad4cf4a96.png)

## What is the value of this and can you measure success?

## Checklist


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
