### PR TITLE
move setErrorHandler into cmp-ui

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -38,8 +38,6 @@ import { fixSecondaryColumn } from 'common/modules/fix-secondary-column';
 import { trackPerformance } from 'common/modules/analytics/google';
 import debounce from 'lodash/debounce';
 import ophan from 'ophan/ng';
-import reportError from 'lib/report-error';
-import { setErrorHandler } from '@guardian/consent-management-platform';
 import { initAtoms } from './atoms';
 
 const setAdTestCookie = (): void => {
@@ -290,21 +288,6 @@ const bootStandard = (): void => {
             },
         ],
     ]);
-
-    // setErrorHandler takes function to be called on errors in the CMP UI
-    setErrorHandler(
-        (errMsg: string): void => {
-            const err = new Error(errMsg);
-
-            reportError(
-                err,
-                {
-                    feature: 'cmp',
-                },
-                false
-            );
-        }
-    );
 };
 
 export { bootStandard };

--- a/static/src/javascripts/projects/common/modules/cmp-ui/index.js
+++ b/static/src/javascripts/projects/common/modules/cmp-ui/index.js
@@ -2,6 +2,8 @@
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import reportError from 'lib/report-error';
+import { setErrorHandler } from '@guardian/consent-management-platform';
 
 export const init = (forceModal: boolean) => {
     const container = document.createElement('div');
@@ -35,6 +37,21 @@ export const init = (forceModal: boolean) => {
     if (document.body) {
         document.body.appendChild(container);
     }
+
+    // setErrorHandler takes function to be called on errors in the CMP UI
+    setErrorHandler(
+        (errMsg: string): void => {
+            const err = new Error(errMsg);
+
+            reportError(
+                err,
+                {
+                    feature: 'cmp',
+                },
+                false
+            );
+        }
+    );
 
     ReactDOM.render(<ConsentManagementPlatform {...props} />, container);
 };


### PR DESCRIPTION
## What does this change?

Moves `setErrorHandler` call (added here https://github.com/guardian/frontend/pull/22213) into `cmp-ui/index.js` as it doesn't need to live in `graun.standard`.