### PR TITLE
Update identity library version to update newsletters

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.198"
+  val identityLibVersion = "3.199"
   val awsVersion = "1.11.240"
   val capiVersion = "16.0"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?

Updating identity library version to make a change to the Coronavirus: the week explained newsletter id.