### PR TITLE
Only compare variants if Epic served in Article

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -86,6 +86,7 @@ export const getEpicTestToRun = memoize(
                 if (config.get('switches.compareVariantDecision')) {
                     // To evaluate the new contributions service logic we send it the actual decision so that it can
                     // compare this against what it *thinks* is the right decision, and log differences.
+
                     // send ~ one in ten to reduce initial volume
                     if (Math.random() < 0.1) {
                         const page = config.get('page');

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -92,7 +92,6 @@ export const getEpicTestToRun = memoize(
                     return result;
                 }
 
-
                 if (config.get('switches.compareVariantDecision')) {
                     // To evaluate the new contributions service logic we send it the actual decision so that it can
                     // compare this against what it *thinks* is the right decision, and log differences.

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -86,32 +86,34 @@ export const getEpicTestToRun = memoize(
                 if (config.get('switches.compareVariantDecision')) {
                     // To evaluate the new contributions service logic we send it the actual decision so that it can
                     // compare this against what it *thinks* is the right decision, and log differences.
-
                     // send ~ one in ten to reduce initial volume
                     if (Math.random() < 0.1) {
                         const page = config.get('page');
-                        const countryCode = geolocationGetSync();
-                        compareVariantDecision({
-                            targeting: {
-                                contentType: page.contentType,
-                                sectionName: page.section,
-                                shouldHideReaderRevenue:
-                                    page.shouldHideReaderRevenue,
-                                isMinuteArticle: config.hasTone('Minute'),
-                                isPaidContent: page.isPaidContent,
-                                tags: buildKeywordTags(page),
-                                countryCode,
-                                showSupportMessaging: !shouldNotBeShownSupportMessaging(),
-                                isRecurringContributor: isRecurringContributor(),
-                                lastOneOffContributionDate: getLastOneOffContributionDate(),
-                                mvtId: getMvtValue(),
-                                epicViewLog: getViewLog(),
-                            },
-                            expectedTest: result ? result.id : '',
-                            expectedVariant: result
-                                ? result.variantToRun.id
-                                : '',
-                        });
+                        // Only compare variants for Epics served in Articles
+                        if (page.contentType === 'Article') {
+                            const countryCode = geolocationGetSync();
+                            compareVariantDecision({
+                                targeting: {
+                                    contentType: page.contentType,
+                                    sectionName: page.section,
+                                    shouldHideReaderRevenue:
+                                        page.shouldHideReaderRevenue,
+                                    isMinuteArticle: config.hasTone('Minute'),
+                                    isPaidContent: page.isPaidContent,
+                                    tags: buildKeywordTags(page),
+                                    countryCode,
+                                    showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+                                    isRecurringContributor: isRecurringContributor(),
+                                    lastOneOffContributionDate: getLastOneOffContributionDate(),
+                                    mvtId: getMvtValue(),
+                                    epicViewLog: getViewLog(),
+                                },
+                                expectedTest: result ? result.id : '',
+                                expectedVariant: result
+                                    ? result.variantToRun.id
+                                    : '',
+                            });
+                        }
                     }
                 }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -83,38 +83,44 @@ export const getEpicTestToRun = memoize(
                     ...lowPriorityHardCodedTests,
                 ]);
 
+                const page = config.get('page');
+
+                // No point in going forward with variant comparison unless
+                // we're in an Article (excludes e.g. live blogs which aren't
+                // supported yet)
+                if (page.contentType !== 'Article') {
+                    return result;
+                }
+
+
                 if (config.get('switches.compareVariantDecision')) {
                     // To evaluate the new contributions service logic we send it the actual decision so that it can
                     // compare this against what it *thinks* is the right decision, and log differences.
 
                     // send ~ one in ten to reduce initial volume
                     if (Math.random() < 0.1) {
-                        const page = config.get('page');
-                        // Only compare variants for Epics served in Articles
-                        if (page.contentType === 'Article') {
-                            const countryCode = geolocationGetSync();
-                            compareVariantDecision({
-                                targeting: {
-                                    contentType: page.contentType,
-                                    sectionName: page.section,
-                                    shouldHideReaderRevenue:
-                                        page.shouldHideReaderRevenue,
-                                    isMinuteArticle: config.hasTone('Minute'),
-                                    isPaidContent: page.isPaidContent,
-                                    tags: buildKeywordTags(page),
-                                    countryCode,
-                                    showSupportMessaging: !shouldNotBeShownSupportMessaging(),
-                                    isRecurringContributor: isRecurringContributor(),
-                                    lastOneOffContributionDate: getLastOneOffContributionDate(),
-                                    mvtId: getMvtValue(),
-                                    epicViewLog: getViewLog(),
-                                },
-                                expectedTest: result ? result.id : '',
-                                expectedVariant: result
-                                    ? result.variantToRun.id
-                                    : '',
-                            });
-                        }
+                        const countryCode = geolocationGetSync();
+                        compareVariantDecision({
+                            targeting: {
+                                contentType: page.contentType,
+                                sectionName: page.section,
+                                shouldHideReaderRevenue:
+                                    page.shouldHideReaderRevenue,
+                                isMinuteArticle: config.hasTone('Minute'),
+                                isPaidContent: page.isPaidContent,
+                                tags: buildKeywordTags(page),
+                                countryCode,
+                                showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+                                isRecurringContributor: isRecurringContributor(),
+                                lastOneOffContributionDate: getLastOneOffContributionDate(),
+                                mvtId: getMvtValue(),
+                                epicViewLog: getViewLog(),
+                            },
+                            expectedTest: result ? result.id : '',
+                            expectedVariant: result
+                                ? result.variantToRun.id
+                                : '',
+                        });
                     }
                 }
 


### PR DESCRIPTION
## What does this change?
Adds an extra check around the compare variants code to ensure we only actually compare variants if we're inside an Article (e.g. not in a live blog). This is because we only support Epics  in Articles for now and therefore don't want any other comparisons for simplicity/performance/financial reasons.

## Notes
This is a very specific tweak related to the Slot Machine integration and shouldn't affect the performance/features of anything else on the site.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
