### PR TITLE
Sign In Gate - Tertius Test: Lower Audience Size

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -6,8 +6,8 @@ export const signInGate: ABTest = {
     author: 'Mahesh Makani, Dominic Kendrick',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
-    audience: 0.15,
-    audienceOffset: 0.85,
+    audience: 0.1,
+    audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',


### PR DESCRIPTION
## What does this change?

Lower the audience size of the test to 10%, as we're currently recording more users seeing the gate in both the control and variant than needed.
