### PR TITLE
Remove the max-snippet attribute for robots

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -186,4 +186,4 @@
 As a European publisher, we need to include snippets and thumbnails in our search previews - https://search.google.com/search-console/settings/eucd?resource_id=https%3A%2F%2Fwww.theguardian.com%2F
 https://developers.google.com/search/reference/robots_meta_tag
 *@
-<meta name="robots" content="max-snippet:20, max-image-preview:large">
+<meta name="robots" content="max-image-preview:large">


### PR DESCRIPTION
## What does this change?
It turns out we didn't need to set this value as part of the previous changes #22219 so this removes it.