### PR TITLE
Fix sign in variant variable

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -61,7 +61,7 @@ const canShow: () => boolean = () =>
     !hasUserDismissedGate({
         componentName,
         componentId: component.id,
-        variant: 'name',
+        variant: name,
     }) &&
     isNPageOrHigherPageView(2) &&
     !isLoggedIn() &&


### PR DESCRIPTION
## What does this change?

`name` should be a variable, not a string