### PR TITLE
Add CodeBlockElement with isMandatory forced to prevent AMP render

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -82,7 +82,7 @@ case class MembershipBlockElement(
 ) extends PageElement
 
 // these don't appear to have typeData on the capi models so we just have empty html
-case class CodeBlockElement(html: Option[String]) extends PageElement
+case class CodeBlockElement(html: Option[String], isMandatory: Boolean) extends PageElement
 case class FormBlockElement(html: Option[String]) extends PageElement
 
 case class RichLinkBlockElement(
@@ -149,6 +149,7 @@ object PageElement {
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true
       case doc: DocumentBlockElement if doc.isMandatory.exists(identity) => true
+      case _: CodeBlockElement => true // Currently will just fail over at DCR
 
       case _ => false
     }
@@ -371,7 +372,7 @@ object PageElement {
       case Document => element.documentTypeData.map(d => DocumentBlockElement(d.html, Role(d.role), d.isMandatory)).toList
       case Instagram => element.instagramTypeData.map(d => InstagramBlockElement(d.originalUrl, d.html, d.caption.isDefined)).toList
       case Vine => element.vineTypeData.map(d => VineBlockElement(d.html)).toList
-      case Code => List(CodeBlockElement(None))
+      case Code => List(CodeBlockElement(None, true)) // Force isMandatory to avoid rendering any articles with Codeblocks in AMP
       case Form => List(FormBlockElement(None))
       case EnumUnknownElementType(f) => List(UnknownBlockElement(None))
     }


### PR DESCRIPTION
## What does this change?

Adds CodeBlockElement so if it is used, we force 'isMandatory' therefore preventing rendering in AMP.

https://github.com/guardian/dotcom-rendering/pull/1153