### PR TITLE
Added comment about duplicated data

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -23,6 +23,8 @@ const popularInTagOverride = (): ?string | false => {
         return false;
     }
 
+    // This list also exists in DCR https://github.com/guardian/dotcom-rendering/blob/88a9693e7ee23e3e7e140ba680b12a19288e96f6/src/web/components/Onwards/Onwards.tsx
+    // If you change this list then you should also update ^
     // order matters here (first match wins)
     const whitelistedTags = [
         // sport tags


### PR DESCRIPTION
## What does this change?
This PR simply adds a comment above the declaration of the tag whitelist used when deciding which related content to show in the onwards section. The same list is used in DCR so the comment is a patch to try and prevent these 2 arrays getting out of sync.

The same comment will appear in DCR as part of https://github.com/guardian/dotcom-rendering/pull/1078