### PR TITLE
Fix pillar styling issues more holistically

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -75,7 +75,7 @@ $pillars: (
         kicker: $highlight-main,
         headline: #ffffff,
         featureHeadline: #ffffff,
-        byline: $special-report-dark,
+        byline: $highlight-main,
         commentCount: $brightness-60,
         headlineIcon: $highlight-main,
         metaText: $brightness-60,
@@ -104,13 +104,15 @@ $pillars: (
 
         .fc-item__timestamp,
         .fc-trail__count--commentcount {
-            background-color: $brightness-97;
+            background-color: $cardBackground;
         }
 
         .fc-item__container.u-faux-block-link--hover {
+            background-color: $darkerCardBackground;
+
             .fc-item__timestamp,
             .fc-trail__count--commentcount {
-                background-color: darken($brightness-97, 3%);
+                background-color: $darkerCardBackground;
             }
         }
     }
@@ -371,13 +373,8 @@ $pillars: (
         }
     }
 
-    &:not(.fc-item--type-comment) {
-        .fc-item__container.u-faux-block-link--hover {
-            background-color: darken($special-report-dark, 2%);
-        }
-        .fc-item__byline {
-            color: $highlight-main;
-        }
+    .fc-item__container.u-faux-block-link--hover {
+        background-color: darken($special-report-dark, 2%);
     }
 
     .fc-sublink__kicker {


### PR DESCRIPTION
## What does this change?

Having gotten a better understanding of the code, this revisits the fixes made in #22353 and #22359 and attempts to fix the issues with fewer exceptions, leveraging the `$pillars` config and the `colours` mixin a bit more. Things seem to be looking good in prod right now so I don't think we urgently need to push this out, but would be good to follow up next week.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

The comment hover issues remain fixed for the polluters tag page:

![2020-02-28 18 26 01](https://user-images.githubusercontent.com/379839/75576673-4df8e300-5a58-11ea-90b5-6422eaed05e0.gif)

![2020-02-28 18 26 14](https://user-images.githubusercontent.com/379839/75576690-53eec400-5a58-11ea-9e00-0099fa043ede.gif)

The byline text on a special report card looks good:

![Screenshot 2020-02-28 at 18 25 16](https://user-images.githubusercontent.com/379839/75576865-ab8d2f80-5a58-11ea-9fb2-faa6f51707f7.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
