### PR TITLE
Bump @guardian/consent-management-platform to 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.8",
+    "@guardian/consent-management-platform": "2.0.9",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,14 +1166,14 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.8.tgz#64357857be785136302dfffcfcd447a4a33b97dd"
-  integrity sha512-71RKQ4z383RT5J12ySLOxAih/fcrE2VNCibwd8JYSn021grhGT1WtrhJokazuuBFN/TRoUUJuX6fgNCXndhDhg==
+"@guardian/consent-management-platform@2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.9.tgz#96247e7ca516e447aaad88cc8d7ef9e756211466"
+  integrity sha512-tqmw5+DssU35Vr1HlcKWtOLgoyE01nYnDhRA4SQ/IabSYt7PqkVtdgbeKJDnpPIUvFfjk1PgHZsBSH1D0SVs5A==
   dependencies:
-    "@guardian/src-button" "^0.5.1"
-    "@guardian/src-foundations" "^0.10.0"
-    "@guardian/src-svgs" "^0.0.6"
+    "@guardian/src-button" "^0.13.0"
+    "@guardian/src-foundations" "^0.13.0"
+    "@guardian/src-svgs" "^0.13.0"
     consent-string "^1.5.1"
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
@@ -1190,20 +1190,22 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/src-button@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.5.1.tgz#b107a5a075e2ad41c59f3d52429a614273f247de"
-  integrity sha512-4i4o+qCd6o/W0Xi5IKcLz0aS+NUBNdBien5pmPlbcRIq/0TBVt7XAKxK4avrf7BiCWAAAtg/0ejq8AWx0wlPjw==
+"@guardian/src-button@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.13.0.tgz#0071e83dff911d43a700fbaaa659ed741bdd486d"
+  integrity sha512-ykKQ1IgU6fWvysmCmj3HWVYql0Hc/WuzYGZMh7EDDAB39YEfbH54ZMjYM3+SNkqoa0yNqRRhivCFpMyPm3mjpA==
+  dependencies:
+    "@guardian/src-svgs" "^0.13.0"
 
-"@guardian/src-foundations@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.10.0.tgz#b7773484f2b9e661d31f1d400950a83fb261fe63"
-  integrity sha512-w5xvrYqCLngxFUsivhVhJ35EppFi2GtPMAUxN6EG/Hc9FDD3qiWHiT0nwSPOReNq3UXOLH6DxbNxanFVaOelCg==
+"@guardian/src-foundations@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
+  integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
-"@guardian/src-svgs@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.0.6.tgz#f8ec43935c5df3860f69cc356b9574a7a72c28e0"
-  integrity sha512-qlHe80XVEyTeiolgNjLsrq7z+19acIa0XIfMByAjo8zDw85S58Fjp/b0XYsYc0V7G8XamZRnMgjFNdF++FUZEw==
+"@guardian/src-svgs@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.13.0.tgz#97d893a6e33feb255666fef6779ffe18a7c4e2f5"
+  integrity sha512-cDIGNOaatYVDk+eWCv2cAdBlXZ2ECDxOcc897GowJYCHmy+HifL0AvzHlHRLKYRQXzVcaPfoXDOjVonA4ViHqw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/consent-management-platform` to `2.0.9` which contains accessibility improvement, details of which can be found at: https://github.com/guardian/consent-management-platform/releases/tag/2.0.9

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (will raise a similar PR)

## What is the value of this and can you measure success?

CMP UI is more accessible for users navigating with a keyboard

### Tested

- [x] Locally