### PR TITLE
Add control group for the commercialCmpUiBannerModal AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -6,7 +6,7 @@ export const commercialCmpUiBannerModal: ABTest = {
     expiry: '2020-01-28',
     author: 'George Haberis',
     description: '2% participation AB test for the new banner/modal CMP UI',
-    audience: 0.02,
+    audience: 0.03,
     audienceOffset: 0.8,
     successMeasure: 'Our new banner/modal CMP UI obtains target consent rates',
     audienceCriteria: 'n/a',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -5,8 +5,8 @@ export const commercialCmpUiBannerModal: ABTest = {
     start: '2020-01-13',
     expiry: '2020-01-28',
     author: 'George Haberis',
-    description: '1% participation AB test for the new banner/modal CMP UI',
-    audience: 0.01,
+    description: '2% participation AB test for the new banner/modal CMP UI',
+    audience: 0.02,
     audienceOffset: 0.8,
     successMeasure: 'Our new banner/modal CMP UI obtains target consent rates',
     audienceCriteria: 'n/a',
@@ -15,6 +15,10 @@ export const commercialCmpUiBannerModal: ABTest = {
     showForSensitive: true,
     canRun: () => true,
     variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
         {
             id: 'variant',
             test: (): void => {},

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -5,7 +5,7 @@ export const commercialCmpUiBannerModal: ABTest = {
     start: '2020-01-13',
     expiry: '2020-01-28',
     author: 'George Haberis',
-    description: '2% participation AB test for the new banner/modal CMP UI',
+    description: '3% participation AB test for the new banner/modal CMP UI',
     audience: 0.03,
     audienceOffset: 0.8,
     successMeasure: 'Our new banner/modal CMP UI obtains target consent rates',

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -10,9 +10,11 @@ import {
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import ophan from 'ophan/ng';
 import { upAlertViewCount } from 'common/modules/analytics/send-privacy-prefs';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialCmpUiBannerModal } from 'common/modules/experiments/tests/commercial-cmp-ui-banner-modal';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import type { Banner } from 'common/modules/ui/bannerPicker';
-import { isInCmpTest } from 'common/modules/ui/cmp-ui';
+import { getCookie } from 'lib/cookies';
 
 type Template = {
     heading: string,
@@ -101,12 +103,28 @@ const trackInteraction = (interaction: string): void => {
     trackNonClickInteraction(interaction);
 };
 
-const canShow = (): Promise<boolean> =>
-    Promise.resolve(
-        hasUnsetAdChoices() &&
-            !hasUserAcknowledgedBanner(messageCode) &&
-            !isInCmpTest()
+const canShow = (): Promise<boolean> => {
+    const hasSubmittedConsent =
+        !hasUnsetAdChoices() || hasUserAcknowledgedBanner(messageCode);
+
+    const consentCookieSetBeforeDate = (): boolean => {
+        const dateToCheck = new Date(1579266000000); // 13.00 17/01/2020 GMT CommercialCmpUiBannerModal test
+        const cookieRaw = getCookie('GU_TK');
+
+        if (!cookieRaw) return true;
+
+        const cookieDate = new Date(parseInt(cookieRaw.split('.')[1], 10));
+
+        return cookieDate < dateToCheck;
+    };
+
+    return Promise.resolve(
+        (!hasSubmittedConsent &&
+            !isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) ||
+            (isInVariantSynchronous(commercialCmpUiBannerModal, 'control') &&
+                consentCookieSetBeforeDate())
     );
+};
 
 const track = (): void => {
     upAlertViewCount();

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -111,8 +111,6 @@ const canShow = (): Promise<boolean> => {
     const hasSubmittedConsent =
         !hasUnsetAdChoices() || hasUserAcknowledgedBanner(messageCode);
 
-    console.log("***", local.get(rePermissionKey));
-
     return Promise.resolve(
         (!hasSubmittedConsent &&
             !isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) ||


### PR DESCRIPTION
## What does this change?
Add a control group for the `commercialCmpUiBannerModal` test introduced in this PR https://github.com/guardian/frontend/pull/22193 that shows users the current consent banner but re-permissions everyone user. Also sets the audience to 3%.

This control group will allow us to compare like for like when looking at the consent rates, bounce rates and predicted revenue between control and variant groups.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)