### PR TITLE
Change the name of the DotcomRendering Experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -23,7 +23,7 @@ object OldTLSSupportDeprecation extends Experiment(
 )
 
 object DotcomRendering extends Experiment(
-  name = "dotcom-rendering-advertisements",
+  name = "dotcom-rendering",
   description = "Show DCR pages to users",
   owners = Seq(Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2020, 12, 1),


### PR DESCRIPTION
## What does this change?

Change the name of the DotcomRendering Experiment
Follow up of https://github.com/guardian/frontend/pull/22323

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No