### PR TITLE
Track YouTube PFP events

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -8,6 +8,7 @@ import { getPageTargeting } from 'common/modules/commercial/build-page-targeting
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import $ from 'lib/$';
+import { buildPfpEvent } from 'common/modules/video/ga-helper';
 import { getPermutivePFPSegments } from '../commercial/permutive';
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
@@ -125,7 +126,9 @@ const setupPlayer = (
     channelId?: string,
     onReady,
     onStateChange,
-    onError
+    onError,
+    onAdStart,
+    onAdEnd
 ) => {
     const disableRelatedVideos = false;
     // relatedChannels needs to be an array, as per YouTube's IFrame Embed Config API
@@ -155,6 +158,8 @@ const setupPlayer = (
             onReady,
             onStateChange,
             onError,
+            onAdStart,
+            onAdEnd,
         },
         embedConfig: {
             relatedChannels,
@@ -194,13 +199,33 @@ export const initYoutubePlayer = (
             console.dir(event);
         };
 
+        const gaTracker = config.get('googleAnalytics.trackers.editorial');
+
+        const onAdStart = () => {
+            window.ga(
+                `${gaTracker}.send`,
+                'event',
+                buildPfpEvent('adStart', videoId)
+            );
+        };
+
+        const onAdEnd = () => {
+            window.ga(
+                `${gaTracker}.send`,
+                'event',
+                buildPfpEvent('adEnd', videoId)
+            );
+        };
+
         return setupPlayer(
             el,
             videoId,
             channelId,
             onPlayerReady,
             onPlayerStateChange,
-            onPlayerError
+            onPlayerError,
+            onAdStart,
+            onAdEnd
         );
     });
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -201,7 +201,7 @@ export const initYoutubePlayer = (
 
         const gaTracker = config.get('googleAnalytics.trackers.editorial');
 
-        const onAdStart = () => {
+        const onAdStart = (): void => {
             window.ga(
                 `${gaTracker}.send`,
                 'event',
@@ -209,7 +209,7 @@ export const initYoutubePlayer = (
             );
         };
 
-        const onAdEnd = () => {
+        const onAdEnd = (): void => {
             window.ga(
                 `${gaTracker}.send`,
                 'event',

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -45,7 +45,20 @@ const getGoogleAnalyticsEventAction = (mediaEvent: MediaEvent) => {
 
 type PfpEventType = 'adStart' | 'adEnd';
 
-const buildPfpEvent = (pfpEventType: PfpEventType, videoId: string) => {
+type PfpEventParams = {
+    eventCategory: string,
+    eventAction: string,
+    eventLabel: string,
+    dimension19: string,
+    dimension20: string,
+    metric17?: number,
+    metric18?: number,
+};
+
+const buildPfpEvent = (
+    pfpEventType: PfpEventType,
+    videoId: string
+): PfpEventParams => {
     const pfpEventMetric = pfpEventType === 'adStart' ? 17 : 18;
     return {
         eventCategory: 'media',

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -43,5 +43,23 @@ const getGoogleAnalyticsEventAction = (mediaEvent: MediaEvent) => {
     return action;
 };
 
+type PfpEventType = 'adStart' | 'adEnd';
+
+const buildPfpEvent = (pfpEventType: PfpEventType, videoId: string) => {
+    const pfpEventMetric = pfpEventType === 'adStart' ? 17 : 18;
+    return {
+        eventCategory: 'media',
+        eventAction: 'video preroll',
+        eventLabel: videoId,
+        dimension19: videoId,
+        dimension20: 'gu-video-youtube',
+        [`metric${pfpEventMetric}`]: 1,
+    };
+};
+
 export type { MediaEvent };
-export { buildGoogleAnalyticsEvent, getGoogleAnalyticsEventAction };
+export {
+    buildGoogleAnalyticsEvent,
+    getGoogleAnalyticsEventAction,
+    buildPfpEvent,
+};


### PR DESCRIPTION
## What does this change?
Implements YouTube PFP `adStart` and `adEnd` tracking. [trello card](https://trello.com/c/K9WRhLQV)
Both events are tracked within the `video preroll` event action and are distinguished by the metric number:
- `metric17` for adStart
- `metric18` for adEnd

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
