### PR TITLE
Remove commercial youtube pfp ad targeting switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -612,19 +612,6 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
-<<<<<<< HEAD
-  val youtubePfpAdTargeting: Switch = Switch(
-    group = Commercial,
-    name = "commercial-youtube-pfp-ad-targeting",
-    description = "YouTube's PfP ad targeting parameters",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = new LocalDate(2021, 2, 17),
-    exposeClientSide = true
-  )
-
-=======
->>>>>>> remove commercialYoutubePfpAdTargeting switch
   val pangaeaUsAuBidder: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-pangaea-us-au",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -612,6 +612,7 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+<<<<<<< HEAD
   val youtubePfpAdTargeting: Switch = Switch(
     group = Commercial,
     name = "commercial-youtube-pfp-ad-targeting",
@@ -622,6 +623,8 @@ trait PrebidSwitches {
     exposeClientSide = true
   )
 
+=======
+>>>>>>> remove commercialYoutubePfpAdTargeting switch
   val pangaeaUsAuBidder: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-pangaea-us-au",

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -101,23 +101,22 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
 
 const createAdsConfig = (
     adFree: boolean,
-    wantPersonalisedAds: boolean,
-    isPfpAdTargetingSwitchedOn: boolean
+    wantPersonalisedAds: boolean
 ): Object => {
     if (adFree) {
         return { disableAds: true };
-    } else if (isPfpAdTargetingSwitchedOn) {
-        const custParams = getPageTargeting();
-        custParams.permutive = getPermutivePFPSegments();
-        return {
-            nonPersonalizedAd: !wantPersonalisedAds,
-            adTagParameters: {
-                iu: config.get('page.adUnit'),
-                cust_params: encodeURIComponent(constructQuery(custParams)),
-            },
-        };
     }
-    return { nonPersonalizedAd: !wantPersonalisedAds };
+
+    const custParams = getPageTargeting();
+    custParams.permutive = getPermutivePFPSegments();
+
+    return {
+        nonPersonalizedAd: !wantPersonalisedAds,
+        adTagParameters: {
+            iu: config.get('page.adUnit'),
+            cust_params: encodeURIComponent(constructQuery(custParams)),
+        },
+    };
 };
 
 const setupPlayer = (
@@ -128,10 +127,6 @@ const setupPlayer = (
     onStateChange,
     onError
 ) => {
-    const isPfpAdTargetingSwitchedOn: boolean = config.get(
-        'switches.commercialYoutubePfpAdTargeting',
-        false
-    );
     const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
     // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
     const relatedChannels = [];
@@ -145,8 +140,7 @@ const setupPlayer = (
 
     const adsConfig = createAdsConfig(
         commercialFeatures.adFree,
-        !!consentState,
-        isPfpAdTargetingSwitchedOn
+        !!consentState
     );
 
     return new window.YT.Player(elt.id, {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -39,7 +39,6 @@ describe('create ads config', () => {
     it('disables ads in ad-free', () => {
         const result = youtubePlayer.createAdsConfig(
             true, // ad-free
-            false,
             false
         );
 
@@ -47,13 +46,13 @@ describe('create ads config', () => {
     });
 
     it('does not disable ads when we are not in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(false, false, false);
+        const result = youtubePlayer.createAdsConfig(false, false);
 
         expect(result.disableAds).toBeFalsy();
     });
 
     it('in non ad-free, returns false nonPersonalizedAds without consent', () => {
-        const result = youtubePlayer.createAdsConfig(false, false, false);
+        const result = youtubePlayer.createAdsConfig(false, false);
 
         if (result.hasOwnProperty('nonPersonalizedAd')) {
             expect(result.nonPersonalizedAd).toBeTruthy();
@@ -63,49 +62,20 @@ describe('create ads config', () => {
     it('in non ad-free, returns true nonPersonalizedAds with consent', () => {
         const result = youtubePlayer.createAdsConfig(
             false,
-            true, // consent
-            false
+            true // consent
         );
 
         expect(result.nonPersonalizedAd).toBeFalsy();
     });
 
-    it('in non ad-free and pfp variant, returns true nonPersonalizedAds with consent', () => {
-        const result = youtubePlayer.createAdsConfig(
-            false,
-            true, // consent
-            true // pfp variant
-        );
-
-        expect(result.nonPersonalizedAd).toBeFalsy();
-    });
-
-    it('in non ad-free and pfp variant, returns false nonPersonalizedAds without consent', () => {
-        const result = youtubePlayer.createAdsConfig(
-            false,
-            false,
-            true // pfp variant
-        );
-
-        expect(result.nonPersonalizedAd).toBeTruthy();
-    });
-
-    it('in non ad-free and pfp variant, includes adUnit', () => {
-        const result = youtubePlayer.createAdsConfig(
-            false,
-            false,
-            true // pfp variant
-        );
+    it('in non ad-free includes adUnit', () => {
+        const result = youtubePlayer.createAdsConfig(false, false);
 
         expect(result.adTagParameters.iu).toEqual('adunit');
     });
 
-    it('in non ad-free and pfp variant, includes url-escaped targeting params', () => {
-        const result = youtubePlayer.createAdsConfig(
-            false,
-            false,
-            true // pfp variant
-        );
+    it('in non ad-free includes url-escaped targeting params', () => {
+        const result = youtubePlayer.createAdsConfig(false, false);
 
         expect(result.adTagParameters.cust_params).toEqual(
             'key%3Dvalue%26permutive%3D42'


### PR DESCRIPTION
## What does this change?

This PR removes the `commercial-youtube-pfp-ad-targeting` switch as this feature is now stable and won't ever need to be switched off. The switch should therefore be removed, leaving the feature permanently in place.

This will mean we no longer need to keep bumping the sell by date!