### PR TITLE
New CMP roll-out

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -17,6 +17,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val CmpUi = Switch(
+    SwitchGroup.Feature,
+    "cmp-ui",
+    "If this switch is on, the CMP UI will be completely unavailable to users.",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val CarrotTrafficDriverSwitch = Switch(
     Commercial,
     "carrot-traffic-driver",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -20,7 +20,7 @@ trait CommercialSwitches {
   val CmpUi = Switch(
     SwitchGroup.Feature,
     "cmp-ui",
-    "If this switch is on, the CMP UI will be completely unavailable to users.",
+    "If this switch is off, the CMP UI will be completely unavailable to users.",
     owners = group(Commercial),
     safeState = On,
     sellByDate = never,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.1",
-    "@guardian/consent-management-platform": "2.0.3",
+    "@guardian/consent-management-platform": "2.0.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -66,9 +66,6 @@ const readConsentCookie = (cookieName: string): boolean | null => {
     return null;
 };
 
-const isInCmpCustomiseTest = (): boolean =>
-    isInVariantSynchronous(commercialCmpUiBannerModal, 'variant');
-
 const generateStore = (isInTest: boolean): CmpStore => {
     const store = new CmpStore(
         CMP_ID,
@@ -283,9 +280,12 @@ export const init = (): void => {
     if (window[CMP_GLOBAL_NAME]) {
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};
-        const shouldAccessTestCookie = isInCmpCustomiseTest();
+        const useIabCookie = !isInVariantSynchronous(
+            commercialCmpUiBannerModal,
+            'control'
+        );
         // Initialize the store with all of our consent data
-        const store = generateStore(shouldAccessTestCookie);
+        const store = generateStore(useIabCookie);
         const cmp = new CmpService(store);
         // Expose `processCommand` as the CMP implementation
         window[CMP_GLOBAL_NAME] = cmp.processCommand;
@@ -298,8 +298,8 @@ export const init = (): void => {
         cmp.cmpReady = true;
         cmp.notify('cmpReady');
 
-        if (shouldAccessTestCookie) {
-            log.info('CMP customise is ACTIVE');
+        if (useIabCookie) {
+            log.info('CMP is using IAB cookie');
         }
     }
 };

--- a/static/src/javascripts/projects/common/modules/cmp-ui/index.js
+++ b/static/src/javascripts/projects/common/modules/cmp-ui/index.js
@@ -1,9 +1,11 @@
 // @flow
-import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import reportError from 'lib/report-error';
+import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
 import { setErrorHandler } from '@guardian/consent-management-platform';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialCmpUiBannerModal } from 'common/modules/experiments/tests/commercial-cmp-ui-banner-modal';
 
 export const init = (forceModal: boolean) => {
     const container = document.createElement('div');
@@ -30,9 +32,12 @@ export const init = (forceModal: boolean) => {
             bodySans:
                 "'Guardian Text Sans Web', Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
         },
-        variant: 'CommercialCmpUiBannerModal-variant',
         forceModal,
     };
+
+    if (isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) {
+        props.variant = 'CommercialCmpUiBannerModal-variant';
+    }
 
     if (document.body) {
         document.body.appendChild(container);

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,4 +1,5 @@
 // @flow
+import config from 'lib/config';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialCmpUiBannerModal } from 'common/modules/experiments/tests/commercial-cmp-ui-banner-modal';
 import { shouldShow } from '@guardian/consent-management-platform';
@@ -33,7 +34,10 @@ const show = (forceModal: ?boolean): Promise<boolean> => {
 };
 
 export const addPrivacySettingsLink = (): void => {
-    if (isInVariantSynchronous(commercialCmpUiBannerModal, 'control')) {
+    if (
+        isInVariantSynchronous(commercialCmpUiBannerModal, 'control') ||
+        !config.get('switches.cmpUi', true)
+    ) {
         return;
     }
 
@@ -78,7 +82,9 @@ export const consentManagementPlatformUi = {
         if (isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) {
             return Promise.resolve(shouldShow(true));
         }
-        return Promise.resolve(shouldShow());
+        return Promise.resolve(
+            config.get('switches.cmpUi', true) && shouldShow()
+        );
     },
     show,
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -32,11 +32,8 @@ const show = (forceModal: ?boolean): Promise<boolean> => {
     return Promise.resolve(true);
 };
 
-export const isInCmpTest = (): boolean =>
-    isInVariantSynchronous(commercialCmpUiBannerModal, 'variant');
-
 export const addPrivacySettingsLink = (): void => {
-    if (!isInCmpTest()) {
+    if (isInVariantSynchronous(commercialCmpUiBannerModal, 'control')) {
         return;
     }
 
@@ -75,11 +72,13 @@ export const addPrivacySettingsLink = (): void => {
 export const consentManagementPlatformUi = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
-        if (isInCmpTest()) {
-            return Promise.resolve(shouldShow());
+        if (isInVariantSynchronous(commercialCmpUiBannerModal, 'control')) {
+            return Promise.resolve(false);
         }
-
-        return Promise.resolve(false);
+        if (isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) {
+            return Promise.resolve(shouldShow(true));
+        }
+        return Promise.resolve(shouldShow());
     },
     show,
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -24,7 +24,18 @@ describe('cmp-ui', () => {
 
     describe('consentManagementPlatformUi', () => {
         describe('canShow', () => {
-            it('returns true if shouldShow true and in CommercialCmpUiBannerModal test variant', () => {
+            it('returns false if in CommercialCmpUiBannerModal control group', () => {
+                isInVariantSynchronous.mockImplementation(
+                    (test, variant) =>
+                        test.id === 'CommercialCmpUiBannerModal' &&
+                        variant === 'control'
+                );
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(false);
+                });
+            });
+            it('returns true if in CommercialCmpUiBannerModal variant group and shouldShow returns true', () => {
                 shouldShow.mockReturnValue(true);
                 isInVariantSynchronous.mockImplementation(
                     (test, variant) =>
@@ -36,19 +47,33 @@ describe('cmp-ui', () => {
                     expect(show).toBe(true);
                 });
             });
-
-            it('returns false if not in CommercialCmpUiBannerModal test', () => {
-                shouldShow.mockReturnValue(true);
-                isInVariantSynchronous.mockReturnValue(false);
+            it('returns false if in CommercialCmpUiBannerModal variant group and shouldShow returns false', () => {
+                shouldShow.mockReturnValue(false);
+                isInVariantSynchronous.mockImplementation(
+                    (test, variant) =>
+                        test.id === 'CommercialCmpUiBannerModal' &&
+                        variant === 'variant'
+                );
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(show).toBe(false);
                 });
             });
+            it('return true if not in CommercialCmpUiBannerModal test and shouldShow returns true', () => {
+                shouldShow.mockReturnValue(true);
+                isInVariantSynchronous.mockImplementation(
+                    test => test.id !== 'CommercialCmpUiBannerModal'
+                );
 
-            it('returns false if shouldShow false', () => {
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(true);
+                });
+            });
+            it('return false if not in CommercialCmpUiBannerModal test and shouldShow returns false', () => {
                 shouldShow.mockReturnValue(false);
-                isInVariantSynchronous.mockReturnValue(true);
+                isInVariantSynchronous.mockImplementation(
+                    test => test.id !== 'CommercialCmpUiBannerModal'
+                );
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(show).toBe(false);

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,5 +1,6 @@
 // @flow
 import { shouldShow } from '@guardian/consent-management-platform';
+import config from 'lib/config';
 import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import { consentManagementPlatformUi } from './cmp-ui';
 
@@ -71,6 +72,16 @@ describe('cmp-ui', () => {
             });
             it('return false if not in CommercialCmpUiBannerModal test and shouldShow returns false', () => {
                 shouldShow.mockReturnValue(false);
+                isInVariantSynchronous.mockImplementation(
+                    test => test.id !== 'CommercialCmpUiBannerModal'
+                );
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(false);
+                });
+            });
+            it('return false if not in CommercialCmpUiBannerModal test and cmpUi switch is off', () => {
+                config.set('switches.cmpUi', false);
                 isInVariantSynchronous.mockImplementation(
                     test => test.id !== 'CommercialCmpUiBannerModal'
                 );

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -113,8 +113,7 @@ const canShow = (): Promise<boolean> => {
 
     return Promise.resolve(
         isInVariantSynchronous(commercialCmpUiBannerModal, 'control') &&
-            !local.get(rePermissionKey) &&
-            !hasSubmittedConsent
+            (!local.get(rePermissionKey) || !hasSubmittedConsent)
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.js
@@ -112,10 +112,9 @@ const canShow = (): Promise<boolean> => {
         !hasUnsetAdChoices() || hasUserAcknowledgedBanner(messageCode);
 
     return Promise.resolve(
-        (!hasSubmittedConsent &&
-            !isInVariantSynchronous(commercialCmpUiBannerModal, 'variant')) ||
-            (isInVariantSynchronous(commercialCmpUiBannerModal, 'control') &&
-                !local.get(rePermissionKey))
+        isInVariantSynchronous(commercialCmpUiBannerModal, 'control') &&
+            !local.get(rePermissionKey) &&
+            !hasSubmittedConsent
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/first-pv-consent-banner.spec.js
@@ -105,30 +105,29 @@ describe('First PV consents banner', () => {
     });
 
     describe('With consents', () => {
-        it('should show up with null consents', () =>
-            banner.canShow().then(showable => {
-                expect(showable).toBe(true);
-            }));
-        it('should not show with set consents', () => {
-            setAdConsentState(0, true);
-            setAdConsentState(1, false);
-            return banner.canShow().then(showable => {
-                expect(showable).toBe(false);
-            });
-        });
-        it('should show when in commercialCmpUiBannerModal control group and has not been re-permissioned', () => {
-            local.get.mockReturnValue(false);
+        it('should not show if not in commercialCmpUiBannerModal test', () => {
             isInVariantSynchronous.mockImplementation(
-                (testId, variantId) =>
-                    testId === commercialCmpUiBannerModal &&
-                    variantId === 'control'
+                testId => testId !== commercialCmpUiBannerModal
             );
 
             banner.canShow().then(showable => {
-                expect(showable).toBe(true);
+                expect(showable).toBe(false);
             });
         });
-        it('should not show when in commercialCmpUiBannerModal control group and has been re-permissioned', () => {
+        it('should not show if in commercialCmpUiBannerModal variant group', () => {
+            isInVariantSynchronous.mockImplementation(
+                (testId, variantId) =>
+                    testId === commercialCmpUiBannerModal &&
+                    variantId === 'variant'
+            );
+
+            banner.canShow().then(showable => {
+                expect(showable).toBe(false);
+            });
+        });
+        it('should not show if in commercialCmpUiBannerModal control group and hasSubmittedConsent is true and rePermissionKey flag present', () => {
+            setAdConsentState(0, true);
+            setAdConsentState(1, true);
             local.get.mockReturnValue(true);
             isInVariantSynchronous.mockImplementation(
                 (testId, variantId) =>
@@ -140,15 +139,29 @@ describe('First PV consents banner', () => {
                 expect(showable).toBe(false);
             });
         });
-        it('should not show when in commercialCmpUiBannerModal variant group', () => {
+        it('should show if in commercialCmpUiBannerModal control group and hasSubmittedConsent is true and rePermissionKey flag not present', () => {
+            setAdConsentState(0, true);
+            setAdConsentState(1, true);
+            local.get.mockReturnValue(null);
             isInVariantSynchronous.mockImplementation(
                 (testId, variantId) =>
                     testId === commercialCmpUiBannerModal &&
-                    variantId === 'variant'
+                    variantId === 'control'
             );
 
-            return banner.canShow().then(showable => {
-                expect(showable).toBe(false);
+            banner.canShow().then(showable => {
+                expect(showable).toBe(true);
+            });
+        });
+        it('should show if in commercialCmpUiBannerModal control group and hasSubmittedConsent is false', () => {
+            isInVariantSynchronous.mockImplementation(
+                (testId, variantId) =>
+                    testId === commercialCmpUiBannerModal &&
+                    variantId === 'control'
+            );
+
+            banner.canShow().then(showable => {
+                expect(showable).toBe(true);
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.3.tgz#cf13262a631567bf2edab013df08757ff5d1e5ed"
-  integrity sha512-JanOjVlHEw2vAbpqrSr6t7Dg/WuMPtLFkXyuNHOks3CH6sDKQpzT7/XgfNIFLQ3RWJKPtmDuT4Khgze6samnsQ==
+"@guardian/consent-management-platform@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.4.tgz#4cb5aff99d0cf41878958cd41873fac04a20849a"
+  integrity sha512-qEpkfdSPySNrP+dTxqanhP9yI4FMJYu0Zka0BrRgZHZxb2p82SEM1kurm+xqHndRFtxos14vADVrf2CsttPZag==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?
This PR sets our default CMP (consent banner) for new users to the new CMP UI contained in https://github.com/guardian/consent-management-platform and wraps the UI code with a `cmpUi` commercial feature switch for more granular control.
From now on the previous consent banner will only be shown to users in the control group of the  `commercialCmpUiBannerModal` test (https://github.com/guardian/frontend/pull/22193). Once this test has finished the code related to the previously consent banner will be removed.

This means any users that have not set their consent settings will be shown this new interface instead of the previous consent banner. Users who had already set their consent choices through the old consent banner and have not cleared their cookies will not be re-permissioned.

A similar change needs to be carried out in DCR, which we will be doing soon. Will probably require further work on the CMP project.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?
Using the new CMP improves how we collect, store, and report consent on our website. It also means we become IAB v1 compliant which removes the risk of being removed from this scheme. Removal from the IAB scheme would potentially mean a big hit to our ad revenue.

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)