### PR TITLE
Tidy up youtube endslate switch logic

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -127,7 +127,7 @@ const setupPlayer = (
     onStateChange,
     onError
 ) => {
-    const disableRelatedVideos = !config.get('switches.youtubeRelatedVideos');
+    const disableRelatedVideos = false;
     // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
     const relatedChannels = [];
     /**
@@ -136,7 +136,6 @@ const setupPlayer = (
      * shown. Therefore for the time being we will pass an
      * empty array.
      */
-    // const relatedChannels = !disableRelatedVideos && channelId ? [channelId] : [];
 
     const adsConfig = createAdsConfig(
         commercialFeatures.adFree,

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -391,7 +391,6 @@ const onPlayerReady = (
 
         if (
             !!config.get('page.section') &&
-            !config.get('switches.youtubeRelatedVideos') &&
             isBreakpoint({
                 min: 'desktop',
             })


### PR DESCRIPTION
## What does this change?
We are currently not showing the youtube related videos end slate after our videos. This introduces them again. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Current
![Screen Shot 2020-02-21 at 10 01 53](https://user-images.githubusercontent.com/2051501/75027697-e90d1e00-5496-11ea-9adf-3a5ba5c9dda1.png)

After fix:
![Screen Shot 2020-02-21 at 10 02 03](https://user-images.githubusercontent.com/2051501/75027703-ec080e80-5496-11ea-8c07-0adcca692b8b.png)

### Tested

- [ ] Locally
- [x] On CODE (optional)

