### PR TITLE
Subs banner display rule changes

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -305,11 +305,11 @@ const initialiseBanner = (): void => {
     // ordered by priority
     const bannerList = [
         consentManagementPlatformUi,
-        subscriptionBanner,
         breakingNews,
         signInGate,
         membershipBanner,
         membershipEngagementBanner,
+        subscriptionBanner,
         smartAppBanner,
         adFreeBanner,
         emailSignInBanner,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -114,7 +114,8 @@ const hasAcknowledgedBanner = region =>
 const canShowBannerInRegion = (region: ReaderRevenueRegion): boolean =>
     !hideBannerInTheseRegions.includes(region);
 
-const threeOrMorePageViews = (currentPageViews: number) => currentPageViews >= 3;
+const threeOrMorePageViews = (currentPageViews: number) =>
+    currentPageViews >= 3;
 
 const closedAt = (lastClosedAtKey: string) =>
     userPrefs.set(lastClosedAtKey, new Date().toISOString());

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner.js
@@ -78,10 +78,7 @@ const subscriptionUrl = addTrackingCodesToUrl({
 const signInUrl = `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Exisiting&CMP_TU=mrtn&CMP_BUNIT=subs`;
 
 const hasAcknowledged = bannerRedeploymentDate => {
-    // In order to migrate between ISO string and millisecond format support both temporarily
-    const stringOrNumberRedeploymentDate =
-        Number(bannerRedeploymentDate) || bannerRedeploymentDate;
-    const redeploymentDate = new Date(stringOrNumberRedeploymentDate);
+    const redeploymentDate = new Date(Number(bannerRedeploymentDate));
     const lastClosedAt = userPrefs.get(SUBSCRIPTION_BANNER_CLOSED_KEY);
     const lastClosedAtTime = new Date(lastClosedAt);
 
@@ -117,7 +114,7 @@ const hasAcknowledgedBanner = region =>
 const canShowBannerInRegion = (region: ReaderRevenueRegion): boolean =>
     !hideBannerInTheseRegions.includes(region);
 
-const fiveOrMorePageViews = (currentPageViews: number) => currentPageViews >= 5;
+const threeOrMorePageViews = (currentPageViews: number) => currentPageViews >= 3;
 
 const closedAt = (lastClosedAtKey: string) =>
     userPrefs.set(lastClosedAtKey, new Date().toISOString());
@@ -269,7 +266,7 @@ const canShow: () => Promise<boolean> = async () => {
     );
 
     const can = Promise.resolve(
-        fiveOrMorePageViews(pageviews) &&
+        threeOrMorePageViews(pageviews) &&
             !hasAcknowledgedSinceLastRedeploy &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&


### PR DESCRIPTION
## What does this change?
Changes the behaviour of the subscription banner so that it appears after 3 page views rather than 5 as at present. It also moves the contributions engagement banner above subscriptions in priority order.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
