### PR TITLE
Subscriptions banner copy update

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -16,13 +16,12 @@ const subscriptionBannerTemplate = (
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            A beautiful way to read it <br /> A powerful way to fund it
+            Open to all, supported by you
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Support The Guardian and enjoy The Guardian Daily,
-            Premium access to The Guardian Live app and ad-free
-            reading on theguardian.com</p>
+            <p>Support open, independent journalism and enjoy two
+             innovative apps and ad-free reading on theguardian.com</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -54,14 +54,14 @@
 
     @include mq($from: tablet) {
         margin-bottom: 10px;
-        width: 60%;
+        width: 61%;
         font-size: 30px;
         line-height: 32px;
     }
 
     @include mq($from: desktop) {
-        width: 48%;
-        margin-right: 52%;
+        width: 51%;
+        margin-right: 49%;
         font-size: 34px;
         line-height: 36px;
     }
@@ -129,6 +129,7 @@
     font-size: 12px;
     font-weight: bold;
     margin: 30px 0 0;
+
 
     @include mq($from: tablet) {
         display: flex;
@@ -264,7 +265,7 @@
 
 
     @include mq($from: desktop) {
-        width: 52%;
+        width: 50%;
     }
 
     @include mq($from: wide) {
@@ -282,17 +283,18 @@
         }
 
         @include mq($from: tablet) {
-            margin-right: 0;
+            max-width: 330px;
+            margin-right: 90px;
         }
 
         @include mq($from: desktop) {
-            max-width: 420px;
+            max-width: 380px;
             margin-right: 90px;
         }
 
         // custom breakpoint
         @include mq($from: leftCol) {
-            max-width: 500px;
+            max-width: 450px;
         }
 
         @media (min-width: 1260px) {


### PR DESCRIPTION
## What does this change?
Changes the title and message copy, which we are refreshing temporarily during the current period of heightened traffic and attention.

2 notes of interest for reviewers:
- @damien-shaw-guardian in particular, this may impact your GW banner work in progress.
- A simple copy change like this ought not to require the tweaking of widths/heights at various breakpoints. E.g. whether the packshot overlaps the close button is/was dependent on the title copy length. I'm going to add a card to see if we can spend some time making this more robust to changes - particularly to the packshot and title copy. This will be essential in the future as we move towards tooling to automatically update these items.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/76949104-fa174680-68ff-11ea-9174-ddcb7ce397a8.png)
![image](https://user-images.githubusercontent.com/8754692/76949153-0a2f2600-6900-11ea-9c90-c4bba11cfc10.png)
![image](https://user-images.githubusercontent.com/8754692/76949193-187d4200-6900-11ea-8c58-4cb3b654697b.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
