### PR TITLE
Add link to crossword app on crossword pages

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -28,6 +28,10 @@
                 </div>
             }
 
+            <div class="hide-from-leftcol">Challenge yourself with thousands of puzzles from The Guardian and Observer in one easy app, <a href="https://puzzles.theguardian.com/download" data-link-name="crossword-mobile-link">available here.</a></div>
+
+            <div class="hide-until-leftcol">Challenge yourself with thousands of puzzles from The Guardian and Observer in one easy app. <a href="https://www.theguardian.com/info/2020/feb/10/the-guardian-puzzles-app?device=other" data-link-name="crossword-desktop-link">Find out more here.</a></div>
+
             <div class="meta__extras meta__extras--crossword">
                 <div class="meta__social" data-component="share">
                 @fragments.social(crosswordPage.item.sharelinks.pageShares, "top")


### PR DESCRIPTION
## What does this change?
The marketing team would like to maximise the potential downloads of the new crosswords app.

Up until a desktop breakpoint, it will show a message designed for mobile and tablet users, with a link to download the app(this link does some special redirect based on user OS). Then above that breakpoint, a more desktop friendly message is displayed.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Desktop
<img width="1440" alt="Screen Shot 2020-02-25 at 12 44 30" src="https://user-images.githubusercontent.com/2051501/75248933-0f032d00-57cd-11ea-80d6-90364912765c.png">
Mobile/tablet
<img width="891" alt="Screen Shot 2020-02-25 at 12 44 52" src="https://user-images.githubusercontent.com/2051501/75248934-10345a00-57cd-11ea-8b95-99e59843a377.png">
