### PR TITLE
Labs media icons fix

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -3,7 +3,7 @@ package layout
 import cards.{MediaList, Standard}
 import com.gu.commercial.branding.Branding
 import com.gu.contentapi.client.model.{v1 => contentapi}
-import com.gu.contentapi.client.utils.DesignType
+import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition.defaultEdition
 import common.{Edition, LinkTo}
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
@@ -390,6 +390,8 @@ case class ContentCard(
   val designType: Option[DesignType] = storyContent.map(_.metadata.designType)
   val pillar: Option[Pillar] = Pillar(storyContent)
   val contentType: DotcomContentType = DotcomContentType(storyContent)
+
+  val isAdvertisementFeature : Boolean = designType.contains(AdvertisementFeature)
 }
 object ContentCard {
 

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -44,6 +44,7 @@ object GetClasses {
       ("fc-item--dynamic-layout", isDynamic && item.cardTypes.canBeDynamicLayout && !item.cutOut.isDefined)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
+      ++ adFeatureMediaClass(item).map(_ -> true)
     )
   }
 
@@ -58,6 +59,10 @@ object GetClasses {
     case Gallery => "fc-item--gallery"
     case Video => "fc-item--video"
     case Audio => "fc-item--audio"
+  }
+
+  def adFeatureMediaClass(faciaCard: ContentCard): Option[String] =  {
+    if (faciaCard.isAdvertisementFeature && faciaCard.isMediaLink) Some("fc-item--type-media") else None
   }
 
   def sublinkMediaTypeClass(sublink: Sublink): Option[String] = sublink.mediaType map {


### PR DESCRIPTION
Co-authored-by: Josh Buckland <buck06191@gmail.com>

## What does this change?
Fixes Advertisement Feature cards CSS for media types.
Since moving to an AdvertisementFeature design type, the cards at The Guardian Labs broke icon styling for media types.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
![Screenshot 2020-02-04 at 12 29 13](https://user-images.githubusercontent.com/12860328/73745034-01b4ce80-474a-11ea-83c5-f3f5b0dc64ca.png)
![Screenshot 2020-02-04 at 12 29 02](https://user-images.githubusercontent.com/12860328/73745038-04172880-474a-11ea-9405-120c395ea913.png)

### After
![Screenshot 2020-02-04 at 12 27 44](https://user-images.githubusercontent.com/12860328/73745057-0c6f6380-474a-11ea-96f8-f27570acd08a.png)
![Screenshot 2020-02-04 at 12 27 56](https://user-images.githubusercontent.com/12860328/73745064-0e392700-474a-11ea-928e-ea3b16c33354.png)

Non advertisement feature cards after fix remain unchanged
<img width="514" alt="Screenshot 2020-02-04 at 17 14 54" src="https://user-images.githubusercontent.com/12860328/73769101-03928800-4772-11ea-9bf5-bdb2343983c6.png">



### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)

This is only for GLabs, the media cards were broken after the above mentioned change.

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
