### PR TITLE
Sign In Gate Test: Fix issue where paragraph was missing after dismissing gate

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -67,8 +67,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -12,7 +12,7 @@ import {
     addPillarColour,
     addClickHandler,
     setUserDismissedGate,
-    setTemplate,
+    showGate,
 } from '../helper';
 
 // define the variant name here
@@ -66,37 +66,13 @@ const show: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
-    const articleBody =
-        document.querySelector('.js-article__body') ||
-        document.querySelector('.article-body-commercial-selector');
-
-    if (articleBody) {
-        if (articleBody.children.length) {
-            // container div to hold our "shadow" article dom while we create it
-            const shadowArticleBody = document.createElement('div');
-            // add the article body classes to the "shadow"
-            shadowArticleBody.className = articleBody.className;
-
-            const shadowOverlay = document.createElement('div');
-            shadowOverlay.appendChild(articleBody.children[0]);
-            if (
-                articleBody.children[0].clientHeight < 125 &&
-                articleBody.children.length > 1
-            ) {
-                shadowOverlay.appendChild(articleBody.children[1]);
-            }
-
-            // set the new article body to be first paragraph with transparent overlay, with the sign in gate component
-            shadowArticleBody.innerHTML = setTemplate({
-                child: shadowOverlay,
-                template: htmlTemplate({
-                    signInUrl,
-                    guUrl,
-                }),
-            });
-
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    showGate({
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        handler: ({ articleBody, shadowArticleBody }) => {
             // check if comment, and add comment/opinion bg colour
             addOpinionBgColour({
                 element: shadowArticleBody,
@@ -150,19 +126,8 @@ const show: ({
                 component,
                 value: 'why-link',
             });
-
-            // Hide the article Body. Append the shadow one.
-            articleBody.style.display = 'none';
-            if (articleBody.parentNode) {
-                articleBody.parentNode.appendChild(shadowArticleBody);
-            }
-
-            return true;
-        }
-    }
-
-    return false;
-};
+        },
+    });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -67,8 +67,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -12,7 +12,7 @@ import {
     addPillarColour,
     addClickHandler,
     setUserDismissedGate,
-    setTemplate,
+    showGate,
 } from '../helper';
 
 // define the variant name here
@@ -66,37 +66,21 @@ const show: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
-    const articleBody =
-        document.querySelector('.js-article__body') ||
-        document.querySelector('.article-body-commercial-selector');
-
-    if (articleBody) {
-        if (articleBody.children.length) {
-            // container div to hold our "shadow" article dom while we create it
-            const shadowArticleBody = document.createElement('div');
-            // add the article body classes to the "shadow"
-            shadowArticleBody.className = articleBody.className;
-
-            const shadowOverlay = document.createElement('div');
-            shadowOverlay.appendChild(articleBody.children[0]);
-            if (
-                articleBody.children[0].clientHeight < 125 &&
-                articleBody.children.length > 1
-            ) {
-                shadowOverlay.appendChild(articleBody.children[1]);
-            }
-
-            // set the new article body to be first paragraph with transparent overlay, with the sign in gate component
-            shadowArticleBody.innerHTML = setTemplate({
-                child: shadowOverlay,
-                template: htmlTemplate({
-                    signInUrl,
-                    guUrl,
-                }),
-            });
-
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    // use the show gate helper to abstract away logic about showing the gate
+    showGate({
+        // the template as a string of the gate itself
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        // the handler function should handle any click events required, including the "dismiss" or "not now" link/button
+        // articleBody - html element that corresponds to the original (now hidden) article
+        // shadowArticleBody - html element that contains the gate, and the overlay
+        // you can show the original article, and hide the gate by using the following in a click event for example:
+        // articleBody.style.display = 'block';
+        // shadowArticleBody.remove();
+        handler: ({ articleBody, shadowArticleBody }) => {
             // check if comment, and add comment/opinion bg colour
             addOpinionBgColour({
                 element: shadowArticleBody,
@@ -150,19 +134,8 @@ const show: ({
                 component,
                 value: 'why-link',
             });
-
-            // Hide the article Body. Append the shadow one.
-            articleBody.style.display = 'none';
-            if (articleBody.parentNode) {
-                articleBody.parentNode.appendChild(shadowArticleBody);
-            }
-
-            return true;
-        }
-    }
-
-    return false;
-};
+        },
+    });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -73,8 +73,10 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body
-    const articleBody = document.querySelector('.js-article__body');
+    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
+    const articleBody =
+        document.querySelector('.js-article__body') ||
+        document.querySelector('.article-body-commercial-selector');
 
     if (articleBody) {
         if (articleBody.children.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -11,7 +11,7 @@ import {
     addOpinionBgColour,
     addClickHandler,
     setUserDismissedGate,
-    setTemplate,
+    showGate,
 } from '../helper';
 
 const name = 'variant';
@@ -72,37 +72,13 @@ const show: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) => {
-    // get the whole article body, .js-article__body for non-DCR and .article-body-commercial-selector for DCR
-    const articleBody =
-        document.querySelector('.js-article__body') ||
-        document.querySelector('.article-body-commercial-selector');
-
-    if (articleBody) {
-        if (articleBody.children.length) {
-            // container div to hold our "shadow" article dom while we create it
-            const shadowArticleBody = document.createElement('div');
-            // add the article body classes to the "shadow"
-            shadowArticleBody.className = articleBody.className;
-
-            const shadowOverlay = document.createElement('div');
-            shadowOverlay.appendChild(articleBody.children[0]);
-            if (
-                articleBody.children[0].clientHeight < 125 &&
-                articleBody.children.length > 1
-            ) {
-                shadowOverlay.appendChild(articleBody.children[1]);
-            }
-
-            // set the new article body to be first paragraph with transparent overlay, with the sign in gate component
-            shadowArticleBody.innerHTML = setTemplate({
-                child: shadowOverlay,
-                template: htmlTemplate({
-                    signInUrl,
-                    guUrl,
-                }),
-            });
-
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    showGate({
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        handler: ({ articleBody, shadowArticleBody }) => {
             // check if comment, and add comment/opinion bg colour
             addOpinionBgColour({
                 element: shadowArticleBody,
@@ -177,18 +153,8 @@ const show: ({
                 component,
                 value: 'help-link',
             });
-
-            // Hide the article Body. Append the shadow one.
-            articleBody.style.display = 'none';
-            if (articleBody.parentNode) {
-                articleBody.parentNode.appendChild(shadowArticleBody);
-            }
-
-            return true;
-        }
-    }
-    return false;
-};
+        },
+    });
 
 export const signInGateVariant: SignInGateVariant = {
     name,


### PR DESCRIPTION
## What does this change?
There was a bug in the Sign In Gate where the first 1 or 2 paragraphs of an article would disappear after dismissing the gate by pressing `Not Now`. This was caused because the paragraphs that had been overlayed by the gate were referenced to the original article element which had been hidden, which meant that when the gate was removed it would delete those paragraphs too.

To fix this we used `cloneNode(true)` which create a deep clone of the element, hence making a new reference not tied to the original article element, allowing us to safely remove it when the gate is dismissed.

The other change we made was to abstract out the method which shows the gate in each variant as there was a lot of duplicate code. The new `showGate` method takes a `template` string of the new gate, and a `handler` function which can be defined to add any DOM/javascript things that may be requried, e.g. adding click event handlers, dismissing the gate etc.

## Screenshots
With Gate:
![m thegulocal com_football_2016_apr_12_everton-roberto-martinez-pressure-crystal-palace](https://user-images.githubusercontent.com/13315440/75546780-4538ea80-5a21-11ea-96ed-7692033168c0.png)

After dismiss, top paragraph now showing:
![m thegulocal com_football_2016_apr_12_everton-roberto-martinez-pressure-crystal-palace (1)](https://user-images.githubusercontent.com/13315440/75546800-54b83380-5a21-11ea-8995-1d161a16e8da.png)

### Tested
- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
