### PR TITLE
Revert "Remove consent tracking"

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -12,6 +12,7 @@ import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
 import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
 import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
 import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
@@ -31,6 +32,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-prepare-cmp', initCmpService],
+    ['cm-track-cmp-consent', trackCmpConsent],
     ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],

--- a/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
+++ b/static/src/javascripts/bootstraps/dotcom-rendering-commercial.js
@@ -14,6 +14,7 @@ import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { init as initCmpService } from 'commercial/modules/cmp/cmp';
 import { init as initLotameCmp } from 'commercial/modules/cmp/lotame-cmp';
 import { init as initLotameDataExtract } from 'commercial/modules/lotame-data-extract';
+import { trackConsent as trackCmpConsent } from 'commercial/modules/cmp/consent-tracker';
 import { init as prepareAdVerification } from 'commercial/modules/ad-verification/prepare-ad-verification';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
 import { init as preparePrebid } from 'commercial/modules/dfp/prepare-prebid';
@@ -34,6 +35,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-prepare-cmp', initCmpService],
+    ['cm-track-cmp-consent', trackCmpConsent],
     ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -50,6 +50,8 @@ import { initEmail } from 'common/modules/email/email';
 import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
 import { init as initBannerPicker } from 'common/modules/ui/bannerPicker';
 import { breakingNews } from 'common/modules/onward/breaking-news';
+import { trackConsentCookies } from 'common/modules/analytics/send-privacy-prefs';
+import { getAllAdConsentsWithState } from 'common/modules/commercial/ad-prefs.lib';
 import ophan from 'ophan/ng';
 import { adFreeBanner } from 'common/modules/commercial/ad-free-banner';
 import { init as initReaderRevenueDevUtils } from 'common/modules/commercial/reader-revenue-dev-utils';
@@ -316,10 +318,14 @@ const initialiseBanner = (): void => {
     initBannerPicker(bannerList);
 };
 
+const initialiseConsentCookieTracking = (): void =>
+    trackConsentCookies(getAllAdConsentsWithState());
+
 const init = (): void => {
     catchErrorsWithContext([
         // Analytics comes at the top. If you think your thing is more important then please think again...
         ['c-analytics', loadAnalytics],
+        ['c-consent-cookie-tracking', initialiseConsentCookieTracking],
         ['c-identity', initIdentity],
         ['c-adverts', requestUserSegmentsFromId],
         ['c-discussion', initDiscussion],

--- a/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/consent-tracker.js
@@ -1,0 +1,55 @@
+// @flow
+import config from 'lib/config';
+import fetch from 'lib/fetch';
+import {
+    getAdConsentState,
+    thirdPartyTrackingAdConsent,
+} from 'common/modules/commercial/ad-prefs.lib';
+import { CMP_GLOBAL_NAME } from 'commercial/modules/cmp/cmp-env';
+import type { ConsentDataResponse } from 'commercial/modules/cmp/types';
+import { getRandomIntInclusive } from 'commercial/modules/header-bidding/utils';
+
+declare type ConsentPayload = {
+    pv: string, // page view ID
+    cs: ?string, // consent string
+    cc: ?boolean, // consent cookie value
+};
+
+const shouldTrack = (): boolean => {
+    // gather analytics from 1% (1 in 100) of page views
+    const inSample = getRandomIntInclusive(1, 100) === 1;
+    return (
+        config.get('switches.commercialPageViewAnalytics') &&
+        (inSample || config.get('page.isDev'))
+    );
+};
+
+const buildPayload = (
+    consent: ConsentDataResponse,
+    pageViewId: string
+): ConsentPayload => ({
+    pv: pageViewId,
+    cs: consent.consentData,
+    cc: getAdConsentState(thirdPartyTrackingAdConsent),
+});
+
+const postConsent = (payload: ConsentPayload): void => {
+    const url = `${config.get('page.ajaxUrl', '')}/commercial/api/pv`;
+    fetch(url, {
+        method: 'post',
+        body: JSON.stringify(payload),
+        mode: 'cors',
+    });
+};
+
+export const trackConsent = (): void => {
+    if (shouldTrack()) {
+        const pageViewId = config.get('ophan.pageViewId');
+        const cmp = window[CMP_GLOBAL_NAME];
+        if (pageViewId && cmp) {
+            cmp('getConsentData', [], result => {
+                postConsent(buildPayload(result, pageViewId));
+            });
+        }
+    }
+};

--- a/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
+++ b/static/src/javascripts/projects/common/modules/analytics/send-privacy-prefs.js
@@ -1,0 +1,52 @@
+// @flow
+import ophan from 'ophan/ng';
+import userPrefs from 'common/modules/user-prefs';
+import type {
+    AdConsent,
+    AdConsentWithState,
+} from 'common/modules/commercial/ad-prefs.lib';
+
+const alertViewCount: string = 'first-pv-consent.lifetime-views';
+
+const getAlertViewCount = (): number =>
+    parseInt(userPrefs.get(alertViewCount) || 0, 10);
+
+const upAlertViewCount = (): void => {
+    userPrefs.set(alertViewCount, getAlertViewCount() + 1);
+    ophan.record({
+        component: `privacy-prefs`,
+        value: `lifetime-alert-views : ${getAlertViewCount()}`,
+    });
+};
+
+const resetAlertViewCount = (): void => {
+    userPrefs.set(alertViewCount, 0);
+};
+
+const onConsentSet = (consent: AdConsent, status: ?boolean): void => {
+    ophan.record({
+        component: `privacy-prefs`,
+        value: `set : ${String(status)} : ${consent.cookie.toLowerCase()}`,
+    });
+    resetAlertViewCount();
+};
+
+const trackConsentCookies = (
+    allConsentsWithState: AdConsentWithState[]
+): void => {
+    allConsentsWithState.forEach((consentWithState: AdConsentWithState) => {
+        ophan.record({
+            component: `privacy-prefs`,
+            value: `pv : ${String(
+                consentWithState.state
+            )} : ${consentWithState.consent.cookie.toLowerCase()}`,
+        });
+    });
+};
+
+export {
+    onConsentSet,
+    trackConsentCookies,
+    upAlertViewCount,
+    getAlertViewCount,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -1,5 +1,7 @@
 // @flow
+
 import { addCookie, getCookie } from 'lib/cookies';
+import { onConsentSet } from 'common/modules/analytics/send-privacy-prefs';
 
 type AdConsent = {
     label: string,
@@ -23,6 +25,7 @@ const allAdConsents: AdConsent[] = [thirdPartyTrackingAdConsent];
 const setAdConsentState = (provider: AdConsent, state: boolean): void => {
     const cookie = [state ? '1' : '0', Date.now()].join('.');
     addCookie(provider.cookie, cookie, cookieExpiryDate, true);
+    onConsentSet(provider, state);
 };
 
 const getAdConsentState = (provider: AdConsent): boolean | null => {

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
@@ -16,6 +16,10 @@ jest.mock('lib/cookies', () => ({
     addCookie: jest.fn(() => null),
 }));
 
+jest.mock('common/modules/analytics/send-privacy-prefs', () => ({
+    onConsentSet: jest.fn(() => null),
+}));
+
 beforeEach(() => {
     addCookie.mockReset();
     getCookie.mockReset();


### PR DESCRIPTION
Reverts guardian/frontend#22268
Because we only rolled out the new CMP UI to new users D&I still need a way to know what the consent state is for the users who have not been presented with the new UI. That code was removed in the PR we are reverting here.

I will be releasing another PR after this that removes everything we don't actually need.