### PR TITLE
Include epic tests in Admin ab test list

### DIFF
--- a/static/src/javascripts/projects/admin/bootstraps/abtests.js
+++ b/static/src/javascripts/projects/admin/bootstraps/abtests.js
@@ -1,7 +1,11 @@
 // @flow
 import { ABTestReportItem as ReportItem } from 'admin/modules/abtests/abtest-report-item';
 import { Audience } from 'admin/modules/abtests/audience';
-import { concurrentTests } from 'common/modules/experiments/ab-tests';
+import {
+    concurrentTests,
+    epicTests,
+    priorityEpicTest,
+} from 'common/modules/experiments/ab-tests';
 import { isExpired } from 'lib/time-utils';
 
 const renderTests = (
@@ -23,8 +27,10 @@ const renderTests = (
 };
 
 const initABTests = (): void => {
+    const tests = [].concat(concurrentTests, epicTests, [priorityEpicTest]);
+
     renderTests(
-        concurrentTests.filter(test => !isExpired(test.expiry)),
+        tests.filter(test => !isExpired(test.expiry)),
         true,
         document.querySelector('.abtests-report__data')
     );


### PR DESCRIPTION
## What does this change?

Adds epic tests to the Admin AB report page.
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screenshot 2020-02-12 at 15 20 19](https://user-images.githubusercontent.com/858402/74348837-3a3c5400-4dab-11ea-8533-6a8e53e6391f.png)

(now appears locally but doesn't appear on PROD atm)

## What is the value of this and can you measure success?

(Useful to see which tests are active.)