### PR TITLE
Fix Comment/Special Report Hover States

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -104,14 +104,13 @@ $pillars: (
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
-            background-color: darken($opinion-faded, 3%);
+            background-color: $brightness-97;
         }
 
-        &.fc-item--pillar-special-report {
+        .fc-item__container.u-faux-block-link--hover {
             .fc-item__timestamp,
             .fc-trail__count--commentcount {
-                background-color: $special-report-dark;
-                color: $brightness-86;
+                background-color: darken($brightness-97, 3%);
             }
         }
     }
@@ -372,8 +371,10 @@ $pillars: (
         }
     }
 
-    .fc-item__container.u-faux-block-link--hover {
-        background-color: darken($special-report-dark, 2%);
+    &:not(.fc-item--type-comment) {
+        .fc-item__container.u-faux-block-link--hover {
+            background-color: darken($special-report-dark, 2%);
+        }
     }
 
     .fc-sublink__kicker {


### PR DESCRIPTION
## What does this change?

Fixes odd looking comment/special report hover states, as seen on https://www.theguardian.com/environment/series/the-polluters.

**I haven't touched these styles before, and I'm a little nervous about unintended side effects of these changes, so 👀 on this would be great.**

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Examples taken from environment/series/the-polluters.

### Before

![2020-02-28 14 42 31](https://user-images.githubusercontent.com/379839/75558502-d451fc80-5a39-11ea-9b58-90b13e8ae879.gif)

![2020-02-28 14 43 24](https://user-images.githubusercontent.com/379839/75558572-eb90ea00-5a39-11ea-9c4f-945a902e95b8.gif)

### After

![2020-02-28 14 48 25](https://user-images.githubusercontent.com/379839/75558619-fc416000-5a39-11ea-8cb4-c684b3a6d122.gif)

![2020-02-28 14 48 47](https://user-images.githubusercontent.com/379839/75558635-03686e00-5a3a-11ea-9952-6a8cce6abf9b.gif)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
