### PR TITLE
Removing age notice warning for one legally sensitive article

### DIFF
--- a/common/app/views/support/ContentOldAgeDescriber.scala
+++ b/common/app/views/support/ContentOldAgeDescriber.scala
@@ -1,37 +1,45 @@
 package views.support
 
+
 import java.util.concurrent.TimeUnit
 import implicits.Dates.CapiRichDateTime
 import model.pressed.{CuratedContent, PressedStory}
 import org.joda.time.DateTime
 
+
 object ContentOldAgeDescriber extends ContentOldAgeDescriber
 
 class ContentOldAgeDescriber {
+
+   private val excludePaths = Set("artanddesign/2019/jun/18/serpentine-galleries-chief-resigns")
+
   def apply(content: model.Content): String = {
-    message(Some(content.trail.webPublicationDate))
+    message(Some(content.trail.webPublicationDate), Some(content.metadata.id))
   }
 
   def apply(content: PressedStory): String = {
-    message(Some(content.trail.webPublicationDate))
+    message(Some(content.trail.webPublicationDate), Some(content.metadata.id))
   }
 
   def apply(content: model.ContentType): String = {
-    message(Some(content.trail.webPublicationDate))
+    message(Some(content.trail.webPublicationDate), Some(content.metadata.id))
   }
 
   def apply(apiContent: com.gu.contentapi.client.model.v1.Content): String = {
-    message(apiContent.webPublicationDate.map(_.toJoda))
+    message(apiContent.webPublicationDate.map(_.toJoda), Some(apiContent.id))
   }
 
   def apply(curatedContent: CuratedContent): String = {
-    message(curatedContent.card.webPublicationDateOption)
+    message(curatedContent.card.webPublicationDateOption, curatedContent.properties.maybeContentId)
   }
 
-  private def message(maybePubDate: Option[DateTime]) = {
+  private def message(maybePubDate: Option[DateTime], id:Option[String]) = {
     maybePubDate.map(pubDate => {
       val warnLimitDays = 30
-      if (pubDate.isBefore(DateTime.now().minusDays(warnLimitDays))) {
+      if(excludePaths.contains(id.getOrElse(""))){
+        ""
+      }
+       else if (pubDate.isBefore(DateTime.now().minusDays(warnLimitDays))) {
         val ageMillis = DateTime.now().getMillis - pubDate.getMillis
         val years = TimeUnit.MILLISECONDS.toDays(ageMillis) / 365
         val months = TimeUnit.MILLISECONDS.toDays(ageMillis) / 31
@@ -45,8 +53,8 @@ class ContentOldAgeDescriber {
         else if (weeks >= 2) s"$weeks weeks"
         else if (weeks > 0) s"$weeks week"
         else s"$days days"
-
-      } else {
+      }
+      else {
         ""
       }
     }).getOrElse("")


### PR DESCRIPTION
## What does this change?
Not sure on the specifics, but there is a request to remove the age warning notice on this article. It should be a one off, but just in case, it should be easy to add further paths.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The logic contained in the edited folder is replicated in DCR agewarning.tsx

