### PR TITLE
Fix truskins on slow network for AUS

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -8,11 +8,10 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 const pageSkin = (): void => {
     const bodyEl = document.body;
     const hasPageSkin: boolean = config.get('page.hasPageSkin');
-
     const isInAUEdition = config.get('page.edition', '').toLowerCase() === 'au';
     const adLabelHeight = 24;
-
     let topPosition: number = 0;
+    let hasTruskin: boolean = false;
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
@@ -41,7 +40,7 @@ const pageSkin = (): void => {
         }
     };
 
-    const initTopPositionOnce = (hasTruskin: boolean): void => {
+    const initTopPositionOnce = (): void => {
         if (topPosition === 0) {
             const navHeader = document.getElementsByClassName('new-header')[0];
             if (navHeader) {
@@ -61,75 +60,86 @@ const pageSkin = (): void => {
         }
     };
 
-    const renderedSlotElementIds = [];
+    const repositionTruskin = (
+        header: HTMLElement,
+        footer: HTMLElement,
+        topBannerAd: HTMLElement
+    ): void => {
+        initTopPositionOnce();
+        shrinkElement(header);
+        shrinkElement(footer);
 
-    const repositionSkin = (event): void => {
-        if (event && event.slot) {
-            renderedSlotElementIds.push(event.slot.getSlotElementId());
+        if (window.pageYOffset === 0) {
+            moveBackgroundVerticalPosition(topPosition);
         }
+
+        const headerBoundaries = header.getBoundingClientRect();
+        const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
+        const headerPosition = headerBoundaries.top;
+        const topBannerBottom = topBannerAdBoundaries.bottom;
+        const fabricScrollStartPosition =
+            topBannerAdBoundaries.height +
+            adLabelHeight -
+            headerBoundaries.height;
+
         if (
-            renderedSlotElementIds.includes('dfp-ad--pageskin-inread') &&
-            renderedSlotElementIds.includes('dfp-ad--top-above-nav')
+            headerPosition <= fabricScrollStartPosition &&
+            topBannerBottom > 0
         ) {
-            const hasTruskin = bodyEl
-                ? bodyEl.classList.contains('truskin-page-skin')
-                : false;
-            const header = document.querySelector('.new-header');
-            const footer = document.querySelector('.l-footer');
-            const topBannerAd = document.querySelector(
-                '.ad-slot--top-banner-ad'
-            );
+            moveBackgroundVerticalPosition(topBannerBottom);
+        } else if (topBannerBottom <= 0) {
+            moveBackgroundVerticalPosition(0);
+        }
+    };
 
-            if (hasTruskin && header && topBannerAd) {
-                initTopPositionOnce(hasTruskin);
+    const repositionPageSkin = (): void => {
+        initTopPositionOnce();
+        if (window.pageYOffset === 0) {
+            moveBackgroundVerticalPosition(topPosition);
+        } else if (window.pageXOffset <= topPosition) {
+            moveBackgroundVerticalPosition(topPosition - window.pageYOffset);
+        }
+        if (window.pageYOffset > topPosition) {
+            moveBackgroundVerticalPosition(0);
+        }
+    };
 
-                if (header) {
-                    shrinkElement(header);
-                }
-                if (footer) {
-                    shrinkElement(footer);
-                }
+    const repositionSkin = (): void => {
+        const header = document.querySelector('.new-header');
+        const footer = document.querySelector('.l-footer');
+        const topBannerAd = document.querySelector('.ad-slot--top-banner-ad');
 
-                if (window.pageYOffset === 0) {
-                    moveBackgroundVerticalPosition(topPosition);
-                }
-
-                const headerBoundaries = header.getBoundingClientRect();
-                const topBannerAdBoundaries = topBannerAd.getBoundingClientRect();
-                const headerPosition = headerBoundaries.top;
-                const topBannerBottom = topBannerAdBoundaries.bottom;
-                const fabricScrollStartPosition =
-                    topBannerAdBoundaries.height +
-                    adLabelHeight -
-                    headerBoundaries.height;
-
-                if (
-                    headerPosition <= fabricScrollStartPosition &&
-                    topBannerBottom > 0
-                ) {
-                    moveBackgroundVerticalPosition(topBannerBottom);
-                } else if (topBannerBottom <= 0) {
-                    moveBackgroundVerticalPosition(0);
-                }
-            }
-            // This is to reposition the Page Skin to start where the navigation header ends.
-            if (!hasTruskin && hasPageSkin && isInAUEdition) {
-                initTopPositionOnce(false);
-                if (window.pageYOffset === 0) {
-                    moveBackgroundVerticalPosition(topPosition);
-                } else if (window.pageXOffset <= topPosition) {
-                    moveBackgroundVerticalPosition(
-                        topPosition - window.pageYOffset
-                    );
-                }
-                if (window.pageYOffset > topPosition) {
-                    moveBackgroundVerticalPosition(0);
-                }
-            }
+        if (hasTruskin && header && topBannerAd && footer) {
+            repositionTruskin(header, footer, topBannerAd);
+        }
+        // This is to reposition the Page Skin to start where the navigation header ends.
+        if (!hasTruskin && hasPageSkin && isInAUEdition) {
+            repositionPageSkin();
         }
     };
 
     togglePageSkin();
+
+    const removeTopAdBorder = (): void => {
+        const topBannerAdContainer = document.querySelector(
+            '.top-banner-ad-container'
+        );
+        if (topBannerAdContainer) {
+            topBannerAdContainer.style.borderBottom = 'none';
+        }
+    };
+
+    window.addEventListener(
+        'message',
+        event => {
+            if (event.data === 'truskinRendered') {
+                hasTruskin = true;
+                removeTopAdBorder();
+                repositionSkin();
+            }
+        },
+        false
+    );
 
     mediator.on('window:throttledResize', togglePageSkin);
     mediator.on('window:throttledScroll', repositionSkin);

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -129,6 +129,8 @@ const pageSkin = (): void => {
     window.addEventListener(
         'message',
         event => {
+            // This event is triggered by the commercial template Truskin to indicate the page skin is also a Truskin
+            // found it: commercial-templates/src/truskin-page-skin/web/index.js
             if (event.data === 'truskinRendered') {
                 truskinRendered = true;
                 repositionSkin();

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -130,7 +130,7 @@ const pageSkin = (): void => {
         'message',
         event => {
             // This event is triggered by the commercial template Truskin to indicate the page skin is also a Truskin
-            // found it: commercial-templates/src/truskin-page-skin/web/index.js
+            // found in: commercial-templates/src/truskin-page-skin/web/index.js
             if (event.data === 'truskinRendered') {
                 truskinRendered = true;
                 repositionSkin();

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -11,7 +11,7 @@ const pageSkin = (): void => {
     const isInAUEdition = config.get('page.edition', '').toLowerCase() === 'au';
     const adLabelHeight = 24;
     let topPosition: number = 0;
-    let hasTruskin: boolean = false;
+    let truskinRendered: boolean = false;
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
@@ -44,7 +44,7 @@ const pageSkin = (): void => {
         if (topPosition === 0) {
             const navHeader = document.getElementsByClassName('new-header')[0];
             if (navHeader) {
-                topPosition = hasTruskin
+                topPosition = truskinRendered
                     ? navHeader.offsetTop + adLabelHeight
                     : navHeader.offsetTop + navHeader.offsetHeight;
             }
@@ -65,6 +65,12 @@ const pageSkin = (): void => {
         footer: HTMLElement,
         topBannerAd: HTMLElement
     ): void => {
+        const topBannerAdContainer = document.querySelector(
+            '.top-banner-ad-container'
+        );
+        if (topBannerAdContainer) {
+            topBannerAdContainer.style.borderBottom = 'none';
+        }
         initTopPositionOnce();
         shrinkElement(header);
         shrinkElement(footer);
@@ -109,32 +115,22 @@ const pageSkin = (): void => {
         const footer = document.querySelector('.l-footer');
         const topBannerAd = document.querySelector('.ad-slot--top-banner-ad');
 
-        if (hasTruskin && header && topBannerAd && footer) {
+        if (truskinRendered && header && topBannerAd && footer) {
             repositionTruskin(header, footer, topBannerAd);
         }
         // This is to reposition the Page Skin to start where the navigation header ends.
-        if (!hasTruskin && hasPageSkin && isInAUEdition) {
+        if (!truskinRendered && hasPageSkin && isInAUEdition) {
             repositionPageSkin();
         }
     };
 
     togglePageSkin();
 
-    const removeTopAdBorder = (): void => {
-        const topBannerAdContainer = document.querySelector(
-            '.top-banner-ad-container'
-        );
-        if (topBannerAdContainer) {
-            topBannerAdContainer.style.borderBottom = 'none';
-        }
-    };
-
     window.addEventListener(
         'message',
         event => {
             if (event.data === 'truskinRendered') {
-                hasTruskin = true;
-                removeTopAdBorder();
+                truskinRendered = true;
                 repositionSkin();
             }
         },

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -87,10 +87,6 @@
     overflow: hidden;
 }
 
-.truskin-page-skin .top-banner-ad-container {
-    border-bottom: 0;
-}
-
 .sticky-top-banner-ad {
     transform: translate3d(0, 0, 0);
     contain: layout;


### PR DESCRIPTION
Co-authored-by: Josh Buckland <buck06191@gmail.com>

## What does this change?

This is a fix for truskins which went out of sync on slow networks. The truskin was not working as expected because the fabric & the truskin weren't loaded at the same time. Sending an event to the frontend from the commercial template (https://github.com/guardian/commercial-templates/pull/232) and listening it to the frontend makes sure both are rendered before we do the calculations for repositioning them

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/51630004/74932117-f368e280-53d8-11ea-874a-bcc501a7e9f6.png)

### After
![image](https://user-images.githubusercontent.com/51630004/74932159-0b406680-53d9-11ea-9b89-99646b47486f.png)

## What is the value of this and can you measure success?
Fixes ad experience on slow network

### Tested

- [x] Locally
- [ ] On CODE (optional)

