### PR TITLE
Remove first-pv-consent-banner code from subscription banner

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -39,7 +39,7 @@ import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-pr
 import { initClickstream } from 'common/modules/ui/clickstream';
 import { init as initDropdowns } from 'common/modules/ui/dropdowns';
 import { fauxBlockLink } from 'common/modules/ui/faux-block-link';
-import { firstPvConsentSubsciptionBanner } from 'common/modules/ui/subscription-banner';
+import { subscriptionBanner } from 'common/modules/ui/subscription-banner';
 import { firstPvConsentPlusEngagementBanner } from 'common/modules/ui/first-pv-consent-plus-engagement-banner';
 import { firstPvConsentBanner } from 'common/modules/ui/first-pv-consent-banner';
 import { init as initRelativeDates } from 'common/modules/ui/relativedates';
@@ -307,7 +307,7 @@ const initialiseBanner = (): void => {
     // ordered by priority
     const bannerList = [
         consentManagementPlatformUi,
-        firstPvConsentSubsciptionBanner,
+        subscriptionBanner,
         firstPvConsentPlusEngagementBanner,
         firstPvConsentBanner,
         breakingNews,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -3,8 +3,6 @@
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 import theGuardianLogo from 'svgs/logo/the-guardian-logo.svg';
 
-import { makeHtml as makeFirstPvConsentHtml } from 'common/modules/ui/first-pv-consent-banner';
-
 const isUserLoggedIn = userLoggedIn =>
     userLoggedIn
         ? 'site-message--subscription-banner__sign-in--already-signed-in'
@@ -98,20 +96,9 @@ const subscriptionBannerTemplate = (
 </div>
 `;
 
-const consentSection = `<div id="js-first-pv-consent-site-message" class="site-message--first-pv-consent" tabindex="-1" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
-        <div class="gs-container">
-            <div class="site-message__inner js-site-message-inner">
-                <div class="site-message__copy js-site-message-copy u-cf">
-                    ${makeFirstPvConsentHtml()}
-                </div>
-            </div>
-        </div>
-    </div>`;
-
 const bannerTemplate = (
     subscriptionUrl: string,
     signInUrl: string,
-    showConsent: boolean,
     userLoggedIn: boolean,
     abTestVariant: boolean
 ): string =>
@@ -130,7 +117,6 @@ const bannerTemplate = (
             userLoggedIn,
             abTestVariant
         )}
-        ${showConsent ? consentSection : ''}
     </div>
     `;
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -14,14 +14,6 @@ import {
     pageShouldHideReaderRevenue,
     getReaderRevenueRegion,
 } from 'common/modules/commercial/contributions-utilities';
-import {
-    track as trackFirstPvConsent,
-    canShow as canShowFirstPvConsent,
-} from 'common/modules/ui/first-pv-consent-banner';
-import {
-    setAdConsentState,
-    allAdConsents,
-} from 'common/modules/commercial/ad-prefs.lib';
 import { bannerTemplate } from 'common/modules/ui/subscription-banner-template';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { isUserLoggedIn } from 'common/modules/identity/api';
@@ -141,12 +133,6 @@ const pageIsIdentity = (): boolean => {
     return isIdentityPage;
 };
 
-const onAgree = (): void => {
-    allAdConsents.forEach(_ => {
-        setAdConsentState(_, true);
-    });
-};
-
 const bindCloseHandler = (button, banner, callback) => {
     const removeBanner = () => {
         callback();
@@ -253,25 +239,9 @@ const bindSubscriptionClickHandlers = () => {
     }
 };
 
-const bindConsentClickHandlers = () => {
-    const consentBannerCloseButton = document.querySelector(
-        '.site-message--first-pv-consent__button'
-    );
-    const consentBannerHtml = document.querySelector(
-        '#js-first-pv-consent-site-message'
-    );
-
-    if (consentBannerHtml) {
-        bindCloseHandler(consentBannerCloseButton, consentBannerHtml, onAgree);
-    }
-};
-
 const show: () => Promise<boolean> = async () => {
-    trackFirstPvConsent();
     trackSubscriptionBannerView();
     trackNonClickInteraction(DISPLAY_EVENT_KEY);
-
-    const showConsent = await canShowFirstPvConsent();
 
     if (document.body) {
         document.body.insertAdjacentHTML(
@@ -279,7 +249,6 @@ const show: () => Promise<boolean> = async () => {
             bannerTemplate(
                 subscriptionUrl,
                 signInUrl,
-                showConsent,
                 isUserLoggedIn(),
                 isInVariantSynchronous(
                     subscriptionsBannerNewYearCopyTest,
@@ -289,7 +258,6 @@ const show: () => Promise<boolean> = async () => {
         );
     }
 
-    bindConsentClickHandlers();
     bindSubscriptionClickHandlers();
 
     return Promise.resolve(true);
@@ -313,7 +281,7 @@ const canShow: () => Promise<boolean> = async () => {
     return can;
 };
 
-export const firstPvConsentSubsciptionBanner: Banner = {
+export const subscriptionBanner: Banner = {
     id: MESSAGE_CODE,
     show,
     canShow,

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -358,19 +358,11 @@
 
 /*********************** footer hacks *********************/
 
-.subscription-banner--holder
-.site-message--first-pv-consent__block.site-message--first-pv-consent__block--intro {
-    margin: 0;
-}
+
 
 .subscription-banner--holder
 .site-message__copy.js-site-message-copy.u-cf {
     margin: 0;
-}
-.subscription-banner--holder .site-message--first-pv-consent {
-    @include mq($from: desktop) {
-        padding: 12px 20px;
-    }
 }
 
 .subscription-banner--holder


### PR DESCRIPTION
## What does this change?
This PR removes the `first-pv-consent-banner` from the subscriptions banner in anticipation for its deletion from the codebase.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)