### PR TITLE
Remove sign in gate ab switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -98,16 +98,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-secundus",
-    "Test new sign in component on 2nd article view",
-    owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 1, 31),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-commercial-a9",
     "Test Amazon A9 header bidding",
     owners = Seq(Owner.withGithub("ioanna0")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -8,7 +8,6 @@ import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
-import { signInGateSecundus } from 'common/modules/experiments/tests/sign-in-gate-first-test';
 import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -19,7 +18,6 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     xaxisAdapterTest,
     appnexusUSAdapter,
     pangaeaAdapterTest,
-    signInGateSecundus,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [


### PR DESCRIPTION
## What does this change?

Removing the sign in gate ab test switch as it has expired, and aren't planning on running this particular test for now.