### PR TITLE
Add missing handler

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -159,6 +159,7 @@ object PressedContentFormat {
       case JsString("GuardianView") => JsSuccess(com.gu.contentapi.client.utils.GuardianView)
       case JsString("Quiz") => JsSuccess(com.gu.contentapi.client.utils.Quiz)
       case JsString("GuardianLabs") => JsSuccess(com.gu.contentapi.client.utils.GuardianLabs)
+      case JsString("AdvertisementFeature") => JsSuccess(com.gu.contentapi.client.utils.AdvertisementFeature)
       case _ => JsError(s"Unknown design type: '$json'")
     }
     override def writes(dt: DesignType): JsValue = dt match {


### PR DESCRIPTION
Fix missing case for AdvertisementFeature, which was added when I bumped the CAPI client version in: 

https://github.com/guardian/frontend/pull/22221