### PR TITLE
Migrate comscore to client-side

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -33,7 +33,7 @@ trait MonitoringSwitches {
     owners = Seq(Owner.withGithub("cb372")),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false
+    exposeClientSide = true
   )
 
   val ScrollDepthSwitch = Switch(

--- a/common/app/views/fragments/analytics/comscore.scala.html
+++ b/common/app/views/fragments/analytics/comscore.scala.html
@@ -4,7 +4,6 @@
 @import java.net.URLEncoder
 
 @if(ComscoreSwitch.isSwitchedOn) {
-
     <noscript>
         @defining(getContent(page).map(_.tags.keywords.map(_.name)).map(_.mkString(","))) { keywords =>
             <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&comscorekw=@keywords.map({kw => URLEncoder.encode(kw, "UTF-8")})" />

--- a/common/app/views/fragments/analytics/comscore.scala.html
+++ b/common/app/views/fragments/analytics/comscore.scala.html
@@ -4,26 +4,7 @@
 @import java.net.URLEncoder
 
 @if(ComscoreSwitch.isSwitchedOn) {
-    <script id='comscore'>
-        var _comscore = _comscore || [];
-        if (guardian.config.page.keywords === "Network Front") {
-            _comscore.push({ c1: "2", c2: "6035250" });
-            (function() {
-                var s = document.createElement("script"), el = document.getElementsByTagName("script")[0];
-                s.async = true;
-                s.src = "https://sb.scorecardresearch.com/beacon.js";
-                el.parentNode.insertBefore(s, el);
-            })()
-        } else {
-            _comscore.push({ c1: "2", c2: "6035250", comscorekw: guardian.config.page.keywords });
-            (function() {
-                var s = document.createElement("script"), el = document.getElementsByTagName("script")[0];
-                s.async = true;
-                s.src = "https://sb.scorecardresearch.com/beacon.js";
-                el.parentNode.insertBefore(s, el);
-            })()
-        };
-    </script>
+
     <noscript>
         @defining(getContent(page).map(_.tags.keywords.map(_.name)).map(_.mkString(","))) { keywords =>
             <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&comscorekw=@keywords.map({kw => URLEncoder.encode(kw, "UTF-8")})" />

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -21,6 +21,7 @@ import { init as initLiveblogAdverts } from 'commercial/modules/liveblog-adverts
 import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
 import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
+import { init as initComscore } from 'commercial/modules/comscore';
 import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
@@ -34,6 +35,7 @@ const commercialModules: Array<Array<any>> = [
     ['cm-checkDispatcher', initCheckDispatcher],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
+    ['cm-comscore', initComscore],
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -27,7 +27,7 @@ export const init = (): Promise<void> => {
         // eslint-disable-next-line no-underscore-dangle
         window._comscore.push(getGlobals(config.get('page.keywords', '')));
 
-        loadScript(comscoreSrc, { id: 'comscore', async: true });
+        return loadScript(comscoreSrc, { id: 'comscore', async: true });
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -3,8 +3,12 @@ import config from 'lib/config';
 
 type comscoreGlobals = { c1: string, c2: string, comscorekw?: string };
 
+const comscoreSrc = 'https://sb.scorecardresearch.com/beacon.js';
+const comscoreC1 = '2';
+const comscoreC2 = '6035250';
+
 const getGlobals = (keywords: string): comscoreGlobals => {
-    const globals: comscoreGlobals = { c1: '2', c2: '6035250' };
+    const globals: comscoreGlobals = { c1: comscoreC1, c2: comscoreC2 };
 
     if (keywords !== 'Network Front') {
         globals.comscorekw = keywords;
@@ -24,12 +28,11 @@ export const init = (): Promise<void> => {
         const s = document.createElement('script');
         s.id = 'comscore';
         s.async = true;
-        s.src = 'https://sb.scorecardresearch.com/beacon.js';
+        s.src = comscoreSrc;
 
-        const el = document.getElementsByTagName('script')[0];
-
-        if (el && el.parentNode) {
-            el.parentNode.insertBefore(s, el);
+        const el = document.getElementsByTagName('head')[0];
+        if (el) {
+            el.appendChild(s);
         }
     }
 
@@ -38,4 +41,7 @@ export const init = (): Promise<void> => {
 
 export const _ = {
     getGlobals,
+    comscoreSrc,
+    comscoreC1,
+    comscoreC2,
 };

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,9 +1,10 @@
 // @flow strict
 import config from 'lib/config';
+import { loadScript } from 'lib/load-script';
 
 type comscoreGlobals = { c1: string, c2: string, comscorekw?: string };
 
-const comscoreSrc = 'https://sb.scorecardresearch.com/beacon.js';
+const comscoreSrc = '//sb.scorecardresearch.com/beacon.js';
 const comscoreC1 = '2';
 const comscoreC2 = '6035250';
 
@@ -25,15 +26,7 @@ export const init = (): Promise<void> => {
         // eslint-disable-next-line no-underscore-dangle
         window._comscore.push(getGlobals(config.get('page.keywords', '')));
 
-        const s = document.createElement('script');
-        s.id = 'comscore';
-        s.async = true;
-        s.src = comscoreSrc;
-
-        const el = document.getElementsByTagName('head')[0];
-        if (el) {
-            el.appendChild(s);
-        }
+        loadScript(comscoreSrc, { id: 'comscore', async: true });
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,6 +1,7 @@
 // @flow strict
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
 type comscoreGlobals = { c1: string, c2: string, comscorekw?: string };
 
@@ -19,7 +20,7 @@ const getGlobals = (keywords: string): comscoreGlobals => {
 };
 
 export const init = (): Promise<void> => {
-    if (config.get('switches.comscore', false)) {
+    if (commercialFeatures.comscore) {
         // eslint-disable-next-line no-underscore-dangle
         window._comscore = window._comscore || [];
 

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,0 +1,41 @@
+// @flow strict
+import config from 'lib/config';
+
+type comscoreGlobals = { c1: string, c2: string, comscorekw?: string };
+
+const getGlobals = (keywords: string): comscoreGlobals => {
+    const globals: comscoreGlobals = { c1: '2', c2: '6035250' };
+
+    if (keywords !== 'Network Front') {
+        globals.comscorekw = keywords;
+    }
+
+    return globals;
+};
+
+export const init = (): Promise<void> => {
+    if (config.get('switches.comscore', false)) {
+        // eslint-disable-next-line no-underscore-dangle
+        window._comscore = window._comscore || [];
+
+        // eslint-disable-next-line no-underscore-dangle
+        window._comscore.push(getGlobals(config.get('page.keywords', '')));
+
+        const s = document.createElement('script');
+        s.id = 'comscore';
+        s.async = true;
+        s.src = 'https://sb.scorecardresearch.com/beacon.js';
+
+        const el = document.getElementsByTagName('script')[0];
+
+        if (el && el.parentNode) {
+            el.parentNode.insertBefore(s, el);
+        }
+    }
+
+    return Promise.resolve();
+};
+
+export const _ = {
+    getGlobals,
+};

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,29 +1,32 @@
 // @flow
-import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './comscore';
 
 jest.mock('lib/load-script', () => ({
     loadScript: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('common/modules/commercial/commercial-features', () => ({
+    commercialFeatures: {
+        comscore: true,
+    },
+}));
+
 const getComscoreScripTags = (): NodeList<HTMLElement> =>
     document.querySelectorAll('script#comscore');
 
 describe('comscore init', () => {
-    beforeEach(() => {
-        config.set('switches.comscore', true);
-    });
-
-    it('should do nothing if the comscore switch is off', () => {
-        config.set('switches.comscore', false);
+    it('should do nothing if the comscore is disabled in commercial features', () => {
+        commercialFeatures.comscore = false;
         init();
 
         const comscoreTags = getComscoreScripTags();
         expect(comscoreTags.length).toBe(0);
     });
 
-    it('should call loadScript with the expected parameters', () => {
+    it('should call loadScript with the expected parameters if enabled in commercial features', () => {
+        commercialFeatures.comscore = true;
         init();
 
         expect(loadScript).toBeCalledWith(_.comscoreSrc, {

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -5,7 +5,7 @@ import { init, _ } from './comscore';
 const getComscoreScripTags = (): NodeList<HTMLElement> =>
     document.querySelectorAll('script#comscore');
 
-const validComscoreScriptTag = (tag: HTMLElement) =>
+const isValidComscoreScriptTag = (tag: HTMLElement) =>
     tag instanceof HTMLScriptElement &&
     tag.src === _.comscoreSrc &&
     tag.async === true;
@@ -22,14 +22,14 @@ describe('comscore init', () => {
         const comscoreTags = getComscoreScripTags();
         expect(comscoreTags.length).toBe(0);
     });
+
     it('should drop the corect script tag if the comscore switch is on', () => {
         config.set('switches.comscore', true);
         init();
 
         const comscoreTags = getComscoreScripTags();
         expect(comscoreTags.length).toBe(1);
-
-        expect(validComscoreScriptTag(comscoreTags[0])).toBe(true);
+        expect(isValidComscoreScriptTag(comscoreTags[0])).toBe(true);
     });
 });
 
@@ -44,12 +44,14 @@ describe('comscore getGlobals', () => {
             comscorekw: randomStr,
         });
     });
+
     it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
         expect(_.getGlobals('Network Front')).toEqual(
             // $FlowFixMe property not does actually exist
             expect.not.objectContaining({ comscorekw: expect.any(Object) })
         );
     });
+
     it('always return an object with the c1 and c2 variables', () => {
         const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
 

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,0 +1,59 @@
+// @flow
+import config from 'lib/config';
+import { init, _ } from './comscore';
+
+const getComscoreScripTags = (): NodeList<HTMLElement> =>
+    document.querySelectorAll('script#comscore');
+
+const validComscoreScriptTag = (tag: HTMLElement) =>
+    tag instanceof HTMLScriptElement &&
+    tag.src === _.comscoreSrc &&
+    tag.async === true;
+
+describe('comscore init', () => {
+    beforeEach(() => {
+        config.set('switches.comscore', true);
+    });
+
+    it('should do nothing if the comscore switch is off', () => {
+        config.set('switches.comscore', false);
+        init();
+
+        const comscoreTags = getComscoreScripTags();
+        expect(comscoreTags.length).toBe(0);
+    });
+    it('should drop the corect script tag if the comscore switch is on', () => {
+        config.set('switches.comscore', true);
+        init();
+
+        const comscoreTags = getComscoreScripTags();
+        expect(comscoreTags.length).toBe(1);
+
+        expect(validComscoreScriptTag(comscoreTags[0])).toBe(true);
+    });
+});
+
+describe('comscore getGlobals', () => {
+    it('returns an object with the correct comscorekw variable set', () => {
+        const randomStr = Math.random()
+            .toString(36)
+            .substring(2);
+
+        expect(_.getGlobals('')).toMatchObject({ comscorekw: '' });
+        expect(_.getGlobals(randomStr)).toMatchObject({
+            comscorekw: randomStr,
+        });
+    });
+    it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
+        expect(_.getGlobals('Network Front')).toEqual(
+            // $FlowFixMe property not does actually exist
+            expect.not.objectContaining({ comscorekw: expect.any(Object) })
+        );
+    });
+    it('always return an object with the c1 and c2 variables', () => {
+        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+
+        expect(_.getGlobals('')).toMatchObject(expectedGlobals);
+        expect(_.getGlobals('Network Front')).toMatchObject(expectedGlobals);
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -5,11 +5,6 @@ import { init, _ } from './comscore';
 const getComscoreScripTags = (): NodeList<HTMLElement> =>
     document.querySelectorAll('script#comscore');
 
-const isValidComscoreScriptTag = (tag: HTMLElement) =>
-    tag instanceof HTMLScriptElement &&
-    tag.src === _.comscoreSrc &&
-    tag.async === true;
-
 describe('comscore init', () => {
     beforeEach(() => {
         config.set('switches.comscore', true);
@@ -23,39 +18,63 @@ describe('comscore init', () => {
         expect(comscoreTags.length).toBe(0);
     });
 
-    it('should drop the corect script tag if the comscore switch is on', () => {
+    it('should drop exactly one script tag if the comscore switch is on', () => {
         config.set('switches.comscore', true);
         init();
 
         const comscoreTags = getComscoreScripTags();
         expect(comscoreTags.length).toBe(1);
-        expect(isValidComscoreScriptTag(comscoreTags[0])).toBe(true);
+    });
+
+    it('should drop a script tag with the correct src if the comscore switch is on', () => {
+        config.set('switches.comscore', true);
+        init();
+
+        const comscoreTags = getComscoreScripTags();
+
+        if (comscoreTags[0] instanceof HTMLScriptElement) {
+            expect(comscoreTags[0].src).toEqual(_.comscoreSrc);
+        } else {
+            throw new Error('Obtained comscore tag is not a script');
+        }
+    });
+
+    it('should drop a script tag with the correct async mode if the comscore switch is on', () => {
+        config.set('switches.comscore', true);
+        init();
+
+        const comscoreTags = getComscoreScripTags();
+
+        if (comscoreTags[0] instanceof HTMLScriptElement) {
+            expect(comscoreTags[0].async).toBe(true);
+        } else {
+            throw new Error('Obtained comscore tag is not a script');
+        }
     });
 });
 
 describe('comscore getGlobals', () => {
-    it('returns an object with the correct comscorekw variable set', () => {
-        const randomStr = Math.random()
-            .toString(36)
-            .substring(2);
+    it('return an object with the c1 and c2 properties correctly set when called with "Network Front" as keywords', () => {
+        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+        expect(_.getGlobals('Network Front')).toMatchObject(expectedGlobals);
+    });
 
-        expect(_.getGlobals('')).toMatchObject({ comscorekw: '' });
-        expect(_.getGlobals(randomStr)).toMatchObject({
-            comscorekw: randomStr,
-        });
+    it('return an object with the c1 and c2 properties correctly set when called with non-"Network Front" as keywords', () => {
+        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+        expect(_.getGlobals('')).toMatchObject(expectedGlobals);
     });
 
     it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
-        expect(_.getGlobals('Network Front')).toEqual(
-            // $FlowFixMe property not does actually exist
-            expect.not.objectContaining({ comscorekw: expect.any(Object) })
-        );
+        const comscoreGlobals = Object.keys(_.getGlobals('Network Front'));
+        expect(comscoreGlobals).not.toContain('comscorekw');
     });
 
-    it('always return an object with the c1 and c2 variables', () => {
-        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+    it('returns an object with the correct comscorekw variable set', () => {
+        const keywords = 'These are the best keywords The greatest!';
 
-        expect(_.getGlobals('')).toMatchObject(expectedGlobals);
-        expect(_.getGlobals('Network Front')).toMatchObject(expectedGlobals);
+        expect(_.getGlobals('')).toMatchObject({ comscorekw: '' });
+        expect(_.getGlobals(keywords)).toMatchObject({
+            comscorekw: keywords,
+        });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -23,7 +23,7 @@ describe('comscore init', () => {
         expect(comscoreTags.length).toBe(0);
     });
 
-    it('should call loadScript with the correctly parameters', () => {
+    it('should call loadScript with the expected parameters', () => {
         init();
 
         expect(loadScript).toBeCalledWith(_.comscoreSrc, {

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,6 +1,11 @@
 // @flow
 import config from 'lib/config';
+import { loadScript } from 'lib/load-script';
 import { init, _ } from './comscore';
+
+jest.mock('lib/load-script', () => ({
+    loadScript: jest.fn(() => Promise.resolve()),
+}));
 
 const getComscoreScripTags = (): NodeList<HTMLElement> =>
     document.querySelectorAll('script#comscore');
@@ -18,38 +23,13 @@ describe('comscore init', () => {
         expect(comscoreTags.length).toBe(0);
     });
 
-    it('should drop exactly one script tag if the comscore switch is on', () => {
-        config.set('switches.comscore', true);
+    it('should call loadScript with the correctly parameters', () => {
         init();
 
-        const comscoreTags = getComscoreScripTags();
-        expect(comscoreTags.length).toBe(1);
-    });
-
-    it('should drop a script tag with the correct src if the comscore switch is on', () => {
-        config.set('switches.comscore', true);
-        init();
-
-        const comscoreTags = getComscoreScripTags();
-
-        if (comscoreTags[0] instanceof HTMLScriptElement) {
-            expect(comscoreTags[0].src).toEqual(_.comscoreSrc);
-        } else {
-            throw new Error('Obtained comscore tag is not a script');
-        }
-    });
-
-    it('should drop a script tag with the correct async mode if the comscore switch is on', () => {
-        config.set('switches.comscore', true);
-        init();
-
-        const comscoreTags = getComscoreScripTags();
-
-        if (comscoreTags[0] instanceof HTMLScriptElement) {
-            expect(comscoreTags[0].async).toBe(true);
-        } else {
-            throw new Error('Obtained comscore tag is not a script');
-        }
+        expect(loadScript).toBeCalledWith(_.comscoreSrc, {
+            id: 'comscore',
+            async: true,
+        });
     });
 });
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -21,6 +21,7 @@ class CommercialFeatures {
     paidforBand: boolean;
     asynchronous: boolean;
     adFree: boolean;
+    comscore: boolean;
 
     constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests
@@ -128,6 +129,11 @@ class CommercialFeatures {
             isLiveBlog && this.dfpAdvertising && !this.adFree;
 
         this.paidforBand = config.get('page.isPaidContent') && !supportsSticky;
+
+        this.comscore =
+            config.get('switches.comscore', false) &&
+            !isIdentityPage &&
+            !isSecureContact;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Moves the comscore code from client-side to server-side and adds unit testing.

comscore is currently not implemented in DCR. Adding this client side module to the dcr commercial bootstrapper will implement it, which I will do in a separate PR after this one is merged.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
We're doing this so we can eventually put it behind a consent check. Doing this on the server side would break our caching.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)