### PR TITLE
Truskin fix

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -64,7 +64,9 @@ const pageSkin = (): void => {
     const renderedSlotElementIds = [];
 
     const repositionSkin = (event): void => {
-        renderedSlotElementIds.push(event.slot.getSlotElementId());
+        if (event.slot) {
+            renderedSlotElementIds.push(event.slot.getSlotElementId());
+        }
         if (
             renderedSlotElementIds.includes('dfp-ad--pageskin-inread') &&
             renderedSlotElementIds.includes('dfp-ad--top-above-nav')

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -61,59 +61,68 @@ const pageSkin = (): void => {
         }
     };
 
-    const repositionSkin = (): void => {
-        const hasTruskin = bodyEl
-            ? bodyEl.classList.contains('truskin-page-skin')
-            : false;
-        const header = document.querySelector('.new-header');
-        const footer = document.querySelector('.l-footer');
-        const topBannerAd = document.querySelector('.ad-slot--top-banner-ad');
+    const renderedSlotElementIds = [];
 
-        if (hasTruskin && header && topBannerAd) {
-            initTopPositionOnce(hasTruskin);
+    const repositionSkin = (event): void => {
+        renderedSlotElementIds.push(event.slot.getSlotElementId());
+        if (
+            renderedSlotElementIds.includes('dfp-ad--pageskin-inread') &&
+            renderedSlotElementIds.includes('dfp-ad--top-above-nav')
+        ) {
+            const hasTruskin = bodyEl
+                ? bodyEl.classList.contains('truskin-page-skin')
+                : false;
+            const header = document.querySelector('.new-header');
+            const footer = document.querySelector('.l-footer');
+            const topBannerAd = document.querySelector(
+                '.ad-slot--top-banner-ad'
+            );
 
-            if (header) {
-                shrinkElement(header);
+            if (hasTruskin && header && topBannerAd) {
+                initTopPositionOnce(hasTruskin);
+
+                if (header) {
+                    shrinkElement(header);
+                }
+                if (footer) {
+                    shrinkElement(footer);
+                }
+
+                if (window.pageYOffset === 0) {
+                    moveBackgroundVerticalPosition(topPosition);
+                }
+
+                const headerBoundaries = header.getBoundingClientRect();
+                const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
+                const headerPosition = headerBoundaries.top;
+                const topBannerBottom = topBannerAdBoundaries.bottom;
+                const fabricScrollStartPosition =
+                    topBannerAdBoundaries.height +
+                    adLabelHeight -
+                    headerBoundaries.height;
+
+                if (
+                    headerPosition <= fabricScrollStartPosition &&
+                    topBannerBottom > 0
+                ) {
+                    moveBackgroundVerticalPosition(topBannerBottom);
+                } else if (topBannerBottom <= 0) {
+                    moveBackgroundVerticalPosition(0);
+                }
             }
-            if (footer) {
-                shrinkElement(footer);
-            }
-
-            if (window.pageYOffset === 0) {
-                moveBackgroundVerticalPosition(topPosition);
-            }
-
-            const headerBoundaries = header.getBoundingClientRect();
-            const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
-            const headerPosition = headerBoundaries.top;
-            const topBannerBottom = topBannerAdBoundaries.bottom;
-            const fabricScrollStartPosition =
-                topBannerAdBoundaries.height +
-                adLabelHeight -
-                headerBoundaries.height;
-
-            if (
-                headerPosition <= fabricScrollStartPosition &&
-                topBannerBottom > 0
-            ) {
-                moveBackgroundVerticalPosition(topBannerBottom);
-            } else if (topBannerBottom <= 0) {
-                moveBackgroundVerticalPosition(0);
-            }
-        }
-
-        // This is to reposition the Page Skin to start where the navigation header ends.
-        if (!hasTruskin && hasPageSkin && isInAUEdition) {
-            initTopPositionOnce(false);
-            if (window.pageYOffset === 0) {
-                moveBackgroundVerticalPosition(topPosition);
-            } else if (window.pageXOffset <= topPosition) {
-                moveBackgroundVerticalPosition(
-                    topPosition - window.pageYOffset
-                );
-            }
-            if (window.pageYOffset > topPosition) {
-                moveBackgroundVerticalPosition(0);
+            // This is to reposition the Page Skin to start where the navigation header ends.
+            if (!hasTruskin && hasPageSkin && isInAUEdition) {
+                initTopPositionOnce(false);
+                if (window.pageYOffset === 0) {
+                    moveBackgroundVerticalPosition(topPosition);
+                } else if (window.pageXOffset <= topPosition) {
+                    moveBackgroundVerticalPosition(
+                        topPosition - window.pageYOffset
+                    );
+                }
+                if (window.pageYOffset > topPosition) {
+                    moveBackgroundVerticalPosition(0);
+                }
             }
         }
     };

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -64,7 +64,7 @@ const pageSkin = (): void => {
     const renderedSlotElementIds = [];
 
     const repositionSkin = (event): void => {
-        if (event.slot) {
+        if (event && event.slot) {
             renderedSlotElementIds.push(event.slot.getSlotElementId());
         }
         if (


### PR DESCRIPTION
## What does this change?
After the release of the Truskins yesterday (https://github.com/guardian/frontend/pull/22283) an issue was observed that occasionally an additional whitespace was added between the top banner and the pageskin

This is a potential fix thats waits for both slots to load before repositioning them to form one image. Have been tested locally and on the code and so far looks good.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
![Picture 27](https://user-images.githubusercontent.com/51630004/74438210-8d70de00-4e61-11ea-8b2e-45c2880133db.png)

### After
<img width="1424" alt="Screenshot 2020-02-13 at 13 02 12" src="https://user-images.githubusercontent.com/51630004/74438236-982b7300-4e61-11ea-909e-05345b26f0e0.png">


## What is the value of this and can you measure success?
Fixes visual issue and improves ad visual performance

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

