### PR TITLE
Refresh window._CMP onIabConsentNotification

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -4,6 +4,7 @@ import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
+import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { log } from './log';
 import { CmpStore } from './store';
 import { encodeVendorConsentData } from './cookie';
@@ -85,12 +86,15 @@ class CmpService {
     generateConsentString: () => string;
     processCommand: () => void;
 
-    constructor(store: CmpStore) {
+    constructor(
+        store: CmpStore,
+        eventListeners: { [string]: Array<(obj: {}) => void> }
+    ) {
         this.isLoaded = false;
         this.cmpReady = false;
         this.store = store;
         this.commandQueue = [];
-        this.eventListeners = {};
+        this.eventListeners = eventListeners;
         this.processCommand.receiveMessage = this.receiveMessage;
         this.cmpConfig = defaultConfig;
         if (getUrlVars().cmpdebug) {
@@ -275,21 +279,42 @@ class CmpService {
 export const init = (): void => {
     // Only run our CmpService if prepareCmp has added the CMP stub
     if (window[CMP_GLOBAL_NAME]) {
+        let cmp: ?CmpService;
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};
-        // Initialize the store with all of our consent data
-        const store = generateStore();
-        const cmp = new CmpService(store);
-        // Expose `processCommand` as the CMP implementation
-        window[CMP_GLOBAL_NAME] = cmp.processCommand;
-        cmp.commandQueue = commandQueue;
-        cmp.isLoaded = true;
-        cmp.notify('isLoaded');
-        // Execute any previously queued command
-        cmp.processCommandQueue();
 
-        cmp.cmpReady = true;
-        cmp.notify('cmpReady');
+        /**
+         * Call onIabConsentNotification with callback, this will
+         * trigger the callback immediately and set up cmp with the initial consent
+         * state. If consent state updates via the UI the callback will be triggered
+         * again which will update cmp with the new consent state.
+         */
+        onIabConsentNotification(() => {
+            // Initialize the store with all of our consent data
+            const store = generateStore();
+            /**
+             * If instance of cmp exists get it's eventListeners
+             * as we'll need to add them to the new instance of cmp.
+             */
+            const eventListeners = cmp ? cmp.eventListeners : {};
+
+            // Create new instance of CmpService and assign to cmp
+            cmp = new CmpService(store, eventListeners);
+
+            // Set window[CMP_GLOBAL_NAME] to new `cmp.processCommand`
+            window[CMP_GLOBAL_NAME] = cmp.processCommand;
+        });
+
+        // Just required when we first initialise cmp on page load
+        if (cmp) {
+            cmp.commandQueue = commandQueue;
+            cmp.isLoaded = true;
+            cmp.notify('isLoaded');
+            // Execute any previously queued command
+            cmp.processCommandQueue();
+            cmp.cmpReady = true;
+            cmp.notify('cmpReady');
+        }
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -116,7 +116,7 @@ describe('cmp', () => {
 
     beforeEach(() => {
         // $FlowFixMe I know the Store is a Mock Flow... this is a test
-        cmp = new CmpService(new StoreMock(shortVendorList));
+        cmp = new CmpService(new StoreMock(shortVendorList), {});
         jest.resetAllMocks();
         fetchJsonMock.mockImplementation(
             () => new Promise(resolve => resolve(globalVendorList))


### PR DESCRIPTION
## What does this change?

Currently after a user submits consent it requires a page reload before the code below (used by 3rd party vendors to get user's consent choices) returns the latest consent state:

```js
window.__cmp('getVendorConsents', [], function(result){
console.log(result);
});
```

However we should be able to update our implementation of `window.__cmp` to return the latest consent state, by using `onIabConsentNotification` to refresh `window.__cmp`.

This PR does that, so `onIabConsentNotification` we now update `window.__cmp` to a new instance of `CmpService` that returns the user's latest consent state.

The benefit of this is that we can start using the user's consent state in the page view they submit  it, rather than the next page view.

Check the console logs in the examples below (follow the cursor):

**BEFORE** (without refreshed `window.__cmp`) requires a page reload to get consent data
![no-refresh](https://user-images.githubusercontent.com/1590704/75251848-555b8a80-57d3-11ea-8c16-aab8eae55866.gif)

**AFTER** (with refreshed `window.__cmp`) does not require a page reload to get consent data
![refresh](https://user-images.githubusercontent.com/1590704/75251835-4ecd1300-57d3-11ea-8e56-126cc75faa3a.gif)

### Tested

- [x] Locally
- [x] On CODE (optional)

Trello: https://trello.com/c/0PD3i2nr/638-cmp-update-windowcmp-so-it-gets-the-latest-consent-state-without-requiring-a-page-reload