### PR TITLE
Log Tone to DotcomponentsLogger

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -41,6 +41,9 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
           case None => Seq()
         }
       ).distinct.mkString(", ")
+    ),
+    LogFieldString(
+      "page.tone", page.article.tags.tones.headOption.map(_.name).getOrElse("")
     )
   )
 


### PR DESCRIPTION
## What does this change?

Logs out the tone so that we're able to review potential high-traffic tones to whitelist.