### PR TITLE
Move cutouts below free text

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -1,3 +1,4 @@
+@import model.pressed.Cutout
 @()(implicit page: model.PressedPage, request: RequestHeader)
 
 @import layout.slices.EmailLayouts
@@ -135,6 +136,12 @@
         @row(Seq("free-text"))(Html(card.header.headline))
 }
 
+@freeTextWithCutoutImage(card: ContentCard, collectionName: String) = {
+        @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
+    @row(Seq("free-text"))(Html(card.header.headline))
+    @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
+}
+
 @freeText(text: String) = {
     @fullRow(Seq("free-text"))(Html(text))
 }
@@ -146,7 +153,14 @@
             @freeText(card.header.headline)
         }
         case EmailFreeText => {
-            @freeTextWithImage(card, collectionName)
+            @card.properties.map(_.image) match {
+                case Some(Some(Cutout(_, _, _))) => {
+                    @freeTextWithCutoutImage(card, collectionName)
+                }
+                case _ => {
+                    @freeTextWithImage(card, collectionName)
+                }
+            }
         }
         case layoutStyle: EmailFaciaCard => {
             @card.cardStyle match {


### PR DESCRIPTION
## What does this change?

If the image provided to a free text snap is a cutout, it appears below the text.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="525" alt="Screenshot 2020-02-19 at 16 49 24" src="https://user-images.githubusercontent.com/5931528/74855258-5bb3b780-5338-11ea-9749-91d2780b1a71.png">

**Note:** this screenshot does not perfectly exemplify our intention with this change because there is currently a restriction in the Fronts tool that insists on the cutout replacement being 5:3 aspect ratio. When this restriction is lifted, we can start doing beautiful things with this layout variation.

## What is the value of this and can you measure success?

For the Europe Moment, we want to support adding a byline cutout to the free text snap that appears at the top of the email.

Currently, free text snaps support adding a replacement image or a cutout image. We want cutouts to appear at the bottom of the snap. AAll other images should continue to appear at the top.

No other email is using the cutout image in this way, so this should be safe to implement without affecting other emails.

**As in previous PR (#22309) someone with razor sharp Scala eyes should ensure I'm doing what I think I ought to be doing! Please let me know if there's a better way.**

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
