### PR TITLE
Remove grey background on free text cards with image

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -130,11 +130,9 @@
 }
 
 @freeTextWithImage(card: ContentCard, collectionName: String) = {
-    @faciaCard(classesForCard(card)) {
-@*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
+        @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
         @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
         @row(Seq("free-text"))(Html(card.header.headline))
-    }
 }
 
 @freeText(text: String) = {


### PR DESCRIPTION
## What does this change?

- Render free text cards with images as table rows rather than as a facia card

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

<img width="525" alt="Screenshot 2020-02-19 at 09 14 53" src="https://user-images.githubusercontent.com/5931528/74819472-59316d80-52f8-11ea-826d-13ce343ab108.png">

**After**

<img width="524" alt="Screenshot 2020-02-19 at 09 15 38" src="https://user-images.githubusercontent.com/5931528/74819526-6e0e0100-52f8-11ea-9c5f-f989c18232b4.png">

## What is the value of this and can you measure success?

This removes the grey background from free text cards with images. This brings it into line with free text cards that don't have images.

This looks like a bug that I introduced 2 years ago (#19689) when adding images to free text cards.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

Nooooo, just emails

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
