### PR TITLE
Geolocation getSync can return null

### DIFF
--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -47,14 +47,15 @@ const init = (): void => {
     get().then(setGeolocation);
 };
 
-const editionToGeolocation = (editionKey: string = 'UK'): string =>
+const editionToGeolocation = (editionKey: string = 'UK'): ?string =>
     editionToGeolocationMap[editionKey];
 
-const getSync = (): string => {
+const getSync = (): ?string => {
     const geolocationFromStorage = getFromStorage();
     return (
         geolocationFromStorage ||
-        editionToGeolocation(config.get('page.edition'))
+        editionToGeolocation(config.get('page.edition')) ||
+        null
     );
 };
 
@@ -378,7 +379,7 @@ const countryGroups: CountryGroups = {
 
 // These are the different 'country groups' we accept when taking payment.
 // See https://github.com/guardian/support-internationalisation/blob/master/src/main/scala/com/gu/i18n/CountryGroup.scala for more context.
-const countryCodeToCountryGroupId = (countryCode: string): CountryGroupId => {
+const countryCodeToCountryGroupId = (countryCode: ?string): CountryGroupId => {
     const availableCountryGroups = Object.keys(countryGroups);
     let response = null;
     availableCountryGroups.forEach(countryGroup => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
@@ -28,7 +28,7 @@ const stripPrefix = (s: string, prefix: string): string => {
     return s.replace(re, '');
 };
 
-const currentGeoLocation = once((): string => geolocationGetSync());
+const currentGeoLocation = once((): ?string => geolocationGetSync());
 
 const contains = (
     sizes: HeaderBiddingSize[],

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -66,7 +66,7 @@ export type ReaderRevenueRegion =
     | 'australia'
     | 'rest-of-world';
 
-const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
+const getReaderRevenueRegion = (geolocation: ?string): ReaderRevenueRegion => {
     switch (geolocation) {
         case 'GB':
             return 'united-kingdom';

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
@@ -50,7 +50,7 @@ export const isBlocked = (
     switches: Array<string> = allSwitches,
     switchBlockConfig: SwitchBlockConfig = defaultSwitchConfig,
     pathname: string = document.location.pathname,
-    geolocation: string = getSync()
+    geolocation: ?string = getSync()
 ): boolean => {
     // the enabled block configurations that apply to the provided geolocation
     const activeBlockConfigs: Array<BlockConfig> = switches

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -117,7 +117,8 @@ const showPreviousVariant = (asExistingSupporter: boolean = false): void => {
 
 const changeGeolocation = (asExistingSupporter: boolean = false): void => {
     const geo = window.prompt(
-        `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${geolocationGetSync()}.`
+        `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${geolocationGetSync() ||
+            'undefined'}.`
     );
     if (geo === 'UK') {
         alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-appnexus-us-adapter.js
@@ -2,7 +2,7 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import once from 'lodash/once';
 
-const currentGeoLocation = once((): string => geolocationGetSync());
+const currentGeoLocation = once((): ?string => geolocationGetSync());
 
 export const appnexusUSAdapter: ABTest = {
     id: 'CommercialAppnexusUsAdapter',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-pangaea-adapter.js
@@ -2,7 +2,7 @@
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import once from 'lodash/once';
 
-const currentGeoLocation = once((): string => geolocationGetSync());
+const currentGeoLocation = once((): ?string => geolocationGetSync());
 
 export const pangaeaAdapterTest: ABTest = {
     id: 'CommercialPangaeaAdapter',


### PR DESCRIPTION
## What does this change?

The types here aren’t quite right, which caused confusion elsewhere since we were always expecting to get a country code back from getSync. The scenario in which it can return null is if there’s no country code in local storage and we _do_ have a page.edition, but it doesn’t
map to a geolocation (e.g. INT).

This had a ripple effect in a bunch of other places, so I updated types in a few spots. I think in all cases given our usage of country code it’s okay if the country code is empty.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Tested

I ran this locally and don't see anything obviously wrong. In theory this is almost all Flow changes. The exception is the return value from `getSync` will now be `null` rather than `undefined` if we can't figure out a country, which I _think_ makes more sense.

- [ ] Locally
- [ ] On CODE (optional)