### PR TITLE
Remove unnecessary consent checks

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -73,10 +73,6 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
     getPageTargeting: () => 'bla',
 }));
 
-jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(),
-}));
-
 jest.mock('../utils');
 
 jest.mock('common/modules/experiments/ab', () => ({

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -2,7 +2,7 @@
 import config from 'lib/config';
 
 export const fbPixel: () => ThirdPartyTag = () => ({
-    shouldRun: config.get('switches.facebookTrackingPixel'),
+    shouldRun: config.get('switches.facebookTrackingPixel', false),
     url: `https://www.facebook.com/tr?id=${config.get(
         'libs.facebookAccountId'
     )}&ev=PageView&noscript=1`,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -1,14 +1,7 @@
 // @flow
-import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 import config from 'lib/config';
 
 import { fbPixel } from 'commercial/modules/third-party-tags/facebook-pixel';
-
-const getAdConsentState: any = _getAdConsentState;
-
-jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(),
-}));
 
 type SetupParams = {
     consent: boolean | null,
@@ -22,7 +15,6 @@ describe('Facebook tracking pixel', () => {
     });
 
     const setup = (params: SetupParams) => {
-        getAdConsentState.mockReturnValueOnce(params.consent);
         config.set('switches.facebookTrackingPixel', params.switchedOn);
     };
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/permutive.js
@@ -2,6 +2,6 @@
 import config from 'lib/config';
 
 export const permutive: ThirdPartyTag = {
-    shouldRun: config.get('switches.permutive'),
+    shouldRun: config.get('switches.permutive', false),
     url: '//cdn.permutive.com/d6691a17-6fdb-4d26-85d6-b3dd27f55f08-web.js',
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -1,9 +1,5 @@
 // @flow
 import config from 'lib/config';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 
 const onLoad = () => {
     window.google_trackConversion({
@@ -14,9 +10,7 @@ const onLoad = () => {
 };
 
 export const remarketing: () => ThirdPartyTag = () => ({
-    shouldRun:
-        config.get('switches.remarketing') &&
-        !!getAdConsentState(thirdPartyTrackingAdConsent),
+    shouldRun: config.get('switches.remarketing'),
     url: '//www.googleadservices.com/pagead/conversion_async.js',
     onLoad,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -10,7 +10,7 @@ const onLoad = () => {
 };
 
 export const remarketing: () => ThirdPartyTag = () => ({
-    shouldRun: config.get('switches.remarketing'),
+    shouldRun: config.get('switches.remarketing', false),
     url: '//www.googleadservices.com/pagead/conversion_async.js',
     onLoad,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
@@ -1,13 +1,6 @@
 // @flow
-import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
 import { remarketing } from 'commercial/modules/third-party-tags/remarketing';
 import config from 'lib/config';
-
-const getAdConsentState: any = _getAdConsentState;
-
-jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(),
-}));
 
 describe('Remarketing', () => {
     beforeAll(() => {
@@ -18,7 +11,6 @@ describe('Remarketing', () => {
     });
 
     it('should exist', () => {
-        getAdConsentState.mockReturnValue(true);
         const { shouldRun, url, onLoad } = remarketing();
 
         expect(shouldRun).toEqual(true);
@@ -28,18 +20,18 @@ describe('Remarketing', () => {
         expect(onLoad).toBeDefined();
     });
 
-    it('shouldRun returns false only if consent has been denied', () => {
-        getAdConsentState.mockReturnValueOnce(true);
-        getAdConsentState.mockReturnValueOnce(false);
-        getAdConsentState.mockReturnValueOnce(null);
+    it('shouldRun to be true if ad the switch is on', () => {
+        config.set('switches.remarketing', true);
+        const { shouldRun } = remarketing();
 
-        const shouldRunTrue = remarketing().shouldRun;
-        const shouldRunFalse = remarketing().shouldRun;
-        const shouldRunNull = remarketing().shouldRun;
+        expect(shouldRun).toEqual(true);
+    });
 
-        expect(shouldRunTrue).toEqual(true);
-        expect(shouldRunFalse).toEqual(false);
-        expect(shouldRunNull).toEqual(false);
+    it('shouldRun to be false if the switch is off', () => {
+        config.set('switches.remarketing', false);
+        const { shouldRun } = remarketing();
+
+        expect(shouldRun).toEqual(false);
     });
 
     it('should call google_trackConversion', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/simple-reach.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/simple-reach.js
@@ -3,8 +3,8 @@ import config from 'lib/config';
 
 const shouldRun =
     !config.get('page.isFront') &&
-    config.get('switches.simpleReach') &&
-    config.get('page.isPaidContent');
+    config.get('page.isPaidContent') &&
+    config.get('switches.simpleReach', false);
 
 let simpleReachUrl = '';
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -1,9 +1,5 @@
 // @flow strict
 import config from 'lib/config';
-import {
-    getAdConsentState,
-    thirdPartyTrackingAdConsent,
-} from 'common/modules/commercial/ad-prefs.lib';
 
 const onLoad = () => {
     // Insert Twitter Pixel ID and Standard Event data below
@@ -15,9 +11,7 @@ const onLoad = () => {
 
 // Twitter universal website tag code
 export const twitterUwt: () => ThirdPartyTag = () => ({
-    shouldRun:
-        config.get('switches.twitterUwt', false) &&
-        !!getAdConsentState(thirdPartyTrackingAdConsent),
+    shouldRun: config.get('switches.twitterUwt', false),
     url: '//static.ads-twitter.com/uwt.js',
     onLoad,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -1,23 +1,10 @@
 // @flow
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
-import { getAdConsentState as _getAdConsentState } from 'common/modules/commercial/ad-prefs.lib';
-
-const getAdConsentState: any = _getAdConsentState;
-
-jest.mock('common/modules/commercial/ad-prefs.lib', () => ({
-    getAdConsentState: jest.fn(),
-}));
-
-jest.mock('lib/config', () => ({ get: () => true }));
+import config from 'lib/config';
 
 describe('twitterUwt', () => {
-    afterEach(() => {
-        getAdConsentState.mockReset();
-    });
-
-    it('shouldRun to be true if ad consent granted', () => {
-        getAdConsentState.mockReturnValueOnce(true);
-
+    it('shouldRun to be true if ad the switch is on', () => {
+        config.set('switches.twitterUwt', true);
         const { shouldRun, url, onLoad } = twitterUwt();
 
         expect(shouldRun).toEqual(true);
@@ -25,19 +12,8 @@ describe('twitterUwt', () => {
         expect(onLoad).toBeDefined();
     });
 
-    it('shouldRun to be false if ad consent not granted or denied', () => {
-        getAdConsentState.mockReturnValueOnce(null);
-
-        const { shouldRun, url, onLoad } = twitterUwt();
-
-        expect(shouldRun).toEqual(false);
-        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
-        expect(onLoad).toBeDefined();
-    });
-
-    it('shouldRun to be false if ad consent denied', () => {
-        getAdConsentState.mockReturnValueOnce(false);
-
+    it('shouldRun to be false if the switch is off', () => {
+        config.set('switches.twitterUwt', false);
         const { shouldRun, url, onLoad } = twitterUwt();
 
         expect(shouldRun).toEqual(false);

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
@@ -28,7 +28,7 @@ const isInExperiment = (): boolean =>
 
 const trackInteraction = (interaction: string): void => {
     ophan.record({
-        component: 'first-pv-consent',
+        component: `${messageCode}`,
         value: interaction,
     });
     trackNonClickInteraction(interaction);


### PR DESCRIPTION
## What does this change?
This PR removes unnecessary consent state checks that were left in by mistake in third party tags modules `remarketing` and `twitter-uwt`, removes unnecessary mocks of `getAdConsentState` and updates unit tests.
It also updates the component name used when tracking `email-sign-in-banner` interactions.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)