### PR TITLE
Extend CommercialCmpUiBannerModal AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Test whether our new banner/modal CMP UI obtains target consent rates",
     owners = Seq(Owner.withGithub("ghaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 28),
+    sellByDate = new LocalDate(2020, 2, 7),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-cmp-ui-banner-modal.js
@@ -3,7 +3,7 @@
 export const commercialCmpUiBannerModal: ABTest = {
     id: 'CommercialCmpUiBannerModal',
     start: '2020-01-13',
-    expiry: '2020-01-28',
+    expiry: '2020-02-07',
     author: 'George Haberis',
     description: '3% participation AB test for the new banner/modal CMP UI',
     audience: 0.03,


### PR DESCRIPTION
## What does this change?
Extends the `CommercialCmpUiBannerModal` so we can continue to gather data.