### PR TITLE
Exclude mobile sticky ad from the hosted pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
@@ -162,7 +162,8 @@ export const shouldIncludeMobileSticky = once(
         (config.get('switches.mobileStickyLeaderboard') &&
             isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) &&
             (isInUsRegion() || isInAuRegion()) &&
-            config.get('page.contentType') === 'Article')
+            config.get('page.contentType') === 'Article' &&
+            !config.get('page.isHosted'))
 );
 
 export const stripMobileSuffix = (s: string): string =>

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
@@ -351,6 +351,15 @@ describe('Utils', () => {
         expect(shouldIncludeMobileSticky()).toBe(false);
     });
 
+    test('shouldIncludeMobileSticky should be false if all conditions true except isHosted condition', () => {
+        config.set('page.contentType', 'Article');
+        isBreakpoint.mockReturnValue(true);
+        config.set('switches.mobileStickyLeaderboard', true);
+        config.set('page.isHosted', true);
+        getSync.mockReturnValue('US');
+        expect(shouldIncludeMobileSticky()).toBe(false);
+    });
+
     test('shouldIncludeMobileSticky should be false if all conditions true except continent', () => {
         config.set('page.contentType', 'Article');
         config.set('switches.mobileStickyLeaderboard', true);


### PR DESCRIPTION
Co-authored-by: Josh Buckland <buck06191@gmail.com>

## What does this change?

This PR excludes the mobile sticky ad unit from the hosted pages

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
<img width="394" alt="Screenshot 2020-02-12 at 11 36 39" src="https://user-images.githubusercontent.com/51630004/74332317-61842880-4d8d-11ea-80c4-027111c47ee1.png">

### After
<img width="394" alt="Screenshot 2020-02-12 at 11 36 08" src="https://user-images.githubusercontent.com/51630004/74332341-6cd75400-4d8d-11ea-90f8-db63fd0a0a42.png">

## What is the value of this and can you measure success?
Allows advertisers to have only their content showing without external ads

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

