### PR TITLE
Only give dynamo cards the dynamic-layout class

### DIFF
--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -48,7 +48,6 @@ sealed trait CardType {
     case _ => false
   }
 
-  /** This is only currently used in the dynamoContentCard.scala.html **/
   def canBeDynamicLayout: Boolean = this match {
     case FullMedia100 | FullMedia75 | ThreeQuarters | ThreeQuartersTall => true
     case _ => false

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -13,7 +13,7 @@
 
 @import Function.const
 
-<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}"
+<div class="@GetClasses.forItem(item, isFirstContainer, true) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}"
     @if(item.discussionSettings.isCommentable) {
         @item.discussionSettings.discussionId.map { id =>
         data-discussion-id="@id"

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -17,7 +17,7 @@ object GetClasses {
     ) ++ item.customCssClasses: _*)
   }
 
-  def forItem(item: ContentCard, isFirstContainer: Boolean)(implicit request: RequestHeader): String = {
+  def forItem(item: ContentCard, isFirstContainer: Boolean, isDynamic: Boolean = false)(implicit request: RequestHeader): String = {
 
     RenderClasses(Map(
       ("fc-item", true),
@@ -41,7 +41,7 @@ object GetClasses {
       ("fc-item--is-commentable", item.discussionSettings.isCommentable),
       ("fc-item--is-media-link", item.isMediaLink),
       ("fc-item--has-video-main-media", item.hasVideoMainMedia),
-      ("fc-item--dynamic-layout", item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined)
+      ("fc-item--dynamic-layout", isDynamic && item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
     )


### PR DESCRIPTION
## What does this change?

Along with the existing checks, ensure we only give dynamo cards the `dynamic-layout` class. Also remove a comment which is slightly misleading.

This came up because a card on https://www.theguardian.com/uk/commentisfree was getting an incorrect background colour because it had the `dynamic-layout` class. The fix is a bit blunt, but allows us to get this fixed quickly.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

![Screenshot 2020-01-17 at 14 46 30](https://user-images.githubusercontent.com/379839/72621456-2da61680-3939-11ea-973b-7be995b6f8ef.png)

### After

![Screenshot 2020-01-17 at 14 46 55](https://user-images.githubusercontent.com/379839/72621463-34348e00-3939-11ea-8564-67390c7b08a9.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)