### PR TITLE
Add article viewing history to comparison payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/slot-machine-client": "^0.2.3",
+    "@guardian/slot-machine-client": "^0.2.6",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -35,6 +35,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import {
     compareVariantDecision,
     getViewLog,
+    getWeeklyArticleHistory,
 } from '@guardian/slot-machine-client';
 import {
     getLastOneOffContributionDate,
@@ -114,6 +115,7 @@ export const getEpicTestToRun = memoize(
                                 lastOneOffContributionDate: getLastOneOffContributionDate(),
                                 mvtId: getMvtValue(),
                                 epicViewLog: getViewLog(),
+                                weeklyArticleHistory: getWeeklyArticleHistory(),
                             },
                             expectedTest: result ? result.id : '',
                             expectedVariant: result

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/slot-machine-client@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.3.tgz#9585e3d3c1379554d5fd43e955881788dfdbde6f"
-  integrity sha512-jZRV1tUcV9bCTcMzirZzFQe9nfD9DfDWA7b4HSHzhga/x6n64ObnpATJEM3mK7kla+p1pGExvt3lTbJnUNxqWw==
+"@guardian/slot-machine-client@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.6.tgz#4d323d31322ad4ae56bd9cc578516ec28e3ef36f"
+  integrity sha512-2rPLnFOs0kBp6rvWYyZURSLcsD6gzP9WSiN3bv/ZSC07LLnKyQwhGB8q/sNtFkkgCdt1sbVcMtlzmCAKsNudBA==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?
Adds the weekly article history to the payload of the variant comparison call. We need this to be able to accurately compare variant decisions.

## Context
Slot Machine integration.