### PR TITLE
Set max-age for security files

### DIFF
--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -1,8 +1,8 @@
 
-# Caching for humans.txt
+# Caching for humans.txt and security files
 "assets.cache./public/humans.txt"="public, max-age=900"
-"assets.cache./public/security.txt"="public, max-age=0"
-"assets.cache./public/security.txt.asc"="public, max-age=0"
+"assets.cache./public/security.txt"="public, max-age=900"
+"assets.cache./public/security.txt.asc"="public, max-age=900"
 
 akka {
   loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]


### PR DESCRIPTION
## What does this change?

Set `max-age` for security files to that of `humans.txt` (15 mins).
