### PR TITLE
Add body end slot switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -462,4 +462,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val slotBodyEnd = Switch(
+    SwitchGroup.Feature,
+    "slot-body-end",
+    "If on, will populate body end slot from Slot Machine (note, only relevant to DCR for now)",
+    owners = Seq(Owner.withEmail("slot.machine.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
This is a kill switch for the body-end slot. Initially it will be used for DCR to toggle remote loading of the epic.

Wrote together with @andre1050 