### PR TITLE
Capture dcrCouldRender Experiences

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -7,7 +7,7 @@ import domready from 'domready';
 import { bootStandard } from 'bootstraps/standard/main';
 import config from 'lib/config';
 import { markTime } from 'lib/user-timing';
-import { capturePerfTimings } from 'lib/capture-perf-timings';
+import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 
 // Let webpack know where to get files from
@@ -93,9 +93,9 @@ const go = () => {
             }),
         ]).then(() => {
             if (document.readyState === 'complete') {
-                capturePerfTimings();
+                captureOphanInfo();
             } else {
-                window.addEventListener('load', capturePerfTimings);
+                window.addEventListener('load', captureOphanInfo);
             }
         });
     });

--- a/static/src/javascripts/lib/capture-ophan-info.js
+++ b/static/src/javascripts/lib/capture-ophan-info.js
@@ -2,8 +2,9 @@
 import ophan from 'ophan/ng';
 import { getMarkTime } from 'lib/user-timing';
 import performanceAPI from 'lib/window-performance';
+import config from './config';
 
-const capturePerfTimings = (): void => {
+const captureOphanInfo = (): void => {
     const supportsPerformanceProperties =
         performanceAPI &&
         'navigation' in performanceAPI &&
@@ -38,9 +39,18 @@ const capturePerfTimings = (): void => {
         })),
     };
 
+    let ophanInfo = {};
+
+    if (config.get('page.dcrCouldRender', false)) {
+        ophanInfo = { ...ophanInfo, ...{ experiences: 'dcrCouldRender' } };
+    }
+
     ophan.record({
-        performance,
+        ...ophanInfo,
+        ...{
+            performance,
+        },
     });
 };
 
-export { capturePerfTimings };
+export { captureOphanInfo };


### PR DESCRIPTION
 and move capture perf to capture Ophan info, to save sending an extra request to Ophan.

## What does this change?

- Moves `capturePerfTimings` to more generic `captureOphanInfo`, to prevent sending another request to Ophan for every page view
- Adds `Experiences` for `dcrCouldRender` to allow us to (hopefully) capture pages that DCR could have rendered but did not (Outside of test).

![image](https://user-images.githubusercontent.com/638051/76754126-821f1400-6779-11ea-9888-d7acefe3e89f.png)

Note: this isn't why we aren't seeing experiences in the data lake, that's a separate issue still.