### PR TITLE
Add standfirst to free text snaps

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -130,35 +130,47 @@
     }
 }
 
-@freeTextWithImage(card: ContentCard, collectionName: String) = {
-        @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
-    @fullRow(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
-    @fullRow(Seq("free-text"))(Html(card.header.headline))
+@renderStandfirst(standfirst: Option[String]) = {
+    @standfirst match {
+        case Some(str) => {
+            @fullRow(Seq("free-text__standfirst"))(Html(str))
+        }
+        case _ => {}
+    }
 }
 
-@freeTextWithCutoutImage(card: ContentCard, collectionName: String) = {
-        @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
+@freeTextWithImage(card: ContentCard, collectionName: String, standfirst: Option[String]) = {
+        @renderStandfirst(standfirst)
+        @* here we override the alt text as 'headline' (normal alt text) may contain HTML *@
+        @fullRow(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
+        @fullRow(Seq("free-text"))(Html(card.header.headline))
+}
+
+@freeTextWithCutoutImage(card: ContentCard, collectionName: String, standfirst: Option[String]) = {
+    @renderStandfirst(standfirst)
     @fullRow(Seq("free-text"))(Html(card.header.headline))
+    @* here we override the alt text as 'headline' (normal alt text) may contain HTML *@
     @fullRow(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
 }
 
-@freeText(text: String) = {
+@freeText(text: String, standfirst: Option[String]) = {
+    @renderStandfirst(standfirst)
     @fullRow(Seq("free-text"))(Html(text))
 }
 
-@renderCard(card: ContentCard, cardStyle: EmailCardStyle, isBranded: Boolean, collectionName: String) = {
+@renderCard(card: ContentCard, cardStyle: EmailCardStyle, isBranded: Boolean, collectionName: String, standfirst: Option[String]) = {
     @cardStyle match {
         case EmailHidden => { }
         case EmailFreeText if card.displayElement.isEmpty => {
-            @freeText(card.header.headline)
+            @freeText(card.header.headline, standfirst)
         }
         case EmailFreeText => {
             @card.properties.map(_.image) match {
                 case Some(Some(Cutout(_, _, _))) => {
-                    @freeTextWithCutoutImage(card, collectionName)
+                    @freeTextWithCutoutImage(card, collectionName, standfirst)
                 }
                 case _ => {
-                    @freeTextWithImage(card, collectionName)
+                    @freeTextWithImage(card, collectionName, standfirst)
                 }
             }
         }
@@ -218,9 +230,10 @@
 
     @collection.cards.zipWithIndex.map { case (card, cardIndex) =>
         @if(cardIndex == 0) {
-            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).firstCard, collection.branding.isDefined, collection.displayName)
+            @* Hack for this-is-europe: the standfirst text comes from description added in the config screen in Fronts tool *@
+            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).firstCard, collection.branding.isDefined, collection.displayName, collection.config.description)
         } else {
-            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).otherCards, collection.branding.isDefined, collection.displayName)
+            @renderCard(card, EmailLayouts.layoutByName(collection.collectionType).otherCards, collection.branding.isDefined, collection.displayName, collection.config.description)
         }
     }
 }

--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -73,6 +73,14 @@ $cta-font-color: #000000;
     }
 }
 
+.free-text__standfirst {
+    font-family: 'Guardian Egyptian Text', Georgia, serif;
+    font-size: 20px;
+    line-height: 23px;
+    padding: 12px $gutter 26px;
+    border-bottom: 1px solid #121212;
+}
+
 // td
 .ct__margin {
     padding: 0 0 12px;


### PR DESCRIPTION
## What does this change?

- add a standfirst to free text snpas. The text for this comes from the "Description" field added to a collection in the config page of the Fronts page.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**With image at the bottom**

![Screenshot 2020-02-21 at 09 07 13](https://user-images.githubusercontent.com/5931528/75020431-a6dddf80-548a-11ea-8bf2-c89dd1cf1aa2.png)

**Without image**

![Screenshot 2020-02-21 at 09 07 27](https://user-images.githubusercontent.com/5931528/75020433-a7767600-548a-11ea-8355-6a0feb353dbe.png)

**With image at the top**

![Screenshot 2020-02-21 at 09 08 04](https://user-images.githubusercontent.com/5931528/75020435-a7767600-548a-11ea-89b1-4adc9133bcf9.png)

## What is the value of this and can you measure success?

A standfirst helps summarise what can sometimes be a lengthy introduction to an email newsletter. 

This was requested to support the work around the upcoming Europe "moment". It will only be used in the _This is Europe_ newsletter.

Yes, I know, this is a total hack until we can support standfirsts natively in the fronts tool.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
