### PR TITLE
Sign In Gate Tertius Test: Fix issue with gate dismiss

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -122,7 +122,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-tertius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -122,7 +122,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-tertius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -26,25 +26,27 @@ export const getVariant: ABTest => string = test => {
     return currentTest ? currentTest.variantToRun.id : '';
 };
 
-// check if the user has dismissed the gate by checking the user preferences
+// check if the user has dismissed the gate by checking the user preferences,
+// name is optional, but can be used to differentiate between multiple sign in gate tests
 export const hasUserDismissedGate: ({
-    name: string,
+    name?: string,
     variant: string,
     componentName: string,
-}) => boolean = ({ name, componentName, variant }) => {
+}) => boolean = ({ name = '', componentName, variant }) => {
     const prefs = userPrefs.get(componentName) || {};
 
     return !!prefs[`${name ? `${name}-` : ''}${variant}`];
 };
 
 // set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
+// name is optional, but can be used to differentiate between multiple sign in gate tests
 export const setUserDismissedGate: ({
-    name: string,
+    name?: string,
     variant: string,
     componentName: string,
-}) => void = ({ name, variant, componentName }) => {
+}) => void = ({ name = '', variant, componentName }) => {
     const prefs = userPrefs.get(componentName) || {};
-    prefs[`${name}-${variant}`] = new Date().toISOString();
+    prefs[`${name ? `${name}-` : ''}${variant}`] = new Date().toISOString();
     userPrefs.set(componentName, prefs);
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -28,13 +28,13 @@ export const getVariant: ABTest => string = test => {
 
 // check if the user has dismissed the gate by checking the user preferences
 export const hasUserDismissedGate: ({
-    componentId?: string,
-    componentName: string,
+    name: string,
     variant: string,
-}) => boolean = ({ componentId = '', componentName, variant }) => {
+    componentName: string,
+}) => boolean = ({ name, componentName, variant }) => {
     const prefs = userPrefs.get(componentName) || {};
 
-    return !!prefs[`${componentId ? `${componentId}-` : ''}${variant}`];
+    return !!prefs[`${name ? `${name}-` : ''}${variant}`];
 };
 
 // set in user preferences that the user has dismissed the gate, set the value to the current ISO date string

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -27,7 +27,7 @@ const canShow: () => Promise<boolean> = () =>
         if (!variant) return resolve(false);
 
         // check if we can show the test for the variant the user is in
-        return resolve(variant.canShow());
+        return resolve(variant.canShow(signInGateTest.id));
     });
 
 const show: () => Promise<boolean> = () =>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
@@ -21,6 +21,6 @@ export type SignInGateVariant = {
         guUrl: string,
         signInUrl: string,
     }) => boolean,
-    canShow: () => boolean,
+    canShow: (name?: string) => boolean,
     name: string,
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -16,7 +16,7 @@ import {
 } from '../helper';
 
 // define the variant name here
-const name = 'control';
+const variant = 'control';
 
 // add the html template as the return of the function below
 // signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
@@ -48,11 +48,11 @@ const htmlTemplate: ({
 `;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow: () => boolean = () =>
+const canShow: (name?: string) => boolean = (name = '') =>
     !hasUserDismissedGate({
         componentName,
-        componentId: component.id,
-        variant: name,
+        name,
+        variant,
     }) &&
     isNPageOrHigherPageView(2) &&
     !isLoggedIn() &&
@@ -131,7 +131,7 @@ const show: ({
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {
-    name,
+    name: variant,
     canShow,
     show,
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -16,7 +16,7 @@ import {
 } from '../helper';
 
 // define the variant name here
-const name = 'example';
+const variant = 'example';
 
 // add the html template as the return of the function below
 // signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
@@ -48,11 +48,11 @@ const htmlTemplate: ({
 `;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow: () => boolean = () =>
+const canShow: (name?: string) => boolean = (name = '') =>
     !hasUserDismissedGate({
         componentName,
-        componentId: component.id,
-        variant: name,
+        name,
+        variant,
     }) &&
     isNPageOrHigherPageView(2) &&
     !isLoggedIn() &&
@@ -139,7 +139,7 @@ const show: ({
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {
-    name,
+    name: variant,
     canShow,
     show,
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -14,7 +14,7 @@ import {
     showGate,
 } from '../helper';
 
-const name = 'variant';
+const variant = 'variant';
 
 const htmlTemplate: ({
     signInUrl: string,
@@ -57,11 +57,11 @@ const htmlTemplate: ({
 </div>
 `;
 
-const canShow: () => boolean = () =>
+const canShow: (name?: string) => boolean = (name = '') =>
     !hasUserDismissedGate({
         componentName,
-        componentId: component.id,
-        variant: name,
+        name,
+        variant,
     }) &&
     isNPageOrHigherPageView(2) &&
     !isLoggedIn() &&
@@ -157,7 +157,7 @@ const show: ({
     });
 
 export const signInGateVariant: SignInGateVariant = {
-    name,
+    name: variant,
     canShow,
     show,
 };


### PR DESCRIPTION
## What does this change?
When a user presses "dismiss" or "not now" on the sign in gate, the gate would disappear, and a value set in the local storage saying that it the gate had been dismissed.

However on a following page view, or refresh of the page the gate would reappear even though the user had previously dismissed the gate.

This was caused by the check for the value in local storage was using the wrong value to see if the user had dismissed the gate, we've corrected this by explicitly passing in the correct name to check against (the sign in gate ABTest id).

### Tested

- [X] Locally
- [ ] On CODE (optional)
