### PR TITLE
Just use path for badges in DCR

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -581,8 +581,7 @@ object DotcomponentsDataModel {
     val badge = Badges.badgeFor(article).map(badge =>
       DCRBadge(
         badge.seriesTag,
-        // We use the assets path in DCR that already has /assets/ suffix
-        Configuration.assets.fullURL(common.Environment.stage) + badge.imageUrl.replace("/assets/","")
+        badge.imageUrl
       )
     )
 


### PR DESCRIPTION
## What does this change?

Badges double domained 😨 

![image](https://user-images.githubusercontent.com/638051/74344372-60aac100-4da4-11ea-8e5b-6e2844dd265d.png)

On PROD we add the domain because of the `Static()` method in https://github.com/guardian/frontend/blob/master/common/app/model/Badges.scala#L40

https://trello.com/c/7QuzGTCU