### PR TITLE
Bump slot-machine-client to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/slot-machine-client": "^0.2.1",
+    "@guardian/slot-machine-client": "^0.2.2",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/slot-machine-client@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.1.tgz#883fd7f2503231c3e1d3fe06947f7b2afe8fce2e"
-  integrity sha512-ztYqAI/BN76smiIQz2ImrkFHypkjqqjwEopIqVlFjhLGkFutwcwJ4yE8KTQn+OD3FJ8GXQpbN+tGBHJ5+t/BcQ==
+"@guardian/slot-machine-client@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.2.tgz#6b8a61475eed80656fa2d6febdc1fd4aa7d88049"
+  integrity sha512-TMilHpnIGwe/dxeMg3bO5jgTS0pwVMU5+wKZ46VoRA2JzsoucVr86hIJ6k6l01wXDuyNLo6x+rx94vVhYO4iAg==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?

This new version targets ES5, so gives us IE11 support.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2020-03-05 at 09 31 37](https://user-images.githubusercontent.com/379839/75972237-fd0b4380-5eca-11ea-9619-d87ce0a15c58.png)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)
