### PR TITLE
Tidy up ab-commercial-outbrain-testing test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,16 +48,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-commercial-outbrain-testing",
-    "Test the outbrain widget",
-    owners = Seq(Owner.withGithub("frankie297")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 4, 22),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-commercial-xaxis-adapter",
     "Test new implementation of xaxis adapter with multiple placement ids",
     owners = Seq(Owner.withGithub("ioanna0")),


### PR DESCRIPTION
## What does this change?

The ` ab-commercial-outbrain-testing` 0% a/b test was added here https://github.com/guardian/frontend/pull/21244 and removed here https://github.com/guardian/frontend/pull/21815, however the reference to the test in `ABTestSwitches.scala` remained but is redundant so should be removed.