### PR TITLE
Fix styling issue with two-card dynamo live blog updates bg colour

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -300,6 +300,12 @@ $block-height: 58px; // Note: duplicated from _item.scss
         }
 
         &:hover {
+            &.fc-item--three-quarters-tablet, &.fc-item--full-media-75-tablet {
+                .fc-item__liveblog-blocks__inner {
+                    background-color: darken($story-package-card-colour, 5%);
+                }
+            }
+
             .fc-item__liveblog-block__text:after {
                 color: mix(#ffffff, $story-package-card-colour, 92%);
                 background-color: darken($story-package-card-colour, 5%);
@@ -364,6 +370,9 @@ $block-height: 58px; // Note: duplicated from _item.scss
             }
         }
 
+        // fc-item--full-media-75-tablet and fc-item--three-quarters-tablet have the light grey background
+        // and the live update blocks with a dark blue background. There's a little extra styling here to
+        // ensure hover states are correct.
         &.fc-item--full-media-75-tablet {
             .fc-item__container.u-faux-block-link--hover .fc-item__liveblog-blocks__inner {
                 background-color: darken($story-package-card-colour, 5%);
@@ -384,6 +393,21 @@ $block-height: 58px; // Note: duplicated from _item.scss
 
             .fc-item__standfirst-wrapper {
                 display: none;
+            }
+        }
+
+        &.fc-item--three-quarters-tablet {
+            .fc-item__container.u-faux-block-link--hover .fc-item__liveblog-blocks__inner {
+                background-color: darken($story-package-card-colour, 5%);
+            }
+
+            .fc-item__liveblog-blocks__inner {
+                background-color: $story-package-card-colour;
+                padding-left: 5px;
+
+                &:hover {
+                    background-color: darken($story-package-card-colour, 5%);
+                }
             }
         }
 


### PR DESCRIPTION
## What does this change?

When live blog updates are turned on for a `fc-item--three-quarters-tablet` (i.e. when there are two cards) the background colour of the live blog update blocks was incorrect and the text was hard to read. This fixes the issue.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

<img width="948" alt="Screenshot 2020-02-27 at 13 12 04" src="https://user-images.githubusercontent.com/379839/75449613-2d9c2c00-5965-11ea-80cb-ed3233595951.png">

### After

<img width="958" alt="Screenshot 2020-02-27 at 13 11 39" src="https://user-images.githubusercontent.com/379839/75449777-82d83d80-5965-11ea-9fa0-4057433f03c9.png">

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
