### PR TITLE
Forward contributions test selection

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -86,4 +86,14 @@ trait MonitoringSwitches {
     false
   )
 
+  val CompareVariantDecisions = Switch(
+    SwitchGroup.Monitoring,
+    "compare-variant-decision",
+    "forward contributions variant (ab test) decision to evaluate new service",
+    Seq(Owner.withEmail("slot.machine.dev@theguardian.com")),
+    Off,
+    never,
+    exposeClientSide = true,
+  )
+
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/slot-machine-client": "^0.2.2",
+    "@guardian/slot-machine-client": "^0.2.3",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -30,6 +30,28 @@ import {
     getEngagementBannerTestsFromGoogleDoc,
     getConfiguredEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
+import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
+
+import {
+    compareVariantDecision,
+    getViewLog,
+} from '@guardian/slot-machine-client';
+import {
+    getLastOneOffContributionDate,
+    isRecurringContributor,
+    shouldNotBeShownSupportMessaging,
+} from 'common/modules/commercial/user-features';
+
+// Tmp for Slot Machine work - can remove shortly
+const buildKeywordTags = page => {
+    const keywordIds = page.keywordIds.split(',');
+    const keywords = page.keywords.split(',');
+    return keywordIds.map((id, idx) => ({
+        id,
+        type: 'Keyword',
+        title: keywords[idx],
+    }));
+};
 
 export const getEpicTestToRun = memoize(
     (): Promise<?Runnable<EpicABTest>> => {
@@ -53,13 +75,40 @@ export const getEpicTestToRun = memoize(
                     test => !test.highPriority
                 );
 
-                return firstRunnableTest<EpicABTest>([
+                const result = firstRunnableTest<EpicABTest>([
                     hardCodedPriorityEpicTest,
                     ...highPriorityConfiguredTests,
                     ...highPriorityHardCodedTests,
                     ...lowPriorityConfiguredTests,
                     ...lowPriorityHardCodedTests,
                 ]);
+
+                if (config.get('switches.compareVariantDecision')) {
+                    // To evaluate the new contributions service logic we send it the actual decision so that it can
+                    // compare this against what it *thinks* is the right decision, and log differences.
+                    const page = config.get('page');
+                    compareVariantDecision({
+                        targeting: {
+                            contentType: page.contentType,
+                            sectionName: page.sectionName,
+                            shouldHideReaderRevenue:
+                                page.shouldHideReaderRevenue,
+                            isMinuteArticle: config.hasTone('Minute'),
+                            isPaidContent: page.isPaidContent,
+                            tags: buildKeywordTags(page),
+
+                            showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+                            isRecurringContributor: isRecurringContributor(),
+                            lastOneOffContributionDate: getLastOneOffContributionDate(),
+                            mvtId: getMvtValue(),
+                            epicViewLog: getViewLog(),
+                        },
+                        expectedTest: result ? result.id : '',
+                        expectedVariant: result ? result.variantToRun.id : '',
+                    });
+                }
+
+                return result;
             });
         }
         return Promise.resolve(

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -86,26 +86,32 @@ export const getEpicTestToRun = memoize(
                 if (config.get('switches.compareVariantDecision')) {
                     // To evaluate the new contributions service logic we send it the actual decision so that it can
                     // compare this against what it *thinks* is the right decision, and log differences.
-                    const page = config.get('page');
-                    compareVariantDecision({
-                        targeting: {
-                            contentType: page.contentType,
-                            sectionName: page.section,
-                            shouldHideReaderRevenue:
-                                page.shouldHideReaderRevenue,
-                            isMinuteArticle: config.hasTone('Minute'),
-                            isPaidContent: page.isPaidContent,
-                            tags: buildKeywordTags(page),
 
-                            showSupportMessaging: !shouldNotBeShownSupportMessaging(),
-                            isRecurringContributor: isRecurringContributor(),
-                            lastOneOffContributionDate: getLastOneOffContributionDate(),
-                            mvtId: getMvtValue(),
-                            epicViewLog: getViewLog(),
-                        },
-                        expectedTest: result ? result.id : '',
-                        expectedVariant: result ? result.variantToRun.id : '',
-                    });
+                    // send ~ one in ten to reduce initial volume
+                    if (Math.random() < 0.1) {
+                        const page = config.get('page');
+                        compareVariantDecision({
+                            targeting: {
+                                contentType: page.contentType,
+                                sectionName: page.section,
+                                shouldHideReaderRevenue:
+                                    page.shouldHideReaderRevenue,
+                                isMinuteArticle: config.hasTone('Minute'),
+                                isPaidContent: page.isPaidContent,
+                                tags: buildKeywordTags(page),
+
+                                showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+                                isRecurringContributor: isRecurringContributor(),
+                                lastOneOffContributionDate: getLastOneOffContributionDate(),
+                                mvtId: getMvtValue(),
+                                epicViewLog: getViewLog(),
+                            },
+                            expectedTest: result ? result.id : '',
+                            expectedVariant: result
+                                ? result.variantToRun.id
+                                : '',
+                        });
+                    }
                 }
 
                 return result;

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -90,7 +90,7 @@ export const getEpicTestToRun = memoize(
                     compareVariantDecision({
                         targeting: {
                             contentType: page.contentType,
-                            sectionName: page.sectionName,
+                            sectionName: page.section,
                             shouldHideReaderRevenue:
                                 page.shouldHideReaderRevenue,
                             isMinuteArticle: config.hasTone('Minute'),

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.js
@@ -23,6 +23,14 @@ import { getConfiguredEpicTests as getConfiguredEpicTests_ } from 'common/module
 
 const getConfiguredEpicTests: any = getConfiguredEpicTests_;
 
+// This is required as loading these seems to cause an error locally (and in CI)
+// because of some implicit dependency evil that I haven't been able to figure out.
+jest.mock('common/modules/commercial/user-features', () => ({
+    getLastOneOffContributionDate: () => null,
+    isRecurringContributor: () => false,
+    shouldNotBeShownSupportMessaging: () => false,
+}));
+
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
 jest.mock('common/modules/experiments/ab-ophan', () => ({

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-render-epic.js
@@ -96,7 +96,7 @@ const remoteRenderTest = {
 
                 const targeting = {
                     contentType: page.contentType,
-                    sectionName: page.sectionName,
+                    sectionName: page.section,
                     shouldHideReaderRevenue: page.shouldHideReaderRevenue,
                     isMinuteArticle: config.hasTone('Minute'),
                     isPaidContent: page.isPaidContent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/slot-machine-client@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.2.tgz#6b8a61475eed80656fa2d6febdc1fd4aa7d88049"
-  integrity sha512-TMilHpnIGwe/dxeMg3bO5jgTS0pwVMU5+wKZ46VoRA2JzsoucVr86hIJ6k6l01wXDuyNLo6x+rx94vVhYO4iAg==
+"@guardian/slot-machine-client@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.3.tgz#9585e3d3c1379554d5fd43e955881788dfdbde6f"
+  integrity sha512-jZRV1tUcV9bCTcMzirZzFQe9nfD9DfDWA7b4HSHzhga/x6n64ObnpATJEM3mK7kla+p1pGExvt3lTbJnUNxqWw==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
**NOTE: do not merge as need to bump client version first once that has been updated - https://github.com/guardian/slot-machine-client/pull/8.**

...to the new Contributions Service, so that we can compare to our
new logic and identify discrepancies without affecting PROD users.