### PR TITLE
Replace webUrl by header.headline in OnwardItemMost

### DIFF
--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -63,7 +63,7 @@ object OnwardItemMost {
       metadata = maybeContent.metadata
       pillar <- metadata.pillar
       url <- properties.webUrl
-      headline = properties.webTitle
+      headline = contentCard.header.headline
       isLiveBlog = properties.isLiveBlog
       showByline = properties.showByline
       image <- maybeContent.trail.thumbnailPath


### PR DESCRIPTION
## What does this change?

Replace `webUrl` by `header.headline` in `OnwardItemMost`, as per @oliverlloyd 's request.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

