### PR TITLE
Remove `isNotImmersive` from 100% article

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -132,7 +132,6 @@ object ArticlePicker {
     val article100PercentPageFeatures = whitelistFeatures.filterKeys(
       Set(
         "isSupportedType",
-        "isNotImmersive",
         "isNotLiveBlog",
         "isNotAGallery",
         "isNotAMP",


### PR DESCRIPTION
## What does this change?

I accidentally defined `isNotImmersive` as part of 100% article but 100% *includes* immersives.