### PR TITLE
A/B test GPT's enableLazyLoad feature

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -141,7 +141,7 @@ trait ABTestSwitches {
     "ab-commercial-gpt-lazy-load",
     "This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution",
     owners = Seq(Owner.withGithub("GHaberis")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 3, 24),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -142,7 +142,7 @@ trait ABTestSwitches {
     "This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution",
     owners = Seq(Owner.withGithub("GHaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 3, 24),
+    sellByDate = new LocalDate(2020, 3, 10),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-gpt-lazy-load",
+    "This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution",
+    owners = Seq(Owner.withGithub("GHaberis")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 3, 24),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -26,13 +26,8 @@ const displayLazyAds = (): void => {
         'variant'
     );
 
-    console.log('*** displayLazyAds isInLazyLoadTest ***', isInLazyLoadTest);
-
     if (isInLazyLoadTest) {
-        window.googletag.pubads().enableLazyLoad({
-            fetchMarginPercent: 0,
-            renderMarginPercent: 0,
-        });
+        window.googletag.pubads().enableLazyLoad();
     }
 
     window.googletag.pubads().collapseEmptyDivs();

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -3,6 +3,8 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialGptLazyLoad } from 'common/modules/experiments/tests/commercial-gpt-lazy-load';
 
 const advertsToInstantlyLoad = ['dfp-ad--merchandising-high', 'dfp-ad--im'];
 
@@ -19,8 +21,23 @@ const instantLoad = (): void => {
 };
 
 const displayLazyAds = (): void => {
+    const isInLazyLoadTest = isInVariantSynchronous(
+        commercialGptLazyLoad,
+        'variant'
+    );
+
+    console.log('*** displayLazyAds isInLazyLoadTest ***', isInLazyLoadTest);
+
+    if (isInLazyLoadTest) {
+        window.googletag.pubads().enableLazyLoad({
+            fetchMarginPercent: 0,
+            renderMarginPercent: 0,
+        });
+    }
+
     window.googletag.pubads().collapseEmptyDivs();
     window.googletag.enableServices();
+
     instantLoad();
 
     dfpEnv.advertsToLoad.forEach(

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -21,12 +21,12 @@ const instantLoad = (): void => {
 };
 
 const displayLazyAds = (): void => {
-    const isInLazyLoadTest = isInVariantSynchronous(
+    const useGptLazyLoad = isInVariantSynchronous(
         commercialGptLazyLoad,
         'variant'
     );
 
-    if (isInLazyLoadTest) {
+    if (useGptLazyLoad) {
         window.googletag.pubads().enableLazyLoad();
     }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -4,6 +4,8 @@ import { Advert } from 'commercial/modules/dfp/Advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { loadAdvert, refreshAdvert } from 'commercial/modules/dfp/load-advert';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialGptLazyLoad } from 'common/modules/experiments/tests/commercial-gpt-lazy-load';
 import once from 'lodash/once';
 
 const displayAd = (advertId: string): void => {
@@ -45,7 +47,14 @@ const getObserver = once(() =>
 );
 
 export const enableLazyLoad = (advert: Advert): void => {
-    if (dfpEnv.lazyLoadObserve) {
+    const isInLazyLoadTest = isInVariantSynchronous(
+        commercialGptLazyLoad,
+        'variant'
+    );
+
+    console.log('*** enableLazyLoad isInLazyLoadTest ***', isInLazyLoadTest);
+
+    if (dfpEnv.lazyLoadObserve && !isInLazyLoadTest) {
         getObserver().then(observer => observer.observe(advert.node));
     } else {
         displayAd(advert.id);

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -47,12 +47,12 @@ const getObserver = once(() =>
 );
 
 export const enableLazyLoad = (advert: Advert): void => {
-    const isInLazyLoadTest = isInVariantSynchronous(
+    const useGptLazyLoad = isInVariantSynchronous(
         commercialGptLazyLoad,
         'variant'
     );
 
-    if (dfpEnv.lazyLoadObserve && !isInLazyLoadTest) {
+    if (dfpEnv.lazyLoadObserve && !useGptLazyLoad) {
         getObserver().then(observer => observer.observe(advert.node));
     } else {
         displayAd(advert.id);

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -52,8 +52,6 @@ export const enableLazyLoad = (advert: Advert): void => {
         'variant'
     );
 
-    console.log('*** enableLazyLoad isInLazyLoadTest ***', isInLazyLoadTest);
-
     if (dfpEnv.lazyLoadObserve && !isInLazyLoadTest) {
         getObserver().then(observer => observer.observe(advert.node));
     } else {

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
@@ -4,6 +4,14 @@ import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 import { getAdvertById as getAdvertById_ } from 'commercial/modules/dfp/get-advert-by-id';
 import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
+import { commercialGptLazyLoad } from 'common/modules/experiments/tests/commercial-gpt-lazy-load';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
+
+const isInVariantSynchronous: any = isInVariantSynchronous_;
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
+}));
 
 jest.mock('lib/config', () => ({
     get: jest.fn(() => false),
@@ -51,13 +59,29 @@ describe('enableLazyLoad', () => {
         expect(windowIntersectionObserver).toBe(undefined);
     });
 
-    it('should create an observer if lazyLoadObserve is true', () => {
+    it('should create an observer if lazyLoadObserve is true and NOT in commercialGptLazyLoad test variant', () => {
+        isInVariantSynchronous.mockImplementation(
+            (test, variantId) =>
+                !(test === commercialGptLazyLoad && variantId === 'variant')
+        );
         dfpEnv.lazyLoadObserve = true;
         enableLazyLoad(testAdvert);
         expect(loadAdvert).not.toHaveBeenCalled();
         expect(window.IntersectionObserver.mock.calls[0][1]).toEqual({
             rootMargin: '200px 0px',
         });
+    });
+
+    it('should still display the adverts if in commercialGptLazyLoad test variant', () => {
+        isInVariantSynchronous.mockImplementation(
+            (test, variantId) =>
+                test === commercialGptLazyLoad && variantId === 'variant'
+        );
+        dfpEnv.lazyLoadObserve = true;
+        getAdvertById.mockReturnValue(testAdvert);
+        enableLazyLoad(testAdvert);
+        expect(getAdvertById.mock.calls).toEqual([['test-advert']]);
+        expect(loadAdvert).toHaveBeenCalledWith(testAdvert);
     });
 
     it('should still display the adverts if lazyLoadObserve is false', () => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -13,6 +13,7 @@ import { remoteRenderEpic } from 'common/modules/experiments/tests/remote-render
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
 import { contributionsEpicPrecontributionReminderRoundOne } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-one';
 import { contributionsEuropeMoment } from 'common/modules/experiments/tests/contribs-banner-europe-moment';
+import { commercialGptLazyLoad } from 'common/modules/experiments/tests/commercial-gpt-lazy-load';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -23,6 +24,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     pangaeaAdapterTest,
     subscriptionsBannerNewYearCopyTest,
     signInGate,
+    commercialGptLazyLoad,
 ];
 
 export const priorityEpicTest: EpicABTest = remoteRenderEpic;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
@@ -13,7 +13,7 @@ export const commercialGptLazyLoad: ABTest = {
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome:
-        'GPT enableLazyLoad out performs our custom build lazy load solution',
+        'GPT enableLazyLoad outperforms our custom built lazy load solution',
     canRun: () => true,
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
@@ -2,8 +2,8 @@
 
 export const commercialGptLazyLoad: ABTest = {
     id: 'CommercialGptLazyLoad',
-    start: '2020-02-24',
-    expiry: '2020-03-24',
+    start: '2020-03-02',
+    expiry: '2020-03-09',
     author: 'George Haberis',
     description:
         'This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
@@ -1,0 +1,28 @@
+// @flow
+
+export const commercialGptLazyLoad: ABTest = {
+    id: 'CommercialGptLazyLoad',
+    start: '2020-02-24',
+    expiry: '2020-03-24',
+    author: 'George Haberis',
+    description:
+        'This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution',
+    audience: 0.01,
+    audienceOffset: 0,
+    successMeasure: 'Measurement of ad impressions',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'GPT enableLazyLoad out performs our custom build lazy load solution',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
@@ -3,7 +3,7 @@
 export const commercialGptLazyLoad: ABTest = {
     id: 'CommercialGptLazyLoad',
     start: '2020-03-02',
-    expiry: '2020-03-09',
+    expiry: '2020-03-10',
     author: 'George Haberis',
     description:
         'This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution',


### PR DESCRIPTION
## What does this change?

Sets up new `CommercialGptLazyLoad` a/b test.

This test will pitch Google Publisher Tag's  [enableLazyLoad](https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableLazyLoad) feature against the current custom built solution we use for lazy loading our adverts, which is what's in production.

We'd like to see whether the GPT `enableLazyLoad` feature outperforms our custom built lazy load solution, if it does we can then strip out our custom built solution, which was required at the time it was written as GPT had not introduced theirs.

We'll use our custom built solution on the `control`, and the `variant` will get GPT's solution.

## What is the value of this and can you measure success?

GPT enableLazyLoad outperforms our custom built lazy load solution

### Tested

- [x] Locally
- [x] On CODE (optional)
