### PR TITLE
update set username for profile message

### DIFF
--- a/identity/app/views/profile/publicProfileForm.scala.html
+++ b/identity/app/views/profile/publicProfileForm.scala.html
@@ -56,8 +56,8 @@
                 @if(!usernameIsSet) {
                     @inputField(Input(publicProfileForm("username"), ('_label, "Username")))
                     <div class="form-field__note">
-                        You can only set your username once. It must be 6-20 characters, letters and/or numbers only
-                        and have no spaces. If you do not set your username, then your full name will be used.
+                        You need to set a username before you can comment.
+                        You can only set your username once. It must be 6-20 characters, letters and/or numbers.
                     </div>
                 } else {
                     <input type="hidden" name="username" value=@user.publicFields.username>


### PR DESCRIPTION
## What does this change?

This message

![image](https://user-images.githubusercontent.com/29203769/76341754-61783980-62f5-11ea-9653-bb4e73fade0e.png)
becomes

```
                        You need to set a username before you can comment.
                        You can only set your username once. It must be 6-20 characters, letters and/or numbers.
```

## Why are we doing this?

User displayNames no longer default to first+last name. We now force users to set a username before commenting.

- [X] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
