### PR TITLE
Adding specific rule for bylines in special report facia cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -385,3 +385,8 @@ $pillars: (
         color: #ffffff;
     }
 }
+
+.fc-item--pillar-special-report .fc-item__byline {
+    color: $highlight-main;
+}
+

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -386,7 +386,7 @@ $pillars: (
     }
 }
 
-.fc-item--pillar-special-report .fc-item__byline {
+.fc-item--pillar-special-report &:not(.fc-item--type-comment) .fc-item__byline {
     color: $highlight-main;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -378,8 +378,6 @@ $pillars: (
         .fc-item__byline {
             color: $highlight-main;
         }
-
-
     }
 
     .fc-sublink__kicker {

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -386,7 +386,7 @@ $pillars: (
     }
 }
 
-.fc-item--pillar-special-report .fc-item__byline {
+.fc-item--pillar-special-report :not(.fc-item--type-comment) .fc-item__byline {
     color: $highlight-main;
 }
 


### PR DESCRIPTION
## What does this change?
Before
<img width="480" alt="Screen Shot 2020-02-28 at 16 49 56" src="https://user-images.githubusercontent.com/2051501/75568024-6c57e200-5a4a-11ea-84a9-5e75a201bf55.png">
After
<img width="480" alt="Screen Shot 2020-02-28 at 16 22 16" src="https://user-images.githubusercontent.com/2051501/75568010-695cf180-5a4a-11ea-8d62-6e3dfdd0713b.png">
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

