### PR TITLE
New Truskin pageskin for AUS

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -10,6 +10,7 @@ const pageSkin = (): void => {
     const hasPageSkin: boolean = config.get('page.hasPageSkin');
 
     const isInAUEdition = config.get('page.edition', '').toLowerCase() === 'au';
+    const adLabelHeight = 24;
 
     let topPosition: number = 0;
 
@@ -40,19 +41,66 @@ const pageSkin = (): void => {
         }
     };
 
-    const initTopPositionOnce = (): void => {
+    const initTopPositionOnce = (hasTruskin: boolean): void => {
         if (topPosition === 0) {
             const navHeader = document.getElementsByClassName('new-header')[0];
             if (navHeader) {
-                topPosition = navHeader.offsetTop + navHeader.offsetHeight;
+                topPosition = hasTruskin
+                    ? navHeader.offsetTop + adLabelHeight
+                    : navHeader.offsetTop + navHeader.offsetHeight;
             }
         }
     };
 
-    // This is to reposition the Page Skin to start where the navigation header ends.
+    const shrinkElement = (element: HTMLElement | null): void => {
+        const frontContainer = document.querySelector('.fc-container__inner');
+        if (element && frontContainer) {
+            element.style.cssText = `max-width: ${
+                frontContainer.clientWidth
+            }px; margin-right: auto; margin-left: auto;`;
+        }
+    };
+
     const repositionSkin = (): void => {
-        if (hasPageSkin && isInAUEdition) {
-            initTopPositionOnce();
+        const bodyElement = document.querySelector('body');
+        const hasTruskin = bodyElement
+            ? bodyElement.classList.contains('truskin-page-skin')
+            : false;
+        const header = document.querySelector('.new-header');
+        const footer = document.querySelector('.l-footer');
+        const topBannerAd = document.querySelector('.ad-slot--top-banner-ad');
+
+        if (hasTruskin && header && topBannerAd) {
+            initTopPositionOnce(hasTruskin);
+
+            shrinkElement(header);
+            shrinkElement(footer);
+
+            if (window.pageYOffset === 0) {
+                moveBackgroundVerticalPosition(topPosition);
+            }
+
+            const headerBoundaries = header.getBoundingClientRect();
+            const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
+            const headerPosition = headerBoundaries.top;
+            const fabricScrollStartPosition =
+                topBannerAdBoundaries.height +
+                adLabelHeight -
+                headerBoundaries.height;
+
+            if (
+                headerPosition <= fabricScrollStartPosition &&
+                topBannerAdBoundaries.bottom > 0
+            ) {
+                moveBackgroundVerticalPosition(topBannerAdBoundaries.bottom);
+            } else if (topBannerAdBoundaries.bottom <= 0) {
+                moveBackgroundVerticalPosition(0);
+            }
+        }
+
+        // This is to reposition the Page Skin to start where the navigation header ends.
+        if (!hasTruskin && hasPageSkin && isInAUEdition) {
+            initTopPositionOnce(false);
             if (window.pageYOffset === 0) {
                 moveBackgroundVerticalPosition(topPosition);
             } else if (window.pageXOffset <= topPosition) {

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -62,9 +62,8 @@ const pageSkin = (): void => {
     };
 
     const repositionSkin = (): void => {
-        const bodyElement = document.body;
-        const hasTruskin = bodyElement
-            ? bodyElement.classList.contains('truskin-page-skin')
+        const hasTruskin = bodyEl
+            ? bodyEl.classList.contains('truskin-page-skin')
             : false;
         const header = document.querySelector('.new-header');
         const footer = document.querySelector('.l-footer');

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -52,9 +52,9 @@ const pageSkin = (): void => {
         }
     };
 
-    const shrinkElement = (element: HTMLElement | null): void => {
+    const shrinkElement = (element: HTMLElement): void => {
         const frontContainer = document.querySelector('.fc-container__inner');
-        if (element && frontContainer) {
+        if (frontContainer) {
             element.style.cssText = `max-width: ${
                 frontContainer.clientWidth
             }px; margin-right: auto; margin-left: auto;`;
@@ -62,7 +62,7 @@ const pageSkin = (): void => {
     };
 
     const repositionSkin = (): void => {
-        const bodyElement = document.querySelector('body');
+        const bodyElement = document.body;
         const hasTruskin = bodyElement
             ? bodyElement.classList.contains('truskin-page-skin')
             : false;
@@ -73,8 +73,12 @@ const pageSkin = (): void => {
         if (hasTruskin && header && topBannerAd) {
             initTopPositionOnce(hasTruskin);
 
-            shrinkElement(header);
-            shrinkElement(footer);
+            if (header) {
+                shrinkElement(header);
+            }
+            if (footer) {
+                shrinkElement(footer);
+            }
 
             if (window.pageYOffset === 0) {
                 moveBackgroundVerticalPosition(topPosition);
@@ -83,6 +87,7 @@ const pageSkin = (): void => {
             const headerBoundaries = header.getBoundingClientRect();
             const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
             const headerPosition = headerBoundaries.top;
+            const topBannerBottom = topBannerAdBoundaries.bottom;
             const fabricScrollStartPosition =
                 topBannerAdBoundaries.height +
                 adLabelHeight -
@@ -90,10 +95,10 @@ const pageSkin = (): void => {
 
             if (
                 headerPosition <= fabricScrollStartPosition &&
-                topBannerAdBoundaries.bottom > 0
+                topBannerBottom > 0
             ) {
-                moveBackgroundVerticalPosition(topBannerAdBoundaries.bottom);
-            } else if (topBannerAdBoundaries.bottom <= 0) {
+                moveBackgroundVerticalPosition(topBannerBottom);
+            } else if (topBannerBottom <= 0) {
                 moveBackgroundVerticalPosition(0);
             }
         }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -87,6 +87,10 @@
     overflow: hidden;
 }
 
+.truskin-page-skin .top-banner-ad-container {
+    border-bottom: 0;
+}
+
 .sticky-top-banner-ad {
     transform: translate3d(0, 0, 0);
     contain: layout;


### PR DESCRIPTION
Co-authored with: @buck06191 

## What does this change?
Introduces new commercial template for a new type of page skin called `Truskin` (already runs in AUS as third party) that should only be run on Fronts. It expands on the page and shrinks the header and footer. 

The pageskin component (i.e. not the Fabric header) can be found in https://github.com/guardian/commercial-templates/pull/227. This is **not** a native ad template, but should be used to generate the code for the creative template sound in Google Ad manager.

The skin should look as if it is a single image that is covering the top and sides of the Front and consists of 2 separate images.

*Only to be used in Australia*

Requires:
 - Fabric scroll type must be set to `none`
 - Height of Fabric **must** be 274px
 - Width of background image and Fabric must be the same.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![truskindemo](https://user-images.githubusercontent.com/51630004/74247569-2c6ccd00-4cde-11ea-8020-ae9a6d4f54d0.gif)

## What is the value of this and can you measure success?
Allow AUS team to create the format natively as they already use it as third party.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

