### PR TITLE
Correct compilation problem in onward

### DIFF
--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -25,7 +25,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
             sponsorName = content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName),
             contributorImage = content.tags.contributors.headOption.flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
             url = content.metadata.url,
-            pillar = OnwardsUtils.findPillar(content.metadata.pillar, content.metadata.designType),
+            pillar = OnwardsUtils.determinePillar(content.metadata.pillar),
           )
           Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -8,7 +8,7 @@ import views.support.{ContentOldAgeDescriber, GUDateTimeFormat, ImgSrc, RemoveOu
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
 import layout.ContentCard
-import models.dotcomponents.OnwardsUtils.findPillar
+import models.dotcomponents.OnwardsUtils.{determinePillar, correctPillar}
 import org.joda.time.DateTimeZone
 
 case class OnwardItem(
@@ -48,15 +48,6 @@ case class OnwardItemMost(
 
 object OnwardItemMost {
 
-  // Todo: when I have a moment, make the correct update in marker: c76ce0f6-25dc-41b0-bc12-527312b96e21
-  // I have created a card for it.
-  def correctPillar(pillar: String): String = {
-    if (pillar == "arts") {
-      "culture"
-    } else {
-      pillar
-    }
-  }
   def maybeFromContentCard(contentCard: ContentCard): Option[OnwardItemMost] = {
     for {
       properties <- contentCard.properties
@@ -127,7 +118,7 @@ object OnwardCollection {
         image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
         ageWarning = ageWarning(content),
         isLiveBlog = content.properties.isLiveBlog,
-        pillar = findPillar(content.maybePillar, content.properties.maybeContent.map(_.metadata.designType)),
+        pillar = determinePillar(content.maybePillar),
         designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,
         webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString,
         headline = content.header.headline,

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,8 +1,19 @@
 package models.dotcomponents
 
-import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
-import model.{DotcomContentType, Pillar, Tag, Tags}
+import com.gu.contentapi.client.utils.{DesignType}
+import model.{DotcomContentType, Pillar}
 import play.api.libs.json.Json
+
+// duplicated in dotcomponentsdatamodel
+case class RichLinkTag(
+    id: String,
+    `type`: String,
+    title: String,
+)
+
+object RichLinkTag {
+  implicit val writes = Json.writes[RichLinkTag]
+}
 
 case class RichLink(
   tags: List[RichLinkTag],
@@ -19,26 +30,13 @@ case class RichLink(
 
 object RichLink {
   implicit val writes = Json.writes[RichLink]
-
-}
-
-// duplicated in dotcomponentsdatamodel
-case class RichLinkTag(
-  id: String,
-  `type`: String,
-  title: String,
-)
-
-object RichLinkTag {
-  implicit val writes = Json.writes[RichLinkTag]
 }
 
 object OnwardsUtils {
   // marker: c76ce0f6-25dc-41b0-bc12-527312b96e21
   def findPillar(pillar: Option[Pillar], designType: Option[DesignType]): String = {
     pillar.map { pillar =>
-      if (designType == AdvertisementFeature) "labs"
-      else if (pillar.toString.toLowerCase == "arts") "culture"
+      if (pillar.toString.toLowerCase == "arts") "culture"
       else pillar.toString.toLowerCase()
     }.getOrElse("news")
   }

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -33,11 +33,17 @@ object RichLink {
 }
 
 object OnwardsUtils {
-  // marker: c76ce0f6-25dc-41b0-bc12-527312b96e21
-  def findPillar(pillar: Option[Pillar], designType: Option[DesignType]): String = {
-    pillar.map { pillar =>
-      if (pillar.toString.toLowerCase == "arts") "culture"
-      else pillar.toString.toLowerCase()
-    }.getOrElse("news")
+
+  def determinePillar(pillar: Option[Pillar]): String = {
+    pillar.map { pillar => correctPillar(pillar.toString.toLowerCase()) }.getOrElse("news")
   }
+
+  def correctPillar(pillar: String): String = {
+    if (pillar == "arts") {
+      "culture"
+    } else {
+      pillar
+    }
+  }
+
 }


### PR DESCRIPTION
## What does this change?

There was a problem in the onward code that prevented proper compilation (surprising that it's been there for so long).  `AdvertisementFeature` is no longer a member of `sealed trait DesignType`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No