### PR TITLE
Extend videojs switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -202,9 +202,9 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "videojs",
     "If this is switched on then videos are enhanced using VideoJS",
-    owners = Seq(Owner.withGithub("siadcock")),
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = On,
-    sellByDate = new LocalDate(2020, 1, 30),
+    sellByDate = new LocalDate(2020, 2, 19),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends videojs switch which apparently could be ready to be removed, but need to check with Matt Ho when he returns from leave.

