### PR TITLE
Load Guardian Text Egyptian on email fronts

### DIFF
--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -26,6 +26,14 @@ $cta-font-color: #000000;
     font-style: normal;
 }
 
+@font-face {
+    font-family: 'Guardian Egyptian Text';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2') format('woff2'), url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+    font-stretch: normal;
+}
+
 // table
 .fc,
 .row,
@@ -51,7 +59,7 @@ $cta-font-color: #000000;
 }
 
 .free-text {
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: 'Guardian Egyptian Text', Georgia, serif;
     font-size: 14px;
     line-height: 18px;
     padding: 6px $gutter;

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -60,8 +60,8 @@ $cta-font-color: #000000;
 
 .free-text {
     font-family: 'Guardian Egyptian Text', Georgia, serif;
-    font-size: 14px;
-    line-height: 18px;
+    font-size: 15px;
+    line-height: 20px;
     padding: 6px $gutter;
 
     a {


### PR DESCRIPTION
## What does this change?

- Load `Guardian Text Egyptian` on email fronts and applies it `EmailFreeText` cards.
- Bump the font size slightly to 15px, and line-height to 20px

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

<img width="507" alt="Screenshot 2020-02-19 at 10 47 56" src="https://user-images.githubusercontent.com/5931528/74827412-4f623700-5305-11ea-8f0e-4172e2e546e7.png">

**After**

<img width="520" alt="Screenshot 2020-02-19 at 11 55 55" src="https://user-images.githubusercontent.com/5931528/74832259-cfd96580-530e-11ea-8e96-3f1a77a15ff3.png">


## What is the value of this and can you measure success?

With the upcoming Europe Moment, there is a desire from Editorial to spruce up the free text cards. These are used heavily in the [This Is Europe email](https://www.theguardian.com/email/this-is-europe) (and elsewhere). 

One thing that will make them more readable is to present them using a better reading font, namely our beloved Guardian Text Egyptian.

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)
