### PR TITLE
Use pageskin event from commercial templates for repositioning page skin in AUS

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -145,7 +145,10 @@ const pageSkin = (): void => {
     );
 
     mediator.on('window:throttledResize', togglePageSkin);
-    mediator.on('window:throttledScroll', repositionSkins);
+
+    if (hasPageSkin) {
+        mediator.on('window:throttledScroll', repositionSkins);
+    }
 };
 
 export { pageSkin };

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -132,13 +132,14 @@ const pageSkin = (): void => {
             // Also found in: commercial-templates/src/page-skin/web/index.html
             if (event.data === 'pageskinRendered') {
                 pageskinRendered = true;
+                repositionSkins();
             }
             // This event is triggered by the commercial template: 'Truskin Template' to indicate the page skin is also a Truskin
             // Also found in: commercial-templates/src/truskin-page-skin/web/index.js
             if (event.data === 'truskinRendered') {
                 truskinRendered = true;
+                repositionSkins();
             }
-            repositionSkins();
         },
         false
     );


### PR DESCRIPTION
##  What does this change?

1. This PR starts using the `pageskinRendered` event introduced here https://github.com/guardian/commercial-templates/pull/233 to indicate the page skin has been rendered instead of relying on `modules:commercial:dfp:rendered` (appeared to not be reliable and wasn't a correct way to differentiate betweeen a `truskin pageskin` and plain `pageskin`). Now the 2 types of skins have their own event been listened to and separating their concerns. 

2. Improves performance & fixes an issue in AUS which was applying both logic of pageskin and truskin together 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

