### PR TITLE
Bump DCR Experiment to 5%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -27,5 +27,5 @@ object DotcomRendering extends Experiment(
   description = "Show DCR pages to users",
   owners = Seq(Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2020, 12, 1),
-  participationGroup = Perc2A // Also see ArticlePicker.scala - our main filter mechanism is by page features
+  participationGroup = Perc5A // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )


### PR DESCRIPTION
## What does this change?

Bump DCR Experiment to 5% (Hoping to bring the number of DCR served pages closer to 2%). 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No