### PR TITLE
Remove old code for handling adslot resize

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -46,7 +46,6 @@ const resize = (
     }
 
     return fastdom.write(() => {
-        Object.assign(adSlot.style, styles);
         Object.assign(iframe.style, styles);
 
         if (iframeContainer) {
@@ -68,18 +67,6 @@ const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
             const adSlot = iframe && iframe.closest('.js-ad-slot');
-
-            if (
-                adSlot &&
-                (adSlot.classList.contains('ad-slot--mostpop') ||
-                    adSlot.classList.contains('ad-slot--right') ||
-                    adSlot.classList.contains('ad-slot--offset-right'))
-            ) {
-                // We ignore resize events (sent mainly by apnx)
-                // for the mostpop (Most popular) slot
-                // See https://trello.com/c/TtuGq6Iy
-                return null;
-            }
             removeAnyOutstreamClass(adSlot);
             const iframeContainer =
                 iframe && iframe.closest('.ad-slot__content');

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -10,7 +10,7 @@ describe('Cross-frame messenger: resize', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
-              <div id="slot01" class="js-ad-slot">
+              <div id="slot01" class="js-ad-slot" style="width: 7px; height: 14px;" >
                 <div id="container01">
                     <div id="iframe01" class="iframe" data-unit="ch"></div>
                 </div>
@@ -64,7 +64,7 @@ describe('Cross-frame messenger: resize', () => {
             expect(result).toBeNull();
         });
 
-        it('should set width and height of the ad slot', () => {
+        it('should set width and height of the iFrame and leave ad slot unchanged', () => {
             const fallback = document.createElement('div');
             const fakeIframeContainer =
                 document.getElementById('container01') || fallback;
@@ -80,8 +80,8 @@ describe('Cross-frame messenger: resize', () => {
             ).then(() => {
                 expect(fakeIframe.style.height).toBe('10px');
                 expect(fakeIframe.style.width).toBe('20px');
-                expect(fakeAdSlot.style.height).toBe('10px');
-                expect(fakeAdSlot.style.width).toBe('20px');
+                expect(fakeAdSlot.style.height).toBe('14px');
+                expect(fakeAdSlot.style.width).toBe('7px');
             });
         });
     });


### PR DESCRIPTION
## What does this change?
On slow connections, ignoring iframe resize events causes adverts to
display poorly. The original decision to bypass resizing was due to
issues with the adslot resizing _as well as_ the iframe.

Here we have removed the adslot resize event and the bypassing of the
overall resize event for specific ad slot types.

### Relevant previous work: ###
Trello card to remove resize for `mostpop` ad slot.
https://trello.com/c/TtuGq6Iy/223-consider-banner-format-for-most-popular-slot-on-tablets
PR to remove resize for RHS and Inline2-n ad slots.
https://github.com/guardian/frontend/pull/21166

Co-authored-by: Ioanna Kyprianou <ioanna.kyprianou.contractor@guardian.co.uk>


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/9122944/75024515-73528380-5491-11ea-996e-4fe68c0a9040.png)

### After


## What is the value of this and can you measure success?

This fixes user experience problems on Guardian Labs paid content pages. A number of customers had complained about this particular ad slot type breaking on poor connections, particularly those in Australia. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)

The bug that triggered this change was found in a GLabs only ad slot.

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->