### PR TITLE
Change Prebid's syncsPerBidder to 0

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -113,8 +113,7 @@ const initialise = (window: {
 
     const userSync = config.get('switches.prebidUserSync', false)
         ? {
-              // syncsPerBidder: 0, // allow all syncs - bug https://github.com/prebid/Prebid.js/issues/2781
-              syncsPerBidder: 999, // temporarily until above bug fixed
+              syncsPerBidder: 0, // allow all syncs
               filterSettings: {
                   all: {
                       bidders: '*', // allow all bidders to sync by iframe or image beacons

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.js
@@ -101,7 +101,7 @@ describe('initialise', () => {
             userSync: {
                 syncDelay: 3000,
                 syncEnabled: true,
-                syncsPerBidder: 999,
+                syncsPerBidder: 0,
                 auctionDelay: 0,
                 filterSettings: {
                     all: {


### PR DESCRIPTION
## What does this change?
Maintenance work that changes Prebid's iframe user sync config `syncsPerBidder` back to 0.

### Context
PR https://github.com/guardian/frontend/pull/20346 set this parameter to 999 due to a bug in Prebid. This bug was raised here https://github.com/prebid/Prebid.js/issues/2781 and fixed here https://github.com/prebid/Prebid.js/pull/3360 so we should be ok to change this parameter back to 0 without change to how our code behaves.

### How to test
Access an article with ads enabled and add the `?pbjs_debug=true` query param to your URL to enable Prebid's debug mode.
When setting `syncsPerBidder` to different values one of two things will happen:
1) The message `Prebid MESSAGE: Invoking iframe user sync for bidder: <adapter>` will appear in the console. This means iframe user syncing is happening for a the specified adapter. This is the desired outcome.
2) The message `Prebid WARNING: Number of user syncs exceeded for "<adapter>"` will appear in the console. This means the number of iframe user syncs returned by the specified adapter is greater than the `syncsPerBidder`.

Setting `syncsPerBidder` to 1 causes the second case to happen but setting it to 0 causes the first case to happen instead, meaning the bug is definitely fixed and we're all good!


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)