### PR TITLE
Sign In Gate - Tertius Test: Update 'variant' design

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -131,7 +131,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-tertius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -131,7 +131,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-tertius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -40,7 +40,7 @@ const htmlTemplate: ({
             <a class="signin-gate__button signin-gate__button--primary js-signin-gate__button" href="${signInUrl}">
                 Sign in
             </a>
-            <a class="signin-gate__padding-left signin-gate__link js-signin-gate__why" href="${guUrl}/help/identity-faq">Why sign in?</a>
+            <a class="signin-gate__padding-left signin-gate__link signin-gate__center-424 js-signin-gate__why" href="${guUrl}/help/identity-faq">Why sign in?</a>
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
         </div>
     </div>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -42,7 +42,7 @@ const htmlTemplate: ({
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in" href="${signInUrl}">Sign in</a>
+            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__buttons">
             <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -18,12 +18,12 @@
 }
 
 .signin-gate__buttons {
+    @include fs-textSans(5);
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    padding-top: 4px;
-    padding-bottom: 4px;
-
+    padding-top: 6px;
+    padding-bottom: 6px;
     // Horizontal alignment
     align-items: flex-start;
 
@@ -32,6 +32,9 @@
 
         // Now vertical alignment, because the flex-direction is row
         align-items: center;
+
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
 }
 
@@ -54,8 +57,18 @@
     font-weight: 700;
     font-size: 17px;
     padding-top: 20px;
+    &-no-ptm {
+        padding-top: 0px;
+    }
     @include mq(424px) {
         padding-top: 0px;
+    }
+}
+
+.signin-gate__center-424 {
+    align-self: center;
+    @include mq(424px) {
+        align-self: auto;
     }
 }
 
@@ -65,10 +78,12 @@
     text-decoration: underline;
     font-weight: 700;
     font-size: 17px;
-    padding-left: $gs-baseline * 1.5;
     padding-top: 20px;
+    align-self: center;
     @include mq(424px) {
         padding-top: 0px;
+        padding-left: $gs-baseline * 1.5;
+        align-self: auto;
     }
 }
 
@@ -123,6 +138,11 @@
     &:focus {
         text-decoration: none;
     }
+
+    align-self: center;
+    @include mq(424px) {
+        align-self: auto;
+    }
 }
 
 .signin-gate__button--primary {
@@ -139,7 +159,7 @@
     line-height: 1.25em;
     font-size: 24px;
     @include mq(tablet) {
-        font-size: 34px;
+        font-size: 32px;
     }
 }
 


### PR DESCRIPTION
## What does this change?

- Update  'Already registered, contributed, or subscribed?' font to match 'Sign In' CTA
- Decrease font size of 'Register for free and continue reading' to have it fit on one line
- Increase spacing between FAQ links
- Center links on mobile for better alignment

## Screenshots
OLD DESKTOP
<img width="808" alt="Screenshot 2020-03-02 at 15 19 29" src="https://user-images.githubusercontent.com/13315440/75689990-0cf01100-5c9a-11ea-9ec5-894a2571844c.png">

NEW DESKTOP
<img width="830" alt="Screenshot 2020-03-02 at 15 19 18" src="https://user-images.githubusercontent.com/13315440/75690014-12e5f200-5c9a-11ea-94a5-7cdfc2ad6e7f.png">

OLD MOBILE
<img width="454" alt="Screenshot 2020-03-02 at 15 23 31" src="https://user-images.githubusercontent.com/13315440/75690026-18dbd300-5c9a-11ea-9ea9-914afcd88c49.png">

NEW MOBILE
<img width="488" alt="Screenshot 2020-03-02 at 15 23 27" src="https://user-images.githubusercontent.com/13315440/75690036-1e391d80-5c9a-11ea-8931-09827ee89f56.png">


### Tested

- [X] Locally
- [ ] On CODE (optional)
