### PR TITLE
Extend client-side remote render test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -58,7 +58,7 @@ const remoteRenderTest = {
     highPriority: true,
 
     start: '2020-01-01',
-    expiry: '2020-02-29',
+    expiry: '2020-04-01',
 
     author: 'Nicolas Long',
     description:


### PR DESCRIPTION
Extend this switch at least for March.

Related to: https://github.com/guardian/frontend/pull/22369 (which is the associated server-side switch).