### PR TITLE
Use slot machine client

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
+    "@guardian/slot-machine-client": "^0.1.2",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/slot-machine-client": "^0.1.2",
+    "@guardian/slot-machine-client": "^0.2.1",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=4
+https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=4

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -13,6 +13,7 @@ import reportError from 'lib/report-error';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
 import fastdom from 'lib/fastdom-promise';
 import config from 'lib/config';
+import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 
 const campaignId = 'remote_epic_test';
 const geolocation = geolocationGetSync();
@@ -106,6 +107,7 @@ const remoteRenderTest = {
                     showSupportMessaging: true,
                     isRecurringContributor: false,
                     lastOneOffContributionDate: 0,
+                    mvtId: getMvtValue(),
                 };
 
                 const payload = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { getBodyEnd } from '@guardian/slot-machine-client';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import {
     makeEpicABTest,
@@ -10,7 +11,6 @@ import {
 } from 'common/modules/commercial/contributions-utilities';
 import reportError from 'lib/report-error';
 import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisitions-epic-buttons';
-import fetch from 'lib/fetch';
 import fastdom from 'lib/fastdom-promise';
 import config from 'lib/config';
 
@@ -25,16 +25,6 @@ const buildKeywordTags = page => {
         type: 'Keyword',
         title: keywords[idx],
     }));
-};
-
-const fetchRemoteEpic = payload => {
-    const api = 'https://contributions.guardianapis.com/epic';
-
-    return fetch(api, {
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        body: payload,
-    });
 };
 
 const checkResponseOk = response => {
@@ -118,11 +108,11 @@ const remoteRenderTest = {
                     lastOneOffContributionDate: 0,
                 };
 
-                const payload = JSON.stringify({
+                const payload = {
                     tracking,
                     localisation,
                     targeting,
-                });
+                };
 
                 const trackingCampaignId = `epic_${campaignId}`; // note exposed on ABTest unfortunately
 
@@ -135,7 +125,7 @@ const remoteRenderTest = {
                     variant.id
                 );
 
-                fetchRemoteEpic(payload)
+                getBodyEnd(payload)
                     .then(checkResponseOk)
                     .then(decodeJson)
                     .then(json => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/slot-machine-client@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.1.2.tgz#5f468d6d1c410badb66f273c2ef94cae2324936d"
-  integrity sha512-Ydh/aIhxdEJdoc5VyO8jDK0tGK5V1mk1L1D8GP3ucbHxkHhDkP2dA1Ur5NxwSdBaQwQ8XvLtvw1VAlCelKSaBw==
+"@guardian/slot-machine-client@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.1.tgz#883fd7f2503231c3e1d3fe06947f7b2afe8fce2e"
+  integrity sha512-ztYqAI/BN76smiIQz2ImrkFHypkjqqjwEopIqVlFjhLGkFutwcwJ4yE8KTQn+OD3FJ8GXQpbN+tGBHJ5+t/BcQ==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
+"@guardian/slot-machine-client@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.1.2.tgz#5f468d6d1c410badb66f273c2ef94cae2324936d"
+  integrity sha512-Ydh/aIhxdEJdoc5VyO8jDK0tGK5V1mk1L1D8GP3ucbHxkHhDkP2dA1Ur5NxwSdBaQwQ8XvLtvw1VAlCelKSaBw==
+
 "@guardian/src-button@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.13.0.tgz#0071e83dff911d43a700fbaaa659ed741bdd486d"


### PR DESCRIPTION
## What does this change?

Use the nascent slot-machine client lib.

**Note:** we also add a `fetch` polyfill (with polyfill.io) here. The overhead for IE11 seems small (2kb we think) but still worth noting.

## Why?

To reduce code in the platform and share code across DCR and Frontend (and anyone else!).