### PR TITLE
Liveblog — Add modified date and use correct date

### DIFF
--- a/article/app/model/structuredData/BlogPosting.scala
+++ b/article/app/model/structuredData/BlogPosting.scala
@@ -14,9 +14,14 @@ object BlogPosting {
 
   def apply(blog: Article, block: BodyBlock)(implicit request: RequestHeader): JsValue = {
 
-    def blockDate(block: BodyBlock) = block.publishedDate match {
+    def blockFirstPublishedDate(block: BodyBlock) = block.firstPublishedDate match {
       case Some(date) => zulu(date)
       case None => zulu(blog.trail.webPublicationDate)
+    }
+    
+    def blockLastModifiedDate(block: BodyBlock) = block.lastModifiedDate match {
+      case Some(date) => zulu(date)
+      case None => zulu(blog.content.fields.lastModified)
     }
 
     def blockBody(block: BodyBlock): String = {
@@ -49,7 +54,10 @@ object BlogPosting {
       "author" -> blockAuthor(blog, block),
       "publisher" -> Json.obj("@id" -> "https://www.theguardian.com#publisher"),
       "url" -> LinkTo{blog.metadata.url+"?page=with:block-"+block.id+"#block-"+block.id},
-      "datePublished" -> blockDate(block),
+      /* Schema.org -- Date of first broadcast/publication */
+      "datePublished" -> blockFirstPublishedDate(block),
+      /*  Schema.org -- The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed */
+      "dateModified" -> blockLastModifiedDate(block), 
       "articleBody" -> blockBody(block)
     )
 


### PR DESCRIPTION
## What does this change?

The associate change ensure we use `datePublished ` as expected from [schema.org](https://schema.org/CreativeWork) and add `dateModified ` which currently appears as a warning in [google console structured data testing tool](https://search.google.com/structured-data/testing-tool)

<img width="752" alt="Screenshot 2020-03-17 at 18 24 36" src="https://user-images.githubusercontent.com/615085/76889106-e971bc80-687c-11ea-800a-ac4b0ca419a9.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

I think there is no plan to migrate, at least for the moment, how we send our structured data in DCR. This may change when liveblogs are migrated.

## Screenshots

## What is the value of this and can you measure success?

We think the missing data may potentially have a role in our liveblogs missing from the "corona virus" search carrousel. In general adding the missing field should help with the SEO but it is difficult to measure.  

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
