### PR TITLE
Delay geo fetch for remote epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -100,7 +100,7 @@ const remoteRenderTest = {
                 };
 
                 const localisation = {
-                    countryCode: geolocation,
+                    countryCode: geolocationGetSync(), // note, there is a race condition so we want to fetch this as late as possible to give a change for the geo local storage value to be set
                 };
 
                 const targeting = {


### PR DESCRIPTION
(Thanks to some good sleuthing by @andre1050 !)

The AB test code is called *before* the geolocation is set. Depending on which one executes first (they are both async) the geolocation may be more or less correct.

Note, geo defaults to an edition-based logic if the local storage has not been set yet.

Fixing this would require substantial code reorganisation. By reloading the value as late as possible, we give ourselves the best chance of getting the right geo.