### PR TITLE
CMP UI bump @guardian/consent-management-platform to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.6-beta.0",
+    "@guardian/consent-management-platform": "2.0.6",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.5",
+    "@guardian/consent-management-platform": "2.0.6-beta.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.5.tgz#d7cfa35d096b5f495b0b1756133ead8b10bc98c0"
-  integrity sha512-NIxnb6P7do81OGnfoJstL5XcR4VBnHcNkMHdlmoBSpPeMH4mqwpeKlKxps2ViUO7dIpJAOY39bWh6+g7BdCIxw==
+"@guardian/consent-management-platform@2.0.6-beta.0":
+  version "2.0.6-beta.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.6-beta.0.tgz#fabfda0c097d5a7330a384dbaae7d00f72deb736"
+  integrity sha512-vVkYHfWMfOAWIvS58KRL0H/3mUmaqEICsrHdFLPi5BRko6StyksxOZISm/uJRUPAUcl9WNZosYBZwqgJmecQRQ==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.6-beta.0":
-  version "2.0.6-beta.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.6-beta.0.tgz#fabfda0c097d5a7330a384dbaae7d00f72deb736"
-  integrity sha512-vVkYHfWMfOAWIvS58KRL0H/3mUmaqEICsrHdFLPi5BRko6StyksxOZISm/uJRUPAUcl9WNZosYBZwqgJmecQRQ==
+"@guardian/consent-management-platform@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.6.tgz#61e7d0670a498dc4c5f144c0bd131a1c047017d6"
+  integrity sha512-JklsKo1vSgGr46/hhClkMUGIigiQzBNE8H7tzdnDAyuFAZxgqhOZ1gVD7P92CLzQKGclRQxxJZVZA3FMMjYKyA==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?

This PR bumps `@guardian/consent-management-platform to 2.0.6`, this version of CMP IO contains the fix for the iOS 10 modal scrollable bug (https://github.com/guardian/consent-management-platform/pull/67)