### PR TITLE
Fix discussion display name bug

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -4,8 +4,6 @@
     <div class="d-comment-box__meta">
         <span class="d-comment-box__avatar-wrapper"></span>
         <div class="d-comment-box__meta-text">
-            <span class="d-comment-box__author-label">Signed in as</span>
-            <span class="d-comment-box__author"></span>
             @fragments.inlineSvg("reply", "icon", List("grey"))
             <span class="d-comment-box__reply-to-author"></span>
             <span class="u-fauxlink d-comment-box__show-parent" role="button">Show comment</span>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -5,7 +5,11 @@ import bonzo from 'bonzo';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { Component } from 'common/modules/component';
-import { postComment, previewComment } from 'common/modules/discussion/api';
+import {
+    getUser,
+    postComment,
+    previewComment,
+} from 'common/modules/discussion/api';
 import {
     getUserFromCookie,
     reset,
@@ -23,6 +27,33 @@ type commentType = {
 };
 
 class CommentBox extends Component {
+    static async refreshUsernameHtml(): Promise<void> {
+        reset();
+
+        const discussionUserResponse = await getUser();
+
+        if (!discussionUserResponse || !discussionUserResponse.userProfile) {
+            return;
+        }
+
+        const discussionUser: DiscussionProfile =
+            discussionUserResponse.userProfile;
+
+        const displayName = discussionUser.displayName;
+        const menuHeaderUsername = document.querySelector('.js-profile-info');
+        const discussionHeaderUsername = document.querySelector(
+            '._author_tywwu_16'
+        );
+
+        if (menuHeaderUsername && displayName) {
+            menuHeaderUsername.innerHTML = displayName;
+        }
+
+        if (discussionHeaderUsername && displayName) {
+            discussionHeaderUsername.innerHTML = displayName;
+        }
+    }
+
     constructor(options: Object): void {
         super();
 
@@ -157,24 +188,6 @@ class CommentBox extends Component {
         this.removeState('invalid');
     }
 
-    refreshUsernameHtml(): void {
-        reset();
-
-        const displayName = this.getUserData().displayName;
-        const menuHeaderUsername = document.querySelector('.js-profile-info');
-        const discussionHeaderUsername = document.querySelector(
-            '._author_tywwu_16'
-        );
-
-        if (menuHeaderUsername && displayName) {
-            menuHeaderUsername.innerHTML = displayName;
-        }
-
-        if (discussionHeaderUsername && displayName) {
-            discussionHeaderUsername.innerHTML = displayName;
-        }
-    }
-
     previewCommentSuccess(comment: commentType, resp: Object): void {
         const previewBody = this.getElem('preview-body');
 
@@ -212,7 +225,7 @@ class CommentBox extends Component {
     }
 
     postCommentSuccess(comment: commentType, resp: Object): commentType {
-        this.refreshUsernameHtml();
+        CommentBox.refreshUsernameHtml();
 
         if (this.options.newCommenter) {
             this.options.newCommenter = false;
@@ -496,11 +509,6 @@ class CommentBox extends Component {
         }
 
         const userData = this.getUserData();
-        const authorEl = this.getElem('author');
-
-        if (authorEl) {
-            authorEl.innerHTML = userData.displayName;
-        }
 
         if (this.options.state === 'response') {
             const submit = this.getElem('submit');


### PR DESCRIPTION
## What does this change?

Fixes some display name rendering bugs on article comments.

- When the user clicked 'View more comments', the identity display name would be rendered over the discussion display name - see Broken screenshot. The overlapping identity display name is removed by this PR.

We plan on removing or deprecating the identity display name.

- When the user successfully posted a comment, the display name is overwritten with the identity display name (I'm guessing we do this refresh in case the user was onboarded on discussion recently). This PR refreshes using the discussion, rather than identity display name

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Broken (with discussion username Guardian User)
![Screenshot 2020-02-21 at 13 55 44](https://user-images.githubusercontent.com/29203769/75040224-31860500-54b2-11ea-8c1d-6bed721c2e9c.png)

Working (with discussion username petertestuser)
![Screenshot 2020-02-21 at 13 56 14](https://user-images.githubusercontent.com/29203769/75040234-35b22280-54b2-11ea-8f27-aa533d8a5029.png)


### Tested

- [X] Locally
- [ ] On CODE (TODO)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
