### PR TITLE
Bump @guardian/consent-management-platform to 2.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.10-beta.0",
+    "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "2.0.9",
+    "@guardian/consent-management-platform": "2.0.10-beta.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.9.tgz#96247e7ca516e447aaad88cc8d7ef9e756211466"
-  integrity sha512-tqmw5+DssU35Vr1HlcKWtOLgoyE01nYnDhRA4SQ/IabSYt7PqkVtdgbeKJDnpPIUvFfjk1PgHZsBSH1D0SVs5A==
+"@guardian/consent-management-platform@2.0.10-beta.0":
+  version "2.0.10-beta.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.10-beta.0.tgz#b4d26d1623dc245abb94888a04d7d102fa29319f"
+  integrity sha512-ujY1DjH7q4RHX/gKZNcqvdUOJcYxVSZ9oPiHk4BFcsWDHMmuoKDBhBw4JeR+8V65b9zJL+mD2djURK/ufGDsfg==
   dependencies:
     "@guardian/src-button" "^0.13.0"
     "@guardian/src-foundations" "^0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/consent-management-platform@2.0.10-beta.0":
-  version "2.0.10-beta.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.10-beta.0.tgz#b4d26d1623dc245abb94888a04d7d102fa29319f"
-  integrity sha512-ujY1DjH7q4RHX/gKZNcqvdUOJcYxVSZ9oPiHk4BFcsWDHMmuoKDBhBw4JeR+8V65b9zJL+mD2djURK/ufGDsfg==
+"@guardian/consent-management-platform@2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.10.tgz#b1d322f7fa5da858353102fb584224218fffbf37"
+  integrity sha512-SqWbB/47CtB9DSMm5wF4YXyrpknZy0Uk2R791gy3cAjUCiZymaQmjUEmytiUCLtwGDTXKD7ZefmyJ5ecN7/m6A==
   dependencies:
     "@guardian/src-button" "^0.13.0"
     "@guardian/src-foundations" "^0.13.0"


### PR DESCRIPTION
## What does this change?

This PR bumps `@guardian/consent-management-platform` to `2.0.10`.

Details of `2.0.10` can be found at: https://github.com/guardian/consent-management-platform/releases/tag/2.0.10

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes, we'll raise a similar PR 

## What is the value of this and can you measure success?

More accessible CMP