### PR TITLE
Adding correct meta tags for European publisher status

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -181,3 +181,9 @@
 @page.metadata.iosId("google").map { iosId =>
     <link rel="alternate" href="ios-app://409128287/gnmguardian/@iosId" />
 }
+
+@*
+As a European publisher, we need to include snippets and thumbnails in our search previews - https://search.google.com/search-console/settings/eucd?resource_id=https%3A%2F%2Fwww.theguardian.com%2F
+https://developers.google.com/search/reference/robots_meta_tag
+*@
+<meta name="robots" content="max-snippet:20, max-image-preview:large">


### PR DESCRIPTION
## What does this change?
Our status as a European press publisher means we have to enable thumbnail meta tags at a page level if we're to display trail images in SERPs in France. Without these enabled, we have seen a ~16% drop in search referral from France.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
