### PR TITLE
Sign In Gate: Fix background tone

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -149,7 +149,7 @@ export const addOpinionBgColour: ({
     element: HTMLElement,
     selector: string,
 }) => void = ({ element, selector }) => {
-    if (config.get(`page.cardStyle`) === 'comment') {
+    if (config.get(`page.tones`) === 'Comment') {
         const overlay = element.querySelector(selector);
         if (overlay) {
             overlay.classList.add(


### PR DESCRIPTION
## What does this change?

Background fade was wrong colour on pages that had comment tone, but not under comment pillar, this PR uses `config.pages.tones` to check the tone that should be used for the background of the sign in gate fade.

## Screenshots
BROKEN:
![Screenshot 2020-03-02 at 10 14 29](https://user-images.githubusercontent.com/13315440/75667050-d781fe00-5c6e-11ea-9d19-dfd886a6caf5.png)

FIXED:
![Screenshot 2020-03-02 at 10 21 06](https://user-images.githubusercontent.com/13315440/75667421-8c1c1f80-5c6f-11ea-89d0-2dc0b22d0fd6.png)

### Tested

- [X] Locally
- [ ] On CODE (optional)

