### PR TITLE
Adds contributions booleans to remote Epic payload

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -28,8 +28,7 @@ const buildKeywordTags = page => {
 };
 
 const fetchRemoteEpic = payload => {
-    // const api = 'https://contributions.guardianapis.com/epic';
-    const api = 'http://localhost:8081/epic';
+    const api = 'https://contributions.guardianapis.com/epic';
 
     return fetch(api, {
         method: 'post',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -28,7 +28,8 @@ const buildKeywordTags = page => {
 };
 
 const fetchRemoteEpic = payload => {
-    const api = 'https://contributions.guardianapis.com/epic';
+    // const api = 'https://contributions.guardianapis.com/epic';
+    const api = 'http://localhost:8081/epic';
 
     return fetch(api, {
         method: 'post',
@@ -112,6 +113,7 @@ const remoteRenderTest = {
                     tags: buildKeywordTags(page),
                     // These are hardcoded as to no stop the Contributions service from sending the Epic.
                     // The targeting logic around this test already ensures this data is observed and respected.
+                    // TODO: make these dynamic - this is a temporary fix because it's safer to pass these than the actual values!
                     showSupportMessaging: true,
                     isRecurringContributor: false,
                     lastOneOffContributionDate: 0,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -110,6 +110,11 @@ const remoteRenderTest = {
                     isMinuteArticle: config.hasTone('Minute'),
                     isPaidContent: page.isPaidContent,
                     tags: buildKeywordTags(page),
+                    // These are hardcoded as to no stop the Contributions service from sending the Epic.
+                    // The targeting logic around this test already ensures this data is observed and respected.
+                    showSupportMessaging: true,
+                    isRecurringContributor: false,
+                    lastOneOffContributionDate: 0,
                 };
 
                 const payload = JSON.stringify({


### PR DESCRIPTION
## What does this change?
Adds 3 new Contributions-related properties to the Epic payload, to fulfil the JSON schema requirements and bring parity DCR's payload. The values are currently hardcoded because they don't need to reflect real values. We just need to ensure the keys exist and have the correct type of value, and the values themselves are just permissive enough for the Contributions service to serve the Epic on every request. The actual targeting code already exists in Frontend and will ensure an existing contributor won't see an Epic.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Notes
This update affects the remote Contributions Epic only and is totally self contained. It won't affect anything else on the app. 
