### PR TITLE
Update atom-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
-    "@guardian/atom-renderer": "1.1.1",
+    "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "1.1.1"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "1.1.6"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,10 +1147,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
-"@guardian/atom-renderer@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.1.1.tgz#edb06e443327c1716f04e3204fa03ec72ffc7c98"
-  integrity sha512-W0Hj9JfwoiJgzyljngnCy9W1G7NicGTqp7KNh3aS9Sy9dm4WildUZi3q3tL3SvJtdt/KooneAe8AlkSc6s3etw==
+"@guardian/atom-renderer@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.1.6.tgz#e5bfc53d48dc3d49191903c133484cbfd3a142b6"
+  integrity sha512-l206iwL+8TcUHwozpw5phTBNVp0jFqk/azAcZ+YxwP3MEqE68XcR/SuP9FybKcAomeOd7xM6TzX1031Ci3LHCw==
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
Fixes an issue where the display of the length of an audio track was wrong. Fix by @shtukas [here](https://github.com/guardian/atom-renderer/pull/79).

Have verified that it works:

- **before**

<img width="645" alt="Screen Shot 2020-01-30 at 09 04 24" src="https://user-images.githubusercontent.com/629976/73434930-929d3b80-433f-11ea-9a6b-9e918da905b1.png">

- **after**

<img width="645" alt="Screen Shot 2020-01-30 at 09 04 12" src="https://user-images.githubusercontent.com/629976/73434986-a8126580-433f-11ea-8c7b-acb4a71f402b.png">
