### PR TITLE
Extend a/b test CommercialGptLazyLoad by 1 week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -142,7 +142,7 @@ trait ABTestSwitches {
     "This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution",
     owners = Seq(Owner.withGithub("GHaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 3, 16),
+    sellByDate = new LocalDate(2020, 3, 23),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.js
@@ -3,7 +3,7 @@
 export const commercialGptLazyLoad: ABTest = {
     id: 'CommercialGptLazyLoad',
     start: '2020-03-02',
-    expiry: '2020-03-16',
+    expiry: '2020-03-23',
     author: 'George Haberis',
     description:
         'This test enables GPT enableLazyLoad as an alternative to our custom build lazy load solution',


### PR DESCRIPTION
## What does this change?

Extend a/b test CommercialGptLazyLoad by 1 week, the switch is OFF right now but will be turned on again later in the week once this test is renamed/refactored.