### PR TITLE
Bump @guardian/consent-management-platform to version 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.4",
+    "@guardian/consent-management-platform": "2.0.5",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.4.tgz#4cb5aff99d0cf41878958cd41873fac04a20849a"
-  integrity sha512-qEpkfdSPySNrP+dTxqanhP9yI4FMJYu0Zka0BrRgZHZxb2p82SEM1kurm+xqHndRFtxos14vADVrf2CsttPZag==
+"@guardian/consent-management-platform@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.5.tgz#d7cfa35d096b5f495b0b1756133ead8b10bc98c0"
+  integrity sha512-NIxnb6P7do81OGnfoJstL5XcR4VBnHcNkMHdlmoBSpPeMH4mqwpeKlKxps2ViUO7dIpJAOY39bWh6+g7BdCIxw==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?
Updates `@guardian/consent-management-platform` to the latest version (2.0.5), introducing 2 big fixes:
- Consent settings aren't saving when accessing .co.uk websites (like viewer.gutools.co.uk)
- CMP modal cannot be scrolled using arrow keys

### Tested

- [ ] Locally
- [x] On CODE (optional)