### PR TITLE
Fix full-width images in email fronts

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -132,14 +132,14 @@
 
 @freeTextWithImage(card: ContentCard, collectionName: String) = {
         @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
-        @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
-        @row(Seq("free-text"))(Html(card.header.headline))
+    @fullRow(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
+    @fullRow(Seq("free-text"))(Html(card.header.headline))
 }
 
 @freeTextWithCutoutImage(card: ContentCard, collectionName: String) = {
         @*        here we override the alt text as 'headline' (normal alt text) may contain HTML*@
-    @row(Seq("free-text"))(Html(card.header.headline))
-    @row(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
+    @fullRow(Seq("free-text"))(Html(card.header.headline))
+    @fullRow(Seq("no-pad")){@imgFromCard(card,altTextOverride = Some(collectionName))}
 }
 
 @freeText(text: String) = {


### PR DESCRIPTION
## What does this change?

Replace `rows` with `fullRows` when rendering free text snaps

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

![Screenshot 2020-02-21 at 13 15 32](https://user-images.githubusercontent.com/5931528/75037548-52e3f280-54ac-11ea-8370-f826f844e8de.png)


**After**

![Screenshot 2020-02-21 at 13 08 47](https://user-images.githubusercontent.com/5931528/75037107-51fe9100-54ab-11ea-848d-8a4968f089d7.png)

## What is the value of this and can you measure success?

This nasty bug manifested when there was more than one free-text snap containing an image on a page.

It's happening because I started using `row` instead of `fullRow` in #22303, and then propagated this further in #22309. This ended up producing malformed HTML that was not picked up in tests.

Lesson 1: [Always listen](https://github.com/guardian/frontend/pull/22303#discussion_r381166100) to @gtrufitt
Lesson 2: Always listen to @andre1050: "Make sure you validate your email HTML because email clients don't like malformed HTML"

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
