### PR TITLE
Email fronts: ensure URL is valid before making image a link

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import conf.Static
-import layout.ContentCard
+import layout.{ContentCard, EditionalisedLink}
 import model._
 import play.twirl.api.Html
 import play.api.mvc._
@@ -52,7 +52,16 @@ object EmailHelpers {
   def imgFromCard(card: ContentCard, colWidth: Int = 12, altTextOverride: Option[String] = None)(implicit requestHeader: RequestHeader): Option[Html] = {
     val width = ((colWidth.toDouble / 12.toDouble) * EmailImageParams.fullWidth).toInt
     imageUrlFromCard(card, width).map { url => Html {
-        s"""<a ${card.header.url.hrefWithRel}>${img(width)(url, Some(altTextOverride.getOrElse(card.header.headline)))}</a>"""
+        val urlMatcher = raw"^(https?|/).*".r
+
+        card.header.url match {
+          case EditionalisedLink(urlMatcher(baseUrl)) => {
+            s"""<a ${card.header.url.hrefWithRel}>${img(width)(url, Some(altTextOverride.getOrElse(card.header.headline)))}</a>"""
+          }
+          case _ => {
+            s"""${img(width)(url, Some(altTextOverride.getOrElse(card.header.headline)))}"""
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## What does this change?

Provide a really simple regex to ensure that when an image is rendered in an email, it will be a link if and only if the link is formatted like a valid absolute or relative URL (i.e. it starts in `http` or `/`).

The regex is not exhaustive, but good enough to catch a dummy value being passed from the Fronts tool.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Free text snaps are used in different ways:

1. to add arbitrary text / HTML to an email front (usually with no image)
2. to add an advert to an email front (usually with an image)

When a free text snap is added to an email front, the fronts editor may or may not provide a URL and may or may not provide an image:

- If there is no image in the snap, the URL is not used. If an editor provides one, it is ignored in frontend
- If there is an image, the image is wrapped in the provided URL
- But what happens if there is an image and no URL?

If no URL is provided by the fronts editor, the Fronts tool always generates a random ID and passes this to the client as a URL. This is for [de-duping reasons](https://github.com/guardian/facia-tool/pull/1105). The image is made into a link, but the href is set to some randomly generated ID. Not great.

So what do we do about the image-but-no-URL scenario? We test to see if the URL is a dummy value generated by the Fronts tool, and if it is, we don't make the image a link.

**Someone with razor sharp Scala eyes should ensure I'm doing what I think I ought to be doing! Please let me know if there's a better way.**

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
