### PR TITLE
Share dpr=2 image urls with DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -200,7 +200,7 @@ object PageElement {
           .map { case (a, i) => ImageAsset.make(a, i) }
         val imageSources: Seq[ImageSource] = BodyMedia.all.map {
           case (weighting, widths) =>
-            val srcSet = widths.breakpoints.flatMap { b =>
+            val srcSet: Seq[SrcSet] = widths.breakpoints.flatMap { b =>
               Seq(
                 ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
                 ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -201,8 +201,11 @@ object PageElement {
         val imageSources: Seq[ImageSource] = BodyMedia.all.map {
           case (weighting, widths) =>
             val srcSet = widths.breakpoints.flatMap { b =>
-              ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)))
-            }
+              Seq(
+                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
+                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
+              )
+            }.flatten
 
             // A few very old articles use non-https hosts, which won't render
             val httpsSrcSet = srcSet.map(set => set.copy(src = ensureHTTPS(set.src)))


### PR DESCRIPTION
This change adds some extra image urls to the DCR data model of double the width but half the quality of the existing source sets. This will help improve the quality of DCR images on 'retina' displays.

Before:
<img width="1560" alt="Screenshot 2020-01-30 at 15 09 50" src="https://user-images.githubusercontent.com/3606555/73461769-98f8db00-4372-11ea-904b-389dc2d73936.png">
After:

<img width="1531" alt="Screenshot 2020-01-30 at 15 09 35" src="https://user-images.githubusercontent.com/3606555/73461764-972f1780-4372-11ea-8524-f476028ca545.png">

