### PR TITLE
Load italic and bold fonts on email fronts

### DIFF
--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -29,9 +29,20 @@ $cta-font-color: #000000;
 @font-face {
     font-family: 'Guardian Egyptian Text';
     src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2') format('woff2'), url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff') format('woff');
-    font-weight: normal;
+    font-weight: 400;
     font-style: normal;
-    font-stretch: normal;
+}
+@font-face {
+    font-family: 'Guardian Egyptian Text';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2') format('woff2'), url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+}
+@font-face {
+    font-family: 'Guardian Egyptian Text';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2') format('woff2'), url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff') format('woff');
+    font-weight: 400;
+    font-style: italic;
 }
 
 // table


### PR DESCRIPTION
## What does this change?

Load italic and bold variants of Guardian Egyptian Web on email fronts

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

![Screenshot 2020-02-20 at 11 57 22](https://user-images.githubusercontent.com/5931528/74931796-4aba8300-53d8-11ea-8979-0ebcb17d43fb.png)

**After**

![Screenshot 2020-02-20 at 11 57 07](https://user-images.githubusercontent.com/5931528/74931793-49895600-53d8-11ea-81ad-dd5714e2b771.png)

## What is the value of this and can you measure success?

Bold and italic text in free text snaps looks a bit weedy at present.

Loading the correct fonts ensures the text is displayed in its full glory.

We are adding these fonts primarily for the _This is Europe_ newsletter as part of the Europe Moment campaign. 

**Note:** this adds ~800 bytes to the email weight

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
