### PR TITLE
Better name for the DCR experiment and move us to 2%

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -1,7 +1,7 @@
 package services.dotcomponents
 
 import controllers.ArticlePage
-import experiments.{ActiveExperiments, DotcomRenderingAdvertisements}
+import experiments.{ActiveExperiments, DotcomRendering}
 import model.PageWithStoryPackage
 import implicits.Requests._
 import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, TextBlockElement, TweetBlockElement, RichLinkBlockElement}
@@ -144,7 +144,7 @@ object ArticlePicker {
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {
     val whitelistFeatures = featureWhitelist(page, request)
-    val userIsInCohort = ActiveExperiments.isParticipating(DotcomRenderingAdvertisements)
+    val userIsInCohort = ActiveExperiments.isParticipating(DotcomRendering)
 
     // Decide if we should render this request with the DCR platform or not
     val tier = if (dcrShouldNotRender(request)) {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,7 @@ import org.joda.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     OldTLSSupportDeprecation,
-    DotcomRenderingAdvertisements
+    DotcomRendering
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -22,10 +22,10 @@ object OldTLSSupportDeprecation extends Experiment(
   participationGroup = TLSSupport
 )
 
-object DotcomRenderingAdvertisements extends Experiment(
+object DotcomRendering extends Experiment(
   name = "dotcom-rendering-advertisements",
-  description = "Activate the display of ads on DCR pages",
+  description = "Show DCR pages to users",
   owners = Seq(Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2020, 12, 1),
-  participationGroup = Perc1A // see ArticlePicker.scala - our main filter mechanism is by page features
+  participationGroup = Perc2A // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )


### PR DESCRIPTION
## What does this change?

Rename experiment `DotcomRenderingAdvertisements` into `DotcomRendering` (the old name is not reflecting the purpose -- experiment was born to control the display of ads, but is not used to control the exposition of DCR). Also pushed us from 1% to 2%

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No