### PR TITLE
Youtube Permutive PFP segments

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -8,6 +8,7 @@ import { getPageTargeting } from 'common/modules/commercial/build-page-targeting
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import $ from 'lib/$';
+import { getPermutivePFPSegments } from '../commercial/permutive';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {
@@ -106,13 +107,13 @@ const createAdsConfig = (
     if (adFree) {
         return { disableAds: true };
     } else if (isPfpAdTargetingSwitchedOn) {
+        const custParams = getPageTargeting();
+        custParams.permutive = getPermutivePFPSegments();
         return {
             nonPersonalizedAd: !wantPersonalisedAds,
             adTagParameters: {
                 iu: config.get('page.adUnit'),
-                cust_params: encodeURIComponent(
-                    constructQuery(getPageTargeting())
-                ),
+                cust_params: encodeURIComponent(constructQuery(custParams)),
             },
         };
     }

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -5,6 +5,10 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
     getPageTargeting: jest.fn(() => ({ key: 'value' })),
 }));
 
+jest.mock('common/modules/commercial/permutive', () => ({
+    getPermutivePFPSegments: jest.fn(() => [42]),
+}));
+
 jest.mock('lib/config', () => ({
     get: jest.fn(key => {
         if (key === 'page.adUnit') {
@@ -103,6 +107,8 @@ describe('create ads config', () => {
             true // pfp variant
         );
 
-        expect(result.adTagParameters.cust_params).toEqual('key%3Dvalue');
+        expect(result.adTagParameters.cust_params).toEqual(
+            'key%3Dvalue%26permutive%3D42'
+        );
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -2,8 +2,8 @@
 import { local } from 'lib/storage';
 
 const PERMUTIVE_KEY = `_papns`;
-const PFP_KEY = `_pdfps`;
-type SegmentsKey = typeof PERMUTIVE_KEY | typeof PFP_KEY;
+const PERMUTIVE_PFP_KEY = `_pdfps`;
+type SegmentsKey = typeof PERMUTIVE_KEY | typeof PERMUTIVE_PFP_KEY;
 
 const getSegments = (key: SegmentsKey): Array<string> => {
     try {
@@ -18,10 +18,10 @@ const getSegments = (key: SegmentsKey): Array<string> => {
 };
 
 export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
-export const getPermutivePFPSegments = () => getSegments(PFP_KEY);
+export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
 export const _ = {
     PERMUTIVE_KEY,
-    PFP_KEY,
+    PERMUTIVE_PFP_KEY,
     getSegments,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -3,9 +3,8 @@ import { local } from 'lib/storage';
 
 const PERMUTIVE_KEY = `_papns`;
 const PERMUTIVE_PFP_KEY = `_pdfps`;
-type SegmentsKey = typeof PERMUTIVE_KEY | typeof PERMUTIVE_PFP_KEY;
 
-const getSegments = (key: SegmentsKey): Array<string> => {
+const getSegments = (key: string): Array<string> => {
     try {
         return JSON.parse(local.getRaw(key) || '[]')
             .slice(0, 250)

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -19,3 +19,9 @@ const getSegments = (key: SegmentsKey): Array<string> => {
 
 export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
 export const getPermutivePFPSegments = () => getSegments(PFP_KEY);
+
+export const _ = {
+    PERMUTIVE_KEY,
+    PFP_KEY,
+    getSegments,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -2,14 +2,20 @@
 import { local } from 'lib/storage';
 
 const PERMUTIVE_KEY = `_papns`;
+const PFP_KEY = `_pdfps`;
+type SegmentsKey = typeof PERMUTIVE_KEY | typeof PFP_KEY;
 
-export const getPermutiveSegments = (): Array<string> => {
+const getSegments = (key: SegmentsKey): Array<string> => {
     try {
-        return JSON.parse(local.getRaw(PERMUTIVE_KEY) || '[]')
+        return JSON.parse(local.getRaw(key) || '[]')
             .slice(0, 250)
-            .filter(s => typeof s === 'number')
+            .map(s => Number.parseInt(s, 10))
+            .filter(n => typeof n === 'number' && !Number.isNaN(n))
             .map(String);
     } catch (e) {
         return [];
     }
 };
+
+export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
+export const getPermutivePFPSegments = () => getSegments(PFP_KEY);

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
@@ -8,6 +8,10 @@ jest.mock('lib/storage', () => ({
     },
 }));
 
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
 describe('getSegments', () => {
     const DUMMY_KEY = `_dummyKey`;
     test('parses Permutive segments correctly', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { local } from 'lib/storage';
-import { getPermutiveSegments } from './permutive';
+import { getPermutiveSegments, getPermutivePFPSegments, _ } from './permutive';
 
 jest.mock('lib/storage', () => ({
     local: {
@@ -8,21 +8,36 @@ jest.mock('lib/storage', () => ({
     },
 }));
 
-describe('getPermutiveSegments', () => {
+describe('getSegments', () => {
+    const DUMMY_KEY = `_dummyKey`;
     test('parses Permutive segments correctly', () => {
         local.getRaw.mockReturnValue(['[42,84,63]']);
-        expect(getPermutiveSegments()).toEqual(['42', '84', '63']);
+        expect(_.getSegments(DUMMY_KEY)).toEqual(['42', '84', '63']);
         local.getRaw.mockReturnValue([]);
-        expect(getPermutiveSegments()).toEqual([]);
+        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
     });
     test('returns an empty array for bad inputs', () => {
         local.getRaw.mockReturnValue('-1');
-        expect(getPermutiveSegments()).toEqual([]);
+        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
         local.getRaw.mockReturnValue('bad-string');
-        expect(getPermutiveSegments()).toEqual([]);
+        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
         local.getRaw.mockReturnValue('{}');
-        expect(getPermutiveSegments()).toEqual([]);
+        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
         local.getRaw.mockReturnValue('["not-a-number-segment"]');
-        expect(getPermutiveSegments()).toEqual([]);
+        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+    });
+});
+
+describe('getPermutiveSegments', () => {
+    test('calls the right key from localStorage', () => {
+        getPermutiveSegments();
+        expect(local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_KEY);
+    });
+});
+
+describe('getPermutivePFPSegments', () => {
+    test('calls the right key from localStorage', () => {
+        getPermutivePFPSegments();
+        expect(local.getRaw).toHaveBeenCalledWith(_.PFP_KEY);
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
@@ -42,6 +42,6 @@ describe('getPermutiveSegments', () => {
 describe('getPermutivePFPSegments', () => {
     test('calls the right key from localStorage', () => {
         getPermutivePFPSegments();
-        expect(local.getRaw).toHaveBeenCalledWith(_.PFP_KEY);
+        expect(local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_PFP_KEY);
     });
 });


### PR DESCRIPTION
## What does this change?
Swaps the permutive segments data from the local storage key `_papns` to `_pdfps`
[Trello card](https://trello.com/c/1H23GifB)

## Does this change need to be reproduced in dotcom-rendering ?
Potentially, need to discuss with DCR team.

## What is the value of this and can you measure success?
This will have the right PFP segments for the youtube player, therefore better targeting.
We can deem this successful when we get confirmation from Commercial about the segments working as expected.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
