### PR TITLE
Sign In Gate Test - Have component target DCR body

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -67,8 +67,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -67,8 +67,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -73,8 +73,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {


### PR DESCRIPTION
## What does this change?

Previously the Sign In Gate component would only target non-DCR body using the `.js-article__body` selector meaning that it would not appear on DCR pages.

Now it also targets `.article-body-commercial-selector` allowing the component to appear on DCR pages too
