### PR TITLE
small refactoring in YouTube Player config

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -127,7 +127,6 @@ const setupPlayer = (
     onStateChange,
     onError
 ) => {
-    const disableRelatedVideos = false;
     // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
     const relatedChannels = [];
     /**
@@ -158,7 +157,6 @@ const setupPlayer = (
         },
         embedConfig: {
             relatedChannels,
-            disableRelatedVideos,
             adsConfig,
         },
     });


### PR DESCRIPTION
## What does this change?

Code cleaning and also `disableRelatedVideos` defaults to `false`.


