### PR TITLE
Adds new A/B test switch for DCR test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -145,4 +145,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 3, 16),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-frontend-dotcom-rendering-epic",
+    "A/B test Default Epic on Frontend vs DCR, both from a remote source, to compare Epic performance",
+    owners = Seq(Owner.withGithub("andre1050")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 5, 13),
+    exposeClientSide = true
+  )
 }


### PR DESCRIPTION
## What does this change?
Adds a new A/B test switch with the specific purpose of controlling the upcoming test for serving Default Epic on Frontend vs DCR via Contributions service.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
