### PR TITLE
Remove reference to Krux in pressed pages

### DIFF
--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -2657,23 +2657,6 @@
     }
 </script>
 
-
-<!-- BEGIN Krux Control Tag for "Guardian R2" -->
-<!-- Source: /snippet/controltag?confid=Jd8GXPAn&site=Guardian%20R2&edit=1 -->
-<script class="kxct" data-id="Jd8GXPAn" data-timing="async" data-version="1.9" type="text/javascript">
-    window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]);
-    (function(){
-        var k=document.createElement('script');k.type='text/javascript';k.async=true;
-        var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]);
-        k.src = /^https?:\/\/([a-z0-9_\-\.]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" :
-        (location.protocol==="https:"?"https:":"http:")+"//cdn.krxd.net/controltag?confid=Jd8GXPAn"
-        ;
-        var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s);
-    }());
-
-</script>
-<!-- END Krux Controltag -->
-
 <!-- Google Code for Remarketing Tag -->
 <!--------------------------------------------------
 Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -843,9 +843,6 @@
     </div>
 </noscript>
 <!-- END Nielsen Online SiteCensus V6.0 -->
-<!-- BEGIN Krux Control Tag for "Guardian R2" -->
-<!-- Source: /snippet/controltag?confid=Jd8GXPAn&site=Guardian%20R2&edit=1 -->
-<!-- END Krux Controltag -->
 <!-- Google Code for Remarketing Tag -->
 <!--
 Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-pixel.js
@@ -1,0 +1,8 @@
+// @flow
+import config from 'lib/config';
+
+export const twitterPixel: () => ThirdPartyTag = () => ({
+    shouldRun: config.get('switches.twitterTrackingPixel', false),
+    url: '',
+    useImage: true,
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-pixel.js
@@ -1,8 +1,0 @@
-// @flow
-import config from 'lib/config';
-
-export const twitterPixel: () => ThirdPartyTag = () => ({
-    shouldRun: config.get('switches.twitterTrackingPixel', false),
-    url: '',
-    useImage: true,
-});


### PR DESCRIPTION
## What does this change?

Remove final references to Krux from pressed page templates, following main clean up: https://github.com/guardian/frontend/pull/22341