### PR TITLE
Discussion • Handle 400 Bad Request USERNAME_MISSING error

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -2,6 +2,7 @@
 
 import bean from 'bean';
 import bonzo from 'bonzo';
+import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { Component } from 'common/modules/component';
 import { postComment, previewComment } from 'common/modules/discussion/api';
@@ -14,7 +15,6 @@ import {
 import { avatarify } from 'common/modules/discussion/user-avatars';
 import { init as initValidationEmail } from 'common/modules/identity/validation-email';
 import { urlify } from './urlify';
-import config from 'lib/config';
 
 type commentType = {
     body: string,

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -14,6 +14,7 @@ import {
 import { avatarify } from 'common/modules/discussion/user-avatars';
 import { init as initValidationEmail } from 'common/modules/identity/validation-email';
 import { urlify } from './urlify';
+import config from 'lib/config';
 
 type commentType = {
     body: string,
@@ -62,6 +63,9 @@ class CommentBox extends Component {
                 'Sorry, your comment was not published as you are no longer signed in. Please sign in and try again.',
             'READ-ONLY-MODE':
                 'Sorry your comment can not currently be published as commenting is undergoing maintenance but will be back shortly. Please try again in a moment.',
+            USERNAME_MISSING: `You must <a href="${config.get(
+                'page.mmaUrl'
+            )}/public-settings">set a username</a> before commenting.`,
 
             /* Custom error codes */
             /* CORS blocked by HTTP/1.0 proxy */


### PR DESCRIPTION
## What does this change?

As part of our on going work on improving the discussion system, we are making a Discussion API [change](https://github.com/guardian/discussion-api/pull/645) where it will be no longer possible to comment without an identity username set.

This change adds the explicit `USERNAME_MISSING` error to the `errorMessages` and text on how to rectify the issue (link to manage public settings to set username).

## Screenshots
![Screenshot 2020-02-07 at 15 05 23](https://user-images.githubusercontent.com/13315440/74040305-5dd25980-49bb-11ea-8d99-5a0afa681098.png)

## TODO
- [ ] Messaging of the error text
- [ ] (Optional) Change wording on setting of username when making a new comment

### Tested

- [X] Locally
- [x] On CODE (optional)
