### PR TITLE
onward most-read api update for DCR

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -7,6 +7,7 @@ import play.api.mvc.RequestHeader
 import views.support.{ContentOldAgeDescriber, GUDateTimeFormat, ImgSrc, RemoveOuterParaHtml}
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
+import layout.ContentCard
 import models.dotcomponents.OnwardsUtils.findPillar
 import org.joda.time.DateTimeZone
 
@@ -25,6 +26,28 @@ case class OnwardItem(
   mediaType: Option[String],
 )
 
+object OnwardItem {
+  def maybeFromContentCard(contentCard: ContentCard): Option[OnwardItem] = {
+    for {
+      url <- contentCard.shortUrl
+      linkText <- contentCard.trailText
+      webPublicationDate <- contentCard.webPublicationDate.map( x => x.toDateTime().toString() )
+    } yield OnwardItem(
+      url= url,
+      linkText = linkText,
+      showByline = false,
+      byline = contentCard.byline.map( x => x.get ),
+      image = None,
+      ageWarning = None,
+      isLiveBlog = false,
+      pillar = "news",
+      designType = "",
+      webPublicationDate = webPublicationDate,
+      headline = "",
+      mediaType = contentCard.mediaType.map( x => x.toString ))
+  }
+}
+
 case class MostPopularGeoResponse(
   country: Option[String],
   heading: String,
@@ -36,26 +59,11 @@ case class OnwardCollectionResponse(
   trails: Seq[OnwardItem]
 )
 
-/*
-interface TrailTabType {
-    heading: string;
-    trails: TrailType[];
-}
- */
-
 case class OnwardCollectionForDCRv2(
   tabs: Seq[OnwardCollectionResponse],
-  //mostCommented: OnwardCollectionResponse,
-  //mostShared: OnwardCollectionResponse
+  mostCommented: Option[OnwardItem],
+  mostShared: Option[OnwardItem]
 )
-
-/*
-interface MostViewedFooterType {
-    tabs: TrailTabType[];
-    mostCommented: TrailType;
-    mostShared: TrailType;
-}
- */
 
 object OnwardCollection {
 

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -60,7 +60,7 @@ object OnwardItemMost {
       webPublicationDate <- contentCard.webPublicationDate.map( x => x.toDateTime().toString() )
     } yield OnwardItemMost(
       designType = metadata.designType.toString,
-      pillar = pillar.toString,
+      pillar = pillar.toString.toLowerCase,
       url = url,
       headline = headline,
       isLiveBlog = isLiveBlog,

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -36,11 +36,33 @@ case class OnwardCollectionResponse(
   trails: Seq[OnwardItem]
 )
 
+/*
+interface TrailTabType {
+    heading: string;
+    trails: TrailType[];
+}
+ */
+
+case class OnwardCollectionForDCRv2(
+  tabs: Seq[OnwardCollectionResponse],
+  //mostCommented: OnwardCollectionResponse,
+  //mostShared: OnwardCollectionResponse
+)
+
+/*
+interface MostViewedFooterType {
+    tabs: TrailTabType[];
+    mostCommented: TrailType;
+    mostShared: TrailType;
+}
+ */
+
 object OnwardCollection {
 
   implicit val itemWrites = Json.writes[OnwardItem]
   implicit val popularGeoWrites = Json.writes[MostPopularGeoResponse]
   implicit val collectionWrites = Json.writes[OnwardCollectionResponse]
+  implicit val onwardCollectionResponseForDRCv2Writes = Json.writes[OnwardCollectionForDCRv2]
 
   def trailsToItems(trails: Seq[PressedContent])(implicit request: RequestHeader): Seq[OnwardItem] = {
     def ageWarning(content: PressedContent): Option[String] = {
@@ -49,8 +71,6 @@ object OnwardCollection {
         .map(ContentOldAgeDescriber.apply)
         .filterNot(_ == "")
     }
-
-
 
     trails.take(10).map(content =>
       OnwardItem(


### PR DESCRIPTION
## What does this change?

This PR updates the answer of `onward`'s `/most-read/*path.json` in the case of DCR. This is an answer to https://trello.com/c/NnisWuAi/1014-enhance-most-popular-api-response

We move away from `OnwardCollectionResponse` to `OnwardCollectionForDCRv2`

```
case class OnwardCollectionForDCRv2(
  tabs: Seq[OnwardCollectionResponse],
  mostCommented: Option[OnwardItemMost],
  mostShared: Option[OnwardItemMost]
)
``` 

Note the introduction of `OnwardItemMost` which is designed to be compatible with DCR's `TrailType`.

Note that we do not need to update DCR because the new return type has already been implemented. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No