### PR TITLE
Merge pull request #22211 from guardian/gtrufitt/video-duration-not-nullable

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -449,7 +449,7 @@ object Article {
 
     // we don't serve pre-roll if there are multiple videos in an article
     // `headOption` as the video could be main media or a regular embed, so just get the first video
-    val videoDuration = content.elements.videos.headOption.map { v => JsNumber(v.videos.duration) }.getOrElse(JsNull)
+    val videoDuration = content.elements.videos.headOption.map { v => JsNumber(v.videos.duration) }.getOrElse(JsNumber(0))
 
     val javascriptConfig: Map[String, JsValue] = Map(
       ("isLiveBlog", JsBoolean(content.tags.isLiveBlog)),


### PR DESCRIPTION
## What does this change?

VideoDuration fails schema validation in DCR as it accepts a number and is not `nullable`. Set default to `videoDuration: 0`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

Schema update is in https://github.com/guardian/dotcom-rendering/pull/1077

This PR must be merged before schema update.


